### PR TITLE
Set HDRI defaults to 4K and 120fps for arena modes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -172,7 +172,7 @@ const BOARD_COLOR_BASE_OPTIONS = Object.freeze([
   }
 ]);
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '4k', '2k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const CHESS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -238,7 +238,7 @@ const CAMERA_PHI_OFFSET = 0;
 const CAMERA_TOPDOWN_EXTRA = 0;
 const CAMERA_INITIAL_PHI_EXTRA = 0;
 const CAMERA_TOPDOWN_LOCK = THREE.MathUtils.degToRad(4);
-const DEFAULT_TARGET_FPS = 90;
+const DEFAULT_TARGET_FPS = 120;
 const MIN_TARGET_FPS = 50;
 const MAX_TARGET_FPS = 144;
 const DEFAULT_RENDER_PIXEL_RATIO_CAP = 1.25;
@@ -379,7 +379,7 @@ const GRAPHICS_OPTIONS = Object.freeze([
     description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
   }
 ]);
-const DEFAULT_GRAPHICS_ID = 'fhd60';
+const DEFAULT_GRAPHICS_ID = 'uhd120';
 
 function resolveDefaultGraphicsId() {
   const hint = detectRefreshRateHint();

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1160,7 +1160,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: '4K-oriented profile for 120 Hz flagships and desktops.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_FRAME_RATE_ID = 'uhd120';
 
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };


### PR DESCRIPTION
## Summary
- set Chess Battle Royale HDRI preference to 4K and default graphics profile to the 120 Hz preset
- increase Chess Battle Royale base target FPS to 120 to match the requested HDRI performance
- default Murlan Royale arena to the Ultra HD 120 Hz frame-rate profile for HDRI scenes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536cc2b5348329a6fbd029db1009d5)