### PR TITLE
Use HDRI-only arenas for Snake & Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -528,7 +528,9 @@ const DEFAULT_APPEARANCE = Object.freeze({
   environmentHdri: DEFAULT_HDRI_INDEX
 });
 
-const DEFAULT_FRAME_RATE_ID = FRAME_RATE_OPTIONS[0]?.id ?? 'balanced60';
+const DEFAULT_FRAME_RATE_ID = 'fast120';
+const DEFAULT_FRAME_RATE_OPTION =
+  FRAME_RATE_OPTIONS.find((option) => option.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
@@ -838,10 +840,10 @@ export default function SnakeAndLadder() {
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
   const activeFrameRateOption = useMemo(
-    () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
+    () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
   );
-  const frameRateValue = activeFrameRateOption?.fps ?? FRAME_RATE_OPTIONS[0]?.fps ?? 90;
+  const frameRateValue = activeFrameRateOption?.fps ?? DEFAULT_FRAME_RATE_OPTION?.fps ?? 90;
 
   useEffect(() => {
     setAppearance((prev) => {


### PR DESCRIPTION
## Summary
- remove the surrounding arena walls, carpets, and floor meshes so Snake & Ladder and Ludo Battle Royal rely solely on their HDRI environments
- drop extra scene and dice lights to let the HDRIs provide lighting, keeping the environment map as both background and illumination
- default both experiences to 4K HDRIs and a 120 Hz frame pacing profile

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536c7569088329910cde23464e885e)