### PR TITLE
Improve Pool Royale online aim sync and replays

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1108,6 +1108,9 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
+        aim: cached.aim || null,
+        replay: cached.replay || null,
+        shooting: Boolean(cached.shooting),
         updatedAt: cached.ts
       });
     }
@@ -1122,12 +1125,15 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
+        aim: cached.aim || null,
+        replay: cached.replay || null,
+        shooting: Boolean(cached.shooting),
         updatedAt: cached.ts
       });
     }
   });
 
-  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs }) => {
+  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs, aim, shooting }) => {
     if (!tableId || !Array.isArray(layout)) return;
     const ts = Number.isFinite(frameTs) ? frameTs : Date.now();
     const cached = poolStates.get(tableId) || {};
@@ -1135,6 +1141,8 @@ io.on('connection', (socket) => {
       tableId,
       layout,
       hud: hud || cached.hud || null,
+      aim: aim || null,
+      shooting: Boolean(shooting),
       updatedAt: ts,
       playerId: playerId || null
     };
@@ -1142,24 +1150,30 @@ io.on('connection', (socket) => {
       state: cached.state || null,
       hud: payload.hud,
       layout,
+      aim: payload.aim || null,
+      shooting: payload.shooting,
       ts
     });
     socket.to(tableId).emit('poolFrame', payload);
   });
 
-  socket.on('poolShot', ({ tableId, state, hud, layout }) => {
+  socket.on('poolShot', ({ tableId, state, hud, layout, replay, shooting }) => {
     if (!tableId || !state) return;
     const payload = {
       tableId,
       state,
       hud: hud || null,
       layout: layout || null,
+      replay: replay || null,
+      shooting: Boolean(shooting),
       updatedAt: Date.now()
     };
     poolStates.set(tableId, {
       state,
       hud: hud || null,
       layout: layout || null,
+      replay: replay || null,
+      shooting: payload.shooting,
       ts: payload.updatedAt
     });
     socket.to(tableId).emit('poolState', payload);


### PR DESCRIPTION
## Summary
- broadcast live aim direction/power/spin and layouts so opponents see real-time aiming overlays without interfering with turns
- stream replay payloads to remote clients and hydrate them for synchronized playback after each shot
- guard cue visibility during shots to keep the stick and aim guides hidden while balls travel and reset cleanly between turns

## Testing
- Not run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce37f88148329a733f7036c7c9261)