### PR TITLE
Sync Pool Royale camera frames online

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1107,6 +1107,7 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        camera: cached.camera,
         layout: cached.layout,
         updatedAt: cached.ts
       });
@@ -1121,13 +1122,14 @@ io.on('connection', (socket) => {
         tableId,
         state: cached.state,
         hud: cached.hud,
+        camera: cached.camera,
         layout: cached.layout,
         updatedAt: cached.ts
       });
     }
   });
 
-  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs }) => {
+  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs, camera }) => {
     if (!tableId || !Array.isArray(layout)) return;
     const ts = Number.isFinite(frameTs) ? frameTs : Date.now();
     const cached = poolStates.get(tableId) || {};
@@ -1135,6 +1137,7 @@ io.on('connection', (socket) => {
       tableId,
       layout,
       hud: hud || cached.hud || null,
+      camera: camera || cached.camera || null,
       updatedAt: ts,
       playerId: playerId || null
     };
@@ -1142,24 +1145,28 @@ io.on('connection', (socket) => {
       state: cached.state || null,
       hud: payload.hud,
       layout,
+      camera: payload.camera,
       ts
     });
     socket.to(tableId).emit('poolFrame', payload);
   });
 
-  socket.on('poolShot', ({ tableId, state, hud, layout }) => {
+  socket.on('poolShot', ({ tableId, state, hud, layout, playerId, camera }) => {
     if (!tableId || !state) return;
     const payload = {
       tableId,
       state,
       hud: hud || null,
       layout: layout || null,
-      updatedAt: Date.now()
+      camera: camera || null,
+      updatedAt: Date.now(),
+      playerId: playerId || null
     };
     poolStates.set(tableId, {
       state,
       hud: hud || null,
       layout: layout || null,
+      camera: camera || null,
       ts: payload.updatedAt
     });
     socket.to(tableId).emit('poolState', payload);


### PR DESCRIPTION
## Summary
- propagate camera snapshots alongside Pool Royale frame and shot events so sockets can replay the exact view
- capture and emit live camera state from the client on every streamed frame and resolved shot
- apply remote camera snapshots for online opponents to mirror aiming/replay viewpoints and keep HUD/broadcast cameras aligned

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cce460b248329b5be8bb6182c492c)