### PR TITLE
Pool Royale: remove select HDRIs, make Colorful Studio free default, and adjust HDRI placements

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -12,21 +12,21 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundRadiusMultiplier: 6.5,
     groundResolution: 112,
     arenaScale: 1.35,
-    rotationY: Math.PI / 2
+    rotationY: 0
   },
   ballroomHall: {
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5.1,
     groundResolution: 112,
     arenaScale: 1.3,
-    rotationY: Math.PI
+    rotationY: Math.PI / 2
   },
   emptyPlayRoom: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
     arenaScale: 1.15,
-    rotationY: -Math.PI / 2
+    rotationY: 0
   },
   christmasPhotoStudio04: {
     cameraHeightM: 1.52,
@@ -58,13 +58,7 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundRadiusMultiplier: 4.8,
     groundResolution: 112,
     arenaScale: 1.2,
-    rotationY: 0.2
-  },
-  hallOfFinfish: {
-    cameraHeightM: 1.6,
-    groundRadiusMultiplier: 5.3,
-    groundResolution: 112,
-    arenaScale: 1.28
+    rotationY: Math.PI / 2
   },
   marryHall: {
     cameraHeightM: 1.57,
@@ -95,7 +89,7 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundRadiusMultiplier: 4.6,
     groundResolution: 120,
     arenaScale: 1.18,
-    rotationY: Math.PI / 2
+    rotationY: Math.PI
   },
   londonPhotoStudioHall: {
     cameraHeightM: 1.56,
@@ -103,19 +97,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundResolution: 120,
     arenaScale: 1.18
   },
-  schoolHall: {
-    cameraHeightM: 1.55,
-    groundRadiusMultiplier: 4.6,
-    groundResolution: 112,
-    arenaScale: 1.2,
-    rotationY: Math.PI
-  },
   countryStudioHall: {
     cameraHeightM: 1.55,
     groundRadiusMultiplier: 4.5,
     groundResolution: 112,
     arenaScale: 1.18,
-    rotationY: Math.PI / 2
+    rotationY: 0
   },
   blockyPhotoStudio: {
     cameraHeightM: 1.5,
@@ -130,18 +117,6 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundResolution: 120,
     arenaScale: 1.16
   },
-  smallEmptyRoom: {
-    cameraHeightM: 1.48,
-    groundRadiusMultiplier: 3.7,
-    groundResolution: 128,
-    arenaScale: 1.12
-  },
-  lebombo: {
-    cameraHeightM: 1.62,
-    groundRadiusMultiplier: 5.4,
-    groundResolution: 112,
-    arenaScale: 1.3
-  },
   cycloramaHardLight: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.8,
@@ -152,43 +127,42 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.51,
     groundRadiusMultiplier: 4,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    rotationY: Math.PI / 2
   },
   christmasPhotoStudio05: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
-    arenaScale: 1.15
+    arenaScale: 1.15,
+    rotationY: Math.PI / 2
   },
   abandonedGarage: {
     cameraHeightM: 1.6,
     groundRadiusMultiplier: 5.1,
     groundResolution: 112,
-    arenaScale: 1.26
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
   },
   vestibule: {
     cameraHeightM: 1.56,
     groundRadiusMultiplier: 4.7,
     groundResolution: 112,
-    arenaScale: 1.2
+    arenaScale: 1.2,
+    rotationY: 0
   },
   countryClub: {
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 4.9,
     groundResolution: 112,
-    arenaScale: 1.24
+    arenaScale: 1.24,
+    rotationY: Math.PI
   },
   brownPhotostudio03: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 3.9,
     groundResolution: 120,
-    arenaScale: 1.14
-  },
-  aftLounge: {
-    cameraHeightM: 1.58,
-    groundRadiusMultiplier: 5,
-    groundResolution: 112,
-    arenaScale: 1.26,
+    arenaScale: 1.14,
     rotationY: Math.PI / 2
   },
   sepulchralChapelRotunda: {
@@ -197,29 +171,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundResolution: 112,
     arenaScale: 1.32
   },
-  smallEmptyRoom2: {
-    cameraHeightM: 1.48,
-    groundRadiusMultiplier: 3.7,
-    groundResolution: 128,
-    arenaScale: 1.12
-  },
   squashCourt: {
     cameraHeightM: 1.5,
     groundRadiusMultiplier: 4.1,
     groundResolution: 120,
-    arenaScale: 1.18
-  },
-  garage: {
-    cameraHeightM: 1.58,
-    groundRadiusMultiplier: 4.9,
-    groundResolution: 112,
-    arenaScale: 1.24
-  },
-  smallEmptyHouse: {
-    cameraHeightM: 1.5,
-    groundRadiusMultiplier: 4,
-    groundResolution: 120,
-    arenaScale: 1.16
+    arenaScale: 1.18,
+    rotationY: Math.PI / 2
   }
 });
 
@@ -295,7 +252,7 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     assetId: 'colorful_studio',
     preferredResolutions: ['4k', '2k'],
     fallbackResolution: '4k',
-    price: 1820,
+    price: 0,
     exposure: 1.02,
     environmentIntensity: 0.92,
     backgroundIntensity: 0.92,
@@ -340,19 +297,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1,
     swatches: ['#a3e635', '#22c55e'],
     description: 'Bright lobby ambience with balanced daylight fill and mild speculars.'
-  },
-  {
-    id: 'hallOfFinfish',
-    name: 'Hall of Finfish',
-    assetId: 'hall_of_finfish',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1940,
-    exposure: 1.1,
-    environmentIntensity: 1.07,
-    backgroundIntensity: 1.02,
-    swatches: ['#22d3ee', '#2563eb'],
-    description: 'Museum hall mood with blue-toned accents and glass case reflections.'
   },
   {
     id: 'marryHall',
@@ -433,19 +377,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     description: 'London studio hall ambiance with cool skylight and warm edge kickers.'
   },
   {
-    id: 'schoolHall',
-    name: 'School Hall',
-    assetId: 'school_hall',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2160,
-    exposure: 1.07,
-    environmentIntensity: 1.05,
-    backgroundIntensity: 0.98,
-    swatches: ['#22c55e', '#94a3b8'],
-    description: 'Clean institutional hall with neutral overhead bounce and even fill.'
-  },
-  {
     id: 'countryStudioHall',
     name: 'Country Studio Hall',
     assetId: 'studio_country_hall',
@@ -483,32 +414,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.06,
     swatches: ['#38bdf8', '#1e40af'],
     description: 'Cool blue studio lighting with bright fills and soft kickers.'
-  },
-  {
-    id: 'smallEmptyRoom',
-    name: 'Small Empty Room',
-    assetId: 'small_empty_room',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2240,
-    exposure: 1.08,
-    environmentIntensity: 1.04,
-    backgroundIntensity: 1,
-    swatches: ['#cbd5f5', '#94a3b8'],
-    description: 'Minimal interior light with subtle reflections and quiet ambience.'
-  },
-  {
-    id: 'lebombo',
-    name: 'Lebombo',
-    assetId: 'lebombo',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2320,
-    exposure: 1.09,
-    environmentIntensity: 1.05,
-    backgroundIntensity: 1.01,
-    swatches: ['#84cc16', '#f97316'],
-    description: 'Outdoor rocky landscape with warm sun highlights and open sky fill.'
   },
   {
     id: 'cycloramaHardLight',
@@ -602,19 +507,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     description: 'Rich brown studio tones with smooth amber reflections.'
   },
   {
-    id: 'aftLounge',
-    name: 'Aft Lounge',
-    assetId: 'aft_lounge',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2420,
-    exposure: 1.12,
-    environmentIntensity: 1.09,
-    backgroundIntensity: 1.04,
-    swatches: ['#0ea5e9', '#f472b6'],
-    description: 'Stylish lounge with colored accents and glossy highlight sweep.'
-  },
-  {
     id: 'sepulchralChapelRotunda',
     name: 'Sepulchral Chapel Rotunda',
     assetId: 'sepulchral_chapel_rotunda',
@@ -626,19 +518,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 0.98,
     swatches: ['#1f2937', '#6b7280'],
     description: 'Stone rotunda with dramatic overhead light and deep shadows.'
-  },
-  {
-    id: 'smallEmptyRoom2',
-    name: 'Small Empty Room 2',
-    assetId: 'small_empty_room_2',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2260,
-    exposure: 1.08,
-    environmentIntensity: 1.04,
-    backgroundIntensity: 1,
-    swatches: ['#e5e7eb', '#94a3b8'],
-    description: 'Quiet neutral room with soft overhead fill and mild reflections.'
   },
   {
     id: 'squashCourt',
@@ -653,32 +532,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     swatches: ['#f8fafc', '#f97316'],
     description: 'Bright court lighting with clean white walls and strong bounce.'
   },
-  {
-    id: 'garage',
-    name: 'Garage',
-    assetId: 'garage',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2460,
-    exposure: 1.07,
-    environmentIntensity: 1.05,
-    backgroundIntensity: 1,
-    swatches: ['#94a3b8', '#475569'],
-    description: 'Neutral garage light with subtle industrial reflections.'
-  },
-  {
-    id: 'smallEmptyHouse',
-    name: 'Small Empty House',
-    assetId: 'small_empty_house',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 2480,
-    exposure: 1.09,
-    environmentIntensity: 1.05,
-    backgroundIntensity: 1.01,
-    swatches: ['#f1f5f9', '#a1a1aa'],
-    description: 'Soft residential interior light with gentle neutral bounce.'
-  }
 ];
 
 const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
@@ -698,7 +551,7 @@ export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
   }, {})
 );
 
-export const POOL_ROYALE_DEFAULT_HDRI_ID = POOL_ROYALE_HDRI_VARIANTS[0].id;
+export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['peelingPaintWeathered'],


### PR DESCRIPTION
### Motivation
- Remove legacy or unwanted HDRI variants from the Pool Royale lineup to limit available environments.  
- Make the `colorfulStudio` HDRI available as a free (default) environment for the game.  
- Align HDRI orientation/placements so table orientation and side rails visually match the bridge and hall environments.  
- Apply the official HDRI placement mapping (move HDRIs, do not reposition tables) for consistent scene layout.

### Description
- Edited `webapp/src/config/poolRoyaleInventoryConfig.js` to remove the specified HDRI variants and their placement entries from `POOL_ROYALE_HDRI_PLACEMENTS` and `RAW_POOL_ROYALE_HDRI_VARIANTS`.  
- Set the `colorfulStudio` variant `price` to `0` and changed `POOL_ROYALE_DEFAULT_HDRI_ID` to `'colorfulStudio'` so it becomes the free default HDRI.  
- Adjusted `rotationY` values (placements) for multiple environments including `adamsBridge`, `ballroomHall`, `emptyPlayRoom`, `entranceHall`, `loftPhotoStudioHall`, `countryStudioHall`, `brownPhotostudio06`, `christmasPhotoStudio05`, `abandonedGarage`, `vestibule`, `countryClub`, `brownPhotostudio03`, and `squashCourt` to correct table orientation without moving the table geometry.  
- Removed the following HDRI variants from the Pool Royale variants list: `schoolHall`, `hallOfFinfish`, `smallEmptyRoom`, `smallEmptyRoom2`, `lebombo`, `aftLounge`, `garage`, and `smallEmptyHouse` (IDs in code: `schoolHall`, `hallOfFinfish`, `smallEmptyRoom`, `smallEmptyRoom2`, `lebombo`, `aftLounge`, `garage`, `smallEmptyHouse`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69556e90dd30832097de2250abc68191)