### PR TITLE
Polish Pool Royale lighting and pocket visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -395,10 +395,10 @@ export default function PoolRoyaleLobby() {
         <div className="space-y-2">
           <h3 className="font-semibold">Ball Colors</h3>
           <p className="text-xs text-subtext">
-            Keep UK yellow/red sets or switch to American billiards visuals with the same UK rules.
+            Keep UK yellow/red sets or switch to Solids & Stripes visuals with the same UK rules.
           </p>
           <div className="flex gap-2">
-            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'American Set' }].map(
+            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'Solids & Stripes' }].map(
               ({ id, label }) => (
                 <button
                   key={id}
@@ -467,9 +467,7 @@ export default function PoolRoyaleLobby() {
 
       <div className="space-y-2">
         <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext">
-          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
-        </p>
+        <p className="text-sm text-subtext">Pick the country flag for the AI rival.</p>
         <button
           type="button"
           onClick={() => setShowAiFlagPicker(true)}


### PR DESCRIPTION
## Summary
- Dim Pool Royale lighting presets slightly and raise corner cushion cut angles to 38° without altering middle-pocket cuts.
- Rename the UK Solids & Stripes ball-set option and update in-game assignments/commentary plus avatar tray chips to reflect solids/stripes.
- Improve middle-pocket capture detection to prevent freezes and refresh potted-ball chips into a horizontal, realistic row under each avatar.

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b75bb81e08329a2b5cabbd5effcab)