### PR TITLE
Improve Pool Royale online state sync

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -559,7 +559,7 @@ function maybeStartGame(table) {
         (t) => t.id !== table.id
       );
       if (table.gameType === 'poolroyale') {
-        poolStates.set(table.id, { state: null, hud: null, ts: Date.now() });
+        poolStates.set(table.id, { state: null, hud: null, snapshot: null, recording: null, actorId: null, ts: Date.now() });
       }
       table.startTimeout = null;
     }, 1000);
@@ -1107,6 +1107,9 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        snapshot: cached.snapshot,
+        recording: cached.recording,
+        actorId: cached.actorId,
         updatedAt: cached.ts
       });
     }
@@ -1120,20 +1123,33 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        snapshot: cached.snapshot,
+        recording: cached.recording,
+        actorId: cached.actorId,
         updatedAt: cached.ts
       });
     }
   });
 
-  socket.on('poolShot', ({ tableId, state, hud }) => {
+  socket.on('poolShot', ({ tableId, state, hud, snapshot, recording, actorId }) => {
     if (!tableId || !state) return;
     const payload = {
       tableId,
       state,
       hud: hud || null,
+      snapshot: snapshot || null,
+      recording: recording || null,
+      actorId: actorId || null,
       updatedAt: Date.now()
     };
-    poolStates.set(tableId, { state, hud: hud || null, ts: payload.updatedAt });
+    poolStates.set(tableId, {
+      state,
+      hud: hud || null,
+      snapshot: snapshot || null,
+      recording: recording || null,
+      actorId: actorId || null,
+      ts: payload.updatedAt
+    });
     socket.to(tableId).emit('poolState', payload);
   });
 


### PR DESCRIPTION
## Summary
- capture ball snapshots and shot recordings for Pool Royale online games and include them in socket updates
- apply incoming snapshots/recordings to play opponent shots and keep ball positions in sync during online matches
- cache and broadcast pool snapshots/recordings on the server so reconnecting players receive the latest table state

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3f0bdea4832996b00aa20166c0d9)