### PR TITLE
Reduce Pool Royale table gloss, enlarge wood pattern, and soften ball reflections

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1300,7 +1300,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3.4, 0.44 / 3.4); // enlarge grain 3× so rails, skirts, and legs read at table scale
-const FIXED_WOOD_REPEAT_SCALE = 500; // locked to 25000% for consistent oversized grain
+const FIXED_WOOD_REPEAT_SCALE = 2500;
 const WOOD_REPEAT_SCALE_MIN = FIXED_WOOD_REPEAT_SCALE;
 const WOOD_REPEAT_SCALE_MAX = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -1822,15 +1822,15 @@ const SHARED_WOOD_REPEAT = Object.freeze({
   y: 5.5
 });
 const SHARED_WOOD_SURFACE_PROPS = Object.freeze({
-  roughnessBase: 0.16,
-  roughnessVariance: 0.22,
-  roughness: 0.34,
-  metalness: 0.12,
-  clearcoat: 0.46,
-  clearcoatRoughness: 0.16,
-  sheen: 0.18,
-  sheenRoughness: 0.36,
-  envMapIntensity: 1.05
+  roughnessBase: 0.22,
+  roughnessVariance: 0.38,
+  roughness: 0.52,
+  metalness: 0.06,
+  clearcoat: 0.2,
+  clearcoatRoughness: 0.5,
+  sheen: 0.08,
+  sheenRoughness: 0.6,
+  envMapIntensity: 0.5
 });
 
 const clampWoodRepeatScaleValue = () => DEFAULT_WOOD_REPEAT_SCALE;
@@ -1900,8 +1900,8 @@ const POOL_ROYALE_WOOD_REPEAT = Object.freeze({
 });
 
 const POOL_ROYALE_WOOD_SURFACE_PROPS = Object.freeze({
-  roughnessBase: 0.16,
-  roughnessVariance: 0.22
+  roughnessBase: 0.2,
+  roughnessVariance: 0.36
 });
 
 const applySnookerStyleWoodPreset = (materials, finishId) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -305,14 +305,14 @@ export function getBallMaterial({
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
-    clearcoat: 1,
-    clearcoatRoughness: 0.03,
-    metalness: 0.24,
-    roughness: 0.08,
-    reflectivity: 0.9,
-    sheen: 0.14,
+    clearcoat: 0.7,
+    clearcoatRoughness: 0.18,
+    metalness: 0.08,
+    roughness: 0.28,
+    reflectivity: 0.5,
+    sheen: 0.08,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 1.05
+    envMapIntensity: 0.6
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
### Motivation
- The Pool Royale table finish was excessively glossy and the wood/pattern detail was too small to read clearly, while balls appeared overly reflective and unnatural.
- The intent is to reduce table shine, make the table finish pattern five times more visible, and make ball reflections look more natural.

### Description
- Increased the wood repeat scale by changing `FIXED_WOOD_REPEAT_SCALE` from `500` to `2500` to scale up wood/grain patterns by 5× in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Reduced table finish gloss and adjusted wood surface parameters by updating `SHARED_WOOD_SURFACE_PROPS` and `POOL_ROYALE_WOOD_SURFACE_PROPS` (roughness, metalness, clearcoat, sheen, and `envMapIntensity`) in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Softened ball materials by lowering `clearcoat`, `metalness`, `reflectivity`, and `envMapIntensity`, while increasing `roughness` in `webapp/src/utils/ballMaterialFactory.js`.
- Changes ensure wood texture application and ball material creation now produce less glossy, higher-contrast wood surfaces and subtler ball reflections (files modified: `PoolRoyale.jsx`, `ballMaterialFactory.js`).

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported the server ready (success).
- Attempted an automated Playwright screenshot against `/games/poolroyale`, but the Chromium run crashed with a `TargetClosedError` so snapshot capture failed (failure).
- No project unit tests were executed as part of this change (`npm test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954d749957083288b95340955f763a8)