### PR TITLE
Fix splaytree resolution for Vite build

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -5,6 +5,15 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/',
   plugins: [react()],
+  resolve: {
+    // Ensure polygon-clipping can load its SplayTree dependency in Vite
+    alias: {
+      splaytree: 'splaytree/dist/splay.esm.js'
+    }
+  },
+  optimizeDeps: {
+    include: ['splaytree']
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- add a Vite alias for `splaytree` so polygon-clipping resolves correctly
- include `splaytree` in optimizeDeps to avoid entry resolution errors

## Testing
- npm run build (webapp)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff3192d18832985843ad6bd78ba1c)