### PR TITLE
Add animated arena HDRI variants with ambient audio

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -33,7 +33,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   loftPhotoStudioHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.6, groundResolution: 120 },
   londonPhotoStudioHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 120 },
   schoolHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.6, groundResolution: 112 },
-  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 }
+  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 },
+  arenaBallroomMotion: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.1, groundResolution: 112 },
+  arenaCinemaMotion: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
+  arenaConcertMotion: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 },
+  arenaEventMotion: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
+  arenaDanceMotion: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 }
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [
@@ -470,6 +475,86 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.02,
     swatches: ['#f472b6', '#16a34a'],
     description: 'Cozy country hall with warm wood bounce and soft window key light.'
+  },
+  {
+    id: 'arenaBallroomMotion',
+    name: 'Arena Ballroom Motion',
+    assetId: 'ballroom',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2260,
+    exposure: 1.16,
+    environmentIntensity: 1.16,
+    backgroundIntensity: 1.08,
+    rotationSpeed: 0.025,
+    ambientSoundUrl: '/assets/sounds/football-crowd-3-69245.mp3',
+    ambientSoundVolume: 0.28,
+    swatches: ['#fde68a', '#f97316'],
+    description: 'Animated ballroom arena with crowd shimmer and rotating highlights.'
+  },
+  {
+    id: 'arenaCinemaMotion',
+    name: 'Arena Cinema Motion',
+    assetId: 'cinema_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2290,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.03,
+    rotationSpeed: 0.03,
+    ambientSoundUrl: '/assets/sounds/football-game-sound-effects-359284.mp3',
+    ambientSoundVolume: 0.26,
+    swatches: ['#ef4444', '#111827'],
+    description: 'Crowd-lit cinema arena with subtle panorama drift and stadium buzz.'
+  },
+  {
+    id: 'arenaConcertMotion',
+    name: 'Arena Concert Motion',
+    assetId: 'music_hall_01',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2320,
+    exposure: 1.1,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.04,
+    rotationSpeed: 0.028,
+    ambientSoundUrl: '/assets/sounds/man-cheering-in-victory-epic-stock-media-1-00-01.mp3',
+    ambientSoundVolume: 0.3,
+    swatches: ['#0ea5e9', '#9333ea'],
+    description: 'Concert arena ambience with animated lighting drift and live crowd roar.'
+  },
+  {
+    id: 'arenaEventMotion',
+    name: 'Arena Event Motion',
+    assetId: 'events_hall_interior',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2350,
+    exposure: 1.14,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.06,
+    rotationSpeed: 0.022,
+    ambientSoundUrl: '/assets/sounds/race-care-151963.mp3',
+    ambientSoundVolume: 0.24,
+    swatches: ['#f59e0b', '#f97316'],
+    description: 'Event arena ambience with flowing crowd motion and glowing chandeliers.'
+  },
+  {
+    id: 'arenaDanceMotion',
+    name: 'Arena Dance Motion',
+    assetId: 'dancing_hall',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2380,
+    exposure: 1.13,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    rotationSpeed: 0.032,
+    ambientSoundUrl: '/assets/sounds/metal-whistle-6121.mp3',
+    ambientSoundVolume: 0.2,
+    swatches: ['#22c55e', '#f97316'],
+    description: 'Dance arena spotlight swirl with animated reflections and whistle cues.'
   }
 ];
 


### PR DESCRIPTION
### Motivation

- Provide five animated HDRI environments for Pool Royale that include subtle motion and ambient sounds to enhance arena-like atmospheres. 
- Make these HDRI variants available in the store and the table setup UI so players can select them like other `POOL_ROYALE_HDRI_VARIANTS`. 
- Reuse the existing HDRI loading/mapping logic so new variants work identically to current HDRIs while adding rotation and ambience metadata. 
- Tie ambient audio to the active environment and obey global mute/volume settings.

### Description

- Added five new HDRI variants to `webapp/src/config/poolRoyaleInventoryConfig.js` (`arenaBallroomMotion`, `arenaCinemaMotion`, `arenaConcertMotion`, `arenaEventMotion`, `arenaDanceMotion`) with `rotationSpeed`, `ambientSoundUrl`, and `ambientSoundVolume` metadata. 
- Extended the Pool Royale scene in `webapp/src/pages/Games/PoolRoyale.jsx` with environment rotation support via `applyEnvironmentRotation`, `updateEnvironmentAnimation`, and `resetEnvironmentAnimation`, and applied the rotation when HDRI environments load. 
- Implemented ambient environment audio playback using the existing audio pipeline by adding `audioBufferLoaderRef`, `ambientSoundBuffersRef`, `syncEnvironmentAmbience`, and `stopEnvironmentAmbience`, and wired ambient playback to HDRI changes and global mute/volume events. 
- Hooked animation updates into the main render loop (`step`) and ensured environment rotation state is preserved/initialized when a new HDRI is applied.

### Testing

- No automated tests were executed for this change. 
- Changes were limited to configuration and client-side rendering/audio logic and include cleanup hooks tied to the existing audio lifecycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a6b2cc5483289f0a1503e2b44d60)