### PR TITLE
Restore Snooker cue pull slider sync

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -8,6 +8,7 @@ export class PowerSlider {
       step = 1,
       cueSrc = '',
       onChange,
+      onDragStateChange,
       onCommit,
       theme = 'default',
       labels = false
@@ -20,6 +21,7 @@ export class PowerSlider {
     this.max = max;
     this.step = step;
     this.onChange = onChange;
+    this.onDragStateChange = onDragStateChange;
     this.onCommit = onCommit;
     this.locked = false;
 
@@ -202,6 +204,9 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this.dragging = true;
+    if (typeof this.onDragStateChange === 'function') {
+      this.onDragStateChange(true);
+    }
     this.dragMoved = false;
     this.dragStartValue = this.value;
     this.el.classList.add('ps-no-animate');
@@ -222,6 +227,9 @@ export class PowerSlider {
   _pointerUp(e) {
     if (!this.dragging) return;
     this.dragging = false;
+    if (typeof this.onDragStateChange === 'function') {
+      this.onDragStateChange(false);
+    }
     this.el.releasePointerCapture(e.pointerId);
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -16234,11 +16234,13 @@ export function PoolRoyaleGame({
           const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const pullTarget = Math.min(desiredPull, maxPull);
           cuePullTargetRef.current = pullTarget;
-          const pull = THREE.MathUtils.lerp(
-            cuePullCurrentRef.current ?? 0,
-            pullTarget,
-            CUE_PULL_SMOOTHING
-          );
+          const pull = powerSliderDraggingRef.current
+            ? pullTarget
+            : THREE.MathUtils.lerp(
+                cuePullCurrentRef.current ?? 0,
+                pullTarget,
+                CUE_PULL_SMOOTHING
+              );
           cuePullCurrentRef.current = pull;
           const offsetSide = ranges.offsetSide ?? 0;
           const offsetVertical = ranges.offsetVertical ?? 0;
@@ -17217,6 +17219,7 @@ export function PoolRoyaleGame({
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
+  const powerSliderDraggingRef = useRef(false);
   const showPowerSlider = !hud.over;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -17229,6 +17232,9 @@ export function PoolRoyaleGame({
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onDragStateChange: (dragging) => {
+        powerSliderDraggingRef.current = dragging;
+      },
       onChange: (v) => setHud((s) => ({ ...s, power: v / 100 })),
       onCommit: () => {
         fireRef.current?.();


### PR DESCRIPTION
## Summary
- add drag state callbacks back to the power slider so consumers can react to pull gestures
- keep the Snooker Club cue pull animation aligned with live slider dragging rather than smoothing during drag

## Testing
- npm test -- --runInBand *(fails: several suites rely on node:test helpers and MongoMemoryServer downloads that do not work in this environment; see console output for proxy/download errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b54ce5248329a4a23e36880ca197)