### PR TITLE
Add Murlan chairs and tables to Chess Battle Royal

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -8,6 +8,7 @@ import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
 } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
 const DEFAULT_TABLE_SHAPE_ID = TABLE_SHAPE_OPTIONS.find((opt) => opt.id !== 'diamondEdge')?.id;
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
@@ -18,6 +19,8 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   chairColor: ['crimsonVelvet'],
   tableShape: [DEFAULT_TABLE_SHAPE_ID],
+  chairTheme: [MURLAN_STOOL_THEMES[0]?.id],
+  tableTheme: [MURLAN_TABLE_THEMES[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
   headStyle: ['current'],
@@ -50,6 +53,18 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     onyxShadow: 'Onyx Shadow',
     royalPlum: 'Royal Chestnut'
   }),
+  chairTheme: Object.freeze(
+    MURLAN_STOOL_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableTheme: Object.freeze(
+    MURLAN_TABLE_THEMES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
   tableShape: Object.freeze(
     TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
@@ -121,6 +136,24 @@ export const CHESS_BATTLE_STORE_ITEMS = [
   { id: 'chess-chair-emerald', type: 'chairColor', optionId: 'emeraldWave', name: 'Emerald Wave Chairs', price: 340, description: 'Emerald upholstery with rich contrast piping.' },
   { id: 'chess-chair-onyx', type: 'chairColor', optionId: 'onyxShadow', name: 'Onyx Shadow Chairs', price: 380, description: 'Shadow-black seating with steel-toned trim.' },
   { id: 'chess-chair-plum', type: 'chairColor', optionId: 'royalPlum', name: 'Royal Chestnut Chairs', price: 360, description: 'Chestnut-plum accent chairs for regal matches.' },
+  ...MURLAN_STOOL_THEMES.slice(1).map((option, idx) => ({
+    id: `chess-chair-theme-${option.id}`,
+    type: 'chairTheme',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 360 + idx * 40,
+    description: option.description || 'Premium chair model imported from Murlan Royale.',
+    thumbnail: option.thumbnail
+  })),
+  ...MURLAN_TABLE_THEMES.slice(1).map((option, idx) => ({
+    id: `chess-table-theme-${option.id}`,
+    type: 'tableTheme',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 980 + idx * 40,
+    description: option.description || 'Imported table model from Murlan Royale.',
+    thumbnail: option.thumbnail
+  })),
   { id: 'chess-shape-oval', type: 'tableShape', optionId: 'grandOval', name: 'Grand Oval Shape', price: 640, description: 'Smooth oval table outline for the chess board.' },
   { id: 'chess-side-marble', type: 'sideColor', optionId: 'marble', name: 'Marble Pieces', price: 1400, description: 'Premium marble-inspired pieces for either side.' },
   { id: 'chess-side-forest', type: 'sideColor', optionId: 'darkForest', name: 'Dark Forest Pieces', price: 1300, description: 'Deep forest hue pieces with luxe accents.' },
@@ -155,6 +188,8 @@ export const CHESS_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
   { type: 'chairColor', optionId: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+  { type: 'chairTheme', optionId: MURLAN_STOOL_THEMES[0]?.id, label: MURLAN_STOOL_THEMES[0]?.label },
+  { type: 'tableTheme', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },
   { type: 'tableShape', optionId: DEFAULT_TABLE_SHAPE_ID, label: CHESS_BATTLE_OPTION_LABELS.tableShape[DEFAULT_TABLE_SHAPE_ID] },
   { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Pieces' },
   { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Pieces' },

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -146,6 +146,8 @@ const CHESS_TYPE_LABELS = {
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
   chairColor: 'Chairs',
+  chairTheme: 'Chair Models',
+  tableTheme: 'Table Models',
   tableShape: 'Table Shape',
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',


### PR DESCRIPTION
## Summary
- add Murlan Royale chair and table themes to the Chess Battle Royal inventory, defaults, and store offerings
- load Poly Haven-based chair and table models inside the chess arena while preserving original materials where appropriate
- extend customization UI and unlock validation to support the new chair and table model selections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ae4e5eb8832981a943e3e3c04db1)