### PR TITLE
Broaden Pool Royale lighting shadow coverage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13785,10 +13785,12 @@ function PoolRoyaleGame({
         const lightRigHeight = tableSurfaceY + TABLE.THICK * 5.8;
         const lightOffsetX = Math.max(PLAY_W * 0.2, TABLE.THICK * 3.8);
         const lightOffsetZ = Math.max(PLAY_H * 0.18, TABLE.THICK * 3.6);
-        const shadowHalfSpan = Math.max(roomWidth, roomDepth) / 2 + TABLE.THICK * 1.8;
+        const tableShadowSpan = Math.max(PLAY_W, PLAY_H) * 1.4;
+        const shadowHalfSpan =
+          Math.max(roomWidth, roomDepth, tableShadowSpan) / 2 + TABLE.THICK * 2.4;
         const targetY = tableSurfaceY + TABLE.THICK * 0.2;
         const shadowDepth =
-          lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 12;
+          lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 16;
 
         const ambient = new THREE.AmbientLight(0xffffff, 0.27);
         lightingRig.add(ambient);


### PR DESCRIPTION
## Summary
- widen the Pool Royale lighting shadow frustum to cover the full table surface
- extend shadow depth so balls cast shadows consistently across the field

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab722f4b48329b12e400cb487d0b0)