### PR TITLE
Adjust Pool Royale HDRI placements and remove Billiard/HallOfMammals variants

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -11,31 +11,28 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.68,
     groundRadiusMultiplier: 6.5,
     groundResolution: 112,
-    arenaScale: 1.35
+    arenaScale: 1.35,
+    rotationY: Math.PI / 2
   },
   ballroomHall: {
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5.1,
     groundResolution: 112,
-    arenaScale: 1.3
+    arenaScale: 1.3,
+    rotationY: Math.PI
   },
   emptyPlayRoom: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    rotationY: -Math.PI / 2
   },
   christmasPhotoStudio04: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
     arenaScale: 1.15
-  },
-  billiardHall: {
-    cameraHeightM: 1.54,
-    groundRadiusMultiplier: 4.8,
-    groundResolution: 128,
-    arenaScale: 1.25
   },
   colorfulStudio: {
     cameraHeightM: 1.5,
@@ -60,15 +57,10 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.56,
     groundRadiusMultiplier: 4.8,
     groundResolution: 112,
-    arenaScale: 1.2
+    arenaScale: 1.2,
+    rotationY: 0.2
   },
   hallOfFinfish: {
-    cameraHeightM: 1.6,
-    groundRadiusMultiplier: 5.3,
-    groundResolution: 112,
-    arenaScale: 1.28
-  },
-  hallOfMammals: {
     cameraHeightM: 1.6,
     groundRadiusMultiplier: 5.3,
     groundResolution: 112,
@@ -192,7 +184,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5,
     groundResolution: 112,
-    arenaScale: 1.26
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
   },
   sepulchralChapelRotunda: {
     cameraHeightM: 1.62,
@@ -293,19 +286,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     description: 'Festive studio wraps with warm gift-light accents.'
   },
   {
-    id: 'billiardHall',
-    name: 'Billiard Hall',
-    assetId: 'billiard_hall',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1800,
-    exposure: 1.11,
-    environmentIntensity: 1.06,
-    backgroundIntensity: 1.02,
-    swatches: ['#0ea5e9', '#22c55e'],
-    description: 'Realistic billiard hall lighting with focused overheads.'
-  },
-  {
     id: 'colorfulStudio',
     name: 'Colorful Studio',
     assetId: 'colorful_studio',
@@ -369,19 +349,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.02,
     swatches: ['#22d3ee', '#2563eb'],
     description: 'Museum hall mood with blue-toned accents and glass case reflections.'
-  },
-  {
-    id: 'hallOfMammals',
-    name: 'Hall of Mammals',
-    assetId: 'hall_of_mammals',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1960,
-    exposure: 1.12,
-    environmentIntensity: 1.09,
-    backgroundIntensity: 1.03,
-    swatches: ['#facc15', '#a16207'],
-    description: 'Golden museum ambience with warm diorama bounce and soft roof fill.'
   },
   {
     id: 'marryHall',


### PR DESCRIPTION
### Motivation
- Align HDRI rotations so the pool table visually matches scene landmarks (center circles, bridge direction, ballroom center, playroom table side, entrance door orientation). 
- Remove unwanted HDRI variants that should no longer be available in the Pool Royale inventory. 
- Provide per-HDRI placement overrides used by the Three.js scene loader to control skybox rotation and arena scale. 

### Description
- Added `rotationY` placement overrides to `POOL_ROYALE_HDRI_PLACEMENTS` for `adamsBridge`, `ballroomHall`, `emptyPlayRoom`, `entranceHall`, and `aftLounge`. 
- Removed the `billiardHall` and `hallOfMammals` entries from the `RAW_POOL_ROYALE_HDRI_VARIANTS` list so they are no longer published in `POOL_ROYALE_HDRI_VARIANTS`. 
- Kept existing placement attributes (`cameraHeightM`, `groundRadiusMultiplier`, `groundResolution`, `arenaScale`) and extended them with rotation control for correct table alignment in the scene. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready, which indicates the config changes load without syntax errors. 
- Attempted an automated Playwright screenshot against `http://127.0.0.1:5173/games/poolroyale`, but the headless Chromium crashed with a SIGSEGV and the screenshot run failed. 
- No unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69555d3e8eac832081d701a15fb3c812)