### PR TITLE
Lower Colorful Studio HDRI brightness and improve table wood visibility

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -312,9 +312,9 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     preferredResolutions: ['4k', '2k'],
     fallbackResolution: '4k',
     price: 1820,
-    exposure: 1.06,
-    environmentIntensity: 1.0,
-    backgroundIntensity: 0.98,
+    exposure: 1.02,
+    environmentIntensity: 0.92,
+    backgroundIntensity: 0.92,
     swatches: ['#ec4899', '#a855f7'],
     description: 'Playful multi-hue studio for glossy highlight variety.'
   },


### PR DESCRIPTION
### Motivation

- The Colorful Studio HDRI produced overly bright/specular lighting that washed out table wood detail. 
- Table wood surfaces were appearing overly reflective (mirror-like) under some HDRI variants and need tuning so original PolyHaven wood textures remain visible. 
- Make a conservative exposure/intensity change so the HDRI remains usable but softer. 
- Add material-level adjustments to ensure wood roughness/clearcoat/envMap settings keep textures readable.

### Description

- Reduced `exposure`, `environmentIntensity`, and `backgroundIntensity` for the `colorfulStudio` HDRI in `webapp/src/config/poolRoyaleInventoryConfig.js`. 
- Added `TABLE_WOOD_VISIBILITY_TUNING` and the helper `applyTableWoodVisibilityTuning` to `webapp/src/pages/Games/PoolRoyale.jsx` to clamp roughness/metalness/clearcoat/envMap and set `normalScale`. 
- Invoked `applyTableWoodVisibilityTuning` alongside `applyTableFinishDulling` when applying wood textures and when stripping wood textures so rails, frames, legs and underlay meshes are tuned for visibility. 
- Kept changes localized to Pool Royale HDRI config and table finish application logic so other games are unaffected.

### Testing

- Launched the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready at the expected host and port. 
- Attempted an automated preview capture with Playwright to verify the Pool Royale scene, but Chromium crashed in the environment and the screenshot attempt failed. 
- No unit tests (`npm test`) or Jest suites were executed as part of this change. 
- Files changed: `webapp/src/config/poolRoyaleInventoryConfig.js` and `webapp/src/pages/Games/PoolRoyale.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955353b2a188320845569b519006269)