### PR TITLE
Domino Royal: HDRI environments, PolyHaven table/chair models, and skybox sync

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -120,10 +120,14 @@
 <script type="module">
 import * as THREE from "https://esm.sh/three@0.160.0";
 import { OrbitControls } from "https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js";
-import { RoomEnvironment } from "https://esm.sh/three@0.160.0/examples/jsm/environments/RoomEnvironment.js";
+import { GroundedSkybox } from "https://esm.sh/three@0.160.0/examples/jsm/objects/GroundedSkybox.js";
 import { RoundedBoxGeometry } from "https://esm.sh/three@0.160.0/examples/jsm/geometries/RoundedBoxGeometry.js";
 import { GLTFLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js";
 import { DRACOLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js";
+import { KTX2Loader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/KTX2Loader.js";
+import { RGBELoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/RGBELoader.js";
+import { EXRLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/EXRLoader.js";
+import { MeshoptDecoder } from "https://esm.sh/three@0.160.0/examples/jsm/libs/meshopt_decoder.module.js";
 import "./flag-emojis.js";
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -744,8 +748,7 @@ renderer.domElement.style.touchAction = 'none';
 const scene = new THREE.Scene();
 const textureLoader = new THREE.TextureLoader();
 const pmrem = new THREE.PMREMGenerator(renderer);
-const envTex = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-scene.environment = envTex;
+pmrem.compileEquirectangularShader();
 
 const LIGHT_INTENSITY_FACTOR = 1;
 const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
@@ -1006,6 +1009,24 @@ controls.touches.THREE = THREE.TOUCH.PAN;
 controls.target.copy(CAMERA_TARGET);
 
 let cameraHasUserControl = false;
+let envTexture = null;
+let envSkybox = null;
+let envSkyboxTexture = null;
+let baseCameraRadius = null;
+let baseSkyboxScale = 1;
+const HDRI_FLOOR_Y = 0;
+
+function syncSkyboxToCamera() {
+  if (!envSkybox) return;
+  const target = getActiveCameraTarget();
+  const radius = camera.position.distanceTo(target);
+  const baseRadius = baseCameraRadius || radius || 1;
+  const scale = THREE.MathUtils.clamp(radius / baseRadius, 0.35, 3.5);
+  envSkybox.scale.setScalar(baseSkyboxScale * scale);
+  if (Number.isFinite(envSkybox.userData?.cameraHeight)) {
+    envSkybox.position.y = HDRI_FLOOR_Y + envSkybox.userData.cameraHeight;
+  }
+}
 controls.addEventListener('start', () => {
   cameraHasUserControl = true;
 });
@@ -1016,6 +1037,7 @@ renderer.domElement.addEventListener(
   },
   { passive: true }
 );
+controls.addEventListener('change', syncSkyboxToCamera);
 
 function getViewportMetrics() {
   const dom = renderer.domElement;
@@ -1130,6 +1152,7 @@ function positionCameraForViewport({ force = false } = {}) {
 
   controls.target.copy(target);
   controls.update();
+  syncSkyboxToCamera();
 }
 
 function updateViewToggleLabel() {
@@ -1162,147 +1185,6 @@ function toggleCameraViewMode() {
 }
 
 
-/* ---------- Lights ---------- */
-const ambient = new THREE.AmbientLight(0xffffff, 0.35);
-scene.add(ambient);
-const keyLight = new THREE.DirectionalLight(0xffffff, 1.2);
-keyLight.position.set(6, 8, 5);
-keyLight.castShadow = true;
-scene.add(keyLight);
-const fillLight = new THREE.DirectionalLight(0xffffff, 0.65);
-fillLight.position.set(-5, 5.5, 3);
-scene.add(fillLight);
-const rimLight = new THREE.DirectionalLight(0xffffff, 0.9);
-rimLight.position.set(0, 6, -6);
-scene.add(rimLight);
-const spot = new THREE.SpotLight(0xffffff, 0.8, TABLE_RADIUS * 10, Math.PI / 3, 0.38, 1);
-spot.position.set(0, 4.2, 4.6);
-scene.add(spot);
-const spotTarget = new THREE.Object3D();
-scene.add(spotTarget);
-spot.target = spotTarget;
-
-const getPoolCarpetTextures = (() => {
-  let cache = null;
-  const clamp01 = (v) => Math.min(1, Math.max(0, v));
-  const prng = (seed) => {
-    let value = seed >>> 0;
-    return () => {
-      value = (value * 1664525 + 1013904223) % 4294967296;
-      return value / 4294967296;
-    };
-  };
-  const drawRoundedRect = (ctx, x, y, w, h, r) => {
-    const radius = Math.max(0, Math.min(r, Math.min(w, h) / 2));
-    ctx.beginPath();
-    ctx.moveTo(x + radius, y);
-    ctx.lineTo(x + w - radius, y);
-    ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
-    ctx.lineTo(x + w, y + h - radius);
-    ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
-    ctx.lineTo(x + radius, y + h);
-    ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
-    ctx.lineTo(x, y + radius);
-    ctx.quadraticCurveTo(x, y, x + radius, y);
-    ctx.closePath();
-  };
-  return (renderer) => {
-    if (cache) return cache;
-    if (typeof document === "undefined") {
-      cache = { map: null, bump: null };
-      return cache;
-    }
-    const size = 1024;
-    const canvas = document.createElement("canvas");
-    canvas.width = canvas.height = size;
-    const ctx = canvas.getContext("2d");
-
-    // Match Pool Royale's crimson carpet palette.
-    const gradient = ctx.createLinearGradient(0, 0, size, size);
-    gradient.addColorStop(0, "#7c242f");
-    gradient.addColorStop(1, "#9d3642");
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, size, size);
-
-    const rand = prng(987654321);
-    const image = ctx.getImageData(0, 0, size, size);
-    const data = image.data;
-    const baseColor = { r: 112, g: 28, b: 34 };
-    const highlightColor = { r: 196, g: 72, b: 82 };
-    const toChannel = (component) => Math.round(clamp01(component / 255) * 255);
-    for (let y = 0; y < size; y++) {
-      for (let x = 0; x < size; x++) {
-        const idx = (y * size + x) * 4;
-        const fiber = (Math.sin((x / size) * Math.PI * 14) + Math.cos((y / size) * Math.PI * 16)) * 0.08;
-        const grain = (rand() - 0.5) * 0.12;
-        const shade = clamp01(0.55 + fiber * 0.75 + grain * 0.6);
-        const r = baseColor.r + (highlightColor.r - baseColor.r) * shade;
-        const g = baseColor.g + (highlightColor.g - baseColor.g) * shade;
-        const b = baseColor.b + (highlightColor.b - baseColor.b) * shade;
-        data[idx] = toChannel(r);
-        data[idx + 1] = toChannel(g);
-        data[idx + 2] = toChannel(b);
-      }
-    }
-    ctx.putImageData(image, 0, 0);
-
-    ctx.globalAlpha = 0.04;
-    ctx.fillStyle = "#4f1119";
-    for (let row = 0; row < size; row += 3) {
-      ctx.fillRect(0, row, size, 1);
-    }
-    ctx.globalAlpha = 1;
-
-    const insetRatio = 0.055;
-    const stripeInset = size * insetRatio;
-    const stripeRadius = size * 0.08;
-    const stripeWidth = size * 0.012;
-    ctx.lineWidth = stripeWidth;
-    ctx.strokeStyle = "#f2b7b4";
-    ctx.shadowColor = "rgba(80,20,30,0.18)";
-    ctx.shadowBlur = stripeWidth * 0.8;
-    drawRoundedRect(ctx, stripeInset, stripeInset, size - stripeInset * 2, size - stripeInset * 2, stripeRadius);
-    ctx.stroke();
-    ctx.shadowBlur = 0;
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.anisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
-    texture.minFilter = THREE.LinearMipMapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.generateMipmaps = true;
-    texture.colorSpace = THREE.SRGBColorSpace;
-
-    const bumpCanvas = document.createElement("canvas");
-    bumpCanvas.width = bumpCanvas.height = size;
-    const bumpCtx = bumpCanvas.getContext("2d");
-    bumpCtx.drawImage(canvas, 0, 0);
-    const bumpImage = bumpCtx.getImageData(0, 0, size, size);
-    const bumpData = bumpImage.data;
-    const bumpRand = prng(246813579);
-    for (let i = 0; i < bumpData.length; i += 4) {
-      const r = bumpData[i];
-      const g = bumpData[i + 1];
-      const b = bumpData[i + 2];
-      const lum = (r * 0.299 + g * 0.587 + b * 0.114) / 255;
-      const noise = (bumpRand() - 0.5) * 0.16;
-      const v = clamp01(0.62 + lum * 0.28 + noise);
-      const value = Math.floor(v * 255);
-      bumpData[i] = bumpData[i + 1] = bumpData[i + 2] = value;
-    }
-    bumpCtx.putImageData(bumpImage, 0, 0);
-
-    const bump = new THREE.CanvasTexture(bumpCanvas);
-    bump.wrapS = bump.wrapT = THREE.ClampToEdgeWrapping;
-    bump.anisotropy = Math.min(texture.anisotropy ?? 4, 6);
-    bump.minFilter = THREE.LinearMipMapLinearFilter;
-    bump.magFilter = THREE.LinearFilter;
-    bump.generateMipmaps = true;
-
-    cache = { map: texture, bump };
-    return cache;
-  };
-})();
 
 const CHAIR_CLOTH_TEXTURE_SIZE = 512;
 const CHAIR_CLOTH_REPEAT = 12;
@@ -1330,6 +1212,654 @@ const CHAIR_MODEL_URLS = [
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
+
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
+  {
+    id: 'neonPhotostudio',
+    name: 'Neon Photo Studio',
+    assetId: 'neon_photostudio',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1420,
+    exposure: 1.18,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#0ea5e9', '#8b5cf6'],
+    description: 'Vibrant cyber studio wrap with strong rim accents.',
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120
+  },
+  {
+    id: 'studioSoftbox08',
+    name: 'Studio Softbox 08',
+    assetId: 'studio_small_08',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1460,
+    exposure: 1.14,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1,
+    swatches: ['#cbd5e1', '#94a3b8'],
+    description: 'Neutral softbox studio with even wrap lighting.',
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.7,
+    groundResolution: 120
+  },
+  {
+    id: 'bronzePhotostudio',
+    name: 'Bronze Photo Loft',
+    assetId: 'brown_photostudio_02',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1490,
+    exposure: 1.16,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.04,
+    swatches: ['#f59e0b', '#b45309'],
+    description: 'Warm loft studio with bronze-toned reflectors.',
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120
+  },
+  {
+    id: 'adamsBridge',
+    name: 'Adams Bridge',
+    assetId: 'adams_place_bridge',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1520,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.02,
+    swatches: ['#1d4ed8', '#0ea5e9'],
+    description: 'Cool twilight bridge lighting with crisp specular pickup.',
+    cameraHeightM: 1.68,
+    groundRadiusMultiplier: 6.5,
+    groundResolution: 112
+  },
+  {
+    id: 'veniceSunset',
+    name: 'Venice Sunset',
+    assetId: 'venice_sunset',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1550,
+    exposure: 1.11,
+    environmentIntensity: 1.14,
+    backgroundIntensity: 1.06,
+    swatches: ['#f59e0b', '#ef4444'],
+    description: 'Golden-hour waterfront reflections with soft falloff.',
+    cameraHeightM: 1.68,
+    groundRadiusMultiplier: 6.7,
+    groundResolution: 112
+  },
+  {
+    id: 'modernRooftops',
+    name: 'Modern Rooftops',
+    assetId: 'modern_buildings',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1580,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 0.98,
+    swatches: ['#22d3ee', '#0ea5e9'],
+    description: 'Reflective skyline mix for sleek chrome highlights.',
+    cameraHeightM: 1.72,
+    groundRadiusMultiplier: 7,
+    groundResolution: 112
+  },
+  {
+    id: 'kloofendalClouds',
+    name: 'Kloofendal Clouds',
+    assetId: 'kloofendal_48d_partly_cloudy',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1610,
+    exposure: 1.06,
+    environmentIntensity: 1.02,
+    backgroundIntensity: 0.96,
+    swatches: ['#0ea5e9', '#22c55e'],
+    description: 'Outdoor overcast balance for natural, even cloth response.',
+    cameraHeightM: 1.66,
+    groundRadiusMultiplier: 6.2,
+    groundResolution: 104
+  },
+  {
+    id: 'ballroomHall',
+    name: 'Ballroom Hall',
+    assetId: 'ballroom',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1640,
+    exposure: 1.15,
+    environmentIntensity: 1.16,
+    backgroundIntensity: 1.08,
+    swatches: ['#fef3c7', '#a16207'],
+    description: 'Grand hall ambience with chandeliers for polished highlights.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112
+  },
+  {
+    id: 'rooftopNight',
+    name: 'Rooftop Night',
+    assetId: 'rooftop_night',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1680,
+    exposure: 1.2,
+    environmentIntensity: 1.18,
+    backgroundIntensity: 1.12,
+    swatches: ['#0ea5e9', '#111827'],
+    description: 'Nocturnal rooftop glow with neon spill for chrome drama.',
+    cameraHeightM: 1.72,
+    groundRadiusMultiplier: 7,
+    groundResolution: 112
+  },
+  {
+    id: 'industrialSunset',
+    name: 'Industrial Sunset',
+    assetId: 'industrial_sunset_02',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1720,
+    exposure: 1.17,
+    environmentIntensity: 1.14,
+    backgroundIntensity: 1.06,
+    swatches: ['#f97316', '#1f2937'],
+    description: 'Rustic industrial dusk with warm rim and cool fill mix.',
+    cameraHeightM: 1.7,
+    groundRadiusMultiplier: 6.3,
+    groundResolution: 112
+  },
+  {
+    id: 'snookerRoom',
+    name: 'Snooker Room',
+    assetUrls: {
+      '4k': 'https://public.blenderkit.com/assets/5484e9402a4c416da2c7f30a9912ca27/files/resolution_4K_5455ef52-a73c-4b55-bf22-a0a9378eb5eb.exr',
+      '2k': 'https://public.blenderkit.com/assets/5484e9402a4c416da2c7f30a9912ca27/files/resolution_2K_378ff822-6c29-4941-9bd1-74e05f220dae.exr',
+      '1k': 'https://public.blenderkit.com/assets/5484e9402a4c416da2c7f30a9912ca27/files/resolution_1K_110774df-afff-4216-aead-6d58b69e8c29.exr'
+    },
+    preferredResolutions: ['4k', '2k', '1k'],
+    fallbackResolution: '4k',
+    fallbackUrl: 'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/4k/billiard_hall_4k.hdr',
+    price: 1740,
+    exposure: 1.13,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#22c55e', '#0ea5e9'],
+    description: 'BlenderKit free snooker hall mood with arcade-side fill.',
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4.4,
+    groundResolution: 128
+  },
+  {
+    id: 'emptyPlayRoom',
+    name: 'Empty Play Room',
+    assetId: 'empty_play_room',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1760,
+    exposure: 1.09,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1,
+    swatches: ['#a855f7', '#22c55e'],
+    description: 'Quiet game room ambience with even indoor bounce.',
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120
+  },
+  {
+    id: 'christmasPhotoStudio04',
+    name: 'Christmas Photo Studio 04',
+    assetId: 'christmas_photo_studio_04',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1780,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#ef4444', '#f59e0b'],
+    description: 'Festive studio wraps with warm gift-light accents.',
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120
+  },
+  {
+    id: 'billiardHall',
+    name: 'Billiard Hall',
+    assetId: 'billiard_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1800,
+    exposure: 1.12,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1,
+    swatches: ['#22c55e', '#fde047'],
+    description: 'Classic billiard hall lighting with bright overhead bounce.',
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 128
+  },
+  {
+    id: 'colorfulStudio',
+    name: 'Colorful Studio',
+    assetId: 'colorful_studio',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1820,
+    exposure: 1.08,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1,
+    swatches: ['#f472b6', '#22c55e'],
+    description: 'Soft pastel studio for vivid felt highlights.',
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4,
+    groundResolution: 120
+  },
+  {
+    id: 'dancingHall',
+    name: 'Dancing Hall',
+    assetId: 'dance_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1840,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.02,
+    swatches: ['#f472b6', '#0ea5e9'],
+    description: 'Mirror-lit ballroom with warm floor reflections.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112
+  },
+  {
+    id: 'abandonedHall',
+    name: 'Abandoned Hall',
+    assetId: 'abandoned_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1860,
+    exposure: 1.08,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#f59e0b', '#0f172a'],
+    description: 'Moody abandoned venue with textured light spill.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112
+  },
+  {
+    id: 'cinemaHall',
+    name: 'Cinema Hall',
+    assetId: 'cinema_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1880,
+    exposure: 1.11,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02,
+    swatches: ['#1d4ed8', '#f59e0b'],
+    description: 'Cinema hall ambience with warm projector flare.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112
+  },
+  {
+    id: 'entranceHall',
+    name: 'Entrance Hall',
+    assetId: 'entrance_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1900,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#f59e0b', '#0ea5e9'],
+    description: 'Grand entrance hall with soft skylight fill.',
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 112
+  },
+  {
+    id: 'eventsHallInterior',
+    name: 'Events Hall Interior',
+    assetId: 'events_hall_interior',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1920,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#22c55e', '#fde047'],
+    description: 'Warm gala lighting with bright ceiling chandeliers.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112
+  },
+  {
+    id: 'hallOfFinfish',
+    name: 'Hall Of Finfish',
+    assetId: 'hall_of_finfish',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1940,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#0ea5e9', '#22c55e'],
+    description: 'Museum hall light with aqua reflections.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112
+  },
+  {
+    id: 'hallOfMammals',
+    name: 'Hall Of Mammals',
+    assetId: 'hall_of_mammals',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1960,
+    exposure: 1.11,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.04,
+    swatches: ['#f59e0b', '#fde047'],
+    description: 'Classic museum hall with warm skylight diffusion.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112
+  },
+  {
+    id: 'leadenhallMarket',
+    name: 'Leadenhall Market',
+    assetId: 'leadenhall_market',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 1980,
+    exposure: 1.13,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#f59e0b', '#0ea5e9'],
+    description: 'Historic market hall with glossy brass highlights.',
+    cameraHeightM: 1.64,
+    groundRadiusMultiplier: 6,
+    groundResolution: 112
+  },
+  {
+    id: 'marryHall',
+    name: 'Marry Hall',
+    assetId: 'marry_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2000,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#f472b6', '#f59e0b'],
+    description: 'Wedding hall ambience with warm lens bloom.',
+    cameraHeightM: 1.57,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112
+  },
+  {
+    id: 'mirroredHall',
+    name: 'Mirrored Hall',
+    assetId: 'mirrored_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2020,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#fef3c7', '#38bdf8'],
+    description: 'Mirror-lined hall with crisp ceiling reflections.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112
+  },
+  {
+    id: 'musicHall01',
+    name: 'Music Hall 01',
+    assetId: 'music_hall_01',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2040,
+    exposure: 1.12,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#f59e0b', '#ef4444'],
+    description: 'Golden theatre lighting with warm fill.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112
+  },
+  {
+    id: 'musicHall02',
+    name: 'Music Hall 02',
+    assetId: 'music_hall_02',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2060,
+    exposure: 1.13,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#f472b6', '#f59e0b'],
+    description: 'Warm stage hall ambiance with rich spotlight pool.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112
+  },
+  {
+    id: 'oldHall',
+    name: 'Old Hall',
+    assetId: 'old_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2080,
+    exposure: 1.11,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.03,
+    swatches: ['#f59e0b', '#1f2937'],
+    description: 'Vintage hall with warm light shafts and deep shadows.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112
+  },
+  {
+    id: 'broadwayPhotoStudioHall',
+    name: 'Broadway Photo Studio Hall',
+    assetId: 'broadway_photo_studio',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2100,
+    exposure: 1.14,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#f472b6', '#38bdf8'],
+    description: 'Studio hall with bright theatrical bounce.',
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 120
+  },
+  {
+    id: 'loftPhotoStudioHall',
+    name: 'Loft Photo Studio Hall',
+    assetId: 'loft_photo_studio',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2120,
+    exposure: 1.14,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#38bdf8', '#f59e0b'],
+    description: 'Loft studio with warm skylight interplay.',
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 120
+  },
+  {
+    id: 'londonPhotoStudioHall',
+    name: 'London Photo Studio Hall',
+    assetId: 'london_photo_studio',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2140,
+    exposure: 1.14,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#fde047', '#0ea5e9'],
+    description: 'London studio hall with neutral diffused daylight.',
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 120
+  },
+  {
+    id: 'schoolHall',
+    name: 'School Hall',
+    assetId: 'school_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2160,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#0ea5e9', '#f97316'],
+    description: 'Classic school hall with matte daylight ambience.',
+    cameraHeightM: 1.55,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 112
+  },
+  {
+    id: 'countryStudioHall',
+    name: 'Country Studio Hall',
+    assetId: 'studio_country_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2180,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.02,
+    swatches: ['#f472b6', '#16a34a'],
+    description: 'Cozy country hall with warm wood bounce and soft window key light.',
+    cameraHeightM: 1.55,
+    groundRadiusMultiplier: 4.5,
+    groundResolution: 112
+  }
+]);
+const POOL_ROYALE_DEFAULT_HDRI_ID = POOL_ROYALE_HDRI_VARIANTS[0]?.id;
+const DOMINO_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+  ...variant,
+  label: `${variant.name} HDRI`
+}));
+const DEFAULT_HDRI_INDEX = Math.max(
+  0,
+  DOMINO_HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID)
+);
+const DEFAULT_HDRI_VARIANT = DOMINO_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? DOMINO_HDRI_OPTIONS[0] ?? null;
+const resolveHdriVariant = (index) => {
+  const max = DOMINO_HDRI_OPTIONS.length - 1;
+  const idx = Number.isFinite(index) ? Math.min(Math.max(Math.round(index), 0), max) : DEFAULT_HDRI_INDEX;
+  return DOMINO_HDRI_OPTIONS[idx] ?? DOMINO_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? DOMINO_HDRI_OPTIONS[0];
+};
+
+const POLYHAVEN_THUMB = (id) => `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;
+const BASE_STOOL_THEMES = [
+  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f', price: 0, description: 'Default ruby cushions with noir legs.' },
+  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a', price: 210, description: 'Slate seats with midnight legs.' },
+  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a', price: 230, description: 'Teal cushions with deep green support.' },
+  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410', price: 250, description: 'Amber seats with rich brown legs.' },
+  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059', price: 270, description: 'Violet cushions with twilight framing.' },
+  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a', price: 290, description: 'Frosted charcoal seats with dark legs.' },
+  { id: 'leather', label: 'Leather', seatColor: '#6a4a32', legColor: '#1a1410', price: 320, description: 'Leather-wrapped seats with dark studio legs.' }
+];
+const POLYHAVEN_CHAIR_THEMES = [
+  { id: 'ArmChair_01', label: 'Arm Chair 01', source: 'polyhaven', assetId: 'ArmChair_01' },
+  { id: 'BarberShopChair_01', label: 'Barber Shop Chair 01', source: 'polyhaven', assetId: 'BarberShopChair_01' },
+  { id: 'GreenChair_01', label: 'Green Chair 01', source: 'polyhaven', assetId: 'GreenChair_01' },
+  { id: 'Rockingchair_01', label: 'Rockingchair 01', source: 'polyhaven', assetId: 'Rockingchair_01' },
+  { id: 'SchoolChair_01', label: 'School Chair 01', source: 'polyhaven', assetId: 'SchoolChair_01' },
+  { id: 'WoodenChair_01', label: 'Wooden Chair 01', source: 'polyhaven', assetId: 'WoodenChair_01' },
+  { id: 'bar_chair_round_01', label: 'Bar Chair Round', source: 'polyhaven', assetId: 'bar_chair_round_01' },
+  { id: 'chinese_armchair', label: 'Chinese Armchair', source: 'polyhaven', assetId: 'chinese_armchair' },
+  { id: 'dining_chair_02', label: 'Dining Chair 02', source: 'polyhaven', assetId: 'dining_chair_02' },
+  { id: 'gallinera_chair', label: 'Gallinera Chair', source: 'polyhaven', assetId: 'gallinera_chair' },
+  { id: 'mid_century_lounge_chair', label: 'Mid-Century Lounge', source: 'polyhaven', assetId: 'mid_century_lounge_chair' },
+  { id: 'modern_arm_chair_01', label: 'Modern Arm Chair', source: 'polyhaven', assetId: 'modern_arm_chair_01' },
+  { id: 'outdoor_table_chair_set_01', label: 'Outdoor Chair Set 01', source: 'polyhaven', assetId: 'outdoor_table_chair_set_01' },
+  { id: 'painted_wooden_chair_01', label: 'Painted Wooden Chair 01', source: 'polyhaven', assetId: 'painted_wooden_chair_01' },
+  { id: 'painted_wooden_chair_02', label: 'Painted Wooden Chair 02', source: 'polyhaven', assetId: 'painted_wooden_chair_02' },
+  { id: 'plastic_monobloc_chair_01', label: 'Plastic Monobloc Chair', source: 'polyhaven', assetId: 'plastic_monobloc_chair_01' },
+  { id: 'wheelchair_01', label: 'Wheelchair 01', source: 'polyhaven', assetId: 'wheelchair_01' }
+].map((option, index) => ({
+  ...option,
+  thumbnail: POLYHAVEN_THUMB(option.assetId),
+  price: 520 + index * 35,
+  description: `${option.label} with preserved original materials.`,
+  preserveMaterials: true
+}));
+const POLYHAVEN_TABLE_THEMES = [
+  { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
+  { id: 'WoodenTable_01', label: 'Wooden Table 01' },
+  { id: 'WoodenTable_02', label: 'Wooden Table 02' },
+  { id: 'WoodenTable_03', label: 'Wooden Table 03' },
+  { id: 'chinese_console_table', label: 'Chinese Console Table' },
+  { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
+  { id: 'coffee_table_round_01', label: 'Coffee Table Round 01' },
+  { id: 'gallinera_table', label: 'Gallinera Table' },
+  { id: 'gothic_coffee_table', label: 'Gothic Coffee Table' },
+  { id: 'industrial_coffee_table', label: 'Industrial Coffee Table' },
+  { id: 'modern_coffee_table_01', label: 'Modern Coffee Table 01' },
+  { id: 'modern_coffee_table_02', label: 'Modern Coffee Table 02' },
+  { id: 'outdoor_table_chair_set_01', label: 'Outdoor Table Chair Set 01' },
+  { id: 'painted_wooden_table', label: 'Painted Wooden Table' },
+  { id: 'round_wooden_table_01', label: 'Round Wooden Table 01' },
+  { id: 'round_wooden_table_02', label: 'Round Wooden Table 02' },
+  { id: 'side_table_01', label: 'Side Table 01' },
+  { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
+  { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' },
+  { id: 'wooden_picnic_table', label: 'Wooden Picnic Table' },
+  { id: 'wooden_table_02', label: 'Wooden Table 02 (Alt)' }
+].map((option, index) => ({
+  ...option,
+  assetId: option.id,
+  source: 'polyhaven',
+  thumbnail: POLYHAVEN_THUMB(option.id),
+  price: 980 + index * 40,
+  preserveMaterials: true,
+  description: option.description || `${option.label} with preserved Poly Haven materials.`
+}));
+const TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'domino-default',
+    label: 'Domino Default Table',
+    source: 'procedural',
+    thumbnail: POLYHAVEN_THUMB('WoodenTable_01')
+  },
+  {
+    id: 'murlan-default',
+    label: 'Murlan Default Table',
+    source: 'procedural',
+    thumbnail: POLYHAVEN_THUMB('WoodenTable_01'),
+    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+  },
+  ...POLYHAVEN_TABLE_THEMES
+]);
+const CHAIR_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'domino-default',
+    label: 'Domino Classic Chair',
+    source: 'procedural',
+    seatColor: DEFAULT_CHAIR_THEME.seatColor,
+    legColor: DEFAULT_CHAIR_THEME.legColor,
+    highlight: DEFAULT_CHAIR_THEME.highlight,
+    thumbnail: POLYHAVEN_THUMB('WoodenChair_01')
+  },
+  ...BASE_STOOL_THEMES,
+  ...POLYHAVEN_CHAIR_THEMES
+]);
 
 const clamp01f = (value) => Math.min(1, Math.max(0, value));
 const normalizeHue = (h) => {
@@ -1362,6 +1892,162 @@ function fitChairModelToFootprint(model) {
   model.position.add(offset);
 }
 
+const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+let sharedKtx2Loader = null;
+
+function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin?.('anonymous');
+
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch {}
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+}
+
+function prepareLoadedModel(model) {
+  if (!model) return;
+  model.traverse((obj) => {
+    if (!obj.isMesh) return;
+    obj.castShadow = false;
+    obj.receiveShadow = false;
+    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+    mats.forEach((mat) => {
+      if (!mat) return;
+      if (mat.map) mat.map.colorSpace = THREE.SRGBColorSpace;
+      if (mat.emissiveMap) mat.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+    });
+  });
+}
+
+function liftModelToGround(model, targetMinY = 0) {
+  const box = new THREE.Box3().setFromObject(model);
+  model.position.y += targetMinY - box.min.y;
+}
+
+function fitModelToHeight(model, targetHeight) {
+  const box = new THREE.Box3().setFromObject(model);
+  const currentHeight = box.max.y - box.min.y;
+  if (currentHeight > 0) {
+    const scale = targetHeight / currentHeight;
+    model.scale.multiplyScalar(scale);
+  }
+  liftModelToGround(model, 0);
+}
+
+function fitTableModelToArena(model) {
+  if (!model) return { surfaceY: TABLE_HEIGHT, radius: TABLE_RADIUS };
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxXZ = Math.max(size.x, size.z);
+  const targetHeight = TABLE_HEIGHT;
+  const targetDiameter = TABLE_RADIUS * 2;
+  const targetRadius = targetDiameter / 2;
+  const scaleY = size.y > 0 ? targetHeight / size.y : 1;
+  const scaleXZ = maxXZ > 0 ? targetDiameter / maxXZ : 1;
+
+  if (scaleY !== 1 || scaleXZ !== 1) {
+    model.scale.set(
+      model.scale.x * scaleXZ,
+      model.scale.y * scaleY,
+      model.scale.z * scaleXZ
+    );
+  }
+
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.add(new THREE.Vector3(-center.x, -scaledBox.min.y, -center.z));
+
+  const recenteredBox = new THREE.Box3().setFromObject(model);
+  const surfaceOffset = targetHeight - recenteredBox.max.y;
+  if (surfaceOffset !== 0) {
+    model.position.y += surfaceOffset;
+    recenteredBox.translate(new THREE.Vector3(0, surfaceOffset, 0));
+  }
+
+  const radius = Math.max(
+    Math.abs(recenteredBox.max.x),
+    Math.abs(recenteredBox.min.x),
+    Math.abs(recenteredBox.max.z),
+    Math.abs(recenteredBox.min.z),
+    targetRadius
+  );
+  return {
+    surfaceY: targetHeight,
+    radius
+  };
+}
+
+function buildPolyhavenModelUrls(assetId) {
+  if (!assetId) return [];
+  return [
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`,
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`
+  ];
+}
+
+async function loadPolyhavenModel(assetId, renderer = null) {
+  if (!assetId) throw new Error('Missing Poly Haven asset id');
+  const loader = createConfiguredGLTFLoader(renderer);
+  let gltf = null;
+  let lastError = null;
+  const urls = buildPolyhavenModelUrls(assetId);
+  for (const url of urls) {
+    try {
+      const resolvedUrl = new URL(url, window.location.href).href;
+      const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+      loader.setResourcePath?.(resourcePath);
+      loader.setPath?.('');
+      gltf = await loader.loadAsync(resolvedUrl);
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (!gltf) {
+    throw lastError || new Error(`Failed to load Poly Haven model ${assetId}`);
+  }
+  const model = gltf.scene || gltf.scenes?.[0];
+  if (!model) {
+    throw new Error(`Poly Haven model missing scene for ${assetId}`);
+  }
+  prepareLoadedModel(model);
+  return model;
+}
+
+async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0, renderer = null) {
+  const root = await loadPolyhavenModel(assetId, renderer);
+  const model = root.clone(true);
+  prepareLoadedModel(model);
+  fitModelToHeight(model, targetHeight);
+  if (rotationY) model.rotation.y += rotationY;
+  return model;
+}
+
+async function createPolyhavenTableInstance(assetId, rotationY = 0, renderer = null) {
+  const root = await loadPolyhavenModel(assetId, renderer);
+  const model = root.clone(true);
+  prepareLoadedModel(model);
+  fitTableModelToArena(model);
+  if (rotationY) model.rotation.y += rotationY;
+  return model;
+}
+
 function extractChairMaterials(model) {
   const upholstery = new Set();
   const metal = new Set();
@@ -1389,10 +2075,7 @@ function extractChairMaterials(model) {
 async function ensureMurlanChairTemplate() {
   if (chairTemplatePromise) return chairTemplatePromise;
   chairTemplatePromise = (async () => {
-    const loader = new GLTFLoader();
-    const draco = new DRACOLoader();
-    draco.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
-    loader.setDRACOLoader(draco);
+    const loader = createConfiguredGLTFLoader(renderer);
 
     let gltf = null;
     let lastError = null;
@@ -1460,6 +2143,77 @@ function cloneChairWithTheme(chairData, option) {
 
   return clone;
 }
+const pickPolyHavenHdriUrl = (json, preferred = DEFAULT_HDRI_RESOLUTIONS) => {
+  if (!json || typeof json !== 'object') return null;
+  const resolutions = Array.isArray(preferred) && preferred.length ? preferred : DEFAULT_HDRI_RESOLUTIONS;
+  for (const res of resolutions) {
+    const entry = json[res];
+    if (entry?.hdr) return entry.hdr;
+    if (entry?.exr) return entry.exr;
+  }
+  const fallback = Object.values(json).find((value) => value?.hdr || value?.exr);
+  if (!fallback) return null;
+  return fallback.hdr || fallback.exr || null;
+};
+
+async function resolvePolyHavenHdriUrl(config = {}) {
+  const preferred =
+    Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+      ? config.preferredResolutions
+      : DEFAULT_HDRI_RESOLUTIONS;
+  const fallbackRes = config?.fallbackResolution || preferred[0] || '4k';
+  const fallbackUrl =
+    config?.fallbackUrl ||
+    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;
+  if (config?.assetUrls && typeof config.assetUrls === 'object') {
+    for (const res of preferred) {
+      if (config.assetUrls[res]) return config.assetUrls[res];
+    }
+    const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
+    if (manual) return manual;
+  }
+  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) return config.assetUrl;
+  if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
+  try {
+    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
+    if (!response?.ok) return fallbackUrl;
+    const json = await response.json();
+    const picked = pickPolyHavenHdriUrl(json, preferred);
+    return picked || fallbackUrl;
+  } catch (error) {
+    console.warn('Failed to resolve Poly Haven HDRI url', error);
+    return fallbackUrl;
+  }
+}
+
+async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+  if (!renderer) return null;
+  const url = await resolvePolyHavenHdriUrl(config);
+  const lowerUrl = `${url ?? ''}`.toLowerCase();
+  const useExr = lowerUrl.endsWith('.exr');
+  const loader = useExr ? new EXRLoader() : new RGBELoader();
+  loader.setCrossOrigin?.('anonymous');
+  return new Promise((resolve) => {
+    loader.load(
+      url,
+      (texture) => {
+        const envMap = pmrem.fromEquirectangular(texture).texture;
+        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+        const skyboxMap = texture;
+        skyboxMap.name = `${config?.assetId ?? 'polyhaven'}-skybox`;
+        skyboxMap.mapping = THREE.EquirectangularReflectionMapping;
+        skyboxMap.needsUpdate = true;
+        resolve({ envMap, skyboxMap, url });
+      },
+      undefined,
+      (error) => {
+        console.warn('Failed to load Poly Haven HDRI', error);
+        resolve(null);
+      }
+    );
+  });
+}
+
 const hslString = (h, s, l) => {
   const sat = clamp01f(s);
   const light = clamp01f(l);
@@ -2101,6 +2855,9 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_SETUP_SECTIONS = [
+  { key: "environmentHdri", label: "HDR Environment", options: DOMINO_HDRI_OPTIONS },
+  { key: "tableModel", label: "Table Model", options: TABLE_MODEL_OPTIONS },
+  { key: "chairModel", label: "Chair Model", options: CHAIR_MODEL_OPTIONS },
   { key: "tableWood", label: "Table Wood", options: TABLE_WOOD_OPTIONS },
   { key: "tableCloth", label: "Table Cloth", options: TABLE_CLOTH_OPTIONS },
   { key: "tableBase", label: "Bazamenti", options: TABLE_BASE_OPTIONS },
@@ -2110,6 +2867,9 @@ const TABLE_SETUP_SECTIONS = [
 ];
 
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
+  environmentHdri: DOMINO_HDRI_OPTIONS,
+  tableModel: TABLE_MODEL_OPTIONS,
+  chairModel: CHAIR_MODEL_OPTIONS,
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
   tableBase: TABLE_BASE_OPTIONS,
@@ -2207,11 +2967,17 @@ const APPEARANCE_STORAGE_KEY = "dominoRoyalArenaAppearanceV2";
 const LEGACY_APPEARANCE_KEYS = ["dominoRoyalArenaAppearance"];
 let appearance = { ...DEFAULT_APPEARANCE };
 let dominoInventory = getDominoInventory();
+let disposeEnvironment = null;
+let hdriBuildToken = 0;
+let activeHdriVariant = DEFAULT_HDRI_VARIANT;
 
 function normalizeAppearance(raw) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const source = raw && typeof raw === "object" ? raw : {};
   const limits = [
+    ["environmentHdri", DOMINO_HDRI_OPTIONS.length],
+    ["tableModel", TABLE_MODEL_OPTIONS.length],
+    ["chairModel", CHAIR_MODEL_OPTIONS.length],
     ["tableWood", TABLE_WOOD_OPTIONS.length],
     ["tableCloth", TABLE_CLOTH_OPTIONS.length],
     ["tableBase", TABLE_BASE_OPTIONS.length],
@@ -2604,508 +3370,6 @@ tableG.rotation.y = 0;
 const piecesG = new THREE.Group();
 tableG.add(piecesG);
 
-/* ---------- Arena Dressings (Carpet & Walls) ---------- */
-const floor = new THREE.Mesh(
-  new THREE.CircleGeometry(FLOOR_RADIUS, 96),
-  new THREE.MeshStandardMaterial({ color: 0x0b1120, roughness: 0.92, metalness: 0.12 })
-);
-floor.rotation.x = -Math.PI / 2;
-floor.position.y = 0;
-floor.receiveShadow = true;
-arenaG.add(floor);
-
-const carpetTextures = getPoolCarpetTextures(renderer);
-// Match Pool Royale's red carpet finish.
-const carpetMat = new THREE.MeshStandardMaterial({
-  color: 0x8c2a2e,
-  roughness: 0.9,
-  metalness: 0.025
-});
-if (carpetTextures.map) {
-  carpetMat.map = carpetTextures.map;
-  carpetMat.map.needsUpdate = true;
-  carpetMat.map.repeat.set(5, 5);
-}
-if (carpetTextures.bump) {
-  carpetMat.bumpMap = carpetTextures.bump;
-  carpetMat.bumpScale = 0.18;
-  carpetMat.bumpMap.needsUpdate = true;
-  carpetMat.bumpMap.repeat.set(5, 5);
-}
-const carpet = new THREE.Mesh(new THREE.CircleGeometry(CARPET_RADIUS, 96), carpetMat);
-carpet.rotation.x = -Math.PI / 2;
-carpet.position.y = 0.01;
-carpet.receiveShadow = true;
-arenaG.add(carpet);
-
-// Align the arena walls with Pool Royale's light blue tone.
-const wallMaterial = new THREE.MeshStandardMaterial({
-  color: 0xb9ddff,
-  roughness: 0.88,
-  metalness: 0.06,
-  side: THREE.DoubleSide
-});
-const wall = new THREE.Mesh(
-  new THREE.CylinderGeometry(
-    ARENA_WALL_INNER_RADIUS,
-    ARENA_WALL_INNER_RADIUS * 1.02,
-    ARENA_WALL_HEIGHT,
-    80,
-    1,
-    true
-  ),
-  wallMaterial
-);
-wall.position.y = ARENA_WALL_CENTER_Y;
-wall.receiveShadow = false;
-wall.castShadow = false;
-arenaG.add(wall);
-
-const ARENA_DOOR_DIMENSIONS = Object.freeze({ width: 2.8, height: 3.4, thickness: 0.12 });
-const carbonFiberTextureBase = createCarbonFiberTexture(renderer, { tile: 4.5 });
-const hallwayDoorTexture = carbonFiberTextureBase ? carbonFiberTextureBase.clone() : null;
-if (hallwayDoorTexture) {
-  hallwayDoorTexture.repeat.set(2.6, 2.8);
-  hallwayDoorTexture.needsUpdate = true;
-}
-const hallwayDoorMaterialConfig = {
-  color: 0x1a1f26,
-  roughness: 0.32,
-  metalness: 0.55,
-  envMapIntensity: 1.05
-};
-if (hallwayDoorTexture) {
-  hallwayDoorMaterialConfig.map = hallwayDoorTexture;
-}
-const hallwayDoorMaterial = new THREE.MeshStandardMaterial(hallwayDoorMaterialConfig);
-const hallwayHandleMaterial = new THREE.MeshStandardMaterial({
-  color: 0xffd87c,
-  metalness: 1,
-  roughness: 0.18,
-  emissive: 0xffeab5,
-  emissiveIntensity: dimIntensity(0.28)
-});
-const hallwayDoorZ = ARENA_WALL_INNER_RADIUS - ARENA_DOOR_DIMENSIONS.thickness * 0.5;
-const hallwayDoorPivot = new THREE.Group();
-hallwayDoorPivot.position.set(-ARENA_DOOR_DIMENSIONS.width / 2, ARENA_DOOR_DIMENSIONS.height / 2, hallwayDoorZ);
-
-const hallwayDoor = new THREE.Mesh(
-  new THREE.BoxGeometry(
-    ARENA_DOOR_DIMENSIONS.width,
-    ARENA_DOOR_DIMENSIONS.height,
-    ARENA_DOOR_DIMENSIONS.thickness
-  ),
-  hallwayDoorMaterial
-);
-hallwayDoor.castShadow = true;
-hallwayDoor.receiveShadow = true;
-hallwayDoor.position.set(ARENA_DOOR_DIMENSIONS.width / 2, 0, 0);
-hallwayDoorPivot.add(hallwayDoor);
-
-const hallwayHandlePlate = new THREE.Mesh(
-  new THREE.BoxGeometry(0.16, 0.46, 0.02),
-  new THREE.MeshStandardMaterial({
-    color: 0xffd87c,
-    metalness: 0.95,
-    roughness: 0.18,
-    emissive: 0xffe6aa,
-    emissiveIntensity: dimIntensity(0.32)
-  })
-);
-hallwayHandlePlate.position.set(
-  ARENA_DOOR_DIMENSIONS.width - 0.6,
-  -0.35,
-  ARENA_DOOR_DIMENSIONS.thickness / 2 - 0.005
-);
-hallwayHandlePlate.castShadow = false;
-hallwayHandlePlate.receiveShadow = false;
-hallwayDoor.add(hallwayHandlePlate);
-
-const hallwayHandle = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.3, 24), hallwayHandleMaterial);
-hallwayHandle.rotation.z = Math.PI / 2;
-hallwayHandle.position.set(ARENA_DOOR_DIMENSIONS.width - 0.6, -0.35, ARENA_DOOR_DIMENSIONS.thickness / 2 + 0.03);
-hallwayHandle.castShadow = true;
-hallwayHandle.receiveShadow = false;
-hallwayDoor.add(hallwayHandle);
-
-const hallwayDoorFrame = new THREE.Mesh(
-  new THREE.BoxGeometry(
-    ARENA_DOOR_DIMENSIONS.width + 0.32,
-    ARENA_DOOR_DIMENSIONS.height + 0.28,
-    ARENA_DOOR_DIMENSIONS.thickness * 0.8
-  ),
-  new THREE.MeshStandardMaterial({
-    color: 0xf2d79b,
-    roughness: 0.18,
-    metalness: 0.94,
-    emissive: 0xffe4b5,
-    emissiveIntensity: dimIntensity(0.4)
-  })
-);
-hallwayDoorFrame.position.set(ARENA_DOOR_DIMENSIONS.width / 2, 0, -ARENA_DOOR_DIMENSIONS.thickness * 0.45);
-hallwayDoorFrame.castShadow = false;
-hallwayDoorFrame.receiveShadow = false;
-hallwayDoorPivot.add(hallwayDoorFrame);
-
-const hallwayDoorGroup = new THREE.Group();
-hallwayDoorGroup.add(hallwayDoorPivot);
-arenaG.add(hallwayDoorGroup);
-
-const ARENA_WALKWAY_LENGTH = 14;
-const ARENA_WALKWAY_WIDTH = 4.2;
-const walkwayFloorMaterial = new THREE.MeshStandardMaterial({
-  color: 0x08090f,
-  roughness: 0.24,
-  metalness: 0.72,
-  envMapIntensity: 1.1
-});
-const walkwayFloor = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH, ARENA_WALKWAY_LENGTH),
-  walkwayFloorMaterial
-);
-walkwayFloor.rotation.x = -Math.PI / 2;
-walkwayFloor.position.set(
-  0,
-  0.005,
-  hallwayDoorZ + ARENA_WALKWAY_LENGTH / 2 - ARENA_DOOR_DIMENSIONS.thickness * 0.5
-);
-walkwayFloor.receiveShadow = true;
-arenaG.add(walkwayFloor);
-
-const walkwayRunnerMaterialConfig = {
-  color: new THREE.Color(carpetMat.color.getHex()),
-  roughness: carpetMat.roughness,
-  metalness: carpetMat.metalness
-};
-if (carpetTextures.map) {
-  const walkwayMap = carpetTextures.map.clone();
-  walkwayMap.wrapS = walkwayMap.wrapT = THREE.RepeatWrapping;
-  walkwayMap.repeat.set(ARENA_WALKWAY_WIDTH / 1.6, ARENA_WALKWAY_LENGTH / 3.2);
-  walkwayMap.colorSpace = THREE.SRGBColorSpace;
-  walkwayMap.needsUpdate = true;
-  walkwayRunnerMaterialConfig.map = walkwayMap;
-}
-if (carpetTextures.bump) {
-  const walkwayBump = carpetTextures.bump.clone();
-  walkwayBump.wrapS = walkwayBump.wrapT = THREE.RepeatWrapping;
-  walkwayBump.repeat.set(ARENA_WALKWAY_WIDTH / 1.6, ARENA_WALKWAY_LENGTH / 3.2);
-  walkwayBump.needsUpdate = true;
-  walkwayRunnerMaterialConfig.bumpMap = walkwayBump;
-  walkwayRunnerMaterialConfig.bumpScale = 0.18;
-}
-const walkwayRunner = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH * 0.42, ARENA_WALKWAY_LENGTH * 0.92),
-  new THREE.MeshStandardMaterial(walkwayRunnerMaterialConfig)
-);
-walkwayRunner.rotation.x = -Math.PI / 2;
-walkwayRunner.position.set(0, walkwayFloor.position.y + 0.008, walkwayFloor.position.z);
-walkwayRunner.receiveShadow = true;
-arenaG.add(walkwayRunner);
-
-const walkwayTrimMat = new THREE.MeshStandardMaterial({
-  color: 0xba7c2c,
-  roughness: 0.26,
-  metalness: 0.88,
-  emissive: 0xffc978,
-  emissiveIntensity: dimIntensity(0.25)
-});
-const walkwayTrimGeo = new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.2, 0.12, 0.4);
-const walkwayFrontTrim = new THREE.Mesh(walkwayTrimGeo, walkwayTrimMat);
-walkwayFrontTrim.position.set(0, 0.06, hallwayDoorZ - 0.2);
-walkwayFrontTrim.castShadow = false;
-walkwayFrontTrim.receiveShadow = false;
-arenaG.add(walkwayFrontTrim);
-const walkwayOuterTrim = walkwayFrontTrim.clone();
-walkwayOuterTrim.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.2;
-arenaG.add(walkwayOuterTrim);
-
-const walkwaySideGeo = new THREE.BoxGeometry(0.35, 1.2, ARENA_WALKWAY_LENGTH);
-const walkwayWallTexture = textureLoader.load(
-  'https://images.unsplash.com/photo-1549187774-b4e9b0445b41?auto=format&fit=crop&w=1600&q=80'
-);
-walkwayWallTexture.wrapS = THREE.RepeatWrapping;
-walkwayWallTexture.wrapT = THREE.RepeatWrapping;
-walkwayWallTexture.colorSpace = THREE.SRGBColorSpace;
-walkwayWallTexture.repeat.set(ARENA_WALKWAY_LENGTH / 2.2, 1.4);
-const walkwaySideMat = new THREE.MeshStandardMaterial({
-  map: walkwayWallTexture,
-  roughness: 0.48,
-  metalness: 0.4,
-  envMapIntensity: 0.8
-});
-const walkwaySideAccentGeo = new THREE.BoxGeometry(0.12, 0.9, ARENA_WALKWAY_LENGTH - 0.6);
-const walkwaySideAccentMat = new THREE.MeshStandardMaterial({
-  color: 0x321c46,
-  roughness: 0.32,
-  metalness: 0.58,
-  emissive: 0xffb964,
-  emissiveIntensity: dimIntensity(0.4)
-});
-const walkwaySideCrownGeo = new THREE.BoxGeometry(0.38, 0.1, ARENA_WALKWAY_LENGTH);
-const walkwaySideCrownMat = new THREE.MeshStandardMaterial({
-  color: 0xf2c36b,
-  roughness: 0.22,
-  metalness: 0.94
-});
-
-function createWalkwaySide(offsetX) {
-  const sideGroup = new THREE.Group();
-  const base = new THREE.Mesh(walkwaySideGeo, walkwaySideMat);
-  base.castShadow = true;
-  base.receiveShadow = true;
-  sideGroup.add(base);
-
-  const accent = new THREE.Mesh(walkwaySideAccentGeo, walkwaySideAccentMat);
-  accent.position.set(offsetX > 0 ? -0.11 : 0.11, 0, 0);
-  accent.castShadow = false;
-  accent.receiveShadow = true;
-  sideGroup.add(accent);
-
-  const crown = new THREE.Mesh(walkwaySideCrownGeo, walkwaySideCrownMat);
-  crown.position.y = 0.55;
-  crown.castShadow = true;
-  crown.receiveShadow = false;
-  sideGroup.add(crown);
-
-  const lightStripGeo = new THREE.BoxGeometry(0.18, 0.08, ARENA_WALKWAY_LENGTH - 0.4);
-  const lightStripMat = new THREE.MeshStandardMaterial({
-    color: 0xffd27e,
-    emissive: 0xfff1b5,
-    emissiveIntensity: dimIntensity(0.85),
-    metalness: 0.7,
-    roughness: 0.18
-  });
-  const lightStrip = new THREE.Mesh(lightStripGeo, lightStripMat);
-  lightStrip.position.set(offsetX > 0 ? -0.14 : 0.14, -0.25, 0);
-  lightStrip.castShadow = false;
-  lightStrip.receiveShadow = false;
-  sideGroup.add(lightStrip);
-
-  sideGroup.position.set(offsetX, 0.6, walkwayFloor.position.z);
-  arenaG.add(sideGroup);
-  return sideGroup;
-}
-
-const walkwaySideLeft = createWalkwaySide(-ARENA_WALKWAY_WIDTH / 2 - 0.175);
-const walkwaySideRight = createWalkwaySide(ARENA_WALKWAY_WIDTH / 2 + 0.175);
-
-const walkwayPortalHeaderTexture = carbonFiberTextureBase ? carbonFiberTextureBase.clone() : null;
-if (walkwayPortalHeaderTexture) {
-  walkwayPortalHeaderTexture.repeat.set((ARENA_WALKWAY_WIDTH + 0.4) / 1.4, 1.6);
-  walkwayPortalHeaderTexture.needsUpdate = true;
-}
-const walkwayPortalHeaderMaterialConfig = {
-  color: 0x1c1f26,
-  metalness: 0.68,
-  roughness: 0.28,
-  emissive: 0x140812,
-  emissiveIntensity: dimIntensity(0.35),
-  envMapIntensity: 0.9
-};
-if (walkwayPortalHeaderTexture) {
-  walkwayPortalHeaderMaterialConfig.map = walkwayPortalHeaderTexture;
-}
-const walkwayPortalHeader = new THREE.Mesh(
-  new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.4, 0.22, 0.5),
-  new THREE.MeshStandardMaterial(walkwayPortalHeaderMaterialConfig)
-);
-walkwayPortalHeader.position.set(0, 1.42, hallwayDoorZ - 0.05);
-walkwayPortalHeader.castShadow = true;
-arenaG.add(walkwayPortalHeader);
-
-const walkwayPortalCrown = new THREE.Mesh(
-  new THREE.TorusGeometry((ARENA_WALKWAY_WIDTH + 0.4) / 2, 0.05, 16, 48),
-  new THREE.MeshStandardMaterial({
-    color: 0xf7d891,
-    emissive: 0xffeeba,
-    emissiveIntensity: dimIntensity(0.6),
-    metalness: 0.92,
-    roughness: 0.15
-  })
-);
-walkwayPortalCrown.rotation.x = Math.PI / 2;
-walkwayPortalCrown.position.set(0, 1.52, hallwayDoorZ - 0.12);
-walkwayPortalCrown.castShadow = false;
-arenaG.add(walkwayPortalCrown);
-
-const walkwayCeiling = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH + 0.8, ARENA_WALKWAY_LENGTH + 1.2),
-  new THREE.MeshStandardMaterial({
-    color: 0x18111f,
-    side: THREE.DoubleSide,
-    roughness: 0.35,
-    metalness: 0.45,
-    emissive: 0x1a0a13,
-    emissiveIntensity: dimIntensity(0.28)
-  })
-);
-walkwayCeiling.rotation.x = Math.PI / 2;
-walkwayCeiling.position.set(0, 1.95, walkwayFloor.position.z);
-walkwayCeiling.receiveShadow = false;
-arenaG.add(walkwayCeiling);
-
-const chandelier = new THREE.Group();
-const chandelierRing = new THREE.Mesh(
-  new THREE.TorusGeometry(0.95, 0.08, 24, 64),
-  new THREE.MeshStandardMaterial({
-    color: 0xf2d79b,
-    emissive: 0xfff0c5,
-    emissiveIntensity: dimIntensity(0.8),
-    metalness: 0.9,
-    roughness: 0.18
-  })
-);
-chandelier.add(chandelierRing);
-const chandelierCore = new THREE.Mesh(
-  new THREE.CylinderGeometry(0.08, 0.16, 0.6, 24),
-  new THREE.MeshStandardMaterial({
-    color: 0x21142d,
-    metalness: 0.65,
-    roughness: 0.28,
-    emissive: 0x110712,
-    emissiveIntensity: dimIntensity(0.3)
-  })
-);
-chandelierCore.position.y = -0.35;
-chandelier.add(chandelierCore);
-chandelier.position.set(0, walkwayCeiling.position.y - 0.18, walkwayFloor.position.z);
-arenaG.add(chandelier);
-
-const walkwayFrontLight = new THREE.Mesh(
-  new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.25, 0.08, 0.12),
-  new THREE.MeshStandardMaterial({
-    color: 0xffd89a,
-    emissive: 0xffecb3,
-    emissiveIntensity: dimIntensity(0.9),
-    metalness: 0.78,
-    roughness: 0.22
-  })
-);
-walkwayFrontLight.position.set(0, 0.18, hallwayDoorZ + 0.18);
-arenaG.add(walkwayFrontLight);
-const walkwayRearLight = walkwayFrontLight.clone();
-walkwayRearLight.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.25;
-arenaG.add(walkwayRearLight);
-
-const hallwayAmbient = new THREE.PointLight(0xffe2b5, dimIntensity(1.3), 18, 1.8);
-hallwayAmbient.position.set(0, walkwayCeiling.position.y - 0.05, walkwayFloor.position.z);
-hallwayAmbient.castShadow = true;
-arenaG.add(hallwayAmbient);
-
-const hallwayDoorState = {
-  pivot: hallwayDoorPivot,
-  openAngle: THREE.MathUtils.degToRad(100),
-  closedAngle: 0
-};
-const walkwayFarZ = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2;
-const walkwayEntryZ = walkwayFarZ + 1.5;
-
-function easeInOutCubic(t) {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
-}
-
-let entrySequenceActive = false;
-let entryStartTime = 0;
-let entryCameraCurve = null;
-let entryTargetCurve = null;
-const ENTRY_TOTAL_DURATION = 6500;
-const ENTRY_SEAT_REMOVAL_PROGRESS = 0.78;
-
-function configureEntryCurves(finalPosition, target = CAMERA_TARGET) {
-  const approachHeight = 1.55;
-  const interiorHeight = CHAIR_BASE_HEIGHT + SEAT_THICKNESS + 0.35;
-  entryCameraCurve = new THREE.CatmullRomCurve3(
-    [
-      new THREE.Vector3(0, approachHeight, walkwayEntryZ),
-      new THREE.Vector3(0, approachHeight, hallwayDoorZ + 0.6),
-      new THREE.Vector3(0, interiorHeight, hallwayDoorZ - 3.4),
-      finalPosition.clone()
-    ],
-    false,
-    'catmullrom',
-    0.45
-  );
-  entryTargetCurve = new THREE.CatmullRomCurve3(
-    [
-      new THREE.Vector3(0, 1.35, hallwayDoorZ - 1.4),
-      new THREE.Vector3(0, interiorHeight, hallwayDoorZ - 2.8),
-      target.clone()
-    ],
-    false,
-    'catmullrom',
-    0.45
-  );
-}
-
-function startHallwayEntry() {
-  fitCamera();
-  const target = getActiveCameraTarget();
-  const finalDesired = clampCameraPosition(getDesiredCameraPosition(target), target);
-  configureEntryCurves(finalDesired, target);
-  entrySequenceActive = true;
-  entryStartTime = performance.now();
-  controls.enabled = false;
-  cameraHasUserControl = false;
-  if (entryCameraCurve) {
-    const startPoint = entryCameraCurve.getPoint(0);
-    camera.position.copy(startPoint);
-  }
-  if (entryTargetCurve) {
-    controls.target.copy(entryTargetCurve.getPoint(0));
-  } else {
-    controls.target.copy(CAMERA_TARGET);
-  }
-  if (hallwayDoorState) {
-    hallwayDoorState.pivot.rotation.y = hallwayDoorState.closedAngle;
-  }
-}
-
-function updateEntrySequence(now) {
-  if (!entrySequenceActive) {
-    return;
-  }
-  const timestamp = Number.isFinite(now) ? now : performance.now();
-  const elapsed = Math.max(0, timestamp - entryStartTime);
-  const progress = Math.min(elapsed / ENTRY_TOTAL_DURATION, 1);
-
-  const doorPhase = easeInOutCubic(Math.min(progress / 0.35, 1));
-  if (hallwayDoorState?.pivot) {
-    const angle = THREE.MathUtils.lerp(
-      hallwayDoorState.closedAngle,
-      hallwayDoorState.closedAngle - hallwayDoorState.openAngle,
-      doorPhase
-    );
-    hallwayDoorState.pivot.rotation.y = angle;
-  }
-
-  if (entryCameraCurve) {
-    const cameraPhase = easeInOutCubic(Math.min(Math.max((progress - 0.05) / 0.85, 0), 1));
-    const point = entryCameraCurve.getPoint(cameraPhase);
-    camera.position.copy(point);
-  }
-
-  if (entryTargetCurve) {
-    const targetPhase = easeInOutCubic(Math.min(Math.max((progress - 0.08) / 0.75, 0), 1));
-    const targetPoint = entryTargetCurve.getPoint(targetPhase);
-    controls.target.copy(targetPoint);
-  }
-
-  if (shouldRunHallwayEntry && seatLabelShouldDisplay && progress >= ENTRY_SEAT_REMOVAL_PROGRESS) {
-    disposeSeatLabel();
-  }
-
-  if (progress >= 1) {
-    entrySequenceActive = false;
-    controls.enabled = true;
-    controls.target.copy(CAMERA_TARGET);
-    if (shouldRunHallwayEntry && seatLabelShouldDisplay) {
-      disposeSeatLabel();
-    }
-    positionCameraForViewport({ force: true });
-  }
-}
 
 /* ---------- Shapes & Table Build ---------- */
 function createRegularPolygonShape(sides = 8, radius = 1) {
@@ -3668,6 +3932,55 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   tableParts.trim = trim;
 })();
 
+const tableModelGroup = new THREE.Group();
+tableG.add(tableModelGroup);
+let tableModelToken = 0;
+
+function setProceduralTableVisibility(visible) {
+  ['top', 'rim', 'accent', 'column', 'base', 'trim'].forEach((key) => {
+    const mesh = tableParts[key];
+    if (mesh) {
+      mesh.visible = visible;
+    }
+  });
+}
+
+function clearTableModelGroup() {
+  while (tableModelGroup.children.length) {
+    const child = tableModelGroup.children.pop();
+    if (!child) continue;
+    child.parent?.remove(child);
+    child.traverse?.((obj) => {
+      if (!obj.isMesh) return;
+      obj.geometry?.dispose?.();
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => mat?.dispose?.());
+    });
+  }
+}
+
+async function buildTableModel(option = TABLE_MODEL_OPTIONS[appearance.tableModel] ?? TABLE_MODEL_OPTIONS[0]) {
+  const token = ++tableModelToken;
+  clearTableModelGroup();
+  if (!option || option.source !== 'polyhaven' || !option.assetId) {
+    setProceduralTableVisibility(true);
+    return;
+  }
+
+  setProceduralTableVisibility(false);
+  try {
+    const model = await createPolyhavenTableInstance(option.assetId, option.modelRotation || 0, renderer);
+    if (token !== tableModelToken) {
+      model.traverse?.((obj) => obj.geometry?.dispose?.());
+      return;
+    }
+    tableModelGroup.add(model);
+  } catch (error) {
+    console.warn('Failed to load table model', error);
+    setProceduralTableVisibility(true);
+  }
+}
+
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SCALE = 1.5 * 1.22; // upscale tiles for stronger readability
 const DOMINO_WORLD_SCALE = SCALE * DOMINO_SCALE;
@@ -3978,7 +4291,13 @@ function applyAppearanceChange({ refresh = true } = {}) {
       material.roughnessMap.needsUpdate = true;
     }
   });
-  buildChairs(CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME);
+  const hdriVariant = resolveHdriVariant(appearance.environmentHdri);
+  applyHdriEnvironment(hdriVariant);
+  buildTableModel(TABLE_MODEL_OPTIONS[appearance.tableModel] ?? TABLE_MODEL_OPTIONS[0]);
+  buildChairs({
+    chairModel: CHAIR_MODEL_OPTIONS[appearance.chairModel] ?? CHAIR_MODEL_OPTIONS[0],
+    chairTheme: CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME
+  });
   renderHands();
   renderChain();
   renderBoneyardStack();
@@ -4001,6 +4320,83 @@ function applyFrameRateSelection(optionId, { refreshUi = true } = {}) {
   }
 }
 
+async function applyHdriEnvironment(variantConfig = activeHdriVariant || DEFAULT_HDRI_VARIANT) {
+  const activeVariant = variantConfig || activeHdriVariant || DEFAULT_HDRI_VARIANT;
+  if (!activeVariant) return;
+  const token = ++hdriBuildToken;
+  const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
+  if (!envResult?.envMap || token !== hdriBuildToken) return;
+  if (disposeEnvironment) {
+    disposeEnvironment();
+  }
+  let skybox = null;
+  const cameraHeight =
+    Math.max(activeVariant?.cameraHeightM ?? 1.5, 0.8);
+  const radiusMultiplier =
+    typeof activeVariant?.groundRadiusMultiplier === 'number'
+      ? activeVariant.groundRadiusMultiplier
+      : 6;
+  const sceneSpan = TABLE_RADIUS;
+  const groundRadius = Math.max(sceneSpan * radiusMultiplier, 24);
+  const skyboxResolution = Math.max(16, Math.floor(activeVariant?.groundResolution ?? 96));
+  const skyboxRadius = Math.max(groundRadius, cameraHeight * 2.5, 24);
+  if (envResult.skyboxMap && skyboxRadius > 0 && cameraHeight > 0) {
+    try {
+      skybox = new GroundedSkybox(envResult.skyboxMap, cameraHeight, skyboxRadius, skyboxResolution);
+      skybox.position.y = HDRI_FLOOR_Y + cameraHeight;
+      skybox.material.depthWrite = false;
+      skybox.userData.cameraHeight = cameraHeight;
+      scene.background = null;
+      scene.add(skybox);
+      envSkybox = skybox;
+      envSkyboxTexture = envResult.skyboxMap;
+      baseSkyboxScale = skybox.scale?.x ?? 1;
+    } catch (error) {
+      console.warn('Failed to create grounded HDRI skybox', error);
+      skybox = null;
+    }
+  }
+  scene.environment = envResult.envMap;
+  if (!skybox) {
+    scene.background = envResult.envMap;
+    envSkybox = null;
+    envSkyboxTexture = null;
+    if ('backgroundIntensity' in scene && typeof activeVariant?.backgroundIntensity === 'number') {
+      scene.backgroundIntensity = activeVariant.backgroundIntensity;
+    }
+  }
+  if (typeof activeVariant?.environmentIntensity === 'number') {
+    scene.environmentIntensity = activeVariant.environmentIntensity;
+  }
+  renderer.toneMappingExposure = activeVariant?.exposure ?? renderer.toneMappingExposure;
+  envTexture = envResult.envMap;
+  baseCameraRadius = camera.position.distanceTo(getActiveCameraTarget());
+  syncSkyboxToCamera();
+  disposeEnvironment = () => {
+    if (scene) {
+      if (scene.environment === envResult.envMap) {
+        scene.environment = null;
+      }
+      if (!skybox && scene.background === envResult.envMap) {
+        scene.background = null;
+      }
+    }
+    envResult.envMap.dispose?.();
+    if (skybox) {
+      skybox.parent?.remove(skybox);
+      skybox.geometry?.dispose?.();
+      skybox.material?.dispose?.();
+      if (envSkybox === skybox) {
+        envSkybox = null;
+      }
+    }
+    if (envResult.skyboxMap) {
+      envResult.skyboxMap.dispose?.();
+    }
+  };
+  activeHdriVariant = activeVariant;
+}
+
 window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
   const targetAccount = resolveDominoAccountId(event?.detail?.accountId);
   const currentAccount = resolveDominoAccountId();
@@ -4018,6 +4414,23 @@ function createOptionPreview(key, option) {
   swatch.style.borderRadius = '0.75rem';
   swatch.style.border = '1px solid rgba(255,255,255,0.12)';
   switch (key) {
+    case 'environmentHdri': {
+      const [a, b] = Array.isArray(option.swatches) && option.swatches.length >= 2
+        ? option.swatches
+        : ['#1f2937', '#0f172a'];
+      swatch.style.background = `linear-gradient(135deg, ${a}, ${b})`;
+      break;
+    }
+    case 'tableModel':
+    case 'chairModel': {
+      swatch.style.background = '#0f172a';
+      if (option.thumbnail) {
+        swatch.style.backgroundImage = `url(${option.thumbnail})`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      }
+      break;
+    }
     case 'tableWood':
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';
@@ -4391,9 +4804,14 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
 
-    const chair = chairData
-      ? cloneChairWithTheme(chairData, option)
-      : createDominoChair(option, renderer, sharedMaterials);
+    let chair = null;
+    if (chairData) {
+      chair = chairData.preserveOriginal
+        ? chairData.chairTemplate.clone(true)
+        : cloneChairWithTheme(chairData, option);
+    } else {
+      chair = createDominoChair(option, renderer, sharedMaterials);
+    }
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 
@@ -4412,9 +4830,31 @@ function placeChairsWithOption(option, chairData, token) {
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
 }
 
-async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
+async function buildChairs({
+  chairModel = CHAIR_MODEL_OPTIONS[appearance.chairModel] ?? CHAIR_MODEL_OPTIONS[0],
+  chairTheme = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME
+} = {}) {
   const token = ++chairBuildToken;
-  const chairDataPromise = ensureMurlanChairTemplate().catch((error) => {
+  const resolvedTheme = chairModel?.seatColor ? chairModel : chairTheme;
+  const chairDataPromise = (async () => {
+    if (chairModel?.source === 'polyhaven' && chairModel?.assetId) {
+      const model = await createPolyhavenInstance(
+        chairModel.assetId,
+        TARGET_CHAIR_SIZE.y - TARGET_CHAIR_MIN_Y,
+        chairModel.modelRotation || 0,
+        renderer
+      );
+      fitChairModelToFootprint(model);
+      chairTemplateBounds = new THREE.Box3().setFromObject(model);
+      return {
+        chairTemplate: model,
+        materials: extractChairMaterials(model),
+        preserveOriginal: true
+      };
+    }
+    const data = await ensureMurlanChairTemplate();
+    return { ...data, preserveOriginal: false };
+  })().catch((error) => {
     console.warn("Falling back to procedural chair for Domino", error);
     return null;
   });
@@ -4424,12 +4864,12 @@ async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?
     new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
   ]);
 
-  placeChairsWithOption(option, chairData, token);
+  placeChairsWithOption(resolvedTheme, chairData, token);
 
   if (!chairData) {
     chairDataPromise.then((resolved) => {
       if (!resolved || token !== chairBuildToken) return;
-      placeChairsWithOption(option, resolved, token);
+      placeChairsWithOption(resolvedTheme, resolved, token);
     });
   }
 }
@@ -5850,7 +6290,6 @@ function tick(now){
   const deltaSeconds = Math.min(0.2, Math.max(0, step / 1000));
   monitorFrameHealth(elapsed, timing);
 
-  updateEntrySequence(current);
   updateDrawAnimations(current);
   updatePlacementAnimations(current);
   updateWinnerHighlight(current);
@@ -5863,39 +6302,14 @@ let lastFrameTime = performance.now();
 requestAnimationFrame(tick);
 function onResize(){
   applyRendererQuality(frameQuality);
-  if (entrySequenceActive) {
-    fitCamera();
-    const target = getActiveCameraTarget();
-    const finalDesired = clampCameraPosition(getDesiredCameraPosition(target), target);
-    configureEntryCurves(finalDesired, target);
-    const now = performance.now();
-    const elapsed = Math.max(0, now - entryStartTime);
-    const progress = Math.min(elapsed / ENTRY_TOTAL_DURATION, 1);
-    if (entryCameraCurve) {
-      const cameraPhase = easeInOutCubic(Math.min(Math.max((progress - 0.05) / 0.85, 0), 1));
-      const point = entryCameraCurve.getPoint(cameraPhase);
-      camera.position.copy(point);
-    }
-    if (entryTargetCurve) {
-      const targetPhase = easeInOutCubic(Math.min(Math.max((progress - 0.08) / 0.75, 0), 1));
-      const targetPoint = entryTargetCurve.getPoint(targetPhase);
-      controls.target.copy(targetPoint);
-    }
-  } else {
-    positionCameraForViewport();
-  }
+  positionCameraForViewport();
   updateSeatBadgePositions();
 }
 addEventListener('resize', onResize); if(window.visualViewport){ visualViewport.addEventListener('resize', onResize); }
 document.addEventListener('visibilitychange', () => {
   slowFrameAccumulatorMs = 0;
 });
-
-if (shouldRunHallwayEntry) {
-  startHallwayEntry();
-} else {
-  positionCameraForViewport({ force: true });
-}
+positionCameraForViewport({ force: true });
 </script>
 </body>
 </html>

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,4 +1,28 @@
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from './poolRoyaleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+
+const DEFAULT_TABLE_MODEL = Object.freeze({
+  id: 'domino-default',
+  label: 'Domino Default Table',
+  source: 'procedural'
+});
+
+const DEFAULT_CHAIR_MODEL = Object.freeze({
+  id: 'domino-default',
+  label: 'Domino Classic Chair',
+  source: 'procedural'
+});
+
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
+  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    id: variant.id,
+    label: `${variant.name} HDRI`
+  })),
+  tableModel: [DEFAULT_TABLE_MODEL, ...MURLAN_TABLE_THEMES.map(({ id, label }) => ({ id, label }))],
+  chairModel: [DEFAULT_CHAIR_MODEL, ...MURLAN_STOOL_THEMES.map(({ id, label }) => ({ id, label }))],
   tableWood: [
     { id: 'oakEstate', label: 'Lis Estate' },
     { id: 'teakStudio', label: 'Tik Studio' }
@@ -62,6 +86,30 @@ export const DOMINO_ROYAL_OPTION_LABELS = Object.freeze(
 );
 
 export const DOMINO_ROYAL_STORE_ITEMS = [
+  ...POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    id: `domino-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 1400,
+    description: variant.description ?? 'Premium HDR environment for Domino Royal.'
+  })).slice(1),
+  ...MURLAN_TABLE_THEMES.filter((theme) => theme.id !== DEFAULT_TABLE_MODEL.id).map((theme, idx) => ({
+    id: `domino-table-${theme.id}`,
+    type: 'tableModel',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 900 + idx * 35,
+    description: theme.description ?? 'Alternate table model with preserved materials.'
+  })),
+  ...MURLAN_STOOL_THEMES.filter((theme) => theme.id !== DEFAULT_CHAIR_MODEL.id).map((theme, idx) => ({
+    id: `domino-chair-model-${theme.id}`,
+    type: 'chairModel',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 480 + idx * 20,
+    description: theme.description ?? 'Alternate chair model with preserved materials.'
+  })),
   ...DOMINO_ROYAL_OPTION_SETS.tableWood.slice(1).map((option) => ({
     id: `domino-wood-${option.id}`,
     type: 'tableWood',
@@ -115,7 +163,13 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
 export const DOMINO_ROYAL_DEFAULT_LOADOUT = Object.entries(DOMINO_ROYAL_OPTION_SETS).map(
   ([type, options]) => ({
     type,
-    optionId: options[0]?.id,
-    label: options[0]?.label
+    optionId:
+      type === 'environmentHdri'
+        ? POOL_ROYALE_DEFAULT_HDRI_ID
+        : options[0]?.id,
+    label:
+      type === 'environmentHdri'
+        ? DOMINO_ROYAL_OPTION_SETS.environmentHdri.find((option) => option.id === POOL_ROYALE_DEFAULT_HDRI_ID)?.label
+        : options[0]?.label
   })
 );

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -177,6 +177,9 @@ const MURLAN_TYPE_LABELS = {
 };
 
 const DOMINO_TYPE_LABELS = {
+  environmentHdri: 'HDR Environments',
+  tableModel: 'Table Models',
+  chairModel: 'Chair Models',
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',


### PR DESCRIPTION
### Motivation
- Replace the fixed Domino arena dressing (floor, walls, carpet, static lights) with HDRI-driven environments to match Pool Royale visuals.
- Reuse the Pool Royale HDRI catalog and Murlan/PolyHaven table & chair assets so Domino can present high-quality 4k HDR environments and preserve original materials.
- Allow players to select HDRI, table model, and chair model from the Domino setup UI and store, using the same techniques as Murlan Royale.
- Keep the sky/background visually coherent when the user zooms by scaling a grounded skybox in sync with camera radius.

### Description
- Added `environmentHdri`, `tableModel`, and `chairModel` option sets to `webapp/src/config/dominoRoyalInventoryConfig.js` and exposed purchasable store items for HDRIs, table models, and chair models.
- Reworked `webapp/public/domino-royal.html` to remove the static floor/walls/carpet/lighting and add PolyHaven HDRI loading (`RGBELoader`/`EXRLoader`), PMREM usage, `GroundedSkybox` creation, and `syncSkyboxToCamera` to scale the skybox with camera distance.
- Implemented PolyHaven model loading and preparation utilities (`createConfiguredGLTFLoader`, `loadPolyhavenModel`, `createPolyhavenInstance`, `createPolyhavenTableInstance`) plus a `tableModelGroup` and `buildTableModel` to load/fit external table models while preserving procedural fallback.
- Extended chair building to support PolyHaven chair models and preserved materials, and updated store UI labels in `webapp/src/pages/Store.jsx` to include `environmentHdri`, `tableModel`, and `chairModel` types.

### Testing
- Launched a local static server (`python -m http.server`) and ran a Playwright script to load `/domino-royal.html` and capture a screenshot to verify HDRI skybox and table/chair loading, which completed successfully and produced an artifact screenshot.
- No automated unit tests were added; visual end-to-end rendering verification was performed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539183b24c8328b2253485e58dad48)