### PR TITLE
Add animated arena HDRIs with ambient audio for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -33,7 +33,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   loftPhotoStudioHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.6, groundResolution: 120 },
   londonPhotoStudioHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 120 },
   schoolHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.6, groundResolution: 112 },
-  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 }
+  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 },
+  royalArenaPulse: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.1, groundResolution: 112 },
+  crowdGrandstand: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
+  arenaRush: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
+  spotlightCircuit: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
+  nightRally: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 }
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [
@@ -470,6 +475,86 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.02,
     swatches: ['#f472b6', '#16a34a'],
     description: 'Cozy country hall with warm wood bounce and soft window key light.'
+  },
+  {
+    id: 'royalArenaPulse',
+    name: 'Royal Arena Pulse',
+    assetId: 'ballroom',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2320,
+    exposure: 1.16,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#facc15', '#f97316'],
+    description: 'Crowd-ready ballroom arena with a slow orbiting glow.',
+    motion: { yawSpeed: 0.024, pitchAmplitude: 0.018, pitchSpeed: 0.35 },
+    ambientSound: '/assets/sounds/football-crowd-3-69245.mp3',
+    ambientVolume: 0.28
+  },
+  {
+    id: 'crowdGrandstand',
+    name: 'Crowd Grandstand',
+    assetId: 'events_hall_interior',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2360,
+    exposure: 1.15,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.05,
+    swatches: ['#f97316', '#1f2937'],
+    description: 'Public arena interior with sweeping overhead motion.',
+    motion: { yawSpeed: 0.028, rollAmplitude: 0.012, rollSpeed: 0.28 },
+    ambientSound: '/assets/sounds/football-game-sound-effects-359284.mp3',
+    ambientVolume: 0.26
+  },
+  {
+    id: 'arenaRush',
+    name: 'Arena Rush',
+    assetId: 'dancing_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2400,
+    exposure: 1.13,
+    environmentIntensity: 1.09,
+    backgroundIntensity: 1.04,
+    swatches: ['#22c55e', '#f97316'],
+    description: 'Bright arena hall with motion-ready spot sweeps.',
+    motion: { yawSpeed: 0.03, pitchAmplitude: 0.014, pitchSpeed: 0.4 },
+    ambientSound: '/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3',
+    ambientVolume: 0.27
+  },
+  {
+    id: 'spotlightCircuit',
+    name: 'Spotlight Circuit',
+    assetId: 'cinema_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2440,
+    exposure: 1.14,
+    environmentIntensity: 1.11,
+    backgroundIntensity: 1.06,
+    swatches: ['#ef4444', '#111827'],
+    description: 'Stadium-style lighting sweep with cinematic crowd energy.',
+    motion: { yawSpeed: 0.022, rollAmplitude: 0.016, rollSpeed: 0.32 },
+    ambientSound: '/assets/sounds/crowd-cheering-383111.mp3',
+    ambientVolume: 0.3
+  },
+  {
+    id: 'nightRally',
+    name: 'Night Rally Arena',
+    assetId: 'music_hall_01',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2480,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.02,
+    swatches: ['#0ea5e9', '#9333ea'],
+    description: 'Night-time rally arena with rolling crowd ambience.',
+    motion: { yawSpeed: 0.026, pitchAmplitude: 0.012, pitchSpeed: 0.3 },
+    ambientSound: '/assets/sounds/football-crowd-3-69245.mp3',
+    ambientVolume: 0.25
   }
 ];
 


### PR DESCRIPTION
### Motivation
- Provide five new animated/arena-style HDRI environments for Pool Royale with motion + ambient sound to increase immersion and offer new store options. 
- Allow HDRI environments to be previewed with subtle motion and looping ambient audio in the Three.js preview. 
- Reuse existing inventory/store wiring so these HDRIs are selectable from the table setup menu.

### Description
- Added five HDRI variants and placement tuning in `webapp/src/config/poolRoyaleInventoryConfig.js` (`royalArenaPulse`, `crowdGrandstand`, `arenaRush`, `spotlightCircuit`, `nightRally`) including `motion`, `ambientSound`, and `ambientVolume` metadata. 
- Implemented HDRI motion state and per-frame updates (yaw/pitch/roll) using `scene.backgroundRotation` / `scene.environmentRotation` and grounded skybox rotation in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added ambient audio support: audio buffer caching, loader (`loadAudioBuffer`), looping ambient source creation, gain management, mute/volume responsiveness, and lifecycle cleanup. 
- Hooked HDRI selection changes to update desired ambient audio and ensured ambient playback starts when the audio context is available and settings permit.

### Testing
- Started the dev server with `npm run dev` and Vite reported the app ready and serving at `http://localhost:4173/`. (succeeded)
- Attempted an automated UI check with Playwright to open `/games/poolroyale` and toggle the table setup to capture a screenshot, but the Playwright run failed due to Chromium crashing (SIGSEGV) during headless launch. (failed)
- No unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538ebc42ac8328bf622506f5657b4a)