### PR TITLE
Add PolyHaven seating NFTs and decor to Murlan Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -138,56 +138,17 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     name: 'Onyx Deck',
     price: 340,
     description: 'Monochrome slate backs with steel edging.'
-  },
-  {
-    id: 'stool-slate',
-    type: 'stools',
-    optionId: 'slate',
-    name: 'Slate Stools',
-    price: 210,
-    description: 'Slate seats with midnight legs.'
-  },
-  {
-    id: 'stool-teal',
-    type: 'stools',
-    optionId: 'teal',
-    name: 'Teal Stools',
-    price: 230,
-    description: 'Teal cushions with deep green support.'
-  },
-  {
-    id: 'stool-amber',
-    type: 'stools',
-    optionId: 'amber',
-    name: 'Amber Stools',
-    price: 250,
-    description: 'Amber seats with rich brown legs.'
-  },
-  {
-    id: 'stool-violet',
-    type: 'stools',
-    optionId: 'violet',
-    name: 'Violet Stools',
-    price: 270,
-    description: 'Violet cushions with twilight framing.'
-  },
-  {
-    id: 'stool-frost',
-    type: 'stools',
-    optionId: 'frost',
-    name: 'Frost Stools',
-    price: 290,
-    description: 'Frosted charcoal seats with dark legs.'
-  },
-  {
-    id: 'stool-leather',
-    type: 'stools',
-    optionId: 'leather',
-    name: 'Leather Stools',
-    price: 320,
-    description: 'Leather-wrapped seats with dark studio legs.'
   }
-];
+].concat(
+  MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+    id: `stool-${theme.id}`,
+    type: 'stools',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 300 + idx * 20,
+    description: theme.description || `Premium ${theme.label} seating with original finish.`
+  }))
+);
 
 export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0].id, label: TABLE_WOOD_OPTIONS[0].label },

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -7,12 +7,42 @@ export const MURLAN_OUTFIT_THEMES = [
   { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
 ];
 
-export const MURLAN_STOOL_THEMES = [
-  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f' },
-  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a' },
-  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a' },
-  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410' },
-  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059' },
-  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a' },
-  { id: 'leather', label: 'Leather', seatColor: '#6a4a32', legColor: '#1a1410' }
+const POLYHAVEN_THUMB = (id) => `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;
+
+const BASE_STOOL_THEMES = [
+  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f', price: 0, description: 'Default ruby cushions with noir legs.' },
+  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a', price: 210, description: 'Slate seats with midnight legs.' },
+  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a', price: 230, description: 'Teal cushions with deep green support.' },
+  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410', price: 250, description: 'Amber seats with rich brown legs.' },
+  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059', price: 270, description: 'Violet cushions with twilight framing.' },
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a', price: 290, description: 'Frosted charcoal seats with dark legs.' },
+  { id: 'leather', label: 'Leather', seatColor: '#6a4a32', legColor: '#1a1410', price: 320, description: 'Leather-wrapped seats with dark studio legs.' }
 ];
+
+const POLYHAVEN_CHAIR_THEMES = [
+  { id: 'ArmChair_01', label: 'Arm Chair 01', source: 'polyhaven', assetId: 'ArmChair_01' },
+  { id: 'BarberShopChair_01', label: 'Barber Shop Chair 01', source: 'polyhaven', assetId: 'BarberShopChair_01' },
+  { id: 'GreenChair_01', label: 'Green Chair 01', source: 'polyhaven', assetId: 'GreenChair_01' },
+  { id: 'Rockingchair_01', label: 'Rockingchair 01', source: 'polyhaven', assetId: 'Rockingchair_01' },
+  { id: 'SchoolChair_01', label: 'School Chair 01', source: 'polyhaven', assetId: 'SchoolChair_01' },
+  { id: 'WoodenChair_01', label: 'Wooden Chair 01', source: 'polyhaven', assetId: 'WoodenChair_01' },
+  { id: 'bar_chair_round_01', label: 'Bar Chair Round', source: 'polyhaven', assetId: 'bar_chair_round_01' },
+  { id: 'chinese_armchair', label: 'Chinese Armchair', source: 'polyhaven', assetId: 'chinese_armchair' },
+  { id: 'dining_chair_02', label: 'Dining Chair 02', source: 'polyhaven', assetId: 'dining_chair_02' },
+  { id: 'gallinera_chair', label: 'Gallinera Chair', source: 'polyhaven', assetId: 'gallinera_chair' },
+  { id: 'mid_century_lounge_chair', label: 'Mid-Century Lounge', source: 'polyhaven', assetId: 'mid_century_lounge_chair' },
+  { id: 'modern_arm_chair_01', label: 'Modern Arm Chair', source: 'polyhaven', assetId: 'modern_arm_chair_01' },
+  { id: 'outdoor_table_chair_set_01', label: 'Outdoor Chair Set 01', source: 'polyhaven', assetId: 'outdoor_table_chair_set_01' },
+  { id: 'painted_wooden_chair_01', label: 'Painted Wooden Chair 01', source: 'polyhaven', assetId: 'painted_wooden_chair_01' },
+  { id: 'painted_wooden_chair_02', label: 'Painted Wooden Chair 02', source: 'polyhaven', assetId: 'painted_wooden_chair_02' },
+  { id: 'plastic_monobloc_chair_01', label: 'Plastic Monobloc Chair', source: 'polyhaven', assetId: 'plastic_monobloc_chair_01' },
+  { id: 'wheelchair_01', label: 'Wheelchair 01', source: 'polyhaven', assetId: 'wheelchair_01' }
+].map((option, index) => ({
+  ...option,
+  thumbnail: POLYHAVEN_THUMB(option.assetId),
+  price: 520 + index * 35,
+  description: `${option.label} with preserved original materials.`,
+  preserveMaterials: true
+}));
+
+export const MURLAN_STOOL_THEMES = [...BASE_STOOL_THEMES, ...POLYHAVEN_CHAIR_THEMES];

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -266,6 +266,81 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
+const POLYHAVEN_PLANT_ASSETS = ['potted_plant_01', 'potted_plant_02', 'potted_plant_04', 'planter_box_01'];
+const POLYHAVEN_MODEL_CACHE = new Map();
+const PLANT_TARGET_HEIGHT = 2.8 * MODEL_SCALE;
+const DECOR_PLANT_RADIUS_SCALE = 0.9;
+
+function stripQueryHash(u) {
+  return u.split('#')[0].split('?')[0];
+}
+
+function basename(p) {
+  const s = p.replace(/\\/g, '/');
+  const parts = s.split('/');
+  return parts[parts.length - 1] || s;
+}
+
+function isModelUrl(u) {
+  const s = stripQueryHash(u).toLowerCase();
+  return s.endsWith('.glb') || s.endsWith('.gltf');
+}
+
+function extractAllHttpUrls(apiJson) {
+  const out = new Set();
+  const walk = (v) => {
+    if (!v) return;
+    if (typeof v === 'string') {
+      if (v.startsWith('http')) out.add(v);
+      return;
+    }
+    if (typeof v !== 'object') return;
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+      return;
+    }
+    Object.values(v).forEach(walk);
+  };
+  walk(apiJson);
+  return Array.from(out);
+}
+
+function pickBestModelUrl(urls) {
+  const modelUrls = urls.filter(isModelUrl);
+  const glbs = modelUrls.filter((u) => stripQueryHash(u).toLowerCase().endsWith('.glb'));
+  const gltfs = modelUrls.filter((u) => stripQueryHash(u).toLowerCase().endsWith('.gltf'));
+
+  const score = (u) => {
+    const lu = u.toLowerCase();
+    let s = 0;
+    if (lu.includes('2k')) s += 3;
+    if (lu.includes('1k')) s += 2;
+    if (lu.includes('4k')) s += 1;
+    if (lu.includes('8k')) s -= 2;
+    if (lu.includes('download')) s += 1;
+    return s;
+  };
+
+  glbs.sort((a, b) => score(b) - score(a));
+  gltfs.sort((a, b) => score(b) - score(a));
+
+  return glbs[0] || gltfs[0] || null;
+}
+
+function prepareLoadedModel(model) {
+  model.traverse((obj) => {
+    if (obj.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => {
+        if (!mat) return;
+        if (mat.map) applySRGBColorSpace(mat.map);
+        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      });
+    }
+  });
+}
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715).multiplyScalar(
   CHAIR_SIZE_SCALE
 );
@@ -381,7 +456,47 @@ function extractChairMaterials(model) {
   };
 }
 
-async function loadGltfChair() {
+function disposeObjectResources(object) {
+  const materials = new Set();
+  object.traverse((obj) => {
+    if (obj.isMesh) {
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => mat && materials.add(mat));
+      obj.geometry?.dispose?.();
+    }
+  });
+  materials.forEach((mat) => {
+    if (mat?.map) mat.map.dispose?.();
+    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    mat?.dispose?.();
+  });
+}
+
+function liftModelToGround(model, targetMinY = 0) {
+  const box = new THREE.Box3().setFromObject(model);
+  model.position.y += targetMinY - box.min.y;
+}
+
+function fitModelToHeight(model, targetHeight) {
+  const box = new THREE.Box3().setFromObject(model);
+  const currentHeight = box.max.y - box.min.y;
+  if (currentHeight > 0) {
+    const scale = targetHeight / currentHeight;
+    model.scale.multiplyScalar(scale);
+  }
+  liftModelToGround(model, 0);
+}
+
+async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0) {
+  const root = await loadPolyhavenModel(assetId);
+  const model = root.clone(true);
+  prepareLoadedModel(model);
+  fitModelToHeight(model, targetHeight);
+  if (rotationY) model.rotation.y += rotationY;
+  return model;
+}
+
+async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
   const loader = new GLTFLoader();
   const draco = new DRACOLoader();
   draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
@@ -389,7 +504,7 @@ async function loadGltfChair() {
 
   let gltf = null;
   let lastError = null;
-  for (const url of CHAIR_MODEL_URLS) {
+  for (const url of urls) {
     try {
       gltf = await loader.loadAsync(url);
       break;
@@ -406,24 +521,71 @@ async function loadGltfChair() {
     throw new Error('Chair model missing scene');
   }
 
-  model.traverse((obj) => {
-    if (obj.isMesh) {
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-      mats.forEach((mat) => {
-        if (mat?.map) applySRGBColorSpace(mat.map);
-        if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
-      });
-    }
-  });
+  prepareLoadedModel(model);
 
   fitChairModelToFootprint(model);
+  if (rotationY) {
+    model.rotation.y += rotationY;
+  }
 
   return {
     chairTemplate: model,
     materials: extractChairMaterials(model)
   };
+}
+
+async function loadPolyhavenModel(assetId) {
+  if (!assetId) throw new Error('Missing Poly Haven asset id');
+  if (POLYHAVEN_MODEL_CACHE.has(assetId)) {
+    return POLYHAVEN_MODEL_CACHE.get(assetId);
+  }
+
+  const promise = (async () => {
+    const filesJson = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`).then((r) => r.json());
+    const allUrls = extractAllHttpUrls(filesJson);
+    const modelUrl = pickBestModelUrl(allUrls);
+    if (!modelUrl) {
+      throw new Error(`No model URL found for ${assetId}`);
+    }
+
+    const fileMap = new Map();
+    for (const u of allUrls) {
+      const b = basename(stripQueryHash(u));
+      if (!fileMap.has(b)) {
+        fileMap.set(b, u);
+      }
+    }
+
+    const base = stripQueryHash(modelUrl);
+    const baseDir = base.substring(0, base.lastIndexOf('/') + 1);
+    const manager = new THREE.LoadingManager();
+    manager.setURLModifier((requestedUrl) => {
+      if (/^https?:\/\//i.test(requestedUrl)) return requestedUrl;
+      const req = stripQueryHash(requestedUrl);
+      const b = basename(req);
+      const mapped = fileMap.get(b);
+      if (mapped) return mapped;
+      try {
+        return new URL(req, baseDir).toString();
+      } catch {
+        return requestedUrl;
+      }
+    });
+
+    const loader = new GLTFLoader(manager);
+    loader.setCrossOrigin?.('anonymous');
+    const gltf = await loader.loadAsync(modelUrl);
+    const root = gltf.scene || gltf.scenes?.[0] || gltf;
+    if (!root) {
+      throw new Error(`Missing scene for ${assetId}`);
+    }
+    prepareLoadedModel(root);
+    return root;
+  })();
+
+  POLYHAVEN_MODEL_CACHE.set(assetId, promise);
+  promise.catch(() => POLYHAVEN_MODEL_CACHE.delete(assetId));
+  return promise;
 }
 
 function createProceduralChair(theme) {
@@ -500,9 +662,31 @@ function createProceduralChair(theme) {
 }
 
 async function buildChairTemplate(theme) {
+  const rotationY = theme?.modelRotation || 0;
   try {
-    const gltfChair = await loadGltfChair();
-    applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
+    if (theme?.source === 'polyhaven' && theme?.assetId) {
+      const polyhavenRoot = await loadPolyhavenModel(theme.assetId);
+      const model = polyhavenRoot.clone(true);
+      prepareLoadedModel(model);
+      fitChairModelToFootprint(model);
+      if (rotationY) model.rotation.y += rotationY;
+      const materials = extractChairMaterials(model);
+      if (!theme?.preserveMaterials) {
+        applyChairThemeMaterials({ chairMaterials: materials }, theme);
+      }
+      return { chairTemplate: model, materials };
+    }
+    if (theme?.source === 'gltf' && Array.isArray(theme.urls) && theme.urls.length) {
+      const gltfChair = await loadGltfChair(theme.urls, rotationY);
+      if (!theme?.preserveMaterials) {
+        applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
+      }
+      return gltfChair;
+    }
+    const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY);
+    if (!theme?.preserveMaterials) {
+      applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
+    }
     return gltfChair;
   } catch (error) {
     console.error('Falling back to procedural chair', error);
@@ -793,6 +977,10 @@ export default function MurlanRoyaleArena({ search }) {
     tableInfo: null,
     chairMaterials: null,
     chairTemplate: null,
+    chairThemeId: null,
+    chairInstances: [],
+    decorPlants: [],
+    decorGroup: null,
     outfitParts: [],
     cardThemeId: '',
     appearance: { ...DEFAULT_APPEARANCE }
@@ -1076,6 +1264,46 @@ export default function MurlanRoyaleArena({ search }) {
     }
   }, []);
 
+  const rebuildChairs = useCallback(
+    async (stoolTheme) => {
+      if (!threeReady) return;
+      const safe = stoolTheme || STOOL_THEMES[0];
+      const chairBuild = await buildChairTemplate(safe);
+      const currentAppearance = normalizeAppearance(appearanceRef.current);
+      const expectedTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
+      if (expectedTheme.id !== safe.id) return;
+      const store = threeStateRef.current;
+      if (store.chairMaterials) {
+        const mats = new Set([
+          store.chairMaterials.seat,
+          store.chairMaterials.leg,
+          ...(store.chairMaterials.upholstery ?? []),
+          ...(store.chairMaterials.metal ?? [])
+        ]);
+        mats.forEach((mat) => mat?.dispose?.());
+      }
+      if (store.chairTemplate) {
+        disposeObjectResources(store.chairTemplate);
+      }
+      store.chairTemplate = chairBuild.chairTemplate;
+      store.chairMaterials = chairBuild.materials;
+      store.chairThemeId = safe.id;
+      applyChairThemeMaterials(store, safe);
+
+      store.chairInstances.forEach((chair) => {
+        const previous = chair?.userData?.chairModel;
+        if (previous) {
+          disposeObjectResources(previous);
+          chair.remove(previous);
+        }
+        const clone = chairBuild.chairTemplate.clone(true);
+        chair.add(clone);
+        chair.userData.chairModel = clone;
+      });
+    },
+    [threeReady]
+  );
+
   const updateSceneAppearance = useCallback(
     (nextAppearance, { refreshCards = false } = {}) => {
       if (!threeReady) return;
@@ -1092,7 +1320,11 @@ export default function MurlanRoyaleArena({ search }) {
       if (three.tableInfo?.materials) {
         applyTableMaterials(three.tableInfo.materials, { woodOption, clothOption, baseOption }, three.renderer);
       }
-      applyChairThemeMaterials(three, stoolTheme);
+      if (three.chairThemeId !== stoolTheme.id) {
+        void rebuildChairs(stoolTheme);
+      } else {
+        applyChairThemeMaterials(three, stoolTheme);
+      }
       applyOutfitThemeMaterials(three, outfitTheme);
 
       const shouldRefreshCards = refreshCards || three.appearance?.cards !== safe.cards;
@@ -1103,7 +1335,7 @@ export default function MurlanRoyaleArena({ search }) {
       ensureCardMeshes(gameStateRef.current);
       applyStateToScene(gameStateRef.current, selectedRef.current, true);
     },
-    [applyStateToScene, ensureCardMeshes, threeReady]
+    [applyStateToScene, ensureCardMeshes, rebuildChairs, threeReady]
   );
 
   const renderPreview = useCallback((type, option) => {
@@ -1185,9 +1417,23 @@ export default function MurlanRoyaleArena({ search }) {
         );
       case 'stools':
         return (
-          <div className="relative flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-950/50">
-            <div className="h-6 w-12 rounded-md" style={{ background: option.seatColor }} />
-            <div className="absolute bottom-1 h-2 w-14 rounded-full opacity-80" style={{ background: option.legColor }} />
+          <div className="relative flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-950/50 overflow-hidden">
+            {option.thumbnail ? (
+              <img
+                src={option.thumbnail}
+                alt={option.label}
+                className="h-full w-full object-cover opacity-90"
+                loading="lazy"
+              />
+            ) : (
+              <>
+                <div className="h-6 w-12 rounded-md" style={{ background: option.seatColor }} />
+                <div
+                  className="absolute bottom-1 h-2 w-14 rounded-full opacity-80"
+                  style={{ background: option.legColor }}
+                />
+              </>
+            )}
           </div>
         );
       case 'outfit':
@@ -1435,6 +1681,30 @@ export default function MurlanRoyaleArena({ search }) {
 
       const cameraBoundRadius = wallInnerRadius - CAMERA_WALL_PADDING;
 
+      const decorGroup = new THREE.Group();
+      arenaGroup.add(decorGroup);
+      threeStateRef.current.decorGroup = decorGroup;
+      threeStateRef.current.decorPlants = [];
+      const addCornerPlants = async () => {
+        try {
+          const radius = wallInnerRadius * DECOR_PLANT_RADIUS_SCALE;
+          for (let i = 0; i < POLYHAVEN_PLANT_ASSETS.length; i += 1) {
+            const assetId = POLYHAVEN_PLANT_ASSETS[i];
+            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT);
+            if (disposed) return;
+            const angle = (i / POLYHAVEN_PLANT_ASSETS.length) * Math.PI * 2 + Math.PI / 4;
+            const pos = new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
+            plant.position.add(pos);
+            plant.lookAt(new THREE.Vector3(0, plant.position.y + 0.1, 0));
+            decorGroup.add(plant);
+            threeStateRef.current.decorPlants.push(plant);
+          }
+        } catch (error) {
+          console.warn('Failed to load decor plants', error);
+        }
+      };
+      void addCornerPlants();
+
       const scoreboardCanvas = document.createElement('canvas');
       scoreboardCanvas.width = 1024;
       scoreboardCanvas.height = 512;
@@ -1495,6 +1765,7 @@ export default function MurlanRoyaleArena({ search }) {
       const chairTemplate = chairBuild.chairTemplate;
       threeStateRef.current.chairTemplate = chairTemplate;
       threeStateRef.current.chairMaterials = chairBuild.materials;
+      threeStateRef.current.chairThemeId = stoolTheme.id;
       applyChairThemeMaterials(threeStateRef.current, stoolTheme);
 
       const avatarRadius = 0.32 * MODEL_SCALE;
@@ -1526,12 +1797,15 @@ export default function MurlanRoyaleArena({ search }) {
       cardGeometry = new THREE.BoxGeometry(CARD_W, CARD_H, CARD_D, 1, 1, 1);
 
       const seatConfigs = [];
+      threeStateRef.current.chairInstances = [];
 
       for (let i = 0; i < CHAIR_COUNT; i++) {
         const player = players[i] ?? null;
         const chair = new THREE.Group();
         const chairModel = chairTemplate.clone(true);
         chair.add(chairModel);
+        chair.userData.chairModel = chairModel;
+        threeStateRef.current.chairInstances.push(chair);
 
         const occupant = new THREE.Group();
         occupant.position.z = -seatDepth * 0.12;
@@ -1854,6 +2128,24 @@ export default function MurlanRoyaleArena({ search }) {
         });
         store.chairTemplate = null;
       }
+      if (store.chairInstances?.length) {
+        store.chairInstances.forEach((group) => {
+          const model = group?.userData?.chairModel;
+          if (model) {
+            disposeObjectResources(model);
+            group.remove(model);
+          }
+        });
+        store.chairInstances = [];
+      }
+      if (store.decorGroup) {
+        disposeObjectResources(store.decorGroup);
+        if (store.decorGroup.parent) {
+          store.decorGroup.parent.remove(store.decorGroup);
+        }
+        store.decorGroup = null;
+        store.decorPlants = [];
+      }
       if (store.outfitParts) {
         store.outfitParts.forEach((mat) => {
           if (mat && typeof mat.dispose === 'function') mat.dispose();
@@ -1878,6 +2170,10 @@ export default function MurlanRoyaleArena({ search }) {
         tableInfo: null,
         chairMaterials: null,
         chairTemplate: null,
+        chairThemeId: null,
+        chairInstances: [],
+        decorPlants: [],
+        decorGroup: null,
         outfitParts: [],
         cardThemeId: '',
         appearance: { ...DEFAULT_APPEARANCE }
@@ -2668,6 +2964,7 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
 function applyChairThemeMaterials(three, theme) {
   const mats = three?.chairMaterials;
   if (!mats) return;
+  if (theme?.preserveMaterials) return;
   if (mats.seat?.color) {
     mats.seat.color.set(theme.seatColor);
     mats.seat.needsUpdate = true;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,7 +175,7 @@ const MURLAN_TYPE_LABELS = {
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
   cards: 'Card Themes',
-  stools: 'Stools'
+  stools: 'Stools & Chairs'
 };
 
 const DOMINO_TYPE_LABELS = {


### PR DESCRIPTION
## Summary
- add PolyHaven chair collection to the Murlan Royale inventory with thumbnails, pricing, and preserved original materials
- load PolyHaven assets in the arena, rebuild seating when themes change, and add four textured potted plants at the room corners
- update the store label for Murlan seating to reflect the expanded chair catalog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb70d60588329b7a330c46d8fa147)