### PR TITLE
Add Polyhaven terry cloth variants for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -125,6 +125,25 @@ const MATERIAL_SERIES = [
     blues: CABAN_OCEAN_BLUE_SWATCHES,
     greenShadeNames: NATURE_SHADE_NAMES,
     blueShadeNames: OCEAN_SHADE_NAMES
+  },
+  {
+    prefix: 'terryCloth',
+    label: 'Polyhaven Terry Cloth',
+    sourceId: 'terry_cloth',
+    basePrice: 740,
+    priceStep: 12,
+    bluePremium: 22,
+    sparkle: 1.05,
+    stray: 1.08,
+    detail: {
+      bumpMultiplier: 1.24,
+      sheen: 0.54,
+      sheenRoughness: 0.58,
+      emissiveIntensity: 0.26,
+      envMapIntensity: 0.17
+    },
+    greens: CABAN_GREEN_SWATCHES,
+    blues: CABAN_OCEAN_BLUE_SWATCHES
   }
 ];
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3293,7 +3293,8 @@ const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
 const CLOTH_PATTERN_OVERRIDES = Object.freeze({
-  polar_fleece: { repeatScale: 0.94 } // 10% larger pattern to emphasize the fleece nap
+  polar_fleece: { repeatScale: 0.94 }, // 10% larger pattern to emphasize the fleece nap
+  terry_cloth: { repeatScale: 3 } // counter Polyhaven repeat scale so terry cloth matches the standard thread density
 });
 
 const CLOTH_TEXTURE_KEYS_BY_SOURCE = CLOTH_LIBRARY.reduce((acc, cloth) => {


### PR DESCRIPTION
## Summary
- add a Polyhaven terry cloth series that reuses existing blue and green palettes for ten new Pool Royale cloth options
- keep terry cloth tiling consistent with other fabrics by overriding the polyhaven repeat scale

## Testing
- npm test -- test/poolRoyalInventoryRoutes.test.js (fails to download MongoDB locally; test continues with in-memory DB disabled)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cd65c6148329aac7b6ac1e0c4b7d)