### PR TITLE
Adjust Pool Royale lighting rig placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14221,14 +14221,19 @@ const powerRef = useRef(hud.power);
         world.add(lightingRig);
 
         const lightSpreadBoost = 1.68; // widen the overhead footprint so fixtures read larger on mobile and reach farther to the sides
-        const lightRigHeight = tableSurfaceY + TABLE.THICK * 7.1; // lift the rig higher for a broader throw and wider coverage
+        const lightRigHeight = tableSurfaceY + TABLE.THICK * 6.4; // lower the rig slightly so reflections read larger while preserving brightness
         const lightOffsetX =
           Math.max(PLAY_W * 0.22, TABLE.THICK * 3.9) * lightSpreadBoost;
         const lightOffsetZ =
           Math.max(PLAY_H * 0.2, TABLE.THICK * 3.8) * lightSpreadBoost;
-        const lightLineX = lightOffsetX * 0.5; // keep the rig aligned along a single long rail with a slightly wider stance
+        const lightLineX = lightOffsetX * 0.42; // spread fixtures across both rails so coverage hits all sides evenly
         const lightSpacing = lightOffsetZ * 0.6; // enforce equal spacing between fixtures to mirror the centred heads
-        const lightPositionsZ = [-1.5, -0.5, 0.5, 1.5].map((mult) => mult * lightSpacing);
+        const lightPositions = [
+          { x: -lightLineX, z: -lightSpacing * 1.1 },
+          { x: lightLineX, z: -lightSpacing * 0.35 },
+          { x: lightLineX, z: lightSpacing * 0.35 },
+          { x: -lightLineX, z: lightSpacing * 1.1 }
+        ];
         const shadowHalfSpan =
           Math.max(roomWidth, roomDepth) * 0.82 + TABLE.THICK * 3.5;
         const targetY = tableSurfaceY + TABLE.THICK * 0.2;
@@ -14239,7 +14244,7 @@ const powerRef = useRef(hud.power);
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(0xffffff, 1.78);
-        key.position.set(lightLineX, lightRigHeight, lightPositionsZ[0]);
+        key.position.set(lightPositions[0].x, lightRigHeight, lightPositions[0].z);
         key.target.position.set(0, targetY, 0);
         key.castShadow = true;
         key.shadow.mapSize.set(2048, 2048);
@@ -14256,19 +14261,19 @@ const powerRef = useRef(hud.power);
         lightingRig.add(key.target);
 
         const fill = new THREE.DirectionalLight(0xffffff, 0.9);
-        fill.position.set(lightLineX, lightRigHeight * 1.02, lightPositionsZ[1]);
+        fill.position.set(lightPositions[1].x, lightRigHeight * 1.02, lightPositions[1].z);
         fill.target.position.set(0, targetY, 0);
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
         const wash = new THREE.DirectionalLight(0xffffff, 0.82);
-        wash.position.set(lightLineX, lightRigHeight * 1.04, lightPositionsZ[2]);
+        wash.position.set(lightPositions[2].x, lightRigHeight * 1.04, lightPositions[2].z);
         wash.target.position.set(0, targetY, 0);
         lightingRig.add(wash);
         lightingRig.add(wash.target);
 
         const rim = new THREE.DirectionalLight(0xffffff, 0.74);
-        rim.position.set(lightLineX, lightRigHeight * 1.06, lightPositionsZ[3]);
+        rim.position.set(lightPositions[3].x, lightRigHeight * 1.06, lightPositions[3].z);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);
         lightingRig.add(rim.target);


### PR DESCRIPTION
## Summary
- reposition the four Pool Royale directional lights so coverage hits all sides evenly
- lower the lighting rig slightly to enlarge ball reflections without changing light colors or intensities

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4468d25c8329a2f73b81a2415ea3)