### PR TITLE
Pool Royale: HDRI resolution control, restore wood textures, shorten legs, adjust rail diamonds

### DIFF
--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -31,6 +31,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
 };
 
 const woodTextureLoader = new THREE.TextureLoader();
+woodTextureLoader.setCrossOrigin?.('anonymous');
 
 const makeSlabTexture = (width, height, hue, sat, light, contrast) => {
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
### Motivation
- Restore original table finish appearance and allow players to control HDRI resolution to match table visuals. 
- Improve table proportions by shortening the legs to match updated stance requirements. 
- Pull rail diamond markers inward for a tighter visual alignment with the playfield. 
- Ensure wood textures load correctly (cross-origin enabled) and mirror Murlan Royale texture behavior. 

### Description
- Added HDRI resolution selection UI and state (`hdriResolutionId`) with storage and an `auto` mode that resolves resolution based on table size. 
- Wired the selected HDRI resolution into environment loading by preferring the chosen resolution in `activeEnvironmentHdri` and `resolvePolyHavenHdriUrl`. 
- Re-enabled table wood textures and preserved per-finish wood texture properties in `tableFinish`, and set `woodTextureLoader` cross-origin via `woodTextureLoader.setCrossOrigin?.('anonymous')`. 
- Shortened legs by applying an additional 15% shrink (`LEG_LENGTH_SHRINK = 0.85`) and pulled rail diamond markers inward by reducing `railMarkerOutset` from 1.02 to 0.92. 

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which reported Vite ready and serving the app. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the page load timed out and the screenshot step failed. 
- No unit or integration test suites were executed as part of this change. 
- Changes were committed locally as "Adjust Pool Royale table visuals".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954355f003c83289bf9418d4a291463)