### PR TITLE
Improve AI cue animation and replay controls in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1018,7 +1018,7 @@ const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up ca
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const STUCK_SHOT_TIMEOUT_MS = 4500; // auto-resolve shots if motion stops but the turn never clears
 const MAX_POWER_BOUNCE_THRESHOLD = 0.98;
-const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 0.95;
+const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 0.65;
 const MAX_POWER_BOUNCE_GRAVITY = BALL_R * 3.2;
 const MAX_POWER_BOUNCE_DAMPING = 0.86;
 const MAX_POWER_LANDING_SOUND_COOLDOWN_MS = 240;
@@ -1174,9 +1174,9 @@ const POCKET_VIEW_MIN_DURATION_MS = 560;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 300;
 const POCKET_VIEW_POST_POT_HOLD_MS = 160;
 const POCKET_VIEW_MAX_HOLD_MS = 3200;
-const SPIN_STRENGTH = BALL_R * 0.0295;
+const SPIN_STRENGTH = BALL_R * 0.0295 * 1.15;
 const SPIN_DECAY = 0.9;
-const SPIN_ROLL_STRENGTH = BALL_R * 0.0175;
+const SPIN_ROLL_STRENGTH = BALL_R * 0.0175 * 1.15;
 const SPIN_ROLL_DECAY = 0.978;
 const SPIN_AIR_DECAY = 0.997; // hold spin energy while the cue ball travels straight pre-impact
 const SWERVE_THRESHOLD = 0.7; // outer 30% of the spin control activates swerve behaviour
@@ -1186,7 +1186,7 @@ const PRE_IMPACT_SPIN_DRIFT = 0.1; // reapply stored sideways swerve once the cu
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_FORCE_BOOST = 1.5 * 0.75 * 0.85 * 0.8 * 1.3 * 0.85 * SHOT_POWER_REDUCTION;
+const SHOT_FORCE_BOOST = 1.5 * 0.75 * 0.85 * 0.8 * 1.3 * 0.85 * SHOT_POWER_REDUCTION * 1.15;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
@@ -1228,8 +1228,8 @@ const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.12; // ensure a visible air gap so the tip never rests on the cue ball
-const CUE_TIP_GAP = BALL_R * 1.04 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
+const CUE_TIP_CLEARANCE = BALL_R * 0.16; // ensure a visible air gap so the tip never rests on the cue ball
+const CUE_TIP_GAP = BALL_R * 1.06 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 1.85;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.55; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.2; // allow extra travel before obstructions cancel the pull
@@ -1247,9 +1247,9 @@ const CUE_FOLLOW_MIN_MS = 180;
 const CUE_FOLLOW_MAX_MS = 420;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 12;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 24;
-const CUE_Y = BALL_CENTER_Y - BALL_R * 0.08; // lower the cue height further so the tip sits just below the topspin zone
+const CUE_Y = BALL_CENTER_Y - BALL_R * 0.16; // lower the cue height further so the tip sits just below the topspin zone
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 5.2;
+const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 2.1;
 const CUE_BUTT_LIFT = BALL_R * 0.64; // keep the butt elevated for clearance while keeping the tip level with the cue-ball centre
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -5275,7 +5275,7 @@ const AI_THINKING_BUDGET_MS =
   AI_MAX_SHOT_TIME_MS - AI_MIN_AIM_PREVIEW_MS; // leave room for the cue preview while keeping decisions under 7 seconds
 const AI_CAMERA_DROP_LEAD_MS = 420; // start lowering into cue view shortly before the AI pulls the trigger
 const AI_CAMERA_SETTLE_MS = 320; // allow time for the cue view to settle before firing
-const AI_CUE_VIEW_HOLD_MS = 3000;
+const AI_CUE_VIEW_HOLD_MS = 2000;
 // Ease the AI camera just partway toward cue view (still above the stick) so the shot preview
 // lingers in a mid-angle frame for a few seconds before firing.
 const AI_CAMERA_DROP_BLEND = 0.65;
@@ -10400,6 +10400,9 @@ function PoolRoyaleGame({
   const replayBannerTimeoutRef = useRef(null);
   const [replaySlate, setReplaySlate] = useState(null);
   const replaySlateTimeoutRef = useRef(null);
+  const lastReplayRef = useRef(null);
+  const [replayReady, setReplayReady] = useState(false);
+  const startReplayRef = useRef(() => {});
   const shotCameraHoldTimeoutRef = useRef(null);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
   useEffect(
@@ -10513,6 +10516,8 @@ const powerRef = useRef(hud.power);
       inHand: nextInHand,
       over: false
     }));
+    lastReplayRef.current = null;
+    setReplayReady(false);
   }, [initialFrame]);
   useEffect(() => {
     if (!isTraining) return;
@@ -14818,12 +14823,90 @@ const powerRef = useRef(hud.power);
           replayTrail.visible = true;
         };
 
+        const applyReplayCueStroke = (cueStroke, targetTime) => {
+          if (!cueStroke || !cueStick) return;
+          const forwardDuration = Math.max(cueStroke.forwardDuration ?? 0, 0);
+          const settleDuration = Math.max(cueStroke.settleDuration ?? 0, 0);
+          const totalDuration = forwardDuration + settleDuration;
+          const start = normalizeVector3Snapshot(cueStroke.start, null);
+          const impact = normalizeVector3Snapshot(cueStroke.impact, null);
+          const settle = normalizeVector3Snapshot(cueStroke.settle, null);
+          if (!start || !impact || !settle || totalDuration <= 0) {
+            cueStick.visible = false;
+            return;
+          }
+          const startVec = new THREE.Vector3(start.x, start.y, start.z);
+          const impactVec = new THREE.Vector3(impact.x, impact.y, impact.z);
+          const settleVec = new THREE.Vector3(settle.x, settle.y, settle.z);
+          const clampedTime = Math.max(0, Math.min(targetTime, totalDuration));
+          let from = startVec;
+          let to = impactVec;
+          let t = 0;
+          if (clampedTime <= forwardDuration) {
+            t = forwardDuration > 0 ? clampedTime / forwardDuration : 1;
+          } else if (clampedTime <= totalDuration) {
+            from = impactVec;
+            to = settleVec;
+            const settleT = clampedTime - forwardDuration;
+            t = settleDuration > 0 ? settleT / settleDuration : 1;
+          } else {
+            cueStick.visible = false;
+            return;
+          }
+          cueStick.position.lerpVectors(from, to, THREE.MathUtils.clamp(t, 0, 1));
+          cueStick.rotation.y =
+            cueStroke.rotationY != null ? cueStroke.rotationY : cueStick.rotation.y;
+          applyCueButtTilt(
+            cueStick,
+            cueStroke.tilt ?? 0,
+            cueStroke.buttHeight ?? CUE_Y
+          );
+          if (tipGroupRef.current) {
+            const len = cueStroke.cueLen ?? cueLen;
+            tipGroupRef.current.position.set(0, 0, -len / 2);
+          }
+          cueStick.visible = true;
+        };
+
+        const cloneRecording = (recording) => {
+          if (!recording) return recording;
+          try {
+            return structuredClone(recording);
+          } catch (err) {
+            return JSON.parse(JSON.stringify(recording));
+          }
+        };
+
+        const resolveCueStrokeSnapshot = (stroke) => {
+          if (!stroke) return null;
+          const start = normalizeVector3Snapshot(stroke.start, null);
+          const impact = normalizeVector3Snapshot(stroke.impact, null);
+          const settle = normalizeVector3Snapshot(stroke.settle, null);
+          if (!start || !impact || !settle) return null;
+          const forwardDuration = Math.max(stroke.forwardDuration ?? 0, 0);
+          const settleDuration = Math.max(stroke.settleDuration ?? 0, 0);
+          return {
+            start,
+            impact,
+            settle,
+            rotationY: Number.isFinite(stroke.rotationY) ? stroke.rotationY : 0,
+            forwardDuration,
+            settleDuration,
+            buttHeight: Number.isFinite(stroke.buttHeight) ? stroke.buttHeight : CUE_Y,
+            tilt: Number.isFinite(stroke.tilt) ? stroke.tilt : 0,
+            cueLen: Number.isFinite(stroke.cueLen) ? stroke.cueLen : cueLen
+          };
+        };
+
         const trimReplayRecording = (recording) => {
           const frames = recording?.frames ?? [];
           const cuePath = recording?.cuePath ?? [];
-          if (frames.length === 0) return { frames, cuePath, duration: 0 };
+          const cueStroke = resolveCueStrokeSnapshot(recording?.cueStroke);
+          const startState = recording?.startState ? cloneRecording(recording.startState) : null;
+          const replayTags = recording?.replayTags ? [...recording.replayTags] : [];
+          if (frames.length === 0) return { frames, cuePath, cueStroke, duration: 0 };
           const duration = frames[frames.length - 1]?.t ?? 0;
-          return { frames, cuePath, duration };
+          return { frames, cuePath, cueStroke, duration, startState, replayTags };
         };
 
         const storeReplayCameraFrame = () => {
@@ -14860,10 +14943,12 @@ const powerRef = useRef(hud.power);
           updateCamera();
         };
 
-        const startShotReplay = (postShotSnapshot) => {
+        const startShotReplay = (postShotSnapshot, recordingOverride = null) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording || !shotRecording.frames?.length) return;
-          const trimmed = trimReplayRecording(shotRecording);
+          const sourceRecording = recordingOverride ?? shotRecording;
+          if (!sourceRecording || !sourceRecording.frames?.length) return;
+          shotRecording = sourceRecording;
+          const trimmed = trimReplayRecording(sourceRecording);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           setReplayActive(true);
@@ -14872,6 +14957,7 @@ const powerRef = useRef(hud.power);
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
+            cueStroke: trimmed.cueStroke,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
@@ -14882,8 +14968,9 @@ const powerRef = useRef(hud.power);
           pocketDropRef.current = new Map();
           replayPlaybackRef.current = replayPlayback;
           lastReplayFrameAt = 0;
-          shotReplayRef.current = shotRecording;
-          applyBallSnapshot(shotRecording.startState ?? []);
+          shotReplayRef.current = sourceRecording;
+          const initialState = sourceRecording.startState ?? trimmed.startState ?? [];
+          applyBallSnapshot(initialState);
           updateReplayTrail(replayPlayback.cuePath, 0);
           const path = replayPlayback.cuePath ?? [];
           if (path.length > 0) {
@@ -14930,11 +15017,29 @@ const powerRef = useRef(hud.power);
             tick();
           });
 
+        startReplayRef.current = (payload) => {
+          if (replayPlaybackRef.current) return;
+          const recording = payload?.recording ? cloneRecording(payload.recording) : null;
+          if (!recording?.frames?.length) return;
+          if (!recording.startState) {
+            recording.startState = payload?.recording?.startState
+              ? cloneRecording(payload.recording.startState)
+              : captureBallSnapshot();
+          }
+          const postState = payload?.postState
+            ? cloneRecording(payload.postState)
+            : captureBallSnapshot();
+          shotReplayRef.current = recording;
+          shotRecording = recording;
+          startShotReplay(postState, recording);
+        };
+
         const finishReplayPlayback = (playback) => {
           if (!playback) return;
           if (playback.postState) {
             applyBallSnapshot(playback.postState);
           }
+          cueStick.visible = false;
           replayTrail.visible = false;
           const storedReplayCamera = replayCameraRef.current;
           const targetFov = Number.isFinite(storedReplayCamera?.restoreFov)
@@ -16982,21 +17087,8 @@ const powerRef = useRef(hud.power);
           resetSpinRef.current?.();
           cue.impacted = false;
           cue.launchDir = aimDir.clone().normalize();
-          if (isMaxPowerShot) {
-            const liftAmount = Math.min(
-              MAX_POWER_LIFT_HEIGHT,
-              Math.max(CUE_TIP_RADIUS, MAX_POWER_BOUNCE_IMPULSE * 0.45)
-            );
-            const liftVelocity = Math.min(
-              MAX_POWER_BOUNCE_IMPULSE * clampedPower,
-              MAX_POWER_BOUNCE_IMPULSE * 0.55
-            );
-            cue.lift = Math.max(cue.lift ?? 0, liftAmount);
-            cue.liftVel = Math.max(cue.liftVel ?? 0, liftVelocity);
-          } else {
-            cue.lift = 0;
-            cue.liftVel = 0;
-          }
+          cue.lift = 0;
+          cue.liftVel = 0;
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -17112,6 +17204,19 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_MIN_MS,
             CUE_FOLLOW_MAX_MS
           );
+          if (shotRecording) {
+            shotRecording.cueStroke = {
+              start: serializeVector3Snapshot(startPos),
+              impact: serializeVector3Snapshot(impactPos),
+              settle: serializeVector3Snapshot(settlePos),
+              rotationY: cueStick.rotation.y,
+              forwardDuration,
+              settleDuration,
+              buttHeight: CUE_Y + spinWorld.y + obstructionLift * 0.25,
+              tilt: extraTilt + obstructionTilt + obstructionTiltFromLift,
+              cueLen
+            };
+          }
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
@@ -18768,6 +18873,17 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
+          if (postShotSnapshot && shotRecording) {
+            const archivedRecording = trimReplayRecording(shotRecording);
+            lastReplayRef.current = {
+              recording: cloneRecording(archivedRecording),
+              postState: cloneRecording(postShotSnapshot)
+            };
+            setReplayReady(true);
+          } else {
+            lastReplayRef.current = null;
+            setReplayReady(false);
+          }
           if (shouldStartReplay && postShotSnapshot) {
             const recordingForReplay = shotRecording;
             const launchReplay = () => {
@@ -18886,6 +19002,7 @@ const powerRef = useRef(hud.power);
               ? THREE.MathUtils.clamp((targetTime - frameA.t) / span, 0, 1)
               : 0;
             applyReplayFrame(frameA, frameB, alpha);
+            applyReplayCueStroke(playback.cueStroke, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);
             replayFrameCameraRef.current = {
               frameA: frameA?.camera ?? null,
@@ -19800,13 +19917,13 @@ const powerRef = useRef(hud.power);
                   const bounceStrength = THREE.MathUtils.clamp(lastShotPower, 0, 1);
                   cueBall.lift = Math.max(
                     cueBall.lift ?? 0,
-                    Math.min(MAX_POWER_LIFT_HEIGHT, MAX_POWER_BOUNCE_IMPULSE * 0.45)
+                    Math.min(MAX_POWER_LIFT_HEIGHT, MAX_POWER_BOUNCE_IMPULSE * 0.32)
                   );
                   cueBall.liftVel = Math.max(
                     cueBall.liftVel ?? 0,
                     Math.min(
-                      MAX_POWER_BOUNCE_IMPULSE * bounceStrength,
-                      MAX_POWER_BOUNCE_IMPULSE * 0.55
+                      MAX_POWER_BOUNCE_IMPULSE * bounceStrength * 0.85,
+                      MAX_POWER_BOUNCE_IMPULSE * 0.42
                     )
                   );
                 }
@@ -20878,6 +20995,12 @@ const powerRef = useRef(hud.power);
     ),
     [avatarSizeClass]
   );
+  const handleReplayClick = useCallback(() => {
+    if (replayActive || shotActive) return;
+    const payload = lastReplayRef.current;
+    if (!payload?.recording?.frames?.length) return;
+    startReplayRef.current?.(payload);
+  }, [replayActive, shotActive]);
 
   return (
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
@@ -20922,6 +21045,32 @@ const powerRef = useRef(hud.power);
       <div
         className={`absolute top-4 left-4 z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
       >
+        <button
+          type="button"
+          onClick={handleReplayClick}
+          disabled={!replayReady || replayActive || shotActive}
+          className={`pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border ${
+            replayReady ? 'border-emerald-400/60 bg-black/70 text-white hover:bg-black/60' : 'border-white/20 bg-black/60 text-white/40'
+          } shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed`}
+          aria-label="Replay last shot"
+          title="Replay last shot"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            className="h-6 w-6"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3 12a9 9 0 1 1 9 9 9 9 0 0 1-9-9zm0 0V6m0 6h6"
+            />
+          </svg>
+        </button>
         <button
           ref={configButtonRef}
           type="button"


### PR DESCRIPTION
## Summary
- increase shot force and spin headroom, adjust cue tip spacing/height, and soften maximum power hop timing
- tune AI cue-view timing and capture cue stroke metadata so the stick animates consistently during shots and replays
- add a replay shortcut button and render the cue stick at the start of replays before restoring the table state at the end

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516012b5f0832999fb748da5ac150c)