### PR TITLE
Improve Pool Royale cloth visuals and replay pacing

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -53,8 +53,8 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.24,
       envMapIntensity: 0.18
     },
-    greens: ['#6b8c4b', '#5f7c3d', '#749a55', '#85aa61', '#56723a'],
-    blues: ['#6a7592', '#7c86a2', '#59647c', '#7081a0', '#8b98b3']
+    greens: ['#4f7b38', '#466f30', '#5d8f45', '#6a9a4f', '#3e6531'],
+    blues: ['#4f6f96', '#597aa3', '#435c82', '#5878a0', '#6b87ad']
   },
   {
     prefix: 'curlyTeddyNatural',
@@ -72,8 +72,8 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.36,
       envMapIntensity: 0.22
     },
-    greens: ['#74c18a', '#68b47e', '#7fcb99', '#8cd2a5', '#61a870'],
-    blues: ['#7da6cf', '#6f98c3', '#8ab4da', '#99c0e2', '#658db2']
+    greens: ['#5da87b', '#519d70', '#6bb487', '#77bd93', '#4b8d66'],
+    blues: ['#5d8fb8', '#5283ac', '#6ea0c8', '#7aaad1', '#4b739c']
   },
   {
     prefix: 'polarFleece',
@@ -91,8 +91,8 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.34,
       envMapIntensity: 0.14
     },
-    greens: ['#7fcf95', '#72c487', '#8ed9a8', '#9ae1b3', '#68b37a'],
-    blues: ['#7faadf', '#709ed5', '#8ab7e9', '#99c3f0', '#6289bd']
+    greens: ['#5fab7a', '#539f6d', '#6ab888', '#74c192', '#4a8a64'],
+    blues: ['#5d97c6', '#528bbc', '#689ed5', '#73a8dd', '#4877a4']
   },
   {
     prefix: 'cottonJersey',
@@ -110,8 +110,8 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.28,
       envMapIntensity: 0.18
     },
-    greens: ['#6eaf73', '#63a567', '#7bb984', '#88c290', '#569658'],
-    blues: ['#6f8fb4', '#6484a8', '#7b9bc0', '#89a7cc', '#557296']
+    greens: ['#5b9c64', '#509159', '#66aa74', '#72b37f', '#45864c'],
+    blues: ['#597fa6', '#4f739a', '#658ab3', '#7096bd', '#466785']
   }
 ];
 


### PR DESCRIPTION
## Summary
- deepen the Pool Royale cloth palettes so cotton jersey, caban wool, curly teddy natural, and polar fleece options render with richer greens and blues
- boost cloth surface definition with brighter bump intensity, larger default thread scale, and per-cloth pattern repeat tuning for cotton jersey, curly teddy natural, and polar fleece
- slightly dim the lighting presets and let replays run at the same frame cadence as regular gameplay

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f8081bb188329a86f7640eaa731eb)