### PR TITLE
Refine Pool Royale lighting, pockets, and solids/stripes UI

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -19,7 +19,7 @@ public class BilliardLighting : MonoBehaviour
             Light spotLight = lightObj.AddComponent<Light>();
             spotLight.type = LightType.Spot;
             spotLight.color = Color.white;
-            spotLight.intensity = 2.25f;       // brightness reduced by 10%
+            spotLight.intensity = 2.1f;        // brightness trimmed slightly for softer highlights
             spotLight.range = 15f;             // distance
             spotLight.spotAngle = 60f;         // cone size
             spotLight.shadows = LightShadows.Soft;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1219,7 +1219,7 @@ const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 96;
 const SPIN_DOT_DIAMETER_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
-const DEFAULT_CUSHION_CUT_ANGLE = 26;
+const DEFAULT_CUSHION_CUT_ANGLE = 38;
 // middle pocket cushion cuts mirror the same trimmed angle for consistent pocket reveals
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 29;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
@@ -1284,7 +1284,7 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
   },
   american: {
     id: 'american',
-    label: 'American 8-Ball',
+    label: 'Solids & Stripes',
     cueColor: 0xffffff,
     rackLayout: 'triangle',
     disableSnookerMarkings: true,
@@ -4876,6 +4876,37 @@ const BALL_LABELS = Object.freeze({
 const formatBallLabel = (colorId) => {
   if (!colorId) return '';
   return BALL_LABELS[colorId] || colorId.charAt(0) + colorId.slice(1).toLowerCase();
+};
+const usesSolidsAndStripes = (variantConfig) => {
+  if (!variantConfig) return false;
+  if (variantConfig.id === 'american') return true;
+  if (variantConfig.id === 'uk' && variantConfig.ballSet === 'american') return true;
+  return false;
+};
+const formatAssignmentLabel = (assignment, variantConfig) => {
+  const normalized = typeof assignment === 'string' ? assignment.toLowerCase() : '';
+  const solidsAndStripes = usesSolidsAndStripes(variantConfig);
+  if (solidsAndStripes) {
+    if (
+      normalized.includes('stripe') ||
+      normalized.includes('high') ||
+      normalized === 'blue' ||
+      normalized === 'yellow'
+    ) {
+      return 'Stripes';
+    }
+    if (
+      normalized.includes('solid') ||
+      normalized.includes('low') ||
+      normalized === 'red'
+    ) {
+      return 'Solids';
+    }
+  }
+  if (normalized === 'blue' || normalized === 'yellow') return 'Yellows';
+  if (normalized === 'red') return 'Reds';
+  if (normalized === 'black') return 'Black';
+  return normalized ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : '';
 };
 const getPocketCenterById = (id) => {
   switch (id) {
@@ -16659,12 +16690,10 @@ const powerRef = useRef(hud.power);
                     : isOnlineMatch
                       ? opponentDisplayName
                       : 'AI';
-                const assignmentLabel =
-                  nextAssign === 'blue'
-                    ? 'Yellows'
-                    : nextAssign === 'red'
-                      ? 'Reds'
-                      : nextAssign.charAt(0).toUpperCase() + nextAssign.slice(1);
+                const assignmentLabel = formatAssignmentLabel(
+                  nextAssign,
+                  activeVariantRef.current
+                );
                 showRuleToast(`${seatLabel} is ${assignmentLabel}`);
               }
             });
@@ -17826,11 +17855,16 @@ const powerRef = useRef(hud.power);
           }
         }
         // Pocket capture
+        const centers = pocketCenters();
+        const captureRadii = centers.map((_, index) =>
+          index >= 4 ? SIDE_CAPTURE_R : CAPTURE_R
+        );
         balls.forEach((b) => {
           if (!b.active) return;
           for (let pocketIndex = 0; pocketIndex < centers.length; pocketIndex++) {
             const c = centers[pocketIndex];
-            if (b.pos.distanceTo(c) < CAPTURE_R) {
+            const captureRadius = captureRadii[pocketIndex] ?? CAPTURE_R;
+            if (b.pos.distanceTo(c) < captureRadius) {
               const entrySpeed = b.vel.length();
               const pocketVolume = THREE.MathUtils.clamp(
                 entrySpeed / POCKET_DROP_SPEED_REFERENCE,
@@ -18346,35 +18380,72 @@ const powerRef = useRef(hud.power);
   );
   const renderPottedRow = useCallback(
     (entries = []) => {
-      if (!entries.length) {
-        return (
-          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60">
-            No pots yet
-          </span>
-        );
-      }
+      const adjustColor = (hex, amount) => {
+        if (typeof hex !== 'string' || hex.length < 6) return hex;
+        const normalized = hex.startsWith('#') ? hex.slice(1) : hex;
+        const num = Number.parseInt(normalized, 16);
+        if (Number.isNaN(num)) return hex;
+        const clamp = (v) => Math.max(0, Math.min(255, v));
+        const shift = Math.round(255 * amount);
+        const r = clamp(((num >> 16) & 0xff) + shift);
+        const g = clamp(((num >> 8) & 0xff) + shift);
+        const b = clamp((num & 0xff) + shift);
+        return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+      };
+      const buildBallStyle = (colorHex, pattern) => {
+        const base = typeof colorHex === 'string' ? colorHex : '#e5e7eb';
+        const shine = adjustColor(base, 0.2);
+        const shadow = adjustColor(base, -0.18);
+        const stripe = adjustColor(base, 0.06);
+        const isStripe = pattern === 'stripe';
+        const backgroundImage = isStripe
+          ? `linear-gradient(90deg, transparent 28%, ${stripe} 28%, ${stripe} 72%, transparent 72%), radial-gradient(circle at 32% 28%, ${shine} 0%, ${shine} 30%, ${base} 58%, ${shadow} 100%)`
+          : `radial-gradient(circle at 32% 28%, ${shine} 0%, ${shine} 30%, ${base} 58%, ${shadow} 100%)`;
+        return {
+          backgroundImage,
+          boxShadow:
+            'inset 0 0 0 1px rgba(255,255,255,0.32), inset 0 -1px 4px rgba(0,0,0,0.28), 0 2px 8px rgba(0,0,0,0.5)'
+        };
+      };
+      const placeholders = Array.from({ length: 5 }).map((_, index) => ({
+        id: `placeholder-${index}`,
+        color: 'CUE',
+        placeholder: true
+      }));
+      const items = entries.length ? entries : placeholders;
+      const opacity = entries.length ? 1 : 0.45;
       return (
-        <div className="flex flex-wrap items-center gap-1">
-          {entries.map((entry, index) => {
+        <div className="flex items-center gap-1 overflow-x-auto pb-0.5">
+          {items.map((entry, index) => {
             const colorKey = String(entry.color || '').toUpperCase();
             const colorHex =
               ballSwatches[colorKey] ??
               (colorKey.startsWith('BALL_') ? '#f5f5f4' : '#e5e7eb');
-            const label =
+            const numberMatch =
               colorKey.startsWith('BALL_') && colorKey.length > 5
                 ? colorKey.replace('BALL_', '')
-                : colorKey === 'BLACK'
-                  ? '8'
+                : null;
+            const pattern =
+              colorKey === 'STRIPE' ||
+              (numberMatch && Number.parseInt(numberMatch, 10) >= 9) ||
+              entry.pattern === 'stripe'
+                ? 'stripe'
+                : 'solid';
+            const label =
+              numberMatch || colorKey === 'BLACK'
+                ? numberMatch || '8'
+                : pattern === 'stripe'
+                  ? 'S'
                   : colorKey.charAt(0);
             const textColor = colorKey === 'BLACK' ? '#f8fafc' : '#0f172a';
             return (
               <span
                 key={`${entry.id ?? colorKey}-${index}`}
-                className="flex h-5 min-w-[1.5rem] items-center justify-center rounded-full border border-white/40 px-1 text-[10px] font-bold leading-4 shadow-[0_2px_6px_rgba(0,0,0,0.35)]"
-                style={{ backgroundColor: colorHex, color: textColor }}
-                title={`Pocketed ${colorKey}`}
+                className="flex h-6 w-6 flex-none items-center justify-center rounded-full text-[10px] font-black leading-none ring-1 ring-white/25"
+                style={{ ...buildBallStyle(colorHex, pattern), color: textColor, opacity }}
+                title={entries.length ? `Pocketed ${colorKey}` : undefined}
               >
-                {label}
+                {entry.placeholder ? '' : label}
               </span>
             );
           })}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -395,10 +395,10 @@ export default function PoolRoyaleLobby() {
         <div className="space-y-2">
           <h3 className="font-semibold">Ball Colors</h3>
           <p className="text-xs text-subtext">
-            Keep UK yellow/red sets or switch to American billiards visuals with the same UK rules.
+            Keep UK yellow/red sets or switch to Solids & Stripes visuals with the same UK rules.
           </p>
           <div className="flex gap-2">
-            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'American Set' }].map(
+            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'Solids & Stripes' }].map(
               ({ id, label }) => (
                 <button
                   key={id}
@@ -468,7 +468,7 @@ export default function PoolRoyaleLobby() {
       <div className="space-y-2">
         <h3 className="font-semibold">AI Avatar Flags</h3>
         <p className="text-sm text-subtext">
-          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
+          Pick the country flag for the AI rival.
         </p>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Slightly dimmed the Pool Royale spotlights and set corner cushion cuts to 38° while keeping side pockets unchanged.
- Updated pocket capture logic to use side-pocket radii to avoid freezes when potting into the middle pockets.
- Refreshed solids/stripes terminology and HUD visuals, including realistic horizontal potted-ball chips and lobby copy.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b75bb81e08329a2b5cabbd5effcab)