### PR TITLE
Fix Poly Haven wood texture mapping for table finishes

### DIFF
--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -46,11 +46,14 @@ const normalizeExternalTexture = (texture, isColor = false, anisotropy = 16) => 
 
 const resolveExternalWoodTextureUrls = (mapUrl) => {
   if (!mapUrl) return null;
-  if (mapUrl.includes('_Color')) {
+  const match = mapUrl.match(/_color\.(jpg|jpeg|png)$/i);
+  if (match) {
+    const extension = match[1];
+    const base = mapUrl.slice(0, match.index);
     return {
       color: mapUrl,
-      roughness: mapUrl.replace('_Color', '_Roughness'),
-      normal: mapUrl.replace('_Color', '_NormalGL')
+      roughness: `${base}_Roughness.${extension}`,
+      normal: `${base}_NormalGL.${extension}`
     };
   }
   return { color: mapUrl };
@@ -243,7 +246,7 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const polyHavenTextureUrl = (assetId) =>
-  `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}_2K_Color.jpg`;
+  `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}_2k_Color.jpg`;
 
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({


### PR DESCRIPTION
### Motivation
- Table finish wood grain textures from Poly Haven were not resolving matching roughness/normal maps due to filename casing and suffix assumptions, causing mirrored or incorrect appearance on table rails.
- The goal is to make external wood texture URL resolution case-insensitive and generate correctly cased roughness/normal URLs so Three.js materials load the intended maps.

### Description
- Adjusted `resolveExternalWoodTextureUrls` in `webapp/src/utils/woodMaterials.js` to match `_color` case-insensitively and construct `*_Roughness` and `*_NormalGL` URLs using the original file extension.
- Updated the `polyHavenTextureUrl` generator to use the expected lowercase path/filename pattern `..._2k_Color.jpg` so external Poly Haven assets are requested with consistent casing.
- The change keeps the existing `applyWoodTextures`/`getExternalWoodTextures` flow and only updates external map URL resolution and the Poly Haven helper.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed the site served at the dev URL, which succeeded.
- Captured a visual snapshot of the Pool Royale table page using a Playwright script that loaded `http://127.0.0.1:4173/games/poolroyale` and saved `artifacts/poolroyale-table-finish.png`, which completed successfully.
- No unit tests were modified or executed as this change is a visual/resource-loading fix.
- Linting and build/test scripts were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954cd98b8248328b34e63a1de2069f6)