### PR TITLE
Fix splaytree resolution for webapp build

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,6 +28,7 @@
     "react-router-dom": "^6.22.3",
     "recharts": "^2.15.4",
     "socket.io-client": "^4.8.1",
+    "splaytree": "^3.1.2",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,10 +1,23 @@
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
+
+const splaytreeEntry = fileURLToPath(
+  new URL('./node_modules/splaytree/dist/splay.esm.js', import.meta.url)
+);
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      splaytree: splaytreeEntry
+    }
+  },
+  optimizeDeps: {
+    include: ['splaytree']
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- add splaytree as an explicit dependency for the webapp
- alias the package to its ESM build so Vite can resolve it cleanly and prebundle it

## Testing
- npm run build --prefix webapp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff3192d18832985843ad6bd78ba1c)