### PR TITLE
Adjust Pool Royale lighting and cloth colors

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -55,13 +55,13 @@ const MATERIAL_SERIES = [
       emissiveIntensity: 0.24,
       envMapIntensity: 0.18
     },
-    greens: ['#2f9a55', '#278f4d', '#3cab66', '#49b870', '#1f7f3c'],
-    blues: ['#3f82c2', '#3578b8', '#4a90cf', '#569bdc', '#2f6fa6']
+    greens: ['#33b46a', '#2ca85f', '#42c47a', '#4fd184', '#238f4a'],
+    blues: ['#2ba5d9', '#2499ce', '#3ab5e6', '#45c0ed', '#1f86b8']
   },
   {
     prefix: 'polarFleece',
     label: 'Polar Fleece',
-    sourceId: 'polar_fleece',
+    sourceId: 'caban',
     basePrice: 640,
     priceStep: 10,
     bluePremium: 20,
@@ -80,7 +80,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleecePlush',
     label: 'Polar Fleece Plush',
-    sourceId: 'polar_fleece',
+    sourceId: 'caban',
     basePrice: 700,
     priceStep: 10,
     bluePremium: 20,
@@ -99,7 +99,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleeceNatureOcean',
     label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'polar_fleece',
+    sourceId: 'caban',
     basePrice: 660,
     priceStep: 10,
     bluePremium: 20,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14987,7 +14987,7 @@ const powerRef = useRef(hud.power);
         const lightLineX = 0; // align fixtures down the center line instead of offsetting per side
         const lightSpacing = Math.max(lightOffsetZ * 0.36, TABLE.THICK * 2); // pull fixtures closer together while keeping even coverage
         const lightPositionsZ = [-1.1, -0.34, 0.34, 1.1].map((mult) => mult * lightSpacing);
-        const lightBrightnessTrim = 0.86; // slightly lower the rig intensity for softer cloth highlights
+        const lightBrightnessTrim = 0.8; // lower the rig intensity a touch for gentler cloth highlights
         const shadowHalfSpan =
           Math.max(roomWidth, roomDepth) * 0.82 + TABLE.THICK * 3.5;
         const targetY = tableSurfaceY + TABLE.THICK * 0.2;


### PR DESCRIPTION
## Summary
- brighten Caban Wool cloth greens and blues to richer, more vibrant tones
- align all Polar Fleece cloth variants to use the Caban wool pattern source
- lower Pool Royale mobile lighting intensity slightly for softer highlights

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f9630e5688329a7e357e28815f60d)