### PR TITLE
Fix Murlan chair textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -341,6 +341,57 @@ function prepareLoadedModel(model) {
     }
   });
 }
+
+const TEXTURE_PROPS = [
+  'map',
+  'emissiveMap',
+  'normalMap',
+  'aoMap',
+  'alphaMap',
+  'bumpMap',
+  'displacementMap',
+  'metalnessMap',
+  'roughnessMap',
+  'clearcoatMap',
+  'clearcoatNormalMap',
+  'clearcoatRoughnessMap',
+  'specularMap',
+  'specularColorMap',
+  'sheenColorMap',
+  'sheenRoughnessMap',
+  'transmissionMap',
+  'thicknessMap'
+];
+
+function cloneModelWithMaterials(source) {
+  const clone = source.clone(true);
+  const materialCache = new Map();
+  clone.traverse((obj) => {
+    if (!obj.isMesh) return;
+    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+    const remapped = mats.map((mat) => {
+      if (!mat) return mat;
+      if (!materialCache.has(mat)) {
+        const matClone = mat.clone();
+        TEXTURE_PROPS.forEach((key) => {
+          const tex = mat[key];
+          if (tex?.isTexture) {
+            const texClone = tex.clone();
+            if (key === 'map' || key === 'emissiveMap') {
+              applySRGBColorSpace(texClone);
+            }
+            matClone[key] = texClone;
+          }
+        });
+        matClone.needsUpdate = true;
+        materialCache.set(mat, matClone);
+      }
+      return materialCache.get(mat);
+    });
+    obj.material = Array.isArray(obj.material) ? remapped : remapped[0];
+  });
+  return clone;
+}
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715).multiplyScalar(
   CHAIR_SIZE_SCALE
 );
@@ -489,7 +540,7 @@ function fitModelToHeight(model, targetHeight) {
 
 async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0) {
   const root = await loadPolyhavenModel(assetId);
-  const model = root.clone(true);
+  const model = cloneModelWithMaterials(root);
   prepareLoadedModel(model);
   fitModelToHeight(model, targetHeight);
   if (rotationY) model.rotation.y += rotationY;
@@ -716,7 +767,7 @@ async function buildChairTemplate(theme) {
   try {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId);
-      const model = polyhavenRoot.clone(true);
+      const model = cloneModelWithMaterials(polyhavenRoot);
       prepareLoadedModel(model);
       fitChairModelToFootprint(model);
       if (rotationY) model.rotation.y += rotationY;


### PR DESCRIPTION
## Summary
- add a reusable helper to clone GLTF models with independent material and texture instances
- build Murlan polyhaven chairs and decor with cloned materials so disposing them no longer wipes shared texture data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fee1ebc08329bab10e9a3f545af2)