### PR TITLE
Align Pool Royale HDRI orientation

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,26 +1,126 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
-  neonPhotostudio: { cameraHeightM: 1.52, groundRadiusMultiplier: 3.8, groundResolution: 120 },
-  adamsBridge: { cameraHeightM: 1.68, groundRadiusMultiplier: 6.5, groundResolution: 112 },
-  ballroomHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5.1, groundResolution: 112 },
-  emptyPlayRoom: { cameraHeightM: 1.5, groundRadiusMultiplier: 3.9, groundResolution: 120 },
-  christmasPhotoStudio04: { cameraHeightM: 1.52, groundRadiusMultiplier: 3.9, groundResolution: 120 },
-  billiardHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.8, groundResolution: 128 },
-  colorfulStudio: { cameraHeightM: 1.5, groundRadiusMultiplier: 4, groundResolution: 120 },
-  dancingHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  abandonedHall: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 },
-  entranceHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 112 },
-  hallOfFinfish: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
-  hallOfMammals: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.3, groundResolution: 112 },
-  marryHall: { cameraHeightM: 1.57, groundRadiusMultiplier: 4.9, groundResolution: 112 },
-  mirroredHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  musicHall02: { cameraHeightM: 1.6, groundRadiusMultiplier: 5.2, groundResolution: 112 },
-  oldHall: { cameraHeightM: 1.58, groundRadiusMultiplier: 5, groundResolution: 112 },
-  loftPhotoStudioHall: { cameraHeightM: 1.54, groundRadiusMultiplier: 4.6, groundResolution: 120 },
-  londonPhotoStudioHall: { cameraHeightM: 1.56, groundRadiusMultiplier: 4.8, groundResolution: 120 },
-  schoolHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.6, groundResolution: 112 },
-  countryStudioHall: { cameraHeightM: 1.55, groundRadiusMultiplier: 4.5, groundResolution: 112 }
+  neonPhotostudio: {
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120,
+    rotationY: 0
+  },
+  adamsBridge: {
+    cameraHeightM: 1.68,
+    groundRadiusMultiplier: 6.5,
+    groundResolution: 112,
+    rotationY: Math.PI / 2
+  },
+  ballroomHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  emptyPlayRoom: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120,
+    rotationY: 0
+  },
+  christmasPhotoStudio04: {
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120,
+    rotationY: 0
+  },
+  billiardHall: {
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 128,
+    rotationY: 0
+  },
+  colorfulStudio: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4,
+    groundResolution: 120,
+    rotationY: 0
+  },
+  dancingHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  abandonedHall: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  entranceHall: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 112,
+    rotationY: Math.PI / 2
+  },
+  hallOfFinfish: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  hallOfMammals: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  marryHall: {
+    cameraHeightM: 1.57,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  mirroredHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  musicHall02: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  oldHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  loftPhotoStudioHall: {
+    cameraHeightM: 1.54,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 120,
+    rotationY: 0
+  },
+  londonPhotoStudioHall: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.8,
+    groundResolution: 120,
+    rotationY: Math.PI / 2
+  },
+  schoolHall: {
+    cameraHeightM: 1.55,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 112,
+    rotationY: 0
+  },
+  countryStudioHall: {
+    cameraHeightM: 1.55,
+    groundRadiusMultiplier: 4.5,
+    groundResolution: 112,
+    rotationY: 0
+  }
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11517,11 +11517,14 @@ const powerRef = useRef(hud.power);
           16,
           Math.floor(activeVariant?.groundResolution ?? HDRI_GROUNDED_RESOLUTION)
         );
+        const envRotation =
+          typeof activeVariant?.rotationY === 'number' ? activeVariant.rotationY : 0;
         let skybox = null;
         if (skyboxMap && skyboxHeight > 0 && skyboxRadius > 0) {
           try {
             skybox = new GroundedSkybox(skyboxMap, skyboxHeight, skyboxRadius, skyboxResolution);
             skybox.position.y = floorWorldY + skyboxHeight;
+            skybox.rotation.y = envRotation;
             skybox.material.depthWrite = false;
             sceneInstance.background = null;
             sceneInstance.add(skybox);
@@ -11543,6 +11546,12 @@ const powerRef = useRef(hud.power);
           ) {
             sceneInstance.backgroundIntensity = activeVariant.backgroundIntensity;
           }
+        }
+        if (sceneInstance.backgroundRotation) {
+          sceneInstance.backgroundRotation.set(0, envRotation, 0);
+        }
+        if (sceneInstance.environmentRotation) {
+          sceneInstance.environmentRotation.set(0, envRotation, 0);
         }
         if (
           'environmentIntensity' in sceneInstance &&


### PR DESCRIPTION
### Motivation
- Ensure Pool Royale HDRI environments can be rotated so the table and arena elements align to the room axes and avoid skewed placements.
- Provide per-HDRI orientation metadata to control skybox/environment orientation per variant.

### Description
- Added `rotationY` metadata to entries in `POOL_ROYALE_HDRI_PLACEMENTS` inside `webapp/src/config/poolRoyaleInventoryConfig.js` to declare per-HDRI yaw values.
- Read `rotationY` from the active HDRI variant and apply it when constructing the grounded skybox via `skybox.rotation.y = envRotation` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- If present, set `sceneInstance.backgroundRotation` and `sceneInstance.environmentRotation` to the same `envRotation` so background/environment orientations track the HDRI rotation.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the Vite server reported ready (succeeded).
- Captured a visual preview using a Playwright script that opened `/games/poolroyale` and saved `artifacts/pool-royale-hdri-alignment.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ee1e097483289661bdcccb212ca2)