### PR TITLE
Tune pool ball material reflections

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -306,13 +306,13 @@ export function getBallMaterial({
     color: 0xffffff,
     map,
     clearcoat: 1,
-    clearcoatRoughness: 0.015,
+    clearcoatRoughness: 0.03,
     metalness: 0.24,
-    roughness: 0.06,
-    reflectivity: 1,
-    sheen: 0.18,
+    roughness: 0.08,
+    reflectivity: 0.9,
+    sheen: 0.14,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.18
+    envMapIntensity: 1.05
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
### Motivation
- Subtly reduce the brightness and mirror-like reflections on Pool Royale balls to better match the intended visual tone.
- Soften highlights by slightly increasing roughness and clearcoat roughness while lowering sheen and environment map intensity.

### Description
- Adjusted material parameters in `webapp/src/utils/ballMaterialFactory.js` for ball materials.
- Changed `clearcoatRoughness` from `0.015` to `0.03` to soften clearcoat highlights.
- Increased `roughness` from `0.06` to `0.08`, reduced `reflectivity` from `1` to `0.9`, and lowered `sheen` from `0.18` to `0.14` for subtler reflections.
- Reduced `envMapIntensity` from `1.18` to `1.05` to dim environment reflections.

### Testing
- Attempted an automated Playwright capture of the `/games/poolroyale` preview to validate visuals, but the screenshot run timed out (failed).
- No unit tests or Jest runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695418c16ba88328b95f82768020de42)