### PR TITLE
Add Poly Haven cloths and leather stool theme to Murlan Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -92,6 +92,118 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: 'Golden amber felt with cinematic warmth.'
   },
   {
+    id: 'cloth-denimFabric03',
+    type: 'tableCloth',
+    optionId: 'denim_fabric_03',
+    name: 'Denim Fabric 03 Cloth',
+    price: 460,
+    description: 'Denim-inspired felt with deep indigo threads.'
+  },
+  {
+    id: 'cloth-hessian230',
+    type: 'tableCloth',
+    optionId: 'hessian_230',
+    name: 'Hessian 230 Cloth',
+    price: 480,
+    description: 'Rustic hessian weave with warm earthy tones.'
+  },
+  {
+    id: 'cloth-polarFleece',
+    type: 'tableCloth',
+    optionId: 'polar_fleece',
+    name: 'Polar Fleece Cloth',
+    price: 500,
+    description: 'Soft polar fleece texture with airy highlights.'
+  },
+  {
+    id: 'cloth-cottonJersey',
+    type: 'tableCloth',
+    optionId: 'cotton_jersey',
+    name: 'Cotton Jersey Cloth',
+    price: 520,
+    description: 'Smooth jersey knit with balanced midtones.'
+  },
+  {
+    id: 'cloth-leatherWeave',
+    type: 'tableCloth',
+    optionId: 'fabric_leather_02',
+    name: 'Leather Weave Cloth',
+    price: 540,
+    description: 'Leather-inspired weave with luxe sheen.'
+  },
+  {
+    id: 'cloth-fauxFurGeo',
+    type: 'tableCloth',
+    optionId: 'faux_fur_geometric',
+    name: 'Faux Fur Geo Cloth',
+    price: 560,
+    description: 'Geometric faux fur nap with soft gradients.'
+  },
+  {
+    id: 'cloth-joggingMelange',
+    type: 'tableCloth',
+    optionId: 'jogging_melange',
+    name: 'Jogging Mélange Cloth',
+    price: 580,
+    description: 'Heathered mélange felt for sport styling.'
+  },
+  {
+    id: 'cloth-knittedFleece',
+    type: 'tableCloth',
+    optionId: 'knitted_fleece',
+    name: 'Knitted Fleece Cloth',
+    price: 600,
+    description: 'Knitted fleece with plush depth and warmth.'
+  },
+  {
+    id: 'cloth-caban',
+    type: 'tableCloth',
+    optionId: 'caban',
+    name: 'Caban Wool Cloth',
+    price: 620,
+    description: 'Caban wool texture with tawny undertones.'
+  },
+  {
+    id: 'cloth-curlyTeddyNatural',
+    type: 'tableCloth',
+    optionId: 'curly_teddy_natural',
+    name: 'Curly Teddy Natural Cloth',
+    price: 640,
+    description: 'Natural teddy curl with soft, pale fibers.'
+  },
+  {
+    id: 'cloth-curlyTeddyCheckered',
+    type: 'tableCloth',
+    optionId: 'curly_teddy_checkered',
+    name: 'Curly Teddy Checkered Cloth',
+    price: 660,
+    description: 'Checkered teddy weave with teal accents.'
+  },
+  {
+    id: 'cloth-denimFabric04',
+    type: 'tableCloth',
+    optionId: 'denim_fabric_04',
+    name: 'Denim Fabric 04 Cloth',
+    price: 680,
+    description: 'Bright indigo denim cloth with crisp texture.'
+  },
+  {
+    id: 'cloth-denimFabric05',
+    type: 'tableCloth',
+    optionId: 'denim_fabric_05',
+    name: 'Denim Fabric 05 Cloth',
+    price: 700,
+    description: 'Dark denim cloth with modern graphite threads.'
+  },
+  {
+    id: 'cloth-scubaSuede',
+    type: 'tableCloth',
+    optionId: 'scuba_suede',
+    name: 'Scuba Suede Cloth',
+    price: 720,
+    description: 'Suede-like scuba finish with deep teal tone.'
+  },
+  {
     id: 'base-forestBronze',
     type: 'tableBase',
     optionId: 'forestBronze',
@@ -210,6 +322,14 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     name: 'Frost Stools',
     price: 290,
     description: 'Frosted charcoal seats with dark legs.'
+  },
+  {
+    id: 'stool-leather',
+    type: 'stools',
+    optionId: 'leather',
+    name: 'Leather Stools',
+    price: 320,
+    description: 'Leather-wrapped seats with dark studio legs.'
   }
 ];
 

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -13,5 +13,6 @@ export const MURLAN_STOOL_THEMES = [
   { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
   { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
   { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
-  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' }
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' },
+  { id: 'leather', label: 'Leather', seatColor: '#6a4a32', legColor: '#1a1410' }
 ];

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -1,6 +1,56 @@
 import { WOOD_FINISH_PRESETS, WOOD_GRAIN_OPTIONS, WOOD_GRAIN_OPTIONS_BY_ID } from './woodMaterials.js';
 import { CARD_THEMES } from './cardThemes.js';
 
+const numberToHex = (value) => `#${value.toString(16).padStart(6, '0')}`;
+const normalizeHex = (value) => (typeof value === 'number' ? numberToHex(value) : value);
+
+const tintHex = (hex, factor) => {
+  const normalized = normalizeHex(hex).replace('#', '');
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  const clamp = (channel) => Math.max(0, Math.min(255, Math.round(channel)));
+  const adjust = (channel) => {
+    const delta = factor >= 0 ? (255 - channel) * factor : channel * factor;
+    return clamp(channel + delta);
+  };
+  const next = (adjust(r) << 16) | (adjust(g) << 8) | adjust(b);
+  return numberToHex(next);
+};
+
+const buildClothOption = (
+  id,
+  label,
+  baseColor,
+  { topTint = 0.08, bottomTint = -0.12, emissiveTint = -0.65 } = {}
+) => {
+  const baseHex = normalizeHex(baseColor);
+  return {
+    id,
+    label,
+    feltTop: tintHex(baseHex, topTint),
+    feltBottom: tintHex(baseHex, bottomTint),
+    emissive: tintHex(baseHex, emissiveTint)
+  };
+};
+
+const POLY_HAVEN_CLOTHS = [
+  { id: 'denim_fabric_03', label: 'Denim Fabric 03 Cloth', base: 0x2b4a7a },
+  { id: 'hessian_230', label: 'Hessian 230 Cloth', base: 0x9b7a45 },
+  { id: 'polar_fleece', label: 'Polar Fleece Cloth', base: 0xd9d2c2 },
+  { id: 'cotton_jersey', label: 'Cotton Jersey Cloth', base: 0xb9a27d },
+  { id: 'fabric_leather_02', label: 'Leather Weave Cloth', base: 0x6a4a32 },
+  { id: 'faux_fur_geometric', label: 'Faux Fur Geo Cloth', base: 0xcaa0a8 },
+  { id: 'jogging_melange', label: 'Jogging Mélange Cloth', base: 0x7a7a7f },
+  { id: 'knitted_fleece', label: 'Knitted Fleece Cloth', base: 0x6e5a4a },
+  { id: 'caban', label: 'Caban Wool Cloth', base: 0xb56a2a },
+  { id: 'curly_teddy_natural', label: 'Curly Teddy Natural Cloth', base: 0xcdbfa9 },
+  { id: 'curly_teddy_checkered', label: 'Curly Teddy Checkered Cloth', base: 0x2f6a70 },
+  { id: 'denim_fabric_04', label: 'Denim Fabric 04 Cloth', base: 0x4a78a8 },
+  { id: 'denim_fabric_05', label: 'Denim Fabric 05 Cloth', base: 0x2c2f35 },
+  { id: 'scuba_suede', label: 'Scuba Suede Cloth', base: 0x2a8c86 }
+];
+
 export const WOOD_PRESETS_BY_ID = Object.freeze(
   WOOD_FINISH_PRESETS.reduce((acc, preset) => {
     acc[preset.id] = preset;
@@ -21,7 +71,8 @@ export const TABLE_CLOTH_OPTIONS = [
   { id: 'arctic', label: 'Arctic Cloth', feltTop: '#2563eb', feltBottom: '#1d4ed8', emissive: '#071a42' },
   { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
   { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
-  { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' }
+  { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' },
+  ...POLY_HAVEN_CLOTHS.map((option) => buildClothOption(option.id, option.label, option.base))
 ];
 
 export const TABLE_BASE_OPTIONS = [


### PR DESCRIPTION
## Summary
- add verified Poly Haven cloth options to the Murlan Royale table customization and store lineup
- derive cloth color ramps programmatically to keep felt/emissive tones consistent
- introduce a leather stool theme so chairs can be wrapped in the leather finish

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec8a6e5608329a7eb75f2e774ab00)