### PR TITLE
Add Polyhaven hallway decor and original-material asset loading; move header to bottom

### DIFF
--- a/webapp/src/components/GamesHallway.jsx
+++ b/webapp/src/components/GamesHallway.jsx
@@ -213,6 +213,7 @@ export default function GamesHallway({ games, onClose }) {
     const gltfLoader = createConfiguredGLTFLoader(renderer);
 
     const potTextureCache = new Map();
+    const assetTextureCache = new Map();
 
     const normalizePlantTexture = (texture, isColor = false) => {
       if (!texture) {
@@ -228,9 +229,9 @@ export default function GamesHallway({ games, onClose }) {
       texture.needsUpdate = true;
     };
 
-    const loadOriginalPlantTextures = async (assetId) => {
-      if (potTextureCache.has(assetId)) {
-        return potTextureCache.get(assetId);
+    const loadOriginalAssetTextures = async (assetId, cache = assetTextureCache) => {
+      if (cache.has(assetId)) {
+        return cache.get(assetId);
       }
 
       const promise = (async () => {
@@ -261,7 +262,7 @@ export default function GamesHallway({ games, onClose }) {
         }
       })();
 
-      potTextureCache.set(assetId, promise);
+      cache.set(assetId, promise);
       return promise;
     };
 
@@ -453,6 +454,9 @@ export default function GamesHallway({ games, onClose }) {
     chandelier.position.y = 6.6;
     scene.add(chandelier);
 
+    const proceduralChandelier = new THREE.Group();
+    chandelier.add(proceduralChandelier);
+
     const centerLanternUrls = [
       'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Binary/Lantern.glb',
       'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/Lantern/glTF-Binary/Lantern.glb'
@@ -507,14 +511,12 @@ export default function GamesHallway({ games, onClose }) {
         gltf.scene.scale.set(0.78, 0.78, 0.78);
         gltf.scene.position.set(0, -0.55, 0);
         gltf.scene.rotation.y = Math.PI;
-        chandelier.add(gltf.scene);
+        proceduralChandelier.add(gltf.scene);
 
         const lanternHighlight = new THREE.PointLight(0xffe8c4, 1.35, 9, 2.1);
         lanternHighlight.position.set(0, -0.35, 0);
-        chandelier.add(lanternHighlight);
-      } catch (error) {
-        // keep procedural chandelier as fallback
-      }
+        proceduralChandelier.add(lanternHighlight);
+      } catch (error) {}
     };
 
     void loadCenterLantern();
@@ -533,7 +535,7 @@ export default function GamesHallway({ games, onClose }) {
       })
     );
     chandelierShade.position.y = -0.05;
-    chandelier.add(chandelierShade);
+    proceduralChandelier.add(chandelierShade);
 
     const chandelierShadeInner = new THREE.Mesh(
       new THREE.CylinderGeometry(1.15, 1.55, 1.1, 64, 1, true),
@@ -549,7 +551,7 @@ export default function GamesHallway({ games, onClose }) {
       })
     );
     chandelierShadeInner.position.y = -0.05;
-    chandelier.add(chandelierShadeInner);
+    proceduralChandelier.add(chandelierShadeInner);
 
     const chandelierDiffuser = new THREE.Mesh(
       new THREE.CircleGeometry(1.35, 48),
@@ -566,18 +568,33 @@ export default function GamesHallway({ games, onClose }) {
     );
     chandelierDiffuser.rotation.x = Math.PI / 2;
     chandelierDiffuser.position.y = -0.6;
-    chandelier.add(chandelierDiffuser);
+    proceduralChandelier.add(chandelierDiffuser);
 
     const chandelierCap = new THREE.Mesh(
       new THREE.CylinderGeometry(0.4, 0.6, 0.3, 32),
       new THREE.MeshStandardMaterial({ color: '#d8b070', metalness: 0.9, roughness: 0.25 })
     );
     chandelierCap.position.y = 0.55;
-    chandelier.add(chandelierCap);
+    proceduralChandelier.add(chandelierCap);
 
     const chandelierGlow = new THREE.PointLight(0xffe6b0, 2.6, 28, 1.6);
     chandelierGlow.position.set(0, chandelier.position.y - 0.15, 0);
     scene.add(chandelierGlow);
+
+    const loadChandelier01 = async () => {
+      try {
+        const model = await loadPolyhavenAssetVariant('chandelier_01', 3.4);
+        if (!model || disposed) {
+          return;
+        }
+        model.position.set(0, -1.1, 0);
+        model.rotation.y = Math.PI;
+        chandelier.add(model);
+        proceduralChandelier.visible = false;
+      } catch (error) {
+        // keep procedural chandelier as fallback
+      }
+    };
 
     const floorGlow = new THREE.PointLight(0xffc890, 0.6, 16, 2.2);
     floorGlow.position.set(0, 1.2, 0);
@@ -820,6 +837,39 @@ export default function GamesHallway({ games, onClose }) {
       }
     };
 
+    const applyAssetTexturesToMaterial = (material, textureSet) => {
+      if (!material || !textureSet) {
+        return;
+      }
+
+      if (textureSet.diffuse) {
+        material.map = textureSet.diffuse;
+        if (material.color) {
+          material.color.set(0xffffff);
+        }
+      }
+
+      if (textureSet.normal) {
+        material.normalMap = textureSet.normal;
+      }
+
+      if (textureSet.roughness) {
+        material.roughnessMap = textureSet.roughness;
+      }
+
+      if (material.map) {
+        normalizePlantTexture(material.map, true);
+      }
+      if (material.normalMap) {
+        normalizePlantTexture(material.normalMap, false);
+      }
+      if (material.roughnessMap) {
+        normalizePlantTexture(material.roughnessMap, false);
+      }
+
+      material.needsUpdate = true;
+    };
+
     const buildProceduralPlant = () => {
       const pot = new THREE.Group();
       const potBody = new THREE.Mesh(
@@ -854,6 +904,36 @@ export default function GamesHallway({ games, onClose }) {
       `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`,
       `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`
     ];
+
+    const loadPolyhavenAssetVariant = async (assetId, targetHeight = null) => {
+      const gltf = await loadGltfWithFallbacks(buildPolyhavenModelUrls(assetId));
+      const textureSet = await loadOriginalAssetTextures(assetId);
+      const modelScene = gltf?.scene;
+      if (modelScene) {
+        modelScene.traverse((child) => {
+          if (child.isMesh && child.material) {
+            child.castShadow = true;
+            child.receiveShadow = true;
+            const materials = Array.isArray(child.material) ? child.material : [child.material];
+            materials.forEach((mat) => applyAssetTexturesToMaterial(mat, textureSet));
+          }
+        });
+        if (targetHeight) {
+          fitModelToHeight(modelScene, targetHeight);
+        }
+      }
+      return modelScene;
+    };
+
+    void loadChandelier01();
+
+    const safeLoadPolyhavenAsset = async (assetId, targetHeight) => {
+      try {
+        return await loadPolyhavenAssetVariant(assetId, targetHeight);
+      } catch (error) {
+        return null;
+      }
+    };
 
     const PLANT_TARGET_HEIGHT = 2.1;
 
@@ -912,7 +992,7 @@ export default function GamesHallway({ games, onClose }) {
               if (!source.textureId) {
                 return null;
               }
-              const textures = await loadOriginalPlantTextures(source.textureId);
+              const textures = await loadOriginalAssetTextures(source.textureId, potTextureCache);
               return [source.textureId, textures];
             })
           )
@@ -970,6 +1050,47 @@ export default function GamesHallway({ games, onClose }) {
         plantVariants.push(buildProceduralPlant());
       }
 
+      const frameAssetIds = [
+        'fancy_picture_frame_01',
+        'fancy_picture_frame_02',
+        'hanging_picture_frame_02',
+        'standing_picture_frame_01',
+        'standing_picture_frame_02',
+        'hanging_picture_frame_03'
+      ];
+
+      const [wallSconceModel, securityCameraModel, extinguisherModel, frameModels] = await Promise.all([
+        safeLoadPolyhavenAsset('industrial_wall_sconce', 1.2),
+        safeLoadPolyhavenAsset('security_camera_01', 0.8),
+        safeLoadPolyhavenAsset('korean_fire_extinguisher_01', 1.25),
+        Promise.all(frameAssetIds.map((assetId) => safeLoadPolyhavenAsset(assetId, 1.1)))
+      ]);
+      const usableFrames = frameModels.filter(Boolean);
+
+      if (disposed) {
+        [wallSconceModel, securityCameraModel, extinguisherModel]
+          .filter(Boolean)
+          .forEach((model) => {
+            model.traverse((child) => {
+              if (child.isMesh) {
+                child.geometry?.dispose?.();
+                disposeMeshMaterials(child.material);
+              }
+            });
+          });
+        frameModels
+          .filter(Boolean)
+          .forEach((model) => {
+            model.traverse((child) => {
+              if (child.isMesh) {
+                child.geometry?.dispose?.();
+                disposeMeshMaterials(child.material);
+              }
+            });
+          });
+        return;
+      }
+
       const referenceIndex = poolIndex !== -1 ? poolIndex % plantVariants.length : 0;
       const referenceVariant = plantVariants[referenceIndex];
 
@@ -999,6 +1120,35 @@ export default function GamesHallway({ games, onClose }) {
           fitModelToHeight(instance, referenceVariant.targetHeight);
         }
         potGroup.add(instance);
+
+        if (wallSconceModel) {
+          const sconceInstance = cloneSkinnedMesh(wallSconceModel);
+          sconceInstance.position.set(0, 3, -1.25);
+          sconceInstance.rotation.y = Math.PI;
+          potGroup.add(sconceInstance);
+        }
+
+      const frameSource = usableFrames.length ? usableFrames[i % usableFrames.length] : null;
+        if (frameSource) {
+          const frameInstance = cloneSkinnedMesh(frameSource);
+          frameInstance.position.set(0, 2.15, -0.7);
+          frameInstance.rotation.y = Math.PI;
+          potGroup.add(frameInstance);
+        }
+
+        if (securityCameraModel) {
+          const cameraInstance = cloneSkinnedMesh(securityCameraModel);
+          cameraInstance.position.set(0, 3.75, -1.35);
+          cameraInstance.rotation.y = Math.PI;
+          potGroup.add(cameraInstance);
+        }
+
+        if (extinguisherModel) {
+          const extinguisherInstance = cloneSkinnedMesh(extinguisherModel);
+          extinguisherInstance.position.set(1.1, 0, 0.35);
+          extinguisherInstance.rotation.y = Math.PI / 2;
+          potGroup.add(extinguisherInstance);
+        }
 
         scene.add(potGroup);
       }
@@ -1255,6 +1405,18 @@ export default function GamesHallway({ games, onClose }) {
 
   return (
     <div className="fixed inset-0 z-[100] flex flex-col bg-black/90 backdrop-blur">
+      <div className="relative flex-1">
+        <div ref={containerRef} className="absolute inset-0" />
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute top-6 inset-x-0 flex justify-center">
+            <div className="inline-flex items-center gap-2 rounded-full bg-black/55 px-4 py-2 text-xs font-semibold tracking-wide text-white shadow-lg shadow-black/40 backdrop-blur-sm">
+              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.8)]" />
+              <span className="text-sm font-semibold text-white">{onlineCount}</span>
+              <span className="text-[0.65rem] uppercase text-white/80">online</span>
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="flex items-center justify-between px-4 py-3 text-text">
         <div>
           <h3 className="text-lg font-semibold">TonPlaygram Luxury Hallway</h3>
@@ -1269,18 +1431,6 @@ export default function GamesHallway({ games, onClose }) {
         >
           Close
         </button>
-      </div>
-      <div className="relative flex-1">
-        <div ref={containerRef} className="absolute inset-0" />
-        <div className="pointer-events-none absolute inset-0">
-          <div className="absolute top-6 inset-x-0 flex justify-center">
-            <div className="inline-flex items-center gap-2 rounded-full bg-black/55 px-4 py-2 text-xs font-semibold tracking-wide text-white shadow-lg shadow-black/40 backdrop-blur-sm">
-              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.8)]" />
-              <span className="text-sm font-semibold text-white">{onlineCount}</span>
-              <span className="text-[0.65rem] uppercase text-white/80">online</span>
-            </div>
-          </div>
-        </div>
       </div>
       {selectedGame && overlayRootRef.current &&
         createPortal(


### PR DESCRIPTION
### Motivation

- Load Polyhaven models (chandelier, wall sconces, picture frames, security cameras, fire extinguishers) and preserve their original material textures like the existing flower pots.
- Place a `Chandelier 01` model at the center ceiling and keep the procedural chandelier as a fallback.
- Attach an `Industrial Wall Sconce` above each flower pot and add a picture frame between the pot and the sconce for each pot.
- Add a `Security Camera 01` above each sconce and a `Korean Fire Extinguisher 01` next to every flower pot, and move the hallway header/close controls to the bottom of the overlay.

### Description

- Added `assetTextureCache` and refactored `loadOriginalPlantTextures` into `loadOriginalAssetTextures` to fetch and cache Polyhaven texture sets, and kept `potTextureCache` for plant textures.
- Implemented `applyAssetTexturesToMaterial`, `loadPolyhavenAssetVariant`, and `safeLoadPolyhavenAsset` to load GLTF models and apply original diffuse/normal/roughness maps to model materials using the existing normalization helpers.
- Loaded `chandelier_01` via `loadChandelier01` (replacing the procedural chandelier when available) and added logic in `addFlowerPotsBetweenDoors` to attach `industrial_wall_sconce`, security camera, picture frames (`fancy_picture_frame_01`, `fancy_picture_frame_02`, `hanging_picture_frame_02`, `standing_picture_frame_01`, `standing_picture_frame_02`, `hanging_picture_frame_03`), and `korean_fire_extinguisher_01` to each pot grouping.
- Reordered the JSX so the hallway overlay scene container is rendered before the metadata header and moved the header/close button block to the bottom of the overlay UI.

### Testing

- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (server started successfully).
- Captured an automated screenshot of `/games` using a Playwright script which completed and produced `artifacts/hallway.png` verifying the scene loads without immediate runtime errors.
- No unit test suites were run as part of this change.
- Build/runtime warnings from Babel were observed but did not fail the run (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ed2363e48328ab6e0f0d5162aacc)