### PR TITLE
Increase Pool Royale table height, prefer 8k HDRIs, and default Full HD to 90 FPS

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -709,9 +709,12 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   }
 ];
 
+const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k']);
+
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
+    preferredResolutions: HDRI_RESOLUTION_STACK,
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))
 );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1207,10 +1207,10 @@ const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
 const POCKET_SOUND_TAIL = 1;
-// Pool Royale previously lifted the table surface dramatically; trim the legs so the playfield sits lower
+// Pool Royale now raises the stance; extend the legs so the playfield sits higher
 const LEG_SCALE = 6.2;
 const LEG_HEIGHT_FACTOR = 4;
-const LEG_HEIGHT_MULTIPLIER = 2.25;
+const LEG_HEIGHT_MULTIPLIER = 4.5;
 const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 1;
@@ -2654,13 +2654,13 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Minimum HD output with higher refresh for battery saver and 60 Hz displays.'
   },
   {
-    id: 'fhd60',
-    label: 'Full HD (75 Hz)',
-    fps: 75,
+    id: 'fhd90',
+    label: 'Full HD (90 Hz)',
+    fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
     resolution: 'Full HD render • DPR 1.55 cap',
-    description: '1080p-focused profile with extra headroom over the Snooker pacing.'
+    description: '1080p-focused profile tuned for 90 Hz full-motion play.'
   },
   {
     id: 'qhd90',
@@ -2690,7 +2690,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Maximum clarity preset while capping refresh at 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_FRAME_RATE_ID = 'fhd90';
 
 const BROADCAST_SYSTEM_STORAGE_KEY = 'poolBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
@@ -4276,7 +4276,7 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 }
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '4k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;


### PR DESCRIPTION
### Motivation
- Make the Pool Royale scene render with higher default visual fidelity and smoother motion. 
- Prefer higher-resolution HDRI environment maps for improved reflections and lighting. 
- Raise the physical table stance so the table appears taller with doubled leg height. 

### Description
- Doubled the effective leg multiplier by updating `LEG_HEIGHT_MULTIPLIER` in `webapp/src/pages/Games/PoolRoyale.jsx` (now `4.5`) and adjusted the inline comment to reflect the raised stance. 
- Changed the Full HD render profile entry in `FRAME_RATE_OPTIONS` to `id: 'fhd90'` with `fps: 90` and updated `DEFAULT_FRAME_RATE_ID` to `fhd90` so Full HD defaults to 90 FPS. 
- Expanded HDRI preference to higher resolutions by setting `DEFAULT_HDRI_RESOLUTIONS` to `['8k','4k']` and adding `HDRI_RESOLUTION_STACK` with `['8k','4k','2k']` in `webapp/src/config/poolRoyaleInventoryConfig.js`, and applied it to `POOL_ROYALE_HDRI_VARIANTS`. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were committed locally and files modified are `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/config/poolRoyaleInventoryConfig.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542155e23483288f02c34cb1c98fc8)