### PR TITLE
Adjust Pool Royale HDRI placements

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,26 +1,26 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
-  neonPhotostudio: { cameraHeightM: 1.52, groundRadiusMultiplier: 3.8, groundResolution: 120 },
-  adamsBridge: { cameraHeightM: 1.68, groundRadiusMultiplier: 6.5, groundResolution: 112 },
-  ballroomHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.1, groundResolution: 112 },
-  emptyPlayRoom: { cameraHeightM: 1.5, groundRadiusMultiplier: 3.9, groundResolution: 120 },
-  christmasPhotoStudio04: { cameraHeightM: 1.52, groundRadiusMultiplier: 3.9, groundResolution: 120 },
-  billiardHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.8, groundResolution: 128 },
-  colorfulStudio: { cameraHeightM: 1.5, groundRadiusMultiplier: 4, groundResolution: 120 },
-  dancingHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  abandonedHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 },
-  entranceHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 112 },
-  hallOfFinfish: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
-  hallOfMammals: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
-  marryHall: { cameraHeightM: 1.57, groundRadiusMultiplier: 4.9, groundResolution: 112 },
-  mirroredHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  musicHall02: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 },
-  oldHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  loftPhotoStudioHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.6, groundResolution: 120 },
-  londonPhotoStudioHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 120 },
-  schoolHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.6, groundResolution: 112 },
-  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 }
+  neonPhotostudio: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.6, groundResolution: 120 },
+  adamsBridge: { cameraHeightM: 1.72, groundRadiusMultiplier: 7.4, groundResolution: 112 },
+  ballroomHall: { cameraHeightM: 1.62, groundRadiusMultiplier: 6.4, groundResolution: 112 },
+  emptyPlayRoom: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.8, groundResolution: 120 },
+  christmasPhotoStudio04: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.8, groundResolution: 120 },
+  billiardHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.8, groundResolution: 128 },
+  colorfulStudio: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.9, groundResolution: 120 },
+  dancingHall: { cameraHeightM: 1.62, groundRadiusMultiplier: 6.3, groundResolution: 112 },
+  abandonedHall: { cameraHeightM: 1.64, groundRadiusMultiplier: 6.6, groundResolution: 112 },
+  entranceHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 6, groundResolution: 112 },
+  hallOfFinfish: { cameraHeightM: 1.66, groundRadiusMultiplier: 6.8, groundResolution: 112 },
+  hallOfMammals: { cameraHeightM: 1.66, groundRadiusMultiplier: 6.8, groundResolution: 112 },
+  marryHall: { cameraHeightM: 1.61, groundRadiusMultiplier: 6.2, groundResolution: 112 },
+  mirroredHall: { cameraHeightM: 1.62, groundRadiusMultiplier: 6.3, groundResolution: 112 },
+  musicHall02: { cameraHeightM: 1.64, groundRadiusMultiplier: 6.5, groundResolution: 112 },
+  oldHall: { cameraHeightM: 1.62, groundRadiusMultiplier: 6.3, groundResolution: 112 },
+  loftPhotoStudioHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.5, groundResolution: 120 },
+  londonPhotoStudioHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.7, groundResolution: 120 },
+  schoolHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.6, groundResolution: 112 },
+  countryStudioHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.5, groundResolution: 112 }
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [


### PR DESCRIPTION
### Motivation

- Retune HDRI placement metrics to improve room scale and camera height consistency for Pool Royale scenes.
- Ensure HDRI-ground radius and camera height better center the table and provide balanced arena spacing.

### Description

- Updated `POOL_ROYALE_HDRI_PLACEMENTS` entries in `webapp/src/config/poolRoyaleInventoryConfig.js` to adjust `cameraHeightM` and `groundRadiusMultiplier` for multiple variants.
- Modified placements for 20 HDRI variants (e.g. `neonPhotostudio`, `adamsBridge`, `ballroomHall`, `billiardHall`, etc.) to larger radius and slightly revised camera heights.
- Kept `groundResolution` and other HDRI variant metadata unchanged aside from the placement tuning.

### Testing

- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready on the configured host and port (success).
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the Playwright runs timed out and failed to capture a screenshot.
- No unit tests or other automated test suites were executed as part of this change.
- Changes were committed to the branch after verification of the file diff (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ee1e097483289661bdcccb212ca2)