### PR TITLE
Adjust Pool Royale shadows

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -899,8 +899,8 @@ const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (1
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
-const BALL_SHADOW_RADIUS_MULTIPLIER = 1.4;
-const BALL_SHADOW_OPACITY = 0.45;
+const BALL_SHADOW_RADIUS_MULTIPLIER = 0.92;
+const BALL_SHADOW_OPACITY = 0.25;
 const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const SIDE_POCKET_EXTRA_SHIFT = 0; // align middle pocket centres flush with the reference layout
 const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.05; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
@@ -10793,7 +10793,7 @@ function PoolRoyaleGame({
         carpetMat
       );
       carpet.castShadow = false;
-      carpet.receiveShadow = true;
+      carpet.receiveShadow = false;
       carpet.position.set(0, floorY - carpetThickness / 2, 0);
       world.add(carpet);
 


### PR DESCRIPTION
## Summary
- reduce Pool Royale ball shadow size and lighten their opacity to better match ball radius
- disable carpet shadow receiving to eliminate floor shadows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adba583608329a3e259676b225f2f)