### PR TITLE
Adjust Pool Royale HDRI scale for larger table feel

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4274,10 +4274,10 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.6;
+const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.0;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
-const DEFAULT_HDRI_RADIUS_MULTIPLIER = 10;
-const MIN_HDRI_RADIUS = 36;
+const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
+const MIN_HDRI_RADIUS = 24;
 const HDRI_GROUNDED_RESOLUTION = 96;
 
 function pickPolyHavenHdriUrl(apiJson, preferredResolutions = []) {


### PR DESCRIPTION
## Summary
- lower the default HDRI camera height so the environment reads closer to the table
- shrink the default HDRI radius and minimum grounded radius to increase the perceived table size without touching geometry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d5e626b88329ae379f761135caf4)