### PR TITLE
Add Poly Haven wood textures and Pool Royale table finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -750,6 +750,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     charredTimber: 'Charred Timber',
     plankStudio: 'Plank Studio',
     weatheredGrey: 'Weathered Grey',
+    peelingPaintWeathered: 'Wood Peeling Paint Weathered',
+    oakVeneer01: 'Oak Veneer 01',
+    woodTable001: 'Wood Table 001',
+    darkWood: 'Dark Wood',
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    kitchenWood: 'Kitchen Wood',
+    japaneseSycamore: 'Japanese Sycamore',
     jetBlackCarbon: 'Jet Black Carbon',
     frostedAsh: 'Frosted Ash',
     amberWharf: 'Amber Wharf',
@@ -815,6 +822,62 @@ export const POOL_ROYALE_STORE_ITEMS = [
     name: 'Weathered Grey Finish',
     price: 940,
     description: 'Driftwood grey rails with soft grain and cooled trim.'
+  },
+  {
+    id: 'finish-peelingPaintWeathered',
+    type: 'tableFinish',
+    optionId: 'peelingPaintWeathered',
+    name: 'Wood Peeling Paint Weathered Finish',
+    price: 980,
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+  },
+  {
+    id: 'finish-oakVeneer01',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01',
+    name: 'Oak Veneer 01 Finish',
+    price: 990,
+    description: 'Warm oak veneer rails with smooth satin polish.'
+  },
+  {
+    id: 'finish-woodTable001',
+    type: 'tableFinish',
+    optionId: 'woodTable001',
+    name: 'Wood Table 001 Finish',
+    price: 1000,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+  },
+  {
+    id: 'finish-darkWood',
+    type: 'tableFinish',
+    optionId: 'darkWood',
+    name: 'Dark Wood Finish',
+    price: 1010,
+    description: 'Deep espresso rails with strong grain contrast.'
+  },
+  {
+    id: 'finish-rosewoodVeneer01',
+    type: 'tableFinish',
+    optionId: 'rosewoodVeneer01',
+    name: 'Rosewood Veneer 01 Finish',
+    price: 1020,
+    description: 'Rosewood veneer rails with rich, reddish undertones.'
+  },
+  {
+    id: 'finish-kitchenWood',
+    type: 'tableFinish',
+    optionId: 'kitchenWood',
+    name: 'Kitchen Wood Finish',
+    price: 1030,
+    description: 'Golden kitchen wood rails with warm highlights.'
+  },
+  {
+    id: 'finish-japaneseSycamore',
+    type: 'tableFinish',
+    optionId: 'japaneseSycamore',
+    name: 'Japanese Sycamore Finish',
+    price: 1040,
+    description: 'Light sycamore rails with clean, refined grain.'
   },
   {
     id: 'finish-jetBlack',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1953,6 +1953,82 @@ const createPocketMaterials = () => ({
   })
 });
 
+const createStandardWoodFinish = ({
+  id,
+  label,
+  cloth = 0x2d7f4b,
+  rail,
+  base,
+  trim,
+  accent,
+  woodTextureId
+}) => ({
+  id,
+  label,
+  colors: makeColorPalette({
+    cloth,
+    rail,
+    base
+  }),
+  woodTextureId,
+  createMaterials: () => {
+    const frameColor = new THREE.Color(base);
+    const railColor = new THREE.Color(rail);
+    const trimColor =
+      trim != null
+        ? new THREE.Color(trim)
+        : railColor.clone().offsetHSL(0.02, 0.08, 0.18);
+    const frame = new THREE.MeshPhysicalMaterial({
+      color: frameColor,
+      metalness: 0.2,
+      roughness: 0.32,
+      clearcoat: 0.42,
+      clearcoatRoughness: 0.22,
+      sheen: 0.2,
+      sheenRoughness: 0.44,
+      reflectivity: 0.56,
+      envMapIntensity: 0.88
+    });
+    const railMat = new THREE.MeshPhysicalMaterial({
+      color: railColor,
+      metalness: 0.24,
+      roughness: 0.34,
+      clearcoat: 0.46,
+      clearcoatRoughness: 0.2,
+      sheen: 0.22,
+      sheenRoughness: 0.46,
+      reflectivity: 0.6,
+      envMapIntensity: 0.94
+    });
+    const trimMat = new THREE.MeshPhysicalMaterial({
+      color: trimColor,
+      metalness: 0.72,
+      roughness: 0.32,
+      clearcoat: 0.44,
+      clearcoatRoughness: 0.18,
+      envMapIntensity: 1.02
+    });
+    const materials = {
+      frame,
+      rail: railMat,
+      leg: frame,
+      trim: trimMat,
+      accent: null
+    };
+    if (accent != null) {
+      materials.accent = new THREE.MeshPhysicalMaterial({
+        color: accent,
+        metalness: 0.32,
+        roughness: 0.48,
+        clearcoat: 0.22,
+        clearcoatRoughness: 0.32,
+        envMapIntensity: 0.72
+      });
+    }
+    applySnookerStyleWoodPreset(materials, id);
+    return { ...materials, ...createPocketMaterials() };
+  }
+});
 
 const TABLE_FINISHES = Object.freeze({
   rusticSplit: {
@@ -2181,6 +2257,62 @@ const TABLE_FINISHES = Object.freeze({
       return { ...materials, ...createPocketMaterials() };
     }
   },
+  peelingPaintWeathered: createStandardWoodFinish({
+    id: 'peelingPaintWeathered',
+    label: 'Wood Peeling Paint Weathered',
+    rail: 0xb8b3aa,
+    base: 0xa89f95,
+    trim: 0xd6d0c7,
+    woodTextureId: 'wood_peeling_paint_weathered'
+  }),
+  oakVeneer01: createStandardWoodFinish({
+    id: 'oakVeneer01',
+    label: 'Oak Veneer 01',
+    rail: 0xc89a64,
+    base: 0xb9854e,
+    trim: 0xe0bb7a,
+    woodTextureId: 'oak_veneer_01'
+  }),
+  woodTable001: createStandardWoodFinish({
+    id: 'woodTable001',
+    label: 'Wood Table 001',
+    rail: 0xa4724f,
+    base: 0x8f6243,
+    trim: 0xc89a64,
+    woodTextureId: 'wood_table_001'
+  }),
+  darkWood: createStandardWoodFinish({
+    id: 'darkWood',
+    label: 'Dark Wood',
+    rail: 0x3d2f2a,
+    base: 0x2f241f,
+    trim: 0x6a5a52,
+    woodTextureId: 'dark_wood'
+  }),
+  rosewoodVeneer01: createStandardWoodFinish({
+    id: 'rosewoodVeneer01',
+    label: 'Rosewood Veneer 01',
+    rail: 0x6f3a2f,
+    base: 0x5b2f26,
+    trim: 0x9b5a44,
+    woodTextureId: 'rosewood_veneer_01'
+  }),
+  kitchenWood: createStandardWoodFinish({
+    id: 'kitchenWood',
+    label: 'Kitchen Wood',
+    rail: 0xd2b28a,
+    base: 0xc39c73,
+    trim: 0xe6c79e,
+    woodTextureId: 'kitchen_wood'
+  }),
+  japaneseSycamore: createStandardWoodFinish({
+    id: 'japaneseSycamore',
+    label: 'Japanese Sycamore',
+    rail: 0xe2d4b6,
+    base: 0xd6c6a4,
+    trim: 0xf1e2c6,
+    woodTextureId: 'japanese_sycamore'
+  }),
   jetBlackCarbon: {
     id: 'jetBlackCarbon',
     label: 'Jet Black Matte Carbon Fibre',
@@ -2429,6 +2561,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.charredTimber,
     TABLE_FINISHES.plankStudio,
     TABLE_FINISHES.weatheredGrey,
+    TABLE_FINISHES.peelingPaintWeathered,
+    TABLE_FINISHES.oakVeneer01,
+    TABLE_FINISHES.woodTable001,
+    TABLE_FINISHES.darkWood,
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.kitchenWood,
+    TABLE_FINISHES.japaneseSycamore,
     TABLE_FINISHES.jetBlackCarbon,
     TABLE_FINISHES.frostedAsh,
     TABLE_FINISHES.amberWharf,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -183,6 +183,8 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 // with no visible tiling seams.
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
+const polyHavenTextureUrl = (assetId) =>
+  `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}_2K_Color.jpg`;
 
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
@@ -213,6 +215,125 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       repeat: { x: FRAME_SLAB_REPEAT_X * 0.92, y: 0.9 },
       rotation: 0,
       textureSize: 4096
+    }
+  }),
+  Object.freeze({
+    id: 'wood_peeling_paint_weathered',
+    label: 'Wood Peeling Paint Weathered',
+    source: 'Poly Haven — Wood Peeling Paint Weathered (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('wood_peeling_paint_weathered')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('wood_peeling_paint_weathered')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01',
+    label: 'Oak Veneer 01',
+    source: 'Poly Haven — Oak Veneer 01 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('oak_veneer_01')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('oak_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'wood_table_001',
+    label: 'Wood Table 001',
+    source: 'Poly Haven — Wood Table 001 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('wood_table_001')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('wood_table_001')
+    }
+  }),
+  Object.freeze({
+    id: 'dark_wood',
+    label: 'Dark Wood',
+    source: 'Poly Haven — Dark Wood (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('dark_wood')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('dark_wood')
+    }
+  }),
+  Object.freeze({
+    id: 'rosewood_veneer_01',
+    label: 'Rosewood Veneer 01',
+    source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('rosewood_veneer_01')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('rosewood_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'kitchen_wood',
+    label: 'Kitchen Wood',
+    source: 'Poly Haven — Kitchen Wood (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('kitchen_wood')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('kitchen_wood')
+    }
+  }),
+  Object.freeze({
+    id: 'japanese_sycamore',
+    label: 'Japanese Sycamore',
+    source: 'Poly Haven — Japanese Sycamore (CC0)',
+    rail: {
+      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('japanese_sycamore')
+    },
+    frame: {
+      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      rotation: 0,
+      textureSize: 2048,
+      mapUrl: polyHavenTextureUrl('japanese_sycamore')
     }
   })
 ]);
@@ -464,4 +585,3 @@ export const disposeMaterialWithWood = (material) => {
     material.dispose();
   }
 };
-


### PR DESCRIPTION
### Motivation
- Add a set of Poly Haven wood textures so Pool Royale tables can use high-fidelity wood grain from Poly Haven. 
- Expose those new wood finishes in the table setup UI so players can preview and select them. 
- Add the new finishes to the in-game store so they can be purchased/unlocked. 
- Keep integration compatible with the existing Three.js material pipeline and texture loader.

### Description
- Added a `polyHavenTextureUrl` helper and new Poly Haven entries to `WOOD_GRAIN_OPTIONS` in `webapp/src/utils/woodMaterials.js` to reference the requested textures and supply `mapUrl`/metadata. 
- Implemented `createStandardWoodFinish` and registered new finish definitions in `webapp/src/pages/Games/PoolRoyale.jsx`, then added those finishes into `TABLE_FINISH_OPTIONS` so they appear in the table setup menu. 
- Added store items and option labels for the new finishes in `webapp/src/config/poolRoyaleInventoryConfig.js` so they show up in the Pool Royale store and inventory, using `optionId` mappings consistent with the new finishes. 
- The changes reuse existing `applySnookerStyleWoodPreset`/`applyWoodTextures` logic so the new finishes integrate with the current Three.js material/UV workflow and wood repeat/rotation handling.

### Testing
- No automated tests were executed for this change (no CI/test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542be25b0083289419f2a2208c1f7b)