### PR TITLE
Enable shadows on chess arena floor

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -6353,6 +6353,8 @@ function Chess3D({
       })
     );
     floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    floor.castShadow = false;
     arena.add(floor);
 
     const carpetMat = createArenaCarpetMaterial();
@@ -6362,6 +6364,8 @@ function Chess3D({
     );
     carpet.rotation.x = -Math.PI / 2;
     carpet.position.y = 0.002;
+    carpet.receiveShadow = true;
+    carpet.castShadow = false;
     arena.add(carpet);
 
     const wallH = 3 * WALL_HEIGHT_MULTIPLIER;


### PR DESCRIPTION
## Summary
- allow the chess arena floor and carpet to receive lighting shadows for a more natural look

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7a11716c8329987adc60dc4798ad)