### PR TITLE
Ensure plywood underlay renders with fallback shape

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6080,12 +6080,42 @@ function Table3D(
   if (plywoodDepth > MICRO_EPS) {
     const plywoodHoleRadius = POCKET_HOLE_R * PLYWOOD_HOLE_SCALE;
     const plywoodShape = buildSurfaceShape(plywoodHoleRadius, -PLYWOOD_OUTSET);
-    const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShape, {
+    const plywoodShapes = (() => {
+      const shapes = Array.isArray(plywoodShape)
+        ? plywoodShape.filter(Boolean)
+        : plywoodShape
+          ? [plywoodShape]
+          : [];
+      if (shapes.length) {
+        return shapes;
+      }
+
+      const insetHalfW = Math.max(MICRO_EPS, halfWext + PLYWOOD_OUTSET);
+      const insetHalfH = Math.max(MICRO_EPS, halfHext + PLYWOOD_OUTSET);
+      const fallback = new THREE.Shape();
+      fallback.moveTo(-insetHalfW, -insetHalfH);
+      fallback.lineTo(insetHalfW, -insetHalfH);
+      fallback.lineTo(insetHalfW, insetHalfH);
+      fallback.lineTo(-insetHalfW, insetHalfH);
+      fallback.lineTo(-insetHalfW, -insetHalfH);
+      pocketPositions.forEach((center, index) => {
+        const isSidePocket = index >= 4;
+        const radius = isSidePocket ? plywoodHoleRadius * sideRadiusScale : plywoodHoleRadius;
+        const hole = new THREE.Path();
+        hole.absarc(center.x, center.y, radius, 0, Math.PI * 2, true);
+        fallback.holes.push(hole);
+      });
+
+      return [fallback];
+    })();
+
+    const plywoodGeo = new THREE.ExtrudeGeometry(plywoodShapes, {
       depth: plywoodDepth,
       bevelEnabled: false,
       curveSegments: 96,
       steps: 1
     });
+    plywoodGeo.computeVertexNormals();
     plywoodGeo.translate(0, 0, -plywoodDepth);
     const plywoodMat = frameMat.clone();
     plywoodMat.color = frameMat.color?.clone() ?? new THREE.Color(0x8a704d);


### PR DESCRIPTION
## Summary
- build the pool table plywood underlay with validated shapes and hole cutouts so the slab always renders and casts shadows
- add normal recomputation for the plywood extrusion to keep shading consistent when fallbacks are used

## Testing
- npm test -- --runInBand *(fails: existing suite issues including mongodb-memory-server download errors and Jest test shims expecting callbacks)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a815120e48329afee56e401d471aa)