### PR TITLE
Expand pool table frame, enlarge wood grain, and unify wood texture wrapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1299,7 +1299,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3.4, 0.44 / 3.4); // enlarge grain 3× so rails, skirts, and legs read at table scale
-const FIXED_WOOD_REPEAT_SCALE = 20; // locked to 2000% for consistent oversized grain
+const FIXED_WOOD_REPEAT_SCALE = 100; // locked to 10000% so the grain reads 5x larger on the table finish
 const WOOD_REPEAT_SCALE_MIN = FIXED_WOOD_REPEAT_SCALE;
 const WOOD_REPEAT_SCALE_MAX = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -6505,10 +6505,7 @@ function Table3D(
   applyWoodTextureToMaterial(railMat, synchronizedRailSurface);
   applyWoodTextureToMaterial(frameMat, synchronizedFrameSurface);
   if (legMat !== frameMat) {
-    applyWoodTextureToMaterial(legMat, {
-      ...synchronizedFrameSurface,
-      rotation: synchronizedFrameSurface.rotation + Math.PI / 2
-    });
+    applyWoodTextureToMaterial(legMat, synchronizedFrameSurface);
   }
   finishParts.woodSurfaces = {
     frame: cloneWoodSurfaceConfig(synchronizedFrameSurface),
@@ -7145,7 +7142,7 @@ function Table3D(
   const railsTopY = frameTopY + railH;
   const longRailW = ORIGINAL_RAIL_WIDTH; // keep the long rail caps as wide as the end rails so side pockets match visually
   const endRailW = ORIGINAL_RAIL_WIDTH;
-  const frameExpansion = TABLE.WALL * 0.08;
+  const frameExpansion = TABLE.WALL * 0.12;
   const frameWidthEnd =
     Math.max(0, ORIGINAL_OUTER_HALF_H - halfH - 2 * endRailW) + frameExpansion;
   const frameWidthLong = frameWidthEnd; // force side rails to carry the same exterior thickness as the short rails
@@ -8957,10 +8954,7 @@ function Table3D(
 
   applyWoodTextureToMaterial(frameMat, synchronizedWoodSurface);
   if (legMat !== frameMat) {
-    applyWoodTextureToMaterial(legMat, {
-      ...synchronizedWoodSurface,
-      rotation: synchronizedWoodSurface.rotation + Math.PI / 2
-    });
+    applyWoodTextureToMaterial(legMat, synchronizedWoodSurface);
   }
   finishParts.woodSurfaces.frame = cloneWoodSurfaceConfig({
     ...woodFrameSurface,
@@ -9207,10 +9201,7 @@ function applyTableFinishToTable(table, finish) {
       mesh.material.needsUpdate = true;
     });
     if (legMat !== frameMat) {
-      applyWoodTextureToMaterial(legMat, {
-        ...synchronizedFrameSurface,
-        rotation: synchronizedFrameSurface.rotation + Math.PI / 2
-      });
+      applyWoodTextureToMaterial(legMat, synchronizedFrameSurface);
     }
     woodSurfaces.rail = cloneWoodSurfaceConfig(synchronizedRailSurface);
     woodSurfaces.frame = cloneWoodSurfaceConfig(synchronizedFrameSurface);

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -397,7 +397,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   })
 ]);
 
-export const DEFAULT_WOOD_GRAIN_ID = WOOD_GRAIN_OPTIONS[0].id;
+export const DEFAULT_WOOD_GRAIN_ID = 'wood_table_001';
 
 export const WOOD_GRAIN_OPTIONS_BY_ID = Object.freeze(
   WOOD_GRAIN_OPTIONS.reduce((acc, option) => {


### PR DESCRIPTION
### Motivation
- Increase the visible wood grain scale on the Pool Royale table so table finishes read larger and more natural. 
- Ensure the wood texture flows as a single continuous piece across rails, frame and legs with a consistent direction. 
- Slightly expand the table frame footprint so the playfield reads with more outer margin. 
- Default the table wood grain to a high-quality Poly Haven texture for authenticity.

### Description
- Increased `FIXED_WOOD_REPEAT_SCALE` from `20` to `100` to make wood grain ~5× larger on table finishes. 
- Removed the per-leg 90° rotation when applying wood textures so legs reuse the same rotation and direction as rails/frames via `applyWoodTextureToMaterial(legMat, ...)`. 
- Increased `frameExpansion` from `TABLE.WALL * 0.08` to `TABLE.WALL * 0.12` to expand the table skirt/apron outward. 
- Changed `DEFAULT_WOOD_GRAIN_ID` to `'wood_table_001'` so the default finish uses the Poly Haven table texture.

### Testing
- Started the dev server with `npm --prefix webapp run dev` which reported Vite ready and served the app (success). 
- Captured a visual smoke screenshot of `/games/poolroyale` using Playwright which produced `artifacts/pool-royale-table.png` (success). 
- No unit or integration test suites were run as part of this change. 
- Changes are primarily visual and should be validated by reviewing the generated screenshot and in-app inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a6cd821c832894237ef5675a6d66)