### PR TITLE
Improve PWA auto-update and offline caching

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -46,7 +46,7 @@ export default function Home() {
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
-  const runtimeCacheName = 'tonplaygram-runtime-v2';
+  const runtimeCacheName = 'tonplaygram-runtime-v3';
 
 
   const handlePwaDownload = async () => {

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,5 +1,6 @@
 const TELEGRAM_ONLY = true;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
+const CACHE_OFFLINE_MESSAGE = { type: 'CACHE_OFFLINE_BUNDLE' };
 
 function shouldRegisterForTelegram() {
   if (!('serviceWorker' in navigator)) return false;
@@ -62,6 +63,15 @@ async function requestPersistentStorage() {
   }
 }
 
+async function prewarmOfflineBundle() {
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    registration.active?.postMessage(CACHE_OFFLINE_MESSAGE);
+  } catch (err) {
+    // Best-effort; ignore failures
+  }
+}
+
 export async function registerTelegramServiceWorker() {
   if (!shouldRegisterForTelegram()) return;
 
@@ -74,6 +84,8 @@ export async function registerTelegramServiceWorker() {
     wireUpdateFlow(registration, hadController);
     registration.update();
     requestPersistentStorage();
+    prewarmOfflineBundle();
+    navigator.serviceWorker.addEventListener('controllerchange', prewarmOfflineBundle);
 
     // Refresh in-session to pick up any new build without prompting the user
     document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- bump service worker cache versions and pre-cache the offline bundle from the manifest to speed up repeat loads
- request the offline cache warmup from the client and keep the auto-update flow skip-waiting
- align the runtime cache name used by the manual offline downloader with the new cache version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e1d2455b4832997029e5985663622)