### PR TITLE
Expand Pool Royale table frame, scale wood grain, and inward-shift rail markers

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1299,7 +1299,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3.4, 0.44 / 3.4); // enlarge grain 3× so rails, skirts, and legs read at table scale
-const FIXED_WOOD_REPEAT_SCALE = 100; // locked to 5000% for consistent oversized grain
+const FIXED_WOOD_REPEAT_SCALE = 500; // locked to 25000% for consistent oversized grain
 const WOOD_REPEAT_SCALE_MIN = FIXED_WOOD_REPEAT_SCALE;
 const WOOD_REPEAT_SCALE_MAX = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -7146,7 +7146,7 @@ function Table3D(
   const railsTopY = frameTopY + railH;
   const longRailW = ORIGINAL_RAIL_WIDTH; // keep the long rail caps as wide as the end rails so side pockets match visually
   const endRailW = ORIGINAL_RAIL_WIDTH;
-  const frameExpansion = TABLE.WALL * 0.08;
+  const frameExpansion = TABLE.WALL * 0.12;
   const frameWidthEnd =
     Math.max(0, ORIGINAL_OUTER_HALF_H - halfH - 2 * endRailW) + frameExpansion;
   const frameWidthLong = frameWidthEnd; // force side rails to carry the same exterior thickness as the short rails
@@ -8329,7 +8329,7 @@ function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = longRailW * 0.92;
+  const railMarkerOutset = longRailW * 0.72;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -9178,12 +9178,14 @@ function applyTableFinishToTable(table, finish) {
       ),
       rotation: nextFrameSurface.rotation,
       textureSize: nextFrameSurface.textureSize,
+      mapUrl: nextFrameSurface.mapUrl,
       woodRepeatScale
     };
     const synchronizedFrameSurface = {
       repeat: new THREE.Vector2(nextFrameSurface.repeat.x, nextFrameSurface.repeat.y),
       rotation: nextFrameSurface.rotation,
       textureSize: nextFrameSurface.textureSize,
+      mapUrl: nextFrameSurface.mapUrl,
       woodRepeatScale
     };
 


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table read slightly larger by expanding the outer frame while leaving the playfield and cushions unchanged.
- Increase visible wood grain scale so wooden finishes read much larger at table scale (match user request for ~5× larger grain).
- Ensure frame/rail wooden finishes use the original Poly Haven texture sources (prevent mismatched/incorrect textures) and synchronize frame/rail/leg mapping.
- Pull the rail diamond markers slightly inward toward the table center for improved alignment.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to increase the fixed wood repeat scale by changing `FIXED_WOOD_REPEAT_SCALE` from `100` to `500` to enlarge wood grain patterns.
- Expanded the table apron by changing `frameExpansion` from `TABLE.WALL * 0.08` to `TABLE.WALL * 0.12` so the outer frame grows on all four sides while playfield/cushions remain as-is.
- Reduced the rail marker outset by changing `railMarkerOutset` from `longRailW * 0.92` to `longRailW * 0.72` to move diamond markers inward.
- Propagated `mapUrl` into the synchronized wood surface configs used when reapplying finishes so external Poly Haven texture URLs are preserved and applied to rail/frame materials.

### Testing
- No automated tests were executed for this change.
- No automated build or CI verification was run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b243f0c08328a89c7f930e895568)