### PR TITLE
Add five moving Pool Royale HDRI arenas with ambient audio and skybox motion

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -33,7 +33,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   loftPhotoStudioHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.6, groundResolution: 120 },
   londonPhotoStudioHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 120 },
   schoolHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.6, groundResolution: 112 },
-  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 }
+  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 },
+  royalGrandArena: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.4, groundResolution: 112 },
+  royalEventsArena: { cameraHeightM: 1.62, groundRadiusMultiplier: 5.5, groundResolution: 112 },
+  royalCinemaArena: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.2, groundResolution: 112 },
+  royalDanceArena: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
+  royalMusicArena: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.4, groundResolution: 112 }
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [
@@ -470,6 +475,81 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.02,
     swatches: ['#f472b6', '#16a34a'],
     description: 'Cozy country hall with warm wood bounce and soft window key light.'
+  },
+  {
+    id: 'royalGrandArena',
+    name: 'Royal Grand Arena',
+    assetId: 'ballroom',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2260,
+    exposure: 1.16,
+    environmentIntensity: 1.18,
+    backgroundIntensity: 1.1,
+    swatches: ['#f59e0b', '#f97316'],
+    motion: { rotationSpeed: 0.06, bobAmplitudeM: 0.12, bobSpeed: 0.18 },
+    sound: { url: '/assets/sounds/football-crowd-3-69245.mp3', volume: 0.18 },
+    description: 'Grand arena hall with subtle motion sweep and crowd ambience.'
+  },
+  {
+    id: 'royalEventsArena',
+    name: 'Royal Events Arena',
+    assetId: 'events_hall_interior',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2280,
+    exposure: 1.14,
+    environmentIntensity: 1.14,
+    backgroundIntensity: 1.08,
+    swatches: ['#f59e0b', '#e11d48'],
+    motion: { rotationSpeed: 0.05, bobAmplitudeM: 0.1, bobSpeed: 0.22 },
+    sound: { url: '/assets/sounds/crowd-cheering-383111.mp3', volume: 0.16 },
+    description: 'Public event arena with slow rotation and cheer floor-bed.'
+  },
+  {
+    id: 'royalCinemaArena',
+    name: 'Royal Cinema Arena',
+    assetId: 'cinema_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2300,
+    exposure: 1.12,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.06,
+    swatches: ['#ef4444', '#111827'],
+    motion: { rotationSpeed: 0.04, bobAmplitudeM: 0.08, bobSpeed: 0.24 },
+    sound: { url: '/assets/sounds/clock-ticking-60-second-countdown-118231.mp3', volume: 0.12 },
+    description: 'Cinematic arena sweep with gentle motion and timed ambience.'
+  },
+  {
+    id: 'royalDanceArena',
+    name: 'Royal Dance Arena',
+    assetId: 'dancing_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2320,
+    exposure: 1.15,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.08,
+    swatches: ['#22c55e', '#f97316'],
+    motion: { rotationSpeed: 0.07, bobAmplitudeM: 0.14, bobSpeed: 0.26 },
+    sound: { url: '/assets/sounds/fireworks-29629.mp3', volume: 0.14 },
+    description: 'Dance arena panorama with rhythmic motion and sparkle bursts.'
+  },
+  {
+    id: 'royalMusicArena',
+    name: 'Royal Music Arena',
+    assetId: 'music_hall_01',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2340,
+    exposure: 1.13,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.06,
+    swatches: ['#a855f7', '#2563eb'],
+    motion: { rotationSpeed: 0.05, bobAmplitudeM: 0.1, bobSpeed: 0.2 },
+    sound: { url: '/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3', volume: 0.15 },
+    description: 'Concert arena with smooth motion drift and stadium roar.'
   }
 ];
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10042,6 +10042,9 @@ function PoolRoyaleGame({
       updateEnvironmentRef.current(activeEnvironmentVariantRef.current);
     }
   }, [activeEnvironmentHdri, environmentHdriId]);
+  useEffect(() => {
+    startEnvironmentSound(activeEnvironmentHdri);
+  }, [activeEnvironmentHdri, environmentHdriId, startEnvironmentSound]);
   const tableFinish = useMemo(() => {
     const baseFinish =
       TABLE_FINISHES[tableFinishId] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
@@ -10530,6 +10533,14 @@ const powerRef = useRef(hud.power);
   const envTextureRef = useRef(null);
   const envSkyboxRef = useRef(null);
   const envSkyboxTextureRef = useRef(null);
+  const envMotionRef = useRef({
+    enabled: false,
+    rotationSpeed: 0,
+    bobAmplitude: 0,
+    bobSpeed: 0,
+    baseY: 0
+  });
+  const envMotionTimeRef = useRef(0);
   const environmentHdriRef = useRef(environmentHdriId);
   const activeEnvironmentVariantRef = useRef(activeEnvironmentHdri);
   const cameraRef = useRef(null);
@@ -10676,9 +10687,13 @@ const powerRef = useRef(hud.power);
     pocket: null,
     knock: null,
     cheer: null,
-    shock: null
+    shock: null,
+    environment: {}
   });
   const activeCrowdSoundRef = useRef(null);
+  const activeEnvironmentSoundRef = useRef(null);
+  const activeEnvironmentSoundIdRef = useRef(null);
+  const environmentGainRef = useRef(null);
   const muteRef = useRef(isGameMuted());
   const volumeRef = useRef(getGameVolume());
   const railSoundTimeRef = useRef(new Map());
@@ -10711,6 +10726,17 @@ const powerRef = useRef(hud.power);
     }
   }, []);
 
+  const stopActiveEnvironmentSound = useCallback(() => {
+    const current = activeEnvironmentSoundRef.current;
+    if (current) {
+      try {
+        current.stop();
+      } catch {}
+      activeEnvironmentSoundRef.current = null;
+      activeEnvironmentSoundIdRef.current = null;
+    }
+  }, []);
+
   const selectCueStyleFromMenu = useCallback(
     async (index) => {
       const charged = await ensureCueFeePaid();
@@ -10735,6 +10761,59 @@ const powerRef = useRef(hud.power);
       node.connect(ctx.destination);
     } catch {}
   }, []);
+
+  const startEnvironmentSound = useCallback(
+    (variant) => {
+      const soundConfig = variant?.sound ?? null;
+      const soundUrl =
+        typeof soundConfig === 'string' ? soundConfig : soundConfig?.url;
+      if (!soundUrl) {
+        stopActiveEnvironmentSound();
+        return;
+      }
+      const ctx = audioContextRef.current;
+      const buffer = audioBuffersRef.current.environment?.[soundUrl];
+      if (!ctx || !buffer || muteRef.current) return;
+      const baseVolume =
+        typeof soundConfig === 'object' && Number.isFinite(soundConfig.volume)
+          ? soundConfig.volume
+          : 0.15;
+      const scaled = clamp(baseVolume * volumeRef.current, 0, 1);
+      if (scaled <= 0) {
+        stopActiveEnvironmentSound();
+        return;
+      }
+      if (
+        activeEnvironmentSoundIdRef.current === soundUrl &&
+        activeEnvironmentSoundRef.current
+      ) {
+        if (environmentGainRef.current) {
+          environmentGainRef.current.gain.value = scaled;
+        }
+        return;
+      }
+      stopActiveEnvironmentSound();
+      ctx.resume().catch(() => {});
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.loop = true;
+      const gain = ctx.createGain();
+      gain.gain.value = scaled;
+      source.connect(gain);
+      routeAudioNode(gain);
+      source.start(0);
+      activeEnvironmentSoundRef.current = source;
+      activeEnvironmentSoundIdRef.current = soundUrl;
+      environmentGainRef.current = gain;
+      source.onended = () => {
+        if (activeEnvironmentSoundRef.current === source) {
+          activeEnvironmentSoundRef.current = null;
+          activeEnvironmentSoundIdRef.current = null;
+        }
+      };
+    },
+    [routeAudioNode, stopActiveEnvironmentSound]
+  );
 
   const playCueHit = useCallback((vol = 1) => {
     const ctx = audioContextRef.current;
@@ -10911,10 +10990,16 @@ const powerRef = useRef(hud.power);
     volumeRef.current = getGameVolume();
     const handleMute = () => {
       muteRef.current = isGameMuted();
-      if (muteRef.current) stopActiveCrowdSound();
+      if (muteRef.current) {
+        stopActiveCrowdSound();
+        stopActiveEnvironmentSound();
+      } else {
+        startEnvironmentSound(activeEnvironmentVariantRef.current);
+      }
     };
     const handleVolume = () => {
       volumeRef.current = getGameVolume();
+      startEnvironmentSound(activeEnvironmentVariantRef.current);
     };
     window.addEventListener('gameMuteChanged', handleMute);
     window.addEventListener('gameVolumeChanged', handleVolume);
@@ -10922,7 +11007,7 @@ const powerRef = useRef(hud.power);
       window.removeEventListener('gameMuteChanged', handleMute);
       window.removeEventListener('gameVolumeChanged', handleVolume);
     };
-  }, [stopActiveCrowdSound]);
+  }, [startEnvironmentSound, stopActiveCrowdSound, stopActiveEnvironmentSound]);
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const AudioContextClass = window.AudioContext || window.webkitAudioContext;
@@ -10961,22 +11046,47 @@ const powerRef = useRef(hud.power);
       if (!cancelled) {
         audioBuffersRef.current = { ...audioBuffersRef.current, ...loaded };
       }
+      const environmentSounds = [
+        ...new Set(
+          POOL_ROYALE_HDRI_VARIANTS.map((variant) =>
+            typeof variant.sound === 'string' ? variant.sound : variant.sound?.url
+          ).filter(Boolean)
+        )
+      ];
+      const environmentBuffers = {};
+      for (const url of environmentSounds) {
+        try {
+          const buffer = await loadBuffer(url);
+          if (!cancelled) environmentBuffers[url] = buffer;
+        } catch (err) {
+          console.warn('Pool environment audio load failed:', url, err);
+        }
+      }
+      if (!cancelled) {
+        audioBuffersRef.current = {
+          ...audioBuffersRef.current,
+          environment: { ...audioBuffersRef.current.environment, ...environmentBuffers }
+        };
+        startEnvironmentSound(activeEnvironmentVariantRef.current);
+      }
     })();
     return () => {
       cancelled = true;
       stopActiveCrowdSound();
+      stopActiveEnvironmentSound();
       audioBuffersRef.current = {
         cue: null,
         ball: null,
         pocket: null,
         knock: null,
         cheer: null,
-        shock: null
+        shock: null,
+        environment: {}
       };
       audioContextRef.current = null;
       ctx.close().catch(() => {});
     };
-  }, [stopActiveCrowdSound]);
+  }, [startEnvironmentSound, stopActiveCrowdSound, stopActiveEnvironmentSound]);
   const formatBallOnLabel = useCallback(
     (rawList = []) => {
       const normalized = rawList
@@ -11549,6 +11659,29 @@ const powerRef = useRef(hud.power);
           sceneInstance.environmentIntensity = activeVariant.environmentIntensity;
         }
         renderer.toneMappingExposure = activeVariant?.exposure ?? renderer.toneMappingExposure;
+        const motionConfig =
+          activeVariant?.motion && typeof activeVariant.motion === 'object'
+            ? activeVariant.motion
+            : null;
+        const rotationSpeed = Number.isFinite(motionConfig?.rotationSpeed)
+          ? motionConfig.rotationSpeed
+          : 0;
+        const bobAmplitudeM = Number.isFinite(motionConfig?.bobAmplitudeM)
+          ? motionConfig.bobAmplitudeM
+          : 0;
+        const bobSpeed = Number.isFinite(motionConfig?.bobSpeed) ? motionConfig.bobSpeed : 0;
+        const bobAmplitude = bobAmplitudeM > 0 ? bobAmplitudeM * unitsPerMeter : 0;
+        if (skybox) {
+          skybox.rotation.set(0, 0, 0);
+        }
+        envMotionRef.current = {
+          enabled: Boolean(motionConfig) && (rotationSpeed !== 0 || bobAmplitude !== 0),
+          rotationSpeed,
+          bobAmplitude,
+          bobSpeed,
+          baseY: skybox?.position.y ?? 0
+        };
+        envMotionTimeRef.current = 0;
         envTextureRef.current = envMap;
         disposeEnvironmentRef.current = () => {
           if (sceneRef.current?.environment === envMap) {
@@ -11572,6 +11705,13 @@ const powerRef = useRef(hud.power);
               envSkyboxTextureRef.current = null;
             }
           }
+          envMotionRef.current = {
+            enabled: false,
+            rotationSpeed: 0,
+            bobAmplitude: 0,
+            bobSpeed: 0,
+            baseY: 0
+          };
         };
         if (prevDispose && prevTexture !== envMap) {
           prevDispose();
@@ -19031,6 +19171,20 @@ const powerRef = useRef(hud.power);
         const deltaMs = Math.min(rawDelta, maxFrameTime);
         const appliedDeltaMs = deltaMs;
         const deltaSeconds = appliedDeltaMs / 1000;
+        const envMotion = envMotionRef.current;
+        const envSkybox = envSkyboxRef.current;
+        if (envMotion?.enabled && envSkybox) {
+          envMotionTimeRef.current += deltaSeconds;
+          if (envMotion.rotationSpeed) {
+            envSkybox.rotation.y += envMotion.rotationSpeed * deltaSeconds;
+          }
+          if (envMotion.bobAmplitude && envMotion.bobSpeed) {
+            envSkybox.position.y =
+              envMotion.baseY +
+              Math.sin(envMotionTimeRef.current * envMotion.bobSpeed * Math.PI * 2) *
+                envMotion.bobAmplitude;
+          }
+        }
         coinTicker.update(deltaSeconds);
         dynamicTextureEntries.forEach((entry) => {
           entry.accumulator += deltaSeconds;


### PR DESCRIPTION
### Motivation
- Provide five new moving HDRI arena environments for Pool Royale that include subtle motion and ambient sounds for richer previews and storefront options. 
- Surface those environments in the existing store and table setup UI by extending the HDRI variants list. 
- Ensure grounded skybox rendering and sizing reuse the Pool Royale mapping so the table remains visually grounded. 
- Play looped ambient audio when a moving HDRI is active and respond to global mute/volume settings.

### Description
- Added five HDRI variants to `POOL_ROYALE_HDRI_VARIANTS` in `webapp/src/config/poolRoyaleInventoryConfig.js` (ids: `royalGrandArena`, `royalEventsArena`, `royalCinemaArena`, `royalDanceArena`, `royalMusicArena`) including `motion` and `sound` metadata and pricing. 
- Implemented environment audio support in `webapp/src/pages/Games/PoolRoyale.jsx` by adding environment audio buffer loading, `startEnvironmentSound` / `stopActiveEnvironmentSound` management, and integrating environment buffers into `audioBuffersRef`. 
- Implemented grounded HDRI motion by introducing `envMotionRef`/`envMotionTimeRef`, initializing motion from variant `motion` config when the HDRI is applied, and animating the `GroundedSkybox` (rotation and vertical bob) inside the main loop. 
- Hooked environment sound lifecycle to variant selection, local mute/volume events, audio context setup/teardown, and environment disposal so sounds start/stop and volume follows `getGameVolume()`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` (Vite) and confirmed the site served successfully at the local URL. (succeeded)
- Captured a Playwright screenshot of `http://127.0.0.1:4173/games/poolroyale` to verify HDRI preview and skybox rendering. (succeeded)
- The earlier combined dev start that attempted to run the bot server failed due to a missing `compression` package, but the webapp-only dev run used for verification completed. (partial failure)
- No unit test suite was executed as part of this rollout. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538ebc42ac8328bf622506f5657b4a)