### PR TITLE
Improve Pool Royale cue alignment and replay UI

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -158,7 +158,8 @@ export class PowerSlider {
     this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);
     if (this.handleText) {
-      this.handleText.textContent = `${Math.round(this.value)}%`;
+      const isResting = this.value <= this.min + this.step * 0.5;
+      this.handleText.textContent = isResting ? 'Pull' : `${Math.round(this.value)}%`;
     }
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));


### PR DESCRIPTION
## Summary
- align cue tip and spin offsets for more precise contact and higher butt lift near obstructions
- reset the power slider to start at 0 with a visible Pull label and hide controls during replays with a TV-style frame
- adjust portrait HUD spacing to sit between the Look/2D buttons and spin control while keeping replays unobstructed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504cf1e99883298b8eec10afecc929)