### PR TITLE
Add table NFT options for Murlan Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,6 +1,6 @@
 import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../utils/cardThemes.js';
-import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -15,7 +15,8 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableCloth: [TABLE_CLOTH_OPTIONS[0].id],
   tableBase: [TABLE_BASE_OPTIONS[0].id],
   cards: [CARD_THEMES[0].id],
-  stools: [MURLAN_STOOL_THEMES[0].id]
+  stools: [MURLAN_STOOL_THEMES[0].id],
+  tables: [MURLAN_TABLE_THEMES[0].id]
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
@@ -23,7 +24,8 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   tableCloth: mapLabels(TABLE_CLOTH_OPTIONS),
   tableBase: mapLabels(TABLE_BASE_OPTIONS),
   cards: mapLabels(CARD_THEMES),
-  stools: mapLabels(MURLAN_STOOL_THEMES)
+  stools: mapLabels(MURLAN_STOOL_THEMES),
+  tables: mapLabels(MURLAN_TABLE_THEMES)
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
@@ -140,6 +142,15 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: 'Monochrome slate backs with steel edging.'
   }
 ].concat(
+  MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+    id: `table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 980 + idx * 40,
+    description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
+    thumbnail: theme.thumbnail
+  })),
   MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `stool-${theme.id}`,
     type: 'stools',
@@ -155,5 +166,6 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0].id, label: TABLE_CLOTH_OPTIONS[0].label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0].id, label: TABLE_BASE_OPTIONS[0].label },
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
+  { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label }
 ];

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -45,4 +45,48 @@ const POLYHAVEN_CHAIR_THEMES = [
   preserveMaterials: true
 }));
 
+const POLYHAVEN_TABLE_THEMES = [
+  { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
+  { id: 'WoodenTable_01', label: 'Wooden Table 01' },
+  { id: 'WoodenTable_02', label: 'Wooden Table 02' },
+  { id: 'WoodenTable_03', label: 'Wooden Table 03' },
+  { id: 'chinese_console_table', label: 'Chinese Console Table' },
+  { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
+  { id: 'coffee_table_round_01', label: 'Coffee Table Round 01' },
+  { id: 'gallinera_table', label: 'Gallinera Table' },
+  { id: 'gothic_coffee_table', label: 'Gothic Coffee Table' },
+  { id: 'industrial_coffee_table', label: 'Industrial Coffee Table' },
+  { id: 'modern_coffee_table_01', label: 'Modern Coffee Table 01' },
+  { id: 'modern_coffee_table_02', label: 'Modern Coffee Table 02' },
+  { id: 'outdoor_table_chair_set_01', label: 'Outdoor Table Chair Set 01' },
+  { id: 'painted_wooden_table', label: 'Painted Wooden Table' },
+  { id: 'round_wooden_table_01', label: 'Round Wooden Table 01' },
+  { id: 'round_wooden_table_02', label: 'Round Wooden Table 02' },
+  { id: 'side_table_01', label: 'Side Table 01' },
+  { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
+  { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' },
+  { id: 'wooden_picnic_table', label: 'Wooden Picnic Table' },
+  { id: 'wooden_table_02', label: 'Wooden Table 02 (Alt)' }
+].map((option, index) => ({
+  ...option,
+  assetId: option.id,
+  source: 'polyhaven',
+  thumbnail: POLYHAVEN_THUMB(option.id),
+  price: 980 + index * 40,
+  preserveMaterials: true,
+  description: option.description || `${option.label} with preserved Poly Haven materials.`
+}));
+
+export const MURLAN_TABLE_THEMES = [
+  {
+    id: 'murlan-default',
+    label: 'Murlan Default Table',
+    source: 'procedural',
+    price: 0,
+    thumbnail: POLYHAVEN_THUMB('WoodenTable_01'),
+    description: 'Standard Murlan Royale table with customizable wood, cloth, and base.'
+  },
+  ...POLYHAVEN_TABLE_THEMES
+];
+
 export const MURLAN_STOOL_THEMES = [...BASE_STOOL_THEMES, ...POLYHAVEN_CHAIR_THEMES];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,7 +175,8 @@ const MURLAN_TYPE_LABELS = {
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
   cards: 'Card Themes',
-  stools: 'Stools & Chairs'
+  stools: 'Stools & Chairs',
+  tables: 'Table Models'
 };
 
 const DOMINO_TYPE_LABELS = {
@@ -256,6 +257,7 @@ const TYPE_SWATCHES = {
   tableWood: ['#4b3621', '#9a7b4f'],
   tableCloth: ['#0f172a', '#34d399'],
   tableBase: ['#0f172a', '#1f2937'],
+  tables: ['#0f172a', '#94a3b8'],
   chairColor: ['#111827', '#f59e0b'],
   tableShape: ['#334155', '#64748b'],
   sideColor: ['#f8fafc', '#1f2937'],
@@ -332,7 +334,8 @@ const PREVIEW_BY_TYPE = {
   tableFinish: 'table',
   tableWood: 'table',
   tableCloth: 'table',
-  tableBase: 'table'
+  tableBase: 'table',
+  tables: 'table'
 };
 
 const PREVIEW_BY_SLUG = {


### PR DESCRIPTION
## Summary
- add Poly Haven table models as selectable NFTs for Murlan Royale and list them in the store
- hook the arena up to the new table selector, preserving textures and scaling to the default table footprint, and remove the placeholder chair tokens
- translate the Murlan scoreboard labels to English

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516a410c10832987901e38ef1b4749)