### PR TITLE
Add HDRI catalog and HDRI-driven lighting for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleHdriPresets.js
+++ b/webapp/src/config/poolRoyaleHdriPresets.js
@@ -1,0 +1,149 @@
+export const DEFAULT_POOL_HDRI_ID = 'neon-photostudio';
+
+export const POOL_ROYALE_HDRI_OPTIONS = Object.freeze([
+  {
+    id: 'neon-photostudio',
+    name: 'Neon Photostudio',
+    assetId: 'neon_photostudio',
+    description: 'Vibrant neon reflections with crisp floor polish for showcase matches.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.18,
+    environmentIntensity: 1.28,
+    backgroundIntensity: 1.12,
+    backgroundBlurriness: 0.14,
+    swatches: ['#1f2937', '#0ea5e9'],
+    price: 1280
+  },
+  {
+    id: 'studio-small-08',
+    name: 'Studio Small 08',
+    assetId: 'studio_small_08',
+    description: 'Soft box studio wrap with controlled highlights for product-like shots.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.12,
+    environmentIntensity: 1.18,
+    backgroundIntensity: 1.04,
+    backgroundBlurriness: 0.12,
+    swatches: ['#f8fafc', '#e2e8f0'],
+    price: 1320
+  },
+  {
+    id: 'venice-sunset',
+    name: 'Venice Sunset Lagoon',
+    assetId: 'venice_sunset',
+    description: 'Golden canal reflections that bathe the table in warm evening light.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.16,
+    environmentIntensity: 1.22,
+    backgroundIntensity: 1.16,
+    backgroundBlurriness: 0.1,
+    swatches: ['#f97316', '#7c2d12'],
+    price: 1360
+  },
+  {
+    id: 'kiara-dawn',
+    name: 'Kiara Dawn Ridge',
+    assetId: 'kiara_1_dawn',
+    description: 'Sunrise hillside with clear skylight for bright, even practice lighting.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.14,
+    environmentIntensity: 1.2,
+    backgroundIntensity: 1.1,
+    backgroundBlurriness: 0.08,
+    swatches: ['#38bdf8', '#fde68a'],
+    price: 1380
+  },
+  {
+    id: 'dikhololo-night',
+    name: 'Dikhololo Night Safari',
+    assetId: 'dikhololo_night',
+    description: 'Moody moonlit dome that leans on HDRI contrast for noir highlight rolls.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.24,
+    environmentIntensity: 1.32,
+    backgroundIntensity: 1.22,
+    backgroundBlurriness: 0.18,
+    swatches: ['#0b132b', '#1e293b'],
+    price: 1420
+  },
+  {
+    id: 'royal-esplanade',
+    name: 'Royal Esplanade',
+    assetId: 'royal_esplanade',
+    description: 'Architectural pavilion with symmetrical bounce for premium specular control.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.2,
+    environmentIntensity: 1.26,
+    backgroundIntensity: 1.14,
+    backgroundBlurriness: 0.12,
+    swatches: ['#cbd5e1', '#475569'],
+    price: 1440
+  },
+  {
+    id: 'potsdamer-platz',
+    name: 'Potsdamer Platz',
+    assetId: 'potsdamer_platz',
+    description: 'City canyons with tall glass facades for dramatic chrome reflections.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.22,
+    environmentIntensity: 1.3,
+    backgroundIntensity: 1.18,
+    backgroundBlurriness: 0.1,
+    swatches: ['#0f172a', '#38bdf8'],
+    price: 1480
+  },
+  {
+    id: 'cayley-interior',
+    name: 'Cayley Studio Loft',
+    assetId: 'cayley_interior',
+    description: 'Open-plan loft with skylights tuned for neutral cloth color accuracy.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.15,
+    environmentIntensity: 1.24,
+    backgroundIntensity: 1.1,
+    backgroundBlurriness: 0.09,
+    swatches: ['#f3f4f6', '#9ca3af'],
+    price: 1500
+  },
+  {
+    id: 'st-fagans-gallery',
+    name: 'St Fagans Gallery',
+    assetId: 'st_fagans_interior',
+    description: 'Museum-grade uplight with soft wall spill for exhibition-style matches.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.18,
+    environmentIntensity: 1.25,
+    backgroundIntensity: 1.12,
+    backgroundBlurriness: 0.11,
+    swatches: ['#e5e7eb', '#6b7280'],
+    price: 1540
+  },
+  {
+    id: 'kloofendal-clouds',
+    name: 'Kloofendal Clouds',
+    assetId: 'kloofendal_48d_partly_cloudy',
+    description: 'High-altitude clouds with clean skylight gradients for competition broadcasts.',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    exposure: 1.16,
+    environmentIntensity: 1.22,
+    backgroundIntensity: 1.1,
+    backgroundBlurriness: 0.08,
+    swatches: ['#bfdbfe', '#e5e7eb'],
+    price: 1580
+  }
+]);
+
+export const HDRI_OPTION_MAP = POOL_ROYALE_HDRI_OPTIONS.reduce((acc, option) => {
+  acc[option.id] = option;
+  return acc;
+}, {});

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,4 +1,8 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import {
+  DEFAULT_POOL_HDRI_ID,
+  POOL_ROYALE_HDRI_OPTIONS
+} from './poolRoyaleHdriPresets.js';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['charredTimber'],
@@ -6,7 +10,8 @@ export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
   cueStyle: ['birch-frost'],
-  pocketLiner: ['blackPocket']
+  pocketLiner: ['blackPocket'],
+  environmentHdri: [DEFAULT_POOL_HDRI_ID]
 });
 
 export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
@@ -53,7 +58,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     emeraldPocket: 'Emerald Pocket Jaws',
     rubyPocket: 'Ruby Pocket Jaws',
     pearlPocket: 'Pearl Pocket Jaws'
-  })
+  }),
+  environmentHdri: Object.freeze(
+    POOL_ROYALE_HDRI_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.name;
+      return acc;
+    }, {})
+  )
 });
 
 export const POOL_ROYALE_STORE_ITEMS = [
@@ -248,7 +259,15 @@ export const POOL_ROYALE_STORE_ITEMS = [
     name: 'Graphite Aurora Cue',
     price: 360,
     description: 'Graphite weave cue with aurora-inspired tint.'
-  }
+  },
+  ...POOL_ROYALE_HDRI_OPTIONS.map((hdri) => ({
+    id: `hdri-${hdri.id}`,
+    type: 'environmentHdri',
+    optionId: hdri.id,
+    name: hdri.name,
+    price: hdri.price,
+    description: hdri.description
+  }))
 ];
 
 export const POOL_ROYALE_DEFAULT_LOADOUT = [
@@ -261,5 +280,6 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
     label: POOL_ROYALE_CLOTH_VARIANTS[0].name
   },
   { type: 'cueStyle', optionId: 'birch-frost', label: 'Birch Frost Cue' },
-  { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' }
+  { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' },
+  { type: 'environmentHdri', optionId: DEFAULT_POOL_HDRI_ID, label: 'Neon Photostudio HDRI' }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -6,6 +6,7 @@ import {
   POOL_ROYALE_STORE_ITEMS
 } from '../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../config/poolRoyaleClothPresets.js';
+import { POOL_ROYALE_HDRI_OPTIONS } from '../config/poolRoyaleHdriPresets.js';
 import {
   SNOOKER_CLUB_DEFAULT_LOADOUT,
   SNOOKER_CLUB_OPTION_LABELS,
@@ -119,7 +120,8 @@ const TYPE_LABELS = {
   railMarkerColor: 'Rail Markers',
   clothColor: 'Cloth Colors',
   cueStyle: 'Cue Styles',
-  pocketLiner: 'Pocket Jaws'
+  pocketLiner: 'Pocket Jaws',
+  environmentHdri: 'HDRI Domes'
 };
 
 const SNOOKER_TYPE_LABELS = {
@@ -286,8 +288,16 @@ const POOL_CLOTH_SWATCHES = POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, cloth) => {
   return acc;
 }, {});
 
+const POOL_HDRI_SWATCHES = POOL_ROYALE_HDRI_OPTIONS.reduce((acc, hdri) => {
+  if (hdri?.swatches?.length) {
+    acc[hdri.id] = hdri.swatches;
+  }
+  return acc;
+}, {});
+
 const OPTION_SWATCH_OVERRIDES = {
   ...POOL_CLOTH_SWATCHES,
+  ...POOL_HDRI_SWATCHES,
   charredTimber: ['#2f2217', '#6b4226'],
   rusticSplit: ['#f3e8ff', '#fef3c7'],
   plankStudio: ['#e0e7ff', '#a78bfa'],
@@ -338,7 +348,8 @@ const PREVIEW_BY_TYPE = {
   tableWood: 'table',
   tableCloth: 'table',
   tableBase: 'table',
-  tables: 'table'
+  tables: 'table',
+  environmentHdri: 'table'
 };
 
 const PREVIEW_BY_SLUG = {


### PR DESCRIPTION
## Summary
- add ten high-resolution HDRI domes with premium pricing to the Pool Royale catalog and defaults
- surface HDRI options in the store and table setup UI with dedicated swatches and preview labeling
- load 4K HDRI environments in-game, retire the old light rig, and drive exposure/background from the selected dome

## Testing
- npm test -- --runTestsByPath test/poolRoyalInventoryRoutes.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526ffde6d883299ac98ff57b5494d5)