### PR TITLE
Adjust Pool Royale plywood underlay

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -990,10 +990,9 @@ const SIDE_CAPTURE_RADIUS_SCALE = 0.88; // shrink middle pocket capture so behav
 const SIDE_CAPTURE_R = CAPTURE_R * SIDE_CAPTURE_RADIUS_SCALE;
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
 const PLYWOOD_THICKNESS = TABLE.THICK * 0.22; // thicken the plywood bed so the entire slab renders and casts contact shadows
-const PLYWOOD_GAP = TABLE.THICK * 0.025; // pull the plywood closer to the cloth so its presence reads on the felt
-const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.2; // keep the plywood dropped enough to sit behind the pocket bowls without disappearing
+const PLYWOOD_GAP = TABLE.THICK * 0.025; // leave breathing room beneath the pocket bowls so the plywood stays unobstructed
+const PLYWOOD_EXTRA_DROP = TABLE.THICK * 0.2; // keep the plywood dropped enough to sit fully beneath the pockets without disappearing
 const PLYWOOD_OUTSET = TABLE.THICK * 0.16; // widen the plywood slab so every edge reads as a single, unbroken piece
-const PLYWOOD_HOLE_SCALE = 1.05; // cut plywood apertures 5% larger than the pocket holes to keep the pockets untouched
 const CLOTH_EXTENDED_DEPTH = TABLE.THICK * 0.362; // preserve the deeper cloth wrap without relying on a stone underlay
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
@@ -6027,7 +6026,9 @@ function Table3D(
   cloth.receiveShadow = true;
   table.add(cloth);
   const clothBottomY = cloth.position.y - CLOTH_EXTENDED_DEPTH;
-  const plywoodTopY = clothBottomY - PLYWOOD_GAP - PLYWOOD_EXTRA_DROP;
+  const pocketTopY = clothBottomY - POCKET_BOARD_TOUCH_OFFSET;
+  const pocketBottomY = pocketTopY - TABLE.THICK;
+  const plywoodTopY = pocketBottomY - PLYWOOD_GAP - PLYWOOD_EXTRA_DROP;
   const pocketEdgeStopY = plywoodTopY - POCKET_BOARD_TOUCH_OFFSET;
   const pocketCutStripes = addPocketCuts(
     table,
@@ -6078,7 +6079,6 @@ function Table3D(
 
   const plywoodDepth = PLYWOOD_THICKNESS;
   if (plywoodDepth > MICRO_EPS) {
-    const plywoodHoleRadius = POCKET_HOLE_R * PLYWOOD_HOLE_SCALE;
     const buildPlywoodShape = () => {
       const insetHalfW = Math.max(MICRO_EPS, halfWext + PLYWOOD_OUTSET);
       const insetHalfH = Math.max(MICRO_EPS, halfHext + PLYWOOD_OUTSET);
@@ -6089,17 +6089,6 @@ function Table3D(
       plywoodShape.lineTo(insetHalfW, insetHalfH);
       plywoodShape.lineTo(-insetHalfW, insetHalfH);
       plywoodShape.lineTo(-insetHalfW, -insetHalfH);
-
-      pocketPositions.forEach((p, index) => {
-        const isSidePocket = index >= 4;
-        const radius = isSidePocket
-          ? plywoodHoleRadius * sideRadiusScale
-          : plywoodHoleRadius;
-        const hole = new THREE.Path();
-        hole.absellipse(p.x, p.y, radius, radius, 0, Math.PI * 2, true);
-        hole.autoClose = true;
-        plywoodShape.holes.push(hole);
-      });
 
       return plywoodShape;
     };
@@ -6191,7 +6180,6 @@ function Table3D(
     spots: spotMeshes
   };
 
-  const pocketTopY = clothBottomY - POCKET_BOARD_TOUCH_OFFSET;
   const pocketGeo = new THREE.CylinderGeometry(
     POCKET_TOP_R,
     POCKET_BOTTOM_R,


### PR DESCRIPTION
## Summary
- remove plywood pocket cutouts so the underlay stays solid across the field
- reposition the plywood slab beneath the pocket bottoms for full rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a785e4678832993e2bf2b091cdfc4)