### PR TITLE
Adjust Pool Royale lighting and cloth options

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -164,12 +164,12 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: 'Caban wool texture with rich evergreen depth.'
   },
   {
-    id: 'cloth-curlyTeddyNatural',
+    id: 'cloth-polarFleecePlush',
     type: 'tableCloth',
-    optionId: 'curly_teddy_natural',
-    name: 'Curly Teddy Natural Cloth',
+    optionId: 'polar_fleece',
+    name: 'Polar Fleece Plush Cloth',
     price: 640,
-    description: 'Natural teddy curl with soft, pale fibers.'
+    description: 'Plush polar fleece take with fuller pile and brighter fibers.'
   },
   {
     id: 'cloth-curlyTeddyCheckered',

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -53,27 +53,8 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.24,
       envMapIntensity: 0.18
     },
-    greens: ['#4f7a3c', '#466f33', '#5d8e47', '#6c9c50', '#3e6430'],
+    greens: ['#3f7f3a', '#357333', '#4a9446', '#58a250', '#2f6030'],
     blues: ['#566e8c', '#667e9c', '#4b5d78', '#5f7896', '#7688ad']
-  },
-  {
-    prefix: 'curlyTeddyNatural',
-    label: 'Curly Teddy Natural',
-    sourceId: 'curly_teddy_natural',
-    basePrice: 700,
-    priceStep: 10,
-    bluePremium: 20,
-    sparkle: 1.16,
-    stray: 1.14,
-    detail: {
-      bumpMultiplier: 1.16,
-      sheen: 0.72,
-      sheenRoughness: 0.44,
-      emissiveIntensity: 0.36,
-      envMapIntensity: 0.22
-    },
-    greens: ['#5fae77', '#54a36c', '#6bb885', '#78c291', '#489662'],
-    blues: ['#6b99c4', '#5f8cba', '#79a6d1', '#88b4db', '#4c7ca3']
   },
   {
     prefix: 'polarFleece',
@@ -93,6 +74,25 @@ const MATERIAL_SERIES = [
     },
     greens: ['#69b980', '#5ead73', '#74c690', '#7fce99', '#4f9d62'],
     blues: ['#6d9ad0', '#608fc5', '#7aacdd', '#86b7e6', '#4e7ead']
+  },
+  {
+    prefix: 'polarFleecePlush',
+    label: 'Polar Fleece Plush',
+    sourceId: 'polar_fleece',
+    basePrice: 700,
+    priceStep: 10,
+    bluePremium: 20,
+    sparkle: 1.14,
+    stray: 1.12,
+    detail: {
+      bumpMultiplier: 1.14,
+      sheen: 0.72,
+      sheenRoughness: 0.5,
+      emissiveIntensity: 0.36,
+      envMapIntensity: 0.16
+    },
+    greens: ['#5fae77', '#54a36c', '#6bb885', '#78c291', '#489662'],
+    blues: ['#6b99c4', '#5f8cba', '#79a6d1', '#88b4db', '#4c7ca3']
   },
   {
     prefix: 'cottonJersey',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3249,9 +3249,8 @@ const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
 const CLOTH_PATTERN_OVERRIDES = Object.freeze({
-  cotton_jersey: { repeatScale: 2 / 3 },
-  curly_teddy_natural: { repeatScale: 1.5 },
-  polar_fleece: { repeatScale: 1.2 }
+  cotton_jersey: { repeatScale: 4 / 9 },
+  polar_fleece: { repeatScale: 1.04 }
 });
 
 const CLOTH_TEXTURE_KEYS_BY_SOURCE = CLOTH_LIBRARY.reduce((acc, cloth) => {
@@ -14989,16 +14988,20 @@ const powerRef = useRef(hud.power);
         const lightLineX = 0; // align fixtures down the center line instead of offsetting per side
         const lightSpacing = Math.max(lightOffsetZ * 0.36, TABLE.THICK * 2); // pull fixtures closer together while keeping even coverage
         const lightPositionsZ = [-1.1, -0.34, 0.34, 1.1].map((mult) => mult * lightSpacing);
+        const lightBrightnessTrim = 0.92; // slightly lower the rig intensity for softer cloth highlights
         const shadowHalfSpan =
           Math.max(roomWidth, roomDepth) * 0.82 + TABLE.THICK * 3.5;
         const targetY = tableSurfaceY + TABLE.THICK * 0.2;
         const shadowDepth =
           lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 12;
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.3);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.3 * lightBrightnessTrim);
         lightingRig.add(ambient);
 
-        const key = new THREE.DirectionalLight(0xffffff, 1.68 * brightnessCompensation);
+        const key = new THREE.DirectionalLight(
+          0xffffff,
+          1.68 * brightnessCompensation * lightBrightnessTrim
+        );
         key.position.set(lightLineX, lightRigHeight, lightPositionsZ[0]);
         key.target.position.set(0, targetY, 0);
         key.castShadow = true;
@@ -15015,19 +15018,28 @@ const powerRef = useRef(hud.power);
         lightingRig.add(key);
         lightingRig.add(key.target);
 
-        const fill = new THREE.DirectionalLight(0xffffff, 0.84 * brightnessCompensation);
+        const fill = new THREE.DirectionalLight(
+          0xffffff,
+          0.84 * brightnessCompensation * lightBrightnessTrim
+        );
         fill.position.set(-lightLineX, lightRigHeight * 1.01, lightPositionsZ[1]);
         fill.target.position.set(0, targetY, 0);
         lightingRig.add(fill);
         lightingRig.add(fill.target);
 
-        const wash = new THREE.DirectionalLight(0xffffff, 0.76 * brightnessCompensation);
+        const wash = new THREE.DirectionalLight(
+          0xffffff,
+          0.76 * brightnessCompensation * lightBrightnessTrim
+        );
         wash.position.set(lightLineX, lightRigHeight * 1.02, lightPositionsZ[2]);
         wash.target.position.set(0, targetY, 0);
         lightingRig.add(wash);
         lightingRig.add(wash.target);
 
-        const rim = new THREE.DirectionalLight(0xffffff, 0.68 * brightnessCompensation);
+        const rim = new THREE.DirectionalLight(
+          0xffffff,
+          0.68 * brightnessCompensation * lightBrightnessTrim
+        );
         rim.position.set(-lightLineX, lightRigHeight * 1.03, lightPositionsZ[3]);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -44,7 +44,6 @@ const POLY_HAVEN_CLOTHS = [
   { id: 'jogging_melange', label: 'Jogging Mélange Cloth', base: 0x7a7a7f },
   { id: 'knitted_fleece', label: 'Knitted Fleece Cloth', base: 0x6e5a4a },
   { id: 'caban', label: 'Caban Wool Cloth', base: 0x3f7242 },
-  { id: 'curly_teddy_natural', label: 'Curly Teddy Natural Cloth', base: 0x6bb885 },
   { id: 'curly_teddy_checkered', label: 'Curly Teddy Checkered Cloth', base: 0x2f6a70 },
   { id: 'denim_fabric_04', label: 'Denim Fabric 04 Cloth', base: 0x4a78a8 },
   { id: 'denim_fabric_05', label: 'Denim Fabric 05 Cloth', base: 0x2c2f35 },


### PR DESCRIPTION
## Summary
- slightly reduce the Pool Royale lighting rig intensities to soften scene brightness
- enlarge cotton jersey and polar fleece cloth patterns while retuning caban wool greens to read richer
- swap out the curly teddy natural cloth for new polar fleece plush options in presets and inventory listings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f8a1ebe48832997f1b9b43a7f5b2a)