### PR TITLE
Align Pool Royale table finish with Snooker Club (disable wood textures)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1880,8 +1880,8 @@ const WOOD_PRESETS_BY_ID = Object.freeze(
 );
 const DEFAULT_WOOD_PRESET_ID = 'walnut';
 
-// Pool Royale keeps wood grain textures enabled for the original table finishes.
-const WOOD_TEXTURES_ENABLED = true;
+// Align Pool Royale wood finishes with the Snooker Club's matte treatment.
+const WOOD_TEXTURES_ENABLED = false;
 
 const DEFAULT_TABLE_FINISH_ID =
   POOL_ROYALE_DEFAULT_UNLOCKS.tableFinish?.[0] ?? 'charredTimber';


### PR DESCRIPTION
### Motivation
- Pool Royale table tops were rendering overly shiny and reflective compared to the Snooker Club matte look. 
- The goal is to reuse the Snooker Club treatment so Pool Royale tables have the same non-reflective/matte finish. 

### Description
- Disabled wood texture-based finishes for Pool Royale by changing `WOOD_TEXTURES_ENABLED` from `true` to `false` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- This causes `applySnookerStyleWoodPreset` and the wood texture application paths to early-return, preventing the wood maps and repeats from being applied. 
- The change reduces env-map/clearcoat-driven reflectivity on Pool Royale rails/frame so the table matches the Snooker Club matte treatment. 
- The single file modified is `webapp/src/pages/Games/PoolRoyale.jsx` to flip the flag and update the explanatory comment. 

### Testing
- No automated tests were run as part of this change. 
- Manual preview/build was not executed in this rollout. 
- Recommend running the app preview and a full build to visually verify the table finish changes. 
- Run unit/integration tests (`npm test`) as a follow-up to validate no regressions in related modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e22041f88328873630a664258eeb)