### PR TITLE
Reduce Pool Royale table reflections and fix PolyHaven cloth URLs

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1830,16 +1830,16 @@ const SHARED_WOOD_SURFACE_PROPS = Object.freeze({
   clearcoatRoughness: 0.16,
   sheen: 0.18,
   sheenRoughness: 0.36,
-  envMapIntensity: 1.05
+  envMapIntensity: 0.88
 });
 const TABLE_FINISH_DULLING = Object.freeze({
-  roughnessLift: 0.14,
-  clearcoatScale: 0.7,
-  clearcoatRoughnessLift: 0.22,
-  envMapScale: 0.62,
-  reflectivityScale: 0.7,
-  sheenScale: 0.6,
-  sheenRoughnessLift: 0.18
+  roughnessLift: 0.22,
+  clearcoatScale: 0.5,
+  clearcoatRoughnessLift: 0.32,
+  envMapScale: 0.48,
+  reflectivityScale: 0.55,
+  sheenScale: 0.45,
+  sheenRoughnessLift: 0.28
 });
 
 const clampWoodRepeatScaleValue = () => DEFAULT_WOOD_REPEAT_SCALE;
@@ -3669,8 +3669,8 @@ const createClothTextures = (() => {
   const buildPolyHavenTextureUrls = (sourceId, resolution) => {
     if (!sourceId) return null;
     const normalized = String(sourceId).replace(/\s+/g, '_');
-    const res = resolution.toUpperCase();
-    const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${resolution}/${normalized}/${normalized}_${res}`;
+    const res = resolution.toLowerCase();
+    const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${res}/${normalized}/${normalized}_${res}`;
     return {
       diffuse: `${base}_Color.jpg`,
       normal: `${base}_NormalGL.jpg`,


### PR DESCRIPTION
### Motivation
- Reduce the overly shiny, mirror-like appearance of the Pool Royale table finishes by lowering reflection-related parameters.  
- Ensure cloth textures from Poly Haven load reliably by fixing fallback URL construction and casing.  
- Make the table wood and chrome materials read as less reflective and more physically plausible under the scene HDRI.  
- Target the in-scene WebGL texture loading failures that caused missing or incorrect cloth maps.

### Description
- Toned down wood reflection settings by lowering `envMapIntensity` and tightening the table dulling parameters in `SHARED_WOOD_SURFACE_PROPS` and `TABLE_FINISH_DULLING` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Increased `roughnessLift` and reduced `clearcoat`/`envMap` scale and `sheen` multipliers to produce a more matte table surface.  
- Fixed `buildPolyHavenTextureUrls` to use lowercase resolution and a corrected path pattern so Poly Haven fallback texture URLs resolve to the actual files.  
- Changes are local to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect table finish and cloth texture lookup logic.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and observed Vite report `ready` (succeeded).  
- Attempted an automated Playwright page capture of `/games/poolroyale`, but the screenshot step timed out (failed due to a 30s timeout).  
- No unit tests were executed as part of this change (none requested).  
- Manual visual verification is recommended in a browser to confirm the lowered sheen and successful cloth texture loading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550643c0b08328928ec069dbbbc2b6)