### PR TITLE
Add ball set selection for UK Pool Royale

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -93,22 +93,24 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
     socket: mockSocket
   };
 
-  await runPoolRoyaleOnlineFlow({
-    stake: { token: 'TPC', amount: 100 },
-    variant: 'uk',
-    playType: 'regular',
-    mode: 'online',
-    tableSize: 'medium',
-    avatar: 'me.png',
-    deps,
-    state,
-    refs,
-    timeouts: { seat: 50, matchmaking: 200 },
-    onGameStart: (payload) => started.push(payload)
-  });
+    await runPoolRoyaleOnlineFlow({
+      stake: { token: 'TPC', amount: 100 },
+      variant: 'uk',
+      ballSet: 'uk',
+      playType: 'regular',
+      mode: 'online',
+      tableSize: 'medium',
+      avatar: 'me.png',
+      deps,
+      state,
+      refs,
+      timeouts: { seat: 50, matchmaking: 200 },
+      onGameStart: (payload) => started.push(payload)
+    });
 
-  assert.equal(mockSocket.seatRequests.length, 1);
-  const seatCb = mockSocket.seatRequests[0].cb;
+    assert.equal(mockSocket.seatRequests.length, 1);
+    assert.equal(mockSocket.seatRequests[0].payload.ballSet, 'uk');
+    const seatCb = mockSocket.seatRequests[0].cb;
   seatCb({
     success: true,
     tableId: 'tbl-1',
@@ -158,6 +160,7 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
   await runPoolRoyaleOnlineFlow({
     stake: { token: 'TPC', amount: 75 },
     variant: 'uk',
+    ballSet: 'uk',
     playType: 'regular',
     mode: 'online',
     tableSize: 'medium',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1395,6 +1395,21 @@ function resolvePoolVariant(variantId) {
   return POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
 }
 
+function resolvePoolBallSet(variantId, ballSetId) {
+  const base = resolvePoolVariant(variantId);
+  const ballSetKey = normalizeVariantKey(ballSetId);
+  if (base.id === 'uk' && ballSetKey === 'american') {
+    const american = POOL_VARIANT_COLOR_SETS.american;
+    return {
+      ...base,
+      objectColors: american.objectColors,
+      objectNumbers: american.objectNumbers,
+      objectPatterns: american.objectPatterns
+    };
+  }
+  return base;
+}
+
 function deriveInHandFromFrame(frame) {
   const meta = frame && typeof frame === 'object' ? frame.meta : null;
   if (!meta || typeof meta !== 'object') return false;
@@ -8427,6 +8442,7 @@ function applyTableFinishToTable(table, finish) {
 // --------------------------------------------------
 function PoolRoyaleGame({
   variantKey,
+  ballSetKey,
   tableSizeKey,
   playType = 'regular',
   mode = 'ai',
@@ -8446,8 +8462,8 @@ function PoolRoyaleGame({
   const worldRef = useRef(null);
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
   const activeVariant = useMemo(
-    () => resolvePoolVariant(variantKey),
-    [variantKey]
+    () => resolvePoolBallSet(variantKey, ballSetKey),
+    [ballSetKey, variantKey]
   );
   const activeTableSize = useMemo(
     () => resolveTableSize(tableSizeKey),
@@ -18841,6 +18857,14 @@ export default function PoolRoyale() {
     const requested = params.get('variant');
     return resolvePoolVariant(requested).id;
   }, [location.search]);
+  const ballSetKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('ballSet');
+    const normalized = normalizeVariantKey(requested);
+    if (variantKey !== 'uk') return variantKey;
+    if (normalized === 'american') return 'american';
+    return 'uk';
+  }, [location.search, variantKey]);
   const tableSizeKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableSize');
@@ -18967,6 +18991,7 @@ export default function PoolRoyale() {
   return (
     <PoolRoyaleGame
       variantKey={variantKey}
+      ballSetKey={ballSetKey}
       tableSizeKey={tableSizeKey}
       playType={playType}
       mode={mode}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -15,6 +15,13 @@ import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 
+function normalizeBallSet(value) {
+  const normalized = (value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (normalized.includes('american')) return 'american';
+  if (normalized === 'uk' || normalized === 'yellowred') return 'uk';
+  return 'uk';
+}
+
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -25,6 +32,7 @@ export default function PoolRoyaleLobby() {
     const requestedType = searchParams.get('type');
     return requestedType === 'tournament' ? 'tournament' : 'regular';
   })();
+  const initialBallSet = normalizeBallSet(searchParams.get('ballSet'));
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('ai');
@@ -34,6 +42,7 @@ export default function PoolRoyaleLobby() {
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
   const [variant, setVariant] = useState('uk');
+  const [ballSet, setBallSet] = useState(initialBallSet);
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -84,6 +93,16 @@ export default function PoolRoyaleLobby() {
     matchPlayersRef.current = matchPlayers;
   }, [matchPlayers]);
 
+  useEffect(() => {
+    if (variant !== 'uk' && ballSet !== variant) {
+      setBallSet(variant);
+      return;
+    }
+    if (variant === 'uk' && ballSet !== 'uk' && ballSet !== 'american') {
+      setBallSet('uk');
+    }
+  }, [ballSet, variant]);
+
   const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
     const selfId = accountId || accountIdRef.current;
     const selfEntry = roster.find((p) => String(p.id) === String(selfId));
@@ -107,6 +126,7 @@ export default function PoolRoyaleLobby() {
     cleanupRef.current?.({ account: accountId, skipRefReset: true });
     const params = new URLSearchParams();
     params.set('variant', variant);
+    if (ballSet) params.set('ballSet', ballSet);
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -138,6 +158,7 @@ export default function PoolRoyaleLobby() {
       await runPoolRoyaleOnlineFlow({
         stake,
         variant,
+        ballSet,
         playType,
         mode,
         tableSize,
@@ -186,6 +207,7 @@ export default function PoolRoyaleLobby() {
 
     const params = new URLSearchParams();
     params.set('variant', variant);
+    if (ballSet) params.set('ballSet', ballSet);
     params.set('tableSize', tableSize);
     params.set('type', playType);
     params.set('mode', mode);
@@ -377,6 +399,28 @@ export default function PoolRoyaleLobby() {
           ))}
         </div>
       </div>
+      {variant === 'uk' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Ball Set</h3>
+          <div className="flex gap-2">
+            {[
+              { id: 'uk', label: 'Yellow & Red' },
+              { id: 'american', label: 'American Billiards' }
+            ].map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => setBallSet(id)}
+                className={`lobby-tile ${ballSet === id ? 'lobby-selected' : ''}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-subtext">
+            Keep UK rules while choosing between classic yellow/red or American stripes and solids.
+          </p>
+        </div>
+      )}
       {playType === 'tournament' && (
         <div className="space-y-2">
           <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -20,6 +20,7 @@ function clearTimeoutSafely(ref) {
 export async function runPoolRoyaleOnlineFlow({
   stake,
   variant,
+  ballSet,
   playType,
   mode,
   tableSize,
@@ -241,6 +242,7 @@ export async function runPoolRoyaleOnlineFlow({
       maxPlayers: 2,
       mode,
       variant,
+      ballSet,
       tableSize,
       playType,
       playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',


### PR DESCRIPTION
## Summary
- add a ball set selector to the Pool Royale lobby when using the UK variant and persist the choice to game URLs
- allow the game renderer to apply American-stripe ball visuals while keeping UK rules intact
- propagate the selected ball set through online matchmaking, including tests for the updated flow

## Testing
- npm test -- poolRoyaleOnlineFlow.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae6d73ec88329a425fbebbdc06af9)