### PR TITLE
Add Murlan tables, chairs, and HDRIs to Texas Hold’em

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,7 +1,6 @@
-import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
-import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
-import { TEXAS_CHAIR_COLOR_OPTIONS } from './texasHoldemOptions.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
 const reduceLabels = (items) =>
   items.reduce((acc, option) => {
@@ -10,63 +9,63 @@ const reduceLabels = (items) =>
   }, {});
 
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
-  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
-  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
-  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
-  chairColor: [TEXAS_CHAIR_COLOR_OPTIONS[0]?.id],
-  tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
+  tables: [MURLAN_TABLE_THEMES[0]?.id],
+  stools: [MURLAN_STOOL_THEMES[0]?.id],
+  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   cards: [CARD_THEMES[0]?.id]
 });
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
-  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
-  tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
-  tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
-  chairColor: Object.freeze(reduceLabels(TEXAS_CHAIR_COLOR_OPTIONS)),
-  tableShape: Object.freeze(reduceLabels(TABLE_SHAPE_OPTIONS)),
-  cards: Object.freeze(reduceLabels(CARD_THEMES))
+  tables: Object.freeze(reduceLabels(MURLAN_TABLE_THEMES)),
+  stools: Object.freeze(reduceLabels(MURLAN_STOOL_THEMES)),
+  environmentHdri: Object.freeze(
+    POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
+      acc[variant.id] = `${variant.name} HDRI`;
+      return acc;
+    }, {})
+  ),
+  cards: Object.freeze(
+    reduceLabels(
+      CARD_THEMES.map((theme) => ({
+        ...theme,
+        label: `${theme.label} Cards`
+      }))
+    )
+  )
 });
 
 export const TEXAS_HOLDEM_STORE_ITEMS = [
-  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-wood-${option.id}`,
-    type: 'tableWood',
+  ...MURLAN_TABLE_THEMES.slice(1).map((option, idx) => ({
+    id: `texas-table-${option.id}`,
+    type: 'tables',
     optionId: option.id,
     name: option.label,
-    price: 540 + idx * 40,
-    description: "Unlock an alternate wood finish for your Hold'em arena table."
+    price: option.price ?? 980 + idx * 40,
+    description: option.description || `${option.label} table pulled from the Murlan Royale collection.`,
+    thumbnail: option.thumbnail,
+    swatches: option.swatches,
+    previewShape: option.previewShape || 'table'
   })),
-  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-cloth-${option.id}`,
-    type: 'tableCloth',
+  ...MURLAN_STOOL_THEMES.slice(1).map((option, idx) => ({
+    id: `texas-stool-${option.id}`,
+    type: 'stools',
     optionId: option.id,
     name: option.label,
-    price: 360 + idx * 35,
-    description: "Swap in a premium felt tone for your poker table."
+    price: option.price ?? 300 + idx * 20,
+    description: option.description || `${option.label} seating migrated from Murlan Royale.`,
+    thumbnail: option.thumbnail,
+    swatches: option.swatches,
+    previewShape: option.previewShape || 'chair'
   })),
-  ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-base-${option.id}`,
-    type: 'tableBase',
-    optionId: option.id,
-    name: option.label,
-    price: 420 + idx * 35,
-    description: 'Upgrade the pedestal finish beneath your Hold\'em surface.'
-  })),
-  ...TEXAS_CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-chair-${option.id}`,
-    type: 'chairColor',
-    optionId: option.id,
-    name: `${option.label} Chairs`,
-    price: 340 + idx * 30,
-    description: 'Unlock an additional lounge chair palette for the poker ring.'
-  })),
-  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-shape-${option.id}`,
-    type: 'tableShape',
-    optionId: option.id,
-    name: option.label,
-    price: 680 + idx * 80,
-    description: 'Change the poker table silhouette.'
+  ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+    id: `texas-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 1400 + idx * 25,
+    description: variant.description || 'Poly Haven HDRI featured in Murlan Royale.',
+    swatches: variant.swatches,
+    previewShape: 'table'
   })),
   ...CARD_THEMES.slice(1).map((option, idx) => ({
     id: `texas-card-${option.id}`,
@@ -79,10 +78,12 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
 ];
 
 export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
-  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
-  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
-  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
-  { type: 'chairColor', optionId: TEXAS_CHAIR_COLOR_OPTIONS[0]?.id, label: `${TEXAS_CHAIR_COLOR_OPTIONS[0]?.label} Chairs` },
-  { type: 'tableShape', optionId: TABLE_SHAPE_OPTIONS[0]?.id, label: TABLE_SHAPE_OPTIONS[0]?.label },
+  { type: 'tables', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },
+  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0]?.id, label: MURLAN_STOOL_THEMES[0]?.label },
+  {
+    type: 'environmentHdri',
+    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
+    label: `${POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID)?.name || 'HDR Environment'} HDRI`
+  },
   { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -202,11 +202,9 @@ const SNAKE_TYPE_LABELS = {
 };
 
 const TEXAS_TYPE_LABELS = {
-  tableWood: 'Table Wood',
-  tableCloth: 'Table Cloth',
-  tableBase: 'Table Base',
-  chairColor: 'Chairs',
-  tableShape: 'Table Shape',
+  tables: 'Table Models',
+  stools: 'Chairs',
+  environmentHdri: 'HDR Environments',
   cards: 'Cards'
 };
 
@@ -263,6 +261,7 @@ const TYPE_SWATCHES = {
   tableCloth: ['#0f172a', '#34d399'],
   tableBase: ['#0f172a', '#1f2937'],
   tables: ['#0f172a', '#94a3b8'],
+  stools: ['#111827', '#f59e0b'],
   chairColor: ['#111827', '#f59e0b'],
   tableShape: ['#334155', '#64748b'],
   sideColor: ['#f8fafc', '#1f2937'],


### PR DESCRIPTION
## Summary
- replace the Texas Hold’em inventory with the Murlan Royale table, stool, and HDRI catalog and surface them in the store
- refresh the Texas Hold’em arena customization to use the new table models, chair themes, and Poly Haven HDRI lighting
- update store labels and previews to match the new cosmetic types

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953654488c8832998f3fb6ae52c3006)