### PR TITLE
Restore Murlan Royale 3D state

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,7 +28,6 @@
     "react-router-dom": "^6.22.3",
     "recharts": "^2.15.4",
     "socket.io-client": "^4.8.1",
-    "splaytree": "^3.1.2",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -9,7 +9,6 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
-import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
@@ -514,7 +513,6 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
   const draco = new DRACOLoader();
   draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
   loader.setDRACOLoader(draco);
-  loader.setMeshoptDecoder?.(MeshoptDecoder);
 
   let gltf = null;
   let lastError = null;
@@ -587,7 +585,6 @@ async function loadPolyhavenModel(assetId) {
     const draco = new DRACOLoader();
     draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
     loader.setDRACOLoader(draco);
-    loader.setMeshoptDecoder?.(MeshoptDecoder);
     loader.setCrossOrigin?.('anonymous');
 
     if (fileMap.size) {

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,23 +1,10 @@
 import { defineConfig } from 'vite';
-import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
-
-const splaytreeEntry = fileURLToPath(
-  new URL('./node_modules/splaytree/dist/splay.esm.js', import.meta.url)
-);
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
   plugins: [react()],
-  resolve: {
-    alias: {
-      splaytree: splaytreeEntry
-    }
-  },
-  optimizeDeps: {
-    include: ['splaytree']
-  },
   build: {
     outDir: 'dist',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- revert Murlan Royale arena loader configuration to its previous setup without Meshopt decoder hooks
- remove the splaytree dependency and related Vite aliasing to match the earlier build configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff604ac7c8329b96a6153fb30d769)