### PR TITLE
Synchronize cue pull with power slider

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -8,6 +8,7 @@ export class PowerSlider {
       step = 1,
       cueSrc = '',
       onChange,
+      onDragStateChange,
       onCommit,
       theme = 'default',
       labels = false
@@ -20,6 +21,7 @@ export class PowerSlider {
     this.max = max;
     this.step = step;
     this.onChange = onChange;
+    this.onDragStateChange = onDragStateChange;
     this.onCommit = onCommit;
     this.locked = false;
 
@@ -202,6 +204,9 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this.dragging = true;
+    if (typeof this.onDragStateChange === 'function') {
+      this.onDragStateChange(true);
+    }
     this.dragMoved = false;
     this.dragStartValue = this.value;
     this.el.classList.add('ps-no-animate');
@@ -222,6 +227,9 @@ export class PowerSlider {
   _pointerUp(e) {
     if (!this.dragging) return;
     this.dragging = false;
+    if (typeof this.onDragStateChange === 'function') {
+      this.onDragStateChange(false);
+    }
     this.el.releasePointerCapture(e.pointerId);
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10357,6 +10357,7 @@ const powerRef = useRef(hud.power);
     shootingRef.current = shotActive;
   }, [shotActive]);
   const sliderInstanceRef = useRef(null);
+  const powerSliderDraggingRef = useRef(false);
   const suggestionAimKeyRef = useRef(null);
   const aiEarlyShotIntentRef = useRef(null);
   const aiShotPreviewRef = useRef(false);
@@ -16637,31 +16638,21 @@ const powerRef = useRef(hud.power);
             if (animFrame < animSteps) {
               requestAnimationFrame(animateCue);
             } else {
-              let backFrame = 0;
-              const animateBack = () => {
-                backFrame++;
-                cueStick.position.lerpVectors(
-                  endPos,
-                  startPos,
-                  backFrame / animSteps
-                );
-                if (backFrame < animSteps) requestAnimationFrame(animateBack);
-                else {
-                  cuePullCurrentRef.current = 0;
-                  cuePullTargetRef.current = 0;
-                  cueStick.visible = false;
-                  cueAnimating = false;
-                  if (cameraRef.current && sphRef.current) {
-                    topViewRef.current = false;
-                    topViewLockedRef.current = false;
-                    setIsTopDownView(false);
-                    const sph = sphRef.current;
-                    sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-                    updateCamera();
-                  }
+              cueStick.position.copy(endPos);
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              requestAnimationFrame(() => {
+                cueStick.visible = false;
+                cueAnimating = false;
+                if (cameraRef.current && sphRef.current) {
+                  topViewRef.current = false;
+                  topViewLockedRef.current = false;
+                  setIsTopDownView(false);
+                  const sph = sphRef.current;
+                  sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+                  updateCamera();
                 }
-              };
-              requestAnimationFrame(animateBack);
+              });
             }
           };
           animateCue();
@@ -18695,11 +18686,13 @@ const powerRef = useRef(hud.power);
           const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const pullTarget = Math.min(desiredPull, maxPull);
           cuePullTargetRef.current = pullTarget;
-          const pull = THREE.MathUtils.lerp(
-            cuePullCurrentRef.current ?? 0,
-            pullTarget,
-            CUE_PULL_SMOOTHING
-          );
+          const pull = powerSliderDraggingRef.current
+            ? pullTarget
+            : THREE.MathUtils.lerp(
+                cuePullCurrentRef.current ?? 0,
+                pullTarget,
+                CUE_PULL_SMOOTHING
+              );
           cuePullCurrentRef.current = pull;
           const offsetSide = ranges.offsetSide ?? 0;
           const offsetVertical = ranges.offsetVertical ?? 0;
@@ -19940,6 +19933,9 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onDragStateChange: (dragging) => {
+        powerSliderDraggingRef.current = dragging;
+      },
       onChange: (v) => applyPower(v / 100),
       onCommit: () => {
         fireRef.current?.();

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -14821,31 +14821,21 @@ export function PoolRoyaleGame({
             if (animFrame < animSteps) {
               requestAnimationFrame(animateCue);
             } else {
-              let backFrame = 0;
-              const animateBack = () => {
-                backFrame++;
-                cueStick.position.lerpVectors(
-                  endPos,
-                  startPos,
-                  backFrame / animSteps
-                );
-                if (backFrame < animSteps) requestAnimationFrame(animateBack);
-                else {
-                  cuePullCurrentRef.current = 0;
-                  cuePullTargetRef.current = 0;
-                  cueStick.visible = false;
-                  cueAnimating = false;
-                  if (cameraRef.current && sphRef.current) {
-                    topViewRef.current = false;
-                    topViewLockedRef.current = false;
-                    setIsTopDownView(false);
-                    const sph = sphRef.current;
-                    sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-                    updateCamera();
-                  }
+              cueStick.position.copy(endPos);
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              requestAnimationFrame(() => {
+                cueStick.visible = false;
+                cueAnimating = false;
+                if (cameraRef.current && sphRef.current) {
+                  topViewRef.current = false;
+                  topViewLockedRef.current = false;
+                  setIsTopDownView(false);
+                  const sph = sphRef.current;
+                  sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+                  updateCamera();
                 }
-              };
-              requestAnimationFrame(animateBack);
+              });
             }
           };
           animateCue();
@@ -16234,11 +16224,13 @@ export function PoolRoyaleGame({
           const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const pullTarget = Math.min(desiredPull, maxPull);
           cuePullTargetRef.current = pullTarget;
-          const pull = THREE.MathUtils.lerp(
-            cuePullCurrentRef.current ?? 0,
-            pullTarget,
-            CUE_PULL_SMOOTHING
-          );
+          const pull = powerSliderDraggingRef.current
+            ? pullTarget
+            : THREE.MathUtils.lerp(
+                cuePullCurrentRef.current ?? 0,
+                pullTarget,
+                CUE_PULL_SMOOTHING
+              );
           cuePullCurrentRef.current = pull;
           const offsetSide = ranges.offsetSide ?? 0;
           const offsetVertical = ranges.offsetVertical ?? 0;
@@ -17217,6 +17209,7 @@ export function PoolRoyaleGame({
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
+  const powerSliderDraggingRef = useRef(false);
   const showPowerSlider = !hud.over;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -17229,6 +17222,9 @@ export function PoolRoyaleGame({
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onDragStateChange: (dragging) => {
+        powerSliderDraggingRef.current = dragging;
+      },
       onChange: (v) => setHud((s) => ({ ...s, power: v / 100 })),
       onCommit: () => {
         fireRef.current?.();


### PR DESCRIPTION
## Summary
- add drag state callbacks to the power slider to report live pull changes
- sync cue stick pull distance to slider movement in Pool Royale and Snooker Club
- update cue strike animation to drive forward from the pulled position before resetting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501565c5208329bc329c4bbaf3b837)