### PR TITLE
Pool Royale: wood texture fixes, add 6K HDRI & 50 FPS, shorten legs/skirt, disable ball floor shadows

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -41,7 +41,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 4,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    tableRotationY: Math.PI / 2
   },
   dancingHall: {
     cameraHeightM: 1.58,
@@ -311,9 +312,9 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     preferredResolutions: ['4k', '2k'],
     fallbackResolution: '4k',
     price: 1820,
-    exposure: 1.11,
-    environmentIntensity: 1.07,
-    backgroundIntensity: 1.03,
+    exposure: 1.08,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1.01,
     swatches: ['#ec4899', '#a855f7'],
     description: 'Playful multi-hue studio for glossy highlight variety.'
   },
@@ -709,7 +710,7 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   }
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({


### PR DESCRIPTION
### Motivation
- Make Pool Royale table finishes match the original Poly Haven mappings and avoid overly reflective/mirrored wood look by applying per-surface texture settings correctly.
- Allow higher HDRI fidelity for large tables and simplify graphics options by adding `6k` and a `50 FPS` profile and removing the redundant Ultra HD+ preset. 
- Adjust table proportions (legs and skirt) to match the requested shorter stance and ensure the Colorful Studio HDRI orients the table as desired with slightly lower lighting. 
- Replace baked ball floor shadow discs with HDRI/lighting-driven shadows so ball shading follows the chosen environment. 

### Description
- Wood textures: split rail/frame surface resolution sources and use `orientRailWoodSurface` / per-surface configs when building `synchronizedRailSurface` and `synchronizedFrameSurface`, and stop applying global repeat scaling when external `mapUrl`/`roughnessMapUrl`/`normalMapUrl` are provided so PolyHaven maps retain their intended scale. 
- HDRI & graphics options: added `6k` to `DEFAULT_HDRI_RESOLUTIONS` and `HDRI_RESOLUTION_OPTIONS` and updated `HDRI_RESOLUTION_STACK`; added a `hd50` / 50 FPS `FRAME_RATE_OPTIONS` entry and removed the `Ultra HD+` preset. 
- Table geometry & orientation: reduced `LEG_LENGTH_SHRINK` to shorten legs, reduced `SKIRT_DROP_MULTIPLIER` to shorten the skirt, and added `tableRotationY` to the `colorfulStudio` HDRI placement plus code to rotate `worldRef.current` when applying an HDRI variant. 
- Shadows: toggled `ENABLE_BALL_FLOOR_SHADOWS` to `false` to disable baked shadow disk geometry and rely on environment/lighting shadows. 
- Files modified: `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/config/poolRoyaleInventoryConfig.js` (changes include constants, HDRI stacks, fps presets, wood application logic, and Colorful Studio variant). 

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, which succeeded. 
- Captured an automated UI screenshot of `/games/poolroyale` using a Playwright script, producing `artifacts/pool-royale-hdri.png` (screenshot run completed). 
- All automated steps above completed without runtime errors during the local dev run. 
- No additional unit tests were added or run for these purely visual/asset mapping changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695518df132483289096c3d42afb7de5)