### PR TITLE
Reduce Pool Royale table finish reflections

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,13 +1833,13 @@ const SHARED_WOOD_SURFACE_PROPS = Object.freeze({
   envMapIntensity: 0.6
 });
 const TABLE_FINISH_DULLING = Object.freeze({
-  roughnessLift: 0.22,
-  clearcoatScale: 0.5,
-  clearcoatRoughnessLift: 0.32,
-  envMapScale: 0.45,
-  reflectivityScale: 0.5,
-  sheenScale: 0.45,
-  sheenRoughnessLift: 0.28
+  roughnessLift: 0.36,
+  clearcoatScale: 0.35,
+  clearcoatRoughnessLift: 0.42,
+  envMapScale: 0.22,
+  reflectivityScale: 0.35,
+  sheenScale: 0.32,
+  sheenRoughnessLift: 0.36
 });
 
 const clampWoodRepeatScaleValue = () => DEFAULT_WOOD_REPEAT_SCALE;


### PR DESCRIPTION
### Motivation

- Fix mirror-like wood/table finishes in the Pool Royale 3D scene so the table reads like real wood rather than a specular mirror. 
- Reduce scene environment-driven reflections and boost roughness/clearcoat dispersion for table materials to match reference photos.

### Description

- Updated `TABLE_FINISH_DULLING` values in `webapp/src/pages/Games/PoolRoyale.jsx` to increase `roughnessLift` and `clearcoatRoughnessLift` while decreasing `envMapScale`, `clearcoatScale`, `reflectivityScale`, and `sheenScale`.
- These changes make `applyTableFinishDulling` drive higher roughness and lower environment map / reflectivity for wood/rail materials so finishes no longer appear mirror-like.

### Testing

- Ran the webapp dev server with `npm --prefix webapp run dev` which started `vite` and served the app successfully.
- Attempted an automated Playwright capture of `/games/poolroyale` to verify visuals but the Chromium run crashed (headless Chromium SIGSEGV) and the screenshot step failed.
- No unit tests (`jest`/`vitest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695511e799dc8328ab814a72d6f4adae)