### PR TITLE
Lower pool ball texture resolution to prevent solids/stripes crash

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -1,7 +1,10 @@
 import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
-const BALL_TEXTURE_SIZE = 4096; // ultra high resolution for sharper billiard ball textures
+// Pool Royale generates up to 15 numbered + striped textures when players pick the
+// Solids & Stripes skin for UK 8-ball. At 4096px this was exhausting mobile GPUs
+// and crashing the session, so dial the texture size back to keep memory in check.
+const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 


### PR DESCRIPTION
## Summary
- reduce the pool ball texture size to 1024px so the Solids & Stripes skin no longer allocates huge GPU textures
- document the memory rationale to prevent mobile crashes when loading 8 Pool UK with the alternative ball set

## Testing
- npm --prefix webapp run build
- npm test -- poolRoyale *(fails: Jest does not support node:test hooks, so `test.after` is undefined in this suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2197cc9883298710481927d6215f)