### PR TITLE
Improve Pool Royale online aim sync and replays

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1108,6 +1108,7 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
+        aim: cached.aim,
         updatedAt: cached.ts
       });
     }
@@ -1122,44 +1123,56 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
+        aim: cached.aim,
         updatedAt: cached.ts
       });
     }
   });
 
-  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs }) => {
-    if (!tableId || !Array.isArray(layout)) return;
+  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs, aim, replay }) => {
+    if (!tableId) return;
+    const hasLayout = Array.isArray(layout);
+    const hasAim = aim && typeof aim === 'object';
+    const hasReplay = replay && typeof replay === 'object';
+    if (!hasLayout && !hasAim && !hasReplay) return;
     const ts = Number.isFinite(frameTs) ? frameTs : Date.now();
     const cached = poolStates.get(tableId) || {};
+    const nextHud = hud || cached.hud || null;
     const payload = {
       tableId,
-      layout,
-      hud: hud || cached.hud || null,
+      hud: nextHud,
       updatedAt: ts,
       playerId: playerId || null
     };
+    if (hasLayout) payload.layout = layout;
+    if (hasAim) payload.aim = aim;
+    if (hasReplay) payload.replay = replay;
     poolStates.set(tableId, {
       state: cached.state || null,
-      hud: payload.hud,
-      layout,
+      hud: nextHud,
+      layout: hasLayout ? layout : cached.layout || null,
+      aim: hasAim ? aim : cached.aim || null,
       ts
     });
     socket.to(tableId).emit('poolFrame', payload);
   });
 
-  socket.on('poolShot', ({ tableId, state, hud, layout }) => {
+  socket.on('poolShot', ({ tableId, state, hud, layout, replay, aim }) => {
     if (!tableId || !state) return;
     const payload = {
       tableId,
       state,
       hud: hud || null,
       layout: layout || null,
+      replay: replay || null,
+      aim: aim || null,
       updatedAt: Date.now()
     };
     poolStates.set(tableId, {
       state,
       hud: hud || null,
       layout: layout || null,
+      aim: aim || null,
       ts: payload.updatedAt
     });
     socket.to(tableId).emit('poolState', payload);


### PR DESCRIPTION
## Summary
- stream live Pool Royale aim snapshots so opponents see cue guides in real time and hide guides once a shot fires
- share recorded Pool Royale replays with both players and trigger playback on receipt
- forward aim/replay payloads through poolFrame/poolShot server events for online matches

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce37f88148329a733f7036c7c9261)