### PR TITLE
Fix Poly Haven textures and Pool Royale top-down view

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4833,8 +4833,8 @@ const TOP_VIEW_PHI = CAMERA_ABS_MIN_PHI + 0.02;
 const TOP_VIEW_RADIUS_SCALE = 0.82;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -BALL_R * 0.85, // nudge the table slightly left in top-down framing
-  z: -BALL_R * 7 // push the table downward in 2D view so the lower rail gains space and top/bottom padding is balanced as requested
+  x: 0, // center the table for the classic top-down framing
+  z: 0 // keep the 2D view aligned with the original overhead composition
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -53,15 +53,23 @@ const resolveExternalWoodTextureUrls = ({ mapUrl, roughnessMapUrl, normalMapUrl 
       normal: normalMapUrl ?? null
     };
   }
-  const match = mapUrl.match(/_color\.(jpg|jpeg|png)$/i);
-  if (match) {
-    const extension = match[1];
-    const base = mapUrl.slice(0, match.index);
-    return {
-      color: mapUrl,
-      roughness: `${base}_Roughness.${extension}`,
-      normal: `${base}_NormalGL.${extension}`
-    };
+  const matchers = [
+    { regex: /_(color|col)\.(jpg|jpeg|png)$/i, rough: '_Roughness', normal: '_NormalGL' },
+    { regex: /_(diff|diffuse)\.(jpg|jpeg|png)$/i, rough: '_rough', normal: '_nor_gl' },
+    { regex: /_basecolor\.(jpg|jpeg|png)$/i, rough: '_rough', normal: '_nor_gl' },
+    { regex: /_albedo\.(jpg|jpeg|png)$/i, rough: '_rough', normal: '_nor_gl' }
+  ];
+  for (const { regex, rough, normal } of matchers) {
+    const match = mapUrl.match(regex);
+    if (match) {
+      const extension = match[2] ?? match[1];
+      const base = mapUrl.slice(0, match.index);
+      return {
+        color: mapUrl,
+        roughness: `${base}${rough}.${extension}`,
+        normal: `${base}${normal}.${extension}`
+      };
+    }
   }
   return { color: mapUrl };
 };
@@ -258,9 +266,9 @@ const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const polyHavenTextureSet = (assetId) => {
   const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}_2k`;
   return {
-    mapUrl: `${base}_Color.jpg`,
-    roughnessMapUrl: `${base}_Roughness.jpg`,
-    normalMapUrl: `${base}_NormalGL.jpg`
+    mapUrl: `${base}_diff.jpg`,
+    roughnessMapUrl: `${base}_rough.jpg`,
+    normalMapUrl: `${base}_nor_gl.jpg`
   };
 };
 


### PR DESCRIPTION
## Summary
- correct Poly Haven wood texture URL mapping so diffuse, roughness, and normal maps load from the original assets
- center the Pool Royale 2D top-down camera to match the earlier overhead framing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69562fc8a56c832984c1501c9c1fea46)