### PR TITLE
Restore meshopt decoder for Murlan chairs

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -9,6 +9,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
@@ -513,6 +514,7 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
   const draco = new DRACOLoader();
   draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
   loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
 
   let gltf = null;
   let lastError = null;
@@ -585,6 +587,7 @@ async function loadPolyhavenModel(assetId) {
     const draco = new DRACOLoader();
     draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
     loader.setDRACOLoader(draco);
+    loader.setMeshoptDecoder?.(MeshoptDecoder);
     loader.setCrossOrigin?.('anonymous');
 
     if (fileMap.size) {


### PR DESCRIPTION
## Summary
- restore the meshopt decoder import for the Murlan Royale Arena GLTF loader
- enable meshopt decoding for chair and PolyHaven model loads so compressed assets render correctly

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff147a84883299761647183bc998d)