### PR TITLE
Align Snooker Club table to Pool Royale visuals

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -406,33 +406,32 @@ function adjustSideNotchDepth(mp) {
   );
 }
 
-const POCKET_VISUAL_EXPANSION = 1.028;
-const CORNER_POCKET_INWARD_SCALE = 1.024; // pull the rounded corner cuts a hair further inward without moving the pocket centers
-const CORNER_POCKET_SCALE_BOOST = 0.994; // ease the restriction so the corner mouth opens slightly wider than before
-const CORNER_POCKET_EXTRA_SCALE = 1.02; // further relax the corner mouth while leaving side pockets unchanged
-const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.034; // widen the chrome arc so the fascia tracks the photographed pocket throat
+const POCKET_VISUAL_EXPANSION = 1.034;
+const CORNER_POCKET_INWARD_SCALE = 1.008; // match the Pool Royale fascia alignment by tucking the rounded corner cuts only slightly inward
+const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to mirror the Pool Royale jaw silhouette
+const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
+const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01; // align the chrome arc to the Pool Royale throat radius so fascia + jaws share the same wrap
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08; // mirror snooker notch depth so the rounded chrome cut hugs the cloth identically
 const CHROME_CORNER_EXPANSION_SCALE = 1.002; // trim back the fascia so it now finishes flush with the pocket jaw edge along the long rail
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.002; // mirror the lighter reach so the chrome stops exactly where the jaw shoulder begins
 const CHROME_CORNER_FIELD_TRIM_SCALE = -0.03; // remove the base trim so the fascia rides the cushion edge without a gap
 const CHROME_CORNER_NOTCH_WEDGE_SCALE = 0;
-const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.052; // carry the fascia farther over the cushion radius so the chrome lip meets the jaw edge like the reference
-const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 0.052; // mirror the deeper wrap so both axes cover the full pocket reveal
+const CHROME_CORNER_FIELD_CLIP_WIDTH_SCALE = 0.034; // extend the fascia slightly farther along the arc so the chrome starts flush with the pocket curve
+const CHROME_CORNER_FIELD_CLIP_DEPTH_SCALE = 0.034; // mirror the extension along the second axis so the rounded arc ends stay covered
 const CHROME_CORNER_FIELD_FILLET_SCALE = 0; // match the pocket radius exactly without additional rounding
-const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0.012; // allow a hair of extra fascia depth so the chrome plate seats flush with the jaws
+const CHROME_CORNER_FIELD_EXTENSION_SCALE = 0; // keep fascia depth identical to Pool Royale
 const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1; // no scaling so the notch mirrors the pocket radius perfectly
 const CHROME_CORNER_DIMENSION_SCALE = 1; // keep the fascia dimensions identical to the cushion span so both surfaces meet cleanly
-const CHROME_CORNER_WIDTH_SCALE = 1.006; // widen the chrome plate to match the photographed rail coverage up to the jaw line
-const CHROME_CORNER_HEIGHT_SCALE = 0.996; // lift the fascia coverage on the short rail so it mirrors the corner wrap in the photos
-const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.01; // ease the offset so the chrome sits centred under the thicker jaw lip
+const CHROME_CORNER_WIDTH_SCALE = 0.978; // shave the chrome plate slightly so it ends at the jaw line on the long rail
+const CHROME_CORNER_HEIGHT_SCALE = 0.962; // mirror the trim on the short rail so the fascia meets the jaw corner without overlap
+const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.02; // align corner fascia offset with the Pool Royale chrome plates
 const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0; // let the corner fascia terminate precisely where the cushion noses stop
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0; // stop pulling the chrome off the short-rail centreline so the jaws stay flush
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker baseline
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
-  CHROME_CORNER_POCKET_RADIUS_SCALE *
-  1.028; // mirror snooker side arches while widening to the photographed middle-pocket chrome radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // match snooker rail rounding so the chrome sits flush
+  CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 0; // keep the wooden rail corners crisp with no rounding on the frame
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
@@ -440,30 +439,30 @@ const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the notch depth identical to th
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
 const CHROME_PLATE_REFLECTION_SCALE = 0.28; // kill pocket-cut reflections by damping env-map intensity on fascia cuts
 const CHROME_PLATE_ROUGHNESS_LIFT = 0.08; // lift roughness on fascia cuts so pocket arches stop casting hot spots on cloth
-const CHROME_PLATE_THICKNESS_SCALE = 0.033; // lift fascia depth to the beefier chrome lip seen in the reference captures
-const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.26; // mirror the deeper middle fascia so all plates share the same heft
+const CHROME_PLATE_THICKNESS_SCALE = 0.0306; // match diamond thickness on the wooden rails for fascia depth
+const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so its depth now matches the corner plates
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0; // keep fascia placement identical to snooker
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.32; // extend the side fascia span so the middle pockets gain the same wraparound as the corners
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 2.88; // grow fascia reach so the middle pocket cuts are fully framed like the photo reference
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2; // push the side fascia farther along the arch so it blankets the larger chrome reveal
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.36; // widen fascia span so the middle plates hug the pocket mouths exactly like the captures
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.34; // push fascia outward to cloak the wood up to the jaw line as seen on-device
-const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 1; // restore full middle fascia width while keeping the rounded cut and outer edge unchanged
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.62; // trim fascia span further so the middle plates finish before intruding into the pocket zone while keeping the rounded edge intact
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.68; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
+const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.986; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.08; // keep the fascia centred over the pocket reveal so both chrome edges mirror the photos
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.052; // open the chrome corner cut to match the photographed jaw reveal
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.1; // widen and deepen the middle chrome arch so it matches the side-pocket captures
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.38; // draw the middle chrome arch farther toward centre for the symmetric jaw alignment in the reference
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.94; // relax the wooden rail pocket relief slightly so the wood cut follows the broader chrome wrap
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
+const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.02; // keep middle rail arches snug while letting the chrome-and-jaw alignment stay balanced
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0.2; // pull the middle-pocket wood arch farther toward centre so the smaller radius aligns with the tighter inboard cut
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.018; // push the middle rail rounded cuts slightly farther outward so they sit farther from the table centre while keeping their slim profile
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.08; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
 
 function buildChromePlateGeometry({
   width,
@@ -869,13 +868,14 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const PINK_FROM_TOP = PINK_FROM_TOP_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
-const POCKET_CORNER_MOUTH_SCALE = 1; // enforce the official WPBSA corner mouth width after scaling
-const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 1; // keep the side pocket mouth at the official scaled width for snooker
+const POCKET_CORNER_MOUTH_SCALE =
+  CORNER_POCKET_SCALE_BOOST * CORNER_POCKET_EXTRA_SCALE; // mirror the Pool Royale jaw openness while staying on the snooker footprint
+const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 0.972; // shrink the middle pocket mouth width a touch more so the radius tightens up further
 const POCKET_SIDE_MOUTH_SCALE =
   (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
   POCKET_CORNER_MOUTH_SCALE *
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // preserve the official side-to-corner ratio while reusing the Pool Royale pocket fascia
-const SIDE_POCKET_CUT_SCALE = 0.972; // make the middle cloth/rail cutouts a touch smaller without altering fascia or jaw geometry
+const SIDE_POCKET_CUT_SCALE = 0.968; // trim the middle cloth/rail cutouts a bit more so the openings follow the tighter pocket radius
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -883,13 +883,13 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.3 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts slightly farther outward toward the rails
+  POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
 const CORNER_RAIL_NOTCH_INSET =
-  POCKET_VIS_R * 0.066 * POCKET_VISUAL_EXPANSION; // let the rail and chrome cutouts follow the outward corner pocket shift
+  POCKET_VIS_R * 0.078 * POCKET_VISUAL_EXPANSION; // let the rail and chrome cutouts follow the outward corner pocket shift
 const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
@@ -953,8 +953,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.072; // lower the cushion base slightly so the lip sits closer to the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops further so they sit a touch lower than before
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.088; // lower the cushion base further so the lip sits at the same stance as Pool Royale despite smaller snooker balls
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.24; // drop the cushion tops a little more to match the Pool Royale height profile
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -2282,16 +2282,11 @@ const LIGHTING_OPTIONS = Object.freeze([
     label: 'Studio Soft',
     description: 'Gentle TV studio fill with reduced contrast for practice.',
     settings: {
-      hemiSky: 0xe3ecff,
-      hemiGround: 0x0c101c,
-      hemiIntensity: 1.02,
-      rimIntensity: 0.62,
-      dirColor: 0xf5f7fb,
-      dirIntensity: 1.2,
-      spotColor: 0xfafcff,
-      spotIntensity: 9.6,
-      spotAngle: Math.PI * 0.4,
-      ambientIntensity: 0.14
+      stripeColor: 0xf5f7fb,
+      stripeIntensity: 1.08,
+      stripeSecondaryIntensity: 0.96,
+      ambientColor: 0xfafcff,
+      ambientIntensity: 0.18
     }
   },
   {
@@ -2299,15 +2294,10 @@ const LIGHTING_OPTIONS = Object.freeze([
     label: 'Arena Prime',
     description: 'Tour stadium key with crisp specular pickup.',
     settings: {
-      hemiSky: 0xdfe8ff,
-      hemiGround: 0x0a0f1a,
-      hemiIntensity: 1.08,
-      rimIntensity: 0.76,
-      dirColor: 0xf6f8ff,
-      dirIntensity: 1.42,
-      spotColor: 0xffffff,
-      spotIntensity: 11.4,
-      spotAngle: Math.PI * 0.36,
+      stripeColor: 0xf6f8ff,
+      stripeIntensity: 1.42,
+      stripeSecondaryIntensity: 1.22,
+      ambientColor: 0xffffff,
       ambientIntensity: 0.16
     }
   },
@@ -2316,15 +2306,10 @@ const LIGHTING_OPTIONS = Object.freeze([
     label: 'Proscenium Contrast',
     description: 'High-contrast stage look with tight rim control.',
     settings: {
-      hemiSky: 0xd8e3ff,
-      hemiGround: 0x0b0f1c,
-      hemiIntensity: 0.96,
-      rimIntensity: 0.9,
-      dirColor: 0xf2f5ff,
-      dirIntensity: 1.58,
-      spotColor: 0xf7fbff,
-      spotIntensity: 12.2,
-      spotAngle: Math.PI * 0.34,
+      stripeColor: 0xf2f5ff,
+      stripeIntensity: 1.58,
+      stripeSecondaryIntensity: 1.34,
+      ambientColor: 0xf7fbff,
       ambientIntensity: 0.12
     }
   },
@@ -2333,15 +2318,10 @@ const LIGHTING_OPTIONS = Object.freeze([
     label: 'Noir Telecast',
     description: 'Cool broadcast grade with soft rim and wider beam.',
     settings: {
-      hemiSky: 0xcfd9ec,
-      hemiGround: 0x0c111c,
-      hemiIntensity: 1,
-      rimIntensity: 0.82,
-      dirColor: 0xeaf1ff,
-      dirIntensity: 1.28,
-      spotColor: 0xf5f8ff,
-      spotIntensity: 10.2,
-      spotAngle: Math.PI * 0.42,
+      stripeColor: 0xeaf1ff,
+      stripeIntensity: 1.26,
+      stripeSecondaryIntensity: 1.08,
+      ambientColor: 0xf8fbff,
       ambientIntensity: 0.18
     }
   }
@@ -9346,32 +9326,37 @@ export function PoolRoyaleGame({
   const applyLightingPreset = useCallback(
     (presetId = lightingId) => {
       const rig = lightingRigRef.current;
-      const world = worldRef.current;
-      if (!rig || !world) return;
+      if (!rig) return;
       const preset =
         LIGHTING_PRESET_MAP[presetId] ?? LIGHTING_PRESET_MAP[DEFAULT_LIGHTING_ID];
       const settings = preset?.settings ?? {};
       const {
-        hemisphere,
-        hemisphereRig,
-        dirLight,
-        spot,
+        leftStripe,
+        rightStripe,
         ambient
       } = rig;
 
-      if (settings.hemiSky && hemisphere) hemisphere.color.set(settings.hemiSky);
-      if (settings.hemiGround && hemisphereRig)
-        hemisphereRig.groundColor.set(settings.hemiGround);
-      if (settings.hemiIntensity && hemisphere)
-        hemisphere.intensity = settings.hemiIntensity;
-      if (settings.rimIntensity && hemisphereRig)
-        hemisphereRig.intensity = settings.rimIntensity;
-      if (settings.dirColor && dirLight) dirLight.color.set(settings.dirColor);
-      if (settings.dirIntensity && dirLight) dirLight.intensity = settings.dirIntensity;
-      if (settings.spotColor && spot) spot.color.set(settings.spotColor);
-      if (settings.spotIntensity && spot) spot.intensity = settings.spotIntensity;
-      if (settings.spotAngle && spot) spot.angle = settings.spotAngle;
-      if (settings.ambientIntensity && ambient)
+      if (settings.stripeColor !== undefined) {
+        if (leftStripe) leftStripe.color.set(settings.stripeColor);
+        if (rightStripe) rightStripe.color.set(settings.stripeColor);
+      }
+      const primaryIntensity =
+        settings.stripeIntensity !== undefined
+          ? settings.stripeIntensity
+          : leftStripe?.intensity;
+      if (leftStripe && Number.isFinite(primaryIntensity)) {
+        leftStripe.intensity = primaryIntensity;
+      }
+      const secondaryIntensity =
+        settings.stripeSecondaryIntensity !== undefined
+          ? settings.stripeSecondaryIntensity
+          : primaryIntensity;
+      if (rightStripe && Number.isFinite(secondaryIntensity)) {
+        rightStripe.intensity = secondaryIntensity;
+      }
+      if (settings.ambientColor !== undefined && ambient)
+        ambient.color.set(settings.ambientColor);
+      if (ambient && settings.ambientIntensity !== undefined)
         ambient.intensity = settings.ambientIntensity;
     },
     [lightingId]
@@ -13161,93 +13146,51 @@ export function PoolRoyaleGame({
         window.addEventListener('keydown', keyRot);
 
       // Lights
-      // Adopt the lighting rig from the standalone snooker demo and scale all
-      // authored coordinates so they sit correctly over the larger table.
+      // Replace the legacy multi-light rig with two elongated stripe keys that sit
+      // above each long rail. This mirrors the real snooker canopy while staying
+      // lightweight for mobile rendering.
       const addMobileLighting = () => {
         const lightingRig = new THREE.Group();
         world.add(lightingRig);
 
-        const SAMPLE_PLAY_W = 1.216;
-        const SAMPLE_PLAY_H = 2.536;
-        const SAMPLE_TABLE_HEIGHT = 0.75;
+        const rigHeight = tableSurfaceY + TABLE.THICK * 6.25;
+        const stripeOffsetX = Math.max(PLAY_W * 0.22, TABLE.THICK * 3.6);
+        const stripeForwardPull = TABLE.THICK * 0.6;
+        const stripeTargetY = tableSurfaceY + BALL_R * 0.08;
+        const shadowHalfSpan = Math.max(PLAY_W, PLAY_H) * 0.8 + TABLE.THICK * 3.2;
+        const shadowDepth = rigHeight + TABLE.THICK * 12;
 
-        const LIGHT_DIMENSION_SCALE = 0.8; // reduce fixture footprint by 20%
-        const LIGHT_HEIGHT_SCALE = 1.4; // lift the rig further above the table
-        const LIGHT_HEIGHT_LIFT_MULTIPLIER = 5.8; // bring fixtures closer so the spot highlight reads on the balls
-        const LIGHT_LATERAL_SCALE = 0.45; // pull shadow-casting lights nearer the table centre
+        const createStripe = (side = 1, castShadow = false) => {
+          const stripe = new THREE.DirectionalLight(0xffffff, 1.3);
+          stripe.position.set(side * stripeOffsetX, rigHeight, stripeForwardPull);
+          stripe.target.position.set(side * stripeOffsetX * 0.12, stripeTargetY, 0);
+          stripe.castShadow = castShadow;
+          if (castShadow) {
+            stripe.shadow.mapSize.set(1024, 1024);
+            stripe.shadow.camera.near = 0.1;
+            stripe.shadow.camera.far = shadowDepth;
+            stripe.shadow.camera.left = -shadowHalfSpan;
+            stripe.shadow.camera.right = shadowHalfSpan;
+            stripe.shadow.camera.top = shadowHalfSpan;
+            stripe.shadow.camera.bottom = -shadowHalfSpan;
+            stripe.shadow.bias = -0.00004;
+            stripe.shadow.normalBias = 0.0008;
+            stripe.shadow.camera.updateProjectionMatrix();
+          }
+          lightingRig.add(stripe);
+          lightingRig.add(stripe.target);
+          return stripe;
+        };
 
-        const baseWidthScale = (PLAY_W / SAMPLE_PLAY_W) * LIGHT_DIMENSION_SCALE;
-        const baseLengthScale = (PLAY_H / SAMPLE_PLAY_H) * LIGHT_DIMENSION_SCALE;
-        const fixtureScale = Math.max(baseWidthScale, baseLengthScale);
-        const heightScale = Math.max(0.001, TABLE_H / SAMPLE_TABLE_HEIGHT);
-        const scaledHeight = heightScale * LIGHT_HEIGHT_SCALE;
-
-        const hemisphere = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.758625);
-        const lightHeightLift = scaledHeight * LIGHT_HEIGHT_LIFT_MULTIPLIER; // lift the lighting rig higher above the table
-        const triangleHeight = tableSurfaceY + 6.6 * scaledHeight + lightHeightLift;
-        const triangleRadius = fixtureScale * 0.98;
-        const lightRetreatOffset = scaledHeight * 0.24;
-        const lightReflectionGuard = scaledHeight * 0.32;
-        hemisphere.position.set(0, triangleHeight, -triangleRadius * 0.6);
-        lightingRig.add(hemisphere);
-
-        const hemisphereRig = new THREE.HemisphereLight(0xdde7ff, 0x0b1020, 0.4284);
-        hemisphereRig.position.set(0, triangleHeight, 0);
-        lightingRig.add(hemisphereRig);
-
-        const dirLight = new THREE.DirectionalLight(0xffffff, 1.176);
-        dirLight.position.set(
-          -triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight,
-          triangleRadius * LIGHT_LATERAL_SCALE * 0.4
-        );
-        dirLight.target.position.set(0, tableSurfaceY + BALL_R * 0.05, 0);
-        lightingRig.add(dirLight);
-        lightingRig.add(dirLight.target);
-
-        const spot = new THREE.SpotLight(
-          0xffffff,
-          12.289725,
-          0,
-          Math.PI * 0.36,
-          0.42,
-          1
-        );
-        spot.position.set(
-          triangleRadius * LIGHT_LATERAL_SCALE,
-          triangleHeight + lightRetreatOffset + lightReflectionGuard,
-          triangleRadius * LIGHT_LATERAL_SCALE * (0.35 + LIGHT_LATERAL_SCALE * 0.12)
-        );
-        spot.target.position.set(0, tableSurfaceY + TABLE_H * 0.18, 0);
-        spot.decay = 1.0;
-        spot.castShadow = true;
-        spot.shadow.mapSize.set(2048, 2048);
-        spot.shadow.bias = -0.00004;
-        spot.shadow.normalBias = 0.006;
-        lightingRig.add(spot);
-        lightingRig.add(spot.target);
-
-        const ambient = new THREE.AmbientLight(
-          0xffffff,
-          0.0223125
-        ); // match the snooker ambient fill for identical arena lighting
-        ambient.position.set(
-          0,
-          tableSurfaceY +
-            scaledHeight * 1.95 +
-            lightHeightLift +
-            lightRetreatOffset +
-            lightReflectionGuard,
-          triangleRadius * LIGHT_LATERAL_SCALE * 0.12
-        );
+        const leftStripe = createStripe(-1, true);
+        const rightStripe = createStripe(1, false);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.14);
         lightingRig.add(ambient);
 
         lightingRigRef.current = {
           group: lightingRig,
-          hemisphere,
-          hemisphereRig,
-          dirLight,
-          spot,
+          leftStripe,
+          rightStripe,
           ambient
         };
         applyLightingPreset();


### PR DESCRIPTION
## Summary
- replace the snooker lighting rig with two lightweight strip keys and updated presets for the broadcast options
- align pocket jaw, chrome fascia, and wooden rail shaping with the Pool Royale profile so cuts sit farther out from the jaws
- lower the cushion stack slightly to mirror Pool Royale proportions despite the smaller snooker balls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d820ffc10832997d0b644714baee1)