### PR TITLE
Restore Murlan Royale to 3-hours-ago state

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,6 +28,7 @@
     "react-router-dom": "^6.22.3",
     "recharts": "^2.15.4",
     "socket.io-client": "^4.8.1",
+    "splaytree": "^3.1.2",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
     "vite": "^4.4.9"

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,10 +1,23 @@
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
+
+const splaytreeEntry = fileURLToPath(
+  new URL('./node_modules/splaytree/dist/splay.esm.js', import.meta.url)
+);
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      splaytree: splaytreeEntry
+    }
+  },
+  optimizeDeps: {
+    include: ['splaytree']
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- restore the webapp dependency set to include splaytree as it was three hours ago
- reintroduce the Vite alias and optimized dependency entry for splaytree to match the earlier configuration

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffe7c82548329ad87e48329d3d2b5)