### PR TITLE
Enable Chrome Google onboarding

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -45,10 +45,12 @@ import SnookerClubLobby from './pages/Games/SnookerClubLobby.jsx';
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
+import useChromeGoogleAuth from './hooks/useChromeGoogleAuth.js';
 
 export default function App() {
   useTelegramAuth();
   useReferralClaim();
+  useChromeGoogleAuth();
 
   const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
 

--- a/webapp/src/components/LinkGoogleButton.jsx
+++ b/webapp/src/components/LinkGoogleButton.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { linkGoogleAccount } from '../utils/api.js';
+import { parseGoogleCredential, persistGoogleProfile } from '../utils/google.js';
 
 export default function LinkGoogleButton({ telegramId, onLinked }) {
   const [ready, setReady] = useState(false);
@@ -8,16 +9,26 @@ export default function LinkGoogleButton({ telegramId, onLinked }) {
   useEffect(() => {
     function handleCredential(res) {
       try {
-        const data = JSON.parse(atob(res.credential.split('.')[1]));
-        if (!data.sub) return;
-        localStorage.setItem('googleId', data.sub);
-        linkGoogleAccount({
-          telegramId,
+        const data = parseGoogleCredential(res.credential);
+        if (!data?.sub) return;
+
+        const profile = {
           googleId: data.sub,
           email: data.email,
           firstName: data.given_name,
           lastName: data.family_name,
           photo: data.picture
+        };
+
+        persistGoogleProfile(profile);
+
+        linkGoogleAccount({
+          telegramId,
+          googleId: profile.googleId,
+          email: profile.email,
+          firstName: profile.firstName,
+          lastName: profile.lastName,
+          photo: profile.photo
         }).then(() => {
           if (onLinked) onLinked();
         });

--- a/webapp/src/hooks/useChromeGoogleAuth.js
+++ b/webapp/src/hooks/useChromeGoogleAuth.js
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react';
+import { createAccount } from '../utils/api.js';
+import { socket } from '../utils/socket.js';
+import {
+  isChromeBrowser,
+  parseGoogleCredential,
+  persistGoogleProfile,
+  readStoredGoogleProfile
+} from '../utils/google.js';
+import { ensureAccountId } from '../utils/telegram.js';
+
+export default function useChromeGoogleAuth() {
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const inTelegram = Boolean(window.Telegram?.WebApp);
+    if (inTelegram) return undefined;
+
+    if (!isChromeBrowser()) return undefined;
+
+    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+    if (!clientId) return undefined;
+
+    let cancelled = false;
+    let promptTimer = null;
+
+    const registerAccount = async (profile) => {
+      if (!profile?.googleId) return;
+      try {
+        const res = await createAccount(undefined, profile.googleId);
+        if (res?.accountId) {
+          localStorage.setItem('accountId', res.accountId);
+          socket.emit('register', { playerId: res.accountId });
+        } else {
+          const fallbackId = await ensureAccountId();
+          socket.emit('register', { playerId: fallbackId });
+        }
+        if (res?.walletAddress) {
+          localStorage.setItem('walletAddress', res.walletAddress);
+        }
+      } catch (err) {
+        console.error('Failed to create account with Google profile', err);
+      }
+    };
+
+    const stored = readStoredGoogleProfile();
+    if (stored.googleId) {
+      registerAccount(stored);
+    }
+
+    const handleCredential = async (res) => {
+      if (!res?.credential) return;
+      const data = parseGoogleCredential(res.credential);
+      if (!data?.sub) return;
+
+      const profile = {
+        googleId: data.sub,
+        email: data.email,
+        firstName: data.given_name,
+        lastName: data.family_name,
+        photo: data.picture
+      };
+
+      persistGoogleProfile(profile);
+      await registerAccount(profile);
+    };
+
+    const initGoogle = () => {
+      if (cancelled || initialized.current) return true;
+      if (!window.google) return false;
+
+      window.google.accounts.id.initialize({
+        client_id: clientId,
+        callback: handleCredential,
+        ux_mode: 'popup'
+      });
+
+      initialized.current = true;
+      window.google.accounts.id.prompt();
+      return true;
+    };
+
+    if (!initGoogle()) {
+      promptTimer = setInterval(() => {
+        if (initGoogle()) {
+          clearInterval(promptTimer);
+        }
+      }, 500);
+    }
+
+    return () => {
+      cancelled = true;
+      if (promptTimer) clearInterval(promptTimer);
+    };
+  }, []);
+}

--- a/webapp/src/utils/google.js
+++ b/webapp/src/utils/google.js
@@ -1,0 +1,65 @@
+function getLocalStorageItem(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (err) {
+    return null;
+  }
+}
+
+function setLocalStorageItem(key, value) {
+  try {
+    if (value) {
+      localStorage.setItem(key, value);
+    }
+  } catch (err) {}
+}
+
+export function parseGoogleCredential(credential) {
+  try {
+    if (typeof credential !== 'string') return null;
+    const parts = credential.split('.');
+    if (parts.length < 2) return null;
+    const normalized = parts[1]
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(parts[1].length / 4) * 4, '=');
+    const decoded = atob(normalized);
+    return JSON.parse(decoded);
+  } catch (err) {
+    return null;
+  }
+}
+
+export function persistGoogleProfile(profile = {}) {
+  if (typeof window === 'undefined') return;
+
+  const { googleId, email, firstName, lastName, photo } = profile;
+  setLocalStorageItem('googleId', googleId);
+  setLocalStorageItem('googleEmail', email);
+  setLocalStorageItem('googleFirstName', firstName);
+  setLocalStorageItem('googleLastName', lastName);
+  setLocalStorageItem('googlePhoto', photo);
+}
+
+export function readStoredGoogleProfile() {
+  if (typeof window === 'undefined') return {};
+
+  const googleId = getLocalStorageItem('googleId') || undefined;
+  const email = getLocalStorageItem('googleEmail') || undefined;
+  const firstName = getLocalStorageItem('googleFirstName') || undefined;
+  const lastName = getLocalStorageItem('googleLastName') || undefined;
+  const photo = getLocalStorageItem('googlePhoto') || undefined;
+
+  return { googleId, email, firstName, lastName, photo };
+}
+
+export function isChromeBrowser() {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const vendor = navigator.vendor || '';
+  const isChrome = /Chrome/i.test(ua) || /CriOS/i.test(ua);
+  const isGoogleVendor = /Google Inc\.?/i.test(vendor);
+  const isEdge = /Edg/i.test(ua);
+  const isOpera = /OPR|Opera/i.test(ua);
+  return isChrome && isGoogleVendor && !isEdge && !isOpera;
+}


### PR DESCRIPTION
## Summary
- add a Chrome-only Google Identity bootstrap hook so browser users can sign in with Gmail and register an account
- reuse parsed Google profile data when linking accounts to avoid broken or blank states during Chrome login
- expose shared Google auth helpers for consistent credential parsing and local persistence

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c431cd078832990fdd6fe86fe80e8)