### PR TITLE
Add Murlan chair NFTs and arena decor

### DIFF
--- a/webapp/src/config/murlanChairs.js
+++ b/webapp/src/config/murlanChairs.js
@@ -1,0 +1,209 @@
+export const MURLAN_CHAIR_MODELS = [
+  {
+    id: 'studioStool',
+    label: 'Studio Stool',
+    source: 'procedural',
+    tintable: true,
+    preserveMaterials: false,
+    price: 0,
+    description: 'Lightweight studio stool that follows your stool palette.',
+    swatches: ['#7c3aed', '#0f172a']
+  },
+  {
+    id: 'armChair_01',
+    label: 'Classic Armchair',
+    source: 'polyhaven',
+    assetId: 'ArmChair_01',
+    preserveMaterials: true,
+    price: 540,
+    description: 'Tufted leather armchair from Poly Haven with original wood grain.',
+    swatches: ['#6b4c32', '#24150e']
+  },
+  {
+    id: 'barberShopChair_01',
+    label: 'Barbershop Chair',
+    source: 'polyhaven',
+    assetId: 'BarberShopChair_01',
+    preserveMaterials: true,
+    price: 560,
+    description: 'Vintage barbershop chair with metal trims and vinyl upholstery.',
+    swatches: ['#3b3b3b', '#d1b48c']
+  },
+  {
+    id: 'GreenChair_01',
+    label: 'Velvet Green Chair',
+    source: 'polyhaven',
+    assetId: 'GreenChair_01',
+    preserveMaterials: true,
+    price: 520,
+    description: 'Emerald velvet lounge chair retaining its original fabric materials.',
+    swatches: ['#1f5133', '#0f172a']
+  },
+  {
+    id: 'Rockingchair_01',
+    label: 'Rocking Chair',
+    source: 'polyhaven',
+    assetId: 'Rockingchair_01',
+    preserveMaterials: true,
+    price: 540,
+    description: 'Wooden rocking chair with natural grain textures intact.',
+    swatches: ['#8b5a2b', '#3b2f2f']
+  },
+  {
+    id: 'SchoolChair_01',
+    label: 'School Chair',
+    source: 'polyhaven',
+    assetId: 'SchoolChair_01',
+    preserveMaterials: true,
+    price: 480,
+    description: 'Stackable school chair with the original steel frame finish.',
+    swatches: ['#9ca3af', '#334155']
+  },
+  {
+    id: 'WoodenChair_01',
+    label: 'Wooden Study Chair',
+    source: 'polyhaven',
+    assetId: 'WoodenChair_01',
+    preserveMaterials: true,
+    price: 500,
+    description: 'Straight-back wooden chair showing untouched timber tones.',
+    swatches: ['#8b6338', '#3d2c1d']
+  },
+  {
+    id: 'bar_chair_round_01',
+    label: 'Round Bar Chair',
+    source: 'polyhaven',
+    assetId: 'bar_chair_round_01',
+    preserveMaterials: true,
+    price: 510,
+    description: 'Round-top bar chair with original vinyl and chrome accents.',
+    swatches: ['#0f172a', '#a3a3a3']
+  },
+  {
+    id: 'chinese_armchair',
+    label: 'Chinese Armchair',
+    source: 'polyhaven',
+    assetId: 'chinese_armchair',
+    preserveMaterials: true,
+    price: 520,
+    description: 'Curved hardwood armchair with preserved lacquer materials.',
+    swatches: ['#4b2d1c', '#2d1b12']
+  },
+  {
+    id: 'dining_chair_02',
+    label: 'Dining Chair',
+    source: 'polyhaven',
+    assetId: 'dining_chair_02',
+    preserveMaterials: true,
+    price: 520,
+    description: 'Modern dining chair with its native fabric and wood finish.',
+    swatches: ['#b0b5b8', '#3f4144']
+  },
+  {
+    id: 'gallinera_chair',
+    label: 'Gallinera Chair',
+    source: 'polyhaven',
+    assetId: 'gallinera_chair',
+    preserveMaterials: true,
+    price: 530,
+    description: 'Woven gallinera chair featuring untouched straw textures.',
+    swatches: ['#d9b574', '#4a311d']
+  },
+  {
+    id: 'mid_century_lounge_chair',
+    label: 'Mid-century Lounge',
+    source: 'polyhaven',
+    assetId: 'mid_century_lounge_chair',
+    preserveMaterials: true,
+    price: 560,
+    description: 'Mid-century lounge chair keeping its original leather and wood.',
+    swatches: ['#6b442d', '#1f1f1f']
+  },
+  {
+    id: 'modern_arm_chair_01',
+    label: 'Modern Arm Chair',
+    source: 'polyhaven',
+    assetId: 'modern_arm_chair_01',
+    preserveMaterials: true,
+    price: 540,
+    description: 'Contemporary arm chair with intact fabric and steel legs.',
+    swatches: ['#9ea2aa', '#1f2937']
+  },
+  {
+    id: 'outdoor_table_chair_set_01',
+    label: 'Outdoor Lounge Chair',
+    source: 'polyhaven',
+    assetId: 'outdoor_table_chair_set_01',
+    preserveMaterials: true,
+    price: 520,
+    description: 'Outdoor woven chair keeping the original wicker materials.',
+    swatches: ['#7b5a3f', '#2b2a28']
+  },
+  {
+    id: 'painted_wooden_chair_01',
+    label: 'Painted Wooden Chair',
+    source: 'polyhaven',
+    assetId: 'painted_wooden_chair_01',
+    preserveMaterials: true,
+    price: 500,
+    description: 'Pastel painted wooden chair with chipped paint intact.',
+    swatches: ['#c7cad5', '#5b6673']
+  },
+  {
+    id: 'painted_wooden_chair_02',
+    label: 'Vintage Painted Chair',
+    source: 'polyhaven',
+    assetId: 'painted_wooden_chair_02',
+    preserveMaterials: true,
+    price: 500,
+    description: 'Weathered painted chair showcasing its native patina.',
+    swatches: ['#b6c5cf', '#38454f']
+  },
+  {
+    id: 'plastic_monobloc_chair_01',
+    label: 'Plastic Monobloc Chair',
+    source: 'polyhaven',
+    assetId: 'plastic_monobloc_chair_01',
+    preserveMaterials: true,
+    price: 460,
+    description: 'Classic plastic monobloc chair with glossy molded finish.',
+    swatches: ['#e5e7eb', '#9ca3af']
+  },
+  {
+    id: 'wheelchair_01',
+    label: 'Wheelchair',
+    source: 'polyhaven',
+    assetId: 'wheelchair_01',
+    preserveMaterials: true,
+    price: 580,
+    description: 'Detailed wheelchair model keeping its metal and fabric materials.',
+    swatches: ['#e5e7eb', '#111827']
+  }
+];
+
+export const MURLAN_FLOWER_POTS = [
+  {
+    id: 'potted_plant_01',
+    label: 'Clay Pot Fern',
+    assetId: 'potted_plant_01',
+    swatches: ['#3f6c3a', '#c07d4f']
+  },
+  {
+    id: 'potted_plant_02',
+    label: 'Marble Pot Palm',
+    assetId: 'potted_plant_02',
+    swatches: ['#2f5135', '#cbd5e1']
+  },
+  {
+    id: 'potted_plant_04',
+    label: 'Studio Planter',
+    assetId: 'potted_plant_04',
+    swatches: ['#4f6b4a', '#746b5c']
+  },
+  {
+    id: 'flower_gazania',
+    label: 'Gazania Flowers',
+    assetId: 'flower_gazania',
+    swatches: ['#f59e0b', '#2e3f1e']
+  }
+];

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,6 +1,7 @@
 import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../utils/cardThemes.js';
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+import { MURLAN_CHAIR_MODELS } from './murlanChairs.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -15,7 +16,8 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableCloth: [TABLE_CLOTH_OPTIONS[0].id],
   tableBase: [TABLE_BASE_OPTIONS[0].id],
   cards: [CARD_THEMES[0].id],
-  stools: [MURLAN_STOOL_THEMES[0].id]
+  stools: [MURLAN_STOOL_THEMES[0].id],
+  chairModel: [MURLAN_CHAIR_MODELS[0].id]
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
@@ -23,7 +25,8 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   tableCloth: mapLabels(TABLE_CLOTH_OPTIONS),
   tableBase: mapLabels(TABLE_BASE_OPTIONS),
   cards: mapLabels(CARD_THEMES),
-  stools: mapLabels(MURLAN_STOOL_THEMES)
+  stools: mapLabels(MURLAN_STOOL_THEMES),
+  chairModel: mapLabels(MURLAN_CHAIR_MODELS)
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
@@ -186,7 +189,15 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     name: 'Leather Stools',
     price: 320,
     description: 'Leather-wrapped seats with dark studio legs.'
-  }
+  },
+  ...MURLAN_CHAIR_MODELS.slice(1).map((option, idx) => ({
+    id: `chair-${option.id}`,
+    type: 'chairModel',
+    optionId: option.id,
+    name: `${option.label}`,
+    price: Number.isFinite(option.price) ? option.price : 520 + idx * 12,
+    description: option.description || 'Unlocks a new seating model with its original materials.'
+  }))
 ];
 
 export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
@@ -194,5 +205,6 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0].id, label: TABLE_CLOTH_OPTIONS[0].label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0].id, label: TABLE_BASE_OPTIONS[0].label },
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
-  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label }
+  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },
+  { type: 'chairModel', optionId: MURLAN_CHAIR_MODELS[0].id, label: MURLAN_CHAIR_MODELS[0].label }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,6 +175,7 @@ const MURLAN_TYPE_LABELS = {
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
   cards: 'Card Themes',
+  chairModel: 'Chairs',
   stools: 'Stools'
 };
 
@@ -256,6 +257,7 @@ const TYPE_SWATCHES = {
   tableWood: ['#4b3621', '#9a7b4f'],
   tableCloth: ['#0f172a', '#34d399'],
   tableBase: ['#0f172a', '#1f2937'],
+  chairModel: ['#e5e7eb', '#1f2937'],
   chairColor: ['#111827', '#f59e0b'],
   tableShape: ['#334155', '#64748b'],
   sideColor: ['#f8fafc', '#1f2937'],
@@ -332,7 +334,8 @@ const PREVIEW_BY_TYPE = {
   tableFinish: 'table',
   tableWood: 'table',
   tableCloth: 'table',
-  tableBase: 'table'
+  tableBase: 'table',
+  chairModel: 'chair'
 };
 
 const PREVIEW_BY_SLUG = {


### PR DESCRIPTION
## Summary
- add a PolyHaven-sourced chair catalog and flower pot assets for Murlan Royale
- expose the chair models as unlockable store items with updated default loadouts
- load the selected chairs with original materials in the arena and place four textured planters in the room corners

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb70d60588329b7a330c46d8fa147)