### PR TITLE
Add chrome foot pads to pool and snooker tables

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8721,8 +8721,15 @@ function Table3D(
   const legTopWorld = legTopLocal + TABLE_Y;
   const legBottomWorld = FLOOR_Y;
   const legReach = Math.max(legTopWorld - legBottomWorld, TABLE_H);
-  const legH = legReach + LEG_TOP_OVERLAP;
+  const legFootingHeight = TABLE.THICK * 0.045;
+  const legH = Math.max(MICRO_EPS, legReach + LEG_TOP_OVERLAP - legFootingHeight);
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 64);
+  const footPadGeo = new THREE.CylinderGeometry(
+    legR * 1.55,
+    legR * 1.4,
+    legFootingHeight,
+    48
+  );
   const legInset = baseRailWidth * 2.85;
   const legPositions = [
     [-frameOuterX + legInset, -frameOuterZ + legInset],
@@ -8734,6 +8741,8 @@ function Table3D(
   ];
   const legY = legTopLocal + LEG_TOP_OVERLAP - legH / 2;
   const legCircumference = 2 * Math.PI * legR;
+  const floorLocal = FLOOR_Y - TABLE_Y;
+  const footPadY = floorLocal + legFootingHeight / 2;
   // Match the skirt/apron wood grain with the cue butt so the pattern reads
   // clearly from the player perspective.
   const baseFrameFallback = {
@@ -8790,6 +8799,14 @@ function Table3D(
     leg.receiveShadow = true;
     table.add(leg);
     finishParts.legMeshes.push(leg);
+
+    const foot = new THREE.Mesh(footPadGeo, trimMat);
+    foot.position.set(lx, footPadY, lz);
+    foot.castShadow = true;
+    foot.receiveShadow = true;
+    foot.userData = { ...(foot.userData || {}), isChromePlate: true };
+    table.add(foot);
+    finishParts.trimMeshes.push(foot);
   });
 
   table.updateMatrixWorld(true);

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -7914,8 +7914,15 @@ function Table3D(
   const legTopWorld = legTopLocal + TABLE_Y;
   const legBottomWorld = FLOOR_Y;
   const legReach = Math.max(legTopWorld - legBottomWorld, TABLE_H);
-  const legH = legReach + LEG_TOP_OVERLAP;
+  const legFootingHeight = TABLE.THICK * 0.045;
+  const legH = Math.max(MICRO_EPS, legReach + LEG_TOP_OVERLAP - legFootingHeight);
   const legGeo = new THREE.CylinderGeometry(legR, legR, legH, 64);
+  const footPadGeo = new THREE.CylinderGeometry(
+    legR * 1.55,
+    legR * 1.4,
+    legFootingHeight,
+    48
+  );
   const legInset = baseRailWidth * 2.2;
   const legPositions = [
     [-frameOuterX + legInset, -frameOuterZ + legInset],
@@ -7927,6 +7934,8 @@ function Table3D(
   ];
   const legY = legTopLocal + LEG_TOP_OVERLAP - legH / 2;
   const legCircumference = 2 * Math.PI * legR;
+  const floorLocal = FLOOR_Y - TABLE_Y;
+  const footPadY = floorLocal + legFootingHeight / 2;
   // Match the skirt/apron wood grain with the cue butt so the pattern reads
   // clearly from the player perspective.
   const baseFrameFallback = {
@@ -7974,6 +7983,14 @@ function Table3D(
     leg.receiveShadow = true;
     table.add(leg);
     finishParts.legMeshes.push(leg);
+
+    const foot = new THREE.Mesh(footPadGeo, trimMat);
+    foot.position.set(lx, footPadY, lz);
+    foot.castShadow = true;
+    foot.receiveShadow = true;
+    foot.userData = { ...(foot.userData || {}), isChromePlate: true };
+    table.add(foot);
+    finishParts.trimMeshes.push(foot);
   });
 
   table.updateMatrixWorld(true);


### PR DESCRIPTION
## Summary
- add chrome-toned footing plates beneath each pool and snooker table leg to match the reference look
- shorten leg meshes to sit on the new pads and keep their color locked to the chrome trim selection

## Testing
- Not run (not requested)
- Attempted Playwright screenshot of /games/poolroyale timed out while loading the scene


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e287bb9008329af20c98def2f787c)