### PR TITLE
Adjust Pool Royale AI cue pacing and camera limits

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1212,7 +1212,7 @@ const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_GAP = BALL_R * 1.45; // pull cue stick slightly farther back for a more natural stance
 const CUE_PULL_BASE = BALL_R * 10 * 0.65 * 1.2;
-const CUE_PULL_SMOOTHING = 0.35;
+const CUE_PULL_SMOOTHING = 0.55;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.05; // drop cue height slightly so the tip lines up with the cue ball centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const CUE_BUTT_LIFT = BALL_R * 0.62; // raise the butt a little more so the rear clears rails while the tip stays aligned
@@ -4958,7 +4958,7 @@ const STANDING_VIEW_MARGIN = 0.0016; // pull the standing frame closer so the ta
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.1;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.32; // halt the downward sweep sooner so the lowest angle stays slightly higher and stops above the cue
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.38; // lift the lowest cue view a touch more so the angle stays higher above the cue
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.018; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
@@ -5118,18 +5118,21 @@ const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 24; // keep camera in standing view 
 const SHORT_RAIL_POCKET_TRIGGER =
   RAIL_LIMIT_Y - POCKET_VIS_R * 0.45; // request pocket cams as soon as play reaches the short rail mouths
 const SHORT_RAIL_POCKET_INTENT_COOLDOWN_MS = 280;
-const AI_MIN_SHOT_TIME_MS = 5000;
-const AI_MAX_SHOT_TIME_MS = 7000;
-const AI_MIN_AIM_PREVIEW_MS = 900;
+const AI_MIN_SHOT_TIME_MS = 7000;
+const AI_MAX_SHOT_TIME_MS = 10000;
+const AI_STANDING_VIEW_MIN_MS = 2000;
+const AI_STANDING_VIEW_MAX_MS = 4000;
+const AI_CUE_DROP_TIME_MIN_MS = 3000;
+const AI_CUE_DROP_TIME_MAX_MS = 5000;
+const AI_MIN_AIM_PREVIEW_MS =
+  AI_STANDING_VIEW_MIN_MS + AI_CUE_DROP_TIME_MIN_MS + 520; // enforce a full stare + slow drop window before firing
 const AI_EARLY_SHOT_DIFFICULTY = 120;
 const AI_EARLY_SHOT_CUE_DISTANCE = PLAY_H * 0.55;
 const AI_EARLY_SHOT_DELAY_MS = AI_MIN_SHOT_TIME_MS; // never bypass the full telegraphed aim window
 const AI_THINKING_BUDGET_MS =
   AI_MAX_SHOT_TIME_MS - AI_MIN_AIM_PREVIEW_MS; // leave room for the cue preview while keeping decisions under 7 seconds
-const AI_CAMERA_DROP_LEAD_MS = 420; // start lowering into cue view shortly before the AI pulls the trigger
-const AI_CAMERA_SETTLE_MS = 320; // allow time for the cue view to settle before firing
+const AI_CAMERA_SETTLE_MS = 520; // allow extra time for the slow cue view drop to stabilise before firing
 const AI_CAMERA_DROP_BLEND = 0.14;
-const AI_CAMERA_DROP_DURATION_MS = 480;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
@@ -16608,10 +16611,17 @@ const powerRef = useRef(hud.power);
           const now = performance.now();
           const startedAt = aiShotWindowRef.current?.startedAt ?? now;
           const duration = aiShotWindowRef.current?.duration ?? AI_MIN_SHOT_TIME_MS;
+          const standMs =
+            aiShotWindowRef.current?.standMs ??
+            THREE.MathUtils.randInt(AI_STANDING_VIEW_MIN_MS, AI_STANDING_VIEW_MAX_MS);
+          const dropMs =
+            aiShotWindowRef.current?.dropMs ??
+            THREE.MathUtils.randInt(AI_CUE_DROP_TIME_MIN_MS, AI_CUE_DROP_TIME_MAX_MS);
           const elapsed = Math.max(0, now - startedAt);
           const maxRemaining = Math.max(0, AI_MAX_SHOT_TIME_MS - elapsed);
           const targetRemaining = duration - elapsed;
-          const desiredWindow = Math.max(AI_MIN_AIM_PREVIEW_MS, targetRemaining);
+          const minPreview = standMs + dropMs + AI_CAMERA_SETTLE_MS;
+          const desiredWindow = Math.max(minPreview, targetRemaining, AI_MIN_AIM_PREVIEW_MS);
           return Math.min(maxRemaining, desiredWindow);
         };
         const scheduleEarlyAiShot = (plan) => {
@@ -17540,13 +17550,24 @@ const powerRef = useRef(hud.power);
             return;
           }
           const started = performance.now();
-          const windowDuration = THREE.MathUtils.randInt(
+          const standMs = THREE.MathUtils.randInt(
+            AI_STANDING_VIEW_MIN_MS,
+            AI_STANDING_VIEW_MAX_MS
+          );
+          const dropMs = THREE.MathUtils.randInt(
+            AI_CUE_DROP_TIME_MIN_MS,
+            AI_CUE_DROP_TIME_MAX_MS
+          );
+          const windowDuration = THREE.MathUtils.clamp(
+            standMs + dropMs + AI_CAMERA_SETTLE_MS + 1200,
             AI_MIN_SHOT_TIME_MS,
             AI_MAX_SHOT_TIME_MS
           );
           aiShotWindowRef.current = {
             startedAt: started,
-            duration: windowDuration
+            duration: windowDuration,
+            standMs,
+            dropMs
           };
           const thinkingBudget = Math.min(
             AI_THINKING_BUDGET_MS,
@@ -17814,14 +17835,34 @@ const powerRef = useRef(hud.power);
               clearTimeout(aiShotCueDropTimeoutRef.current);
               aiShotCueDropTimeoutRef.current = null;
             }
-            const previewDelayMs = resolveAiPreviewDelay();
-            const dropDelay = Math.max(0, previewDelayMs - AI_CAMERA_DROP_LEAD_MS);
-            const shotDelay = Math.max(previewDelayMs, dropDelay + AI_CAMERA_SETTLE_MS);
+            const standMs =
+              aiShotWindowRef.current?.standMs ??
+              THREE.MathUtils.randInt(
+                AI_STANDING_VIEW_MIN_MS,
+                AI_STANDING_VIEW_MAX_MS
+              );
+            const dropMs =
+              aiShotWindowRef.current?.dropMs ??
+              THREE.MathUtils.randInt(
+                AI_CUE_DROP_TIME_MIN_MS,
+                AI_CUE_DROP_TIME_MAX_MS
+              );
+            const previewDelayMs = Math.max(
+              resolveAiPreviewDelay(),
+              standMs + dropMs + AI_CAMERA_SETTLE_MS
+            );
+            const clampedDropMs = THREE.MathUtils.clamp(
+              dropMs,
+              AI_CUE_DROP_TIME_MIN_MS,
+              AI_CUE_DROP_TIME_MAX_MS
+            );
+            const dropDelay = Math.max(standMs, 0);
+            const shotDelay = dropDelay + clampedDropMs + AI_CAMERA_SETTLE_MS;
             const beginCueView = () => {
               setAiShotCueViewActive(true);
               setAiShotPreviewActive(false);
               aiCueViewBlendRef.current = AI_CAMERA_DROP_BLEND;
-              tweenCameraBlend(aiCueViewBlendRef.current, AI_CAMERA_DROP_DURATION_MS);
+              tweenCameraBlend(aiCueViewBlendRef.current, clampedDropMs);
               if (aiShotTimeoutRef.current) {
                 clearTimeout(aiShotTimeoutRef.current);
               }


### PR DESCRIPTION
## Summary
- Slow down Pool Royale AI shot routine with explicit standing and cue-drop windows plus longer settle time before firing
- Raise the cue camera minimum tilt to keep the view slightly higher above the cue during aiming
- Increase cue pull smoothing so slider pulls visibly move the cue stick in sync before the shot

## Testing
- jest --runTestsByPath webapp/src/pages/Games/PoolRoyale.jsx --watch=false *(fails: no tests defined for this path)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb28785b883298aab7e01d68f145c)