### PR TITLE
Fix Murlan Royale texture set application

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -453,39 +453,38 @@ async function loadPolyhavenTextureSet(assetId, textureLoader, maxAnisotropy = 1
 }
 
 function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotropy = 1) {
+  const updateTextureSlot = (material, slot, nextTexture, isColor = false) => {
+    if (!nextTexture && !material[slot]) return;
+    const previous = material[slot];
+    if (nextTexture && previous !== nextTexture) {
+      material[slot] = nextTexture;
+      material.needsUpdate = true;
+    }
+    const activeTexture = material[slot];
+    if (activeTexture) {
+      if (isColor) {
+        applySRGBColorSpace(activeTexture);
+      }
+      activeTexture.anisotropy = Math.max(activeTexture.anisotropy ?? 1, maxAnisotropy);
+      activeTexture.needsUpdate = true;
+    }
+  };
+
   const applyToMaterial = (material) => {
     if (!material) return;
     material.roughness = Math.max(material.roughness ?? 0.4, 0.4);
     material.metalness = Math.min(material.metalness ?? 0.4, 0.4);
 
-    if (material.map) {
-      applySRGBColorSpace(material.map);
-      material.map.anisotropy = Math.max(material.map.anisotropy ?? 1, maxAnisotropy);
-    } else if (textureSet?.diffuse) {
-      material.map = textureSet.diffuse;
-      applySRGBColorSpace(material.map);
-      material.needsUpdate = true;
-    } else if (fallbackTexture) {
-      material.map = fallbackTexture;
-      applySRGBColorSpace(material.map);
-      material.needsUpdate = true;
-    }
+    const colorMap = textureSet?.diffuse ?? material.map ?? fallbackTexture;
+    updateTextureSlot(material, 'map', colorMap, true);
 
-    if (material.emissiveMap) {
-      applySRGBColorSpace(material.emissiveMap);
-      material.emissiveMap.anisotropy = Math.max(material.emissiveMap.anisotropy ?? 1, maxAnisotropy);
-    }
+    updateTextureSlot(material, 'emissiveMap', material.emissiveMap, true);
 
-    if (!material.normalMap && textureSet?.normal) {
-      material.normalMap = textureSet.normal;
-    }
-    if (material.normalMap) {
-      material.normalMap.anisotropy = Math.max(material.normalMap.anisotropy ?? 1, maxAnisotropy);
-    }
+    const normalMap = textureSet?.normal ?? material.normalMap;
+    updateTextureSlot(material, 'normalMap', normalMap, false);
 
-    if (!material.roughnessMap && textureSet?.roughness) {
-      material.roughnessMap = textureSet.roughness;
-    }
+    const roughnessMap = textureSet?.roughness ?? material.roughnessMap;
+    updateTextureSlot(material, 'roughnessMap', roughnessMap, false);
   };
 
   model.traverse((obj) => {


### PR DESCRIPTION
## Summary
- ensure loaded texture sets override existing material maps instead of being skipped by default glTF textures
- centralize texture slot updates so color/normal/roughness maps all receive sRGB and anisotropy adjustments

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514887d424832991c3608fde100ae7)