### PR TITLE
Improve cue stick animation and replay clarity

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1234,12 +1234,12 @@ const CUE_TIP_GAP = BALL_R * 1.08 + CUE_TIP_CLEARANCE; // pull the blue tip into
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 1.85;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.55; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.2; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.5;
+const CUE_PULL_VISUAL_MULTIPLIER = 1.85;
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_PULL_ALIGNMENT_BOOST = 0.26; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
-const CUE_PULL_CUE_CAMERA_DAMPING = 0.18; // trim the pull depth in cue view so the cue stays tight to the ball
-const CUE_PULL_STANDING_CAMERA_BONUS = 0.18; // add extra draw for higher orbit angles so the stroke feels weightier
-const CUE_PULL_MAX_VISUAL_BONUS = 0.32; // cap the compensation so the cue never overextends past the intended stroke
+const CUE_PULL_CUE_CAMERA_DAMPING = 0.1; // trim the pull depth in cue view so the cue stays tight to the ball
+const CUE_PULL_STANDING_CAMERA_BONUS = 0.22; // add extra draw for higher orbit angles so the stroke feels weightier
+const CUE_PULL_MAX_VISUAL_BONUS = 0.4; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_STROKE_MIN_MS = 95;
 const CUE_STROKE_MAX_MS = 420;
 const CUE_STROKE_SPEED_MIN = BALL_R * 18;
@@ -10812,6 +10812,7 @@ const powerRef = useRef(hud.power);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
+  const replayRestoreAimRef = useRef(false);
   const updateSpinDotPosition = useCallback((value, blocked) => {
     if (!value) value = { x: 0, y: 0 };
     const dot = spinDotElRef.current;
@@ -14860,6 +14861,7 @@ const powerRef = useRef(hud.power);
             cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
             return;
           }
+          cueStick.visible = false;
           cueStick.position.set(settleSnap.x, settleSnap.y, settleSnap.z);
           cueAnimating = false;
         };
@@ -14896,6 +14898,68 @@ const powerRef = useRef(hud.power);
           replayTrail.visible = true;
         };
 
+        const buildFallbackReplayCueStroke = (recording) => {
+          const frames = recording?.frames ?? [];
+          const cuePath = recording?.cuePath ?? [];
+          const firstFrame = frames[0]?.balls ?? [];
+          const cueEntry = firstFrame.find((ball) => String(ball.id) === 'cue');
+          const cuePos2D = cueEntry?.pos ?? null;
+          if (!cuePos2D) return null;
+          const cueOrigin = new THREE.Vector3(cuePos2D.x, CUE_Y, cuePos2D.y);
+          let aimDir2D = null;
+          if (cuePath.length >= 2) {
+            const a = cuePath[0]?.pos;
+            const b = cuePath[1]?.pos;
+            if (a && b) {
+              aimDir2D = new THREE.Vector2(b.x - a.x, b.z - a.z);
+            }
+          }
+          if (!aimDir2D && frames.length > 1) {
+            const nextCue = frames[1].balls?.find((ball) => String(ball.id) === 'cue');
+            if (nextCue?.pos) {
+              aimDir2D = new THREE.Vector2(
+                nextCue.pos.x - cuePos2D.x,
+                nextCue.pos.y - cuePos2D.y
+              );
+            }
+          }
+          if (!aimDir2D || aimDir2D.lengthSq() < 1e-8) {
+            aimDir2D = new THREE.Vector2(0, -1);
+          }
+          aimDir2D.normalize();
+          const aimDir = new THREE.Vector3(aimDir2D.x, 0, aimDir2D.y);
+          const pullDepth = Math.max(CUE_PULL_MIN_VISUAL * 1.1, BALL_R * 4.25);
+          const warmupDepth = Math.max(0, pullDepth * 0.55);
+          const warmup = cueOrigin
+            .clone()
+            .sub(aimDir.clone().multiplyScalar(cueLen / 2 + CUE_TIP_GAP + warmupDepth));
+          const start = cueOrigin
+            .clone()
+            .sub(aimDir.clone().multiplyScalar(cueLen / 2 + CUE_TIP_GAP + pullDepth));
+          const impact = cueOrigin
+            .clone()
+            .add(aimDir.clone().multiplyScalar(CUE_TIP_GAP));
+          const settle = impact
+            .clone()
+            .sub(
+              aimDir
+                .clone()
+                .multiplyScalar(Math.max(pullDepth * 0.9, BALL_R * 3.5))
+            );
+          return {
+            warmup: serializeVector3Snapshot(warmup),
+            start: serializeVector3Snapshot(start),
+            impact: serializeVector3Snapshot(impact),
+            settle: serializeVector3Snapshot(settle),
+            rotationX: 0,
+            rotationY: Math.atan2(aimDir.x, aimDir.z) + Math.PI,
+            pullback: AI_CAMERA_DROP_DURATION_MS * 0.5,
+            forward: AI_CAMERA_DROP_DURATION_MS * 0.9,
+            settleTime: AI_CAMERA_DROP_DURATION_MS * 0.45,
+            startOffset: 0
+          };
+        };
+
         const trimReplayRecording = (recording) => {
           const frames = recording?.frames ?? [];
           const cuePath = recording?.cuePath ?? [];
@@ -14918,7 +14982,7 @@ const powerRef = useRef(hud.power);
                 ),
                 startOffset: Math.max(0, cueStrokeRaw.startOffset ?? 0)
               }
-            : null;
+            : buildFallbackReplayCueStroke({ frames, cuePath });
           if (frames.length === 0) return { frames, cuePath, duration: 0, cueStroke };
           const duration = frames[frames.length - 1]?.t ?? 0;
           return { frames, cuePath, duration, cueStroke };
@@ -14965,6 +15029,7 @@ const powerRef = useRef(hud.power);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           setReplayActive(true);
+          if (cueStick) cueStick.visible = true;
           storeReplayCameraFrame();
           resetCameraForReplay();
           replayPlayback = {
@@ -15045,7 +15110,10 @@ const powerRef = useRef(hud.power);
           }
           if (cueStick) {
             cueStick.visible = false;
+            cuePullCurrentRef.current = 0;
+            cuePullTargetRef.current = 0;
           }
+          replayRestoreAimRef.current = true;
           cueAnimating = false;
           if (playback.pocketDrops) {
             const pocketDuration = Number.isFinite(playback.duration)
@@ -17150,10 +17218,12 @@ const powerRef = useRef(hud.power);
               CUE_Y + spinWorld.y,
               cue.pos.y - dir.z * (cueLen / 2 + pullAmount + CUE_TIP_GAP) + spinWorld.z
             );
-          const warmupPull =
-            aiOpponentEnabled && hudRef.current?.turn === 1
-              ? Math.max(0, Math.min(visualPull, BALL_R * 0.75))
-              : visualPull;
+          const isAiTurn = aiOpponentEnabled && hudRef.current?.turn === 1;
+          const warmupDepth = Math.min(
+            visualPull * 0.72 + (isAiTurn ? BALL_R * 0.45 : BALL_R * 0.25),
+            visualPull - BALL_R * 0.05
+          );
+          const warmupPull = Math.max(0, Math.min(warmupDepth, visualPull * 0.95));
           const startPos = buildCuePosition(visualPull);
           const warmupPos = buildCuePosition(warmupPull);
           const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
@@ -17195,7 +17265,7 @@ const powerRef = useRef(hud.power);
             CUE_STROKE_SPEED_MAX,
             clampedPower
           );
-          const forwardDuration = THREE.MathUtils.clamp(
+          let forwardDuration = THREE.MathUtils.clamp(
             (forwardDistance / Math.max(forwardSpeed, 1e-4)) * 1000,
             CUE_STROKE_MIN_MS,
             CUE_STROKE_MAX_MS
@@ -17205,15 +17275,21 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_SPEED_MAX,
             clampedPower
           );
-          const settleDuration = THREE.MathUtils.clamp(
+          let settleDuration = THREE.MathUtils.clamp(
             (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
             CUE_FOLLOW_MIN_MS,
             CUE_FOLLOW_MAX_MS
           );
-          const pullbackDuration =
-            aiOpponentEnabled && hudRef.current?.turn === 1
-              ? Math.max(CUE_STROKE_MIN_MS, forwardDuration * 0.65)
-              : 0;
+          const basePullbackDuration = Math.max(CUE_STROKE_MIN_MS * 0.75, forwardDuration * 0.4);
+          let pullbackDuration = isAiTurn
+            ? Math.max(basePullbackDuration, forwardDuration * 0.65)
+            : basePullbackDuration;
+          if (isAiTurn) {
+            const aiTempoScale = Math.max(1, AI_CAMERA_DROP_DURATION_MS / forwardDuration);
+            forwardDuration *= aiTempoScale;
+            settleDuration *= Math.max(1, aiTempoScale * 0.9);
+            pullbackDuration = Math.max(pullbackDuration, forwardDuration * 0.9);
+          }
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;
@@ -18384,7 +18460,7 @@ const powerRef = useRef(hud.power);
             suggestionAimKeyRef.current = key;
             return true;
           };
-          const preferAutoAim = autoAimRequestRef.current || plan?.viaCushion;
+          const preferAutoAim = autoAimRequestRef.current;
           if (preferAutoAim) {
             let autoDir = resolveAutoAimDirection();
             if (!autoDir && plan?.targetBall && cue?.pos) {
@@ -19026,6 +19102,13 @@ const powerRef = useRef(hud.power);
           }
           scheduleNext();
           return;
+        }
+        if (replayRestoreAimRef.current && cueStick) {
+          replayRestoreAimRef.current = false;
+          cueAnimating = false;
+          cueStick.visible = true;
+          cuePullCurrentRef.current = 0;
+          cuePullTargetRef.current = 0;
         }
         const nowMs = now;
         if (remoteShotActiveRef.current && remoteShotUntilRef.current > 0 && nowMs > remoteShotUntilRef.current) {


### PR DESCRIPTION
## Summary
- increase cue pull visibility and add pullback timing for both users and AI while slowing AI strokes to match the camera drop tempo
- ensure replays always render a cue stroke (with a fallback when missing) and hide the cue after impact
- restore the cue and aim line after replays and keep user aim suggestions off cushions unless auto-aim is requested

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695182c2e8c48329b89c4aa886c78c7c)