### PR TITLE
Adjust Pool Royale ball shadow size and brightness

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -899,8 +899,8 @@ const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (1
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
-const BALL_SHADOW_RADIUS_MULTIPLIER = 1.4;
-const BALL_SHADOW_OPACITY = 0.32;
+const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
+const BALL_SHADOW_OPACITY = 0.24;
 const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const SIDE_POCKET_EXTRA_SHIFT = 0; // align middle pocket centres flush with the reference layout
 const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.05; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
@@ -17361,10 +17361,10 @@ function PoolRoyaleGame({
               b.shadow.visible = shadowVisible;
               if (shadowVisible) {
                 b.shadow.position.set(b.pos.x, BALL_SHADOW_Y, b.pos.y);
-                const spread = 1 + THREE.MathUtils.clamp(speed * 0.08, 0, 0.35);
+                const spread = 0.98 + THREE.MathUtils.clamp(speed * 0.05, 0, 0.2);
                 b.shadow.scale.setScalar(spread);
                 b.shadow.material.opacity = THREE.MathUtils.clamp(
-                  BALL_SHADOW_OPACITY + 0.08,
+                  BALL_SHADOW_OPACITY + THREE.MathUtils.clamp(speed * 0.04, 0, 0.06),
                   0,
                   1
                 );


### PR DESCRIPTION
## Summary
- reduce Pool Royale ball shadow radius and lighten default opacity so it matches the ball footprint
- soften shadow scaling and tie opacity to speed for a subtler, brighter contact shadow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acd8af3c483298dfb441bcf022b9b)