### PR TITLE
Lock Murlan Royale camera at max zoom

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2330,7 +2330,7 @@ export default function MurlanRoyaleArena({ search }) {
       const safeHorizontalReach = Math.max(2.6 * MODEL_SCALE, cameraBoundRadius);
       const maxOrbitRadius = Math.max(3.6 * MODEL_SCALE, safeHorizontalReach / Math.sin(ARENA_CAMERA_DEFAULTS.phiMax));
       const minOrbitRadius = Math.max(2.4 * MODEL_SCALE, maxOrbitRadius * 0.55);
-      const desiredRadius = THREE.MathUtils.clamp(spherical.radius * 1.05, minOrbitRadius, maxOrbitRadius);
+      const desiredRadius = minOrbitRadius;
       spherical.radius = desiredRadius;
       spherical.phi = THREE.MathUtils.clamp(
         spherical.phi,
@@ -2344,14 +2344,14 @@ export default function MurlanRoyaleArena({ search }) {
       controls = new OrbitControls(camera, renderer.domElement);
       controls.enableDamping = true;
       controls.enablePan = true;
-      controls.enableZoom = true;
+      controls.enableZoom = false;
       controls.enableRotate = true;
       controls.minPolarAngle = ARENA_CAMERA_DEFAULTS.phiMin;
       controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
       controls.minDistance = minOrbitRadius;
-      controls.maxDistance = maxOrbitRadius;
+      controls.maxDistance = minOrbitRadius;
       controls.rotateSpeed = 0.6;
       controls.target.copy(target);
       controls.update();


### PR DESCRIPTION
### Motivation
- The Murlan Royale arena should not allow user zooming and must stay at the closest (max-zoom) camera distance for a consistent view.

### Description
- Set `desiredRadius` to `minOrbitRadius` so the camera is placed at the closest orbit radius regardless of initial spherical radius.
- Disabled orbit controls zoom via `controls.enableZoom = false` to prevent user-initiated zooming.
- Locked the orbit distance range by setting `controls.maxDistance` to `minOrbitRadius` so `minDistance` and `maxDistance` are identical.
- Modified file `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to apply these changes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e2316104832892ea54adad5a11aa)