### PR TITLE
Align Murlan arena decor with hallway styling

### DIFF
--- a/webapp/src/utils/arenaDecor.js
+++ b/webapp/src/utils/arenaDecor.js
@@ -144,11 +144,30 @@ export function createArenaCarpetMaterial() {
   return material;
 }
 
-export function createArenaWallMaterial() {
-  return new THREE.MeshStandardMaterial({
-    color: 0xeeeeee,
+export function createArenaWallMaterial(baseColor = '#eeeeee', accentColor = null, textureSet = null) {
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(baseColor),
     roughness: 0.88,
     metalness: 0.06,
     side: THREE.DoubleSide
   });
+
+  if (accentColor) {
+    material.emissive = new THREE.Color(accentColor);
+    material.emissiveIntensity = 0.08;
+  }
+
+  if (textureSet?.diffuse) {
+    material.map = textureSet.diffuse;
+    applySRGBColorSpace(material.map);
+    material.color.set('#ffffff');
+  }
+  if (textureSet?.normal) {
+    material.normalMap = textureSet.normal;
+  }
+  if (textureSet?.roughness) {
+    material.roughnessMap = textureSet.roughness;
+  }
+
+  return material;
 }


### PR DESCRIPTION
## Summary
- reuse the hallway flower pot asset for Murlan decor plants and simplify the placement setup
- reposition seat layout and fallback HUD anchors into a centered cross pattern for clearer player alignment
- wrap arena walls with the Coffee Table Round 01 wood material for a consistent premium finish

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517d2f48188329b081ac74e03de883)