### PR TITLE
Add HDRI options and declutter Murlan Royale arena

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,6 +1,10 @@
 import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../utils/cardThemes.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from './poolRoyaleInventoryConfig.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -16,7 +20,8 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableBase: [TABLE_BASE_OPTIONS[0].id],
   cards: [CARD_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
-  tables: [MURLAN_TABLE_THEMES[0].id]
+  tables: [MURLAN_TABLE_THEMES[0].id],
+  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
@@ -25,7 +30,13 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   tableBase: mapLabels(TABLE_BASE_OPTIONS),
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
-  tables: mapLabels(MURLAN_TABLE_THEMES)
+  tables: mapLabels(MURLAN_TABLE_THEMES),
+  environmentHdri: Object.freeze(
+    POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
+      acc[variant.id] = `${variant.name} HDRI`;
+      return acc;
+    }, {})
+  )
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
@@ -158,6 +169,16 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     name: theme.label,
     price: theme.price ?? 300 + idx * 20,
     description: theme.description || `Premium ${theme.label} seating with original finish.`
+  })),
+  POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+    id: `murlan-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 1400 + idx * 30,
+    description: 'Pool Royale HDRI environment, tuned for Murlan Royale promos.',
+    swatches: variant.swatches,
+    previewShape: 'table'
   }))
 );
 
@@ -167,5 +188,12 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0].id, label: TABLE_BASE_OPTIONS[0].label },
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
-  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label }
+  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },
+  {
+    type: 'environmentHdri',
+    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
+    label:
+      MURLAN_ROYALE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID] ||
+      `${POOL_ROYALE_DEFAULT_HDRI_ID} HDRI`
+  }
 ];

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -10,11 +10,9 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
-import {
-  createArenaCarpetMaterial,
-  createArenaWallMaterial
-} from '../../utils/arenaDecor.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
 import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
@@ -52,6 +50,10 @@ import {
   MURLAN_STOOL_THEMES as STOOL_THEMES,
   MURLAN_TABLE_THEMES as TABLE_THEMES
 } from '../../config/murlanThemes.js';
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from '../../config/poolRoyaleInventoryConfig.js';
 
 const MODEL_SCALE = 0.75;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
@@ -269,11 +271,7 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
-const HALLWAY_PLANT_ASSETS = ['potted_plant_04'];
 const POLYHAVEN_MODEL_CACHE = new Map();
-const PLANT_TARGET_HEIGHT = 2.8 * MODEL_SCALE;
-const HALLWAY_PLANT_SCALE = 1;
-const DECOR_PLANT_COUNT = 4;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 
@@ -527,12 +525,6 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.91737499003112
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
 
-const DEFAULT_APPEARANCE = {
-  outfit: 0,
-  stools: 0,
-  tables: 0,
-  ...DEFAULT_TABLE_CUSTOMIZATION
-};
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
 const CUSTOMIZATION_SECTIONS = [
@@ -541,7 +533,8 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
-  { key: 'stools', label: 'Stools', options: STOOL_THEMES }
+  { key: 'stools', label: 'Stools', options: STOOL_THEMES },
+  { key: 'environmentHdri', label: 'HDR Environment', options: POOL_ROYALE_HDRI_VARIANTS }
 ];
 
 function createRegularPolygonShape(sides = 8, radius = 1) {
@@ -557,6 +550,25 @@ function createRegularPolygonShape(sides = 8, radius = 1) {
   return shape;
 }
 
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '4k', '2k']);
+const DEFAULT_HDRI_INDEX = Math.max(
+  0,
+  POOL_ROYALE_HDRI_VARIANTS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID)
+);
+const resolveHdriVariant = (index) => {
+  const max = POOL_ROYALE_HDRI_VARIANTS.length - 1;
+  const idx = Number.isFinite(index) ? Math.min(Math.max(0, Math.round(index)), max) : DEFAULT_HDRI_INDEX;
+  return POOL_ROYALE_HDRI_VARIANTS[idx] ?? POOL_ROYALE_HDRI_VARIANTS[DEFAULT_HDRI_INDEX] ?? POOL_ROYALE_HDRI_VARIANTS[0];
+};
+
+const DEFAULT_APPEARANCE = {
+  outfit: 0,
+  stools: 0,
+  tables: 0,
+  environmentHdri: DEFAULT_HDRI_INDEX,
+  ...DEFAULT_TABLE_CUSTOMIZATION
+};
+
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
@@ -566,7 +578,8 @@ function normalizeAppearance(value = {}) {
     ['tableBase', TABLE_BASE_OPTIONS.length],
     ['cards', CARD_THEMES.length],
     ['stools', STOOL_THEMES.length],
-    ['tables', TABLE_THEMES.length]
+    ['tables', TABLE_THEMES.length],
+    ['environmentHdri', POOL_ROYALE_HDRI_VARIANTS.length]
   ];
   entries.forEach(([key, max]) => {
     const raw = Number(value?.[key]);
@@ -575,6 +588,9 @@ function normalizeAppearance(value = {}) {
       normalized[key] = clamped;
     }
   });
+  if (!Number.isFinite(normalized.environmentHdri)) {
+    normalized.environmentHdri = DEFAULT_HDRI_INDEX;
+  }
   const legacyTable = Number(value?.table);
   if (Number.isFinite(legacyTable)) {
     const legacyIndex = Math.min(
@@ -760,182 +776,73 @@ function shouldPreserveChairMaterials(theme) {
   return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');
 }
 
-function createHallwayCeilingWallMaterial(textureLoader, maxAnisotropy = 1) {
-  if (!textureLoader) {
-    return createArenaWallMaterial('#0b1120', '#1e293b');
+function pickPolyHavenHdriUrl(json, resolutions = DEFAULT_HDRI_RESOLUTIONS) {
+  if (!json || typeof json !== 'object') return null;
+  for (const res of resolutions) {
+    const entry = json[res];
+    if (entry?.hdr) return entry.hdr;
+    if (entry?.exr) return entry.exr;
   }
-  const ceilingTex = textureLoader.load('https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/water.jpg');
-  ceilingTex.wrapS = THREE.RepeatWrapping;
-  ceilingTex.wrapT = THREE.RepeatWrapping;
-  ceilingTex.repeat.set(4, 4);
-  ceilingTex.colorSpace = THREE.SRGBColorSpace;
-  ceilingTex.anisotropy = Math.max(ceilingTex.anisotropy ?? 1, maxAnisotropy);
-
-  return new THREE.MeshStandardMaterial({
-    color: '#fdf8ef',
-    emissive: '#f0e8d0',
-    emissiveIntensity: 0.4,
-    metalness: 0.25,
-    roughness: 0.15,
-    map: ceilingTex
-  });
+  const fallback = Object.values(json).find((value) => value?.hdr || value?.exr);
+  if (!fallback) return null;
+  return fallback.hdr || fallback.exr || null;
 }
 
-const WALL_TEXTURE_CONFIG = {
-  sourceId: 'white_planks_clean',
-  fallbackColor: 0xdedede,
-  repeat: new THREE.Vector2(1.875, 3.4),
-  anisotropy: 12,
-  preferredResolutionK: 4
-};
-
-const loadWallPlankTextures = (() => {
-  let cache = null;
-  let pending = null;
-
-  const pickTextureUrls = (apiJson) => {
-    const urls = [];
-    const walk = (value) => {
-      if (!value) return;
-      if (typeof value === 'string') {
-        const lower = value.toLowerCase();
-        if (value.startsWith('http') && (lower.includes('.jpg') || lower.includes('.png'))) {
-          urls.push(value);
-        }
-        return;
-      }
-      if (Array.isArray(value)) {
-        value.forEach(walk);
-        return;
-      }
-      if (typeof value === 'object') {
-        Object.values(value).forEach(walk);
-      }
-    };
-    walk(apiJson);
-    const pickTexture = (candidateUrls, preferredResolutions) => {
-      const lowerUrls = candidateUrls.map((u) => u.toLowerCase());
-      for (const res of preferredResolutions) {
-        const match = lowerUrls.find((u) => u.includes(`_${res}.`));
-        if (match) return candidateUrls[lowerUrls.indexOf(match)];
-      }
-      return candidateUrls[0] ?? null;
-    };
-    const scoreAndPick = (keys) => {
-      const candidates = [];
-      keys.forEach((key) => {
-        Object.entries(apiJson || {}).forEach(([k, v]) => {
-          if (k.toLowerCase().includes(key)) candidates.push(v);
-        });
-      });
-      const flat = [];
-      const flatten = (v) => {
-        if (!v) return;
-        if (typeof v === 'string') {
-          flat.push(v);
-          return;
-        }
-        if (Array.isArray(v)) {
-          v.forEach(flatten);
-          return;
-        }
-        if (typeof v === 'object') {
-          Object.values(v).forEach(flatten);
-        }
-      };
-      flatten(candidates);
-      return pickTexture(
-        flat,
-        WALL_TEXTURE_CONFIG.preferredResolutionK ? [`${WALL_TEXTURE_CONFIG.preferredResolutionK}k`, '4k', '2k'] : ['4k', '2k']
-      );
-    };
-    return {
-      diffuse: scoreAndPick(['diff', 'diffuse', 'albedo', 'basecolor']),
-      normal: scoreAndPick(['nor_gl', 'normal_gl', 'nor', 'normal']),
-      roughness: scoreAndPick(['rough', 'roughness'])
-    };
-  };
-
-  const loadTexture = (loader, url, isColor) =>
-    new Promise((resolve) => {
-      if (!url) {
-        resolve(null);
-        return;
-      }
-      loader.load(
-        url,
-        (texture) => {
-          if (isColor) {
-            applySRGBColorSpace(texture);
-          }
-          resolve(texture);
-        },
-        undefined,
-        () => resolve(null)
-      );
-    });
-
-  return async (anisotropy) => {
-    if (cache) return cache;
-    if (!pending) {
-      pending = (async () => {
-        if (typeof fetch !== 'function') return null;
-        try {
-          const response = await fetch(`https://api.polyhaven.com/files/${WALL_TEXTURE_CONFIG.sourceId}`);
-          if (!response?.ok) return null;
-          const json = await response.json();
-          const urls = pickTextureUrls(json);
-          if (!urls.diffuse) return null;
-          const loader = new THREE.TextureLoader();
-          loader.setCrossOrigin('anonymous');
-          const [map, normal, roughness] = await Promise.all([
-            loadTexture(loader, urls.diffuse, true),
-            loadTexture(loader, urls.normal, false),
-            loadTexture(loader, urls.roughness, false)
-          ]);
-          [map, normal, roughness].forEach((tex) => {
-            if (!tex) return;
-            tex.wrapS = THREE.RepeatWrapping;
-            tex.wrapT = THREE.RepeatWrapping;
-            tex.anisotropy = Math.max(1, anisotropy ?? WALL_TEXTURE_CONFIG.anisotropy);
-            tex.needsUpdate = true;
-          });
-          cache = { map, normal, roughness };
-          return cache;
-        } catch (err) {
-          console.warn('Failed to load Poly Haven wall plank textures', err);
-          return null;
-        }
-      })();
+async function resolvePolyHavenHdriUrl(config = {}) {
+  const preferred = Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+    ? config.preferredResolutions
+    : DEFAULT_HDRI_RESOLUTIONS;
+  const fallbackRes = config?.fallbackResolution || preferred[0] || '8k';
+  const fallbackUrl =
+    config?.fallbackUrl ||
+    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;
+  if (config?.assetUrls && typeof config.assetUrls === 'object') {
+    for (const res of preferred) {
+      if (config.assetUrls[res]) return config.assetUrls[res];
     }
-    return pending;
-  };
-})();
+    const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
+    if (manual) return manual;
+  }
+  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) return config.assetUrl;
+  if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
+  try {
+    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
+    if (!response?.ok) return fallbackUrl;
+    const json = await response.json();
+    const picked = pickPolyHavenHdriUrl(json, preferred);
+    return picked || fallbackUrl;
+  } catch (error) {
+    console.warn('Failed to resolve Poly Haven HDRI url', error);
+    return fallbackUrl;
+  }
+}
 
-async function applyPoolWallMaterial(material, { repeat, anisotropy, isCancelled } = {}) {
-  if (!material || (typeof isCancelled === 'function' && isCancelled())) return null;
-  const targetRepeat = new THREE.Vector2(
-    repeat?.x ?? WALL_TEXTURE_CONFIG.repeat.x,
-    repeat?.y ?? WALL_TEXTURE_CONFIG.repeat.y
-  );
-  const textures = await loadWallPlankTextures(anisotropy);
-  if (!textures || (typeof isCancelled === 'function' && isCancelled())) return null;
-  const applyRepeat = (tex) => {
-    if (!tex) return;
-    tex.repeat.copy(targetRepeat);
-    tex.needsUpdate = true;
-  };
-  applyRepeat(textures.map);
-  applyRepeat(textures.normal);
-  applyRepeat(textures.roughness);
-  material.map = textures.map ?? material.map;
-  material.normalMap = textures.normal ?? material.normalMap;
-  material.roughnessMap = textures.roughness ?? material.roughnessMap;
-  material.color = new THREE.Color(0xffffff);
-  material.roughness = 0.78;
-  material.metalness = 0.03;
-  material.needsUpdate = true;
-  return textures;
+async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+  if (!renderer) return null;
+  const url = await resolvePolyHavenHdriUrl(config);
+  const lowerUrl = `${url ?? ''}`.toLowerCase();
+  const useExr = lowerUrl.endsWith('.exr');
+  const loader = useExr ? new EXRLoader() : new RGBELoader();
+  loader.setCrossOrigin?.('anonymous');
+  return new Promise((resolve) => {
+    loader.load(
+      url,
+      (texture) => {
+        const pmrem = new THREE.PMREMGenerator(renderer);
+        pmrem.compileEquirectangularShader();
+        const envMap = pmrem.fromEquirectangular(texture).texture;
+        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+        texture.dispose();
+        pmrem.dispose();
+        resolve({ envMap, url });
+      },
+      undefined,
+      (error) => {
+        console.warn('Failed to load Poly Haven HDRI', error);
+        resolve(null);
+      }
+    );
+  });
 }
 
 function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
@@ -1433,14 +1340,15 @@ export default function MurlanRoyaleArena({ search }) {
   const ensureAppearanceUnlocked = useCallback(
     (value = DEFAULT_APPEARANCE) => {
       const normalized = normalizeAppearance(value);
-      const map = {
-        tableWood: TABLE_WOOD_OPTIONS,
-        tableCloth: TABLE_CLOTH_OPTIONS,
-        tableBase: TABLE_BASE_OPTIONS,
-        cards: CARD_THEMES,
-        stools: STOOL_THEMES,
-        tables: TABLE_THEMES
-      };
+    const map = {
+      tableWood: TABLE_WOOD_OPTIONS,
+      tableCloth: TABLE_CLOTH_OPTIONS,
+      tableBase: TABLE_BASE_OPTIONS,
+      cards: CARD_THEMES,
+      stools: STOOL_THEMES,
+      tables: TABLE_THEMES,
+      environmentHdri: POOL_ROYALE_HDRI_VARIANTS
+    };
       let changed = false;
       const next = { ...normalized };
       Object.entries(map).forEach(([key, options]) => {
@@ -1486,6 +1394,10 @@ export default function MurlanRoyaleArena({ search }) {
   const gameStateRef = useRef(gameState);
   const selectedRef = useRef(selectedIds);
   const humanTurnRef = useRef(false);
+  const hdriVariantRef = useRef(resolveHdriVariant(DEFAULT_HDRI_INDEX));
+  const envTextureRef = useRef(null);
+  const disposeEnvironmentRef = useRef(null);
+  const updateEnvironmentRef = useRef(null);
 
   const threeStateRef = useRef({
     renderer: null,
@@ -1941,6 +1853,7 @@ export default function MurlanRoyaleArena({ search }) {
       const outfitTheme = OUTFIT_THEMES[safe.outfit] ?? OUTFIT_THEMES[0];
       const cardTheme = CARD_THEMES[safe.cards] ?? CARD_THEMES[0];
       const tableTheme = TABLE_THEMES[safe.tables] ?? TABLE_THEMES[0];
+      const hdriVariant = resolveHdriVariant(safe.environmentHdri);
 
       void (async () => {
         const three = threeStateRef.current;
@@ -1968,6 +1881,11 @@ export default function MurlanRoyaleArena({ search }) {
         applyCardThemeMaterials(three, cardTheme, shouldRefreshCards);
 
         three.appearance = { ...safe };
+        const hdriChanged = !hdriVariantRef.current || hdriVariantRef.current.id !== hdriVariant.id;
+        hdriVariantRef.current = hdriVariant;
+        if (hdriChanged && typeof updateEnvironmentRef.current === 'function') {
+          updateEnvironmentRef.current(hdriVariant);
+        }
 
         ensureCardMeshes(gameStateRef.current);
         applyStateToScene(gameStateRef.current, selectedRef.current, true);
@@ -2092,6 +2010,21 @@ export default function MurlanRoyaleArena({ search }) {
             )}
           </div>
         );
+      case 'environmentHdri': {
+        const swatches =
+          Array.isArray(option.swatches) && option.swatches.length >= 2
+            ? option.swatches
+            : ['#0ea5e9', '#0f172a'];
+        return (
+          <div className="relative h-14 w-full overflow-hidden rounded-xl border border-white/10 bg-slate-950/50">
+            <div
+              className="absolute inset-0"
+              style={{ background: `linear-gradient(120deg, ${swatches[0]}, ${swatches[1]})` }}
+            />
+            <div className="absolute inset-x-0 bottom-0 h-4 bg-gradient-to-t from-black/50 to-transparent" />
+          </div>
+        );
+      }
       case 'outfit':
       default:
         return (
@@ -2192,6 +2125,7 @@ export default function MurlanRoyaleArena({ search }) {
 
   useEffect(() => {
     appearanceRef.current = appearance;
+    hdriVariantRef.current = resolveHdriVariant(appearance.environmentHdri);
     if (typeof window !== 'undefined') {
       try {
         window.localStorage?.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(appearance));
@@ -2300,6 +2234,38 @@ export default function MurlanRoyaleArena({ search }) {
       scene.add(spotTarget);
       spot.target = spotTarget;
 
+      const applyHdriEnvironment = async (variantConfig = hdriVariantRef.current || resolveHdriVariant(DEFAULT_HDRI_INDEX)) => {
+        const activeVariant = variantConfig || hdriVariantRef.current || resolveHdriVariant(DEFAULT_HDRI_INDEX);
+        const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
+        if (!envResult || disposed) {
+          envResult?.envMap?.dispose?.();
+          return;
+        }
+        const { envMap } = envResult;
+        const prevDispose = disposeEnvironmentRef.current;
+        const prevTexture = envTextureRef.current;
+        scene.environment = envMap;
+        scene.background = envMap;
+        if ('backgroundIntensity' in scene && typeof activeVariant?.backgroundIntensity === 'number') {
+          scene.backgroundIntensity = activeVariant.backgroundIntensity;
+        }
+        if (typeof activeVariant?.environmentIntensity === 'number') {
+          scene.environmentIntensity = activeVariant.environmentIntensity;
+        }
+        renderer.toneMappingExposure = activeVariant?.exposure ?? renderer.toneMappingExposure;
+        envTextureRef.current = envMap;
+        disposeEnvironmentRef.current = () => {
+          if (scene.environment === envMap) scene.environment = null;
+          if (scene.background === envMap) scene.background = null;
+          envMap.dispose?.();
+        };
+        if (prevDispose && prevTexture !== envMap) {
+          prevDispose();
+        }
+      };
+      updateEnvironmentRef.current = applyHdriEnvironment;
+      void applyHdriEnvironment(environmentVariant);
+
       arenaGroup = new THREE.Group();
       scene.add(arenaGroup);
 
@@ -2313,17 +2279,17 @@ export default function MurlanRoyaleArena({ search }) {
       const stoolTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
       const tableTheme = TABLE_THEMES[currentAppearance.tables] ?? TABLE_THEMES[0];
       const outfitTheme = OUTFIT_THEMES[currentAppearance.outfit] ?? OUTFIT_THEMES[0];
+      const environmentVariant = resolveHdriVariant(currentAppearance.environmentHdri);
+      hdriVariantRef.current = environmentVariant;
 
       const arenaScale = 1.3 * ARENA_GROWTH;
       const boardSize = (TABLE_RADIUS * 2 + 1.2 * MODEL_SCALE) * arenaScale;
       const camConfig = buildArenaCameraConfig(boardSize);
-      const wallThickness = 0.8 * MODEL_SCALE;
+      const wallThickness = 0.1 * MODEL_SCALE;
       const interiorWidth = Math.max(TABLE_RADIUS * ARENA_GROWTH * 3.6, CHAIR_RADIUS * 2 + 4 * MODEL_SCALE);
       const interiorDepth = interiorWidth;
       const roomWidth = interiorWidth + wallThickness * 2;
       const roomDepth = interiorDepth + wallThickness * 2;
-      const halfWidth = roomWidth / 2;
-      const halfDepth = roomDepth / 2;
       const innerHalfWidth = interiorWidth / 2;
       const innerHalfDepth = interiorDepth / 2;
 
@@ -2335,105 +2301,12 @@ export default function MurlanRoyaleArena({ search }) {
       floor.receiveShadow = true;
       arenaGroup.add(floor);
 
-      const carpet = new THREE.Mesh(
-        new THREE.PlaneGeometry(interiorWidth * 0.9, interiorDepth * 0.9),
-        createArenaCarpetMaterial(new THREE.Color('#0f172a'), new THREE.Color('#1e3a8a'))
-      );
-      carpet.rotation.x = -Math.PI / 2;
-      carpet.position.y = 0.01;
-      carpet.receiveShadow = true;
-      arenaGroup.add(carpet);
-
-      const wallMaterial = new THREE.MeshStandardMaterial({
-        color: WALL_TEXTURE_CONFIG.fallbackColor,
-        roughness: 0.78,
-        metalness: 0.03,
-        flatShading: true
-      });
-      void applyPoolWallMaterial(wallMaterial, {
-        repeat: new THREE.Vector2(
-          Math.max(WALL_TEXTURE_CONFIG.repeat.x, roomWidth / 160),
-          Math.max(WALL_TEXTURE_CONFIG.repeat.y, ARENA_WALL_HEIGHT / 40)
-        ),
-        anisotropy: maxAnisotropy,
-        isCancelled: () => disposed
-      });
-
-      const makeWall = (width, depth, position) => {
-        const wall = new THREE.Mesh(new THREE.BoxGeometry(width, ARENA_WALL_HEIGHT, depth), wallMaterial);
-        wall.castShadow = false;
-        wall.receiveShadow = true;
-        wall.position.set(position.x, ARENA_WALL_CENTER_Y, position.z);
-        arenaGroup.add(wall);
-        return wall;
-      };
-
-      makeWall(roomWidth, wallThickness, { x: 0, z: halfDepth - wallThickness / 2 });
-      makeWall(roomWidth, wallThickness, { x: 0, z: -halfDepth + wallThickness / 2 });
-      makeWall(wallThickness, roomDepth, { x: -halfWidth + wallThickness / 2, z: 0 });
-      makeWall(wallThickness, roomDepth, { x: halfWidth - wallThickness / 2, z: 0 });
-
-      const ceilingMaterial = createHallwayCeilingWallMaterial(textureLoader, maxAnisotropy);
-      ceilingMaterial.side = THREE.DoubleSide;
-      const ceiling = new THREE.Mesh(new THREE.PlaneGeometry(roomWidth, roomDepth), ceilingMaterial);
-      ceiling.rotation.x = Math.PI / 2;
-      ceiling.position.y = ARENA_WALL_HEIGHT;
-      ceiling.receiveShadow = false;
-      arenaGroup.add(ceiling);
-
       const cameraBoundRadius = Math.hypot(innerHalfWidth, innerHalfDepth) - CAMERA_WALL_PADDING;
 
       const decorGroup = new THREE.Group();
       arenaGroup.add(decorGroup);
       threeStateRef.current.decorGroup = decorGroup;
       threeStateRef.current.decorPlants = [];
-      const addCornerPlants = async () => {
-        try {
-          const plantTextures = new Map(
-            (
-              await Promise.all(
-                HALLWAY_PLANT_ASSETS.map(async (assetId) => {
-                  const textures = await loadPolyhavenTextureSet(
-                    assetId,
-                    textureLoader,
-                    maxAnisotropy,
-                    threeStateRef.current.textureCache
-                  );
-                  return [assetId, textures];
-                })
-              )
-            ).filter((entry) => entry[1])
-          );
-          const plantPadding = Math.max(0.8 * MODEL_SCALE, wallThickness * 1.1);
-          const cornerOffsets = [
-            new THREE.Vector3(innerHalfWidth - plantPadding, 0, innerHalfDepth - plantPadding),
-            new THREE.Vector3(-(innerHalfWidth - plantPadding), 0, innerHalfDepth - plantPadding),
-            new THREE.Vector3(innerHalfWidth - plantPadding, 0, -(innerHalfDepth - plantPadding)),
-            new THREE.Vector3(-(innerHalfWidth - plantPadding), 0, -(innerHalfDepth - plantPadding))
-          ];
-          const targetOffsets = cornerOffsets.slice(0, DECOR_PLANT_COUNT);
-          for (let i = 0; i < targetOffsets.length; i += 1) {
-            const assetId = HALLWAY_PLANT_ASSETS[0];
-            const plant = await createPolyhavenInstance(assetId, PLANT_TARGET_HEIGHT, 0, renderer, {
-              textureLoader,
-              maxAnisotropy,
-              fallbackTexture,
-              textureCache: threeStateRef.current.textureCache,
-              textureSet: plantTextures.get(assetId)
-            });
-            if (disposed) return;
-            plant.scale.multiplyScalar(HALLWAY_PLANT_SCALE);
-            const pos = targetOffsets[i];
-            plant.position.copy(pos);
-            plant.lookAt(new THREE.Vector3(0, plant.position.y + 0.1, 0));
-            decorGroup.add(plant);
-            threeStateRef.current.decorPlants.push(plant);
-          }
-        } catch (error) {
-          console.warn('Failed to load decor plants', error);
-        }
-      };
-      void addCornerPlants();
 
       const scoreboardCanvas = document.createElement('canvas');
       scoreboardCanvas.width = 1024;
@@ -2771,6 +2644,9 @@ export default function MurlanRoyaleArena({ search }) {
     return () => {
       disposed = true;
       const store = threeStateRef.current;
+      disposeEnvironmentRef.current?.();
+      envTextureRef.current = null;
+      updateEnvironmentRef.current = null;
       if (frameId) {
         cancelAnimationFrame(frameId);
       }

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -179,7 +179,8 @@ const MURLAN_TYPE_LABELS = {
   tableBase: 'Table Base',
   cards: 'Card Themes',
   stools: 'Stools & Chairs',
-  tables: 'Table Models'
+  tables: 'Table Models',
+  environmentHdri: 'HDR Environments'
 };
 
 const DOMINO_TYPE_LABELS = {


### PR DESCRIPTION
## Summary
- add Pool Royale HDRI environments to the Murlan Royale store, defaults, and table setup menu with appropriate previews
- simplify the arena scene by removing walls, carpet, and plants while relying on HDRI lighting for backdrop and exposure
- wire the new HDRI appearance option through inventory unlocking, persistence, and in-game environment updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952add6e0a48329b2d6d99e4171ea19)