### PR TITLE
Add UK ball set picker and refine Pool Royale replay and AI

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -34,6 +34,7 @@ export default function PoolRoyaleLobby() {
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
   const [variant, setVariant] = useState('uk');
+  const [ballSet, setBallSet] = useState('classic');
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -56,6 +57,12 @@ export default function PoolRoyaleLobby() {
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    if (variant !== 'uk') {
+      setBallSet('classic');
+    }
+  }, [variant]);
 
   useEffect(() => {
     try {
@@ -107,6 +114,7 @@ export default function PoolRoyaleLobby() {
     cleanupRef.current?.({ account: accountId, skipRefReset: true });
     const params = new URLSearchParams();
     params.set('variant', variant);
+    if (variant === 'uk' && ballSet) params.set('ballSet', ballSet);
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -118,6 +126,7 @@ export default function PoolRoyaleLobby() {
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     if (tableSize) params.set('tableSize', tableSize);
+    if (variant === 'uk' && ballSet) params.set('ballSet', ballSet);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -138,6 +147,7 @@ export default function PoolRoyaleLobby() {
       await runPoolRoyaleOnlineFlow({
         stake,
         variant,
+        ballSet,
         playType,
         mode,
         tableSize,
@@ -186,6 +196,7 @@ export default function PoolRoyaleLobby() {
 
     const params = new URLSearchParams();
     params.set('variant', variant);
+    if (variant === 'uk' && ballSet) params.set('ballSet', ballSet);
     params.set('tableSize', tableSize);
     params.set('type', playType);
     params.set('mode', mode);
@@ -377,6 +388,28 @@ export default function PoolRoyaleLobby() {
           ))}
         </div>
       </div>
+      {variant === 'uk' && (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Ball Set</h3>
+          <div className="flex gap-2 flex-wrap">
+            {[
+              { id: 'classic', label: 'Yellow & Red' },
+              { id: 'american', label: 'American Solids/Stripes' }
+            ].map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => setBallSet(id)}
+                className={`lobby-tile ${ballSet === id ? 'lobby-selected' : ''}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-subtext">
+            Keep UK 8-ball rules while choosing between classic red/yellow balls or American billiard colors.
+          </p>
+        </div>
+      )}
       {playType === 'tournament' && (
         <div className="space-y-2">
           <h3 className="font-semibold">Players</h3>

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -20,6 +20,7 @@ function clearTimeoutSafely(ref) {
 export async function runPoolRoyaleOnlineFlow({
   stake,
   variant,
+  ballSet,
   playType,
   mode,
   tableSize,
@@ -241,6 +242,7 @@ export async function runPoolRoyaleOnlineFlow({
       maxPlayers: 2,
       mode,
       variant,
+      ballSet,
       tableSize,
       playType,
       playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',


### PR DESCRIPTION
## Summary
- add a lobby ball-set selector for UK 8-ball and propagate the choice through matchmaking and game setup
- support American-style balls for UK rules by resolving visual variants and adjusting ball identifiers
- polish replay padding, AI shot evaluation, and ball-in-hand placement to smooth camera cuts and smarter aiming

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae6d73ec88329a425fbebbdc06af9)