### PR TITLE
Add dedicated Magazine 3D warehouse view

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -13,6 +13,7 @@ import Messages from './pages/Messages.jsx';
 import Trending from './pages/Trending.jsx';
 import Notifications from './pages/Notifications.jsx';
 import InfluencerAdmin from './pages/InfluencerAdmin.jsx';
+import MagazineWarehouse from './pages/MagazineWarehouse.jsx';
 
 import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
 import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
@@ -141,6 +142,7 @@ export default function App() {
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/trending" element={<Trending />} />
             <Route path="/account" element={<MyAccount />} />
+            <Route path="/dev/magazine-warehouse" element={<MagazineWarehouse />} />
           </Routes>
         </Layout>
       </TonConnectUIProvider>

--- a/webapp/src/pages/MagazineWarehouse.jsx
+++ b/webapp/src/pages/MagazineWarehouse.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Magazine3D from '../components/Magazine3D.jsx';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+import { DEV_INFO } from '../utils/constants.js';
+
+export default function MagazineWarehouse() {
+  const navigate = useNavigate();
+  const [isDev, setIsDev] = useState(() => {
+    try {
+      return localStorage.getItem('accountId') === DEV_INFO.account;
+    } catch {
+      return false;
+    }
+  });
+
+  useTelegramBackButton(() => navigate('/account'));
+
+  useEffect(() => {
+    try {
+      const storedAccountId = localStorage.getItem('accountId');
+      setIsDev(storedAccountId === DEV_INFO.account);
+    } catch {
+      setIsDev(false);
+    }
+  }, []);
+
+  if (!isDev) {
+    return (
+      <div className="p-4 space-y-3 wide-card mx-auto text-center">
+        <h1 className="text-xl font-semibold">Magazine Warehouse</h1>
+        <p className="text-sm text-subtext">
+          This area is restricted to the developer account.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <Link
+            to="/account"
+            className="inline-flex items-center justify-center px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold"
+          >
+            Back to Account
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-3 wide-card mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Magazine Warehouse</h1>
+        <span className="text-xs text-subtext">Dev only</span>
+      </div>
+      <p className="text-sm text-subtext">
+        Full-screen view of the curated Poly Haven 3D objects arranged in order.
+      </p>
+      <Magazine3D />
+    </div>
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   getAccountInfo,
   createAccount,
@@ -28,7 +29,6 @@ import DevTasksModal from '../components/DevTasksModal.jsx';
 import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import { loadGoogleProfile } from '../utils/google.js';
-import Magazine3D from '../components/Magazine3D.jsx';
 import {
   getDefaultPoolRoyalLoadout,
   getPoolRoyalInventory,
@@ -553,10 +553,22 @@ export default function MyAccount() {
               <span className="text-xs text-subtext">Dev only</span>
             </div>
             <p className="text-sm text-subtext">
-              Internal 3D magazine curated for Poly Haven assets with preserved materials. Items are
-              grouped by category with article numbers for quick reference.
+              Open the developer warehouse to browse all curated Poly Haven assets in order.
             </p>
-            <Magazine3D />
+            <div className="rounded-lg border border-dashed border-border bg-surface/60 p-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div className="space-y-1">
+                <p className="font-medium text-sm">Magazine Warehouse</p>
+                <p className="text-xs text-subtext">
+                  Launch the full-screen gallery with organized 3D models and tickets.
+                </p>
+              </div>
+              <Link
+                to="/dev/magazine-warehouse"
+                className="inline-flex items-center justify-center px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold"
+              >
+                Open
+              </Link>
+            </div>
           </div>
 
           <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">


### PR DESCRIPTION
## Summary
- add a dedicated Magazine Warehouse page with developer access gating and back button handling
- update the My Account dev section to show a simple frame with an Open button into the warehouse
- register a new route so the warehouse view can be opened from the dev profile card

## Testing
- npm --prefix webapp run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69522443f4f083298e99354d1d7d42b9)