### PR TITLE
Fix rail UV orientation for table finishes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4362,12 +4362,33 @@ function projectRailUVs(geometry, bounds) {
     const absY = Math.abs(faceNormal.y);
     const absZ = Math.abs(faceNormal.z);
     const dominantZ = absZ >= Math.max(absX, absY);
-    const uAxis = dominantZ ? 'x' : absX >= absY ? 'y' : 'x';
-    const vAxis = dominantZ ? 'y' : 'z';
+    let uAxis;
+    let vAxis;
+    let flipU = false;
+    let flipV = false;
+    if (dominantZ) {
+      uAxis = 'x';
+      vAxis = 'y';
+      flipU = faceNormal.z < 0;
+    } else if (absX >= absY) {
+      uAxis = 'z';
+      vAxis = 'y';
+      flipU = faceNormal.x < 0;
+    } else {
+      uAxis = 'x';
+      vAxis = 'z';
+      flipV = faceNormal.y < 0;
+    }
 
     verts.forEach((v, idx) => {
-      const u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
-      const vCoord = (v[vAxis] + extents[vAxis] / 2) / extents[vAxis];
+      let u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
+      let vCoord = (v[vAxis] + extents[vAxis] / 2) / extents[vAxis];
+      if (flipU) {
+        u = 1 - u;
+      }
+      if (flipV) {
+        vCoord = 1 - vCoord;
+      }
       const uvIndex = (i + idx) * 2;
       uv[uvIndex] = u;
       uv[uvIndex + 1] = vCoord;

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -3459,14 +3459,38 @@ function projectRailUVs(geometry, bounds) {
     faceNormal.crossVectors(edgeA, edgeB).normalize();
     center.set(0, 0, 0).add(verts[0]).add(verts[1]).add(verts[2]).multiplyScalar(1 / 3);
 
-    const dominantZ = Math.abs(faceNormal.z) >= Math.max(Math.abs(faceNormal.x), Math.abs(faceNormal.y));
+    const absX = Math.abs(faceNormal.x);
+    const absY = Math.abs(faceNormal.y);
+    const absZ = Math.abs(faceNormal.z);
+    const dominantZ = absZ >= Math.max(absX, absY);
     const alignWithLongRail = Math.abs(center.y) > Math.abs(center.x);
-    const uAxis = dominantZ ? (alignWithLongRail ? 'x' : 'y') : Math.abs(faceNormal.x) >= Math.abs(faceNormal.y) ? 'z' : 'x';
-    const vAxis = dominantZ ? (alignWithLongRail ? 'y' : 'x') : Math.abs(faceNormal.x) >= Math.abs(faceNormal.y) ? 'y' : 'z';
+    let uAxis;
+    let vAxis;
+    let flipU = false;
+    let flipV = false;
+    if (dominantZ) {
+      uAxis = alignWithLongRail ? 'x' : 'y';
+      vAxis = alignWithLongRail ? 'y' : 'x';
+      flipU = faceNormal.z < 0;
+    } else if (absX >= absY) {
+      uAxis = 'z';
+      vAxis = 'y';
+      flipU = faceNormal.x < 0;
+    } else {
+      uAxis = 'x';
+      vAxis = 'z';
+      flipV = faceNormal.y < 0;
+    }
 
     verts.forEach((v, idx) => {
-      const u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
-      const vCoord = (v[vAxis] + extents[vAxis] / 2) / extents[vAxis];
+      let u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
+      let vCoord = (v[vAxis] + extents[vAxis] / 2) / extents[vAxis];
+      if (flipU) {
+        u = 1 - u;
+      }
+      if (flipV) {
+        vCoord = 1 - vCoord;
+      }
       const uvIndex = (i + idx) * 2;
       uv[uvIndex] = u;
       uv[uvIndex + 1] = vCoord;


### PR DESCRIPTION
### Motivation
- Table finish textures were appearing mirrored along some rail faces which made PolyHaven-sourced wood textures and procedural finishes look incorrect. 
- The UV projection used for rail geometry did not account for face normal orientation, causing inconsistent U/V direction on flipped faces. 
- Ensure table wood grain and cloth mapping read consistently across Pool Royale and Snooker Club scenes. 
- Preserve existing projection approach while correcting mirrored results by flipping UVs when necessary. 

### Description
- Updated `projectRailUVs` in `webapp/src/pages/Games/PoolRoyale.jsx` to select projection axes per-face and flip U/V when the face normal indicates an inverted orientation. 
- Applied the same UV orientation fix to `projectRailUVs` in `webapp/src/pages/Games/SnookerClubGame.jsx` so both game scenes share consistent rail UV behavior. 
- Logic now computes absolute face normal components, chooses the dominant axis, and conditionally inverts `u` or `v` coordinates based on the sign of the face normal. 
- Kept existing extents-based UV math and only post-processes `u/v` by flipping (i.e. `u = 1 - u`) when required to avoid mirrored textures. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954cd98b8248328b34e63a1de2069f6)