### PR TITLE
Enable directional light shadows in pool arena

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -13193,6 +13193,19 @@ export function PoolRoyaleGame({
           triangleRadius * LIGHT_LATERAL_SCALE * 0.4
         );
         dirLight.target.position.set(0, tableSurfaceY + BALL_R * 0.05, 0);
+        dirLight.castShadow = true;
+        dirLight.shadow.mapSize.set(2048, 2048);
+        const shadowHalfExtent = Math.max(roomWidth, roomDepth) * 0.7;
+        const shadowCam = dirLight.shadow.camera;
+        shadowCam.left = -shadowHalfExtent;
+        shadowCam.right = shadowHalfExtent;
+        shadowCam.top = shadowHalfExtent;
+        shadowCam.bottom = -shadowHalfExtent;
+        shadowCam.near = Math.max(0.5, triangleHeight * 0.25);
+        shadowCam.far = triangleHeight * 2.4;
+        shadowCam.updateProjectionMatrix();
+        dirLight.shadow.bias = -0.00008;
+        dirLight.shadow.normalBias = 0.0025;
         lightingRig.add(dirLight);
         lightingRig.add(dirLight.target);
 


### PR DESCRIPTION
## Summary
- enable the pool arena directional light to cast shadows
- size the shadow camera to cover the full room and tune bias to reduce artifacts

## Testing
- npm run build --prefix webapp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5d53d1888329846dd7233ce7fe96)