### PR TITLE
Adjust Pool Royale ball shadow sizing and brightness

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -899,8 +899,8 @@ const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (1
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
-const BALL_SHADOW_RADIUS_MULTIPLIER = 1.4;
-const BALL_SHADOW_OPACITY = 0.32;
+const BALL_SHADOW_RADIUS_MULTIPLIER = 1.02;
+const BALL_SHADOW_OPACITY = 0.26;
 const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const SIDE_POCKET_EXTRA_SHIFT = 0; // align middle pocket centres flush with the reference layout
 const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.05; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
@@ -986,7 +986,7 @@ const BALL_SHADOW_GEOMETRY = new THREE.CircleGeometry(
 );
 BALL_SHADOW_GEOMETRY.rotateX(-Math.PI / 2);
 const BALL_SHADOW_MATERIAL = new THREE.MeshBasicMaterial({
-  color: 0x111111,
+  color: 0x1a1a1a,
   transparent: true,
   opacity: BALL_SHADOW_OPACITY,
   depthWrite: false,


### PR DESCRIPTION
## Summary
- shrink Pool Royale ball shadow radius so it matches the ball footprint more closely
- lighten ball shadow color and opacity for a brighter, less heavy appearance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acd8af3c483298dfb441bcf022b9b)