### PR TITLE
Handle Chrome access and persist TPC accounts

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -1,20 +1,19 @@
 import React, { useEffect } from 'react';
-import { createAccount } from '../utils/api.js';
 import { ensureAccountId } from '../utils/telegram.js';
+import { ensureAccountForUser, persistAccountLocally } from '../utils/account.js';
 
 export default function LoginOptions() {
   useEffect(() => {
     (async () => {
       const accountId = await ensureAccountId();
       try {
-        const res = await createAccount(undefined, localStorage.getItem('googleId'));
-        if (res?.accountId) {
-          localStorage.setItem('accountId', res.accountId);
+        const account = await ensureAccountForUser({
+          googleId: localStorage.getItem('googleId')
+        });
+        if (account?.accountId) {
+          persistAccountLocally({ ...account, googleId: account.googleId });
         } else if (accountId) {
           localStorage.setItem('accountId', accountId);
-        }
-        if (res?.walletAddress) {
-          localStorage.setItem('walletAddress', res.walletAddress);
         }
       } catch (err) {
         console.error('Account setup failed', err);

--- a/webapp/src/components/NftGiftCard.jsx
+++ b/webapp/src/components/NftGiftCard.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { createAccount, getAccountInfo, convertGifts } from '../utils/api.js';
+import { getAccountInfo, convertGifts } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 import GiftShopPopup from './GiftShopPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 import ConfirmPopup from './ConfirmPopup.jsx';
+import { ensureAccountForUser, persistAccountLocally } from '../utils/account.js';
 
 export default function NftGiftCard({ accountId: propAccountId }) {
   const [accountId, setAccountId] = useState(propAccountId || '');
@@ -21,16 +22,17 @@ export default function NftGiftCard({ accountId: propAccountId }) {
       let id = propAccountId || localStorage.getItem('accountId');
       if (!id) {
         try {
-          const acc = await createAccount(
-            getTelegramId(),
-            localStorage.getItem('googleId')
-          );
-          if (acc?.accountId) {
-            id = acc.accountId;
-            localStorage.setItem('accountId', id);
-            if (acc.walletAddress) {
-              localStorage.setItem('walletAddress', acc.walletAddress);
-            }
+          const account = await ensureAccountForUser({
+            telegramId: getTelegramId(),
+            googleId: localStorage.getItem('googleId')
+          });
+          if (account?.accountId) {
+            id = account.accountId;
+            persistAccountLocally({
+              ...account,
+              telegramId: account.telegramId,
+              googleId: account.googleId
+            });
           }
         } catch {}
       }

--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { createAccount, getAccountBalance, getTonBalance } from '../utils/api.js';
+import { getAccountBalance, getTonBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 import { useTonAddress } from '@tonconnect/ui-react';
+import { ensureAccountForUser } from '../utils/account.js';
 
 export default function useTokenBalances() {
   let telegramId;
@@ -22,11 +23,7 @@ export default function useTokenBalances() {
     async function loadTpc() {
       if (!telegramId && !googleId) return;
       try {
-        const acc = await createAccount(telegramId, googleId);
-        if (acc?.error) throw new Error(acc.error);
-        if (acc.walletAddress) {
-          localStorage.setItem('walletAddress', acc.walletAddress);
-        }
+        const acc = await ensureAccountForUser({ telegramId, googleId });
         const bal = await getAccountBalance(acc.accountId);
         if (bal?.error) throw new Error(bal.error);
         setTpcBalance(bal.balance ?? 0);

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getAccountInfo,
-  createAccount,
   updateProfile,
   fetchTelegramInfo,
   depositAccount,
@@ -27,6 +26,7 @@ import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import { ensureAccountForUser, persistAccountLocally } from '../utils/account.js';
 import {
   getDefaultPoolRoyalLoadout,
   getPoolRoyalInventory,
@@ -149,16 +149,13 @@ export default function MyAccount() {
 
   useEffect(() => {
     async function load() {
-      const acc = await createAccount(telegramId, googleId);
-      if (acc?.error) {
-        console.error('Failed to load account:', acc.error);
+      let acc;
+      try {
+        acc = await ensureAccountForUser({ telegramId, googleId });
+        persistAccountLocally({ ...acc, telegramId, googleId });
+      } catch (err) {
+        console.error('Failed to load account:', err);
         return;
-      }
-      if (acc.accountId) {
-        localStorage.setItem('accountId', acc.accountId);
-      }
-      if (acc.walletAddress) {
-        localStorage.setItem('walletAddress', acc.walletAddress);
       }
 
       const data = await getAccountInfo(acc.accountId);

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import QRCode from 'react-qr-code';
 import {
-  createAccount,
   getAccountBalance,
   sendAccountTpc,
   getAccountTransactions,
@@ -15,6 +14,7 @@ import TransactionDetailsPopup from '../components/TransactionDetailsPopup.jsx';
 import NftGiftCard from '../components/NftGiftCard.jsx';
 import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import { ensureAccountForUser, persistAccountLocally } from '../utils/account.js';
 
 const urlParams = new URLSearchParams(window.location.search);
 const DEV_ACCOUNT_ID =
@@ -97,16 +97,14 @@ export default function Wallet({ hideClaim = false }) {
     if (id) {
       acc = { accountId: id };
     } else {
-      acc = await createAccount(telegramId, googleId);
-      if (acc?.error) {
-        console.error('Failed to load account:', acc.error);
+      try {
+        acc = await ensureAccountForUser({ telegramId, googleId });
+        persistAccountLocally({ ...acc, telegramId, googleId });
+        id = acc.accountId;
+      } catch (err) {
+        console.error('Failed to load account:', err);
         return null;
       }
-      localStorage.setItem('accountId', acc.accountId);
-      if (acc.walletAddress) {
-        localStorage.setItem('walletAddress', acc.walletAddress);
-      }
-      id = acc.accountId;
     }
     setAccountId(acc.accountId || id);
 

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,4 +1,4 @@
-const TELEGRAM_ONLY = true;
+const TELEGRAM_ONLY = false;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
 
 function shouldRegisterForTelegram() {
@@ -70,4 +70,3 @@ export async function registerTelegramServiceWorker() {
     console.error('Service worker registration failed', err);
   }
 }
-

--- a/webapp/src/utils/account.js
+++ b/webapp/src/utils/account.js
@@ -1,0 +1,86 @@
+import { createAccount } from './api.js';
+
+const OWNER_KEY = 'accountOwner';
+
+function normalizeId(id) {
+  if (id == null) return null;
+  return String(id);
+}
+
+function readOwner() {
+  const raw = localStorage.getItem(OWNER_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      telegramId: parsed.telegramId ? String(parsed.telegramId) : null,
+      googleId: parsed.googleId || null
+    };
+  } catch {
+    return {};
+  }
+}
+
+export function persistAccountLocally({ accountId, walletAddress, telegramId, googleId }) {
+  if (accountId) localStorage.setItem('accountId', accountId);
+  if (walletAddress) localStorage.setItem('walletAddress', walletAddress);
+
+  const owner = {};
+  if (telegramId) owner.telegramId = normalizeId(telegramId);
+  if (googleId) owner.googleId = googleId;
+
+  if (owner.telegramId || owner.googleId) {
+    localStorage.setItem(OWNER_KEY, JSON.stringify(owner));
+  }
+}
+
+export function getStoredAccount() {
+  const accountId = localStorage.getItem('accountId');
+  const walletAddress = localStorage.getItem('walletAddress');
+  const owner = readOwner();
+
+  if (!accountId) return null;
+
+  return {
+    accountId,
+    walletAddress,
+    telegramId: owner.telegramId || null,
+    googleId: owner.googleId || null
+  };
+}
+
+export async function ensureAccountForUser({ telegramId, googleId } = {}) {
+  const normalizedTelegram = normalizeId(telegramId);
+  const normalizedGoogle = googleId || null;
+  const cached = getStoredAccount();
+
+  const matchesCached =
+    cached?.accountId &&
+    (!normalizedTelegram || cached.telegramId === normalizedTelegram) &&
+    (!normalizedGoogle || cached.googleId === normalizedGoogle);
+
+  if (matchesCached) {
+    const merged = {
+      ...cached,
+      telegramId: cached.telegramId || normalizedTelegram,
+      googleId: cached.googleId || normalizedGoogle
+    };
+    if (normalizedTelegram || normalizedGoogle) {
+      persistAccountLocally(merged);
+    }
+    return merged;
+  }
+
+  const res = await createAccount(normalizedTelegram, normalizedGoogle);
+  if (res?.error) throw new Error(res.error);
+
+  const account = {
+    accountId: res.accountId,
+    walletAddress: res.walletAddress || cached?.walletAddress || null,
+    telegramId: normalizedTelegram,
+    googleId: normalizedGoogle
+  };
+
+  persistAccountLocally(account);
+  return account;
+}


### PR DESCRIPTION
## Summary
- register the service worker for all browsers so Chrome users load the app reliably
- add a shared account utility to persist account IDs, owners, and wallet details
- update auth, balance, wallet, and gift flows to reuse stored accounts instead of recreating them

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2c4fdad48329aeaf131b8db49fc4)