### PR TITLE
Fix Vite resolution for splaytree dependency

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,6 +12,12 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true
+  },
+  resolve: {
+    // splaytree package ships without the declared ESM entry; point to the UMD build so Vite can bundle polygon-clipping
+    alias: {
+      splaytree: path.resolve(__dirname, 'node_modules/splaytree/dist/splaytree.js')
+    }
   },
   // SPA fallback for React Router
   server: {


### PR DESCRIPTION
## Summary
- add explicit Vite alias to use the bundled splaytree build required by polygon-clipping
- resolve the alias via absolute path so builds succeed in environments that enforce package exports

## Testing
- npm run build (webapp)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500a911c2083298f832df3758fb3b9)