### PR TITLE
Add chess sync handler for chess battle

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1085,6 +1085,14 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('chessSyncRequest', ({ tableId }) => {
+    if (!tableId) return;
+    const state = getChessState(tableId);
+    if (state) {
+      socket.emit('chessState', { tableId, ...state });
+    }
+  });
+
   socket.on('poolShot', ({ tableId, state, hud }) => {
     if (!tableId || !state) return;
     const payload = {


### PR DESCRIPTION
## Summary
- add socket handler for chess sync requests to return the latest board state
- reuse stored chess state when players reconnect to the same table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3853a1308329b49256aa2ef79f92)