### PR TITLE
Pool Royale: HDRI 6K, graphics options, wood finish & table geometry tweaks

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -41,7 +41,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 4,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    rotationY: Math.PI / 2
   },
   dancingHall: {
     cameraHeightM: 1.58,
@@ -311,9 +312,9 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     preferredResolutions: ['4k', '2k'],
     fallbackResolution: '4k',
     price: 1820,
-    exposure: 1.11,
-    environmentIntensity: 1.07,
-    backgroundIntensity: 1.03,
+    exposure: 1.09,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1.01,
     swatches: ['#ec4899', '#a855f7'],
     description: 'Playful multi-hue studio for glossy highlight variety.'
   },
@@ -709,7 +710,7 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   }
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({


### PR DESCRIPTION
### Motivation
- Align table wood finishes with original Poly Haven materials so rails/skirts/legs stop appearing overly mirror-like.
- Expose a 6K HDRI option and add a 50 FPS graphics profile while removing the Ultra HD+ preset to match requested graphics options.
- Shorten table legs and skirt by ~15% to adjust visual proportions for the Pool Royale tables.
- Make the colorful HDRI orientation and intensity configurable so studio HDRIs can be rotated and slightly lowered for correct lighting.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to disable synthetic ball floor shadows (`ENABLE_BALL_FLOOR_SHADOWS = false`), shorten legs (`LEG_LENGTH_SHRINK`) and reduce apron drop (`SKIRT_DROP_MULTIPLIER`), and refine table finish/material parameters (`SHARED_WOOD_SURFACE_PROPS`, `TABLE_FINISH_DULLING`) plus added `POLYHAVEN_WOOD_SURFACE_PROPS` to better match Poly Haven maps.
- Added HDRI rotation support and applied `rotationY` to grounded skyboxes and scene rotation, and wired scene `backgroundRotation`/`environmentRotation` when available so HDRIs can be oriented without moving the table.
- Adjusted the frame-rate presets in `PoolRoyale.jsx` to add a 50 FPS `hd50` profile and removed the `ultra144` option, and made `detectPreferredFrameRateId` return `DEFAULT_FRAME_RATE_ID` in fallback cases.
- Expanded HDRI resolution stack to include `6k` in `webapp/src/config/poolRoyaleInventoryConfig.js` and added a `rotationY` setting and slightly reduced exposure/environment/background intensities for the `colorfulStudio` variant.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, allowing manual inspection of the page.
- Automated screenshot attempts via Playwright timed out when capturing `/games/poolroyale`, so headless capture did not complete successfully. 
- No unit test suite (`npm test`) was executed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551f3d063483288188e9132fe7d85b)