### PR TITLE
Add nebula board theme and new chess piece palettes

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -57,7 +57,9 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     mintVale: 'Mint Vale',
     royalWave: 'Royal Wave',
     roseMist: 'Rose Mist',
-    amethyst: 'Amethyst'
+    amethyst: 'Amethyst',
+    cinderBlaze: 'Cinder Blaze',
+    arcticDrift: 'Arctic Drift'
   }),
   boardTheme: Object.freeze({
     classic: 'Classic',
@@ -66,7 +68,8 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     sand: 'Sand/Brown',
     ocean: 'Ocean',
     violet: 'Violet',
-    chrome: 'Chrome'
+    chrome: 'Chrome',
+    nebulaGlass: 'Nebula Glass'
   }),
   headStyle: Object.freeze({
     current: 'Current',
@@ -112,12 +115,15 @@ export const CHESS_BATTLE_STORE_ITEMS = [
   { id: 'chess-side-royal', type: 'sideColor', optionId: 'royalWave', name: 'Royal Wave Pieces', price: 420, description: 'Royal blue quick-select palette.' },
   { id: 'chess-side-rose', type: 'sideColor', optionId: 'roseMist', name: 'Rose Mist Pieces', price: 420, description: 'Rosy quick-select palette with soft glow.' },
   { id: 'chess-side-amethyst', type: 'sideColor', optionId: 'amethyst', name: 'Amethyst Pieces', price: 460, description: 'Amethyst quick-select palette with sheen.' },
+  { id: 'chess-side-cinder', type: 'sideColor', optionId: 'cinderBlaze', name: 'Cinder Blaze Pieces', price: 480, description: 'Molten orange-on-charcoal palette for fiery showdowns.' },
+  { id: 'chess-side-arctic', type: 'sideColor', optionId: 'arcticDrift', name: 'Arctic Drift Pieces', price: 520, description: 'Icy stone palette with frosted metallic hints.' },
   { id: 'chess-board-ivorySlate', type: 'boardTheme', optionId: 'ivorySlate', name: 'Ivory/Slate Board', price: 380, description: 'Alternate board palette for fast swaps.' },
   { id: 'chess-board-forest', type: 'boardTheme', optionId: 'forest', name: 'Forest Board', price: 410, description: 'Alternate board palette for fast swaps.' },
   { id: 'chess-board-sand', type: 'boardTheme', optionId: 'sand', name: 'Sand/Brown Board', price: 440, description: 'Alternate board palette for fast swaps.' },
   { id: 'chess-board-ocean', type: 'boardTheme', optionId: 'ocean', name: 'Ocean Board', price: 470, description: 'Alternate board palette for fast swaps.' },
   { id: 'chess-board-violet', type: 'boardTheme', optionId: 'violet', name: 'Violet Board', price: 500, description: 'Alternate board palette for fast swaps.' },
   { id: 'chess-board-chrome', type: 'boardTheme', optionId: 'chrome', name: 'Chrome Board', price: 540, description: 'Alternate board palette for fast swaps.' },
+  { id: 'chess-board-nebula', type: 'boardTheme', optionId: 'nebulaGlass', name: 'Nebula Glass Board', price: 580, description: 'Cosmic glass palette with deep-space contrasts.' },
   { id: 'chess-head-ruby', type: 'headStyle', optionId: 'headRuby', name: 'Ruby Pawn Heads', price: 310, description: 'Unlocks an additional pawn head glass preset.' },
   { id: 'chess-head-sapphire', type: 'headStyle', optionId: 'headSapphire', name: 'Sapphire Pawn Heads', price: 335, description: 'Unlocks an additional pawn head glass preset.' },
   { id: 'chess-head-chrome', type: 'headStyle', optionId: 'headChrome', name: 'Chrome Pawn Heads', price: 360, description: 'Unlocks an additional pawn head glass preset.' },

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1019,7 +1019,9 @@ const QUICK_SIDE_COLORS = [
   { id: 'mintVale', hex: 0x10b981, label: 'Mint Vale' },
   { id: 'royalWave', hex: 0x3b82f6, label: 'Royal Wave' },
   { id: 'roseMist', hex: 0xef4444, label: 'Rose Mist' },
-  { id: 'amethyst', hex: 0x8b5cf6, label: 'Amethyst' }
+  { id: 'amethyst', hex: 0x8b5cf6, label: 'Amethyst' },
+  { id: 'cinderBlaze', hex: 0xff6b35, label: 'Cinder Blaze' },
+  { id: 'arcticDrift', hex: 0xbcd7ff, label: 'Arctic Drift' }
 ];
 
 const QUICK_HEAD_PRESETS = [
@@ -1037,7 +1039,8 @@ const QUICK_BOARD_THEMES = [
   { id: 'sand', name: 'Sand/Brown', light: 0xddd0b8, dark: 0x6b4f3a },
   { id: 'ocean', name: 'Ocean', light: 0xa4c8e1, dark: 0x1e3a5f },
   { id: 'violet', name: 'Violet', light: 0xddd6fe, dark: 0x3b2a6e },
-  { id: 'chrome', name: 'Chrome', light: 0xb0b0b0, dark: 0x6e6e6e, special: 'chrome' }
+  { id: 'chrome', name: 'Chrome', light: 0xb0b0b0, dark: 0x6e6e6e, special: 'chrome' },
+  { id: 'nebulaGlass', name: 'Nebula Glass', light: 0xe0f2fe, dark: 0x0b1024 }
 ];
 
 const SNOOKER_TABLE_SCALE = 1.3;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -309,7 +309,10 @@ const OPTION_SWATCH_OVERRIDES = {
   emeraldSide: ['#22c55e', '#16a34a'],
   royalIvory: ['#f8fafc', '#e2e8f0'],
   neonRush: ['#f472b6', '#22d3ee'],
-  duskMallet: ['#0f172a', '#1e3a8a']
+  duskMallet: ['#0f172a', '#1e3a8a'],
+  cinderBlaze: ['#ff6b35', '#2b1a12'],
+  arcticDrift: ['#bcd7ff', '#1f2f52'],
+  nebulaGlass: ['#e0f2fe', '#0b1024']
 };
 
 const PREVIEW_BY_TYPE = {


### PR DESCRIPTION
## Summary
- add a Nebula Glass board theme and expose it in the chess store
- add Cinder Blaze and Arctic Drift chess piece color options for quick setup and store unlocks
- include swatch overrides so the new chess cosmetics preview with the same texture technique as other items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518a3e9f64832987e9bf4166401be7)