### PR TITLE
Fix chess online listener order

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -5496,7 +5496,17 @@ function Chess3D({
       socket.emit('chessSyncRequest', { tableId: target });
     };
 
-    socket.emit('register', { playerId: accountId });
+    socket.on('gameStart', handleGameStart);
+    socket.on('chessState', handleChessState);
+    socket.on('chessMove', handleChessState);
+
+    cleanups.push(() => {
+      socket.off('gameStart', handleGameStart);
+      socket.off('chessState', handleChessState);
+      socket.off('chessMove', handleChessState);
+      if (tableJoin.current)
+        socket.emit('leaveLobby', { accountId, tableId: tableJoin.current });
+    });
 
     const joinExistingTable = (tableIdToJoin) => {
       setTableId(tableIdToJoin);
@@ -5506,6 +5516,8 @@ function Chess3D({
       socket.emit('joinChessRoom', { tableId: tableIdToJoin, accountId });
       onlineRef.current.requestSync?.();
     };
+
+    socket.emit('register', { playerId: accountId });
 
     if (initialTableId) {
       joinExistingTable(initialTableId);
@@ -5531,18 +5543,6 @@ function Chess3D({
         }
       );
     }
-
-    socket.on('gameStart', handleGameStart);
-    socket.on('chessState', handleChessState);
-    socket.on('chessMove', handleChessState);
-
-    cleanups.push(() => {
-      socket.off('gameStart', handleGameStart);
-      socket.off('chessState', handleChessState);
-      socket.off('chessMove', handleChessState);
-      if (tableJoin.current)
-        socket.emit('leaveLobby', { accountId, tableId: tableJoin.current });
-    });
 
     return () => {
       active = false;


### PR DESCRIPTION
## Summary
- attach chess Battle Royal online socket listeners before joining or syncing a table to avoid missing initial state
- keep existing lobby cleanup logic intact while registering earlier listeners

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3853a1308329b49256aa2ef79f92)