### PR TITLE
Improve Pool Royale cue alignment and replay UI

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -157,10 +157,11 @@ export class PowerSlider {
     const pct = ratio * 100;
     this.powerFill.style.clipPath = `inset(0 0 ${100 - pct}% 0)`;
     this._updateHandleColor(ratio);
+    const pctValue = Math.round(this.value);
     if (this.handleText) {
-      this.handleText.textContent = `${Math.round(this.value)}%`;
+      this.handleText.textContent = pctValue <= this.min ? 'Pull' : `${pctValue}%`;
     }
-    this.tooltip.textContent = `${Math.round(this.value)}%`;
+    this.tooltip.textContent = `${pctValue}%`;
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));
     if (ratio >= 0.9) this.el.classList.add('ps-hot');
     else this.el.classList.remove('ps-hot');


### PR DESCRIPTION
## Summary
- calibrate cue height, tip gap, obstruction tilt/lift and max-power bounce to keep the blue tip centred on the cueball and lift harder at full power
- adjust portrait HUD insets so the bottom player frame sits between Look/2D and the spin controller and hide controls during replays behind a TV-style frame
- default the Pool Royale power slider to 0 with a visible Pull label and keep the live cue pull synced while dragging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b592eb5c8329b2824d60a2580df5)