### PR TITLE
Refine Pool Royale pockets and fouls

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -49,11 +49,6 @@ export class AmericanBilliards {
       reason = 'scratch';
     }
 
-    if (!foul && shot.noCushionAfterContact && pottedList.length === 0) {
-      foul = true;
-      reason = 'no cushion';
-    }
-
     const pottedBalls = pottedList.filter(id => id !== 0);
     const points = pottedBalls.reduce((a, b) => a + b, 0);
 

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -43,11 +43,6 @@ export class NineBall {
       reason = 'scratch';
     }
 
-    if (!foul && shot.noCushionAfterContact && pottedList.length === 0) {
-      foul = true;
-      reason = 'no cushion';
-    }
-
     const pottedBalls = pottedList.filter(id => id !== 0);
 
     let nextPlayer = current;

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -1,7 +1,7 @@
 export const DEFAULT_RULES = {
   blackOnBreak: 're-rack',
   allowCombinations: false,
-  requireCushionIfNoPot: true,
+  requireCushionIfNoPot: false,
   twoVisitsCarryOnBlack: false,
   stalemateTurns: 6
 };

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -38,7 +38,7 @@ test('after foul player must hit a valid colour first', () => {
   assert.equal(res.reason, 'wrong first contact');
 });
 
-test('no pot and no cushion is foul', () => {
+test('no pot and no cushion stays legal when contact is made', () => {
   const game = new UkPool();
   const res = game.shotTaken({
     contactOrder: ['blue'],
@@ -47,8 +47,9 @@ test('no pot and no cushion is foul', () => {
     noCushionAfterContact: true,
     placedFromHand: false
   });
-  assert.equal(res.foul, true);
-  assert.equal(res.reason, 'no cushion');
+  assert.equal(res.foul, false);
+  assert.equal(res.nextPlayer, 'B');
+  assert.equal(res.shotsRemainingNext, 1);
 });
 
 test('potting opponent ball is foul', () => {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -395,10 +395,10 @@ export default function PoolRoyaleLobby() {
         <div className="space-y-2">
           <h3 className="font-semibold">Ball Colors</h3>
           <p className="text-xs text-subtext">
-            Keep UK yellow/red sets or switch to American billiards visuals with the same UK rules.
+            Keep UK yellow/red sets or switch to Solids &amp; Stripes visuals while retaining 8 Pool UK rules.
           </p>
           <div className="flex gap-2">
-            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'American Set' }].map(
+            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'Solids & Stripes' }].map(
               ({ id, label }) => (
                 <button
                   key={id}

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -258,6 +258,28 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   return texture;
 }
 
+export function createBallPreviewDataUrl({
+  color,
+  pattern = 'solid',
+  number = null,
+  variantKey = 'pool',
+  size = 256
+} = {}) {
+  if (typeof document === 'undefined') return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  const baseColor = color ?? 0xffffff;
+  if (variantKey === 'pool') {
+    drawPoolBallTexture(ctx, size, baseColor, pattern, number);
+  } else {
+    drawDefaultBallTexture(ctx, size, baseColor, pattern, number);
+  }
+  return canvas.toDataURL('image/png');
+}
+
 export function getBallMaterial({
   color,
   pattern = 'solid',


### PR DESCRIPTION
## Summary
- remove the cloth underlay and retune pocket geometry/capture to open the corner entries and smooth rebounds
- shrink HUD potted-ball badges with rendered ball previews and clarify solids/stripes messaging, including lobby copy
- drop cushion-contact fouls across pool variants and update the UK pool test expectations

## Testing
- npm test -- poolUk8Ball.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b82beaae48329b184fe9e6c773286)