### PR TITLE
Adjust billiardHall HDRI placement to better align Pool table

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -32,10 +32,10 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     arenaScale: 1.15
   },
   billiardHall: {
-    cameraHeightM: 1.54,
-    groundRadiusMultiplier: 4.8,
+    cameraHeightM: 1.62,
+    groundRadiusMultiplier: 5.6,
     groundResolution: 128,
-    arenaScale: 1.25
+    arenaScale: 1.34
   },
   colorfulStudio: {
     cameraHeightM: 1.5,


### PR DESCRIPTION
### Motivation
- The billiard hall HDRI placement needed retuning so the Pool Royale table appears centered and matches size/height relative to the HDRI reference.
- HDRI placement values drive grounded skybox, camera height and arena scaling used by the Pool Royale scene.

### Description
- Updated `billiardHall` placement in `webapp/src/config/poolRoyaleInventoryConfig.js` to better match the official mapping.
- Changed `cameraHeightM` from `1.54` to `1.62` to raise the HDRI camera reference point.
- Increased `groundRadiusMultiplier` from `4.8` to `5.6` to expand the grounded HDRI radius for correct table spacing.
- Adjusted `arenaScale` from `1.25` to `1.34` so the in-scene table footprint matches HDRI table sizing.

### Testing
- Started the dev server with `npm run dev` and the Vite dev server came up and served the site (succeeded).
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate the visual alignment and the screenshot run timed out (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fa6620d883289ad44db3902e18ea)