### PR TITLE
Fix GLTF loader for Murlan Royale arena assets

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -9,6 +9,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
 import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
@@ -50,10 +51,12 @@ import {
   MURLAN_OUTFIT_THEMES as OUTFIT_THEMES,
   MURLAN_STOOL_THEMES as STOOL_THEMES
 } from '../../config/murlanThemes.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 
 const MODEL_SCALE = 0.75;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1.3;
+let sharedKTX2Loader = null;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const CHAIR_COUNT = 4;
@@ -271,6 +274,31 @@ const POLYHAVEN_MODEL_CACHE = new Map();
 const PLANT_TARGET_HEIGHT = 2.8 * MODEL_SCALE;
 const DECOR_PLANT_RADIUS_SCALE = 0.9;
 
+function createConfiguredGLTFLoader(renderer = null, manager = null) {
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKTX2Loader) {
+    sharedKTX2Loader = new KTX2Loader();
+    sharedKTX2Loader.setTranscoderPath('https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/');
+  }
+  if (renderer && sharedKTX2Loader) {
+    try {
+      sharedKTX2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('MurlanRoyale: KTX2 detection failed', error);
+    }
+  }
+  if (sharedKTX2Loader) {
+    loader.setKTX2Loader(sharedKTX2Loader);
+  }
+  return loader;
+}
+
 function stripQueryHash(u) {
   return u.split('#')[0].split('?')[0];
 }
@@ -487,8 +515,8 @@ function fitModelToHeight(model, targetHeight) {
   liftModelToGround(model, 0);
 }
 
-async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0) {
-  const root = await loadPolyhavenModel(assetId);
+async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0, renderer = null) {
+  const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone(true);
   prepareLoadedModel(model);
   fitModelToHeight(model, targetHeight);
@@ -508,17 +536,23 @@ function shouldPreserveChairMaterials(theme) {
   return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');
 }
 
-async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
-  const loader = new GLTFLoader();
-  const draco = new DRACOLoader();
-  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
-  loader.setDRACOLoader(draco);
+function configureLoaderPaths(loader, resolvedUrl) {
+  const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+  const isAbsolute = /^https?:\/\//i.test(resolvedUrl);
+  loader.setResourcePath(resourcePath);
+  loader.setPath(isAbsolute ? '' : resourcePath);
+}
+
+async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = null) {
+  const loader = createConfiguredGLTFLoader(renderer);
 
   let gltf = null;
   let lastError = null;
   for (const url of urls) {
     try {
-      gltf = await loader.loadAsync(url);
+      const resolvedUrl = new URL(url, typeof window !== 'undefined' ? window.location.href : undefined).href;
+      configureLoaderPaths(loader, resolvedUrl);
+      gltf = await loader.loadAsync(resolvedUrl);
       break;
     } catch (error) {
       lastError = error;
@@ -546,7 +580,7 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
   };
 }
 
-async function loadPolyhavenModel(assetId) {
+async function loadPolyhavenModel(assetId, renderer = null) {
   if (!assetId) throw new Error('Missing Poly Haven asset id');
   const normalizedId = assetId.toLowerCase();
   const cacheKey = normalizedId;
@@ -585,11 +619,7 @@ async function loadPolyhavenModel(assetId) {
     }
 
     const manager = fileMap.size ? new THREE.LoadingManager() : undefined;
-    const loader = new GLTFLoader(manager);
-    const draco = new DRACOLoader();
-    draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
-    loader.setDRACOLoader(draco);
-    loader.setCrossOrigin?.('anonymous');
+    const loader = createConfiguredGLTFLoader(renderer, manager);
 
     if (fileMap.size) {
       const base = stripQueryHash(modelUrlList[0]);
@@ -612,7 +642,9 @@ async function loadPolyhavenModel(assetId) {
     let lastError = null;
     for (const modelUrl of modelUrlList) {
       try {
-        gltf = await loader.loadAsync(modelUrl);
+        const resolvedUrl = new URL(modelUrl, typeof window !== 'undefined' ? window.location.href : undefined).href;
+        configureLoaderPaths(loader, resolvedUrl);
+        gltf = await loader.loadAsync(resolvedUrl);
         break;
       } catch (error) {
         lastError = error;
@@ -710,12 +742,12 @@ function createProceduralChair(theme) {
   };
 }
 
-async function buildChairTemplate(theme) {
+async function buildChairTemplate(theme, renderer = null) {
   const rotationY = theme?.modelRotation || 0;
   const preserveMaterials = shouldPreserveChairMaterials(theme);
   try {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
-      const polyhavenRoot = await loadPolyhavenModel(theme.assetId);
+      const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
       prepareLoadedModel(model);
       fitChairModelToFootprint(model);
@@ -727,13 +759,13 @@ async function buildChairTemplate(theme) {
       return { chairTemplate: model, materials, preserveOriginal: preserveMaterials };
     }
     if (theme?.source === 'gltf' && Array.isArray(theme.urls) && theme.urls.length) {
-      const gltfChair = await loadGltfChair(theme.urls, rotationY);
+      const gltfChair = await loadGltfChair(theme.urls, rotationY, renderer);
       if (!preserveMaterials) {
         applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
       }
       return { ...gltfChair, preserveOriginal: preserveMaterials };
     }
-    const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY);
+    const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY, renderer);
     if (!preserveMaterials) {
       applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
     }
@@ -1319,7 +1351,7 @@ export default function MurlanRoyaleArena({ search }) {
     async (stoolTheme) => {
       if (!threeReady) return;
       const safe = stoolTheme || STOOL_THEMES[0];
-      const chairBuild = await buildChairTemplate(safe);
+      const chairBuild = await buildChairTemplate(safe, threeStateRef.current.renderer);
       const currentAppearance = normalizeAppearance(appearanceRef.current);
       const expectedTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
       if (expectedTheme.id !== safe.id) return;
@@ -1747,7 +1779,7 @@ export default function MurlanRoyaleArena({ search }) {
           const radius = wallInnerRadius * DECOR_PLANT_RADIUS_SCALE;
           for (let i = 0; i < POLYHAVEN_PLANT_ASSETS.length; i += 1) {
             const assetId = POLYHAVEN_PLANT_ASSETS[i];
-            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT);
+            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT, 0, renderer);
             if (disposed) return;
             const angle = (i / POLYHAVEN_PLANT_ASSETS.length) * Math.PI * 2 + Math.PI / 4;
             const pos = new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
@@ -1817,7 +1849,7 @@ export default function MurlanRoyaleArena({ search }) {
         -TABLE_RADIUS * 0.62
       );
 
-      const chairBuild = await buildChairTemplate(stoolTheme);
+      const chairBuild = await buildChairTemplate(stoolTheme, renderer);
       if (disposed) return;
       const chairTemplate = chairBuild.chairTemplate;
       threeStateRef.current.chairTemplate = chairTemplate;


### PR DESCRIPTION
## Summary
- configure the Murlan Royale arena GLTF loader with Draco, Meshopt, and KTX2 support plus proper resource paths
- reuse the configured loader for chairs and Poly Haven plants so original materials and textures are preserved

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695132a69464832998c4026c1bd3241c)