### PR TITLE
Add HDRI environments for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleHdriPresets.js
+++ b/webapp/src/config/poolRoyaleHdriPresets.js
@@ -1,0 +1,141 @@
+const DEFAULT_RESOLUTION_ORDER = Object.freeze(['4k', '2k', '1k']);
+
+export const POOL_ROYALE_HDRI_PRESETS = Object.freeze([
+  {
+    id: 'neon-photostudio',
+    name: 'Neon Photostudio',
+    assetId: 'neon_photostudio',
+    description: 'Vibrant neon cove lights with tight falloff around the table.',
+    storeDescription: 'Signature neon stage built for reflective chrome trims and bright cloth colors.',
+    storePrice: 1650,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.28,
+    envMapIntensity: 1.16
+  },
+  {
+    id: 'studio-small-08',
+    name: 'Studio Stage 08',
+    assetId: 'studio_small_08',
+    description: 'Softbox studio bowl with even tone for competition broadcasts.',
+    storeDescription: 'Balanced TV studio bowl that keeps the cloth evenly exposed for streams.',
+    storePrice: 1680,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.24,
+    envMapIntensity: 1.12
+  },
+  {
+    id: 'brown-photostudio-02',
+    name: 'Bronze Photostudio',
+    assetId: 'brown_photostudio_02',
+    description: 'Warm, controlled bronze bounce that flatters wood grains.',
+    storeDescription: 'Cinematic bronze studio that pairs perfectly with amber or walnut finishes.',
+    storePrice: 1720,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.26,
+    envMapIntensity: 1.14
+  },
+  {
+    id: 'industrial-sunset',
+    name: 'Industrial Sunset',
+    assetId: 'industrial_sunset_puresky',
+    description: 'High-contrast sunset sky with crisp rim and metal highlights.',
+    storeDescription: 'Sunset-grade HDRI for dramatic chrome reflections and silhouette shots.',
+    storePrice: 1780,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.18,
+    envMapIntensity: 1.22
+  },
+  {
+    id: 'dikhololo-night',
+    name: 'Dikhololo Night',
+    assetId: 'dikhololo_night',
+    description: 'Moody night park lighting with cool top-down ambience.',
+    storeDescription: 'Nighttime park sky to showcase glowing markers and chrome fascias.',
+    storePrice: 1820,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.32,
+    envMapIntensity: 1.26
+  },
+  {
+    id: 'kloofendal-partly-cloudy',
+    name: 'Kloofendal Clouds',
+    assetId: 'kloofendal_48d_partly_cloudy',
+    description: 'Open-air daylight with soft clouds for neutral match coverage.',
+    storeDescription: 'Outdoor daylight dome with soft clouds for neutral, competition-ready light.',
+    storePrice: 1750,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.22,
+    envMapIntensity: 1.15
+  },
+  {
+    id: 'rooitou-park',
+    name: 'Rooitou Park',
+    assetId: 'rooitou_park',
+    description: 'Lush green park reflections that accent emerald cloths.',
+    storeDescription: 'Bright park ambience that keeps greens vibrant and chrome clean.',
+    storePrice: 1720,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.25,
+    envMapIntensity: 1.18
+  },
+  {
+    id: 'spruit-sunrise',
+    name: 'Spruit Sunrise',
+    assetId: 'spruit_sunrise',
+    description: 'Golden-hour sun for cinematic rim highlights on rails.',
+    storeDescription: 'Sunrise glow with warm rims and deep floor gradients for hero shots.',
+    storePrice: 1880,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.2,
+    envMapIntensity: 1.24
+  },
+  {
+    id: 'forest-slope',
+    name: 'Forest Slope',
+    assetId: 'forest_slope',
+    description: 'Tree-lined hillside ambience with soft green bounce.',
+    storeDescription: 'Natural forest surround that grounds the table without harsh hotspots.',
+    storePrice: 1740,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.23,
+    envMapIntensity: 1.17
+  },
+  {
+    id: 'barcelona-rooftop',
+    name: 'Barcelona Rooftop',
+    assetId: 'barcelona_rooftop',
+    description: 'Urban rooftop skyline with balanced late-afternoon warmth.',
+    storeDescription: 'Premium cityscape HDRI for polished chrome and glass reflections.',
+    storePrice: 1800,
+    preferredResolutions: DEFAULT_RESOLUTION_ORDER,
+    fallbackResolution: '4k',
+    exposure: 1.21,
+    envMapIntensity: 1.19
+  }
+]);
+
+export const DEFAULT_POOL_HDRI_ID = 'neon-photostudio';
+
+export const POOL_ROYALE_HDRI_LABELS = Object.freeze(
+  POOL_ROYALE_HDRI_PRESETS.reduce((acc, preset) => {
+    acc[preset.id] = preset.name;
+    return acc;
+  }, {})
+);
+
+export function findPoolHdriPreset(id) {
+  const preset =
+    POOL_ROYALE_HDRI_PRESETS.find((entry) => entry.id === id) ??
+    POOL_ROYALE_HDRI_PRESETS.find((entry) => entry.id === DEFAULT_POOL_HDRI_ID) ??
+    POOL_ROYALE_HDRI_PRESETS[0];
+  return preset;
+}

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,4 +1,9 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import {
+  DEFAULT_POOL_HDRI_ID,
+  POOL_ROYALE_HDRI_LABELS,
+  POOL_ROYALE_HDRI_PRESETS
+} from './poolRoyaleHdriPresets.js';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['charredTimber'],
@@ -6,7 +11,8 @@ export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
   cueStyle: ['birch-frost'],
-  pocketLiner: ['blackPocket']
+  pocketLiner: ['blackPocket'],
+  environmentHdri: [DEFAULT_POOL_HDRI_ID]
 });
 
 export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
@@ -53,7 +59,8 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     emeraldPocket: 'Emerald Pocket Jaws',
     rubyPocket: 'Ruby Pocket Jaws',
     pearlPocket: 'Pearl Pocket Jaws'
-  })
+  }),
+  environmentHdri: Object.freeze(POOL_ROYALE_HDRI_LABELS)
 });
 
 export const POOL_ROYALE_STORE_ITEMS = [
@@ -248,7 +255,15 @@ export const POOL_ROYALE_STORE_ITEMS = [
     name: 'Graphite Aurora Cue',
     price: 360,
     description: 'Graphite weave cue with aurora-inspired tint.'
-  }
+  },
+  ...POOL_ROYALE_HDRI_PRESETS.map((preset) => ({
+    id: `hdri-${preset.id}`,
+    type: 'environmentHdri',
+    optionId: preset.id,
+    name: preset.name,
+    price: preset.storePrice ?? 1600,
+    description: preset.storeDescription ?? preset.description
+  }))
 ];
 
 export const POOL_ROYALE_DEFAULT_LOADOUT = [
@@ -261,5 +276,10 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
     label: POOL_ROYALE_CLOTH_VARIANTS[0].name
   },
   { type: 'cueStyle', optionId: 'birch-frost', label: 'Birch Frost Cue' },
-  { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' }
+  { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' },
+  {
+    type: 'environmentHdri',
+    optionId: DEFAULT_POOL_HDRI_ID,
+    label: POOL_ROYALE_HDRI_LABELS[DEFAULT_POOL_HDRI_ID]
+  }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -119,7 +119,8 @@ const TYPE_LABELS = {
   railMarkerColor: 'Rail Markers',
   clothColor: 'Cloth Colors',
   cueStyle: 'Cue Styles',
-  pocketLiner: 'Pocket Jaws'
+  pocketLiner: 'Pocket Jaws',
+  environmentHdri: 'HDRI Environments'
 };
 
 const SNOOKER_TYPE_LABELS = {
@@ -338,7 +339,8 @@ const PREVIEW_BY_TYPE = {
   tableWood: 'table',
   tableCloth: 'table',
   tableBase: 'table',
-  tables: 'table'
+  tables: 'table',
+  environmentHdri: 'table'
 };
 
 const PREVIEW_BY_SLUG = {


### PR DESCRIPTION
## Summary
- add 10 high-resolution Pool Royale HDRI presets with pricing and labels for store and default unlock/loadout
- expose HDRI selections in the table setup UI and persist the chosen environment
- switch Pool Royale rendering to HDRI-driven lighting and backgrounds at 4k-preferred resolution, removing the old rig lights

## Testing
- npm --prefix webapp run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526ffde6d883299ac98ff57b5494d5)