### PR TITLE
Switch Murlan textures to Poly Haven materials

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -15,7 +15,12 @@ import {
 } from '../../utils/arenaDecor.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
-import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
+import {
+  createMurlanStyleTable,
+  applyTableMaterials,
+  clonePolyHavenTexture,
+  requestPolyHavenClothTextures
+} from '../../utils/murlanTable.js';
 import {
   WOOD_FINISH_PRESETS,
   WOOD_GRAIN_OPTIONS,
@@ -1092,7 +1097,7 @@ export default function MurlanRoyaleArena({ search }) {
       if (three.tableInfo?.materials) {
         applyTableMaterials(three.tableInfo.materials, { woodOption, clothOption, baseOption }, three.renderer);
       }
-      applyChairThemeMaterials(three, stoolTheme);
+      applyChairThemeMaterials(three, stoolTheme, three.renderer);
       applyOutfitThemeMaterials(three, outfitTheme);
 
       const shouldRefreshCards = refreshCards || three.appearance?.cards !== safe.cards;
@@ -1495,7 +1500,7 @@ export default function MurlanRoyaleArena({ search }) {
       const chairTemplate = chairBuild.chairTemplate;
       threeStateRef.current.chairTemplate = chairTemplate;
       threeStateRef.current.chairMaterials = chairBuild.materials;
-      applyChairThemeMaterials(threeStateRef.current, stoolTheme);
+      applyChairThemeMaterials(threeStateRef.current, stoolTheme, renderer);
 
       const avatarRadius = 0.32 * MODEL_SCALE;
       const avatarHeight = 0.9 * MODEL_SCALE;
@@ -2665,9 +2670,24 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
   return texture;
 }
 
-function applyChairThemeMaterials(three, theme) {
+const LEATHER_TEXTURE_ID = 'fabric_leather_02';
+const LEATHER_REPEAT = 2.4 / 3;
+
+function disposeChairLeatherTextures(mats) {
+  const toDispose = mats?.__leatherTextures;
+  if (!toDispose?.length) return;
+  toDispose.forEach((tex) => tex?.dispose?.());
+  mats.__leatherTextures = null;
+}
+
+function applyChairThemeMaterials(three, theme, renderer = null) {
   const mats = three?.chairMaterials;
   if (!mats) return;
+  const isLeather = theme?.id === 'leather';
+  mats.__leatherThemeActive = isLeather;
+  if (!isLeather) {
+    disposeChairLeatherTextures(mats);
+  }
   if (mats.seat?.color) {
     mats.seat.color.set(theme.seatColor);
     mats.seat.needsUpdate = true;
@@ -2681,6 +2701,12 @@ function applyChairThemeMaterials(three, theme) {
       mat.color.set(theme.seatColor);
       mat.needsUpdate = true;
     }
+    if (!isLeather && mat) {
+      mat.map = null;
+      mat.normalMap = null;
+      mat.roughnessMap = null;
+      mat.needsUpdate = true;
+    }
   });
   (mats.metal ?? []).forEach((mat) => {
     if (mat?.color) {
@@ -2688,6 +2714,51 @@ function applyChairThemeMaterials(three, theme) {
       mat.needsUpdate = true;
     }
   });
+
+  if (!isLeather) return;
+
+  const applyLeatherTextures = (entry) => {
+    if (!mats.__leatherThemeActive || !entry?.ready) return false;
+    disposeChairLeatherTextures(mats);
+    const targets = [mats.seat, ...(mats.upholstery ?? [])].filter(Boolean);
+    if (!targets.length) return false;
+    const clonedTextures = [];
+    targets.forEach((mat) => {
+      const map = clonePolyHavenTexture(entry.map, LEATHER_REPEAT);
+      const normal = clonePolyHavenTexture(entry.normal, LEATHER_REPEAT);
+      const roughness = clonePolyHavenTexture(entry.roughness, LEATHER_REPEAT);
+      if (map) {
+        mat.map = map;
+        clonedTextures.push(map);
+      }
+      if (normal) {
+        mat.normalMap = normal;
+        clonedTextures.push(normal);
+      }
+      if (roughness) {
+        mat.roughnessMap = roughness;
+        clonedTextures.push(roughness);
+      }
+      if (map || normal || roughness) {
+        mat.color?.set?.('#ffffff');
+        mat.roughness = 0.48;
+        mat.metalness = Math.max(0.16, mat.metalness ?? 0.2);
+        mat.needsUpdate = true;
+      }
+    });
+    mats.__leatherTextures = clonedTextures;
+    return clonedTextures.length > 0;
+  };
+
+  const leatherEntry = requestPolyHavenClothTextures(LEATHER_TEXTURE_ID, renderer);
+  const applied = applyLeatherTextures(leatherEntry);
+  if (!applied) {
+    leatherEntry?.promise?.then(() => {
+      if (!mats.__leatherThemeActive) return;
+      const latest = requestPolyHavenClothTextures(LEATHER_TEXTURE_ID, renderer);
+      applyLeatherTextures(latest);
+    });
+  }
 }
 
 function applyOutfitThemeMaterials(three, theme) {

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -34,7 +34,7 @@ const buildClothOption = (
   };
 };
 
-const POLY_HAVEN_CLOTHS = [
+export const POLY_HAVEN_CLOTHS = [
   { id: 'denim_fabric_03', label: 'Denim Fabric 03 Cloth', base: 0x2b4a7a },
   { id: 'hessian_230', label: 'Hessian 230 Cloth', base: 0x9b7a45 },
   { id: 'polar_fleece', label: 'Polar Fleece Cloth', base: 0xd9d2c2 },
@@ -72,7 +72,11 @@ export const TABLE_CLOTH_OPTIONS = [
   { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
   { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
   { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' },
-  ...POLY_HAVEN_CLOTHS.map((option) => buildClothOption(option.id, option.label, option.base))
+  ...POLY_HAVEN_CLOTHS.map((option) => ({
+    ...buildClothOption(option.id, option.label, option.base),
+    sourceId: option.id,
+    baseColor: normalizeHex(option.base)
+  }))
 ];
 
 export const TABLE_BASE_OPTIONS = [


### PR DESCRIPTION
## Summary
- load Poly Haven cloth texture sets for Murlan Royale tables and scale the weave 3x larger at higher anisotropy
- keep cloths procedurally shaded only as a temporary fallback while Poly Haven maps download
- apply the Poly Haven leather material to the leather stool theme so seating uses the same scanned texture

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed9b57a608329b1223661a5121c25)