### PR TITLE
Lock Murlan Royale camera zoom to max distance

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2330,8 +2330,7 @@ export default function MurlanRoyaleArena({ search }) {
       const safeHorizontalReach = Math.max(2.6 * MODEL_SCALE, cameraBoundRadius);
       const maxOrbitRadius = Math.max(3.6 * MODEL_SCALE, safeHorizontalReach / Math.sin(ARENA_CAMERA_DEFAULTS.phiMax));
       const minOrbitRadius = Math.max(2.4 * MODEL_SCALE, maxOrbitRadius * 0.55);
-      const desiredRadius = THREE.MathUtils.clamp(spherical.radius * 1.05, minOrbitRadius, maxOrbitRadius);
-      spherical.radius = desiredRadius;
+      spherical.radius = maxOrbitRadius;
       spherical.phi = THREE.MathUtils.clamp(
         spherical.phi,
         ARENA_CAMERA_DEFAULTS.phiMin,
@@ -2344,13 +2343,13 @@ export default function MurlanRoyaleArena({ search }) {
       controls = new OrbitControls(camera, renderer.domElement);
       controls.enableDamping = true;
       controls.enablePan = true;
-      controls.enableZoom = true;
+      controls.enableZoom = false;
       controls.enableRotate = true;
       controls.minPolarAngle = ARENA_CAMERA_DEFAULTS.phiMin;
       controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
-      controls.minDistance = minOrbitRadius;
+      controls.minDistance = maxOrbitRadius;
       controls.maxDistance = maxOrbitRadius;
       controls.rotateSpeed = 0.6;
       controls.target.copy(target);


### PR DESCRIPTION
### Motivation
- Prevent user zooming in/out in the Murlan Royale arena and keep the view at the current maximum distance for consistent framing.
- Eliminate pinch/scroll zoom interactions that change camera radius and can break intended composition.

### Description
- Set the camera orbit radius to `maxOrbitRadius` during initialization to force the farthest allowed distance.
- Disable OrbitControls zoom by setting `controls.enableZoom = false` for the arena.
- Clamp both `controls.minDistance` and `controls.maxDistance` to `maxOrbitRadius` so the radius cannot be changed.
- Changes applied to `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Started the dev server using `npm --prefix webapp run dev` and confirmed Vite served the app successfully.
- Captured a page screenshot via a Playwright script navigated to `/games/murlanroyale` which completed and produced `artifacts/murlan-royale-zoom-locked.png`.
- No unit tests were run as part of this change.
- Manual interaction checks implied zoom input is disabled (no automated interaction tests were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e2316104832892ea54adad5a11aa)