### PR TITLE
Fix PolyHaven wood texture scaling for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1845,6 +1845,16 @@ function scaleWoodRepeatVector (repeatVec, scale) {
   return vec
 }
 
+function resolveWoodRepeatScaleValue (finish, woodOption) {
+  const hasExternalMap = Boolean(
+    woodOption?.frame?.mapUrl || woodOption?.rail?.mapUrl
+  );
+  if (hasExternalMap && !Number.isFinite(finish?.woodRepeatScale)) {
+    return 1;
+  }
+  return clampWoodRepeatScaleValue(finish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE);
+}
+
 function applySharedWoodSurfaceProps(material) {
   if (!material) return;
   const props = SHARED_WOOD_SURFACE_PROPS;
@@ -6476,9 +6486,7 @@ function Table3D(
       : (typeof finish === 'string' && TABLE_FINISHES[finish]) ||
         (finish?.id && TABLE_FINISHES[finish.id]) ||
         TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
-  const woodRepeatScale = clampWoodRepeatScaleValue(
-    resolvedFinish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
-  );
+  const woodRepeatScale = resolveWoodRepeatScaleValue(resolvedFinish, resolvedWoodOption);
   const clothTextureKey =
     resolvedFinish?.clothTextureKey ?? DEFAULT_CLOTH_TEXTURE_KEY;
   const palette = resolvedFinish?.colors ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID].colors;
@@ -9228,8 +9236,12 @@ function applyTableFinishToTable(table, finish) {
         rotation: 0
       }
     );
-    const woodRepeatScale = clampWoodRepeatScaleValue(
-      resolvedFinish?.woodRepeatScale ?? finishInfo.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
+    const woodRepeatScale = resolveWoodRepeatScaleValue(
+      {
+        woodRepeatScale:
+          resolvedFinish?.woodRepeatScale ?? finishInfo.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
+      },
+      resolvedWoodOption
     );
     const synchronizedRailSurface = {
       repeat: new THREE.Vector2(


### PR DESCRIPTION
### Motivation
- External PolyHaven wood color maps were being over-scaled by the global wood repeat multiplier causing the original material detail to disappear. 
- The goal is to preserve original PolyHaven texture detail for specific wood presets (e.g. `wood_peeling_paint_weathered`, `oak_veneer_01`, `wood_table_001`, `dark_wood`, `rosewood_veneer_01`, `kitchen_wood`, `japanese_sycamore`).
- The change avoids forcing the fixed large repeat scale on externally-sourced textures so their original UV density remains visible. 

### Description
- Added a new helper `resolveWoodRepeatScaleValue(finish, woodOption)` that returns `1` for external PolyHaven `mapUrl` textures when no explicit `woodRepeatScale` is provided, otherwise defers to the existing clamp logic. 
- Replaced previous `clampWoodRepeatScaleValue(...)` calls with `resolveWoodRepeatScaleValue(...)` when initializing table finishes (in `Table3D`) and when applying/updating finishes (in `applyTableFinishToTable`) so external maps keep native repeat. 
- No changes to `applyWoodTextureToMaterial` internals were made; the patch only adjusts the computed `woodRepeatScale` fed into existing texture application flow. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and the server came up and served the app successfully. 
- Automated browser check using Playwright loaded `/games/poolroyale` and captured a screenshot (`artifacts/poolroyale-wood-textures.png`) to validate visible wood textures, and the script completed successfully. 
- No unit test suite (`jest`) was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e5750d388328a03fe599060e8df9)