### PR TITLE
Add live ball sync streaming for Pool Royale

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1127,6 +1127,26 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs }) => {
+    if (!tableId || !Array.isArray(layout)) return;
+    const ts = Number.isFinite(frameTs) ? frameTs : Date.now();
+    const cached = poolStates.get(tableId) || {};
+    const payload = {
+      tableId,
+      layout,
+      hud: hud || cached.hud || null,
+      updatedAt: ts,
+      playerId: playerId || null
+    };
+    poolStates.set(tableId, {
+      state: cached.state || null,
+      hud: payload.hud,
+      layout,
+      ts
+    });
+    socket.to(tableId).emit('poolFrame', payload);
+  });
+
   socket.on('poolShot', ({ tableId, state, hud, layout }) => {
     if (!tableId || !state) return;
     const payload = {


### PR DESCRIPTION
## Summary
- stream Pool Royale ball layouts every frame during online shots so opponents see live movement
- apply incoming pool frame updates without requiring a full state payload
- relay poolFrame events on the server while caching the latest layout for sync requests

## Testing
- npm test -- --runTestsByPath test/poolRoyalInventoryRoutes.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4d10e8d08329b3ff4b13ae4c7fc1)