### PR TITLE
Improve Pool Royale replay overlay and cue alignment

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -158,7 +158,8 @@ export class PowerSlider {
     this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);
     if (this.handleText) {
-      this.handleText.textContent = `${Math.round(this.value)}%`;
+      const showPullLabel = ratio <= 0.05;
+      this.handleText.textContent = showPullLabel ? 'Pull' : `${Math.round(this.value)}%`;
     }
     this.tooltip.textContent = `${Math.round(this.value)}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));


### PR DESCRIPTION
## Summary
- Recalibrated cue height, offset, and spin ranges so the tip aligns with the cue ball and lifts more on max-power shots while clearing nearby balls.
- Started the power slider at a visible Pull state with live cue pull syncing, and tightened HUD spacing to sit between the view buttons and spin control on portrait.
- Hid gameplay controls during replays and added a broadcast-style replay frame for a cleaner presentation.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b592eb5c8329b2824d60a2580df5)