### PR TITLE
Fix Vite resolution for splaytree dependency

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,6 +12,15 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true
+  },
+  resolve: {
+    alias: {
+      // splaytree package publishes dist/splaytree.js but points exports to a missing file
+      splaytree: resolve(__dirname, 'node_modules/splaytree/dist/splaytree.js')
+    }
+  },
+  optimizeDeps: {
+    include: ['splaytree']
   },
   // SPA fallback for React Router
   server: {


### PR DESCRIPTION
## Summary
- add a Vite alias pointing to the published splaytree build so the dependency resolves correctly
- prebundle splaytree to avoid resolution failures during production builds

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500a911c2083298f832df3758fb3b9)