### PR TITLE
Add Poly Haven wood textures and new Pool Royale table finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -753,7 +753,14 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     jetBlackCarbon: 'Jet Black Carbon',
     frostedAsh: 'Frosted Ash',
     amberWharf: 'Amber Wharf',
-    obsidianMist: 'Obsidian Mist'
+    obsidianMist: 'Obsidian Mist',
+    peelingPaintWeathered: 'Wood Peeling Paint Weathered',
+    oakVeneer01: 'Oak Veneer 01',
+    woodTable001: 'Wood Table 001',
+    darkWood: 'Dark Wood',
+    rosewoodVeneer1: 'Rosewood Veneer 1',
+    kitchenWood: 'Kitchen Wood',
+    japaneseSycamore: 'Japanese Sycamore'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -847,6 +854,62 @@ export const POOL_ROYALE_STORE_ITEMS = [
     name: 'Obsidian Mist Finish',
     price: 1050,
     description: 'Smoked obsidian rails with misted graphite accents.'
+  },
+  {
+    id: 'finish-peelingPaintWeathered',
+    type: 'tableFinish',
+    optionId: 'peelingPaintWeathered',
+    name: 'Wood Peeling Paint Weathered Finish',
+    price: 1080,
+    description: 'Weathered paint woodgrain with soft pastel undertones.'
+  },
+  {
+    id: 'finish-oakVeneer01',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01',
+    name: 'Oak Veneer 01 Finish',
+    price: 1040,
+    description: 'Clean oak veneer planks with warm, balanced grain.'
+  },
+  {
+    id: 'finish-woodTable001',
+    type: 'tableFinish',
+    optionId: 'woodTable001',
+    name: 'Wood Table 001 Finish',
+    price: 1030,
+    description: 'Classic table timber tone with rich mid-brown depth.'
+  },
+  {
+    id: 'finish-darkWood',
+    type: 'tableFinish',
+    optionId: 'darkWood',
+    name: 'Dark Wood Finish',
+    price: 1100,
+    description: 'Deep espresso wood with strong contrast and low gloss.'
+  },
+  {
+    id: 'finish-rosewoodVeneer1',
+    type: 'tableFinish',
+    optionId: 'rosewoodVeneer1',
+    name: 'Rosewood Veneer 1 Finish',
+    price: 1120,
+    description: 'Rich rosewood veneer with warm red undertones.'
+  },
+  {
+    id: 'finish-kitchenWood',
+    type: 'tableFinish',
+    optionId: 'kitchenWood',
+    name: 'Kitchen Wood Finish',
+    price: 1020,
+    description: 'Bright kitchen-grade wood with soft golden hues.'
+  },
+  {
+    id: 'finish-japaneseSycamore',
+    type: 'tableFinish',
+    optionId: 'japaneseSycamore',
+    name: 'Japanese Sycamore Finish',
+    price: 1060,
+    description: 'Pale sycamore finish with refined linear grain.'
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2420,6 +2420,384 @@ const TABLE_FINISHES = Object.freeze({
       applySnookerStyleWoodPreset(materials, 'obsidianMist');
       return { ...materials, ...createPocketMaterials() };
     }
+  },
+  peelingPaintWeathered: {
+    id: 'peelingPaintWeathered',
+    label: 'Wood Peeling Paint Weathered',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0xd3cec6,
+      base: 0xbfb9b1
+    }),
+    woodTextureId: 'ph_woodPeelingPaintWeathered',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#bfb9b1');
+      const railColor = new THREE.Color('#d3cec6');
+      const trimColor = new THREE.Color('#e2ddd6');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.2,
+        roughness: 0.34,
+        clearcoat: 0.38,
+        clearcoatRoughness: 0.2,
+        sheen: 0.18,
+        sheenRoughness: 0.46,
+        reflectivity: 0.52,
+        envMapIntensity: 0.86
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.24,
+        roughness: 0.32,
+        clearcoat: 0.42,
+        clearcoatRoughness: 0.18,
+        sheen: 0.2,
+        sheenRoughness: 0.44,
+        reflectivity: 0.56,
+        envMapIntensity: 0.92
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.68,
+        roughness: 0.26,
+        clearcoat: 0.46,
+        clearcoatRoughness: 0.18,
+        envMapIntensity: 1
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'peelingPaintWeathered');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  oakVeneer01: {
+    id: 'oakVeneer01',
+    label: 'Oak Veneer 01',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0xd0a56f,
+      base: 0xc6955c
+    }),
+    woodTextureId: 'ph_oakVeneer01',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#c6955c');
+      const railColor = new THREE.Color('#d0a56f');
+      const trimColor = new THREE.Color('#e3c08d');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.18,
+        roughness: 0.3,
+        clearcoat: 0.4,
+        clearcoatRoughness: 0.18,
+        sheen: 0.2,
+        sheenRoughness: 0.42,
+        reflectivity: 0.54,
+        envMapIntensity: 0.92
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.22,
+        roughness: 0.3,
+        clearcoat: 0.44,
+        clearcoatRoughness: 0.18,
+        sheen: 0.22,
+        sheenRoughness: 0.44,
+        reflectivity: 0.58,
+        envMapIntensity: 0.98
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.7,
+        roughness: 0.28,
+        clearcoat: 0.46,
+        clearcoatRoughness: 0.2,
+        envMapIntensity: 1.02
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'oakVeneer01');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  woodTable001: {
+    id: 'woodTable001',
+    label: 'Wood Table 001',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0x9b6a44,
+      base: 0x8d5f3b
+    }),
+    woodTextureId: 'ph_woodTable001',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#8d5f3b');
+      const railColor = new THREE.Color('#9b6a44');
+      const trimColor = new THREE.Color('#c38c5a');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.2,
+        roughness: 0.34,
+        clearcoat: 0.38,
+        clearcoatRoughness: 0.2,
+        sheen: 0.18,
+        sheenRoughness: 0.46,
+        reflectivity: 0.52,
+        envMapIntensity: 0.88
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.24,
+        roughness: 0.32,
+        clearcoat: 0.42,
+        clearcoatRoughness: 0.2,
+        sheen: 0.2,
+        sheenRoughness: 0.44,
+        reflectivity: 0.56,
+        envMapIntensity: 0.94
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.72,
+        roughness: 0.32,
+        clearcoat: 0.44,
+        clearcoatRoughness: 0.2,
+        envMapIntensity: 1
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'woodTable001');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  darkWood: {
+    id: 'darkWood',
+    label: 'Dark Wood',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0x3a2a1e,
+      base: 0x2a1c14
+    }),
+    woodTextureId: 'ph_darkWood',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#2a1c14');
+      const railColor = new THREE.Color('#3a2a1e');
+      const trimColor = new THREE.Color('#8a6a4a');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.26,
+        roughness: 0.46,
+        clearcoat: 0.3,
+        clearcoatRoughness: 0.28,
+        sheen: 0.14,
+        sheenRoughness: 0.52,
+        reflectivity: 0.44,
+        envMapIntensity: 0.72
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.28,
+        roughness: 0.42,
+        clearcoat: 0.32,
+        clearcoatRoughness: 0.26,
+        sheen: 0.16,
+        sheenRoughness: 0.5,
+        reflectivity: 0.46,
+        envMapIntensity: 0.78
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.74,
+        roughness: 0.34,
+        clearcoat: 0.38,
+        clearcoatRoughness: 0.24,
+        envMapIntensity: 0.9
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'darkWood');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  rosewoodVeneer1: {
+    id: 'rosewoodVeneer1',
+    label: 'Rosewood Veneer 1',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0x8b4a3a,
+      base: 0x7a3d2f
+    }),
+    woodTextureId: 'ph_rosewoodVeneer1',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#7a3d2f');
+      const railColor = new THREE.Color('#8b4a3a');
+      const trimColor = new THREE.Color('#c07962');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.22,
+        roughness: 0.36,
+        clearcoat: 0.38,
+        clearcoatRoughness: 0.2,
+        sheen: 0.18,
+        sheenRoughness: 0.46,
+        reflectivity: 0.5,
+        envMapIntensity: 0.86
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.24,
+        roughness: 0.34,
+        clearcoat: 0.42,
+        clearcoatRoughness: 0.2,
+        sheen: 0.2,
+        sheenRoughness: 0.44,
+        reflectivity: 0.54,
+        envMapIntensity: 0.92
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.7,
+        roughness: 0.3,
+        clearcoat: 0.44,
+        clearcoatRoughness: 0.2,
+        envMapIntensity: 0.98
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'rosewoodVeneer1');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  kitchenWood: {
+    id: 'kitchenWood',
+    label: 'Kitchen Wood',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0xd2c0a2,
+      base: 0xc7b08b
+    }),
+    woodTextureId: 'ph_kitchenWood',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#c7b08b');
+      const railColor = new THREE.Color('#d2c0a2');
+      const trimColor = new THREE.Color('#e4d1b3');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.18,
+        roughness: 0.28,
+        clearcoat: 0.44,
+        clearcoatRoughness: 0.16,
+        sheen: 0.2,
+        sheenRoughness: 0.4,
+        reflectivity: 0.58,
+        envMapIntensity: 0.96
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.22,
+        roughness: 0.28,
+        clearcoat: 0.46,
+        clearcoatRoughness: 0.16,
+        sheen: 0.22,
+        sheenRoughness: 0.4,
+        reflectivity: 0.62,
+        envMapIntensity: 1.02
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.72,
+        roughness: 0.26,
+        clearcoat: 0.5,
+        clearcoatRoughness: 0.16,
+        envMapIntensity: 1.06
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'kitchenWood');
+      return { ...materials, ...createPocketMaterials() };
+    }
+  },
+  japaneseSycamore: {
+    id: 'japaneseSycamore',
+    label: 'Japanese Sycamore',
+    colors: makeColorPalette({
+      cloth: 0x2d7f4b,
+      rail: 0xe1d9ca,
+      base: 0xd3c9b6
+    }),
+    woodTextureId: 'ph_japaneseSycamore',
+    createMaterials: () => {
+      const frameColor = new THREE.Color('#d3c9b6');
+      const railColor = new THREE.Color('#e1d9ca');
+      const trimColor = new THREE.Color('#f1e9dc');
+      const frame = new THREE.MeshPhysicalMaterial({
+        color: frameColor,
+        metalness: 0.18,
+        roughness: 0.26,
+        clearcoat: 0.48,
+        clearcoatRoughness: 0.16,
+        sheen: 0.2,
+        sheenRoughness: 0.38,
+        reflectivity: 0.6,
+        envMapIntensity: 1
+      });
+      const rail = new THREE.MeshPhysicalMaterial({
+        color: railColor,
+        metalness: 0.22,
+        roughness: 0.26,
+        clearcoat: 0.5,
+        clearcoatRoughness: 0.16,
+        sheen: 0.22,
+        sheenRoughness: 0.38,
+        reflectivity: 0.64,
+        envMapIntensity: 1.06
+      });
+      const trim = new THREE.MeshPhysicalMaterial({
+        color: trimColor,
+        metalness: 0.74,
+        roughness: 0.24,
+        clearcoat: 0.52,
+        clearcoatRoughness: 0.14,
+        envMapIntensity: 1.1
+      });
+      const materials = {
+        frame,
+        rail,
+        leg: frame,
+        trim,
+        accent: null
+      };
+      applySnookerStyleWoodPreset(materials, 'japaneseSycamore');
+      return { ...materials, ...createPocketMaterials() };
+    }
   }
 });
 
@@ -2432,7 +2810,14 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.jetBlackCarbon,
     TABLE_FINISHES.frostedAsh,
     TABLE_FINISHES.amberWharf,
-    TABLE_FINISHES.obsidianMist
+    TABLE_FINISHES.obsidianMist,
+    TABLE_FINISHES.peelingPaintWeathered,
+    TABLE_FINISHES.oakVeneer01,
+    TABLE_FINISHES.woodTable001,
+    TABLE_FINISHES.darkWood,
+    TABLE_FINISHES.rosewoodVeneer1,
+    TABLE_FINISHES.kitchenWood,
+    TABLE_FINISHES.japaneseSycamore
   ].filter(Boolean)
 );
 

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -31,6 +31,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
 };
 
 const woodTextureLoader = new THREE.TextureLoader();
+woodTextureLoader.setCrossOrigin?.('anonymous');
 
 const makeSlabTexture = (width, height, hue, sat, light, contrast) => {
   const canvas = document.createElement('canvas');
@@ -184,6 +185,10 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 
+const POLYHAVEN_TEXTURE_BASE = 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k';
+const getPolyhavenTextureUrl = (assetId) =>
+  `${POLYHAVEN_TEXTURE_BASE}/${assetId}/${assetId}_2K_Color.jpg`;
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -213,6 +218,125 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       repeat: { x: FRAME_SLAB_REPEAT_X * 0.92, y: 0.9 },
       rotation: 0,
       textureSize: 4096
+    }
+  }),
+  Object.freeze({
+    id: 'ph_woodPeelingPaintWeathered',
+    label: 'Wood Peeling Paint Weathered',
+    source: 'Poly Haven — Wood Peeling Paint Weathered (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 0.94, y: 0.88 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('WoodPeelingPaintWeathered')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 0.94, y: 0.86 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('WoodPeelingPaintWeathered')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_oakVeneer01',
+    label: 'Oak Veneer 01',
+    source: 'Poly Haven — Oak Veneer 01 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 1.02, y: 0.92 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('OakVeneer01')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 1.02, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('OakVeneer01')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_woodTable001',
+    label: 'Wood Table 001',
+    source: 'Poly Haven — Wood Table 001 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 0.98, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('WoodTable001')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 0.98, y: 0.88 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('WoodTable001')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_darkWood',
+    label: 'Dark Wood',
+    source: 'Poly Haven — Dark Wood (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 0.96, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('DarkWood')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 0.96, y: 0.88 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('DarkWood')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_rosewoodVeneer1',
+    label: 'Rosewood Veneer 1',
+    source: 'Poly Haven — Rosewood Veneer 1 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 1.04, y: 0.92 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('RosewoodVeneer1')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 1.04, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('RosewoodVeneer1')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_kitchenWood',
+    label: 'Kitchen Wood',
+    source: 'Poly Haven — Kitchen Wood (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 1.02, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('KitchenWood')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 1.02, y: 0.88 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('KitchenWood')
+    }
+  }),
+  Object.freeze({
+    id: 'ph_japaneseSycamore',
+    label: 'Japanese Sycamore',
+    source: 'Poly Haven — Japanese Sycamore (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X * 1.06, y: 0.92 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('JapaneseSycamore')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X * 1.06, y: 0.9 },
+      rotation: 0,
+      textureSize: 4096,
+      mapUrl: getPolyhavenTextureUrl('JapaneseSycamore')
     }
   })
 ]);
@@ -464,4 +588,3 @@ export const disposeMaterialWithWood = (material) => {
     material.dispose();
   }
 };
-


### PR DESCRIPTION
### Motivation

- Add a set of Poly Haven wood textures to be usable as table finishes for Pool Royale so players can select high-fidelity wood grains.  
- Expose those finishes in the in-game Table Setup menu so they can be previewed.  
- Put the new finishes into the Pool Royale store metadata so they can be bought/unlocked.  
- Ensure texture loading from external sources works correctly by setting appropriate loader options.

### Description

- Added `POLYHAVEN_TEXTURE_BASE` and `getPolyhavenTextureUrl` and enabled `woodTextureLoader.setCrossOrigin?.('anonymous')` in `webapp/src/utils/woodMaterials.js` and added multiple `ph_*` `WOOD_GRAIN_OPTIONS` entries (e.g. `ph_woodPeelingPaintWeathered`, `ph_oakVeneer01`, `ph_woodTable001`, `ph_darkWood`, `ph_rosewoodVeneer1`, `ph_kitchenWood`, `ph_japaneseSycamore`) with `mapUrl` pointing to Poly Haven assets.  
- Added corresponding `TABLE_FINISHES` entries in `webapp/src/pages/Games/PoolRoyale.jsx` (e.g. `peelingPaintWeathered`, `oakVeneer01`, `woodTable001`, `darkWood`, `rosewoodVeneer1`, `kitchenWood`, `japaneseSycamore`) that reference the new wood textures via `woodTextureId` and register them in `TABLE_FINISH_OPTIONS`.  
- Updated store metadata in `webapp/src/config/poolRoyaleInventoryConfig.js` to add new `POOL_ROYALE_OPTION_LABELS.tableFinish` entries and new `POOL_ROYALE_STORE_ITEMS` entries for the added finishes.  
- Minor texture-loader compatibility fix: ensure texture loader uses anonymous cross-origin so external Poly Haven assets can be fetched by the client.

### Testing

- Started the local web dev server with `npm --prefix webapp run dev` and Vite reported ready (Local/Network URLs) indicating the app builds and serves the changed files.  
- Attempted an automated UI capture using Playwright to open `/games/poolroyale` and show the Table Setup panel, but the Playwright browser crashed with `TargetClosedError` / SIGSEGV in the container, so the screenshot run failed.  
- No unit tests or Jest runs were executed as part of this change.  
- Changes were committed locally (`Add Poly Haven wood finishes to Pool Royale`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542be25b0083289419f2a2208c1f7b)