### PR TITLE
Adjust Pool Royale HDRI placements and apply arena offsets

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -11,31 +11,30 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.68,
     groundRadiusMultiplier: 6.5,
     groundResolution: 112,
-    arenaScale: 1.35
+    arenaScale: 1.35,
+    rotationY: Math.PI / 2
   },
   ballroomHall: {
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5.1,
     groundResolution: 112,
-    arenaScale: 1.3
+    arenaScale: 1.3,
+    arenaOffsetZ: -10
   },
   emptyPlayRoom: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    arenaOffsetX: -24,
+    arenaOffsetZ: 8,
+    rotationY: Math.PI / 2
   },
   christmasPhotoStudio04: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
     arenaScale: 1.15
-  },
-  billiardHall: {
-    cameraHeightM: 1.54,
-    groundRadiusMultiplier: 4.8,
-    groundResolution: 128,
-    arenaScale: 1.25
   },
   colorfulStudio: {
     cameraHeightM: 1.5,
@@ -60,15 +59,10 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.56,
     groundRadiusMultiplier: 4.8,
     groundResolution: 112,
-    arenaScale: 1.2
+    arenaScale: 1.2,
+    rotationY: Math.PI / 14
   },
   hallOfFinfish: {
-    cameraHeightM: 1.6,
-    groundRadiusMultiplier: 5.3,
-    groundResolution: 112,
-    arenaScale: 1.28
-  },
-  hallOfMammals: {
     cameraHeightM: 1.6,
     groundRadiusMultiplier: 5.3,
     groundResolution: 112,
@@ -192,7 +186,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5,
     groundResolution: 112,
-    arenaScale: 1.26
+    arenaScale: 1.26,
+    arenaOffsetZ: -16
   },
   sepulchralChapelRotunda: {
     cameraHeightM: 1.62,
@@ -293,19 +288,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     description: 'Festive studio wraps with warm gift-light accents.'
   },
   {
-    id: 'billiardHall',
-    name: 'Billiard Hall',
-    assetId: 'billiard_hall',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1800,
-    exposure: 1.11,
-    environmentIntensity: 1.06,
-    backgroundIntensity: 1.02,
-    swatches: ['#0ea5e9', '#22c55e'],
-    description: 'Realistic billiard hall lighting with focused overheads.'
-  },
-  {
     id: 'colorfulStudio',
     name: 'Colorful Studio',
     assetId: 'colorful_studio',
@@ -369,19 +351,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.02,
     swatches: ['#22d3ee', '#2563eb'],
     description: 'Museum hall mood with blue-toned accents and glass case reflections.'
-  },
-  {
-    id: 'hallOfMammals',
-    name: 'Hall of Mammals',
-    assetId: 'hall_of_mammals',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1960,
-    exposure: 1.12,
-    environmentIntensity: 1.09,
-    backgroundIntensity: 1.03,
-    swatches: ['#facc15', '#a16207'],
-    description: 'Golden museum ambience with warm diorama bounce and soft roof fill.'
   },
   {
     id: 'marryHall',


### PR DESCRIPTION
### Motivation
- Align pool table placement to features in several HDRI environments (lounge circles, bridge direction, ballroom center, playroom table side, entrance rails). 
- Remove deprecated/unwanted HDRI environments that should no longer be available. 
- Make world and camera respect per-HDRI arena offsets so the table and broadcast/camera targets visually align with the HDRI scene. 
- Provide small rotation tweaks for a few HDRIs to match scene orientations.

### Description
- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` to tune HDRI placement metadata: added `rotationY` for `adamsBridge` and `emptyPlayRoom`, added `arenaOffsetZ` for `ballroomHall` and `aftLounge`, added `arenaOffsetX`/`arenaOffsetZ` for `emptyPlayRoom`, and added a small `rotationY` for `entranceHall`.
- Removed the `billiardHall` and `hallOfMammals` HDRI variant entries from the raw HDRI list so they are no longer exposed as options.
- Extended `webapp/src/pages/Games/PoolRoyale.jsx` to support arena offsets by adding `DEFAULT_ARENA_OFFSET`, `resolveArenaOffset`, an `arenaOffsetRef`, and using the resolved offsets to set `world.position` and adjust broadcast camera focus and various camera focus targets (`focusTarget`, `topFocusTarget`, pocket/shot views) so the table aligns with HDRI geometry.
- Added logic to recompute and apply the arena offset when the active HDRI changes via an effect that invokes `applyWorldScaleRef.current`.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported ready and serving the app, which succeeded.
- Captured an automated Playwright screenshot of `/games/poolroyale` to verify HDRI/world alignment; the screenshot run completed and produced an artifact.
- No unit tests were run as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695559cce82c83208ba022f9a07078d3)