### PR TITLE
Improve Pool Royale replay and cue feel

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -158,7 +158,9 @@ export class PowerSlider {
     this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);
     if (this.handleText) {
-      this.handleText.textContent = `${Math.round(this.value)}%`;
+      const showPull = ratio <= 0.02;
+      this.handleText.dataset.state = showPull ? 'pull' : 'value';
+      this.handleText.textContent = showPull ? 'Pull' : `${Math.round(this.value)}%`;
     }
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));


### PR DESCRIPTION
## Summary
- Adjust portrait HUD spacing and hide controls during replays behind a TV-style overlay
- Calibrate cue position and spin offsets, raising the butt near blockers and adding cue-ball lift on hard strokes
- Reset the power slider to a visible 0% "Pull" state with live cue pull feedback

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504cf1e99883298b8eec10afecc929)