### PR TITLE
Sync Pool Royale ball layouts in online matches

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -559,7 +559,7 @@ function maybeStartGame(table) {
         (t) => t.id !== table.id
       );
       if (table.gameType === 'poolroyale') {
-        poolStates.set(table.id, { state: null, hud: null, ts: Date.now() });
+        poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
       }
       table.startTimeout = null;
     }, 1000);
@@ -1107,6 +1107,7 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        layout: cached.layout,
         updatedAt: cached.ts
       });
     }
@@ -1120,20 +1121,27 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        layout: cached.layout,
         updatedAt: cached.ts
       });
     }
   });
 
-  socket.on('poolShot', ({ tableId, state, hud }) => {
+  socket.on('poolShot', ({ tableId, state, hud, layout }) => {
     if (!tableId || !state) return;
     const payload = {
       tableId,
       state,
       hud: hud || null,
+      layout: layout || null,
       updatedAt: Date.now()
     };
-    poolStates.set(tableId, { state, hud: hud || null, ts: payload.updatedAt });
+    poolStates.set(tableId, {
+      state,
+      hud: hud || null,
+      layout: layout || null,
+      ts: payload.updatedAt
+    });
     socket.to(tableId).emit('poolState', payload);
   });
 


### PR DESCRIPTION
## Summary
- include Pool Royale HUD and layout snapshots in socket payloads and cache them server-side for reconnects
- capture and apply ball snapshots on clients so online opponents see the resolved table state after each shot
- defer layout application until the 3D scene is ready to avoid dropping remote updates on load

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3f0bdea4832996b00aa20166c0d9)