### PR TITLE
Fix Murlan Royale texture set application

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -455,20 +455,23 @@ async function loadPolyhavenTextureSet(assetId, textureLoader, maxAnisotropy = 1
 function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotropy = 1) {
   const applyToMaterial = (material) => {
     if (!material) return;
+    const diffuseMap = textureSet?.diffuse;
+    const normalMap = textureSet?.normal;
+    const roughnessMap = textureSet?.roughness;
     material.roughness = Math.max(material.roughness ?? 0.4, 0.4);
     material.metalness = Math.min(material.metalness ?? 0.4, 0.4);
+
+    if (diffuseMap && material.map !== diffuseMap) {
+      material.map = diffuseMap;
+      material.needsUpdate = true;
+    } else if (!material.map && fallbackTexture) {
+      material.map = fallbackTexture;
+      material.needsUpdate = true;
+    }
 
     if (material.map) {
       applySRGBColorSpace(material.map);
       material.map.anisotropy = Math.max(material.map.anisotropy ?? 1, maxAnisotropy);
-    } else if (textureSet?.diffuse) {
-      material.map = textureSet.diffuse;
-      applySRGBColorSpace(material.map);
-      material.needsUpdate = true;
-    } else if (fallbackTexture) {
-      material.map = fallbackTexture;
-      applySRGBColorSpace(material.map);
-      material.needsUpdate = true;
     }
 
     if (material.emissiveMap) {
@@ -476,15 +479,23 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
       material.emissiveMap.anisotropy = Math.max(material.emissiveMap.anisotropy ?? 1, maxAnisotropy);
     }
 
-    if (!material.normalMap && textureSet?.normal) {
-      material.normalMap = textureSet.normal;
+    if (normalMap && material.normalMap !== normalMap) {
+      material.normalMap = normalMap;
+      material.needsUpdate = true;
     }
     if (material.normalMap) {
       material.normalMap.anisotropy = Math.max(material.normalMap.anisotropy ?? 1, maxAnisotropy);
     }
 
-    if (!material.roughnessMap && textureSet?.roughness) {
-      material.roughnessMap = textureSet.roughness;
+    if (roughnessMap && material.roughnessMap !== roughnessMap) {
+      material.roughnessMap = roughnessMap;
+      material.needsUpdate = true;
+    }
+    if (material.roughnessMap) {
+      material.roughnessMap.anisotropy = Math.max(
+        material.roughnessMap.anisotropy ?? 1,
+        maxAnisotropy
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure loaded Poly Haven texture sets replace fallback placeholders on Murlan Royale models
- refresh normal and roughness maps when new textures arrive and carry over anisotropy handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514887d424832991c3608fde100ae7)