### PR TITLE
Fix Pool Royale wood texture fallback and continuous slab mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1300,7 +1300,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3.4, 0.44 / 3.4); // enlarge grain 3× so rails, skirts, and legs read at table scale
-const FIXED_WOOD_REPEAT_SCALE = 500; // locked to 25000% for consistent oversized grain
+const FIXED_WOOD_REPEAT_SCALE = 1;
 const WOOD_REPEAT_SCALE_MIN = FIXED_WOOD_REPEAT_SCALE;
 const WOOD_REPEAT_SCALE_MAX = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -1891,7 +1891,17 @@ const POOL_ROYALE_WOOD_PRESET_FOR_FINISH = Object.freeze({
   charredTimber: 'wenge',
   plankStudio: 'oak',
   weatheredGrey: 'smokedOak',
-  jetBlackCarbon: 'ebony'
+  peelingPaintWeathered: 'smokedOak',
+  oakVeneer01: 'oak',
+  woodTable001: 'walnut',
+  darkWood: 'wenge',
+  rosewoodVeneer01: 'cherry',
+  kitchenWood: 'maple',
+  japaneseSycamore: 'birch',
+  jetBlackCarbon: 'ebony',
+  frostedAsh: 'birch',
+  amberWharf: 'teak',
+  obsidianMist: 'ebony'
 });
 
 const POOL_ROYALE_WOOD_REPEAT = Object.freeze({


### PR DESCRIPTION
### Motivation
- External wood maps (PolyHaven/AmbientCG) can fail to load, leaving table rails/frames without a coherent wood grain. 
- The table should render its wood finish as a single continuous slab (no visible tiling seams) matching menu selections. 
- Menu finishes must consistently map to a wood preset so finishes always receive an appropriate grain. 

### Description
- Add robust fallback behavior to `webapp/src/utils/woodMaterials.js` so `loadExternalTexture` accepts a `fallback` and `getExternalWoodTextures` will use procedural slab/roughness textures when external maps fail. 
- Make `applyWoodTextures` use the fallback textures when external fetches fail and preserve prior behavior for shared textures. 
- Update `webapp/src/pages/Games/PoolRoyale.jsx` to set `FIXED_WOOD_REPEAT_SCALE` to `1` so wood repeats render as a single continuous slab and extend `POOL_ROYALE_WOOD_PRESET_FOR_FINISH` to map all table finishes to wood presets. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite served the site successfully (dev server started). 
- Attempted an automated Playwright screenshot to validate visuals, but Chromium crashed in this environment so the headless capture failed. 
- No unit tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bfe031e88328bccdbc8d36399eb1)