### PR TITLE
Fix Pool Royale online matchmaking metadata

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -20,6 +20,7 @@ function clearTimeoutSafely(ref) {
 export async function runPoolRoyaleOnlineFlow({
   stake,
   variant,
+  ballSet,
   playType,
   mode,
   tableSize,
@@ -241,6 +242,7 @@ export async function runPoolRoyaleOnlineFlow({
       maxPlayers: 2,
       mode,
       variant,
+      ballSet,
       tableSize,
       playType,
       playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',


### PR DESCRIPTION
## Summary
- propagate Pool Royale matchmaking metadata (variant, table size, ball set, mode, play type, token) into table selection and game start events
- send the selected ball set when joining online Pool Royale and surface lobby/game metadata in socket responses
- stabilize Pool Royale online flow tests by asserting seat payload data and closing the real socket client

## Testing
- node --test test/poolRoyaleOnlineFlow.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3a0178588329ba7e8b4cc0f6b07b)