### PR TITLE
Widen Pool Royale table footprint and increase table height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -799,6 +799,7 @@ const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus 
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
 const TABLE_DISPLAY_SCALE = 0.88; // pull the entire table set ~12% closer so the arena feels more intimate without distorting proportions
+const TABLE_FOOTPRINT_SCALE = 1.22; // widen the table footprint ~22% while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -816,7 +817,7 @@ const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
   const TABLE_BASE_SCALE = 1.17;
-  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
+  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_FOOTPRINT_SCALE; // widen Pool Royale footprint without altering proportions
   const TABLE = {
     W: 72 * TABLE_SCALE,
     H: 132 * TABLE_SCALE,
@@ -1212,7 +1213,8 @@ const LEG_HEIGHT_MULTIPLIER = 2.25;
 const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 0.9;
-const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION; // physical height of table used for legs/skirt after a lighter 10% reduction to lift the stance
+const TABLE_HEIGHT_SCALE = 1.3;
+const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE; // physical height of table used for legs/skirt after a 30% height boost
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;


### PR DESCRIPTION
### Motivation
- Meet the requested layout change to make the Pool Royale table wider by ~20–25% while preserving proportions. 
- Increase the table stance to be 30% taller so the playfield sits higher across all sides. 
- Apply the changes in the Pool Royale 3D build so pockets, rails and ball sizing remain consistent.
- Keep the adjustments localized to table scaling and height variables to avoid shape distortion elsewhere.

### Description
- Added `TABLE_FOOTPRINT_SCALE = 1.22` and applied it to `TABLE_SCALE` so the table footprint is widened ~22% without altering proportions. 
- Introduced `TABLE_HEIGHT_SCALE = 1.3` and applied it to `TABLE_H` so the physical table height is increased by 30%. 
- Updated derived geometry that depends on `TABLE_SCALE` / `TABLE_H` by changing calculations in `webapp/src/pages/Games/PoolRoyale.jsx` to use the new scale factors. 
- Preserved existing pocket, ball and rail proportion math so playfield shape and pocket sizing remain consistent.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and Vite started successfully and served the app (ready state reported). 
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the screenshot step timed out (page screenshot timed out). 
- No unit test suite (`jest`) was executed as part of this change. 
- The code change was staged and committed locally (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d3404a248328901e1704fa5e7b03)