### PR TITLE
Restore full Pool Royale plywood slab rendering

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6079,7 +6079,32 @@ function Table3D(
   const plywoodDepth = PLYWOOD_THICKNESS;
   if (plywoodDepth > MICRO_EPS) {
     const plywoodHoleRadius = POCKET_HOLE_R * PLYWOOD_HOLE_SCALE;
-    const plywoodShape = buildSurfaceShape(plywoodHoleRadius, -PLYWOOD_OUTSET);
+    const buildPlywoodShape = () => {
+      const insetHalfW = Math.max(MICRO_EPS, halfWext + PLYWOOD_OUTSET);
+      const insetHalfH = Math.max(MICRO_EPS, halfHext + PLYWOOD_OUTSET);
+
+      const plywoodShape = new THREE.Shape();
+      plywoodShape.moveTo(-insetHalfW, -insetHalfH);
+      plywoodShape.lineTo(insetHalfW, -insetHalfH);
+      plywoodShape.lineTo(insetHalfW, insetHalfH);
+      plywoodShape.lineTo(-insetHalfW, insetHalfH);
+      plywoodShape.lineTo(-insetHalfW, -insetHalfH);
+
+      pocketPositions.forEach((p, index) => {
+        const isSidePocket = index >= 4;
+        const radius = isSidePocket
+          ? plywoodHoleRadius * sideRadiusScale
+          : plywoodHoleRadius;
+        const hole = new THREE.Path();
+        hole.absellipse(p.x, p.y, radius, radius, 0, Math.PI * 2, true);
+        hole.autoClose = true;
+        plywoodShape.holes.push(hole);
+      });
+
+      return plywoodShape;
+    };
+
+    const plywoodShape = buildPlywoodShape();
     const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
       depth: plywoodDepth,
       bevelEnabled: false,


### PR DESCRIPTION
## Summary
- rebuild the Pool Royale plywood underlay geometry using an explicit shape with pocket cutouts so the entire slab renders
- keep pocket hole sizing and side-pocket scaling consistent with the table layout while retaining material properties

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6eae4ca48329aed6862dce538dbc)