### PR TITLE
Use Poly Haven cloth and leather materials

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -15,7 +15,12 @@ import {
 } from '../../utils/arenaDecor.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
-import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
+import {
+  createMurlanStyleTable,
+  applyTableMaterials,
+  clampTexture,
+  loadPolyHavenTextures
+} from '../../utils/murlanTable.js';
 import {
   WOOD_FINISH_PRESETS,
   WOOD_GRAIN_OPTIONS,
@@ -2668,6 +2673,54 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
 function applyChairThemeMaterials(three, theme) {
   const mats = three?.chairMaterials;
   if (!mats) return;
+  const renderer = three?.renderer;
+  const isLeather = theme?.id === 'leather';
+
+  const clearUpholsteryTextures = () => {
+    mats.leatherToken = null;
+    (mats.upholstery ?? []).forEach((mat) => {
+      if (!mat) return;
+      mat.map = null;
+      mat.normalMap = null;
+      mat.roughnessMap = null;
+      mat.needsUpdate = true;
+    });
+  };
+
+  const applyLeatherUpholstery = () => {
+    const token = Symbol('leather-seat');
+    mats.leatherToken = token;
+    loadPolyHavenTextures('fabric_leather_02')
+      .then((textures) => {
+        if (mats.leatherToken !== token) return;
+        const { map, normal, roughness } = textures || {};
+        (mats.upholstery ?? []).forEach((mat) => {
+          if (!mat) return;
+          const texturesToClamp = [map, normal, roughness].filter(Boolean);
+          texturesToClamp.forEach((tex) => clampTexture(tex, renderer));
+          if (map) {
+            mat.map = map;
+            mat.color?.set?.('#ffffff');
+          }
+          if (normal) {
+            mat.normalMap = normal;
+            mat.normalScale = new THREE.Vector2(0.8, 0.8);
+          } else {
+            mat.normalMap = null;
+          }
+          if (roughness) {
+            mat.roughnessMap = roughness;
+            mat.roughness = 0.65;
+          } else {
+            mat.roughnessMap = null;
+          }
+          mat.metalness = 0.06;
+          mat.needsUpdate = true;
+        });
+      })
+      .catch(() => {});
+  };
+
   if (mats.seat?.color) {
     mats.seat.color.set(theme.seatColor);
     mats.seat.needsUpdate = true;
@@ -2688,6 +2741,12 @@ function applyChairThemeMaterials(three, theme) {
       mat.needsUpdate = true;
     }
   });
+
+  if (isLeather) {
+    applyLeatherUpholstery();
+  } else {
+    clearUpholsteryTextures();
+  }
 }
 
 function applyOutfitThemeMaterials(three, theme) {

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -8,6 +8,7 @@ import {
   DEFAULT_WOOD_GRAIN_ID,
   disposeMaterialWithWood
 } from './woodMaterials.js';
+import { POLY_HAVEN_CLOTH_IDS } from './tableCustomizationOptions.js';
 
 const DEFAULT_TABLE_BASE_OPTION = Object.freeze({
   id: 'obsidian',
@@ -33,6 +34,160 @@ export const DEFAULT_TABLE_CLOTH_OPTION = Object.freeze({
   feltBottom: '#054d24',
   emissive: '#021a0b'
 });
+
+const POLY_HAVEN_REPEAT = 0.34; // 3x larger weave footprint (fewer tiles) at high-res
+const POLY_HAVEN_MAX_ANISOTROPY = 16;
+const POLY_HAVEN_CACHE = new Map();
+const POLY_HAVEN_PENDING = new Map();
+
+export const clampTexture = (texture, renderer) => {
+  if (!texture) return;
+  const maxAniso = renderer?.capabilities?.getMaxAnisotropy?.();
+  const anisotropy = Math.max(4, Math.min(maxAniso ?? 8, POLY_HAVEN_MAX_ANISOTROPY));
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(POLY_HAVEN_REPEAT, POLY_HAVEN_REPEAT);
+  texture.anisotropy = anisotropy;
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+};
+
+const pickPolyHavenTextureUrls = (apiJson) => {
+  const urls = [];
+  const walk = (v) => {
+    if (!v) return;
+    if (typeof v === 'string') {
+      const lower = v.toLowerCase();
+      if (v.startsWith('http') && (lower.includes('.jpg') || lower.includes('.png'))) {
+        urls.push(v);
+      }
+      return;
+    }
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+      return;
+    }
+    if (typeof v === 'object') {
+      Object.values(v).forEach(walk);
+    }
+  };
+  walk(apiJson);
+  const score = (url) => {
+    const lower = url.toLowerCase();
+    let value = 0;
+    if (lower.includes('8k')) value += 12;
+    if (lower.includes('4k')) value += 9;
+    if (lower.includes('2k')) value += 6;
+    if (lower.includes('1k')) value += 3;
+    if (lower.includes('jpg')) value += 3;
+    if (lower.includes('png')) value += 2;
+    if (lower.includes('diff') || lower.includes('albedo') || lower.includes('basecolor')) value += 2;
+    if (lower.includes('nor_gl') || lower.includes('normal_gl')) value += 2;
+    if (lower.includes('nor') || lower.includes('normal')) value += 1;
+    if (lower.includes('rough')) value += 1;
+    if (lower.includes('preview')) value -= 8;
+    return value;
+  };
+  const pick = (keywords) =>
+    urls
+      .filter((u) => keywords.some((kw) => u.toLowerCase().includes(kw)))
+      .map((u) => ({ url: u, score: score(u) }))
+      .sort((a, b) => b.score - a.score)?.[0]?.url;
+  return {
+    diffuse: pick(['diff', 'diffuse', 'albedo', 'basecolor']),
+    normal: pick(['nor_gl', 'normal_gl', 'nor', 'normal']),
+    roughness: pick(['rough', 'roughness'])
+  };
+};
+
+const loadTexture = (loader, url, isColor) =>
+  new Promise((resolve, reject) => {
+    if (!url) {
+      resolve(null);
+      return;
+    }
+    loader.load(
+      url,
+      (texture) => {
+        if (isColor) applySRGBColorSpace(texture);
+        resolve(texture);
+      },
+      undefined,
+      (err) => reject(err || new Error('Texture load failed'))
+    );
+  });
+
+export async function loadPolyHavenTextures(sourceId) {
+  const cached = POLY_HAVEN_CACHE.get(sourceId);
+  if (cached) return cached;
+  if (POLY_HAVEN_PENDING.has(sourceId)) {
+    return POLY_HAVEN_PENDING.get(sourceId);
+  }
+  const promise = (async () => {
+    try {
+      const response = await fetch(`https://api.polyhaven.com/files/${sourceId}`);
+      if (!response?.ok) throw new Error(`Poly Haven response ${response?.status ?? 'unknown'}`);
+      const json = await response.json();
+      const urls = pickPolyHavenTextureUrls(json);
+      if (!urls.diffuse) throw new Error('Missing diffuse map');
+      const loader = new THREE.TextureLoader();
+      loader.setCrossOrigin?.('anonymous');
+      const [map, normal, roughness] = await Promise.all([
+        loadTexture(loader, urls.diffuse, true),
+        loadTexture(loader, urls.normal, false),
+        loadTexture(loader, urls.roughness, false)
+      ]);
+      const payload = { map, normal, roughness, sourceId };
+      POLY_HAVEN_CACHE.set(sourceId, payload);
+      return payload;
+    } finally {
+      POLY_HAVEN_PENDING.delete(sourceId);
+    }
+  })();
+  POLY_HAVEN_PENDING.set(sourceId, promise);
+  return promise;
+}
+
+function applyPolyHavenClothToMaterial(material, clothOption, renderer) {
+  if (!material || !clothOption?.id) return;
+  const targetId = clothOption.id;
+  material.userData = {
+    ...(material.userData || {}),
+    clothSourceId: targetId
+  };
+  const token = Symbol(targetId);
+  material.userData.clothToken = token;
+
+  const applyTextures = ({ map, normal, roughness }) => {
+    if (material.userData?.clothToken !== token) return;
+    const textures = [map, normal, roughness].filter(Boolean);
+    textures.forEach((tex) => clampTexture(tex, renderer));
+    if (map) {
+      material.map = map;
+      material.color?.set?.('#ffffff');
+    }
+    if (normal) {
+      material.normalMap = normal;
+      material.normalScale = new THREE.Vector2(0.82, 0.82);
+    } else {
+      material.normalMap = null;
+    }
+    if (roughness) {
+      material.roughnessMap = roughness;
+      material.roughness = 0.72;
+    } else {
+      material.roughnessMap = null;
+    }
+    material.metalness = 0.02;
+    material.needsUpdate = true;
+  };
+
+  loadPolyHavenTextures(clothOption.sourceId ?? clothOption.id)
+    .then(applyTextures)
+    .catch(() => {});
+}
 
 export function createRegularPolygonShape(sides = 8, radius = 1) {
   const shape = new THREE.Shape();
@@ -316,15 +471,12 @@ export function applyTableMaterials(parts, { woodOption, clothOption, baseOption
   applyWoodSelectionToMaterials(parts.topWoodMat, parts.rimWoodMat, woodOption);
 
   if (parts.surfaceMat && clothOption) {
-    parts.velvetTexture?.dispose?.();
-    const tex = makeRoughClothTexture(
-      1024,
-      clothOption.feltTop,
-      clothOption.feltBottom,
-      renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
-    );
-    parts.surfaceMat.map = tex;
-    parts.surfaceMat.color?.set?.('#ffffff');
+    const isPolyHavenCloth = POLY_HAVEN_CLOTH_IDS.has(clothOption.id);
+    parts.surfaceMat.userData = {
+      ...(parts.surfaceMat.userData || {}),
+      clothOptionId: clothOption.id
+    };
+
     if (typeof clothOption.roughness === 'number') {
       parts.surfaceMat.roughness = clothOption.roughness;
     }
@@ -341,8 +493,30 @@ export function applyTableMaterials(parts, { woodOption, clothOption, baseOption
         : 0.08;
       parts.surfaceMat.emissiveIntensity = intensity;
     }
+
+    if (isPolyHavenCloth) {
+      if (parts.velvetTexture) {
+        parts.velvetTexture.dispose?.();
+        parts.velvetTexture = null;
+      }
+      parts.surfaceMat.bumpMap = null;
+      applyPolyHavenClothToMaterial(parts.surfaceMat, clothOption, renderer);
+    } else {
+      parts.velvetTexture?.dispose?.();
+      const tex = makeRoughClothTexture(
+        2048,
+        clothOption.feltTop,
+        clothOption.feltBottom,
+        renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
+      );
+      parts.surfaceMat.map = tex;
+      parts.surfaceMat.normalMap = null;
+      parts.surfaceMat.roughnessMap = null;
+      parts.surfaceMat.color?.set?.('#ffffff');
+      parts.surfaceMat.needsUpdate = true;
+      parts.velvetTexture = tex;
+    }
     parts.surfaceMat.needsUpdate = true;
-    parts.velvetTexture = tex;
   }
 }
 

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -22,12 +22,13 @@ const buildClothOption = (
   id,
   label,
   baseColor,
-  { topTint = 0.08, bottomTint = -0.12, emissiveTint = -0.65 } = {}
+  { topTint = 0.08, bottomTint = -0.12, emissiveTint = -0.65, sourceId } = {}
 ) => {
   const baseHex = normalizeHex(baseColor);
   return {
     id,
     label,
+    sourceId,
     feltTop: tintHex(baseHex, topTint),
     feltBottom: tintHex(baseHex, bottomTint),
     emissive: tintHex(baseHex, emissiveTint)
@@ -51,6 +52,8 @@ const POLY_HAVEN_CLOTHS = [
   { id: 'scuba_suede', label: 'Scuba Suede Cloth', base: 0x2a8c86 }
 ];
 
+export const POLY_HAVEN_CLOTH_IDS = Object.freeze(new Set(POLY_HAVEN_CLOTHS.map((option) => option.id)));
+
 export const WOOD_PRESETS_BY_ID = Object.freeze(
   WOOD_FINISH_PRESETS.reduce((acc, preset) => {
     acc[preset.id] = preset;
@@ -72,7 +75,7 @@ export const TABLE_CLOTH_OPTIONS = [
   { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
   { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
   { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' },
-  ...POLY_HAVEN_CLOTHS.map((option) => buildClothOption(option.id, option.label, option.base))
+  ...POLY_HAVEN_CLOTHS.map((option) => buildClothOption(option.id, option.label, option.base, { sourceId: option.id }))
 ];
 
 export const TABLE_BASE_OPTIONS = [


### PR DESCRIPTION
## Summary
- load Poly Haven cloth textures for Murlan tables with enlarged, high-resolution pattern tiling
- reuse the Poly Haven leather material for stool upholstery when the leather theme is selected
- expose Poly Haven cloth metadata so table cloth options fetch verified texture sets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed9b57a608329b1223661a5121c25)