### PR TITLE
Restore hallway plant textures and target 90Hz pacing

### DIFF
--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -184,12 +184,27 @@ export default function GamesHallway({ games, onClose }) {
     gltfLoader.setCrossOrigin('anonymous');
 
     const loadGltfWithFallbacks = async (urls) => {
+      const resetLoaderPaths = () => {
+        gltfLoader.setPath('');
+        gltfLoader.setResourcePath('');
+      };
       for (const url of urls) {
         try {
+          const resolvedUrl = new URL(url, window.location.href).href;
+          const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+          const isAbsolute = /^https?:\/\//i.test(resolvedUrl);
+          gltfLoader.setResourcePath(resourcePath);
+          gltfLoader.setPath(isAbsolute ? '' : resourcePath);
           // eslint-disable-next-line no-await-in-loop
-          return await gltfLoader.loadAsync(url);
+          const gltf = await new Promise((resolve, reject) => {
+            gltfLoader.load(resolvedUrl, resolve, undefined, reject);
+          });
+          resetLoaderPaths();
+          return gltf;
         } catch (error) {
           // try next fallback
+        } finally {
+          resetLoaderPaths();
         }
       }
       throw new Error('All GLTF sources failed');
@@ -1099,25 +1114,31 @@ export default function GamesHallway({ games, onClose }) {
     renderer.domElement.addEventListener('contextmenu', contextMenuHandler);
     window.addEventListener('resize', handleResize);
 
-    const clock = new THREE.Clock();
+    const targetFrameMs = 1000 / 90;
+    const maxFrameMs = targetFrameMs * 3;
     let animationId = 0;
+    let lastRenderTime = performance.now() - targetFrameMs;
 
-    const animate = () => {
+    const animate = (now) => {
       animationId = requestAnimationFrame(animate);
-      const delta = clock.getDelta();
-      const now = performance.now();
+      const elapsedMs = now - lastRenderTime;
+      if (elapsedMs < targetFrameMs - 0.5) {
+        return;
+      }
+      const clampedDelta = Math.min(elapsedMs, maxFrameMs) / 1000;
+      lastRenderTime = now - Math.max(0, elapsedMs - clampedDelta * 1000);
 
       targetPitch = clampPitch(targetPitch);
       targetRadius = clampRadius(targetRadius);
       targetYaw = wrapAngle(targetYaw);
 
       if (!dragging && now - lastInteraction > 4500) {
-        targetYaw = wrapAngle(targetYaw - THREE.MathUtils.degToRad(4) * delta);
+        targetYaw = wrapAngle(targetYaw - THREE.MathUtils.degToRad(4) * clampedDelta);
       }
 
-      const yawLerp = 1 - Math.exp(-delta * 4.5);
-      const pitchLerp = 1 - Math.exp(-delta * 5.5);
-      const radiusLerp = 1 - Math.exp(-delta * 5);
+      const yawLerp = 1 - Math.exp(-clampedDelta * 4.5);
+      const pitchLerp = 1 - Math.exp(-clampedDelta * 5.5);
+      const radiusLerp = 1 - Math.exp(-clampedDelta * 5);
       yaw = lerpAngle(yaw, targetYaw, yawLerp);
       pitch = THREE.MathUtils.lerp(pitch, targetPitch, pitchLerp);
       radius = THREE.MathUtils.lerp(radius, targetRadius, radiusLerp);
@@ -1127,7 +1148,7 @@ export default function GamesHallway({ games, onClose }) {
     };
 
     updateCamera();
-    animate();
+    animate(performance.now());
 
     return () => {
       disposed = true;


### PR DESCRIPTION
## Summary
- ensure hallway flower pot GLTFs load with their original textures by resolving resource paths like Chess Battle Royal
- retime the hallway render loop to target 90 Hz frame pacing similar to the Murlan Royale experience

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511900ac6083299dd884ec80b48642)