### PR TITLE
Adjust pool lighting coverage

### DIFF
--- a/billiards.Unity/BilliardLighting.cs
+++ b/billiards.Unity/BilliardLighting.cs
@@ -20,8 +20,8 @@ public class BilliardLighting : MonoBehaviour
             spotLight.type = LightType.Spot;
             spotLight.color = Color.white;
             spotLight.intensity = 2.25f;       // brightness reduced by 10%
-            spotLight.range = 15f;             // distance
-            spotLight.spotAngle = 60f;         // cone size
+            spotLight.range = 17f;             // slightly broader coverage
+            spotLight.spotAngle = 70f;         // wider cone for bigger pools of light
             spotLight.shadows = LightShadows.Soft;
 
             lightObj.transform.position = lightPositions[i];
@@ -78,7 +78,7 @@ public class BilliardLighting : MonoBehaviour
         Light spotLight = lightObj.AddComponent<Light>();
         spotLight.type = LightType.Spot;
         spotLight.cookie = Texture2D.whiteTexture; // square reflection
-        const float sizeMultiplier = 0.2f;          // 5x smaller highlight
+        const float sizeMultiplier = 0.25f;         // modestly larger highlight footprint
         spotLight.range = 2.5f * sizeMultiplier;
         spotLight.intensity = 3f;
         spotLight.spotAngle = 10f * sizeMultiplier;


### PR DESCRIPTION
## Summary
- widen the primary spotlight range and cone for better table coverage
- increase highlight light footprint on balls for larger reflective cues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2444fb2c8329b78f49eabf1d046a)