### PR TITLE
Handle task data errors in webapp

### DIFF
--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -18,7 +18,17 @@ export default function DevTasksModal({ open, onClose }) {
 
   const load = async () => {
     const data = await adminListTasks();
-    if (!data.error) setTasks(data.tasks || data);
+    if (data?.error) {
+      console.error('Failed to load tasks:', data.error);
+      setTasks([]);
+      return;
+    }
+    const taskList = Array.isArray(data?.tasks)
+      ? data.tasks
+      : Array.isArray(data)
+        ? data
+        : [];
+    setTasks(taskList);
   };
 
   useEffect(() => {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -93,9 +93,17 @@ export default function TasksCard() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    const tasksList = (data.tasks || data).filter((t) => !t.hideOnHome);
+    if (data?.error) {
+      console.error('Failed to load tasks:', data.error);
+    }
+    const taskList = Array.isArray(data?.tasks)
+      ? data.tasks
+      : Array.isArray(data)
+        ? data
+        : [];
+    const tasksList = taskList.filter((t) => !t.hideOnHome);
     setTasks(tasksList);
-    if (data.version) {
+    if (data?.version) {
       const seen = localStorage.getItem('tasksVersion');
       if (seen !== String(data.version)) {
         setShowNew(true);

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -74,9 +74,16 @@ export default function Tasks() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    const tasksList = data.tasks || data;
+    if (data?.error) {
+      console.error('Failed to load tasks:', data.error);
+    }
+    const tasksList = Array.isArray(data?.tasks)
+      ? data.tasks
+      : Array.isArray(data)
+        ? data
+        : [];
     setTasks(tasksList);
-    if (data.version) {
+    if (data?.version) {
       const seen = localStorage.getItem('tasksVersion');
       if (seen !== String(data.version)) {
         setShowNew(true);


### PR DESCRIPTION
## Summary
- guard task loading across task components so missing API responses no longer crash the app
- log task fetch failures and fall back to empty lists when data is unavailable

## Testing
- npm --prefix webapp run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7404bec8329b2b15e92b0b811c8)