### PR TITLE
Fix Pool Royale table finish textures and PolyHaven texture handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1824,13 +1824,13 @@ const SHARED_WOOD_REPEAT = Object.freeze({
 const SHARED_WOOD_SURFACE_PROPS = Object.freeze({
   roughnessBase: 0.16,
   roughnessVariance: 0.22,
-  roughness: 0.34,
-  metalness: 0.12,
-  clearcoat: 0.46,
-  clearcoatRoughness: 0.16,
-  sheen: 0.18,
-  sheenRoughness: 0.36,
-  envMapIntensity: 1.05
+  roughness: 0.58,
+  metalness: 0.08,
+  clearcoat: 0.22,
+  clearcoatRoughness: 0.28,
+  sheen: 0.12,
+  sheenRoughness: 0.48,
+  envMapIntensity: 0.72
 });
 
 const clampWoodRepeatScaleValue = () => DEFAULT_WOOD_REPEAT_SCALE;
@@ -4364,10 +4364,16 @@ function projectRailUVs(geometry, bounds) {
     const dominantZ = absZ >= Math.max(absX, absY);
     const uAxis = dominantZ ? 'x' : absX >= absY ? 'y' : 'x';
     const vAxis = dominantZ ? 'y' : 'z';
+    const flipU =
+      (dominantZ && faceNormal.z < 0) ||
+      (!dominantZ && absX >= absY ? faceNormal.x < 0 : faceNormal.y < 0);
 
     verts.forEach((v, idx) => {
-      const u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
+      let u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
       const vCoord = (v[vAxis] + extents[vAxis] / 2) / extents[vAxis];
+      if (flipU) {
+        u = 1 - u;
+      }
       const uvIndex = (i + idx) * 2;
       uv[uvIndex] = u;
       uv[uvIndex + 1] = vCoord;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -46,12 +46,15 @@ const normalizeExternalTexture = (texture, isColor = false, anisotropy = 16) => 
 
 const resolveExternalWoodTextureUrls = (mapUrl) => {
   if (!mapUrl) return null;
-  if (mapUrl.includes('_Color')) {
-    return {
-      color: mapUrl,
-      roughness: mapUrl.replace('_Color', '_Roughness'),
-      normal: mapUrl.replace('_Color', '_NormalGL')
-    };
+  const tokens = ['_Color', '_BaseColor', '_Albedo', '_Diffuse'];
+  for (const token of tokens) {
+    if (mapUrl.includes(token)) {
+      return {
+        color: mapUrl,
+        roughness: mapUrl.replace(token, '_Roughness'),
+        normal: mapUrl.replace(token, '_NormalGL')
+      };
+    }
   }
   return { color: mapUrl };
 };


### PR DESCRIPTION
### Motivation
- Table wood finishes were rendering overly reflective and sometimes looked like mirrored reflections instead of natural grain.  
- Rail UV projection could flip the grain direction on some faces causing inconsistent/mirrored wood flow.  
- External PolyHaven texture files use multiple naming conventions which prevented associated roughness/normal maps from being inferred and loaded.  

### Description
- Tuned shared wood surface response by modifying `SHARED_WOOD_SURFACE_PROPS` to reduce clearcoat/env intensity and raise roughness in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Prevent mirrored grain on rails by adding a `flipU` calculation and flipping the U coordinate in `projectRailUVs` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Expanded `resolveExternalWoodTextureUrls` in `webapp/src/utils/woodMaterials.js` to recognize additional tokens (`_BaseColor`, `_Albedo`, `_Diffuse`) when deriving roughness and normal map URLs from a color map.  
- Modified files: `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/utils/woodMaterials.js` to implement the above changes.  

### Testing
- No automated tests were run for this change.  
- CI / test suite will validate the changes after push/merge as part of the normal pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954cd98b8248328b34e63a1de2069f6)