### PR TITLE
Widen and raise Pool Royale table (width +22%, height +30%)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -816,7 +816,8 @@ const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
   const TABLE_BASE_SCALE = 1.17;
-  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION; // shrink snooker build to Pool Royale footprint without altering proportions
+  const TABLE_WIDTH_SCALE = 1.22;
+  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE = {
     W: 72 * TABLE_SCALE,
     H: 132 * TABLE_SCALE,
@@ -1212,7 +1213,8 @@ const LEG_HEIGHT_MULTIPLIER = 2.25;
 const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 0.9;
-const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION; // physical height of table used for legs/skirt after a lighter 10% reduction to lift the stance
+const TABLE_HEIGHT_SCALE = 1.3;
+const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE;
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;


### PR DESCRIPTION
### Motivation
- Implement the requested table size adjustments so the Pool Royale table is wider (~20–25%) and taller (+30%) while preserving overall shape and proportions.
- Keep changes local to the Pool Royale rendering code so other games and assets remain unchanged.

### Description
- Added a `TABLE_WIDTH_SCALE = 1.22` and applied it to the computed `TABLE_SCALE` so the playfield footprint is widened by ~22%.
- Added a `TABLE_HEIGHT_SCALE = 1.3` and applied it to the `TABLE_H` computation to raise the table height by 30%.
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to incorporate the two new scale factors and keep existing dependent constants intact.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (succeeded).
- Attempted an automated Playwright screenshot of `/games/poolroyale` which timed out (failed).
- No unit test suite was executed as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d3404a248328901e1704fa5e7b03)