### PR TITLE
Improve Polyhaven assets in Murlan arena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -7,8 +7,10 @@ import React, {
 } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {
   createArenaCarpetMaterial,
   createArenaWallMaterial
@@ -270,6 +272,10 @@ const POLYHAVEN_PLANT_ASSETS = ['potted_plant_01', 'potted_plant_02', 'potted_pl
 const POLYHAVEN_MODEL_CACHE = new Map();
 const PLANT_TARGET_HEIGHT = 2.8 * MODEL_SCALE;
 const DECOR_PLANT_RADIUS_SCALE = 0.9;
+const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+
+let sharedKtx2Loader = null;
 
 function stripQueryHash(u) {
   return u.split('#')[0].split('?')[0];
@@ -487,8 +493,8 @@ function fitModelToHeight(model, targetHeight) {
   liftModelToGround(model, 0);
 }
 
-async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0) {
-  const root = await loadPolyhavenModel(assetId);
+async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0, renderer = null) {
+  const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone(true);
   prepareLoadedModel(model);
   fitModelToHeight(model, targetHeight);
@@ -508,11 +514,34 @@ function shouldPreserveChairMaterials(theme) {
   return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');
 }
 
-async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
-  const loader = new GLTFLoader();
+function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin?.('anonymous');
+
   const draco = new DRACOLoader();
-  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+  draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('Murlan KTX2 support detection failed', error);
+    }
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+}
+
+async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = null) {
+  const loader = createConfiguredGLTFLoader(renderer);
 
   let gltf = null;
   let lastError = null;
@@ -546,7 +575,7 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0) {
   };
 }
 
-async function loadPolyhavenModel(assetId) {
+async function loadPolyhavenModel(assetId, renderer = null) {
   if (!assetId) throw new Error('Missing Poly Haven asset id');
   const normalizedId = assetId.toLowerCase();
   const cacheKey = normalizedId;
@@ -585,11 +614,7 @@ async function loadPolyhavenModel(assetId) {
     }
 
     const manager = fileMap.size ? new THREE.LoadingManager() : undefined;
-    const loader = new GLTFLoader(manager);
-    const draco = new DRACOLoader();
-    draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
-    loader.setDRACOLoader(draco);
-    loader.setCrossOrigin?.('anonymous');
+    const loader = createConfiguredGLTFLoader(renderer, manager);
 
     if (fileMap.size) {
       const base = stripQueryHash(modelUrlList[0]);
@@ -612,7 +637,11 @@ async function loadPolyhavenModel(assetId) {
     let lastError = null;
     for (const modelUrl of modelUrlList) {
       try {
-        gltf = await loader.loadAsync(modelUrl);
+        const resolvedUrl = new URL(modelUrl, typeof window !== 'undefined' ? window.location?.href : modelUrl).href;
+        const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+        loader.setResourcePath?.(resourcePath);
+        loader.setPath?.('');
+        gltf = await loader.loadAsync(resolvedUrl);
         break;
       } catch (error) {
         lastError = error;
@@ -710,12 +739,12 @@ function createProceduralChair(theme) {
   };
 }
 
-async function buildChairTemplate(theme) {
+async function buildChairTemplate(theme, renderer = null) {
   const rotationY = theme?.modelRotation || 0;
   const preserveMaterials = shouldPreserveChairMaterials(theme);
   try {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
-      const polyhavenRoot = await loadPolyhavenModel(theme.assetId);
+      const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
       prepareLoadedModel(model);
       fitChairModelToFootprint(model);
@@ -727,13 +756,13 @@ async function buildChairTemplate(theme) {
       return { chairTemplate: model, materials, preserveOriginal: preserveMaterials };
     }
     if (theme?.source === 'gltf' && Array.isArray(theme.urls) && theme.urls.length) {
-      const gltfChair = await loadGltfChair(theme.urls, rotationY);
+      const gltfChair = await loadGltfChair(theme.urls, rotationY, renderer);
       if (!preserveMaterials) {
         applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
       }
       return { ...gltfChair, preserveOriginal: preserveMaterials };
     }
-    const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY);
+    const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY, renderer);
     if (!preserveMaterials) {
       applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
     }
@@ -1319,7 +1348,7 @@ export default function MurlanRoyaleArena({ search }) {
     async (stoolTheme) => {
       if (!threeReady) return;
       const safe = stoolTheme || STOOL_THEMES[0];
-      const chairBuild = await buildChairTemplate(safe);
+      const chairBuild = await buildChairTemplate(safe, threeStateRef.current.renderer);
       const currentAppearance = normalizeAppearance(appearanceRef.current);
       const expectedTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
       if (expectedTheme.id !== safe.id) return;
@@ -1747,7 +1776,7 @@ export default function MurlanRoyaleArena({ search }) {
           const radius = wallInnerRadius * DECOR_PLANT_RADIUS_SCALE;
           for (let i = 0; i < POLYHAVEN_PLANT_ASSETS.length; i += 1) {
             const assetId = POLYHAVEN_PLANT_ASSETS[i];
-            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT);
+            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT, 0, renderer);
             if (disposed) return;
             const angle = (i / POLYHAVEN_PLANT_ASSETS.length) * Math.PI * 2 + Math.PI / 4;
             const pos = new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
@@ -1817,7 +1846,7 @@ export default function MurlanRoyaleArena({ search }) {
         -TABLE_RADIUS * 0.62
       );
 
-      const chairBuild = await buildChairTemplate(stoolTheme);
+      const chairBuild = await buildChairTemplate(stoolTheme, renderer);
       if (disposed) return;
       const chairTemplate = chairBuild.chairTemplate;
       threeStateRef.current.chairTemplate = chairTemplate;


### PR DESCRIPTION
## Summary
- configure a shared GLTF loader with KTX2, Draco, and Meshopt support for Murlan assets
- route chair and decor loading through the configured loader to preserve original Poly Haven textures
- thread the renderer into chair and plant builders so compressed materials decode correctly in the arena

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695132a69464832998c4026c1bd3241c)