### PR TITLE
Pool Royale: default Full HD (90 FPS), higher HDRI resolution, and taller table legs

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -255,7 +255,7 @@ function classifyRendererTier(rendererString) {
 
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'fhd60';
+    return 'fhd90';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -286,7 +286,7 @@ function detectPreferredFrameRateId() {
     ) {
       return 'qhd90';
     }
-    return 'fhd60';
+    return 'fhd90';
   }
 
   if (rendererTier === 'desktopHigh' && highRefresh) {
@@ -301,7 +301,7 @@ function detectPreferredFrameRateId() {
     return 'qhd90';
   }
 
-  return 'fhd60';
+  return 'fhd90';
 }
 
 function resolveDefaultPixelRatioCap() {
@@ -1207,7 +1207,7 @@ const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
 const POCKET_SOUND_TAIL = 1;
-// Pool Royale previously lifted the table surface dramatically; trim the legs so the playfield sits lower
+// Pool Royale previously lifted the table surface dramatically; extend the legs for a taller table stance
 const LEG_SCALE = 6.2;
 const LEG_HEIGHT_FACTOR = 4;
 const LEG_HEIGHT_MULTIPLIER = 2.25;
@@ -1221,7 +1221,7 @@ const TABLE_LIFT =
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;
 const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
-const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension by 20% to lower the playfield
+const LEG_ELEVATION_SCALE = 1.92; // double the current leg extension so the table sits higher
 const LEG_LENGTH_SCALE = BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE;
 const LEG_HEIGHT_OFFSET = FRAME_TOP_Y - 0.3; // relationship between leg room and visible leg height
 const LEG_ROOM_HEIGHT_RAW = BASE_LEG_HEIGHT + TABLE_LIFT;
@@ -2654,13 +2654,13 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Minimum HD output with higher refresh for battery saver and 60 Hz displays.'
   },
   {
-    id: 'fhd60',
-    label: 'Full HD (75 Hz)',
-    fps: 75,
+    id: 'fhd90',
+    label: 'Full HD (90 Hz)',
+    fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
     resolution: 'Full HD render • DPR 1.55 cap',
-    description: '1080p-focused profile with extra headroom over the Snooker pacing.'
+    description: '1080p-focused profile tuned for smooth 90 Hz play.'
   },
   {
     id: 'qhd90',
@@ -2690,7 +2690,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Maximum clarity preset while capping refresh at 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_FRAME_RATE_ID = 'fhd90';
 
 const BROADCAST_SYSTEM_STORAGE_KEY = 'poolBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
@@ -4276,12 +4276,12 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 }
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const MIN_HDRI_RADIUS = 24;
-const HDRI_GROUNDED_RESOLUTION = 96;
+const HDRI_GROUNDED_RESOLUTION = 128;
 
 function pickPolyHavenHdriUrl(apiJson, preferredResolutions = []) {
   const urls = [];
@@ -9324,8 +9324,9 @@ function PoolRoyaleGame({
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
-      if (stored && FRAME_RATE_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored;
+      const normalizedStored = stored === 'fhd60' ? 'fhd90' : stored;
+      if (normalizedStored && FRAME_RATE_OPTIONS.some((opt) => opt.id === normalizedStored)) {
+        return normalizedStored;
       }
       const detected = detectPreferredFrameRateId();
       if (detected && FRAME_RATE_OPTIONS.some((opt) => opt.id === detected)) {


### PR DESCRIPTION
### Motivation
- Improve default visual fidelity and smoothness by switching the Pool Royale default frame-rate preset to `fhd90` (90 FPS).
- Provide higher-quality environment lighting by raising `DEFAULT_HDRI_RESOLUTIONS` to `8k` and increasing grounded skybox detail.
- Make the table stance taller by doubling the leg elevation scale via `LEG_ELEVATION_SCALE` to `1.92`.
- Preserve existing saved presets by normalizing legacy `fhd60` storage to the new `fhd90` preset.

### Description
- Changed `detectPreferredFrameRateId` and the default frame-rate id to return `fhd90` and replaced the prior `fhd60` option with `fhd90` (90 FPS) in `FRAME_RATE_OPTIONS`.
- Added normalization of stored frame-rate values so `fhd60` falls back to the new `fhd90` when reading `FRAME_RATE_STORAGE_KEY`.
- Increased `DEFAULT_HDRI_RESOLUTIONS` from `['4k']` to `['8k']` and bumped `HDRI_GROUNDED_RESOLUTION` from `96` to `128` for higher-res HDRI skyboxes.
- Updated table stance comment and doubled table leg extension by setting `LEG_ELEVATION_SCALE` to `1.92` in the table layout constants.

### Testing
- Started the dev server with `npm run dev` and Vite reported "ready" and served the app successfully.
- Attempted an automated Playwright capture of `/games/poolroyale`, but the page load/screenshot timed out and did not complete.
- No unit test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542155e23483288f02c34cb1c98fc8)