### PR TITLE
Rebuild Pool Royale plywood geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6079,7 +6079,26 @@ function Table3D(
   const plywoodDepth = PLYWOOD_THICKNESS;
   if (plywoodDepth > MICRO_EPS) {
     const plywoodHoleRadius = POCKET_HOLE_R * PLYWOOD_HOLE_SCALE;
-    const plywoodShape = buildSurfaceShape(plywoodHoleRadius, -PLYWOOD_OUTSET);
+    const plywoodHalfW = Math.max(MICRO_EPS, halfWext + PLYWOOD_OUTSET);
+    const plywoodHalfH = Math.max(MICRO_EPS, halfHext + PLYWOOD_OUTSET);
+    const plywoodShape = new THREE.Shape();
+    plywoodShape.moveTo(-plywoodHalfW, -plywoodHalfH);
+    plywoodShape.lineTo(plywoodHalfW, -plywoodHalfH);
+    plywoodShape.lineTo(plywoodHalfW, plywoodHalfH);
+    plywoodShape.lineTo(-plywoodHalfW, plywoodHalfH);
+    plywoodShape.lineTo(-plywoodHalfW, -plywoodHalfH);
+
+    pocketPositions.forEach((p, index) => {
+      const hole = new THREE.Path();
+      const isSidePocket = index >= 4;
+      const radius = isSidePocket
+        ? plywoodHoleRadius * sideRadiusScale
+        : plywoodHoleRadius;
+      hole.absellipse(p.x, p.y, radius, radius, 0, Math.PI * 2, true);
+      hole.autoClose = true;
+      plywoodShape.holes.push(hole);
+    });
+
     const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
       depth: plywoodDepth,
       bevelEnabled: false,


### PR DESCRIPTION
## Summary
- rebuild the plywood slab for Pool Royale with an explicit rectangular shape
- add oversized pocket holes directly to the plywood geometry so the entire board renders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6eae4ca48329aed6862dce538dbc)