### PR TITLE
Improve account provisioning for web users

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -1,20 +1,14 @@
 import React, { useEffect } from 'react';
-import { createAccount } from '../utils/api.js';
-import { ensureAccountId } from '../utils/telegram.js';
+import { provisionAccount } from '../utils/account.js';
 
 export default function LoginOptions() {
   useEffect(() => {
     (async () => {
-      const accountId = await ensureAccountId();
+      const alreadyProvisioned = localStorage.getItem('accountProvisioned') === 'true';
       try {
-        const res = await createAccount(undefined, localStorage.getItem('googleId'));
-        if (res?.accountId) {
-          localStorage.setItem('accountId', res.accountId);
-        } else if (accountId) {
-          localStorage.setItem('accountId', accountId);
-        }
-        if (res?.walletAddress) {
-          localStorage.setItem('walletAddress', res.walletAddress);
+        await provisionAccount({ googleId: localStorage.getItem('googleId') });
+        if (!alreadyProvisioned) {
+          window.location.reload();
         }
       } catch (err) {
         console.error('Account setup failed', err);

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { createAccount, getAccountInfo, convertGifts } from '../utils/api.js';
+import { getAccountInfo, convertGifts } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 import GiftShopPopup from './GiftShopPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 import ConfirmPopup from './ConfirmPopup.jsx';
+import { provisionAccount } from '../utils/account.js';
 
 export default function NftGiftCard({ accountId: propAccountId }) {
   const [accountId, setAccountId] = useState(propAccountId || '');
@@ -21,16 +22,12 @@ export default function NftGiftCard({ accountId: propAccountId }) {
       let id = propAccountId || localStorage.getItem('accountId');
       if (!id) {
         try {
-          const acc = await createAccount(
-            getTelegramId(),
-            localStorage.getItem('googleId')
-          );
+          const acc = await provisionAccount({
+            telegramId: getTelegramId(),
+            googleId: localStorage.getItem('googleId')
+          });
           if (acc?.accountId) {
             id = acc.accountId;
-            localStorage.setItem('accountId', id);
-            if (acc.walletAddress) {
-              localStorage.setItem('walletAddress', acc.walletAddress);
-            }
           }
         } catch {}
       }

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -1,31 +1,35 @@
 import { useEffect } from 'react';
 import { socket } from '../utils/socket.js';
-import { createAccount } from '../utils/api.js';
+import { provisionAccount, getStoredAccount } from '../utils/account.js';
 import { ensureAccountId } from '../utils/telegram.js';
 
 export default function useTelegramAuth() {
   useEffect(() => {
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
     const acc = localStorage.getItem('accountId');
+    const googleId = localStorage.getItem('googleId');
+    const fallbackAccountId = acc || getStoredAccount().accountId;
+    if (fallbackAccountId) {
+      socket.emit('register', { playerId: fallbackAccountId });
+    }
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
-      socket.emit('register', { playerId: acc || user.id });
-      createAccount(user.id).catch(err => {
-        console.error('Failed to create account', err);
-      });
+      (async () => {
+        try {
+          const { accountId } = await provisionAccount({ telegramId: user.id, googleId });
+          if (accountId) {
+            socket.emit('register', { playerId: accountId });
+          }
+        } catch (err) {
+          console.error('Failed to create account', err);
+        }
+      })();
     } else {
       (async () => {
         const accountId = acc || (await ensureAccountId());
         socket.emit('register', { playerId: accountId });
-        const googleId = localStorage.getItem('googleId');
         try {
-          const res = await createAccount(undefined, googleId);
-          if (res?.accountId) {
-            localStorage.setItem('accountId', res.accountId);
-          }
-          if (res?.walletAddress) {
-            localStorage.setItem('walletAddress', res.walletAddress);
-          }
+          await provisionAccount({ googleId, telegramId: undefined });
         } catch (err) {
           console.error('Failed to create account', err);
         }

--- a/webapp/src/utils/account.js
+++ b/webapp/src/utils/account.js
@@ -1,0 +1,85 @@
+import { createAccount } from './api.js';
+import { ensureAccountId } from './telegram.js';
+
+function readLocal(key) {
+  if (typeof window === 'undefined') return null;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocal(key, value) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value === undefined || value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+function resolveOwnerKey(telegramId, googleId) {
+  if (telegramId) return `tg:${telegramId}`;
+  if (googleId) return `gg:${googleId}`;
+  return 'anon';
+}
+
+/**
+ * Ensure we have a persistent TPC account for the current user/device.
+ * - Reuses the stored account when present.
+ * - Creates a new account for first-time visitors.
+ * - Avoids creating duplicate accounts on every login.
+ */
+export async function provisionAccount({ telegramId, googleId } = {}) {
+  const ownerKey = resolveOwnerKey(telegramId, googleId);
+  const lastOwner = readLocal('accountOwnerKey');
+  if (lastOwner && lastOwner !== ownerKey) {
+    writeLocal('accountProvisioned', null);
+  }
+  writeLocal('accountOwnerKey', ownerKey);
+
+  let accountId = readLocal('accountId');
+  if (!accountId) {
+    accountId = await ensureAccountId();
+  }
+
+  const alreadyProvisioned =
+    readLocal('accountProvisioned') === 'true' && Boolean(accountId);
+
+  if (alreadyProvisioned) {
+    return {
+      accountId,
+      walletAddress: readLocal('walletAddress')
+    };
+  }
+
+  const res = await createAccount({
+    telegramId,
+    googleId,
+    accountId
+  });
+
+  if (res?.error) throw new Error(res.error);
+
+  const finalAccountId = res?.accountId || accountId;
+  if (finalAccountId) {
+    writeLocal('accountId', finalAccountId);
+  }
+  if (res?.walletAddress) {
+    writeLocal('walletAddress', res.walletAddress);
+  }
+  writeLocal('accountProvisioned', 'true');
+
+  return {
+    accountId: finalAccountId,
+    walletAddress: res?.walletAddress || readLocal('walletAddress')
+  };
+}
+
+export function getStoredAccount() {
+  const accountId = readLocal('accountId');
+  const walletAddress = readLocal('walletAddress');
+  return { accountId, walletAddress };
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -546,10 +546,19 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId, googleId) {
-  const body = {};
-  if (telegramId) body.telegramId = telegramId;
-  if (googleId) body.googleId = googleId;
+export function createAccount(telegramId, googleId, accountId) {
+  let body = {};
+  if (telegramId && typeof telegramId === 'object') {
+    body = { ...telegramId };
+  } else {
+    if (telegramId) body.telegramId = telegramId;
+    if (googleId) body.googleId = googleId;
+    if (accountId) body.accountId = accountId;
+  }
+  if (!body.accountId && typeof window !== 'undefined') {
+    const stored = localStorage.getItem('accountId');
+    if (stored) body.accountId = stored;
+  }
   return post('/api/account/create', body);
 }
 


### PR DESCRIPTION
## Summary
- add a shared account provisioning helper that reuses stored IDs and only creates new TPC accounts for new users
- update auth, balance, wallet, and gift flows to provision once and persist account and wallet details for Chrome/guest users
- trigger a one-time reload from the login fallback so Chrome visitors can load the app after their account is created

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2c4fdad48329aeaf131b8db49fc4)