### PR TITLE
Reduce Pool Royale table and ball gloss

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -305,14 +305,14 @@ export function getBallMaterial({
   const material = new THREE.MeshPhysicalMaterial({
     color: 0xffffff,
     map,
-    clearcoat: 0.7,
-    clearcoatRoughness: 0.18,
-    metalness: 0.08,
-    roughness: 0.28,
-    reflectivity: 0.5,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.28,
+    metalness: 0.04,
+    roughness: 0.36,
+    reflectivity: 0.32,
     sheen: 0.08,
     sheenColor: new THREE.Color(0xf8f9ff),
-    envMapIntensity: 0.6
+    envMapIntensity: 0.42
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);


### PR DESCRIPTION
### Motivation
- Reduce excessive shine and hot reflections on the Pool Royale table finish so wood surfaces read more natural.
- Tone down ball specular pickup and mirror-like reflections so balls look less glossy and more physically plausible.
- Apply a tunable, consistent approach across table wood surfaces and ball materials to keep visual changes scoped and reversible.

### Description
- Add `TABLE_FINISH_SHINE_TUNING` and `softenTableFinishMaterial` in `webapp/src/pages/Games/PoolRoyale.jsx` to raise roughness, scale down clearcoat, increase clearcoat roughness, and reduce env map intensity, reflectivity, and sheen on table finish materials.
- Resolve and include `accentMat` when softening so accent materials receive the same finish damping as frame, rail, and leg materials. 
- Update `webapp/src/utils/ballMaterialFactory.js` to lower `clearcoat`, reduce `metalness` and `reflectivity`, increase `roughness` and `clearcoatRoughness`, and reduce `envMapIntensity` on billiard ball materials. 
- Changes are purely material/property adjustments and do not alter geometry, texture pipelines, or control logic.

### Testing
- Launched the webapp dev server (Vite) and confirmed it served the site on localhost successfully. 
- Attempted an automated Playwright screenshot of the Pool Royale scene but the capture timed out and did not complete. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954da80768c8328978467de14b96442)