### PR TITLE
Add Murlan tables and HDRIs to Ludo Battle Royal

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -1,25 +1,18 @@
 import {
-  CHAIR_COLOR_OPTIONS,
-  HEAD_PRESET_OPTIONS,
   TOKEN_PALETTE_OPTIONS,
   TOKEN_PIECE_OPTIONS,
   TOKEN_STYLE_OPTIONS
 } from './ludoBattleOptions.js';
-import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
-import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
-
-const DEFAULT_TABLE_SHAPE_ID = TABLE_SHAPE_OPTIONS[0]?.id;
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
-  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
-  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
-  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
-  chairColor: [CHAIR_COLOR_OPTIONS[0]?.id],
-  tableShape: [DEFAULT_TABLE_SHAPE_ID],
+  tables: [MURLAN_TABLE_THEMES[0]?.id],
+  stools: [MURLAN_STOOL_THEMES[0]?.id],
+  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   tokenPalette: [TOKEN_PALETTE_OPTIONS[0]?.id],
   tokenStyle: [TOKEN_STYLE_OPTIONS[0]?.id],
-  tokenPiece: [TOKEN_PIECE_OPTIONS[0]?.id],
-  headStyle: [HEAD_PRESET_OPTIONS[0]?.id]
+  tokenPiece: [TOKEN_PIECE_OPTIONS[0]?.id]
 });
 
 const reduceLabels = (options) =>
@@ -29,57 +22,48 @@ const reduceLabels = (options) =>
   }, {});
 
 export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
-  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
-  tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
-  tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
-  chairColor: Object.freeze(reduceLabels(CHAIR_COLOR_OPTIONS)),
-  tableShape: Object.freeze(reduceLabels(TABLE_SHAPE_OPTIONS)),
+  tables: Object.freeze(reduceLabels(MURLAN_TABLE_THEMES)),
+  stools: Object.freeze(reduceLabels(MURLAN_STOOL_THEMES)),
+  environmentHdri: Object.freeze(
+    reduceLabels(
+      POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+        id: variant.id,
+        label: `${variant.name} HDRI`
+      }))
+    )
+  ),
   tokenPalette: Object.freeze(reduceLabels(TOKEN_PALETTE_OPTIONS)),
   tokenStyle: Object.freeze(reduceLabels(TOKEN_STYLE_OPTIONS)),
-  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS)),
-  headStyle: Object.freeze(reduceLabels(HEAD_PRESET_OPTIONS))
+  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS))
 });
 
 export const LUDO_BATTLE_STORE_ITEMS = [
-  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-wood-${option.id}`,
-    type: 'tableWood',
-    optionId: option.id,
-    name: option.label,
-    price: 620 + idx * 40,
-    description: 'Alternate wood finish for the Ludo royale table.'
+  ...MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+    id: `ludo-table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 980 + idx * 40,
+    description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
+    thumbnail: theme.thumbnail
   })),
-  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-cloth-${option.id}`,
-    type: 'tableCloth',
-    optionId: option.id,
-    name: option.label,
-    price: 360 + idx * 35,
-    description: 'Premium felt hue to swap into the arena surface.'
+  ...MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+    id: `ludo-stool-${theme.id}`,
+    type: 'stools',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 300 + idx * 20,
+    description: theme.description || `Premium ${theme.label} seating with original finish.`
   })),
-  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-base-${option.id}`,
-    type: 'tableBase',
-    optionId: option.id,
-    name: option.label,
-    price: 460 + idx * 40,
-    description: 'Pedestal and trim upgrade for the Ludo table.'
-  })),
-  ...CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-chair-${option.id}`,
-    type: 'chairColor',
-    optionId: option.id,
-    name: `${option.label} Chairs`,
-    price: 320 + idx * 20,
-    description: 'Unlock an alternate lounge chair upholstery color.'
-  })),
-  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-shape-${option.id}`,
-    type: 'tableShape',
-    optionId: option.id,
-    name: option.label,
-    price: 640 + idx * 80,
-    description: 'Swap the arena outline for a new premium silhouette.'
+  ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+    id: `ludo-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 1400 + idx * 25,
+    description: variant.description || 'Pool Royale HDRI environment tuned for wide-table arenas.',
+    swatches: variant.swatches,
+    previewShape: 'table'
   })),
   ...TOKEN_PALETTE_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-palette-${option.id}`,
@@ -104,25 +88,18 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     name: option.label,
     price: 300 + idx * 20,
     description: 'Unlock an alternate piece identity for your pawns.'
-  })),
-  ...HEAD_PRESET_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-head-${option.id}`,
-    type: 'headStyle',
-    optionId: option.id,
-    name: `${option.label} Heads`,
-    price: 310 + idx * 20,
-    description: 'Unlock a new glass preset for the pawn and bishop heads.'
   }))
 ];
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [
-  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
-  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
-  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
-  { type: 'chairColor', optionId: CHAIR_COLOR_OPTIONS[0]?.id, label: `${CHAIR_COLOR_OPTIONS[0]?.label} Chairs` },
-  { type: 'tableShape', optionId: DEFAULT_TABLE_SHAPE_ID, label: LUDO_BATTLE_OPTION_LABELS.tableShape[DEFAULT_TABLE_SHAPE_ID] },
+  { type: 'tables', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },
+  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0]?.id, label: MURLAN_STOOL_THEMES[0]?.label },
+  {
+    type: 'environmentHdri',
+    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
+    label: LUDO_BATTLE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID] || 'HDR Environment'
+  },
   { type: 'tokenPalette', optionId: TOKEN_PALETTE_OPTIONS[0]?.id, label: `${TOKEN_PALETTE_OPTIONS[0]?.label} Palette` },
   { type: 'tokenStyle', optionId: TOKEN_STYLE_OPTIONS[0]?.id, label: TOKEN_STYLE_OPTIONS[0]?.label },
-  { type: 'tokenPiece', optionId: TOKEN_PIECE_OPTIONS[0]?.id, label: TOKEN_PIECE_OPTIONS[0]?.label },
-  { type: 'headStyle', optionId: HEAD_PRESET_OPTIONS[0]?.id, label: `${HEAD_PRESET_OPTIONS[0]?.label} Heads` }
+  { type: 'tokenPiece', optionId: TOKEN_PIECE_OPTIONS[0]?.id, label: TOKEN_PIECE_OPTIONS[0]?.label }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -164,15 +164,12 @@ const BLACKJACK_TYPE_LABELS = {
 };
 
 const LUDO_TYPE_LABELS = {
-  tableWood: 'Table Wood',
-  tableCloth: 'Table Cloth',
-  tableBase: 'Table Base',
-  chairColor: 'Chairs',
-  tableShape: 'Table Shape',
+  tables: 'Table Models',
+  stools: 'Stools & Chairs',
+  environmentHdri: 'HDR Environments',
   tokenPalette: 'Token Palette',
   tokenStyle: 'Token Style',
-  tokenPiece: 'Token Piece',
-  headStyle: 'Heads'
+  tokenPiece: 'Token Piece'
 };
 
 const MURLAN_TYPE_LABELS = {


### PR DESCRIPTION
## Summary
- Swap Ludo Battle Royal inventory and store items to use the Murlan table, stool, and HDRI collections while trimming the old table cloth/base/shape/head options.
- Update the Ludo arena customization flow to load Poly Haven tables/chairs, apply HDRI environments, and refresh board builds with the new option set.
- Refresh store metadata for Ludo to reflect the new option types.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695364d75d18832982e7b1fdcab6bcc0)