### PR TITLE
Adjust Pool Royale table frame, wood textures, and rail markers

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1299,7 +1299,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3.4, 0.44 / 3.4); // enlarge grain 3× so rails, skirts, and legs read at table scale
-const FIXED_WOOD_REPEAT_SCALE = 100; // locked to 5000% for consistent oversized grain
+const FIXED_WOOD_REPEAT_SCALE = 500; // locked to 25000% for consistent oversized grain
 const WOOD_REPEAT_SCALE_MIN = FIXED_WOOD_REPEAT_SCALE;
 const WOOD_REPEAT_SCALE_MAX = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -7146,7 +7146,7 @@ function Table3D(
   const railsTopY = frameTopY + railH;
   const longRailW = ORIGINAL_RAIL_WIDTH; // keep the long rail caps as wide as the end rails so side pockets match visually
   const endRailW = ORIGINAL_RAIL_WIDTH;
-  const frameExpansion = TABLE.WALL * 0.08;
+  const frameExpansion = TABLE.WALL * 0.12;
   const frameWidthEnd =
     Math.max(0, ORIGINAL_OUTER_HALF_H - halfH - 2 * endRailW) + frameExpansion;
   const frameWidthLong = frameWidthEnd; // force side rails to carry the same exterior thickness as the short rails
@@ -7166,6 +7166,7 @@ function Table3D(
     ),
     rotation: alignedRailSurface.rotation,
     textureSize: alignedRailSurface.textureSize,
+    mapUrl: alignedRailSurface.mapUrl,
     woodRepeatScale
   });
   finishParts.underlayMeshes.forEach((mesh) => {
@@ -7178,6 +7179,7 @@ function Table3D(
       ),
       rotation: underlaySurface.rotation,
       textureSize: underlaySurface.textureSize,
+      mapUrl: underlaySurface.mapUrl,
       woodRepeatScale
     });
     mesh.material.needsUpdate = true;
@@ -8329,7 +8331,7 @@ function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = longRailW * 0.92;
+  const railMarkerOutset = longRailW * 0.8;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -9178,12 +9180,14 @@ function applyTableFinishToTable(table, finish) {
       ),
       rotation: nextFrameSurface.rotation,
       textureSize: nextFrameSurface.textureSize,
+      mapUrl: nextFrameSurface.mapUrl,
       woodRepeatScale
     };
     const synchronizedFrameSurface = {
       repeat: new THREE.Vector2(nextFrameSurface.repeat.x, nextFrameSurface.repeat.y),
       rotation: nextFrameSurface.rotation,
       textureSize: nextFrameSurface.textureSize,
+      mapUrl: nextFrameSurface.mapUrl,
       woodRepeatScale
     };
 


### PR DESCRIPTION
### Motivation
- Expand the Pool Royale table frame slightly on all sides while keeping the playfield and cushions unchanged to match updated visual references.
- Increase the visible wood grain scale so rail/frame/skirts read as larger continuous slabs on-screen.
- Ensure PolyHaven wood maps are applied consistently to frame/rail/underlay materials so external `mapUrl` textures are used when available.
- Pull the rail diamond markers slightly inward so they sit closer to the table center.

### Description
- Increased `FIXED_WOOD_REPEAT_SCALE` from `100` to `500` to enlarge wood-grain repeat density for rails/frames (`PoolRoyale.jsx`).
- Increased the frame expansion by changing `frameExpansion` from `TABLE.WALL * 0.08` to `TABLE.WALL * 0.12` so the outer frame is slightly larger without moving the playfield.
- Passed `mapUrl` into `applyWoodTextureToMaterial` for aligned rail/frame/underlay and synchronized surfaces so PolyHaven color/normal/roughness maps are used (`mapUrl` now propagated to multiple `applyWoodTextureToMaterial` calls).
- Reduced the rail marker outset by changing `railMarkerOutset` from `longRailW * 0.92` to `longRailW * 0.8` to pull diamonds inward.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported the app ready (dev server started successfully).
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the headless screenshot timed out (failed).
- No unit tests were executed in this rollout (no `npm test`/`jest` runs were performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b243f0c08328a89c7f930e895568)