### PR TITLE
Improve Pool Royale cue view hold and ball readability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1015,6 +1015,7 @@ const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing phys
 const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up cannot stall the render loop
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const STUCK_SHOT_TIMEOUT_MS = 4500; // auto-resolve shots if motion stops but the turn never clears
+const CUE_SHOT_HOLD_MS = 3000; // linger in cue view before striking so players can adjust spin
 const MAX_POWER_BOUNCE_THRESHOLD = 0.98;
 const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 0.85;
 const MAX_POWER_BOUNCE_GRAVITY = BALL_R * 3.6;
@@ -5311,7 +5312,7 @@ const STANDING_VIEW_MARGIN = 0.0016; // pull the standing frame closer so the ta
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.1;
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
-const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.32; // halt the downward sweep sooner so the lowest angle stays slightly higher and stops above the cue
+const CAMERA_MAX_PHI = CUE_SHOT_PHI - 0.28; // allow the cue view to dip lower while still stopping above the cloth
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
 const PLAYER_CAMERA_DISTANCE_FACTOR = 0.018; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
@@ -10673,6 +10674,12 @@ const powerRef = useRef(hud.power);
       cueBallPlacedFromHandRef.current = false;
     }
   }, [hud.inHand, hud.turn]);
+  const [shotHoldActive, setShotHoldActive] = useState(false);
+  const shotHoldRef = useRef(shotHoldActive);
+  useEffect(() => {
+    shotHoldRef.current = shotHoldActive;
+  }, [shotHoldActive]);
+  const shotHoldTimeoutRef = useRef(null);
   const [shotActive, setShotActive] = useState(false);
   const shootingRef = useRef(shotActive);
   useEffect(() => {
@@ -10703,6 +10710,15 @@ const powerRef = useRef(hud.power);
       aiRetryTimeoutRef.current = null;
     }
   }, []);
+  useEffect(
+    () => () => {
+      if (shotHoldTimeoutRef.current) {
+        clearTimeout(shotHoldTimeoutRef.current);
+        shotHoldTimeoutRef.current = null;
+      }
+    },
+    []
+  );
   const recomputeAiShotState = useCallback(() => {
     const hudState = hudRef.current;
     const aiTurn = aiOpponentEnabled && hudState?.turn === 1;
@@ -10768,13 +10784,16 @@ const powerRef = useRef(hud.power);
     if (!slider) return;
     const hudState = hudRef.current;
     const shouldLock =
-      hudState?.turn !== 0 || hudState?.over || shootingRef.current;
+      hudState?.turn !== 0 ||
+      hudState?.over ||
+      shootingRef.current ||
+      shotHoldRef.current;
     if (shouldLock) slider.lock();
     else slider.unlock();
   }, []);
   useEffect(() => {
     applySliderLock();
-  }, [applySliderLock, hud.turn, hud.over, shotActive]);
+  }, [applySliderLock, hud.turn, hud.over, shotActive, shotHoldActive]);
 
   const applyLightingPreset = useCallback(
     (presetId = lightingId) => {
@@ -16648,7 +16667,8 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-        const fire = () => {
+        const fire = (options = {}) => {
+          const { bypassHold = false } = options;
           const currentHud = hudRef.current;
           const frameSnapshot = frameRef.current ?? frameState;
           const fullTableHandPlacement =
@@ -16668,13 +16688,40 @@ const powerRef = useRef(hud.power);
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
         }
+        alignStandingCameraToAim(cue, aimDirRef.current);
+        const shouldHoldCueShot =
+          !bypassHold &&
+          !shotHoldRef.current &&
+          currentHud?.turn === 0 &&
+          !replayPlaybackRef.current;
+        if (shouldHoldCueShot) {
+          if (shotHoldTimeoutRef.current) {
+            clearTimeout(shotHoldTimeoutRef.current);
+          }
+          setShotHoldActive(true);
+          shotHoldRef.current = true;
+          const slider = sliderInstanceRef.current;
+          if (slider) slider.lock();
+          applyCameraBlend(0);
+          updateCamera();
+          shotHoldTimeoutRef.current = window.setTimeout(() => {
+            shotHoldTimeoutRef.current = null;
+            shotHoldRef.current = false;
+            setShotHoldActive(false);
+            applySliderLock();
+            fire({ bypassHold: true });
+          }, CUE_SHOT_HOLD_MS);
+          return;
+        }
+        if (shotHoldRef.current && !bypassHold) {
+          return;
+        }
         const forcedCueView = aiShotCueViewRef.current;
         setAiShotCueViewActive(false);
         setAiShotPreviewActive(false);
-        alignStandingCameraToAim(cue, aimDirRef.current);
         cancelCameraBlendTween();
         const forcedCueBlend = aiCueViewBlendRef.current ?? AI_CAMERA_DROP_BLEND;
-        applyCameraBlend(forcedCueView ? forcedCueBlend : 1);
+        applyCameraBlend(forcedCueView ? forcedCueBlend : 0);
         updateCamera();
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -2,9 +2,9 @@ import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
 // Pool Royale generates up to 15 numbered + striped textures when players pick the
-// Solids & Stripes skin for UK 8-ball. At 4096px this was exhausting mobile GPUs
-// and crashing the session, so dial the texture size back to keep memory in check.
-const BALL_TEXTURE_SIZE = 1024;
+// Solids & Stripes skin for UK 8-ball. Raise resolution so the enlarged patterns stay
+// crisp while keeping memory below the old 4096px baseline.
+const BALL_TEXTURE_SIZE = 2048;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 
@@ -80,7 +80,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.08; // shrink the badge so numbers sit farther inside the stripes
+  const radius = size * 0.18; // enlarge the badge so numbers stay readable on oversized stripes
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -93,14 +93,14 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.fillStyle = '#ffffff';
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.016));
+  ctx.lineWidth = Math.max(3, Math.floor(size * 0.028));
   ctx.strokeStyle = '#000000';
   ctx.stroke();
 
   const numStr = String(number);
 
   ctx.fillStyle = '#000000';
-  const fontSize = numStr.length === 2 ? size * 0.1296 : size * 0.144; // ~20% smaller label text
+  const fontSize = numStr.length === 2 ? size * 0.205 : size * 0.228; // larger label text to match the bigger badge
   ctx.font = `900 ${fontSize}px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -128,9 +128,17 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   if (pattern === 'stripe') {
     ctx.fillStyle = baseHex;
-    const stripeHeight = size * 0.45;
+    const stripeHeight = size * 0.82;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+    ctx.lineWidth = Math.max(3, Math.floor(size * 0.02));
+    ctx.strokeStyle = darken(baseHex, 0.1);
+    ctx.beginPath();
+    ctx.moveTo(0, stripeY);
+    ctx.lineTo(size, stripeY);
+    ctx.moveTo(0, stripeY + stripeHeight);
+    ctx.lineTo(size, stripeY + stripeHeight);
+    ctx.stroke();
   }
 
   if (Number.isFinite(number)) {
@@ -224,7 +232,7 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
   ctx.fillRect(0, 0, size, size);
   ctx.restore();
 
-    addNoise(ctx, size, 0.02, 3600);
+  addNoise(ctx, size, 0.02, 3600);
 
   if (Number.isFinite(number)) {
     drawNumberBadge(ctx, size, number);
@@ -305,14 +313,14 @@ export function getBallMaterial({
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
-    clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
-    reflectivity: 1,
-    sheen: 0.18,
+    clearcoat: 0.08,
+    clearcoatRoughness: 0.52,
+    metalness: 0.04,
+    roughness: 0.78,
+    reflectivity: 0.12,
+    sheen: 0.05,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    envMapIntensity: 0.32
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- increase Pool Royale ball texture resolution, enlarge stripe/number patterns, and switch to a matte material so surfaces stay crisp without glare
- add a 3-second cue-view hold before firing shots so players can adjust spin while the camera stays low
- allow the cue camera to tilt a bit lower to match the updated cue-view limit

## Testing
- npm test -- --runTestsByPath test/poolRoyaleRules.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee44a7c44832990408d06ec082732)