### PR TITLE
Domino Royal: add HDRI environments, grounded skybox zoom sync, and Murlan table/chair support

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -120,10 +120,16 @@
 <script type="module">
 import * as THREE from "https://esm.sh/three@0.160.0";
 import { OrbitControls } from "https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js";
-import { RoomEnvironment } from "https://esm.sh/three@0.160.0/examples/jsm/environments/RoomEnvironment.js";
 import { RoundedBoxGeometry } from "https://esm.sh/three@0.160.0/examples/jsm/geometries/RoundedBoxGeometry.js";
 import { GLTFLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js";
 import { DRACOLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js";
+import { KTX2Loader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/KTX2Loader.js";
+import { MeshoptDecoder } from "https://esm.sh/three@0.160.0/examples/jsm/libs/meshopt_decoder.module.js";
+import { RGBELoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/RGBELoader.js";
+import { EXRLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/EXRLoader.js";
+import { GroundedSkybox } from "https://esm.sh/three@0.160.0/examples/jsm/objects/GroundedSkybox.js";
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from "/src/config/poolRoyaleInventoryConfig.js";
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from "/src/config/murlanThemes.js";
 import "./flag-emojis.js";
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -187,6 +193,25 @@ const FRAME_DROP_THRESHOLD = 1.35;
 const FRAME_DROP_WINDOW_MS = 3200;
 const FRAME_FAILSAFE_COOLDOWN_MS = 9000;
 const FEEDBACK_STORAGE_KEY = 'dominoRoyalFeedback';
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
+const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
+const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
+const MIN_HDRI_RADIUS = 24;
+const HDRI_GROUNDED_RESOLUTION = 96;
+const HDRI_UNITS_PER_METER = 1;
+const HDRI_OPTIONS = Object.freeze(
+  POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    ...variant,
+    preferredResolutions: DEFAULT_HDRI_RESOLUTIONS,
+    fallbackResolution: '4k'
+  }))
+);
+const DEFAULT_HDRI_INDEX = Math.max(
+  0,
+  HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID)
+);
+const DEFAULT_HDRI_VARIANT = HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? HDRI_OPTIONS[0] ?? null;
 
 function detectCoarsePointer() {
   if (typeof window === 'undefined') {
@@ -743,9 +768,15 @@ renderer.domElement.style.touchAction = 'none';
 
 const scene = new THREE.Scene();
 const textureLoader = new THREE.TextureLoader();
-const pmrem = new THREE.PMREMGenerator(renderer);
-const envTex = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-scene.environment = envTex;
+scene.background = new THREE.Color(0x050812);
+let envTexture = null;
+let envSkybox = null;
+let envSkyboxTexture = null;
+let disposeEnvironment = null;
+let environmentFloorY = 0;
+let baseSkyboxScale = 1;
+let baseCameraRadius = 1;
+let syncSkyboxToCamera = () => {};
 
 const LIGHT_INTENSITY_FACTOR = 1;
 const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
@@ -995,6 +1026,16 @@ controls.zoomSpeed = 1.05;
 controls.enablePan = true;
 controls.panSpeed = 0.9;
 controls.screenSpacePanning = true;
+syncSkyboxToCamera = () => {
+  if (!envSkybox) return;
+  const radius = camera.position.distanceTo(controls.target);
+  if (!Number.isFinite(baseCameraRadius) || baseCameraRadius === 0) {
+    baseCameraRadius = radius || 1;
+  }
+  const scale = THREE.MathUtils.clamp(radius / baseCameraRadius, 0.35, 3.5);
+  envSkybox.scale.setScalar(baseSkyboxScale * scale);
+};
+controls.addEventListener("change", syncSkyboxToCamera);
 controls.enableRotate = true;
 controls.minDistance = CAMERA_MIN_RADIUS;
 controls.maxDistance = CAMERA_MAX_RADIUS;
@@ -1130,6 +1171,7 @@ function positionCameraForViewport({ force = false } = {}) {
 
   controls.target.copy(target);
   controls.update();
+  syncSkyboxToCamera();
 }
 
 function updateViewToggleLabel() {
@@ -1161,26 +1203,6 @@ function toggleCameraViewMode() {
   setCameraViewMode(next);
 }
 
-
-/* ---------- Lights ---------- */
-const ambient = new THREE.AmbientLight(0xffffff, 0.35);
-scene.add(ambient);
-const keyLight = new THREE.DirectionalLight(0xffffff, 1.2);
-keyLight.position.set(6, 8, 5);
-keyLight.castShadow = true;
-scene.add(keyLight);
-const fillLight = new THREE.DirectionalLight(0xffffff, 0.65);
-fillLight.position.set(-5, 5.5, 3);
-scene.add(fillLight);
-const rimLight = new THREE.DirectionalLight(0xffffff, 0.9);
-rimLight.position.set(0, 6, -6);
-scene.add(rimLight);
-const spot = new THREE.SpotLight(0xffffff, 0.8, TABLE_RADIUS * 10, Math.PI / 3, 0.38, 1);
-spot.position.set(0, 4.2, 4.6);
-scene.add(spot);
-const spotTarget = new THREE.Object3D();
-scene.add(spotTarget);
-spot.target = spotTarget;
 
 const getPoolCarpetTextures = (() => {
   let cache = null;
@@ -1306,27 +1328,15 @@ const getPoolCarpetTextures = (() => {
 
 const CHAIR_CLOTH_TEXTURE_SIZE = 512;
 const CHAIR_CLOTH_REPEAT = 12;
-const DEFAULT_CHAIR_THEME = Object.freeze({
+const TABLE_MODEL_OPTIONS = Object.freeze(MURLAN_TABLE_THEMES.map((theme) => ({ ...theme })));
+const CHAIR_THEME_OPTIONS = Object.freeze(MURLAN_STOOL_THEMES.map((theme) => ({ ...theme })));
+const DEFAULT_CHAIR_THEME = CHAIR_THEME_OPTIONS[0] || {
   id: "crimsonVelvet",
   label: "Crimson Velvet",
   seatColor: "#8b1538",
   legColor: "#1f1f1f",
   highlight: "#d35a7a"
-});
-
-const CHAIR_THEME_OPTIONS = Object.freeze([
-  DEFAULT_CHAIR_THEME,
-  { id: "midnightNavy", label: "Midnight Blue", seatColor: "#153a8b", legColor: "#10131c", highlight: "#4d74d8" },
-  { id: "emeraldWave", label: "Emerald Wave", seatColor: "#0f6a2f", legColor: "#142318", highlight: "#48b26a" },
-  { id: "onyxShadow", label: "Onyx Shadow", seatColor: "#202020", legColor: "#080808", highlight: "#6f6f6f" },
-  { id: "royalPlum", label: "Royal Chestnut", seatColor: "#3f1f5b", legColor: "#140a24", highlight: "#7c4ae0" }
-]);
-
-const CHAIR_MODEL_URLS = [
-  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb",
-  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb",
-  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb"
-];
+};
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
@@ -1338,9 +1348,168 @@ const normalizeHue = (h) => {
   return hue;
 };
 
-let chairTemplatePromise = null;
-let chairTemplateBounds = null;
 let chairBuildToken = 0;
+const POLYHAVEN_MODEL_CACHE = new Map();
+const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/";
+const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/v1/decoders/";
+let sharedKtx2Loader = null;
+
+function applySRGBColorSpace(texture) {
+  if (!texture) return;
+  texture.colorSpace = THREE.SRGBColorSpace;
+}
+
+function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin?.("anonymous");
+
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn("Domino KTX2 support detection failed", error);
+    }
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+}
+
+function prepareLoadedModel(model) {
+  model.traverse((obj) => {
+    if (!obj.isMesh) return;
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+    mats.forEach((mat) => {
+      if (mat?.map) applySRGBColorSpace(mat.map);
+      if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+    });
+  });
+}
+
+function buildPolyhavenModelUrls(assetId) {
+  if (!assetId) return [];
+  return [
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`,
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`
+  ];
+}
+
+async function loadPolyhavenModel(assetId, renderer = null) {
+  if (!assetId) throw new Error("Missing Poly Haven asset id");
+  const normalizedId = assetId.toLowerCase();
+  if (POLYHAVEN_MODEL_CACHE.has(normalizedId)) {
+    return POLYHAVEN_MODEL_CACHE.get(normalizedId);
+  }
+
+  const promise = (async () => {
+    const loader = createConfiguredGLTFLoader(renderer);
+    const modelUrlList = buildPolyhavenModelUrls(assetId);
+    let gltf = null;
+    let lastError = null;
+    for (const modelUrl of modelUrlList) {
+      try {
+        const resolvedUrl = new URL(modelUrl, window.location.href).href;
+        const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf("/") + 1);
+        loader.setResourcePath?.(resourcePath);
+        loader.setPath?.("");
+        gltf = await loader.loadAsync(resolvedUrl);
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (!gltf) {
+      throw lastError || new Error(`Failed to load model for ${assetId}`);
+    }
+    const model = gltf.scene || gltf.scenes?.[0];
+    if (!model) {
+      throw new Error(`Missing scene for ${assetId}`);
+    }
+    prepareLoadedModel(model);
+    return model;
+  })();
+
+  POLYHAVEN_MODEL_CACHE.set(normalizedId, promise);
+  promise.catch(() => POLYHAVEN_MODEL_CACHE.delete(normalizedId));
+  return promise;
+}
+
+function liftModelToGround(model, targetMinY = 0) {
+  const box = new THREE.Box3().setFromObject(model);
+  model.position.y += targetMinY - box.min.y;
+}
+
+function fitModelToHeight(model, targetHeight) {
+  const box = new THREE.Box3().setFromObject(model);
+  const currentHeight = box.max.y - box.min.y;
+  if (currentHeight > 0) {
+    const scale = targetHeight / currentHeight;
+    model.scale.multiplyScalar(scale);
+  }
+  liftModelToGround(model, 0);
+}
+
+function fitTableModelToArena(model, targetHeight, targetDiameter) {
+  if (!model) return { surfaceY: targetHeight, radius: targetDiameter / 2 };
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxXZ = Math.max(size.x, size.z);
+  const targetRadius = targetDiameter / 2;
+  const scaleY = size.y > 0 ? targetHeight / size.y : 1;
+  const scaleXZ = maxXZ > 0 ? targetDiameter / maxXZ : 1;
+
+  if (scaleY !== 1 || scaleXZ !== 1) {
+    model.scale.set(
+      model.scale.x * scaleXZ,
+      model.scale.y * scaleY,
+      model.scale.z * scaleXZ
+    );
+  }
+
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.add(new THREE.Vector3(-center.x, -scaledBox.min.y, -center.z));
+
+  const recenteredBox = new THREE.Box3().setFromObject(model);
+  const surfaceOffset = targetHeight - recenteredBox.max.y;
+  if (surfaceOffset !== 0) {
+    model.position.y += surfaceOffset;
+    recenteredBox.translate(new THREE.Vector3(0, surfaceOffset, 0));
+  }
+
+  const radius = Math.max(
+    Math.abs(recenteredBox.max.x),
+    Math.abs(recenteredBox.min.x),
+    Math.abs(recenteredBox.max.z),
+    Math.abs(recenteredBox.min.z),
+    targetRadius
+  );
+  return {
+    surfaceY: targetHeight,
+    radius
+  };
+}
+
+async function createPolyhavenInstance(assetId, targetHeight, rotationY = 0, renderer = null) {
+  const root = await loadPolyhavenModel(assetId, renderer);
+  const model = root.clone(true);
+  prepareLoadedModel(model);
+  fitModelToHeight(model, targetHeight);
+  if (rotationY) model.rotation.y += rotationY;
+  return model;
+}
 
 function fitChairModelToFootprint(model) {
   const box = new THREE.Box3().setFromObject(model);
@@ -1362,104 +1531,6 @@ function fitChairModelToFootprint(model) {
   model.position.add(offset);
 }
 
-function extractChairMaterials(model) {
-  const upholstery = new Set();
-  const metal = new Set();
-  model.traverse((obj) => {
-    if (!obj.isMesh) return;
-    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-    mats.forEach((mat) => {
-      if (!mat) return;
-      if (mat.map) mat.map.colorSpace = THREE.SRGBColorSpace;
-      if (mat.emissiveMap) mat.emissiveMap.colorSpace = THREE.SRGBColorSpace;
-      const bucket = (mat.metalness ?? 0) > 0.35 ? metal : upholstery;
-      bucket.add(mat);
-    });
-  });
-  const upholsteryArr = Array.from(upholstery);
-  const metalArr = Array.from(metal);
-  return {
-    seat: upholsteryArr[0] ?? metalArr[0] ?? null,
-    leg: metalArr[0] ?? upholsteryArr[0] ?? null,
-    upholstery: upholsteryArr,
-    metal: metalArr
-  };
-}
-
-async function ensureMurlanChairTemplate() {
-  if (chairTemplatePromise) return chairTemplatePromise;
-  chairTemplatePromise = (async () => {
-    const loader = new GLTFLoader();
-    const draco = new DRACOLoader();
-    draco.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
-    loader.setDRACOLoader(draco);
-
-    let gltf = null;
-    let lastError = null;
-    for (const url of CHAIR_MODEL_URLS) {
-      try {
-        gltf = await loader.loadAsync(url);
-        break;
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    if (!gltf) {
-      throw lastError || new Error("Failed to load chair model");
-    }
-
-    const model = gltf.scene || gltf.scenes?.[0];
-    if (!model) {
-      throw new Error("Chair model missing scene");
-    }
-
-    model.traverse((obj) => {
-      if (!obj.isMesh) return;
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-      mats.forEach((mat) => {
-        if (mat?.map) mat.map.colorSpace = THREE.SRGBColorSpace;
-        if (mat?.emissiveMap) mat.emissiveMap.colorSpace = THREE.SRGBColorSpace;
-      });
-    });
-
-    fitChairModelToFootprint(model);
-    chairTemplateBounds = new THREE.Box3().setFromObject(model);
-
-    return { chairTemplate: model, materials: extractChairMaterials(model) };
-  })();
-
-  return chairTemplatePromise;
-}
-
-function cloneChairWithTheme(chairData, option) {
-  const { chairTemplate, materials } = chairData;
-  const clone = chairTemplate.clone(true);
-  const upholsterySet = new Set(materials.upholstery);
-  const metalSet = new Set(materials.metal);
-
-  clone.traverse((obj) => {
-    if (!obj.isMesh) return;
-    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-    const themed = mats.map((mat) => {
-      if (!mat) return mat;
-      const next = mat.clone();
-      if (upholsterySet.has(mat)) {
-        if (next.color) next.color.set(option?.seatColor ?? DEFAULT_CHAIR_THEME.seatColor);
-        if (next.emissive) next.emissive.set(option?.highlight ?? option?.seatColor ?? DEFAULT_CHAIR_THEME.highlight);
-      } else if (metalSet.has(mat)) {
-        if (next.color) next.color.set(option?.legColor ?? DEFAULT_CHAIR_THEME.legColor);
-      }
-      return next;
-    });
-    obj.material = Array.isArray(obj.material) ? themed : themed[0];
-    obj.castShadow = true;
-    obj.receiveShadow = true;
-  });
-
-  return clone;
-}
 const hslString = (h, s, l) => {
   const sat = clamp01f(s);
   const light = clamp01f(l);
@@ -1473,6 +1544,184 @@ const hslToHexNumber = (h, s, l) => {
 const hslToHexString = (h, s, l) => `#${hslToHexNumber(h, s, l).toString(16).padStart(6, '0')}`;
 const shiftLightness = (light, delta) => clamp01f(light + delta);
 const shiftSaturation = (sat, delta) => clamp01f(sat + delta);
+const pickPolyHavenHdriUrl = (json, preferred = DEFAULT_HDRI_RESOLUTIONS) => {
+  if (!json || typeof json !== "object") return null;
+  const resolutions = Array.isArray(preferred) && preferred.length ? preferred : DEFAULT_HDRI_RESOLUTIONS;
+  for (const res of resolutions) {
+    const entry = json[res];
+    if (entry?.hdr) return entry.hdr;
+    if (entry?.exr) return entry.exr;
+  }
+  const fallback = Object.values(json).find((value) => value?.hdr || value?.exr);
+  if (!fallback) return null;
+  return fallback.hdr || fallback.exr || null;
+};
+
+async function resolvePolyHavenHdriUrl(config = {}) {
+  const preferred = Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+    ? config.preferredResolutions
+    : DEFAULT_HDRI_RESOLUTIONS;
+  const fallbackRes = config?.fallbackResolution || preferred[0] || "4k";
+  const fallbackUrl =
+    config?.fallbackUrl ||
+    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? "neon_photostudio"}_${fallbackRes}.hdr`;
+  if (config?.assetUrls && typeof config.assetUrls === "object") {
+    for (const res of preferred) {
+      if (config.assetUrls[res]) return config.assetUrls[res];
+    }
+    const manual = Object.values(config.assetUrls).find((value) => typeof value === "string" && value.length);
+    if (manual) return manual;
+  }
+  if (typeof config?.assetUrl === "string" && config.assetUrl.length) return config.assetUrl;
+  if (!config?.assetId || typeof fetch !== "function") return fallbackUrl;
+  try {
+    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
+    if (!response?.ok) return fallbackUrl;
+    const json = await response.json();
+    const picked = pickPolyHavenHdriUrl(json, preferred);
+    return picked || fallbackUrl;
+  } catch (error) {
+    console.warn("Failed to resolve Poly Haven HDRI url", error);
+    return fallbackUrl;
+  }
+}
+
+async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+  if (!renderer) return null;
+  const url = await resolvePolyHavenHdriUrl(config);
+  const lowerUrl = `${url ?? ""}`.toLowerCase();
+  const useExr = lowerUrl.endsWith(".exr");
+  const loader = useExr ? new EXRLoader() : new RGBELoader();
+  loader.setCrossOrigin?.("anonymous");
+  return new Promise((resolve) => {
+    loader.load(
+      url,
+      (texture) => {
+        const pmrem = new THREE.PMREMGenerator(renderer);
+        pmrem.compileEquirectangularShader();
+        const envMap = pmrem.fromEquirectangular(texture).texture;
+        envMap.name = `${config?.assetId ?? "polyhaven"}-env`;
+        const skyboxMap = texture;
+        skyboxMap.name = `${config?.assetId ?? "polyhaven"}-skybox`;
+        skyboxMap.mapping = THREE.EquirectangularReflectionMapping;
+        skyboxMap.needsUpdate = true;
+        pmrem.dispose();
+        resolve({ envMap, skyboxMap, url });
+      },
+      undefined,
+      (error) => {
+        console.warn("Failed to load Poly Haven HDRI", error);
+        resolve(null);
+      }
+    );
+  });
+}
+
+function computeGroupFloorY(objects = []) {
+  const box = new THREE.Box3();
+  let hasValue = false;
+  objects.forEach((obj) => {
+    if (!obj) return;
+    const nextBox = new THREE.Box3().setFromObject(obj);
+    if (!Number.isFinite(nextBox.min.y)) return;
+    if (!hasValue) {
+      box.copy(nextBox);
+      hasValue = true;
+      return;
+    }
+    box.union(nextBox);
+  });
+  return hasValue ? box.min.y : 0;
+}
+
+function resolveHdriVariant(index) {
+  const max = HDRI_OPTIONS.length - 1;
+  const idx = Number.isFinite(index) ? Math.min(Math.max(Math.round(index), 0), max) : DEFAULT_HDRI_INDEX;
+  return HDRI_OPTIONS[idx] ?? HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? HDRI_OPTIONS[0];
+}
+
+async function applyHdriEnvironment(variantConfig = resolveHdriVariant(appearance.environmentHdri)) {
+  const activeVariant = variantConfig || DEFAULT_HDRI_VARIANT;
+  if (!activeVariant) return;
+  const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
+  if (!envResult) return;
+  const { envMap, skyboxMap } = envResult;
+  if (!envMap) return;
+  const prevDispose = disposeEnvironment;
+  const prevTexture = envTexture;
+  const prevSkybox = envSkybox;
+  const cameraHeight =
+    Math.max(activeVariant?.cameraHeightM ?? DEFAULT_HDRI_CAMERA_HEIGHT_M, MIN_HDRI_CAMERA_HEIGHT_M) *
+    HDRI_UNITS_PER_METER;
+  const radiusMultiplier =
+    typeof activeVariant?.groundRadiusMultiplier === "number"
+      ? activeVariant.groundRadiusMultiplier
+      : DEFAULT_HDRI_RADIUS_MULTIPLIER;
+  const sceneSpan = Math.max(TABLE_RADIUS, CHAIR_RADIUS, tableModelRadius);
+  const groundRadius = Math.max(sceneSpan * radiusMultiplier, MIN_HDRI_RADIUS);
+  const skyboxResolution = Math.max(
+    16,
+    Math.floor(activeVariant?.groundResolution ?? HDRI_GROUNDED_RESOLUTION)
+  );
+  const skyboxRadius = Math.max(groundRadius, cameraHeight * 2.5, MIN_HDRI_RADIUS);
+  let skybox = null;
+  if (skyboxMap && skyboxRadius > 0 && cameraHeight > 0) {
+    try {
+      skybox = new GroundedSkybox(skyboxMap, cameraHeight, skyboxRadius, skyboxResolution);
+      skybox.position.y = environmentFloorY + cameraHeight;
+      skybox.material.depthWrite = false;
+      scene.background = null;
+      scene.add(skybox);
+      envSkybox = skybox;
+      envSkyboxTexture = skyboxMap;
+      baseSkyboxScale = skybox.scale?.x ?? 1;
+    } catch (error) {
+      console.warn("Failed to create grounded HDRI skybox", error);
+      skybox = null;
+    }
+  }
+  scene.environment = envMap;
+  if (!skybox) {
+    scene.background = envMap;
+    envSkybox = null;
+    envSkyboxTexture = null;
+    if ("backgroundIntensity" in scene && typeof activeVariant?.backgroundIntensity === "number") {
+      scene.backgroundIntensity = activeVariant.backgroundIntensity;
+    }
+  }
+  if (typeof activeVariant?.environmentIntensity === "number") {
+    scene.environmentIntensity = activeVariant.environmentIntensity;
+  }
+  renderer.toneMappingExposure = activeVariant?.exposure ?? renderer.toneMappingExposure;
+  envTexture = envMap;
+  syncSkyboxToCamera();
+  disposeEnvironment = () => {
+    if (scene.environment === envMap) {
+      scene.environment = null;
+    }
+    if (!skybox && scene.background === envMap) {
+      scene.background = null;
+    }
+    envMap.dispose?.();
+    if (skybox) {
+      skybox.parent?.remove(skybox);
+      skybox.geometry?.dispose?.();
+      skybox.material?.dispose?.();
+      if (envSkybox === skybox) {
+        envSkybox = null;
+      }
+    }
+    if (skyboxMap) {
+      skyboxMap.dispose?.();
+      if (envSkyboxTexture === skyboxMap) {
+        envSkyboxTexture = null;
+      }
+    }
+  };
+  if (prevDispose && (prevTexture !== envMap || prevSkybox !== skybox)) {
+    prevDispose();
+  }
+}
 
 const WOOD_FINISH_PRESETS = Object.freeze([
   Object.freeze({ id: 'birch', label: 'Birch', hue: 38, sat: 0.25, light: 0.84, contrast: 0.42 }),
@@ -2101,21 +2350,25 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_SETUP_SECTIONS = [
+  { key: "tableModel", label: "Table Model", options: TABLE_MODEL_OPTIONS },
   { key: "tableWood", label: "Table Wood", options: TABLE_WOOD_OPTIONS },
   { key: "tableCloth", label: "Table Cloth", options: TABLE_CLOTH_OPTIONS },
   { key: "tableBase", label: "Bazamenti", options: TABLE_BASE_OPTIONS },
   { key: "dominoStyle", label: "Domino", options: DOMINO_STYLE_OPTIONS },
   { key: "highlightStyle", label: "Highlights", options: HIGHLIGHT_STYLE_OPTIONS },
-  { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
+  { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS },
+  { key: "environmentHdri", label: "HDR Environment", options: HDRI_OPTIONS }
 ];
 
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
+  tableModel: TABLE_MODEL_OPTIONS,
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
   tableBase: TABLE_BASE_OPTIONS,
   dominoStyle: DOMINO_STYLE_OPTIONS,
   highlightStyle: HIGHLIGHT_STYLE_OPTIONS,
-  chairTheme: CHAIR_THEME_OPTIONS
+  chairTheme: CHAIR_THEME_OPTIONS,
+  environmentHdri: HDRI_OPTIONS
 });
 
 const DOMINO_DEFAULT_UNLOCKS = Object.freeze(
@@ -2212,12 +2465,14 @@ function normalizeAppearance(raw) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const source = raw && typeof raw === "object" ? raw : {};
   const limits = [
+    ["tableModel", TABLE_MODEL_OPTIONS.length],
     ["tableWood", TABLE_WOOD_OPTIONS.length],
     ["tableCloth", TABLE_CLOTH_OPTIONS.length],
     ["tableBase", TABLE_BASE_OPTIONS.length],
     ["dominoStyle", DOMINO_STYLE_OPTIONS.length],
     ["highlightStyle", HIGHLIGHT_STYLE_OPTIONS.length],
-    ["chairTheme", CHAIR_THEME_OPTIONS.length]
+    ["chairTheme", CHAIR_THEME_OPTIONS.length],
+    ["environmentHdri", HDRI_OPTIONS.length]
   ];
   limits.forEach(([key, max]) => {
     const value = Number(source[key]);
@@ -2604,401 +2859,9 @@ tableG.rotation.y = 0;
 const piecesG = new THREE.Group();
 tableG.add(piecesG);
 
-/* ---------- Arena Dressings (Carpet & Walls) ---------- */
-const floor = new THREE.Mesh(
-  new THREE.CircleGeometry(FLOOR_RADIUS, 96),
-  new THREE.MeshStandardMaterial({ color: 0x0b1120, roughness: 0.92, metalness: 0.12 })
-);
-floor.rotation.x = -Math.PI / 2;
-floor.position.y = 0;
-floor.receiveShadow = true;
-arenaG.add(floor);
-
-const carpetTextures = getPoolCarpetTextures(renderer);
-// Match Pool Royale's red carpet finish.
-const carpetMat = new THREE.MeshStandardMaterial({
-  color: 0x8c2a2e,
-  roughness: 0.9,
-  metalness: 0.025
-});
-if (carpetTextures.map) {
-  carpetMat.map = carpetTextures.map;
-  carpetMat.map.needsUpdate = true;
-  carpetMat.map.repeat.set(5, 5);
-}
-if (carpetTextures.bump) {
-  carpetMat.bumpMap = carpetTextures.bump;
-  carpetMat.bumpScale = 0.18;
-  carpetMat.bumpMap.needsUpdate = true;
-  carpetMat.bumpMap.repeat.set(5, 5);
-}
-const carpet = new THREE.Mesh(new THREE.CircleGeometry(CARPET_RADIUS, 96), carpetMat);
-carpet.rotation.x = -Math.PI / 2;
-carpet.position.y = 0.01;
-carpet.receiveShadow = true;
-arenaG.add(carpet);
-
-// Align the arena walls with Pool Royale's light blue tone.
-const wallMaterial = new THREE.MeshStandardMaterial({
-  color: 0xb9ddff,
-  roughness: 0.88,
-  metalness: 0.06,
-  side: THREE.DoubleSide
-});
-const wall = new THREE.Mesh(
-  new THREE.CylinderGeometry(
-    ARENA_WALL_INNER_RADIUS,
-    ARENA_WALL_INNER_RADIUS * 1.02,
-    ARENA_WALL_HEIGHT,
-    80,
-    1,
-    true
-  ),
-  wallMaterial
-);
-wall.position.y = ARENA_WALL_CENTER_Y;
-wall.receiveShadow = false;
-wall.castShadow = false;
-arenaG.add(wall);
-
-const ARENA_DOOR_DIMENSIONS = Object.freeze({ width: 2.8, height: 3.4, thickness: 0.12 });
-const carbonFiberTextureBase = createCarbonFiberTexture(renderer, { tile: 4.5 });
-const hallwayDoorTexture = carbonFiberTextureBase ? carbonFiberTextureBase.clone() : null;
-if (hallwayDoorTexture) {
-  hallwayDoorTexture.repeat.set(2.6, 2.8);
-  hallwayDoorTexture.needsUpdate = true;
-}
-const hallwayDoorMaterialConfig = {
-  color: 0x1a1f26,
-  roughness: 0.32,
-  metalness: 0.55,
-  envMapIntensity: 1.05
-};
-if (hallwayDoorTexture) {
-  hallwayDoorMaterialConfig.map = hallwayDoorTexture;
-}
-const hallwayDoorMaterial = new THREE.MeshStandardMaterial(hallwayDoorMaterialConfig);
-const hallwayHandleMaterial = new THREE.MeshStandardMaterial({
-  color: 0xffd87c,
-  metalness: 1,
-  roughness: 0.18,
-  emissive: 0xffeab5,
-  emissiveIntensity: dimIntensity(0.28)
-});
-const hallwayDoorZ = ARENA_WALL_INNER_RADIUS - ARENA_DOOR_DIMENSIONS.thickness * 0.5;
-const hallwayDoorPivot = new THREE.Group();
-hallwayDoorPivot.position.set(-ARENA_DOOR_DIMENSIONS.width / 2, ARENA_DOOR_DIMENSIONS.height / 2, hallwayDoorZ);
-
-const hallwayDoor = new THREE.Mesh(
-  new THREE.BoxGeometry(
-    ARENA_DOOR_DIMENSIONS.width,
-    ARENA_DOOR_DIMENSIONS.height,
-    ARENA_DOOR_DIMENSIONS.thickness
-  ),
-  hallwayDoorMaterial
-);
-hallwayDoor.castShadow = true;
-hallwayDoor.receiveShadow = true;
-hallwayDoor.position.set(ARENA_DOOR_DIMENSIONS.width / 2, 0, 0);
-hallwayDoorPivot.add(hallwayDoor);
-
-const hallwayHandlePlate = new THREE.Mesh(
-  new THREE.BoxGeometry(0.16, 0.46, 0.02),
-  new THREE.MeshStandardMaterial({
-    color: 0xffd87c,
-    metalness: 0.95,
-    roughness: 0.18,
-    emissive: 0xffe6aa,
-    emissiveIntensity: dimIntensity(0.32)
-  })
-);
-hallwayHandlePlate.position.set(
-  ARENA_DOOR_DIMENSIONS.width - 0.6,
-  -0.35,
-  ARENA_DOOR_DIMENSIONS.thickness / 2 - 0.005
-);
-hallwayHandlePlate.castShadow = false;
-hallwayHandlePlate.receiveShadow = false;
-hallwayDoor.add(hallwayHandlePlate);
-
-const hallwayHandle = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.3, 24), hallwayHandleMaterial);
-hallwayHandle.rotation.z = Math.PI / 2;
-hallwayHandle.position.set(ARENA_DOOR_DIMENSIONS.width - 0.6, -0.35, ARENA_DOOR_DIMENSIONS.thickness / 2 + 0.03);
-hallwayHandle.castShadow = true;
-hallwayHandle.receiveShadow = false;
-hallwayDoor.add(hallwayHandle);
-
-const hallwayDoorFrame = new THREE.Mesh(
-  new THREE.BoxGeometry(
-    ARENA_DOOR_DIMENSIONS.width + 0.32,
-    ARENA_DOOR_DIMENSIONS.height + 0.28,
-    ARENA_DOOR_DIMENSIONS.thickness * 0.8
-  ),
-  new THREE.MeshStandardMaterial({
-    color: 0xf2d79b,
-    roughness: 0.18,
-    metalness: 0.94,
-    emissive: 0xffe4b5,
-    emissiveIntensity: dimIntensity(0.4)
-  })
-);
-hallwayDoorFrame.position.set(ARENA_DOOR_DIMENSIONS.width / 2, 0, -ARENA_DOOR_DIMENSIONS.thickness * 0.45);
-hallwayDoorFrame.castShadow = false;
-hallwayDoorFrame.receiveShadow = false;
-hallwayDoorPivot.add(hallwayDoorFrame);
-
-const hallwayDoorGroup = new THREE.Group();
-hallwayDoorGroup.add(hallwayDoorPivot);
-arenaG.add(hallwayDoorGroup);
-
-const ARENA_WALKWAY_LENGTH = 14;
-const ARENA_WALKWAY_WIDTH = 4.2;
-const walkwayFloorMaterial = new THREE.MeshStandardMaterial({
-  color: 0x08090f,
-  roughness: 0.24,
-  metalness: 0.72,
-  envMapIntensity: 1.1
-});
-const walkwayFloor = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH, ARENA_WALKWAY_LENGTH),
-  walkwayFloorMaterial
-);
-walkwayFloor.rotation.x = -Math.PI / 2;
-walkwayFloor.position.set(
-  0,
-  0.005,
-  hallwayDoorZ + ARENA_WALKWAY_LENGTH / 2 - ARENA_DOOR_DIMENSIONS.thickness * 0.5
-);
-walkwayFloor.receiveShadow = true;
-arenaG.add(walkwayFloor);
-
-const walkwayRunnerMaterialConfig = {
-  color: new THREE.Color(carpetMat.color.getHex()),
-  roughness: carpetMat.roughness,
-  metalness: carpetMat.metalness
-};
-if (carpetTextures.map) {
-  const walkwayMap = carpetTextures.map.clone();
-  walkwayMap.wrapS = walkwayMap.wrapT = THREE.RepeatWrapping;
-  walkwayMap.repeat.set(ARENA_WALKWAY_WIDTH / 1.6, ARENA_WALKWAY_LENGTH / 3.2);
-  walkwayMap.colorSpace = THREE.SRGBColorSpace;
-  walkwayMap.needsUpdate = true;
-  walkwayRunnerMaterialConfig.map = walkwayMap;
-}
-if (carpetTextures.bump) {
-  const walkwayBump = carpetTextures.bump.clone();
-  walkwayBump.wrapS = walkwayBump.wrapT = THREE.RepeatWrapping;
-  walkwayBump.repeat.set(ARENA_WALKWAY_WIDTH / 1.6, ARENA_WALKWAY_LENGTH / 3.2);
-  walkwayBump.needsUpdate = true;
-  walkwayRunnerMaterialConfig.bumpMap = walkwayBump;
-  walkwayRunnerMaterialConfig.bumpScale = 0.18;
-}
-const walkwayRunner = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH * 0.42, ARENA_WALKWAY_LENGTH * 0.92),
-  new THREE.MeshStandardMaterial(walkwayRunnerMaterialConfig)
-);
-walkwayRunner.rotation.x = -Math.PI / 2;
-walkwayRunner.position.set(0, walkwayFloor.position.y + 0.008, walkwayFloor.position.z);
-walkwayRunner.receiveShadow = true;
-arenaG.add(walkwayRunner);
-
-const walkwayTrimMat = new THREE.MeshStandardMaterial({
-  color: 0xba7c2c,
-  roughness: 0.26,
-  metalness: 0.88,
-  emissive: 0xffc978,
-  emissiveIntensity: dimIntensity(0.25)
-});
-const walkwayTrimGeo = new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.2, 0.12, 0.4);
-const walkwayFrontTrim = new THREE.Mesh(walkwayTrimGeo, walkwayTrimMat);
-walkwayFrontTrim.position.set(0, 0.06, hallwayDoorZ - 0.2);
-walkwayFrontTrim.castShadow = false;
-walkwayFrontTrim.receiveShadow = false;
-arenaG.add(walkwayFrontTrim);
-const walkwayOuterTrim = walkwayFrontTrim.clone();
-walkwayOuterTrim.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.2;
-arenaG.add(walkwayOuterTrim);
-
-const walkwaySideGeo = new THREE.BoxGeometry(0.35, 1.2, ARENA_WALKWAY_LENGTH);
-const walkwayWallTexture = textureLoader.load(
-  'https://images.unsplash.com/photo-1549187774-b4e9b0445b41?auto=format&fit=crop&w=1600&q=80'
-);
-walkwayWallTexture.wrapS = THREE.RepeatWrapping;
-walkwayWallTexture.wrapT = THREE.RepeatWrapping;
-walkwayWallTexture.colorSpace = THREE.SRGBColorSpace;
-walkwayWallTexture.repeat.set(ARENA_WALKWAY_LENGTH / 2.2, 1.4);
-const walkwaySideMat = new THREE.MeshStandardMaterial({
-  map: walkwayWallTexture,
-  roughness: 0.48,
-  metalness: 0.4,
-  envMapIntensity: 0.8
-});
-const walkwaySideAccentGeo = new THREE.BoxGeometry(0.12, 0.9, ARENA_WALKWAY_LENGTH - 0.6);
-const walkwaySideAccentMat = new THREE.MeshStandardMaterial({
-  color: 0x321c46,
-  roughness: 0.32,
-  metalness: 0.58,
-  emissive: 0xffb964,
-  emissiveIntensity: dimIntensity(0.4)
-});
-const walkwaySideCrownGeo = new THREE.BoxGeometry(0.38, 0.1, ARENA_WALKWAY_LENGTH);
-const walkwaySideCrownMat = new THREE.MeshStandardMaterial({
-  color: 0xf2c36b,
-  roughness: 0.22,
-  metalness: 0.94
-});
-
-function createWalkwaySide(offsetX) {
-  const sideGroup = new THREE.Group();
-  const base = new THREE.Mesh(walkwaySideGeo, walkwaySideMat);
-  base.castShadow = true;
-  base.receiveShadow = true;
-  sideGroup.add(base);
-
-  const accent = new THREE.Mesh(walkwaySideAccentGeo, walkwaySideAccentMat);
-  accent.position.set(offsetX > 0 ? -0.11 : 0.11, 0, 0);
-  accent.castShadow = false;
-  accent.receiveShadow = true;
-  sideGroup.add(accent);
-
-  const crown = new THREE.Mesh(walkwaySideCrownGeo, walkwaySideCrownMat);
-  crown.position.y = 0.55;
-  crown.castShadow = true;
-  crown.receiveShadow = false;
-  sideGroup.add(crown);
-
-  const lightStripGeo = new THREE.BoxGeometry(0.18, 0.08, ARENA_WALKWAY_LENGTH - 0.4);
-  const lightStripMat = new THREE.MeshStandardMaterial({
-    color: 0xffd27e,
-    emissive: 0xfff1b5,
-    emissiveIntensity: dimIntensity(0.85),
-    metalness: 0.7,
-    roughness: 0.18
-  });
-  const lightStrip = new THREE.Mesh(lightStripGeo, lightStripMat);
-  lightStrip.position.set(offsetX > 0 ? -0.14 : 0.14, -0.25, 0);
-  lightStrip.castShadow = false;
-  lightStrip.receiveShadow = false;
-  sideGroup.add(lightStrip);
-
-  sideGroup.position.set(offsetX, 0.6, walkwayFloor.position.z);
-  arenaG.add(sideGroup);
-  return sideGroup;
-}
-
-const walkwaySideLeft = createWalkwaySide(-ARENA_WALKWAY_WIDTH / 2 - 0.175);
-const walkwaySideRight = createWalkwaySide(ARENA_WALKWAY_WIDTH / 2 + 0.175);
-
-const walkwayPortalHeaderTexture = carbonFiberTextureBase ? carbonFiberTextureBase.clone() : null;
-if (walkwayPortalHeaderTexture) {
-  walkwayPortalHeaderTexture.repeat.set((ARENA_WALKWAY_WIDTH + 0.4) / 1.4, 1.6);
-  walkwayPortalHeaderTexture.needsUpdate = true;
-}
-const walkwayPortalHeaderMaterialConfig = {
-  color: 0x1c1f26,
-  metalness: 0.68,
-  roughness: 0.28,
-  emissive: 0x140812,
-  emissiveIntensity: dimIntensity(0.35),
-  envMapIntensity: 0.9
-};
-if (walkwayPortalHeaderTexture) {
-  walkwayPortalHeaderMaterialConfig.map = walkwayPortalHeaderTexture;
-}
-const walkwayPortalHeader = new THREE.Mesh(
-  new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.4, 0.22, 0.5),
-  new THREE.MeshStandardMaterial(walkwayPortalHeaderMaterialConfig)
-);
-walkwayPortalHeader.position.set(0, 1.42, hallwayDoorZ - 0.05);
-walkwayPortalHeader.castShadow = true;
-arenaG.add(walkwayPortalHeader);
-
-const walkwayPortalCrown = new THREE.Mesh(
-  new THREE.TorusGeometry((ARENA_WALKWAY_WIDTH + 0.4) / 2, 0.05, 16, 48),
-  new THREE.MeshStandardMaterial({
-    color: 0xf7d891,
-    emissive: 0xffeeba,
-    emissiveIntensity: dimIntensity(0.6),
-    metalness: 0.92,
-    roughness: 0.15
-  })
-);
-walkwayPortalCrown.rotation.x = Math.PI / 2;
-walkwayPortalCrown.position.set(0, 1.52, hallwayDoorZ - 0.12);
-walkwayPortalCrown.castShadow = false;
-arenaG.add(walkwayPortalCrown);
-
-const walkwayCeiling = new THREE.Mesh(
-  new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH + 0.8, ARENA_WALKWAY_LENGTH + 1.2),
-  new THREE.MeshStandardMaterial({
-    color: 0x18111f,
-    side: THREE.DoubleSide,
-    roughness: 0.35,
-    metalness: 0.45,
-    emissive: 0x1a0a13,
-    emissiveIntensity: dimIntensity(0.28)
-  })
-);
-walkwayCeiling.rotation.x = Math.PI / 2;
-walkwayCeiling.position.set(0, 1.95, walkwayFloor.position.z);
-walkwayCeiling.receiveShadow = false;
-arenaG.add(walkwayCeiling);
-
-const chandelier = new THREE.Group();
-const chandelierRing = new THREE.Mesh(
-  new THREE.TorusGeometry(0.95, 0.08, 24, 64),
-  new THREE.MeshStandardMaterial({
-    color: 0xf2d79b,
-    emissive: 0xfff0c5,
-    emissiveIntensity: dimIntensity(0.8),
-    metalness: 0.9,
-    roughness: 0.18
-  })
-);
-chandelier.add(chandelierRing);
-const chandelierCore = new THREE.Mesh(
-  new THREE.CylinderGeometry(0.08, 0.16, 0.6, 24),
-  new THREE.MeshStandardMaterial({
-    color: 0x21142d,
-    metalness: 0.65,
-    roughness: 0.28,
-    emissive: 0x110712,
-    emissiveIntensity: dimIntensity(0.3)
-  })
-);
-chandelierCore.position.y = -0.35;
-chandelier.add(chandelierCore);
-chandelier.position.set(0, walkwayCeiling.position.y - 0.18, walkwayFloor.position.z);
-arenaG.add(chandelier);
-
-const walkwayFrontLight = new THREE.Mesh(
-  new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.25, 0.08, 0.12),
-  new THREE.MeshStandardMaterial({
-    color: 0xffd89a,
-    emissive: 0xffecb3,
-    emissiveIntensity: dimIntensity(0.9),
-    metalness: 0.78,
-    roughness: 0.22
-  })
-);
-walkwayFrontLight.position.set(0, 0.18, hallwayDoorZ + 0.18);
-arenaG.add(walkwayFrontLight);
-const walkwayRearLight = walkwayFrontLight.clone();
-walkwayRearLight.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.25;
-arenaG.add(walkwayRearLight);
-
-const hallwayAmbient = new THREE.PointLight(0xffe2b5, dimIntensity(1.3), 18, 1.8);
-hallwayAmbient.position.set(0, walkwayCeiling.position.y - 0.05, walkwayFloor.position.z);
-hallwayAmbient.castShadow = true;
-arenaG.add(hallwayAmbient);
-
-const hallwayDoorState = {
-  pivot: hallwayDoorPivot,
-  openAngle: THREE.MathUtils.degToRad(100),
-  closedAngle: 0
-};
-const walkwayFarZ = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2;
-const walkwayEntryZ = walkwayFarZ + 1.5;
+const hallwayDoorZ = TABLE_RADIUS * 2.6;
+const walkwayEntryZ = hallwayDoorZ + TABLE_RADIUS * 1.6;
+const hallwayDoorState = null;
 
 function easeInOutCubic(t) {
   if (t <= 0) return 0;
@@ -3270,6 +3133,17 @@ function updateTableMaterials() {
 updateTableMaterials();
 
 const tableParts = {};
+const proceduralTableGroup = new THREE.Group();
+tableG.add(proceduralTableGroup);
+const tableModelGroup = new THREE.Group();
+tableG.add(tableModelGroup);
+let activeTableModel = null;
+let tableModelThemeId = TABLE_MODEL_OPTIONS[0]?.id || "murlan-default";
+let tableModelSurfaceY = TABLE_HEIGHT;
+let tableModelRadius = TABLE_RADIUS;
+const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
+const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
+const tableModelCache = new Map();
 const chairs = [];
 let seatLabelMesh = null;
 let seatLabelShouldDisplay = shouldShowSeatLabel;
@@ -3580,7 +3454,8 @@ const TABLE_BASE_Y = TABLE_HEIGHT - TABLE_TOP_DEPTH;
 const CLOTH_TOP = TABLE_HEIGHT;
 const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
-(function buildTable() {
+function buildProceduralTable() {
+  proceduralTableGroup.clear();
   const sides = 8;
   const topShape = createRegularPolygonShape(sides, TABLE_OUTER_RADIUS);
   const feltShape = createRegularPolygonShape(sides, CLOTH_RADIUS);
@@ -3600,7 +3475,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   topMesh.position.y = TABLE_BASE_Y;
   topMesh.castShadow = true;
   topMesh.receiveShadow = true;
-  tableG.add(topMesh);
+  proceduralTableGroup.add(topMesh);
   tableParts.top = topMesh;
 
   const feltGeo = new THREE.ExtrudeGeometry(feltShape, { depth: 0.01, bevelEnabled: false });
@@ -3608,7 +3483,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   const feltMesh = new THREE.Mesh(feltGeo, tableMaterials.felt);
   feltMesh.position.y = CLOTH_TOP + 0.0025;
   feltMesh.receiveShadow = true;
-  tableG.add(feltMesh);
+  proceduralTableGroup.add(feltMesh);
   tableParts.felt = feltMesh;
 
   const rimShape = topShape.clone();
@@ -3625,7 +3500,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   rimMesh.position.y = TABLE_BASE_Y + TABLE_TOP_DEPTH * 0.55;
   rimMesh.castShadow = true;
   rimMesh.receiveShadow = true;
-  tableG.add(rimMesh);
+  proceduralTableGroup.add(rimMesh);
   tableParts.rim = rimMesh;
 
   const accentShape = rimInnerShape.clone();
@@ -3634,7 +3509,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   accentGeo.rotateX(-Math.PI / 2);
   const accentMesh = new THREE.Mesh(accentGeo, tableMaterials.accent);
   accentMesh.position.y = CLOTH_TOP - 0.003;
-  tableG.add(accentMesh);
+  proceduralTableGroup.add(accentMesh);
   tableParts.accent = accentMesh;
 
   const columnHeight = TABLE_HEIGHT + 0.25;
@@ -3645,7 +3520,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   column.position.y = TABLE_BASE_Y - columnHeight / 2;
   column.castShadow = true;
   column.receiveShadow = true;
-  tableG.add(column);
+  proceduralTableGroup.add(column);
   tableParts.column = column;
 
   const base = new THREE.Mesh(
@@ -3655,7 +3530,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   base.position.y = column.position.y - columnHeight / 2 - 0.11;
   base.castShadow = true;
   base.receiveShadow = true;
-  tableG.add(base);
+  proceduralTableGroup.add(base);
   tableParts.base = base;
 
   const trim = new THREE.Mesh(
@@ -3664,9 +3539,69 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   );
   trim.rotation.x = Math.PI / 2;
   trim.position.y = base.position.y + 0.11;
-  tableG.add(trim);
+  proceduralTableGroup.add(trim);
   tableParts.trim = trim;
-})();
+}
+
+buildProceduralTable();
+
+function disposeObjectResources(object) {
+  if (!object) return;
+  const materials = new Set();
+  object.traverse((obj) => {
+    if (obj.isMesh) {
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => mat && materials.add(mat));
+      obj.geometry?.dispose?.();
+    }
+  });
+  materials.forEach((mat) => {
+    if (mat?.map) mat.map.dispose?.();
+    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    mat?.dispose?.();
+  });
+}
+
+async function applyTableModel(option = TABLE_MODEL_OPTIONS[appearance.tableModel] ?? TABLE_MODEL_OPTIONS[0]) {
+  const theme = option ?? TABLE_MODEL_OPTIONS[0];
+  if (theme?.id && tableModelThemeId === theme.id && activeTableModel) {
+    return;
+  }
+  if (activeTableModel) {
+    tableModelGroup.remove(activeTableModel);
+    disposeObjectResources(activeTableModel);
+    activeTableModel = null;
+  }
+  if (theme?.source === "polyhaven" && theme.assetId) {
+    proceduralTableGroup.visible = false;
+    const cacheKey = theme.id || theme.assetId;
+    const modelPromise = tableModelCache.get(cacheKey) || loadPolyhavenModel(theme.assetId, renderer);
+    tableModelCache.set(cacheKey, modelPromise);
+    const root = await modelPromise;
+    const model = root.clone(true);
+    prepareLoadedModel(model);
+    if (theme.rotationY) {
+      model.rotation.y += theme.rotationY;
+    }
+    const tableGroup = new THREE.Group();
+    tableGroup.add(model);
+    const fitted = fitTableModelToArena(
+      tableGroup,
+      TABLE_MODEL_TARGET_HEIGHT,
+      TABLE_MODEL_TARGET_DIAMETER
+    );
+    tableModelSurfaceY = fitted.surfaceY;
+    tableModelRadius = fitted.radius;
+    tableModelGroup.add(tableGroup);
+    activeTableModel = tableGroup;
+    tableModelThemeId = theme.id;
+    return;
+  }
+  proceduralTableGroup.visible = true;
+  tableModelSurfaceY = TABLE_HEIGHT;
+  tableModelRadius = TABLE_RADIUS;
+  tableModelThemeId = theme?.id || "murlan-default";
+}
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SCALE = 1.5 * 1.22; // upscale tiles for stronger readability
@@ -3978,7 +3913,15 @@ function applyAppearanceChange({ refresh = true } = {}) {
       material.roughnessMap.needsUpdate = true;
     }
   });
-  buildChairs(CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME);
+  const tablePromise = applyTableModel(TABLE_MODEL_OPTIONS[appearance.tableModel] ?? TABLE_MODEL_OPTIONS[0]);
+  const chairPromise = buildChairs(CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME);
+  Promise.all([tablePromise, chairPromise]).then(() => {
+    const tableRoot = activeTableModel ?? proceduralTableGroup;
+    environmentFloorY = computeGroupFloorY([tableRoot, ...chairs]);
+    baseCameraRadius = camera.position.distanceTo(controls.target) || baseCameraRadius;
+    void applyHdriEnvironment(resolveHdriVariant(appearance.environmentHdri));
+    syncSkyboxToCamera();
+  });
   renderHands();
   renderChain();
   renderBoneyardStack();
@@ -4057,6 +4000,16 @@ function createOptionPreview(key, option) {
     case 'tableBase':
       swatch.style.background = `linear-gradient(135deg, ${option.base}, ${option.trim})`;
       break;
+    case 'tableModel': {
+      if (option.thumbnail) {
+        swatch.style.backgroundImage = `url(${option.thumbnail})`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      } else {
+        swatch.style.background = '#1f2937';
+      }
+      break;
+    }
     case 'dominoStyle':
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';
@@ -4115,8 +4068,25 @@ function createOptionPreview(key, option) {
       break;
     }
     case 'chairTheme':
-      swatch.style.background = option.seatColor;
+      if (option.thumbnail) {
+        swatch.style.backgroundImage = `url(${option.thumbnail})`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      } else {
+        swatch.style.background = option.seatColor || '#1f2937';
+      }
       break;
+    case 'environmentHdri': {
+      const swatches = Array.isArray(option.swatches) ? option.swatches : null;
+      if (swatches && swatches.length >= 2) {
+        swatch.style.background = `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})`;
+      } else if (swatches && swatches.length === 1) {
+        swatch.style.background = swatches[0];
+      } else {
+        swatch.style.background = '#0f172a';
+      }
+      break;
+    }
     default:
       swatch.style.background = '#1f2937';
   }
@@ -4356,14 +4326,15 @@ function placeChairsWithOption(option, chairData, token) {
   }
 
   const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
-  const seatBottomOffset = chairData
-    ? -chairTemplateBounds.min.y
+  const chairBounds = chairData?.bounds;
+  const seatBottomOffset = chairBounds
+    ? -chairBounds.min.y
     : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight;
-  const labelHeight = chairData
-    ? seatBottomOffset + chairTemplateBounds.max.y + 0.12
+  const labelHeight = chairBounds
+    ? seatBottomOffset + chairBounds.max.y + 0.12
     : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness + 0.72;
-  const labelDepth = chairData
-    ? -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35
+  const labelDepth = chairBounds
+    ? -chairBounds.getSize(new THREE.Vector3()).z * 0.35
     : -CHAIR_DIMENSIONS.seatDepth * 0.35;
 
   const sharedMaterials = chairData
@@ -4391,8 +4362,8 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
 
-    const chair = chairData
-      ? cloneChairWithTheme(chairData, option)
+    const chair = chairData?.template
+      ? chairData.template.clone(true)
       : createDominoChair(option, renderer, sharedMaterials);
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
@@ -4412,26 +4383,46 @@ function placeChairsWithOption(option, chairData, token) {
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
 }
 
+const chairTemplateCache = new Map();
+
+async function resolveChairTemplate(option) {
+  if (!option?.assetId || option?.source !== "polyhaven") return null;
+  const key = option.id || option.assetId;
+  if (chairTemplateCache.has(key)) return chairTemplateCache.get(key);
+  const promise = (async () => {
+    const model = await loadPolyhavenModel(option.assetId, renderer);
+    const template = model.clone(true);
+    fitChairModelToFootprint(template);
+    const bounds = new THREE.Box3().setFromObject(template);
+    return { template, bounds };
+  })();
+  chairTemplateCache.set(key, promise);
+  promise.catch(() => chairTemplateCache.delete(key));
+  return promise;
+}
+
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
   const token = ++chairBuildToken;
-  const chairDataPromise = ensureMurlanChairTemplate().catch((error) => {
-    console.warn("Falling back to procedural chair for Domino", error);
-    return null;
-  });
-
-  const chairData = await Promise.race([
-    chairDataPromise,
-    new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
-  ]);
-
-  placeChairsWithOption(option, chairData, token);
-
-  if (!chairData) {
-    chairDataPromise.then((resolved) => {
-      if (!resolved || token !== chairBuildToken) return;
-      placeChairsWithOption(option, resolved, token);
+  if (option?.assetId && option?.source === "polyhaven") {
+    const chairDataPromise = resolveChairTemplate(option).catch((error) => {
+      console.warn("Failed to load Poly Haven chair", error);
+      return null;
     });
+    const chairData = await Promise.race([
+      chairDataPromise,
+      new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
+    ]);
+    placeChairsWithOption(option, chairData, token);
+    if (!chairData) {
+      chairDataPromise.then((resolved) => {
+        if (!resolved || token !== chairBuildToken) return;
+        placeChairsWithOption(option, resolved, token);
+      });
+    }
+    return;
   }
+
+  placeChairsWithOption(option, null, token);
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,3 +1,6 @@
+import { POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: [
     { id: 'oakEstate', label: 'Lis Estate' },
@@ -33,13 +36,27 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'iceTracer', label: 'Ice Tracer' },
     { id: 'violetPulse', label: 'Violet Pulse' }
   ],
-  chairTheme: [
-    { id: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
-    { id: 'midnightNavy', label: 'Midnight Blue Chairs' },
-    { id: 'emeraldWave', label: 'Emerald Wave Chairs' },
-    { id: 'onyxShadow', label: 'Onyx Shadow Chairs' },
-    { id: 'royalPlum', label: 'Royal Chestnut Chairs' }
-  ]
+  chairTheme: MURLAN_STOOL_THEMES.map((theme) => ({
+    id: theme.id,
+    label: theme.label,
+    price: theme.price,
+    description: theme.description,
+    thumbnail: theme.thumbnail
+  })),
+  tableModel: MURLAN_TABLE_THEMES.map((theme) => ({
+    id: theme.id,
+    label: theme.label,
+    price: theme.price,
+    description: theme.description,
+    thumbnail: theme.thumbnail
+  })),
+  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    id: variant.id,
+    label: `${variant.name} HDRI`,
+    price: variant.price,
+    description: variant.description,
+    swatches: variant.swatches
+  }))
 });
 
 export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze(
@@ -107,8 +124,28 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     type: 'chairTheme',
     optionId: option.id,
     name: option.label,
-    price: 300 + idx * 20,
-    description: 'Alternate spectator chair upholstery for the arena.'
+    price: option.price ?? 300 + idx * 20,
+    description: option.description || 'Alternate spectator chair upholstery for the arena.',
+    thumbnail: option.thumbnail
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.tableModel.slice(1).map((option, idx) => ({
+    id: `domino-table-${option.id}`,
+    type: 'tableModel',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 980 + idx * 40,
+    description: option.description || `${option.label} table with preserved Poly Haven materials.`,
+    thumbnail: option.thumbnail
+  })),
+  ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+    id: `domino-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 1400 + idx * 25,
+    description: variant.description || 'Pool Royale HDRI environment tuned for Domino Royale.',
+    swatches: variant.swatches,
+    previewShape: 'table'
   }))
 ];
 

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -177,12 +177,14 @@ const MURLAN_TYPE_LABELS = {
 };
 
 const DOMINO_TYPE_LABELS = {
+  tableModel: 'Table Models',
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
   dominoStyle: 'Domino Styles',
   highlightStyle: 'Highlights',
-  chairTheme: 'Chairs'
+  chairTheme: 'Chairs',
+  environmentHdri: 'HDR Environments'
 };
 
 const SNAKE_TYPE_LABELS = {
@@ -347,7 +349,8 @@ const PREVIEW_BY_TYPE = {
   tableWood: 'table',
   tableCloth: 'table',
   tableBase: 'table',
-  tables: 'table'
+  tables: 'table',
+  tableModel: 'table'
 };
 
 const PREVIEW_BY_SLUG = {


### PR DESCRIPTION
### Motivation
- Replace the hard-coded arena floor/walls/carpet/lighting with HDRI-driven illumination to match Pool Royale's environment workflow and preserve high‑quality 4k HDRI lookups.
- Reuse the existing Murlan/Pool assets so Domino Royal can offer the same table models, chairs, and Poly Haven HDRIs available in other games.
- Grounded HDRI skyboxes must scale with camera zoom so environment composition remains consistent when users zoom or orbit the table.

### Description
- Removed procedural floor/walls/carpet and three-directional lights in `domino-royal.html` and added HDRI loading via `loadPolyHavenHdriEnvironment` and runtime application in `applyHdriEnvironment`, plus grounded skybox support using `GroundedSkybox` and `syncSkyboxToCamera`.
- Added Poly Haven model/texture loaders and helpers (`KTX2Loader`, `MeshoptDecoder`, `RGBELoader`/`EXRLoader`, `loadPolyhavenModel`, `createPolyhavenInstance`) and table handling (`applyTableModel`, `fitTableModelToArena`) to place and fit Poly Haven table models into the Domino arena.
- Integrated Murlan chair/table themes into the Domino UI and runtime by importing `MURLAN_STOOL_THEMES`/`MURLAN_TABLE_THEMES`, supporting preserved materials and procedural fallbacks, and reworked `buildChairs` to use loaded templates when available.
- Extended inventory and store config in `webapp/src/config/dominoRoyalInventoryConfig.js` and `webapp/src/pages/Store.jsx` to add `tableModel` and `environmentHdri` options and store items for tables and HDRIs, plus UI preview updates to show thumbnails/swatches.

### Testing
- Launched the dev server with `npm run dev` which started successfully and served the app.
- Executed a Playwright script that opened `/domino-royal.html` and produced a screenshot `artifacts/domino-royal-hdri.png`, confirming the page loads with the new HDRI/table logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539183b24c8328b2253485e58dad48)