### PR TITLE
Fix Pool Royale wood UV wrapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4358,10 +4358,12 @@ function projectRailUVs(geometry, bounds) {
     faceNormal.crossVectors(edgeA, edgeB).normalize();
     center.set(0, 0, 0).add(verts[0]).add(verts[1]).add(verts[2]).multiplyScalar(1 / 3);
 
-    const dominantZ = Math.abs(faceNormal.z) >= Math.max(Math.abs(faceNormal.x), Math.abs(faceNormal.y));
-    const alignWithLongRail = Math.abs(center.y) > Math.abs(center.x);
-    const uAxis = dominantZ ? (alignWithLongRail ? 'x' : 'y') : Math.abs(faceNormal.x) >= Math.abs(faceNormal.y) ? 'z' : 'x';
-    const vAxis = dominantZ ? (alignWithLongRail ? 'y' : 'x') : Math.abs(faceNormal.x) >= Math.abs(faceNormal.y) ? 'y' : 'z';
+    const absX = Math.abs(faceNormal.x);
+    const absY = Math.abs(faceNormal.y);
+    const absZ = Math.abs(faceNormal.z);
+    const dominantZ = absZ >= Math.max(absX, absY);
+    const uAxis = dominantZ ? 'x' : absX >= absY ? 'y' : 'x';
+    const vAxis = dominantZ ? 'y' : 'z';
 
     verts.forEach((v, idx) => {
       const u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
@@ -8941,6 +8943,7 @@ function Table3D(
     depth: skirtH,
     bevelEnabled: false
   });
+  projectRailUVs(skirtGeo, { outerHalfW: outW, outerHalfH: outZ, railH: skirtH });
   const skirt = new THREE.Mesh(skirtGeo, frameMat);
   skirt.rotation.x = -Math.PI / 2;
   skirt.position.y = frameTopY - skirtH + SKIRT_RAIL_GAP_FILL + MICRO_EPS * 0.5;


### PR DESCRIPTION
### Motivation
- Fix visible seams and misaligned wood grain on the Pool Royale table so the wood finish reads as a single slab across rails and skirt.
- The `projectRailUVs` function selected projection axes inconsistently which caused stretched or mismatched UVs for some faces.
- The table skirt was not UV-projected the same way as the rails, preventing a continuous wood wrap.
- Improve visual fidelity of table finishes by making rail and skirt UVs consistent.

### Description
- Updated `projectRailUVs` to compute absolute face normal components and select `uAxis`/`vAxis` deterministically instead of the previous center-based branching logic.
- Applied `projectRailUVs` to the skirt geometry (`skirtGeo`) so the skirt uses the same UV projection and wood grain scale as the rails.
- All edits were made in `webapp/src/pages/Games/PoolRoyale.jsx` and keep existing projection behavior for rail geometry while fixing axis selection.
- This change stabilizes UV generation for rails and skirt so external wood textures and procedurally generated wood appear continuous.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bfe031e88328bccdbc8d36399eb1)