### PR TITLE
Add fallback source bundle when Telegram APK missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ The server honors a few extra environment variables when building or serving the
 - `TELEGRAM_APK_URL` – optional absolute URL for the Telegram launcher APK. If unset, drop the APK into
   `webapp/public/downloads/tonplaygram-telegram-launcher.apk` (or override the file name with
   `TELEGRAM_APK_FILE`) and the backend will expose it at `/api/downloads/apk` and
-  `/downloads/<filename>` so users can grab the entire web app and bundled games from one link.
+  `/downloads/<filename>` so users can grab the entire web app and bundled games from one link. If no APK is present,
+  the server now generates a ZIP bundle of the project (excluding `node_modules`, `.env*`, built assets and private
+  binaries) so the download button always returns a usable package without leaking credentials.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/bot/routes/downloads.js
+++ b/bot/routes/downloads.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
+import archiver from 'archiver';
 import path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync, createWriteStream, copyFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 const router = Router();
@@ -10,6 +11,9 @@ const apkFileName = process.env.TELEGRAM_APK_FILE || 'tonplaygram-telegram-launc
 const apkRelativePath = path.join('downloads', apkFileName);
 const envApkUrl = (process.env.TELEGRAM_APK_URL || process.env.VITE_TELEGRAM_APK_URL || '').trim();
 const publicHint = 'Place the APK at webapp/public/downloads/ or set TELEGRAM_APK_URL.';
+const codeBundleFile = process.env.TELEGRAM_CODE_BUNDLE || 'tonplaygram-source-bundle.zip';
+const codeBundleRelativePath = path.join('downloads', codeBundleFile);
+const repoRoot = path.join(__dirname, '../..');
 
 function resolveLocalApk() {
   const distPath = path.join(__dirname, '../../webapp/dist', apkRelativePath);
@@ -19,26 +23,94 @@ function resolveLocalApk() {
   return null;
 }
 
-router.get('/apk', (req, res) => {
+function ensureServedFile(localPath, relativePath) {
+  const distTarget = path.join(__dirname, '../../webapp/dist', relativePath);
+  if (!existsSync(distTarget)) {
+    mkdirSync(path.dirname(distTarget), { recursive: true });
+    copyFileSync(localPath, distTarget);
+  }
+  return distTarget;
+}
+
+function originFromRequest(req) {
+  return (process.env.PUBLIC_APP_URL || `${req.protocol}://${req.get('host')}`).replace(/\/$/, '');
+}
+
+async function generateCodeBundle(targetPath) {
+  return new Promise((resolve, reject) => {
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    const output = createWriteStream(targetPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    output.on('close', () => resolve(targetPath));
+    archive.on('error', reject);
+
+    archive.pipe(output);
+    archive.glob('**/*', {
+      cwd: repoRoot,
+      ignore: [
+        '**/node_modules/**',
+        '**/.git/**',
+        '**/.env*',
+        'webapp/dist/**',
+        'webapp/public/downloads/**',
+        '**/*.log',
+        'billiards.Unity/**'
+      ]
+    });
+
+    archive.finalize();
+  });
+}
+
+async function ensureCodeBundle() {
+  const distPath = path.join(__dirname, '../../webapp/dist', codeBundleRelativePath);
+  if (existsSync(distPath)) return { path: distPath, source: 'dist' };
+
+  const publicPath = path.join(__dirname, '../../webapp/public', codeBundleRelativePath);
+  if (existsSync(publicPath)) {
+    ensureServedFile(publicPath, codeBundleRelativePath);
+    return { path: distPath, source: 'public' };
+  }
+
+  await generateCodeBundle(publicPath);
+  ensureServedFile(publicPath, codeBundleRelativePath);
+  return { path: distPath, source: 'generated' };
+}
+
+router.get('/apk', async (req, res) => {
   if (envApkUrl) {
     return res.json({ url: envApkUrl, source: 'env' });
   }
 
-  const localApk = resolveLocalApk();
-  if (localApk) {
-    const origin =
-      (process.env.PUBLIC_APP_URL || `${req.protocol}://${req.get('host')}`).replace(/\/$/, '');
-    const normalizedPath = apkRelativePath.replace(/\\/g, '/');
+  try {
+    const localApk = resolveLocalApk();
+    if (localApk) {
+      ensureServedFile(localApk, apkRelativePath);
+      const origin = originFromRequest(req);
+      const normalizedPath = apkRelativePath.replace(/\\/g, '/');
+      return res.json({
+        url: `${origin}/${normalizedPath}`,
+        source: localApk.includes('/dist/') ? 'dist' : 'public'
+      });
+    }
+
+    const bundle = await ensureCodeBundle();
+    const origin = originFromRequest(req);
+    const normalizedPath = codeBundleRelativePath.replace(/\\/g, '/');
     return res.json({
       url: `${origin}/${normalizedPath}`,
-      source: localApk.includes('/dist/') ? 'dist' : 'public'
+      source: bundle.source,
+      type: 'zip',
+      message: 'Fallback code bundle without private credentials or node_modules.'
+    });
+  } catch (err) {
+    console.error('Failed to resolve apk download:', err);
+    return res.status(500).json({
+      error: 'Failed to build download link',
+      hint: publicHint
     });
   }
-
-  return res.status(404).json({
-    error: 'APK link not configured',
-    hint: publicHint
-  });
 });
 
 export default router;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "archiver": "^7.0.1",
     "dotenv": "^16.3.1",
     "emoji-name-map": "^2.0.3",
     "express": "^4.19.2",

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -44,6 +44,7 @@ export default function Home() {
     []
   );
   const [telegramApkUrl, setTelegramApkUrl] = useState(defaultTelegramApkUrl);
+  const [apkLinkType, setApkLinkType] = useState('apk');
   const [apkLinkError, setApkLinkError] = useState('');
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
@@ -117,6 +118,7 @@ export default function Home() {
       if (cancelled) return;
       if (result?.url) {
         setTelegramApkUrl(result.url);
+        setApkLinkType(result.type || 'apk');
         setApkLinkError('');
       } else if (!defaultTelegramApkUrl) {
         setApkLinkError(result?.error || 'APK link not configured yet.');
@@ -251,13 +253,27 @@ export default function Home() {
       <div className="mt-4 bg-surface border border-border rounded-xl p-4 space-y-3">
         <div className="text-center space-y-1">
           <h3 className="text-lg font-semibold text-white">Telegram APK launcher</h3>
-          <p className="text-sm text-subtext">
-            Download the Telegram-optimized APK to bundle the entire TonPlaygram web app and all games into one launch
-            link inside the Telegram browser.
-          </p>
-          <p className="text-[11px] text-subtext">
-            Use the Telegram in-app browser to download and install the launcher for the best experience.
-          </p>
+          {apkLinkType === 'apk' ? (
+            <>
+              <p className="text-sm text-subtext">
+                Download the Telegram-optimized APK to bundle the entire TonPlaygram web app and all games into one
+                launch link inside the Telegram browser.
+              </p>
+              <p className="text-[11px] text-subtext">
+                Use the Telegram in-app browser to download and install the launcher for the best experience.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-subtext">
+                APK not yet uploaded. Download the full TonPlaygram web bundle (without private credentials or
+                node_modules) to sideload or inspect the code while the official APK is prepared.
+              </p>
+              <p className="text-[11px] text-subtext">
+                The ZIP includes the webapp and games; sensitive files like .env and build artifacts are excluded.
+              </p>
+            </>
+          )}
         </div>
         <div className="space-y-3">
           <a
@@ -275,7 +291,11 @@ export default function Home() {
               }
             }}
           >
-            {telegramApkUrl ? 'Download Telegram APK' : 'APK link not available yet'}
+            {telegramApkUrl
+              ? apkLinkType === 'apk'
+                ? 'Download Telegram APK'
+                : 'Download source bundle (ZIP)'
+              : 'APK link not available yet'}
           </a>
           <div className="space-y-1 text-xs text-subtext text-left bg-background/50 border border-border rounded-lg p-3">
             <p className="text-white font-semibold text-sm">Install via Telegram</p>


### PR DESCRIPTION
## Summary
- generate a sanitized ZIP bundle when no Telegram launcher APK is available and serve it via the existing download endpoint
- add the archiver dependency required for on-demand bundle creation
- update the homepage download CTA and documentation to clarify the ZIP fallback when the APK is missing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e52f49d6483298d9d3d9a6046dbfc)