### PR TITLE
Enlarge Domino Royal hallway wall tiles

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2826,7 +2826,7 @@ const walkwayWallTexture = textureLoader.load(
 walkwayWallTexture.wrapS = THREE.RepeatWrapping;
 walkwayWallTexture.wrapT = THREE.RepeatWrapping;
 walkwayWallTexture.colorSpace = THREE.SRGBColorSpace;
-walkwayWallTexture.repeat.set(ARENA_WALKWAY_LENGTH / 2.2, 1.4);
+walkwayWallTexture.repeat.set(ARENA_WALKWAY_LENGTH / 2.2 / 4, 1.4 / 4);
 const walkwaySideMat = new THREE.MeshStandardMaterial({
   map: walkwayWallTexture,
   roughness: 0.48,


### PR DESCRIPTION
## Summary
- reduce the hallway wall texture repeat so the wall tiles appear four times larger

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950e92ced9c8329881554d1193d7c48)