### PR TITLE
Adjust Pool Royale AI cue camera drop

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5078,7 +5078,9 @@ const AI_THINKING_BUDGET_MS =
 const AI_CAMERA_DROP_LEAD_MS = 420; // start lowering into cue view shortly before the AI pulls the trigger
 const AI_CAMERA_SETTLE_MS = 320; // allow time for the cue view to settle before firing
 const AI_CUE_VIEW_HOLD_MS = 3000;
-const AI_CAMERA_DROP_BLEND = 0.14;
+// Ease the AI camera just partway toward cue view (still above the stick) so the shot preview
+// lingers in a mid-angle frame for a few seconds before firing.
+const AI_CAMERA_DROP_BLEND = 0.65;
 const AI_CAMERA_DROP_DURATION_MS = 480;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>


### PR DESCRIPTION
## Summary
- raise the AI cue camera drop blend so Pool Royale AI settles slightly above cue view before shooting while keeping the 3-second hold

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950101edf0c832983b6c9edc282dcc1)