### PR TITLE
Simplify Murlan Royale table options and bases

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,4 +1,3 @@
-import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../utils/cardThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
@@ -12,9 +11,6 @@ const mapLabels = (options) =>
   );
 
 export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
-  tableWood: [TABLE_WOOD_OPTIONS[0].id],
-  tableCloth: [TABLE_CLOTH_OPTIONS[0].id],
-  tableBase: [TABLE_BASE_OPTIONS[0].id],
   cards: [CARD_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
@@ -22,9 +18,6 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
-  tableWood: mapLabels(TABLE_WOOD_OPTIONS),
-  tableCloth: mapLabels(TABLE_CLOTH_OPTIONS),
-  tableBase: mapLabels(TABLE_BASE_OPTIONS),
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   tables: mapLabels(MURLAN_TABLE_THEMES),
@@ -37,78 +30,6 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
-  {
-    id: 'wood-warmBrown',
-    type: 'tableWood',
-    optionId: 'warmBrown',
-    name: 'Warm Brown Table Wood',
-    price: 760,
-    description: 'Walnut tone rails with a gentle satin sheen.'
-  },
-  {
-    id: 'wood-cleanStrips',
-    type: 'tableWood',
-    optionId: 'cleanStrips',
-    name: 'Clean Strips Table Wood',
-    price: 840,
-    description: 'Striped oak planks with a studio polish.'
-  },
-  {
-    id: 'wood-oldWoodFloor',
-    type: 'tableWood',
-    optionId: 'oldWoodFloor',
-    name: 'Heritage Wood Table',
-    price: 920,
-    description: 'Vintage smoked boards with deep grain detail.'
-  },
-  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
-    id: `cloth-${option.id}`,
-    type: 'tableCloth',
-    optionId: option.id,
-    name: option.label,
-    price: 360 + idx * 20,
-    description: `Premium ${option.label} felt for the Murlan table.`
-  })),
-  {
-    id: 'base-forestBronze',
-    type: 'tableBase',
-    optionId: 'forestBronze',
-    name: 'Forest Base',
-    price: 620,
-    description: 'Verdant metallic base with bronzed trim.'
-  },
-  {
-    id: 'base-midnightChrome',
-    type: 'tableBase',
-    optionId: 'midnightChrome',
-    name: 'Midnight Base',
-    price: 690,
-    description: 'Midnight blue base with chrome-inspired highlights.'
-  },
-  {
-    id: 'base-emberCopper',
-    type: 'tableBase',
-    optionId: 'emberCopper',
-    name: 'Copper Base',
-    price: 740,
-    description: 'Copper-accent base with warm metallic glints.'
-  },
-  {
-    id: 'base-violetShadow',
-    type: 'tableBase',
-    optionId: 'violetShadow',
-    name: 'Violet Shadow Base',
-    price: 780,
-    description: 'Shadowed violet base with luxe gloss trim.'
-  },
-  {
-    id: 'base-desertGold',
-    type: 'tableBase',
-    optionId: 'desertGold',
-    name: 'Desert Base',
-    price: 820,
-    description: 'Desert-inspired base with brushed gold finish.'
-  },
   {
     id: 'cards-solstice',
     type: 'cards',
@@ -180,9 +101,6 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
 );
 
 export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
-  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0].id, label: TABLE_WOOD_OPTIONS[0].label },
-  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0].id, label: TABLE_CLOTH_OPTIONS[0].label },
-  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0].id, label: TABLE_BASE_OPTIONS[0].label },
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -26,7 +26,6 @@ import {
   TABLE_WOOD_OPTIONS,
   TABLE_CLOTH_OPTIONS,
   TABLE_BASE_OPTIONS,
-  DEFAULT_TABLE_CUSTOMIZATION,
   WOOD_PRESETS_BY_ID
 } from '../../utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../../utils/cardThemes.js';
@@ -615,16 +614,13 @@ const DEFAULT_APPEARANCE = {
   outfit: 0,
   stools: 0,
   tables: 0,
-  environmentHdri: DEFAULT_HDRI_INDEX,
-  ...DEFAULT_TABLE_CUSTOMIZATION
+  cards: 0,
+  environmentHdri: DEFAULT_HDRI_INDEX
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
 const CUSTOMIZATION_SECTIONS = [
   { key: 'tables', label: 'Table Model', options: TABLE_THEMES },
-  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
-  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
-  { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
   { key: 'stools', label: 'Stools', options: STOOL_THEMES },
   { key: 'environmentHdri', label: 'HDR Environment', options: MURLAN_HDRI_OPTIONS }
@@ -647,9 +643,6 @@ function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
     ['outfit', OUTFIT_THEMES.length],
-    ['tableWood', TABLE_WOOD_OPTIONS.length],
-    ['tableCloth', TABLE_CLOTH_OPTIONS.length],
-    ['tableBase', TABLE_BASE_OPTIONS.length],
     ['cards', CARD_THEMES.length],
     ['stools', STOOL_THEMES.length],
     ['tables', TABLE_THEMES.length],
@@ -662,22 +655,6 @@ function normalizeAppearance(value = {}) {
       normalized[key] = clamped;
     }
   });
-  const legacyTable = Number(value?.table);
-  if (Number.isFinite(legacyTable)) {
-    const legacyIndex = Math.min(
-      Math.max(0, Math.round(legacyTable)),
-      Math.min(TABLE_CLOTH_OPTIONS.length, TABLE_BASE_OPTIONS.length) - 1
-    );
-    if (!Number.isFinite(Number(value?.tableWood))) {
-      normalized.tableWood = Math.min(legacyIndex, TABLE_WOOD_OPTIONS.length - 1);
-    }
-    if (!Number.isFinite(Number(value?.tableCloth))) {
-      normalized.tableCloth = Math.min(legacyIndex, TABLE_CLOTH_OPTIONS.length - 1);
-    }
-    if (!Number.isFinite(Number(value?.tableBase))) {
-      normalized.tableBase = Math.min(legacyIndex, TABLE_BASE_OPTIONS.length - 1);
-    }
-  }
   return normalized;
 }
 
@@ -1051,15 +1028,6 @@ function createProceduralChair(theme) {
   legMesh.receiveShadow = true;
   chair.add(legMesh);
 
-  const foot = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.32 * MODEL_SCALE * STOOL_SCALE, 0.32 * MODEL_SCALE * STOOL_SCALE, 0.08 * MODEL_SCALE, 24),
-    legMaterial
-  );
-  foot.position.y = legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE;
-  foot.castShadow = true;
-  foot.receiveShadow = true;
-  chair.add(foot);
-
   return {
     chairTemplate: chair,
     materials: {
@@ -1341,9 +1309,6 @@ export default function MurlanRoyaleArena({ search }) {
     (value = DEFAULT_APPEARANCE) => {
       const normalized = normalizeAppearance(value);
       const map = {
-        tableWood: TABLE_WOOD_OPTIONS,
-        tableCloth: TABLE_CLOTH_OPTIONS,
-        tableBase: TABLE_BASE_OPTIONS,
         cards: CARD_THEMES,
         stools: STOOL_THEMES,
         tables: TABLE_THEMES,
@@ -1883,9 +1848,9 @@ export default function MurlanRoyaleArena({ search }) {
     (nextAppearance, { refreshCards = false } = {}) => {
       if (!threeReady) return;
       const safe = normalizeAppearance(nextAppearance);
-      const woodOption = TABLE_WOOD_OPTIONS[safe.tableWood] ?? TABLE_WOOD_OPTIONS[0];
-      const clothOption = TABLE_CLOTH_OPTIONS[safe.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
-      const baseOption = TABLE_BASE_OPTIONS[safe.tableBase] ?? TABLE_BASE_OPTIONS[0];
+      const woodOption = TABLE_WOOD_OPTIONS[0];
+      const clothOption = TABLE_CLOTH_OPTIONS[0];
+      const baseOption = TABLE_BASE_OPTIONS[0];
       const stoolTheme = STOOL_THEMES[safe.stools] ?? STOOL_THEMES[0];
       const outfitTheme = OUTFIT_THEMES[safe.outfit] ?? OUTFIT_THEMES[0];
       const cardTheme = CARD_THEMES[safe.cards] ?? CARD_THEMES[0];
@@ -2275,12 +2240,9 @@ export default function MurlanRoyaleArena({ search }) {
       scene.add(arenaGroup);
 
       const currentAppearance = normalizeAppearance(appearanceRef.current);
-      const woodOption =
-        TABLE_WOOD_OPTIONS[currentAppearance.tableWood] ?? TABLE_WOOD_OPTIONS[0];
-      const clothOption =
-        TABLE_CLOTH_OPTIONS[currentAppearance.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
-      const baseOption =
-        TABLE_BASE_OPTIONS[currentAppearance.tableBase] ?? TABLE_BASE_OPTIONS[0];
+      const woodOption = TABLE_WOOD_OPTIONS[0];
+      const clothOption = TABLE_CLOTH_OPTIONS[0];
+      const baseOption = TABLE_BASE_OPTIONS[0];
       const stoolTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
       const tableTheme = TABLE_THEMES[currentAppearance.tables] ?? TABLE_THEMES[0];
       const outfitTheme = OUTFIT_THEMES[currentAppearance.outfit] ?? OUTFIT_THEMES[0];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,9 +175,6 @@ const LUDO_TYPE_LABELS = {
 };
 
 const MURLAN_TYPE_LABELS = {
-  tableWood: 'Table Wood',
-  tableCloth: 'Table Cloth',
-  tableBase: 'Table Base',
   cards: 'Card Themes',
   stools: 'Stools & Chairs',
   tables: 'Table Models',

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -472,19 +472,7 @@ export function createMurlanStyleTable({
   rimMesh.receiveShadow = true;
   tableGroup.add(rimMesh);
 
-  const baseGeometry = new ThreeNamespace.CylinderGeometry(0.68 * scaleFactor, 0.95 * scaleFactor, baseHeight, 8, 1, false);
-  const baseMesh = new ThreeNamespace.Mesh(baseGeometry, baseMat);
-  baseMesh.position.y = tableY - baseHeight / 2;
-  baseMesh.castShadow = true;
-  baseMesh.receiveShadow = true;
-  tableGroup.add(baseMesh);
-
-  const trimGeometry = new ThreeNamespace.CylinderGeometry(tableRadius * 0.985, tableRadius, trimHeight, 64, 1, false);
-  const trimMesh = new ThreeNamespace.Mesh(trimGeometry, trimMat);
-  trimMesh.position.y = tableY - trimOffset;
-  trimMesh.castShadow = true;
-  trimMesh.receiveShadow = true;
-  tableGroup.add(trimMesh);
+  // Rounded pedestal removed for a sleeker profile
 
   const normalizedRotation = Number.isFinite(rotationY) ? rotationY : 0;
   tableGroup.position.y = 0;


### PR DESCRIPTION
## Summary
- remove table wood/cloth/base unlocks and store items from Murlan Royale, keeping cosmetics to cards, stools, tables, and HDRIs
- simplify Murlan Royale customization UI to drop table material selectors and use fixed default materials
- strip the rounded pedestal meshes from the Murlan table model and chair template for a cleaner base

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535a362a008329ab881d86ebc33fbd)