### PR TITLE
Restore Poly Haven wood texture mapping and disable oversized repeat for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1962,7 +1962,8 @@ const createStandardWoodFinish = ({
   base,
   trim,
   accent,
-  woodTextureId
+  woodTextureId,
+  woodRepeatScale
 }) => ({
   id,
   label,
@@ -1972,6 +1973,7 @@ const createStandardWoodFinish = ({
     base
   }),
   woodTextureId,
+  woodRepeatScale,
   createMaterials: () => {
     const frameColor = new THREE.Color(base);
     const railColor = new THREE.Color(rail);
@@ -2041,6 +2043,7 @@ const TABLE_FINISHES = Object.freeze({
       base: 0xefe5d6
     }),
     woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1,
     createMaterials: () => {
       const frameColor = new THREE.Color('#efe5d6');
       const railColor = new THREE.Color('#f2eadf');
@@ -2094,6 +2097,7 @@ const TABLE_FINISHES = Object.freeze({
       base: 0x302118
     }),
     woodTextureId: 'dark_wood',
+    woodRepeatScale: 1,
     createMaterials: () => {
       const frameColor = new THREE.Color('#302118');
       const railColor = new THREE.Color('#3c2c22');
@@ -2154,6 +2158,7 @@ const TABLE_FINISHES = Object.freeze({
       base: 0xae7a46
     }),
     woodTextureId: 'wood_table_001',
+    woodRepeatScale: 1,
     createMaterials: () => {
       const frameColor = new THREE.Color('#ae7a46');
       const railColor = new THREE.Color('#b88452');
@@ -2207,6 +2212,7 @@ const TABLE_FINISHES = Object.freeze({
       base: 0x4e463f
     }),
     woodTextureId: 'wood_peeling_paint_weathered',
+    woodRepeatScale: 1,
     createMaterials: () => {
       const frameColor = new THREE.Color('#4e463f');
       const railColor = new THREE.Color('#5f5750');
@@ -2264,7 +2270,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xb8b3aa,
     base: 0xa89f95,
     trim: 0xd6d0c7,
-    woodTextureId: 'wood_peeling_paint_weathered'
+    woodTextureId: 'wood_peeling_paint_weathered',
+    woodRepeatScale: 1
   }),
   oakVeneer01: createStandardWoodFinish({
     id: 'oakVeneer01',
@@ -2272,7 +2279,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xc89a64,
     base: 0xb9854e,
     trim: 0xe0bb7a,
-    woodTextureId: 'oak_veneer_01'
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
   }),
   woodTable001: createStandardWoodFinish({
     id: 'woodTable001',
@@ -2280,7 +2288,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xa4724f,
     base: 0x8f6243,
     trim: 0xc89a64,
-    woodTextureId: 'wood_table_001'
+    woodTextureId: 'wood_table_001',
+    woodRepeatScale: 1
   }),
   darkWood: createStandardWoodFinish({
     id: 'darkWood',
@@ -2288,7 +2297,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x3d2f2a,
     base: 0x2f241f,
     trim: 0x6a5a52,
-    woodTextureId: 'dark_wood'
+    woodTextureId: 'dark_wood',
+    woodRepeatScale: 1
   }),
   rosewoodVeneer01: createStandardWoodFinish({
     id: 'rosewoodVeneer01',
@@ -2296,7 +2306,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x6f3a2f,
     base: 0x5b2f26,
     trim: 0x9b5a44,
-    woodTextureId: 'rosewood_veneer_01'
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: 1
   }),
   kitchenWood: createStandardWoodFinish({
     id: 'kitchenWood',
@@ -2304,7 +2315,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xd2b28a,
     base: 0xc39c73,
     trim: 0xe6c79e,
-    woodTextureId: 'kitchen_wood'
+    woodTextureId: 'kitchen_wood',
+    woodRepeatScale: 1
   }),
   japaneseSycamore: createStandardWoodFinish({
     id: 'japaneseSycamore',
@@ -2312,7 +2324,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xe2d4b6,
     base: 0xd6c6a4,
     trim: 0xf1e2c6,
-    woodTextureId: 'japanese_sycamore'
+    woodTextureId: 'japanese_sycamore',
+    woodRepeatScale: 1
   }),
   jetBlackCarbon: {
     id: 'jetBlackCarbon',

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -300,13 +300,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Wood Peeling Paint Weathered',
     source: 'Poly Haven — Wood Peeling Paint Weathered (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
@@ -317,13 +317,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Oak Veneer 01',
     source: 'Poly Haven — Oak Veneer 01 (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('oak_veneer_01')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('oak_veneer_01')
@@ -334,13 +334,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Wood Table 001',
     source: 'Poly Haven — Wood Table 001 (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('wood_table_001')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('wood_table_001')
@@ -351,13 +351,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Dark Wood',
     source: 'Poly Haven — Dark Wood (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('dark_wood')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('dark_wood')
@@ -368,13 +368,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Rosewood Veneer 01',
     source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
@@ -385,13 +385,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Kitchen Wood',
     source: 'Poly Haven — Kitchen Wood (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('kitchen_wood')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('kitchen_wood')
@@ -402,13 +402,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Japanese Sycamore',
     source: 'Poly Haven — Japanese Sycamore (CC0)',
     rail: {
-      repeat: { x: LARGE_SLAB_REPEAT_X, y: 0.92 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
     },
     frame: {
-      repeat: { x: FRAME_SLAB_REPEAT_X, y: 0.9 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')


### PR DESCRIPTION
### Motivation

- Poly Haven wood finishes were being stretched by the global oversized repeat scale which broke original mapping and appearance. 
- The goal is to show Poly Haven textures using their original color, normal and roughness maps and preserve the source mapping.
- Ensure the specified finishes (Peeling Paint Weathered, Oak Veneer 01, Wood Table 001, Dark Wood, Rosewood Veneer 01, Kitchen Wood, Japanese Sycamore) use native repeats so their materials look as authored.

### Description

- Set Poly Haven wood grain `rail` and `frame` `repeat` to `{ x: 1, y: 1 }` for the listed assets in `webapp/src/utils/woodMaterials.js` so external maps use original tiling.  
- Added a `woodRepeatScale: 1` override to Pool Royale table finishes and propagated `woodRepeatScale` through `createStandardWoodFinish` in `webapp/src/pages/Games/PoolRoyale.jsx` to disable the previous oversized repeat scale for those finishes.  
- Kept external `map/roughness/normal` URLs via `polyHavenTextureSet(...)` so original Poly Haven maps remain used by `applyWoodTextures` and related texture loaders.  

### Testing

- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready (served at `http://localhost:4173/`).  
- Attempted an automated visual smoke check using Playwright to capture `/games/poolroyale`, but the screenshot attempts timed out and no image was captured.  
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954fd2f4ae08328822b76f054383033)