### PR TITLE
Update Pool Royale cloth catalog and textures

### DIFF
--- a/webapp/src/config/poolRoyaleClothCatalog.js
+++ b/webapp/src/config/poolRoyaleClothCatalog.js
@@ -1,0 +1,82 @@
+const normalizeHex = (value) => {
+  if (typeof value === 'number') {
+    return `#${value.toString(16).padStart(6, '0')}`;
+  }
+  const str = `${value ?? ''}`.trim();
+  if (!str) return '#000000';
+  return str.startsWith('#') ? str : `#${str}`;
+};
+
+const clamp01 = (value) => Math.max(0, Math.min(1, value));
+
+const hexToRgb = (hex) => {
+  const normalized = normalizeHex(hex).replace('#', '');
+  const int = parseInt(normalized, 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255
+  };
+};
+
+const rgbToHex = (r, g, b) =>
+  `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+
+export const mixHex = (a, b, factor = 0.5) => {
+  const t = clamp01(factor);
+  const start = hexToRgb(a);
+  const end = hexToRgb(b);
+  const lerp = (from, to) => Math.round(from + (to - from) * t);
+  return rgbToHex(lerp(start.r, end.r), lerp(start.g, end.g), lerp(start.b, end.b));
+};
+
+export const lightenHex = (hex, factor = 0.2) => mixHex(hex, '#ffffff', factor);
+
+export const POOL_ROYALE_CLOTH_TINTS = Object.freeze([
+  Object.freeze({ id: 'green', label: 'Green Tint', hex: '#25d366' }),
+  Object.freeze({ id: 'blue', label: 'Blue Tint', hex: '#2f80ff' })
+]);
+
+export const POOL_ROYALE_BASE_CLOTHS = Object.freeze([
+  Object.freeze({ id: 'denim_fabric_03', label: 'Denim Fabric 03 Cloth', fallbackColor: 0x2b4a7a }),
+  Object.freeze({ id: 'hessian_230', label: 'Hessian 230 Cloth', fallbackColor: 0x9b7a45 }),
+  Object.freeze({ id: 'polar_fleece', label: 'Polar Fleece Cloth', fallbackColor: 0xd9d2c2 }),
+  Object.freeze({ id: 'cotton_jersey', label: 'Cotton Jersey Cloth', fallbackColor: 0xb9a27d }),
+  Object.freeze({ id: 'faux_fur_geometric', label: 'Faux Fur Geo Cloth', fallbackColor: 0xcaa0a8 }),
+  Object.freeze({ id: 'jogging_melange', label: 'Jogging Mélange Cloth', fallbackColor: 0x7a7a7f }),
+  Object.freeze({ id: 'knitted_fleece', label: 'Knitted Fleece Cloth', fallbackColor: 0x6e5a4a }),
+  Object.freeze({ id: 'caban', label: 'Caban Wool Cloth', fallbackColor: 0xb56a2a }),
+  Object.freeze({ id: 'curly_teddy_natural', label: 'Curly Teddy Natural Cloth', fallbackColor: 0xcdbfa9 }),
+  Object.freeze({ id: 'curly_teddy_checkered', label: 'Curly Teddy Checkered Cloth', fallbackColor: 0x2f6a70 }),
+  Object.freeze({ id: 'denim_fabric_04', label: 'Denim Fabric 04 Cloth', fallbackColor: 0x4a78a8 }),
+  Object.freeze({ id: 'denim_fabric_05', label: 'Denim Fabric 05 Cloth', fallbackColor: 0x2c2f35 })
+]);
+
+export const buildPoolRoyalClothVariants = () =>
+  POOL_ROYALE_BASE_CLOTHS.flatMap((cloth) =>
+    POOL_ROYALE_CLOTH_TINTS.map((tint) => {
+      const tintedHex = mixHex(cloth.fallbackColor, tint.hex, 0.35);
+      return {
+        id: `${cloth.id}-${tint.id}`,
+        baseId: cloth.id,
+        tintId: tint.id,
+        label: `${cloth.label} (${tint.label})`,
+        tintLabel: tint.label,
+        baseHex: normalizeHex(cloth.fallbackColor),
+        tintHex: tint.hex,
+        tintedHex
+      };
+    })
+  );
+
+export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
+  buildPoolRoyalClothVariants().map((variant) => Object.freeze(variant))
+);
+export const DEFAULT_POOL_ROYALE_CLOTH_ID = POOL_ROYALE_CLOTH_VARIANTS[0]?.id ?? 'denim_fabric_03-green';
+
+export const POOL_ROYALE_CLOTH_SWATCHES = Object.freeze(
+  POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
+    acc[variant.id] = [variant.tintedHex, lightenHex(variant.tintedHex, 0.22)];
+    return acc;
+  }, {})
+);

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,8 +1,20 @@
+import {
+  DEFAULT_POOL_ROYALE_CLOTH_ID,
+  POOL_ROYALE_CLOTH_VARIANTS
+} from './poolRoyaleClothCatalog.js';
+
+const CLOTH_LABELS = Object.freeze(
+  POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
+    acc[variant.id] = `${variant.label}`;
+    return acc;
+  }, {})
+);
+
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['charredTimber'],
   chromeColor: ['gold'],
   railMarkerColor: ['gold'],
-  clothColor: ['freshGreen'],
+  clothColor: [DEFAULT_POOL_ROYALE_CLOTH_ID],
   cueStyle: ['birch-frost'],
   pocketLiner: ['blackPocket']
 });
@@ -27,23 +39,7 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     pearl: 'Pearl',
     gold: 'Gold'
   }),
-  clothColor: Object.freeze({
-    freshGreen: 'Tour Green',
-    graphite: 'Arcadia Graphite',
-    arcticBlue: 'Arctic Blue',
-    emeraldPulse: 'Emerald Pulse',
-    ivyDrift: 'Ivy Drift',
-    mintRadiance: 'Mint Radiance',
-    cobaltFrost: 'Cobalt Frost',
-    midnightWave: 'Midnight Wave',
-    neonAzure: 'Neon Azure',
-    crimsonFlash: 'Crimson Flash',
-    rubyInferno: 'Ruby Inferno',
-    garnetVelvet: 'Garnet Velvet',
-    forestPrime: 'Forest Prime',
-    evergreenLuxe: 'Evergreen Luxe',
-    jadeCurrent: 'Jade Current'
-  }),
+  clothColor: Object.freeze(CLOTH_LABELS),
   cueStyle: Object.freeze({
     'redwood-ember': 'Redwood Ember',
     'birch-frost': 'Birch Frost',
@@ -146,118 +142,14 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 240,
     description: 'Chrome-lined diamond markers that match fascia shine.'
   },
-  {
-    id: 'cloth-graphite',
+  ...POOL_ROYALE_CLOTH_VARIANTS.map((variant, index) => ({
+    id: `cloth-${variant.id}`,
     type: 'clothColor',
-    optionId: 'graphite',
-    name: 'Arcadia Graphite Cloth',
-    price: 520,
-    description: 'Tournament graphite cloth for a darker arena feel.'
-  },
-  {
-    id: 'cloth-arcticBlue',
-    type: 'clothColor',
-    optionId: 'arcticBlue',
-    name: 'Arctic Blue Cloth',
-    price: 560,
-    description: 'Cool arctic blue tournament cloth with crisp sheen.'
-  },
-  {
-    id: 'cloth-emeraldPulse',
-    type: 'clothColor',
-    optionId: 'emeraldPulse',
-    name: 'Emerald Pulse Cloth',
-    price: 590,
-    description: 'Glowing emerald cloth with a pulsing luxe nap.'
-  },
-  {
-    id: 'cloth-ivyDrift',
-    type: 'clothColor',
-    optionId: 'ivyDrift',
-    name: 'Ivy Drift Cloth',
-    price: 610,
-    description: 'Deep ivy cloth with shaded railside gradients.'
-  },
-  {
-    id: 'cloth-mintRadiance',
-    type: 'clothColor',
-    optionId: 'mintRadiance',
-    name: 'Mint Radiance Cloth',
-    price: 620,
-    description: 'Bright mint cloth that lifts ambient highlights.'
-  },
-  {
-    id: 'cloth-cobaltFrost',
-    type: 'clothColor',
-    optionId: 'cobaltFrost',
-    name: 'Cobalt Frost Cloth',
-    price: 630,
-    description: 'Frosted cobalt cloth with crisp cool reflections.'
-  },
-  {
-    id: 'cloth-midnightWave',
-    type: 'clothColor',
-    optionId: 'midnightWave',
-    name: 'Midnight Wave Cloth',
-    price: 640,
-    description: 'Midnight navy cloth with wavey sapphire sheen.'
-  },
-  {
-    id: 'cloth-neonAzure',
-    type: 'clothColor',
-    optionId: 'neonAzure',
-    name: 'Neon Azure Cloth',
-    price: 660,
-    description: 'Electric azure cloth with high-contrast glow.'
-  },
-  {
-    id: 'cloth-crimsonFlash',
-    type: 'clothColor',
-    optionId: 'crimsonFlash',
-    name: 'Crimson Flash Cloth',
-    price: 670,
-    description: 'Deep crimson cloth with bright ruby sheen for bold arenas.'
-  },
-  {
-    id: 'cloth-rubyInferno',
-    type: 'clothColor',
-    optionId: 'rubyInferno',
-    name: 'Ruby Inferno Cloth',
-    price: 680,
-    description: 'Hot ruby felt with fiery highlights tuned for neon rigs.'
-  },
-  {
-    id: 'cloth-garnetVelvet',
-    type: 'clothColor',
-    optionId: 'garnetVelvet',
-    name: 'Garnet Velvet Cloth',
-    price: 690,
-    description: 'Velvet garnet nap with dark wine undertones.'
-  },
-  {
-    id: 'cloth-forestPrime',
-    type: 'clothColor',
-    optionId: 'forestPrime',
-    name: 'Forest Prime Cloth',
-    price: 620,
-    description: 'Deep forest tournament cloth with neutral grain.'
-  },
-  {
-    id: 'cloth-evergreenLuxe',
-    type: 'clothColor',
-    optionId: 'evergreenLuxe',
-    name: 'Evergreen Luxe Cloth',
-    price: 640,
-    description: 'Luxe evergreen felt with polished highlights.'
-  },
-  {
-    id: 'cloth-jadeCurrent',
-    type: 'clothColor',
-    optionId: 'jadeCurrent',
-    name: 'Jade Current Cloth',
-    price: 650,
-    description: 'Jade-tinted cloth with cool current-like sheen.'
-  },
+    optionId: variant.id,
+    name: `${variant.label}`,
+    price: 640 + (index % 2) * 20 + Math.floor(index / 2) * 6,
+    description: `High-resolution Poly Haven weave with a ${variant.tintLabel.toLowerCase()} bias and pronounced texture.`
+  })),
   {
     id: 'pocket-graphite',
     type: 'pocketLiner',
@@ -368,7 +260,11 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
   { type: 'tableFinish', optionId: 'charredTimber', label: 'Charred Timber Finish' },
   { type: 'chromeColor', optionId: 'gold', label: 'Gold Chrome Plates' },
   { type: 'railMarkerColor', optionId: 'gold', label: 'Gold Diamond Markers' },
-  { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
+  {
+    type: 'clothColor',
+    optionId: DEFAULT_POOL_ROYALE_CLOTH_ID,
+    label: CLOTH_LABELS[DEFAULT_POOL_ROYALE_CLOTH_ID] ?? POOL_ROYALE_CLOTH_VARIANTS[0]?.label
+  },
   { type: 'cueStyle', optionId: 'birch-frost', label: 'Birch Frost Cue' },
   { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' }
 ];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -41,6 +41,7 @@ import {
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
 import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../config/poolRoyaleInventoryConfig.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothCatalog.js';
 import {
   getCachedPoolRoyalInventory,
   getPoolRoyalInventory,
@@ -1682,10 +1683,10 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 0.74;
-const CLOTH_HAIR_INTENSITY = 0.7;
-const CLOTH_BUMP_INTENSITY = 0.94;
-const CLOTH_SOFT_BLEND = 0.42;
+const CLOTH_TEXTURE_INTENSITY = 0.9;
+const CLOTH_HAIR_INTENSITY = 0.76;
+const CLOTH_BUMP_INTENSITY = 1.08;
+const CLOTH_SOFT_BLEND = 0.36;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
@@ -2413,376 +2414,72 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
   }
 ]);
 
-// Palettes derived from CC0 textile scans (ambientCG FabricWool series) and
-// popular tournament felts so every option mirrors a real pool cloth.
-const CLOTH_TEXTURE_PRESETS = Object.freeze({
-  freshGreen: Object.freeze({
-    id: 'freshGreen',
-    palette: {
-      shadow: 0x1d8048,
-      base: 0x3ab86e,
-      accent: 0x54cf88,
-      highlight: 0x7ef2af
-    },
-    sparkle: 1,
-    stray: 1
-  }),
-  snookerGreen: Object.freeze({
-    id: 'snookerGreen',
-    palette: {
-      shadow: 0x1c5b35,
-      base: 0x2d7f4b,
-      accent: 0x3f9b60,
-      highlight: 0x59c57f
-    },
-    sparkle: 0.9,
-    stray: 0.96
-  }),
-  graphite: Object.freeze({
-    id: 'graphite',
-    palette: {
-      shadow: 0x181b23,
-      base: 0x3d414e,
-      accent: 0x626a7b,
-      highlight: 0x95a1b6
-    },
-    sparkle: 0.65,
-    stray: 0.9
-  }),
-  arcticBlue: Object.freeze({
-    id: 'arcticBlue',
-    palette: {
-      shadow: 0x1c4f73,
-      base: 0x3f84b8,
-      accent: 0x5aa7d8,
-      highlight: 0x9ac9ed
-    },
-    sparkle: 1.05,
-    stray: 1.12
-  }),
-  emeraldPulse: Object.freeze({
-    id: 'emeraldPulse',
-    palette: {
-      shadow: 0x0f4c2f,
-      base: 0x1b8a51,
-      accent: 0x2eae68,
-      highlight: 0x58d994
-    },
-    sparkle: 1.08,
-    stray: 1.05
-  }),
-  ivyDrift: Object.freeze({
-    id: 'ivyDrift',
-    palette: {
-      shadow: 0x0d3320,
-      base: 0x1b5c33,
-      accent: 0x2d7a49,
-      highlight: 0x4aa76d
-    },
-    sparkle: 0.9,
-    stray: 0.92
-  }),
-  mintRadiance: Object.freeze({
-    id: 'mintRadiance',
-    palette: {
-      shadow: 0x1f5338,
-      base: 0x3a9662,
-      accent: 0x54b67c,
-      highlight: 0x83d7a5
-    },
-    sparkle: 1.12,
-    stray: 1.18
-  }),
-  cobaltFrost: Object.freeze({
-    id: 'cobaltFrost',
-    palette: {
-      shadow: 0x0d3c73,
-      base: 0x1f6ecf,
-      accent: 0x4da2ff,
-      highlight: 0x8fd3ff
-    },
-    sparkle: 1,
-    stray: 1.05
-  }),
-  midnightWave: Object.freeze({
-    id: 'midnightWave',
-    palette: {
-      shadow: 0x0d1f38,
-      base: 0x1c3f7a,
-      accent: 0x2f5a9d,
-      highlight: 0x4f7fbf
-    },
-    sparkle: 0.82,
-    stray: 0.88
-  }),
-  neonAzure: Object.freeze({
-    id: 'neonAzure',
-    palette: {
-      shadow: 0x0f3e64,
-      base: 0x2b8ac2,
-      accent: 0x46b1e4,
-      highlight: 0x7ad5ff
-    },
-    sparkle: 1.18,
-    stray: 1.2
-  }),
-  crimsonFlash: Object.freeze({
-    id: 'crimsonFlash',
-    palette: {
-      shadow: 0x2a0b14,
-      base: 0x8c1224,
-      accent: 0xb81f35,
-      highlight: 0xf2455c
-    },
-    sparkle: 1.04,
-    stray: 1.02
-  }),
-  rubyInferno: Object.freeze({
-    id: 'rubyInferno',
-    palette: {
-      shadow: 0x2c0f12,
-      base: 0x9f1e2f,
-      accent: 0xd43145,
-      highlight: 0xff6a7a
-    },
-    sparkle: 1.08,
-    stray: 1.1
-  }),
-  garnetVelvet: Object.freeze({
-    id: 'garnetVelvet',
-    palette: {
-      shadow: 0x190910,
-      base: 0x702136,
-      accent: 0x9b2f4a,
-      highlight: 0xc4576d
-    },
-    sparkle: 0.92,
-    stray: 0.9
-  }),
-  forestPrime: Object.freeze({
-    id: 'forestPrime',
-    palette: {
-      shadow: 0x0e2f1d,
-      base: 0x1f6d3c,
-      accent: 0x2f8a55,
-      highlight: 0x4fb67a
-    },
-    sparkle: 0.88,
-    stray: 0.94
-  }),
-  evergreenLuxe: Object.freeze({
-    id: 'evergreenLuxe',
-    palette: {
-      shadow: 0x103923,
-      base: 0x2a7c4c,
-      accent: 0x3f9961,
-      highlight: 0x65c08a
-    },
-    sparkle: 1.02,
-    stray: 1
-  }),
-  jadeCurrent: Object.freeze({
-    id: 'jadeCurrent',
-    palette: {
-      shadow: 0x0f3f2d,
-      base: 0x2a8b63,
-      accent: 0x40a57c,
-      highlight: 0x6ccca4
-    },
-    sparkle: 1.1,
-    stray: 1.12
-  })
+const FALLBACK_CLOTH_VARIANT = Object.freeze({
+  id: 'denim_fabric_03-green',
+  label: 'Denim Fabric 03 Cloth (Green Tint)',
+  baseHex: '#2b4a7a',
+  tintHex: '#25d366',
+  tintedHex: '#3ea16d'
 });
 
-const DEFAULT_CLOTH_TEXTURE_KEY = 'freshGreen';
-const DEFAULT_CLOTH_COLOR_ID = 'freshGreen';
-const CLOTH_COLOR_OPTIONS = Object.freeze([
-  {
-    id: 'freshGreen',
-    label: 'Tour Green',
-    color: 0x55cf93,
-    textureKey: 'freshGreen',
-    detail: {
-      bumpMultiplier: 1,
-      sheen: 0.55,
-      sheenRoughness: 0.46,
-      emissiveIntensity: 0.36
-    }
-  },
-  {
-    id: 'graphite',
-    label: 'Arcadia Graphite',
-    color: 0x4a5566,
-    textureKey: 'graphite',
-    detail: {
-      bumpMultiplier: 0.92,
-      roughness: 0.72,
-      envMapIntensity: 0.16
-    }
-  },
-  {
-    id: 'arcticBlue',
-    label: 'Arctic Blue',
-    color: 0x5aa7d8,
-    textureKey: 'arcticBlue',
-    detail: {
-      sheen: 0.58,
-      sheenRoughness: 0.46,
-      envMapIntensity: 0.14
-    }
-  },
-  {
-    id: 'emeraldPulse',
-    label: 'Emerald Pulse',
-    color: 0x1f9d5a,
-    textureKey: 'emeraldPulse',
-    detail: {
-      sheen: 0.6,
-      sheenRoughness: 0.5,
-      bumpMultiplier: 1.05,
-      emissiveIntensity: 0.32
-    }
-  },
-  {
-    id: 'ivyDrift',
-    label: 'Ivy Drift',
-    color: 0x1b5c33,
-    textureKey: 'ivyDrift',
-    detail: {
-      sheen: 0.56,
-      sheenRoughness: 0.5,
-      roughness: 0.78,
-      bumpMultiplier: 0.96,
-      envMapIntensity: 0.1
-    }
-  },
-  {
-    id: 'mintRadiance',
-    label: 'Mint Radiance',
-    color: 0x3fa56b,
-    textureKey: 'mintRadiance',
-    detail: {
-      sheen: 0.64,
-      sheenRoughness: 0.46,
-      emissiveIntensity: 0.36,
-      envMapIntensity: 0.18
-    }
-  },
-  {
-    id: 'cobaltFrost',
-    label: 'Cobalt Frost',
-    color: 0x3388e0,
-    textureKey: 'cobaltFrost',
-    detail: {
-      sheen: 0.66,
-      sheenRoughness: 0.38,
-      bumpMultiplier: 1.02,
-      envMapIntensity: 0.22
-    }
-  },
-  {
-    id: 'midnightWave',
-    label: 'Midnight Wave',
-    color: 0x1c3f7a,
-    textureKey: 'midnightWave',
-    detail: {
-      roughness: 0.84,
-      bumpMultiplier: 0.9,
-      emissiveIntensity: 0.24
-    }
-  },
-  {
-    id: 'neonAzure',
-    label: 'Neon Azure',
-    color: 0x2b9ad6,
-    textureKey: 'neonAzure',
-    detail: {
-      sheen: 0.7,
-      sheenRoughness: 0.4,
-      bumpMultiplier: 1.05,
-      emissiveIntensity: 0.34,
-      envMapIntensity: 0.18
-    }
-  },
-  {
-    id: 'crimsonFlash',
-    label: 'Crimson Flash',
-    color: 0x9c1a2b,
-    textureKey: 'crimsonFlash',
-    detail: {
-      sheen: 0.62,
-      sheenRoughness: 0.42,
-      bumpMultiplier: 1.02,
-      emissiveIntensity: 0.44,
-      envMapIntensity: 0.18
-    }
-  },
-  {
-    id: 'rubyInferno',
-    label: 'Ruby Inferno',
-    color: 0xaf2136,
-    textureKey: 'rubyInferno',
-    detail: {
-      sheen: 0.7,
-      sheenRoughness: 0.38,
-      bumpMultiplier: 1.08,
-      emissiveIntensity: 0.48,
-      envMapIntensity: 0.22
-    }
-  },
-  {
-    id: 'garnetVelvet',
-    label: 'Garnet Velvet',
-    color: 0x7a2c3f,
-    textureKey: 'garnetVelvet',
-    detail: {
-      roughness: 0.82,
-      bumpMultiplier: 0.94,
-      sheen: 0.54,
-      sheenRoughness: 0.48,
-      envMapIntensity: 0.14
-    }
-  },
-  {
-    id: 'forestPrime',
-    label: 'Forest Prime',
-    color: 0x1f6d3c,
-    textureKey: 'forestPrime',
-    detail: {
-      roughness: 0.76,
-      sheen: 0.6,
-      sheenRoughness: 0.48,
-      emissiveIntensity: 0.28,
-      envMapIntensity: 0.12
-    }
-  },
-  {
-    id: 'evergreenLuxe',
-    label: 'Evergreen Luxe',
-    color: 0x2a7c4c,
-    textureKey: 'evergreenLuxe',
-    detail: {
-      sheen: 0.62,
-      sheenRoughness: 0.44,
-      bumpMultiplier: 1,
-      emissiveIntensity: 0.34,
-      envMapIntensity: 0.18
-    }
-  },
-  {
-    id: 'jadeCurrent',
-    label: 'Jade Current',
-    color: 0x2a8b63,
-    textureKey: 'jadeCurrent',
-    detail: {
-      sheen: 0.66,
-      sheenRoughness: 0.42,
-      bumpMultiplier: 1.02,
-      emissiveIntensity: 0.36,
-      envMapIntensity: 0.2
-    }
-  }
-]);
+const CLOTH_VARIANTS = POOL_ROYALE_CLOTH_VARIANTS.length
+  ? POOL_ROYALE_CLOTH_VARIANTS
+  : [FALLBACK_CLOTH_VARIANT];
+
+const buildClothPalette = (variant) => {
+  const baseTint = new THREE.Color(variant.tintedHex ?? variant.baseHex);
+  const tint = new THREE.Color(variant.tintHex ?? '#25d366');
+  const base = baseTint.clone().lerp(tint, 0.16);
+  const accent = base.clone().lerp(tint, 0.22);
+  const shadow = base.clone().lerp(new THREE.Color(0x000000), 0.32);
+  const highlight = base.clone().lerp(new THREE.Color(0xffffff), 0.28);
+  return {
+    shadow: shadow.getHex(),
+    base: base.getHex(),
+    accent: accent.getHex(),
+    highlight: highlight.getHex()
+  };
+};
+
+const CLOTH_TEXTURE_PRESETS = Object.freeze(
+  CLOTH_VARIANTS.reduce((acc, variant) => {
+    const palette = buildClothPalette(variant);
+    acc[variant.id] = Object.freeze({
+      id: variant.id,
+      palette,
+      sparkle: 1.14,
+      stray: 1.08
+    });
+    return acc;
+  }, {})
+);
+
+const DEFAULT_CLOTH_TEXTURE_KEY = CLOTH_VARIANTS[0]?.id ?? FALLBACK_CLOTH_VARIANT.id;
+const DEFAULT_CLOTH_COLOR_ID = DEFAULT_CLOTH_TEXTURE_KEY;
+const CLOTH_COLOR_OPTIONS = Object.freeze(
+  CLOTH_VARIANTS.map((variant) => {
+    const palette = CLOTH_TEXTURE_PRESETS[variant.id]?.palette ?? buildClothPalette(variant);
+    const baseColor = new THREE.Color(palette.base);
+    const tintColor = new THREE.Color(variant.tintHex ?? '#25d366');
+    const clothColor = baseColor.clone().lerp(tintColor, 0.12);
+    const cushionColor = clothColor.clone().lerp(tintColor, 0.08);
+    return Object.freeze({
+      id: variant.id,
+      label: variant.label,
+      color: clothColor.getHex(),
+      cushionColor: cushionColor.getHex(),
+      textureKey: variant.id,
+      detail: {
+        bumpMultiplier: 1.16,
+        roughness: 0.9,
+        sheen: 0.64,
+        sheenRoughness: 0.42,
+        emissiveIntensity: 0.42,
+        envMapIntensity: 0.18
+      }
+    });
+  })
+);
 
 const DEFAULT_RAIL_MARKER_SHAPE = 'diamond';
 const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
@@ -3550,7 +3247,7 @@ const ORIGINAL_OUTER_HALF_H =
   ORIGINAL_HALF_H + ORIGINAL_RAIL_WIDTH * 2 + ORIGINAL_FRAME_WIDTH;
 
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
-const CLOTH_THREAD_PITCH = 12 * 1.32; // widen thread spacing (~10% more) for a coarser weave
+const CLOTH_THREAD_PITCH = 12 * 1.52; // widen thread spacing further for a larger, more legible weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 
 const createClothTextures = (() => {
@@ -6434,7 +6131,7 @@ function Table3D(
   const clothSheenRoughness = Math.min(1, CLOTH_QUALITY.sheenRoughness * 1.08);
   const clothMat = new THREE.MeshPhysicalMaterial({
     color: clothColor,
-    roughness: 0.97,
+    roughness: 0.9,
     sheen: clothSheen,
     sheenColor,
     sheenRoughness: clothSheenRoughness,
@@ -6448,8 +6145,8 @@ function Table3D(
   clothMat.side = THREE.DoubleSide;
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
-  const threadsPerBallTarget = 12; // base density before global scaling adjustments
-  const clothPatternUpscale = (1 / 1.3) * 0.5 * 1.25 * 1.5; // double the thread pattern size for a looser, woollier weave
+  const threadsPerBallTarget = 10; // dial back repeats so the weave reads larger on screen
+  const clothPatternUpscale = 0.68; // enlarge each texture tile before repeating for bolder patterns
   const clothTextureScale =
     0.032 * 1.35 * 1.56 * 1.12 * clothPatternUpscale; // stretch the weave while keeping the cloth visibly taut
   const baseRepeat =

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -5,6 +5,7 @@ import {
   POOL_ROYALE_OPTION_LABELS,
   POOL_ROYALE_STORE_ITEMS
 } from '../config/poolRoyaleInventoryConfig.js';
+import { POOL_ROYALE_CLOTH_SWATCHES } from '../config/poolRoyaleClothCatalog.js';
 import {
   SNOOKER_CLUB_DEFAULT_LOADOUT,
   SNOOKER_CLUB_OPTION_LABELS,
@@ -275,6 +276,8 @@ const TYPE_SWATCHES = {
   default: ['#22c55e', '#0ea5e9']
 };
 
+const CLOTH_SWATCH_OVERRIDES = Object.freeze(POOL_ROYALE_CLOTH_SWATCHES);
+
 const OPTION_SWATCH_OVERRIDES = {
   charredTimber: ['#2f2217', '#6b4226'],
   rusticSplit: ['#f3e8ff', '#fef3c7'],
@@ -282,15 +285,7 @@ const OPTION_SWATCH_OVERRIDES = {
   weatheredGrey: ['#94a3b8', '#e2e8f0'],
   jetBlackCarbon: ['#0b1220', '#111827'],
   gold: ['#f59e0b', '#fbbf24'],
-  freshGreen: ['#0f5132', '#2dd4bf'],
-  graphite: ['#111827', '#4b5563'],
-  arcticBlue: ['#2f6a9e', '#8ac4ed'],
-  emeraldPulse: ['#145a34', '#39c276'],
-  ivyDrift: ['#0f3520', '#3f8a5a'],
-  mintRadiance: ['#2c7a50', '#71d19b'],
-  cobaltFrost: ['#0ea5e9', '#60a5fa'],
-  midnightWave: ['#13294f', '#3f6fb6'],
-  neonAzure: ['#1f5e8c', '#63c1f0'],
+  ...CLOTH_SWATCH_OVERRIDES,
   chrome: ['#e5e7eb', '#a1a1aa'],
   pearl: ['#f5f3ff', '#e2e8f0'],
   'redwood-ember': ['#7f1d1d', '#b45309'],


### PR DESCRIPTION
## Summary
- replace Pool Royale cloth inventory with Poly Haven green- and blue-tinted variants and remove legacy cloth entries
- centralize cloth metadata/swatch generation for Pool Royale and hook the store into the new catalog
- retune cloth texture intensity, scale, and bump detail for higher-resolution weave presentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecb0be26483298695daeba35f4332)