### PR TITLE
Set rotationY for selected Pool Royale HDRI placements

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -94,7 +94,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.54,
     groundRadiusMultiplier: 4.6,
     groundResolution: 120,
-    arenaScale: 1.18
+    arenaScale: 1.18,
+    rotationY: Math.PI / 2
   },
   londonPhotoStudioHall: {
     cameraHeightM: 1.56,
@@ -106,19 +107,22 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.55,
     groundRadiusMultiplier: 4.6,
     groundResolution: 112,
-    arenaScale: 1.2
+    arenaScale: 1.2,
+    rotationY: Math.PI
   },
   countryStudioHall: {
     cameraHeightM: 1.55,
     groundRadiusMultiplier: 4.5,
     groundResolution: 112,
-    arenaScale: 1.18
+    arenaScale: 1.18,
+    rotationY: Math.PI / 2
   },
   blockyPhotoStudio: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
-    arenaScale: 1.14
+    arenaScale: 1.14,
+    rotationY: -Math.PI / 2
   },
   bluePhotoStudio: {
     cameraHeightM: 1.52,


### PR DESCRIPTION
### Motivation
- Align HDRI orientations so the pool table remains stationary while the environment is rotated to match photographic references.
- Apply specific orientations requested for `loftPhotoStudioHall`, `schoolHall`, `countryStudioHall`, and `blockyPhotoStudio` so table-facing directions match the scene.
- Avoid moving table models by adjusting HDRI rotation instead of table transforms.

### Description
- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` to add `rotationY` entries for the four HDRI placements.
- Set `loftPhotoStudioHall.rotationY` to `Math.PI / 2` and `schoolHall.rotationY` to `Math.PI`.
- Set `countryStudioHall.rotationY` to `Math.PI / 2` and `blockyPhotoStudio.rotationY` to `-Math.PI / 2`.

### Testing
- No automated tests were executed against these configuration changes.
- The change is configuration-only and does not modify runtime logic or assets beyond HDRI orientation values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955625ca2108320b8061ccedfb7ab2b)