### PR TITLE
Improve Pool Royale shot prep and ball visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1015,6 +1015,7 @@ const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing phys
 const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up cannot stall the render loop
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const STUCK_SHOT_TIMEOUT_MS = 4500; // auto-resolve shots if motion stops but the turn never clears
+const PLAYER_SHOT_HOLD_MS = 3000; // keep the cue camera pinned for 3s before releasing a player shot
 const MAX_POWER_BOUNCE_THRESHOLD = 0.98;
 const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 0.85;
 const MAX_POWER_BOUNCE_GRAVITY = BALL_R * 3.6;
@@ -10523,11 +10524,17 @@ function PoolRoyaleGame({
   const [replayBanner, setReplayBanner] = useState(null);
   const replayBannerTimeoutRef = useRef(null);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
+  const shotHoldTimeoutRef = useRef(null);
+  const holdCueViewRef = useRef(() => {});
   useEffect(
     () => () => {
       if (replayBannerTimeoutRef.current) {
         clearTimeout(replayBannerTimeoutRef.current);
         replayBannerTimeoutRef.current = null;
+      }
+      if (shotHoldTimeoutRef.current) {
+        clearTimeout(shotHoldTimeoutRef.current);
+        shotHoldTimeoutRef.current = null;
       }
     },
     []
@@ -15062,6 +15069,13 @@ const powerRef = useRef(hud.power);
           exit: (immediate = true) => exitTopView(immediate)
         };
         cameraUpdateRef.current = () => updateCamera();
+        holdCueViewRef.current = () => {
+          topViewRef.current = false;
+          topViewLockedRef.current = false;
+          setIsTopDownView(false);
+          applyCameraBlend(0);
+          updateCamera();
+        };
         const clampSpinToLimits = () => {
           const limits = spinLimitsRef.current || DEFAULT_SPIN_LIMITS;
           const current = spinRef.current || { x: 0, y: 0 };
@@ -16671,10 +16685,13 @@ const powerRef = useRef(hud.power);
         const forcedCueView = aiShotCueViewRef.current;
         setAiShotCueViewActive(false);
         setAiShotPreviewActive(false);
+        topViewRef.current = false;
+        topViewLockedRef.current = false;
+        setIsTopDownView(false);
         alignStandingCameraToAim(cue, aimDirRef.current);
         cancelCameraBlendTween();
         const forcedCueBlend = aiCueViewBlendRef.current ?? AI_CAMERA_DROP_BLEND;
-        applyCameraBlend(forcedCueView ? forcedCueBlend : 1);
+        applyCameraBlend(forcedCueView ? forcedCueBlend : 0);
         updateCamera();
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
@@ -20229,6 +20246,18 @@ const powerRef = useRef(hud.power);
     applyRailMarkerStyleRef.current?.(railMarkerStyleRef.current);
   }, [tableFinish]);
 
+  const queuePlayerShot = useCallback(() => {
+    if (shotHoldTimeoutRef.current) {
+      clearTimeout(shotHoldTimeoutRef.current);
+      shotHoldTimeoutRef.current = null;
+    }
+    holdCueViewRef.current?.();
+    shotHoldTimeoutRef.current = window.setTimeout(() => {
+      shotHoldTimeoutRef.current = null;
+      fireRef.current?.();
+    }, PLAYER_SHOT_HOLD_MS);
+  }, []);
+
   // --------------------------------------------------
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
@@ -20247,7 +20276,7 @@ const powerRef = useRef(hud.power);
       labels: true,
       onChange: (v) => applyPower(v / 100),
       onCommit: () => {
-        fireRef.current?.();
+        queuePlayerShot();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
         });
@@ -20259,7 +20288,7 @@ const powerRef = useRef(hud.power);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, showPowerSlider]);
+  }, [applySliderLock, queuePlayerShot, showPowerSlider]);
 
   const isPlayerTurn = hud.turn === 0;
   const isOpponentTurn = hud.turn === 1;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -2,9 +2,9 @@ import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
 // Pool Royale generates up to 15 numbered + striped textures when players pick the
-// Solids & Stripes skin for UK 8-ball. At 4096px this was exhausting mobile GPUs
-// and crashing the session, so dial the texture size back to keep memory in check.
-const BALL_TEXTURE_SIZE = 1024;
+// Solids & Stripes skin for UK 8-ball. Increase the resolution for crisper patterns
+// while staying well below the 4K floor that previously overwhelmed mobile GPUs.
+const BALL_TEXTURE_SIZE = 2048;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
 
@@ -80,7 +80,7 @@ function drawNumberBadge(ctx, size, number) {
 }
 
 function drawPoolNumberBadge(ctx, size, number) {
-  const radius = size * 0.08; // shrink the badge so numbers sit farther inside the stripes
+  const radius = size * 0.24; // enlarge badge so labels sit boldly across every skin
   const badgeStretch = 2; // compensate equirectangular vertical compression on spheres
   const cx = size * 0.5;
   const cy = size * 0.5;
@@ -93,14 +93,14 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.fillStyle = '#ffffff';
   ctx.fill();
 
-  ctx.lineWidth = Math.max(2, Math.floor(size * 0.016));
+  ctx.lineWidth = Math.max(3, Math.floor(size * 0.024));
   ctx.strokeStyle = '#000000';
   ctx.stroke();
 
   const numStr = String(number);
 
   ctx.fillStyle = '#000000';
-  const fontSize = numStr.length === 2 ? size * 0.1296 : size * 0.144; // ~20% smaller label text
+  const fontSize = numStr.length === 2 ? size * 0.216 : size * 0.24; // keep dual digits centered while scaling up
   ctx.font = `900 ${fontSize}px ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -128,7 +128,7 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
 
   if (pattern === 'stripe') {
     ctx.fillStyle = baseHex;
-    const stripeHeight = size * 0.45;
+    const stripeHeight = size * 0.72;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
   }
@@ -305,14 +305,14 @@ export function getBallMaterial({
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
-    clearcoat: 1,
-    clearcoatRoughness: 0.015,
-    metalness: 0.24,
-    roughness: 0.06,
-    reflectivity: 1,
-    sheen: 0.18,
-    sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    clearcoat: 0.32,
+    clearcoatRoughness: 0.34,
+    metalness: 0.08,
+    roughness: 0.42,
+    reflectivity: 0.35,
+    sheen: 0.12,
+    sheenColor: new THREE.Color(0xf4f5fa),
+    envMapIntensity: 0.42
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
## Summary
- enlarge Pool Royale ball patterns, raise texture resolution, and reduce reflective materials so skins stay clear and non-glare
- hold the cue camera low for three seconds after power release so players can finish spin adjustments before the shot fires

## Testing
- npm test -- --runTestsByPath test/poolRoyaleRules.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eed84ff3c8329bebb2db190be1960)