### PR TITLE
Add cache recovery and broaden service worker registration

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -3,11 +3,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { registerTelegramServiceWorker } from './pwa/registerServiceWorker.js';
+import { installChunkErrorRecovery } from './utils/cacheRecovery.js';
 
 // Prevent Telegram in-app browser swipe-down from closing the game
 if (window.Telegram?.WebApp?.disableVerticalSwipes) {
   window.Telegram.WebApp.disableVerticalSwipes();
 }
+
+// Auto-recover from stale caches that can blank the screen
+installChunkErrorRecovery();
 
 // Register a Telegram-friendly service worker for instant updates
 registerTelegramServiceWorker();

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,11 +1,12 @@
-const TELEGRAM_ONLY = true;
+const TELEGRAM_ONLY = false;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
 
-function shouldRegisterForTelegram() {
+function shouldRegisterServiceWorker() {
   if (!('serviceWorker' in navigator)) return false;
   const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
-  if (isLocalhost) return true;
-  if (TELEGRAM_ONLY && !window.Telegram?.WebApp) return false;
+  const inTelegram = Boolean(window.Telegram?.WebApp);
+  if (!isLocalhost && !window.isSecureContext) return false;
+  if (TELEGRAM_ONLY && !inTelegram) return false;
   return true;
 }
 
@@ -63,7 +64,9 @@ async function requestPersistentStorage() {
 }
 
 export async function registerTelegramServiceWorker() {
-  if (!shouldRegisterForTelegram()) return;
+  if (!shouldRegisterServiceWorker()) {
+    return;
+  }
 
   try {
     const hadController = Boolean(navigator.serviceWorker.controller);

--- a/webapp/src/utils/cacheRecovery.js
+++ b/webapp/src/utils/cacheRecovery.js
@@ -1,0 +1,69 @@
+const RECOVERY_FLAG = 'tonplaygram-cache-recovered';
+
+async function clearTonplaygramCaches() {
+  if (!('caches' in window)) return;
+  try {
+    const keys = await caches.keys();
+    const targets = keys.filter((key) => key.includes('tonplaygram'));
+    await Promise.all(targets.map((key) => caches.delete(key)));
+  } catch (err) {
+    console.warn('Cache cleanup skipped', err);
+  }
+}
+
+async function refreshServiceWorkers() {
+  if (!('serviceWorker' in navigator)) return;
+  try {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(
+      regs.map(async (reg) => {
+        try {
+          await reg.update();
+        } catch {
+          // noop
+        }
+      })
+    );
+  } catch {
+    // ignore
+  }
+}
+
+async function recoverFromChunkError() {
+  if (sessionStorage.getItem(RECOVERY_FLAG)) return;
+  sessionStorage.setItem(RECOVERY_FLAG, '1');
+  await clearTonplaygramCaches();
+  await refreshServiceWorkers();
+  window.location.reload();
+}
+
+function isChunkLoadError(event) {
+  if (!event) return false;
+  if (event?.message?.includes?.('ChunkLoadError')) return true;
+  if (event?.error?.name === 'ChunkLoadError') return true;
+  if (typeof event?.reason === 'object' && event.reason?.name === 'ChunkLoadError') return true;
+  if (typeof event?.reason === 'string' && event.reason.includes('ChunkLoadError')) return true;
+  const target = event?.target;
+  if (target?.tagName === 'SCRIPT' && target.src?.includes('/assets/')) return true;
+  return false;
+}
+
+export function installChunkErrorRecovery() {
+  window.addEventListener(
+    'error',
+    (event) => {
+      if (isChunkLoadError(event)) {
+        event.preventDefault?.();
+        recoverFromChunkError();
+      }
+    },
+    true
+  );
+
+  window.addEventListener('unhandledrejection', (event) => {
+    if (isChunkLoadError(event)) {
+      event.preventDefault?.();
+      recoverFromChunkError();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- enable the service worker on all secure browsers instead of limiting to Telegram-only loads
- add a chunk load recovery hook to clear stale caches and refresh the page if the app would otherwise blank out
- wire the recovery hook into app startup to keep browser users on Chrome and others running smoothly

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d90858f7883299763fe06617eff05)