### PR TITLE
Use HDRI-only lighting for snake and ludo scenes

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -8,7 +8,6 @@ import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 import { EXRLoader } from 'three/addons/loaders/EXRLoader.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 
-import { createArenaCarpetMaterial, createArenaWallMaterial } from '../utils/arenaDecor.js';
 import {
   createMurlanStyleTable,
   applyTableMaterials,
@@ -26,7 +25,7 @@ const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const DEFAULT_HDRI_RESOLUTIONS = ['4k', '2k', '1k'];
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 
 const MODEL_SCALE = 0.75;
 const ARENA_GROWTH = 1.45;
@@ -53,8 +52,6 @@ const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const ARENA_WALL_HEIGHT = 3.6 * 1.3;
-const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const CUSTOM_CHAIR_ANGLES = [
@@ -2180,7 +2177,6 @@ function parseJumpMap(data = {}) {
 
 function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanceOptions = {}) {
   const arenaTheme = appearanceOptions.arena ?? {};
-  const lightsTheme = arenaTheme.lights ?? {};
   const tableTheme = appearanceOptions.tableTheme || {};
   const stoolTheme = appearanceOptions.stoolTheme || DEFAULT_STOOL_THEME;
   const environmentHdri = appearanceOptions.environmentHdri;
@@ -2188,29 +2184,9 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
 
   scene.background = toThreeColor(arenaTheme.background, '#030712');
 
-  const ambient = new THREE.AmbientLight(
-    toThreeColor(lightsTheme.ambientColor, 0xffffff),
-    Number.isFinite(lightsTheme.ambient) ? lightsTheme.ambient : 1.08
-  );
-  scene.add(ambient);
-  const spot = new THREE.SpotLight(
-    toThreeColor(lightsTheme.spot, 0xffffff),
-    Number.isFinite(lightsTheme.spotIntensity) ? lightsTheme.spotIntensity : 4.8384,
-    TABLE_RADIUS * 10,
-    Math.PI / 3,
-    0.35,
-    1
-  );
-  spot.position.set(3, 7, 3);
-  spot.castShadow = true;
-  scene.add(spot);
-  if (Number.isFinite(environmentHdri?.environmentIntensity)) {
-    ambient.intensity *= environmentHdri.environmentIntensity;
-  }
-  if (Number.isFinite(environmentHdri?.spotIntensity)) {
-    spot.intensity *= environmentHdri.spotIntensity;
-  }
-
+  scene.environmentIntensity = Number.isFinite(environmentHdri?.environmentIntensity)
+    ? environmentHdri.environmentIntensity
+    : 1;
   let environmentCleanup = null;
   if (environmentHdri) {
     loadPolyHavenHdriEnvironment(renderer, environmentHdri).then((result) => {
@@ -2224,13 +2200,6 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
       };
     });
   }
-  const rim = new THREE.PointLight(
-    toThreeColor(lightsTheme.rim, 0x33ccff),
-    Number.isFinite(lightsTheme.rimIntensity) ? lightsTheme.rimIntensity : 1.728
-  );
-  rim.position.set(-4, 3, -4);
-  scene.add(rim);
-
   const arenaGroup = new THREE.Group();
   scene.add(arenaGroup);
 
@@ -2246,32 +2215,6 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   floor.rotation.x = -Math.PI / 2;
   floor.receiveShadow = true;
   arenaGroup.add(floor);
-
-  const carpet = new THREE.Mesh(
-    new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.2, 64),
-    createArenaCarpetMaterial(
-      toThreeColor(arenaTheme.carpet?.primary, '#0f172a'),
-      toThreeColor(arenaTheme.carpet?.accent, '#1e3a8a')
-    )
-  );
-  carpet.rotation.x = -Math.PI / 2;
-  carpet.position.y = 0.01;
-  carpet.receiveShadow = true;
-  arenaGroup.add(carpet);
-
-  const wall = new THREE.Mesh(
-    new THREE.CylinderGeometry(
-      TABLE_RADIUS * ARENA_GROWTH * 2.4,
-      TABLE_RADIUS * ARENA_GROWTH * 2.6,
-      ARENA_WALL_HEIGHT,
-      32,
-      1,
-      true
-    ),
-    createArenaWallMaterial(arenaTheme.wall?.base ?? '#1f2937', arenaTheme.wall?.accent ?? '#64748b')
-  );
-  wall.position.y = ARENA_WALL_CENTER_Y;
-  arenaGroup.add(wall);
 
   const woodOption = TABLE_WOOD_OPTIONS[DEFAULT_TABLE_CUSTOMIZATION.tableWood] ?? TABLE_WOOD_OPTIONS[0];
   const clothOption = TABLE_CLOTH_OPTIONS[DEFAULT_TABLE_CUSTOMIZATION.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
@@ -2460,14 +2403,9 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     });
     if (tableInfo?.dispose) tableInfo.dispose();
     environmentCleanup?.();
-    scene.remove(ambient, spot, rim);
     floor.geometry.dispose();
     floor.material.map?.dispose?.();
     floor.material.dispose();
-    carpet.geometry.dispose();
-    carpet.material.dispose();
-    wall.geometry.dispose();
-    wall.material.dispose();
     arenaGroup.parent?.remove(arenaGroup);
   });
 
@@ -2803,31 +2741,6 @@ function buildSnakeBoard(
     diceSet.push(die);
   }
   boardRoot.add(diceGroup);
-
-  const diceLightTarget = new THREE.Object3D();
-  diceLightTarget.position.set(0, diceBaseY, diceAnchorZ);
-  boardRoot.add(diceLightTarget);
-
-  const diceAccent = new THREE.SpotLight(
-    toThreeColor(diceTheme.rim, 0xfff1c1),
-    2.25,
-    RAW_BOARD_SIZE * 1.2,
-    Math.PI / 5,
-    0.42,
-    1.25
-  );
-  diceAccent.userData.offset = new THREE.Vector3(DICE_SIZE * 2.6, DICE_SIZE * 7.5, DICE_SIZE * 3.4);
-  diceAccent.target = diceLightTarget;
-  boardRoot.add(diceAccent);
-
-  const diceFill = new THREE.PointLight(
-    toThreeColor(diceTheme.body, 0xffe4a3),
-    1.18,
-    RAW_BOARD_SIZE * 0.9,
-    2.2
-  );
-  diceFill.userData.offset = new THREE.Vector3(-DICE_SIZE * 3.2, DICE_SIZE * 6.2, -DICE_SIZE * 3.6);
-  boardRoot.add(diceFill);
 
   disposeHandlers.push(() => {
     platformMeshes.forEach((mesh) => {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -10,7 +10,6 @@ import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.j
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
-import { createArenaCarpetMaterial, createArenaWallMaterial } from '../../utils/arenaDecor.js';
 import {
   createMurlanStyleTable,
   applyTableMaterials
@@ -450,7 +449,9 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_FRAME_RATE_ID = 'uhd120';
+const DEFAULT_FRAME_RATE_OPTION =
+  FRAME_RATE_OPTIONS.find((option) => option.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
@@ -2382,12 +2383,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return DEFAULT_FRAME_RATE_ID;
   });
   const activeFrameRateOption = useMemo(
-    () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
+    () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
   );
   const frameQualityProfile = useMemo(() => {
-    const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
-    const fallback = FRAME_RATE_OPTIONS[0];
+    const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
+    const fallback = DEFAULT_FRAME_RATE_OPTION;
     const fps =
       Number.isFinite(option?.fps) && option.fps > 0
         ? option.fps
@@ -2415,8 +2416,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   }, [frameQualityProfile]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
-      Number.isFinite(FRAME_RATE_OPTIONS[0]?.fps) && FRAME_RATE_OPTIONS[0].fps > 0
-        ? FRAME_RATE_OPTIONS[0].fps
+      Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
+        ? DEFAULT_FRAME_RATE_OPTION.fps
         : 60;
     const fps =
       Number.isFinite(frameQualityProfile?.fps) && frameQualityProfile.fps > 0
@@ -2424,7 +2425,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         : fallbackFps;
     const targetMs = 1000 / fps;
     return {
-      id: frameQualityProfile?.id ?? FRAME_RATE_OPTIONS[0]?.id ?? DEFAULT_FRAME_RATE_ID,
+      id: frameQualityProfile?.id ?? DEFAULT_FRAME_RATE_OPTION?.id ?? DEFAULT_FRAME_RATE_ID,
       fps,
       targetMs,
       maxMs: targetMs * FRAME_TIME_CATCH_UP_MULTIPLIER
@@ -3601,112 +3602,79 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         Math.sin(cameraSeatAngle) * cameraRadius
       );
 
-      const ambient = new THREE.AmbientLight(0xffffff, 1.08);
-      scene.add(ambient);
-      const spot = new THREE.SpotLight(0xffffff, 4.8384, TABLE_RADIUS * 10, Math.PI / 3, 0.35, 1);
-      spot.position.set(3, 7, 3);
-      spot.castShadow = true;
-      scene.add(spot);
-      const rim = new THREE.PointLight(0x33ccff, 1.728);
-      rim.position.set(-4, 3, -4);
-      scene.add(rim);
-
       const arenaGroup = new THREE.Group();
       scene.add(arenaGroup);
 
-    const floor = new THREE.Mesh(
-      new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 3.2, 64),
-      new THREE.MeshStandardMaterial({ color: 0x0b1120, roughness: 0.9, metalness: 0.1 })
-    );
-    floor.rotation.x = -Math.PI / 2;
-    floor.receiveShadow = true;
-    arenaGroup.add(floor);
+      const floor = new THREE.Mesh(
+        new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 3.2, 64),
+        new THREE.MeshStandardMaterial({ color: 0x0b1120, roughness: 0.9, metalness: 0.1 })
+      );
+      floor.rotation.x = -Math.PI / 2;
+      floor.receiveShadow = true;
+      arenaGroup.add(floor);
 
-    const carpet = new THREE.Mesh(
-      new THREE.CircleGeometry(TABLE_RADIUS * ARENA_GROWTH * 2.2, 64),
-      createArenaCarpetMaterial(new THREE.Color('#0f172a'), new THREE.Color('#1e3a8a'))
-    );
-    carpet.rotation.x = -Math.PI / 2;
-    carpet.position.y = 0.01;
-    carpet.receiveShadow = true;
-    arenaGroup.add(carpet);
+      const initialAppearanceRaw = normalizeAppearance(appearanceRef.current);
+      const initialAppearance = ensureAppearanceUnlocked(initialAppearanceRaw);
+      const tableTheme = MURLAN_TABLE_THEMES[initialAppearance.tables] ?? MURLAN_TABLE_THEMES[0];
+      const stoolTheme = MURLAN_STOOL_THEMES[initialAppearance.stools] ?? MURLAN_STOOL_THEMES[0];
+      const envVariant = resolveHdriVariant(initialAppearance.environmentHdri);
+      const tokenStyleOption = TOKEN_STYLE_OPTIONS[initialAppearance.tokenStyle] ?? TOKEN_STYLE_OPTIONS[0];
+      const tokenPieceOption = TOKEN_PIECE_OPTIONS[initialAppearance.tokenPiece] ?? TOKEN_PIECE_OPTIONS[0];
+      const headOption = HEAD_PRESET_OPTIONS[0] ?? null;
+      const initialPlayerColors = resolvePlayerColors(initialAppearance);
+      appearanceRef.current = initialAppearance;
+      playerColorsRef.current = initialPlayerColors;
 
-    const wall = new THREE.Mesh(
-      new THREE.CylinderGeometry(
-        TABLE_RADIUS * ARENA_GROWTH * 2.4,
-        TABLE_RADIUS * ARENA_GROWTH * 2.6,
-        ARENA_WALL_HEIGHT,
-        32,
-        1,
-        true
-      ),
-      createArenaWallMaterial('#0b1120', '#1e293b')
-    );
-    wall.position.y = ARENA_WALL_CENTER_Y;
-    arenaGroup.add(wall);
-
-    const initialAppearanceRaw = normalizeAppearance(appearanceRef.current);
-    const initialAppearance = ensureAppearanceUnlocked(initialAppearanceRaw);
-    const tableTheme = MURLAN_TABLE_THEMES[initialAppearance.tables] ?? MURLAN_TABLE_THEMES[0];
-    const stoolTheme = MURLAN_STOOL_THEMES[initialAppearance.stools] ?? MURLAN_STOOL_THEMES[0];
-    const envVariant = resolveHdriVariant(initialAppearance.environmentHdri);
-    const tokenStyleOption = TOKEN_STYLE_OPTIONS[initialAppearance.tokenStyle] ?? TOKEN_STYLE_OPTIONS[0];
-    const tokenPieceOption = TOKEN_PIECE_OPTIONS[initialAppearance.tokenPiece] ?? TOKEN_PIECE_OPTIONS[0];
-    const headOption = HEAD_PRESET_OPTIONS[0] ?? null;
-    const initialPlayerColors = resolvePlayerColors(initialAppearance);
-    appearanceRef.current = initialAppearance;
-    playerColorsRef.current = initialPlayerColors;
-
-    let tableInfo = null;
-    if (tableTheme?.source === 'polyhaven' && tableTheme?.assetId) {
-      try {
-        const model = await createPolyhavenInstance(
-          tableTheme.assetId,
-          TABLE_HEIGHT,
-          tableTheme.rotationY || 0,
-          renderer
-        );
-        const tableGroup = new THREE.Group();
-        tableGroup.add(model);
-        const { surfaceY, radius } = fitTableModelToArena(tableGroup);
-        arenaGroup.add(tableGroup);
-        tableInfo = {
-          group: tableGroup,
-          surfaceY,
-          tableHeight: surfaceY,
-          radius,
-          dispose: () => {
-            disposeObjectResources(tableGroup);
-            if (tableGroup.parent) tableGroup.parent.remove(tableGroup);
-          },
-          materials: null,
-          shapeId: tableTheme.id,
-          rotationY: tableTheme.rotationY ?? 0,
-          themeId: tableTheme.id,
-          getOuterRadius: () => radius,
-          getInnerRadius: () => radius * 0.72
-        };
-      } catch (error) {
-        console.warn('Failed to load Poly Haven table', error);
+      let tableInfo = null;
+      if (tableTheme?.source === 'polyhaven' && tableTheme?.assetId) {
+        try {
+          const model = await createPolyhavenInstance(
+            tableTheme.assetId,
+            TABLE_HEIGHT,
+            tableTheme.rotationY || 0,
+            renderer
+          );
+          const tableGroup = new THREE.Group();
+          tableGroup.add(model);
+          const { surfaceY, radius } = fitTableModelToArena(tableGroup);
+          arenaGroup.add(tableGroup);
+          tableInfo = {
+            group: tableGroup,
+            surfaceY,
+            tableHeight: surfaceY,
+            radius,
+            dispose: () => {
+              disposeObjectResources(tableGroup);
+              if (tableGroup.parent) tableGroup.parent.remove(tableGroup);
+            },
+            materials: null,
+            shapeId: tableTheme.id,
+            rotationY: tableTheme.rotationY ?? 0,
+            themeId: tableTheme.id,
+            getOuterRadius: () => radius,
+            getInnerRadius: () => radius * 0.72
+          };
+        } catch (error) {
+          console.warn('Failed to load Poly Haven table', error);
+        }
       }
-    }
 
-    if (!tableInfo) {
-      const woodOption = TABLE_WOOD_OPTIONS[0];
-      const clothOption = TABLE_CLOTH_OPTIONS[0];
-      const baseOption = TABLE_BASE_OPTIONS[0];
-      const procedural = createMurlanStyleTable({
-        arena: arenaGroup,
-        renderer,
-        tableRadius: TABLE_RADIUS,
-        tableHeight: TABLE_HEIGHT,
-        woodOption,
-        clothOption,
-        baseOption
-      });
-      applyTableMaterials(procedural.materials, { woodOption, clothOption, baseOption }, renderer);
-      tableInfo = { ...procedural, themeId: tableTheme?.id || procedural.shapeId };
-    }
+      if (!tableInfo) {
+        const woodOption = TABLE_WOOD_OPTIONS[0];
+        const clothOption = TABLE_CLOTH_OPTIONS[0];
+        const baseOption = TABLE_BASE_OPTIONS[0];
+        const procedural = createMurlanStyleTable({
+          arena: arenaGroup,
+          renderer,
+          tableRadius: TABLE_RADIUS,
+          tableHeight: TABLE_HEIGHT,
+          woodOption,
+          clothOption,
+          baseOption
+        });
+        applyTableMaterials(procedural.materials, { woodOption, clothOption, baseOption }, renderer);
+        tableInfo = { ...procedural, themeId: tableTheme?.id || procedural.shapeId };
+      }
 
     const boardGroup = new THREE.Group();
     boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0);
@@ -5069,24 +5037,6 @@ async function buildLudoBoard(
   dice.userData.isRolling = false;
   dice.userData.railPads = Array.from({ length: playerCount }, () => null);
   scene.add(dice);
-
-  const diceLightTarget = new THREE.Object3D();
-  scene.add(diceLightTarget);
-
-  const diceAccent = new THREE.SpotLight(0xffffff, 2.1, 3.4, Math.PI / 5, 0.42, 1.25);
-  diceAccent.userData.offset = new THREE.Vector3(0.45, 1.55, 1.05);
-  diceAccent.target = diceLightTarget;
-  scene.add(diceAccent);
-
-  const diceFill = new THREE.PointLight(0xfff8e1, 1.05, 2.6, 2.2);
-  diceFill.userData.offset = new THREE.Vector3(-0.65, 1.25, -0.75);
-  scene.add(diceFill);
-
-  dice.userData.lights = {
-    accent: diceAccent,
-    fill: diceFill,
-    target: diceLightTarget
-  };
 
   const indicatorMat = new THREE.MeshStandardMaterial({
     color: playerColors[0],

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -528,7 +528,9 @@ const DEFAULT_APPEARANCE = Object.freeze({
   environmentHdri: DEFAULT_HDRI_INDEX
 });
 
-const DEFAULT_FRAME_RATE_ID = FRAME_RATE_OPTIONS[0]?.id ?? 'balanced60';
+const DEFAULT_FRAME_RATE_ID = 'fast120';
+const DEFAULT_FRAME_RATE_OPTION =
+  FRAME_RATE_OPTIONS.find((option) => option.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
@@ -838,10 +840,10 @@ export default function SnakeAndLadder() {
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
   const activeFrameRateOption = useMemo(
-    () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
+    () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
   );
-  const frameRateValue = activeFrameRateOption?.fps ?? FRAME_RATE_OPTIONS[0]?.fps ?? 90;
+  const frameRateValue = activeFrameRateOption?.fps ?? DEFAULT_FRAME_RATE_OPTION?.fps ?? 90;
 
   useEffect(() => {
     setAppearance((prev) => {


### PR DESCRIPTION
## Summary
- remove arena carpets, walls, and manual lights from the Snake & Ladder and Ludo Battle Royal 3D scenes to rely solely on HDRI illumination
- force HDRI loads to 4K assets and default both games to 120 Hz frame pacing
- drop auxiliary dice spot/point lights so board elements are lit exclusively by the environment maps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536c7569088329910cde23464e885e)