### PR TITLE
Improve Snake online sync

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -13,6 +13,7 @@ export default function DiceRoller({
   showButton = true,
   muted = false,
   emitRollEvent = false,
+  rollPayload,
   divRef,
   className = '',
   diceTransparent = false,
@@ -92,7 +93,7 @@ export default function DiceRoller({
           startValuesRef.current = results;
           onRollEnd && onRollEnd(results);
           if (emitRollEvent) {
-            socket.emit('rollDice');
+            socket.emit('rollDice', rollPayload || {});
           }
         }, tick);
       }


### PR DESCRIPTION
## Summary
- add reconnection-aware seating and ready confirmation for Snake & Ladder online matches
- ensure multiplayer sockets re-register/join tables and dice rolls carry table context for sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c404074e4832984fe4aefd93a2b69)