### PR TITLE
Fix Murlan chair textures by cloning GLTF resources

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -327,6 +327,53 @@ function pickBestModelUrl(urls) {
   return glbs[0] || gltfs[0] || null;
 }
 
+function cloneModelWithResources(source) {
+  if (!source) return null;
+  const clone = source.clone(true);
+  const materialCache = new Map();
+  const textureCache = new Map();
+  const geometryCache = new Map();
+
+  clone.traverse((obj) => {
+    if (!obj.isMesh) return;
+
+    if (obj.geometry) {
+      let clonedGeo = geometryCache.get(obj.geometry);
+      if (!clonedGeo) {
+        clonedGeo = obj.geometry.clone();
+        geometryCache.set(obj.geometry, clonedGeo);
+      }
+      obj.geometry = clonedGeo;
+    }
+
+    if (obj.material) {
+      const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+      const clonedMats = materials.map((mat) => {
+        if (!mat) return mat;
+        if (materialCache.has(mat)) return materialCache.get(mat);
+        const matClone = mat.clone();
+        Object.keys(mat).forEach((key) => {
+          const value = mat[key];
+          if (value?.isTexture) {
+            let texClone = textureCache.get(value);
+            if (!texClone) {
+              texClone = value.clone();
+              texClone.needsUpdate = true;
+              textureCache.set(value, texClone);
+            }
+            matClone[key] = texClone;
+          }
+        });
+        materialCache.set(mat, matClone);
+        return matClone;
+      });
+      obj.material = Array.isArray(obj.material) ? clonedMats : clonedMats[0];
+    }
+  });
+
+  return clone;
+}
+
 function prepareLoadedModel(model) {
   model.traverse((obj) => {
     if (obj.isMesh) {
@@ -489,7 +536,7 @@ function fitModelToHeight(model, targetHeight) {
 
 async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0) {
   const root = await loadPolyhavenModel(assetId);
-  const model = root.clone(true);
+  const model = cloneModelWithResources(root);
   prepareLoadedModel(model);
   fitModelToHeight(model, targetHeight);
   if (rotationY) model.rotation.y += rotationY;
@@ -716,7 +763,7 @@ async function buildChairTemplate(theme) {
   try {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId);
-      const model = polyhavenRoot.clone(true);
+      const model = cloneModelWithResources(polyhavenRoot);
       prepareLoadedModel(model);
       fitChairModelToFootprint(model);
       if (rotationY) model.rotation.y += rotationY;


### PR DESCRIPTION
## Summary
- add a reusable helper to deep-clone geometries, materials, and textures from shared GLTF assets
- use the new cloning helper when instantiating Poly Haven models so Murlan chairs keep their textures when resources are disposed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fee1ebc08329bab10e9a3f545af2)