### PR TITLE
Harden service worker handling for browsers

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -10,7 +10,11 @@ if (window.Telegram?.WebApp?.disableVerticalSwipes) {
 }
 
 // Register a Telegram-friendly service worker for instant updates
-registerTelegramServiceWorker();
+try {
+  registerTelegramServiceWorker();
+} catch (err) {
+  console.warn('Skipping service worker registration', err);
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,6 +1,23 @@
 const TELEGRAM_ONLY = true;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
 
+function safeSetSession(key, value) {
+  try {
+    sessionStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeGetSession(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
 function shouldRegisterForTelegram() {
   if (!('serviceWorker' in navigator)) return false;
   const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
@@ -10,17 +27,41 @@ function shouldRegisterForTelegram() {
 }
 
 function markRefreshed() {
-  sessionStorage.setItem(REFRESH_FLAG_KEY, '1');
+  safeSetSession(REFRESH_FLAG_KEY, '1');
 }
 
 function hasRefreshedAlready() {
-  return sessionStorage.getItem(REFRESH_FLAG_KEY) === '1';
+  return safeGetSession(REFRESH_FLAG_KEY) === '1';
 }
 
 function forceReloadOnceReady() {
   if (hasRefreshedAlready()) return;
   markRefreshed();
   window.location.reload();
+}
+
+async function unregisterStaleServiceWorkers() {
+  if (!('serviceWorker' in navigator) || !navigator.serviceWorker?.getRegistrations) return;
+
+  try {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    if (!registrations.length) return;
+
+    await Promise.all(registrations.map(reg => reg.unregister()));
+    try {
+      const cacheNames = await caches.keys();
+      await Promise.all(cacheNames.map(name => caches.delete(name)));
+    } catch {
+      // Cache cleanup is best-effort
+    }
+
+    if (navigator.serviceWorker.controller && !hasRefreshedAlready()) {
+      markRefreshed();
+      window.location.reload();
+    }
+  } catch (err) {
+    console.warn('Service worker cleanup failed', err);
+  }
 }
 
 function wireUpdateFlow(registration, shouldReload) {
@@ -63,7 +104,10 @@ async function requestPersistentStorage() {
 }
 
 export async function registerTelegramServiceWorker() {
-  if (!shouldRegisterForTelegram()) return;
+  if (!shouldRegisterForTelegram()) {
+    unregisterStaleServiceWorkers();
+    return;
+  }
 
   try {
     const hadController = Boolean(navigator.serviceWorker.controller);


### PR DESCRIPTION
## Summary
- guard service worker session storage access to avoid bootstrap failures
- clean up stale registrations and caches when opened outside Telegram so browser users avoid black screens
- wrap the service worker registration call to prevent the app from breaking if registration fails

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d90858f7883299763fe06617eff05)