### PR TITLE
Rebuild Pool Royale plywood underlay geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6079,7 +6079,26 @@ function Table3D(
   const plywoodDepth = PLYWOOD_THICKNESS;
   if (plywoodDepth > MICRO_EPS) {
     const plywoodHoleRadius = POCKET_HOLE_R * PLYWOOD_HOLE_SCALE;
-    const plywoodShape = buildSurfaceShape(plywoodHoleRadius, -PLYWOOD_OUTSET);
+    const plywoodShape = (() => {
+      const plywoodHalfW = Math.max(MICRO_EPS, halfWext + PLYWOOD_OUTSET);
+      const plywoodHalfH = Math.max(MICRO_EPS, halfHext + PLYWOOD_OUTSET);
+      const shape = new THREE.Shape();
+      shape.moveTo(-plywoodHalfW, -plywoodHalfH);
+      shape.lineTo(plywoodHalfW, -plywoodHalfH);
+      shape.lineTo(plywoodHalfW, plywoodHalfH);
+      shape.lineTo(-plywoodHalfW, plywoodHalfH);
+      shape.lineTo(-plywoodHalfW, -plywoodHalfH);
+      shape.autoClose = true;
+      pocketPositions.forEach((p, index) => {
+        const isSidePocket = index >= 4;
+        const radius = isSidePocket ? plywoodHoleRadius * sideRadiusScale : plywoodHoleRadius;
+        const hole = new THREE.Path();
+        hole.absellipse(p.x, p.y, radius, radius, 0, Math.PI * 2, true);
+        hole.autoClose = true;
+        shape.holes.push(hole);
+      });
+      return shape;
+    })();
     const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
       depth: plywoodDepth,
       bevelEnabled: false,


### PR DESCRIPTION
## Summary
- rebuild the Pool Royale plywood underlay using an explicit rectangular shape with cutouts to avoid missing sections
- preserve the widened footprint and pocket offsets so the underlay renders fully beneath the cloth

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6eae4ca48329aed6862dce538dbc)