### PR TITLE
Improve Pool Royale lighting balance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14222,13 +14222,14 @@ const powerRef = useRef(hud.power);
 
         const lightSpreadBoost = 1.68; // widen the overhead footprint so fixtures read larger on mobile and reach farther to the sides
         const lightRigHeight = tableSurfaceY + TABLE.THICK * 7.1; // lift the rig higher for a broader throw and wider coverage
-        const lightOffsetX =
+        const lightReachX =
           Math.max(PLAY_W * 0.22, TABLE.THICK * 3.9) * lightSpreadBoost;
-        const lightOffsetZ =
+        const lightReachZ =
           Math.max(PLAY_H * 0.2, TABLE.THICK * 3.8) * lightSpreadBoost;
-        const lightLineX = lightOffsetX * 0.5; // keep the rig aligned along a single long rail with a slightly wider stance
-        const lightSpacing = lightOffsetZ * 0.6; // enforce equal spacing between fixtures to mirror the centred heads
-        const lightPositionsZ = [-1.5, -0.5, 0.5, 1.5].map((mult) => mult * lightSpacing);
+        const lightLineX = lightReachX * 0.36; // mirror the fixtures on both long rails for even coverage
+        const lightSpacing = lightReachZ * 0.42; // tighten spacing so every gap reads identical in ball reflections
+        const lightRowsX = [-lightLineX, lightLineX];
+        const lightPositionsZ = [-1, 1].map((mult) => mult * lightSpacing);
         const shadowHalfSpan =
           Math.max(roomWidth, roomDepth) * 0.82 + TABLE.THICK * 3.5;
         const targetY = tableSurfaceY + TABLE.THICK * 0.2;
@@ -14239,8 +14240,8 @@ const powerRef = useRef(hud.power);
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(0xffffff, 1.78);
-        key.position.set(lightLineX, lightRigHeight, lightPositionsZ[0]);
-        key.target.position.set(0, targetY, 0);
+        key.position.set(lightRowsX[0], lightRigHeight, lightPositionsZ[0]);
+        key.target.position.set(lightRowsX[0], targetY, lightPositionsZ[0]);
         key.castShadow = true;
         key.shadow.mapSize.set(2048, 2048);
         key.shadow.camera.near = 0.1;
@@ -14256,20 +14257,20 @@ const powerRef = useRef(hud.power);
         lightingRig.add(key.target);
 
         const fill = new THREE.DirectionalLight(0xffffff, 0.9);
-        fill.position.set(lightLineX, lightRigHeight * 1.02, lightPositionsZ[1]);
-        fill.target.position.set(0, targetY, 0);
+        fill.position.set(lightRowsX[0], lightRigHeight * 1.02, lightPositionsZ[1]);
+        fill.target.position.set(lightRowsX[0], targetY, lightPositionsZ[1]);
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
         const wash = new THREE.DirectionalLight(0xffffff, 0.82);
-        wash.position.set(lightLineX, lightRigHeight * 1.04, lightPositionsZ[2]);
-        wash.target.position.set(0, targetY, 0);
+        wash.position.set(lightRowsX[1], lightRigHeight * 1.04, lightPositionsZ[0]);
+        wash.target.position.set(lightRowsX[1], targetY, lightPositionsZ[0]);
         lightingRig.add(wash);
         lightingRig.add(wash.target);
 
         const rim = new THREE.DirectionalLight(0xffffff, 0.74);
-        rim.position.set(lightLineX, lightRigHeight * 1.06, lightPositionsZ[3]);
-        rim.target.position.set(0, targetY, 0);
+        rim.position.set(lightRowsX[1], lightRigHeight * 1.06, lightPositionsZ[1]);
+        rim.target.position.set(lightRowsX[1], targetY, lightPositionsZ[1]);
         lightingRig.add(rim);
         lightingRig.add(rim.target);
 


### PR DESCRIPTION
## Summary
- mirror the Pool Royale overhead fixtures across both rails and tighten spacing so all four lights reflect with matching gaps
- aim each fixture straight down to brighten the previously dark side of the arena and keep shadows under the balls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d36609d208329b8314a254a31e1b6)