### PR TITLE
Adjust Pool Royale white plank wall tiling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4436,7 +4436,7 @@ const createCarpetTextures = (() => {
 const WALL_TEXTURE_CONFIG = {
   sourceId: 'white_planks_clean',
   fallbackColor: 0xdedede,
-  repeat: new THREE.Vector2(3.75, 3.4),
+  repeat: new THREE.Vector2(1.875, 3.4),
   anisotropy: 12,
   preferredResolutionK: 4
 };
@@ -12098,7 +12098,7 @@ const powerRef = useRef(hud.power);
         flatShading: true
       });
       const wallTextureRepeat = new THREE.Vector2(
-        Math.max(WALL_TEXTURE_CONFIG.repeat.x, roomWidth / 80),
+        Math.max(WALL_TEXTURE_CONFIG.repeat.x, roomWidth / 160),
         Math.max(WALL_TEXTURE_CONFIG.repeat.y, wallHeight / 40)
       );
       const wallTextureAnisotropy =


### PR DESCRIPTION
## Summary
- halve the white wall plank texture repeat to double visible plank width in Pool Royale
- keep tiling scale tied to room size with updated minimum repeat for the wider planks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f843e9a48329a4c419b6cb595995)