### PR TITLE
Fix pool table finish reflections

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2033,33 +2033,33 @@ const createStandardWoodFinish = ({
         : railColor.clone().offsetHSL(0.02, 0.08, 0.18);
     const frame = new THREE.MeshPhysicalMaterial({
       color: frameColor,
-      metalness: 0.2,
-      roughness: 0.32,
-      clearcoat: 0.42,
-      clearcoatRoughness: 0.22,
-      sheen: 0.2,
-      sheenRoughness: 0.44,
-      reflectivity: 0.56,
-      envMapIntensity: 0.88
+      metalness: 0.08,
+      roughness: 0.58,
+      clearcoat: 0.22,
+      clearcoatRoughness: 0.4,
+      sheen: 0.14,
+      sheenRoughness: 0.58,
+      reflectivity: 0.22,
+      envMapIntensity: 0.45
     });
     const railMat = new THREE.MeshPhysicalMaterial({
       color: railColor,
-      metalness: 0.24,
-      roughness: 0.34,
-      clearcoat: 0.46,
-      clearcoatRoughness: 0.2,
-      sheen: 0.22,
-      sheenRoughness: 0.46,
-      reflectivity: 0.6,
-      envMapIntensity: 0.94
+      metalness: 0.1,
+      roughness: 0.55,
+      clearcoat: 0.26,
+      clearcoatRoughness: 0.38,
+      sheen: 0.18,
+      sheenRoughness: 0.6,
+      reflectivity: 0.24,
+      envMapIntensity: 0.5
     });
     const trimMat = new THREE.MeshPhysicalMaterial({
       color: trimColor,
-      metalness: 0.72,
-      roughness: 0.32,
-      clearcoat: 0.44,
-      clearcoatRoughness: 0.18,
-      envMapIntensity: 1.02
+      metalness: 0.16,
+      roughness: 0.5,
+      clearcoat: 0.28,
+      clearcoatRoughness: 0.36,
+      envMapIntensity: 0.55
     });
     const materials = {
       frame,


### PR DESCRIPTION
### Motivation
- Pool Royale table wood and trim were rendering too mirror-like and needed more realistic, less reflective finishes.
- Reduce strong env map/metalness/clearcoat values so wood reads like varnished timber instead of polished metal.

### Description
- Lowered `metalness`, increased `roughness`, and reduced `clearcoat` and `envMapIntensity` on the table `frame`, `rail`, and `trim` `THREE.MeshPhysicalMaterial` definitions.
- Tweaked `sheen` / `sheenRoughness` and `reflectivity` to produce subtler highlights rather than sharp reflections.
- Change made in `webapp/src/pages/Games/PoolRoyale.jsx` and existing wood-preset application (`applySnookerStyleWoodPreset`) kept intact.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched Vite successfully. 
- Attempted a visual smoke test using Playwright to capture a screenshot, but the headless Chromium crashed with a SIGSEGV and the screenshot step failed. 
- No unit tests (`npm test`) or other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695511e799dc8328ab814a72d6f4adae)