### PR TITLE
Adjust hallway marble tiling and quality

### DIFF
--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import * as THREE from 'three';
 import { getOnlineCount } from '../utils/api.js';
 
-const WALL_REPEAT = new THREE.Vector2(3.5, 2); // 4x larger wall tiles
+const WALL_REPEAT = new THREE.Vector2(5, 2.8); // 30% smaller wall tiles
 const PREFERRED_SIZES = ['2k', '1k'];
 
 const fallbackGameNames = [
@@ -92,6 +92,7 @@ export default function GamesHallway({ games, onClose }) {
     renderer.domElement.style.touchAction = 'none';
     renderer.domElement.style.cursor = 'grab';
     container.appendChild(renderer.domElement);
+    const maxAnisotropy = renderer.capabilities.getMaxAnisotropy();
 
     const camera = new THREE.PerspectiveCamera(
       60,
@@ -164,6 +165,9 @@ export default function GamesHallway({ games, onClose }) {
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
       texture.repeat.copy(WALL_REPEAT);
+      texture.anisotropy = maxAnisotropy;
+      texture.minFilter = THREE.LinearMipmapLinearFilter;
+      texture.magFilter = THREE.LinearFilter;
       texture.needsUpdate = true;
     };
 


### PR DESCRIPTION
## Summary
- reduce hallway marble wall tile size by increasing texture repeat by 30%
- improve marble wall texture clarity with maximum anisotropy and mipmapped filtering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f1dabf1c8329b9e77b8e52d62675)