### PR TITLE
Adjust Pool Royale plywood depth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -991,8 +991,10 @@ const SIDE_CAPTURE_R = CAPTURE_R * SIDE_CAPTURE_RADIUS_SCALE;
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
 const PLYWOOD_THICKNESS = TABLE.THICK * 0.18; // add a full plywood bed under the cloth with the same footprint as the table
 const PLYWOOD_GAP = TABLE.THICK * 0.04; // leave a subtle clearance between the cloth wrap and the plywood surface
-const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.14; // drop the plywood deeper so it never crowds the pocket bowls
+const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.22; // lower the plywood so it kisses the pocket bowls instead of hovering above them
 const PLYWOOD_OUTSET = TABLE.THICK * 0.12; // widen the plywood slab so every edge reads as a single, unbroken piece
+const PLYWOOD_POCKET_RELIEF_R = POCKET_VIS_R * 1.04; // carve plywood openings that align with the pocket bowls
+const PLYWOOD_POCKET_RELIEF_SIDE_SCALE = 0.96; // side pockets are smaller so relief cuts follow their tighter radii
 const CLOTH_EXTENDED_DEPTH = TABLE.THICK * 0.362; // preserve the deeper cloth wrap without relying on a stone underlay
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
@@ -6086,6 +6088,17 @@ function Table3D(
       shape.lineTo(insetHalfW, insetHalfH);
       shape.lineTo(-insetHalfW, insetHalfH);
       shape.lineTo(-insetHalfW, -insetHalfH);
+      if (PLYWOOD_POCKET_RELIEF_R > MICRO_EPS) {
+        pocketPositions.forEach((p, index) => {
+          const hole = new THREE.Path();
+          const isSidePocket = index >= 4;
+          const radius =
+            PLYWOOD_POCKET_RELIEF_R * (isSidePocket ? PLYWOOD_POCKET_RELIEF_SIDE_SCALE : 1);
+          hole.absellipse(p.x, p.y, radius, radius, 0, Math.PI * 2, true);
+          hole.autoClose = true;
+          shape.holes.push(hole);
+        });
+      }
       return shape;
     };
 


### PR DESCRIPTION
## Summary
- lower the Pool Royale plywood bed so it sits against the pocket bowls instead of hovering
- carve plywood reliefs around each pocket to keep the underlay visible and allow proper shadowing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4b8d10c88329805f0e742dbb0541)