### PR TITLE
Pool Royale: expand table frame, fix PolyHaven texture loading, and shift rail diamonds inward

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -819,11 +819,20 @@ const SHOW_SHORT_RAIL_TRIPODS = false;
   const TABLE_WIDTH_SCALE = 1.25;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
-  const TABLE = {
+  const BASE_TABLE_THICK = 1.8 * TABLE_SCALE;
+  const BASE_TABLE_WALL = 2.6 * TABLE_SCALE;
+  const BASE_TABLE = {
     W: 72 * TABLE_SCALE,
     H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE,
-    THICK: 1.8 * TABLE_SCALE,
-    WALL: 2.6 * TABLE_SCALE
+    THICK: BASE_TABLE_THICK,
+    WALL: BASE_TABLE_WALL
+  };
+  const TABLE_OUTER_EXPANSION = BASE_TABLE.THICK * 0.32;
+  const TABLE = {
+    W: BASE_TABLE.W + TABLE_OUTER_EXPANSION * 2,
+    H: BASE_TABLE.H + TABLE_OUTER_EXPANSION * 2,
+    THICK: BASE_TABLE.THICK,
+    WALL: BASE_TABLE.WALL
   };
 const RAIL_HEIGHT = TABLE.THICK * 1.82; // return rail height to the lower stance used previously so cushions no longer sit too tall
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
@@ -891,15 +900,16 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
-  const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
+  const BASE_SIDE_RAIL_INNER_THICKNESS = BASE_TABLE.WALL * SIDE_RAIL_INNER_SCALE;
+  const SIDE_RAIL_INNER_THICKNESS = BASE_SIDE_RAIL_INNER_THICKNESS + TABLE_OUTER_EXPANSION;
   // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
   // and preserving pocket proportions from the previous build.
   const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
-  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
-  (2 * TABLE.WALL);
+  (BASE_TABLE.H - TARGET_RATIO * (BASE_TABLE.W - 2 * BASE_SIDE_RAIL_INNER_THICKNESS)) /
+  (2 * BASE_TABLE.WALL);
 const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
-const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
+const END_RAIL_INNER_THICKNESS = BASE_TABLE.WALL * END_RAIL_INNER_SCALE + TABLE_OUTER_EXPANSION;
 const PLAY_W = TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS;
 const PLAY_H = TABLE.H - 2 * END_RAIL_INNER_THICKNESS;
 const innerLong = Math.max(PLAY_W, PLAY_H);
@@ -3561,6 +3571,16 @@ const createClothTextures = (() => {
       roughness: scoreAndPick(['rough', 'roughness'])
     };
   };
+  const resolvePolyHavenFallbackUrls = (sourceId, resolution = '2k') => {
+    if (!sourceId) return { diffuse: null, normal: null, roughness: null };
+    const resUpper = resolution.toUpperCase();
+    const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${resolution}/${sourceId}/${sourceId}_${resUpper}_`;
+    return {
+      diffuse: `${base}Color.jpg`,
+      normal: `${base}NormalGL.jpg`,
+      roughness: `${base}Roughness.jpg`
+    };
+  };
 
   const loadTexture = (loader, url, isColor) =>
     new Promise((resolve, reject) => {
@@ -3580,6 +3600,8 @@ const createClothTextures = (() => {
         (err) => reject(err || new Error('Texture load failed'))
       );
     });
+  const loadTextureSafe = (loader, url, isColor) =>
+    loadTexture(loader, url, isColor).catch(() => null);
 
   const applyTextureDefaults = (texture, { isPolyHaven = false } = {}) => {
     if (!texture) return;
@@ -3819,18 +3841,22 @@ const createClothTextures = (() => {
 
     const promise = (async () => {
       try {
+        let urls = null;
         const response = await fetch(`https://api.polyhaven.com/files/${preset.sourceId}`);
-        if (!response?.ok) return;
-        const json = await response.json();
-        const urls = pickPolyHavenTextureUrls(json);
-        if (!urls.diffuse) return;
+        if (response?.ok) {
+          const json = await response.json();
+          urls = pickPolyHavenTextureUrls(json);
+        }
+        if (!urls?.diffuse) {
+          urls = resolvePolyHavenFallbackUrls(preset.sourceId, '2k');
+        }
         const loader = new THREE.TextureLoader();
         loader.setCrossOrigin('anonymous');
 
         let [map, normal, roughness] = await Promise.all([
-          loadTexture(loader, urls.diffuse, true),
-          loadTexture(loader, urls.normal, false),
-          loadTexture(loader, urls.roughness, false)
+          loadTextureSafe(loader, urls.diffuse, true),
+          loadTextureSafe(loader, urls.normal, false),
+          loadTextureSafe(loader, urls.roughness, false)
         ]);
 
         if (map) {
@@ -8332,6 +8358,7 @@ function Table3D(
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
   const railMarkerOutset = longRailW * 0.8;
+  const railMarkerInset = TABLE.THICK * 0.35;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -8424,8 +8451,8 @@ function Table3D(
     clearRailMarkerMeshes();
     const longDiamondSpacing = PLAY_H / 8;
     const shortDiamondSpacing = PLAY_W / 4;
-    const longRailX = halfW + longRailW + railMarkerOutset;
-    const shortRailZ = halfH + endRailW + railMarkerOutset;
+    const longRailX = halfW + longRailW + railMarkerOutset - railMarkerInset;
+    const shortRailZ = halfH + endRailW + railMarkerOutset - railMarkerInset;
     const addMarker = (x, z, rotation = 0) => {
       const mesh = new THREE.Mesh(geometry, railMarkerMat);
       mesh.position.set(x, railMarkerLift, z);


### PR DESCRIPTION
### Motivation
- Expand the Pool Royale table footprint slightly from all four sides while keeping the existing playfield and cushion geometry unchanged so arena framing reads larger without breaking gameplay alignment.
- Fix unreliable cloth textures from PolyHaven by adding robust fallback/resolution behavior so PolyHaven-based presets load reliably across environments.
- Pull the rail diamond markers a bit inward so the markings sit closer to the playfield center for improved visual alignment.

### Description
- Widened the table shell by introducing `BASE_TABLE`, `TABLE_OUTER_EXPANSION` and computing `TABLE` from those values, and adjusted `SIDE_RAIL_INNER_THICKNESS` and `END_RAIL_INNER_THICKNESS` to preserve the original playfield/cushion footprint.  (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Added `resolvePolyHavenFallbackUrls` and `loadTextureSafe`, and updated `ensurePolyHavenTextures` to first query the PolyHaven API and then fall back to direct `dl.polyhaven.org` texture URLs while using the safe loader for more resilient downloads. 
- Kept the existing neutralization and texture-application logic, and ensured `applyTextureDefaults` is used for PolyHaven textures; texture consumer registration remains intact. 
- Introduced `railMarkerInset` and adjusted marker placement math (subtracting the inset from computed rail X/Z) so diamond markers are nudged inward.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready (local/ network URLs), indicating the app served successfully. 
- Ran a Playwright-based page snapshot of `/games/poolroyale` which completed and produced a screenshot artifact, confirming the scene renders with the applied changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b7b78d2c8328a68dd6399e1a9f09)