### PR TITLE
Lower Colorful Studio HDRI brightness

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -312,9 +312,9 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     preferredResolutions: ['4k', '2k'],
     fallbackResolution: '4k',
     price: 1820,
-    exposure: 1.09,
-    environmentIntensity: 1.04,
-    backgroundIntensity: 1.01,
+    exposure: 1.06,
+    environmentIntensity: 1.0,
+    backgroundIntensity: 0.98,
     swatches: ['#ec4899', '#a855f7'],
     description: 'Playful multi-hue studio for glossy highlight variety.'
   },


### PR DESCRIPTION
### Motivation

- The "Colorful Studio" HDRI was producing excessive brightness and highlights that should be reduced for better visual balance.

### Description

- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` for the `colorfulStudio` variant to reduce HDRI brightness parameters.
- Changed `exposure` from `1.09` to `1.06`, `environmentIntensity` from `1.04` to `1.0`, and `backgroundIntensity` from `1.01` to `0.98`.

### Testing

- Started the dev server with `npm run dev` and Vite served the site at port 4173 successfully.
- Attempted an automated Playwright capture of `/games/poolroyale`, but the screenshot run timed out and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552ff487dc83208e94ecd799a02f13)