### PR TITLE
Integrate Murlan assets into Domino Royal

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -1181,6 +1181,28 @@ scene.add(spot);
 const spotTarget = new THREE.Object3D();
 scene.add(spotTarget);
 spot.target = spotTarget;
+const LIGHT_BASE_INTENSITIES = Object.freeze({
+  ambient: ambient.intensity,
+  key: keyLight.intensity,
+  fill: fillLight.intensity,
+  rim: rimLight.intensity,
+  spot: spot.intensity
+});
+
+function applyEnvironmentOption(option = HDRI_OPTIONS[0]) {
+  const env = option || HDRI_OPTIONS[0];
+  const swatches = Array.isArray(env?.swatches) && env.swatches.length > 0 ? env.swatches : ['#0b1220', '#050812'];
+  const [primary, secondary] = swatches;
+  renderer.setClearColor(primary, 1);
+  document.body.style.background = `radial-gradient(circle at 50% 18%, ${primary}, ${secondary ?? primary})`;
+  const envScale = env.environmentIntensity ?? 1;
+  const bgScale = env.backgroundIntensity ?? envScale;
+  ambient.intensity = LIGHT_BASE_INTENSITIES.ambient * envScale;
+  keyLight.intensity = LIGHT_BASE_INTENSITIES.key * envScale;
+  fillLight.intensity = LIGHT_BASE_INTENSITIES.fill * envScale;
+  rimLight.intensity = LIGHT_BASE_INTENSITIES.rim * envScale;
+  spot.intensity = LIGHT_BASE_INTENSITIES.spot * bgScale;
+}
 
 const getPoolCarpetTextures = (() => {
   let cache = null;
@@ -1314,12 +1336,47 @@ const DEFAULT_CHAIR_THEME = Object.freeze({
   highlight: "#d35a7a"
 });
 
+const MURLAN_STOOL_THEME_OPTIONS = Object.freeze(
+  [
+    { id: "ruby", label: "Ruby", seatColor: "#8b0000", legColor: "#1f1f1f" },
+    { id: "slate", label: "Slate", seatColor: "#374151", legColor: "#0f172a" },
+    { id: "teal", label: "Teal", seatColor: "#0f766e", legColor: "#082f2a" },
+    { id: "amber", label: "Amber", seatColor: "#b45309", legColor: "#2f2410" },
+    { id: "violet", label: "Violet", seatColor: "#7c3aed", legColor: "#2b1059" },
+    { id: "frost", label: "Ice", seatColor: "#1f2937", legColor: "#0f172a" },
+    { id: "leather", label: "Leather", seatColor: "#6a4a32", legColor: "#1a1410" },
+    { id: "ArmChair_01", label: "Arm Chair 01" },
+    { id: "BarberShopChair_01", label: "Barber Shop Chair 01" },
+    { id: "GreenChair_01", label: "Green Chair 01" },
+    { id: "Rockingchair_01", label: "Rockingchair 01" },
+    { id: "SchoolChair_01", label: "School Chair 01" },
+    { id: "WoodenChair_01", label: "Wooden Chair 01" },
+    { id: "bar_chair_round_01", label: "Bar Chair Round" },
+    { id: "chinese_armchair", label: "Chinese Armchair" },
+    { id: "dining_chair_02", label: "Dining Chair 02" },
+    { id: "gallinera_chair", label: "Gallinera Chair" },
+    { id: "mid_century_lounge_chair", label: "Mid-Century Lounge" },
+    { id: "modern_arm_chair_01", label: "Modern Arm Chair" },
+    { id: "outdoor_table_chair_set_01", label: "Outdoor Chair Set 01" },
+    { id: "painted_wooden_chair_01", label: "Painted Wooden Chair 01" },
+    { id: "painted_wooden_chair_02", label: "Painted Wooden Chair 02" },
+    { id: "plastic_monobloc_chair_01", label: "Plastic Monobloc Chair" },
+    { id: "wheelchair_01", label: "Wheelchair 01" }
+  ].map((option) => ({
+    ...option,
+    seatColor: option.seatColor ?? "#d9d9d9",
+    legColor: option.legColor ?? "#111827",
+    highlight: option.highlight ?? adjustHexColor(option.seatColor ?? "#d9d9d9", 0.18)
+  }))
+);
+
 const CHAIR_THEME_OPTIONS = Object.freeze([
   DEFAULT_CHAIR_THEME,
   { id: "midnightNavy", label: "Midnight Blue", seatColor: "#153a8b", legColor: "#10131c", highlight: "#4d74d8" },
   { id: "emeraldWave", label: "Emerald Wave", seatColor: "#0f6a2f", legColor: "#142318", highlight: "#48b26a" },
   { id: "onyxShadow", label: "Onyx Shadow", seatColor: "#202020", legColor: "#080808", highlight: "#6f6f6f" },
-  { id: "royalPlum", label: "Royal Chestnut", seatColor: "#3f1f5b", legColor: "#140a24", highlight: "#7c4ae0" }
+  { id: "royalPlum", label: "Royal Chestnut", seatColor: "#3f1f5b", legColor: "#140a24", highlight: "#7c4ae0" },
+  ...MURLAN_STOOL_THEME_OPTIONS
 ]);
 
 const CHAIR_MODEL_URLS = [
@@ -1825,6 +1882,68 @@ const TABLE_BASE_OPTIONS = Object.freeze([
   { id: "desertGold", label: "Desert Base", base: "#1c1a12", column: "#0f0d06", trim: "#5a4524" }
 ]);
 
+const TABLE_THEME_OPTIONS = Object.freeze(
+  [
+    { id: "murlan-default", label: "Murlan Default Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/WoodenTable_01.png?width=256&height=256" },
+    { id: "CoffeeTable_01", label: "Coffee Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/CoffeeTable_01.png?width=256&height=256" },
+    { id: "WoodenTable_01", label: "Wooden Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/WoodenTable_01.png?width=256&height=256" },
+    { id: "WoodenTable_02", label: "Wooden Table 02", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/WoodenTable_02.png?width=256&height=256" },
+    { id: "WoodenTable_03", label: "Wooden Table 03", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/WoodenTable_03.png?width=256&height=256" },
+    { id: "chinese_console_table", label: "Chinese Console Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/chinese_console_table.png?width=256&height=256" },
+    { id: "chinese_tea_table", label: "Chinese Tea Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/chinese_tea_table.png?width=256&height=256" },
+    { id: "coffee_table_round_01", label: "Coffee Table Round 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/coffee_table_round_01.png?width=256&height=256" },
+    { id: "gallinera_table", label: "Gallinera Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/gallinera_table.png?width=256&height=256" },
+    { id: "gothic_coffee_table", label: "Gothic Coffee Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/gothic_coffee_table.png?width=256&height=256" },
+    { id: "industrial_coffee_table", label: "Industrial Coffee Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/industrial_coffee_table.png?width=256&height=256" },
+    { id: "modern_coffee_table_01", label: "Modern Coffee Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/modern_coffee_table_01.png?width=256&height=256" },
+    { id: "modern_coffee_table_02", label: "Modern Coffee Table 02", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/modern_coffee_table_02.png?width=256&height=256" },
+    { id: "outdoor_table_chair_set_01", label: "Outdoor Table Chair Set 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/outdoor_table_chair_set_01.png?width=256&height=256" },
+    { id: "painted_wooden_table", label: "Painted Wooden Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/painted_wooden_table.png?width=256&height=256" },
+    { id: "round_wooden_table_01", label: "Round Wooden Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/round_wooden_table_01.png?width=256&height=256" },
+    { id: "round_wooden_table_02", label: "Round Wooden Table 02", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/round_wooden_table_02.png?width=256&height=256" },
+    { id: "side_table_01", label: "Side Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/side_table_01.png?width=256&height=256" },
+    { id: "side_table_tall_01", label: "Side Table Tall 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/side_table_tall_01.png?width=256&height=256" },
+    { id: "small_wooden_table_01", label: "Small Wooden Table 01", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/small_wooden_table_01.png?width=256&height=256" },
+    { id: "wooden_picnic_table", label: "Wooden Picnic Table", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/wooden_picnic_table.png?width=256&height=256" },
+    { id: "wooden_table_02", label: "Wooden Table 02 (Alt)", thumbnail: "https://cdn.polyhaven.com/asset_img/thumbs/wooden_table_02.png?width=256&height=256" }
+  ].map((option, idx) => ({
+    ...option,
+    woodIndex: idx % TABLE_WOOD_OPTIONS.length,
+    clothIndex: (idx + 1) % TABLE_CLOTH_OPTIONS.length,
+    baseIndex: (idx + 2) % TABLE_BASE_OPTIONS.length
+  }))
+);
+
+const HDRI_OPTIONS = Object.freeze([
+  { id: "neonPhotostudio", label: "Neon Photo Studio HDRI", swatches: ["#0ea5e9", "#8b5cf6"] },
+  { id: "adamsBridge", label: "Adams Bridge HDRI", swatches: ["#1d4ed8", "#0ea5e9"] },
+  { id: "ballroomHall", label: "Ballroom Hall HDRI", swatches: ["#fef3c7", "#a16207"] },
+  { id: "emptyPlayRoom", label: "Empty Play Room HDRI", swatches: ["#a855f7", "#22c55e"] },
+  { id: "christmasPhotoStudio04", label: "Christmas Photo Studio 04 HDRI", swatches: ["#ef4444", "#f59e0b"] },
+  { id: "colorfulStudio", label: "Colorful Studio HDRI", swatches: ["#ec4899", "#a855f7"] },
+  { id: "dancingHall", label: "Dancing Hall HDRI", swatches: ["#22c55e", "#f97316"] },
+  { id: "abandonedHall", label: "Abandoned Hall HDRI", swatches: ["#64748b", "#0f172a"] },
+  { id: "entranceHall", label: "Entrance Hall HDRI", swatches: ["#a3e635", "#22c55e"] },
+  { id: "marryHall", label: "Marry Hall HDRI", swatches: ["#f8fafc", "#a3e635"] },
+  { id: "mirroredHall", label: "Mirrored Hall HDRI", swatches: ["#22c55e", "#10b981"] },
+  { id: "musicHall02", label: "Music Hall 02 HDRI", swatches: ["#a855f7", "#2563eb"] },
+  { id: "oldHall", label: "Old Hall HDRI", swatches: ["#78350f", "#fbbf24"] },
+  { id: "loftPhotoStudioHall", label: "Loft Photo Studio Hall HDRI", swatches: ["#22d3ee", "#f59e0b"] },
+  { id: "londonPhotoStudioHall", label: "London Photo Studio Hall HDRI", swatches: ["#0ea5e9", "#fbbf24"] },
+  { id: "countryStudioHall", label: "Country Studio Hall HDRI", swatches: ["#f472b6", "#16a34a"] },
+  { id: "blockyPhotoStudio", label: "Blocky Photo Studio HDRI", swatches: ["#60a5fa", "#a855f7"] },
+  { id: "bluePhotoStudio", label: "Blue Photo Studio HDRI", swatches: ["#38bdf8", "#1e40af"] },
+  { id: "cycloramaHardLight", label: "Cyclorama Hard Light HDRI", swatches: ["#f8fafc", "#94a3b8"] },
+  { id: "brownPhotostudio06", label: "Brown Photostudio 06 HDRI", swatches: ["#a16207", "#f59e0b"] },
+  { id: "christmasPhotoStudio05", label: "Christmas Photo Studio 05 HDRI", swatches: ["#ef4444", "#22c55e"] },
+  { id: "abandonedGarage", label: "Abandoned Garage HDRI", swatches: ["#334155", "#94a3b8"] },
+  { id: "vestibule", label: "Vestibule HDRI", swatches: ["#e2e8f0", "#64748b"] },
+  { id: "countryClub", label: "Country Club HDRI", swatches: ["#f8fafc", "#22c55e"] },
+  { id: "brownPhotostudio03", label: "Brown Photostudio 03 HDRI", swatches: ["#92400e", "#fbbf24"] },
+  { id: "sepulchralChapelRotunda", label: "Sepulchral Chapel Rotunda HDRI", swatches: ["#1f2937", "#6b7280"] },
+  { id: "squashCourt", label: "Squash Court HDRI", swatches: ["#f8fafc", "#f97316"] }
+]);
+
 const HIGHLIGHT_STYLE_OPTIONS = Object.freeze([
   {
     id: 'marksmanAmber',
@@ -2101,6 +2220,8 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 ]);
 
 const TABLE_SETUP_SECTIONS = [
+  { key: "environmentHdri", label: "HDRI", options: HDRI_OPTIONS },
+  { key: "tableTheme", label: "Murlan Tables", options: TABLE_THEME_OPTIONS },
   { key: "tableWood", label: "Table Wood", options: TABLE_WOOD_OPTIONS },
   { key: "tableCloth", label: "Table Cloth", options: TABLE_CLOTH_OPTIONS },
   { key: "tableBase", label: "Bazamenti", options: TABLE_BASE_OPTIONS },
@@ -2110,6 +2231,8 @@ const TABLE_SETUP_SECTIONS = [
 ];
 
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
+  environmentHdri: HDRI_OPTIONS,
+  tableTheme: TABLE_THEME_OPTIONS,
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
   tableBase: TABLE_BASE_OPTIONS,
@@ -2118,12 +2241,18 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   chairTheme: CHAIR_THEME_OPTIONS
 });
 
-const DOMINO_DEFAULT_UNLOCKS = Object.freeze(
-  Object.entries(DOMINO_OPTIONS_BY_KEY).reduce((acc, [key, options]) => {
+const DOMINO_DEFAULT_UNLOCKS = (() => {
+  const base = Object.entries(DOMINO_OPTIONS_BY_KEY).reduce((acc, [key, options]) => {
     acc[key] = options.length && options[0]?.id ? [options[0].id] : [];
     return acc;
-  }, {})
-);
+  }, {});
+  const preferredHdri = HDRI_OPTIONS.find((option) => option.id === "colorfulStudio");
+  if (HDRI_OPTIONS.length) {
+    const preferredId = preferredHdri?.id ?? HDRI_OPTIONS[0].id;
+    base.environmentHdri = Array.from(new Set([preferredId, ...HDRI_OPTIONS.map((option) => option.id)]));
+  }
+  return Object.freeze(base);
+})();
 
 const DOMINO_INVENTORY_STORAGE_KEY = "dominoRoyalInventoryByAccount";
 
@@ -2212,6 +2341,8 @@ function normalizeAppearance(raw) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const source = raw && typeof raw === "object" ? raw : {};
   const limits = [
+    ["environmentHdri", HDRI_OPTIONS.length],
+    ["tableTheme", TABLE_THEME_OPTIONS.length],
     ["tableWood", TABLE_WOOD_OPTIONS.length],
     ["tableCloth", TABLE_CLOTH_OPTIONS.length],
     ["tableBase", TABLE_BASE_OPTIONS.length],
@@ -2604,6 +2735,10 @@ tableG.rotation.y = 0;
 const piecesG = new THREE.Group();
 tableG.add(piecesG);
 
+const arenaDecorG = new THREE.Group();
+arenaDecorG.visible = false;
+arenaG.add(arenaDecorG);
+
 /* ---------- Arena Dressings (Carpet & Walls) ---------- */
 const floor = new THREE.Mesh(
   new THREE.CircleGeometry(FLOOR_RADIUS, 96),
@@ -2612,7 +2747,7 @@ const floor = new THREE.Mesh(
 floor.rotation.x = -Math.PI / 2;
 floor.position.y = 0;
 floor.receiveShadow = true;
-arenaG.add(floor);
+arenaDecorG.add(floor);
 
 const carpetTextures = getPoolCarpetTextures(renderer);
 // Match Pool Royale's red carpet finish.
@@ -2636,7 +2771,7 @@ const carpet = new THREE.Mesh(new THREE.CircleGeometry(CARPET_RADIUS, 96), carpe
 carpet.rotation.x = -Math.PI / 2;
 carpet.position.y = 0.01;
 carpet.receiveShadow = true;
-arenaG.add(carpet);
+arenaDecorG.add(carpet);
 
 // Align the arena walls with Pool Royale's light blue tone.
 const wallMaterial = new THREE.MeshStandardMaterial({
@@ -2659,7 +2794,7 @@ const wall = new THREE.Mesh(
 wall.position.y = ARENA_WALL_CENTER_Y;
 wall.receiveShadow = false;
 wall.castShadow = false;
-arenaG.add(wall);
+arenaDecorG.add(wall);
 
 const ARENA_DOOR_DIMENSIONS = Object.freeze({ width: 2.8, height: 3.4, thickness: 0.12 });
 const carbonFiberTextureBase = createCarbonFiberTexture(renderer, { tile: 4.5 });
@@ -2749,7 +2884,7 @@ hallwayDoorPivot.add(hallwayDoorFrame);
 
 const hallwayDoorGroup = new THREE.Group();
 hallwayDoorGroup.add(hallwayDoorPivot);
-arenaG.add(hallwayDoorGroup);
+arenaDecorG.add(hallwayDoorGroup);
 
 const ARENA_WALKWAY_LENGTH = 14;
 const ARENA_WALKWAY_WIDTH = 4.2;
@@ -2770,7 +2905,7 @@ walkwayFloor.position.set(
   hallwayDoorZ + ARENA_WALKWAY_LENGTH / 2 - ARENA_DOOR_DIMENSIONS.thickness * 0.5
 );
 walkwayFloor.receiveShadow = true;
-arenaG.add(walkwayFloor);
+arenaDecorG.add(walkwayFloor);
 
 const walkwayRunnerMaterialConfig = {
   color: new THREE.Color(carpetMat.color.getHex()),
@@ -2800,7 +2935,7 @@ const walkwayRunner = new THREE.Mesh(
 walkwayRunner.rotation.x = -Math.PI / 2;
 walkwayRunner.position.set(0, walkwayFloor.position.y + 0.008, walkwayFloor.position.z);
 walkwayRunner.receiveShadow = true;
-arenaG.add(walkwayRunner);
+arenaDecorG.add(walkwayRunner);
 
 const walkwayTrimMat = new THREE.MeshStandardMaterial({
   color: 0xba7c2c,
@@ -2814,10 +2949,10 @@ const walkwayFrontTrim = new THREE.Mesh(walkwayTrimGeo, walkwayTrimMat);
 walkwayFrontTrim.position.set(0, 0.06, hallwayDoorZ - 0.2);
 walkwayFrontTrim.castShadow = false;
 walkwayFrontTrim.receiveShadow = false;
-arenaG.add(walkwayFrontTrim);
+arenaDecorG.add(walkwayFrontTrim);
 const walkwayOuterTrim = walkwayFrontTrim.clone();
 walkwayOuterTrim.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.2;
-arenaG.add(walkwayOuterTrim);
+arenaDecorG.add(walkwayOuterTrim);
 
 const walkwaySideGeo = new THREE.BoxGeometry(0.35, 1.2, ARENA_WALKWAY_LENGTH);
 const walkwayWallTexture = textureLoader.load(
@@ -2882,7 +3017,7 @@ function createWalkwaySide(offsetX) {
   sideGroup.add(lightStrip);
 
   sideGroup.position.set(offsetX, 0.6, walkwayFloor.position.z);
-  arenaG.add(sideGroup);
+  arenaDecorG.add(sideGroup);
   return sideGroup;
 }
 
@@ -2911,7 +3046,7 @@ const walkwayPortalHeader = new THREE.Mesh(
 );
 walkwayPortalHeader.position.set(0, 1.42, hallwayDoorZ - 0.05);
 walkwayPortalHeader.castShadow = true;
-arenaG.add(walkwayPortalHeader);
+arenaDecorG.add(walkwayPortalHeader);
 
 const walkwayPortalCrown = new THREE.Mesh(
   new THREE.TorusGeometry((ARENA_WALKWAY_WIDTH + 0.4) / 2, 0.05, 16, 48),
@@ -2926,7 +3061,7 @@ const walkwayPortalCrown = new THREE.Mesh(
 walkwayPortalCrown.rotation.x = Math.PI / 2;
 walkwayPortalCrown.position.set(0, 1.52, hallwayDoorZ - 0.12);
 walkwayPortalCrown.castShadow = false;
-arenaG.add(walkwayPortalCrown);
+arenaDecorG.add(walkwayPortalCrown);
 
 const walkwayCeiling = new THREE.Mesh(
   new THREE.PlaneGeometry(ARENA_WALKWAY_WIDTH + 0.8, ARENA_WALKWAY_LENGTH + 1.2),
@@ -2942,7 +3077,7 @@ const walkwayCeiling = new THREE.Mesh(
 walkwayCeiling.rotation.x = Math.PI / 2;
 walkwayCeiling.position.set(0, 1.95, walkwayFloor.position.z);
 walkwayCeiling.receiveShadow = false;
-arenaG.add(walkwayCeiling);
+arenaDecorG.add(walkwayCeiling);
 
 const chandelier = new THREE.Group();
 const chandelierRing = new THREE.Mesh(
@@ -2969,7 +3104,7 @@ const chandelierCore = new THREE.Mesh(
 chandelierCore.position.y = -0.35;
 chandelier.add(chandelierCore);
 chandelier.position.set(0, walkwayCeiling.position.y - 0.18, walkwayFloor.position.z);
-arenaG.add(chandelier);
+arenaDecorG.add(chandelier);
 
 const walkwayFrontLight = new THREE.Mesh(
   new THREE.BoxGeometry(ARENA_WALKWAY_WIDTH + 0.25, 0.08, 0.12),
@@ -2982,15 +3117,15 @@ const walkwayFrontLight = new THREE.Mesh(
   })
 );
 walkwayFrontLight.position.set(0, 0.18, hallwayDoorZ + 0.18);
-arenaG.add(walkwayFrontLight);
+arenaDecorG.add(walkwayFrontLight);
 const walkwayRearLight = walkwayFrontLight.clone();
 walkwayRearLight.position.z = walkwayFloor.position.z + ARENA_WALKWAY_LENGTH / 2 - 0.25;
-arenaG.add(walkwayRearLight);
+arenaDecorG.add(walkwayRearLight);
 
 const hallwayAmbient = new THREE.PointLight(0xffe2b5, dimIntensity(1.3), 18, 1.8);
 hallwayAmbient.position.set(0, walkwayCeiling.position.y - 0.05, walkwayFloor.position.z);
 hallwayAmbient.castShadow = true;
-arenaG.add(hallwayAmbient);
+arenaDecorG.add(hallwayAmbient);
 
 const hallwayDoorState = {
   pivot: hallwayDoorPivot,
@@ -3214,8 +3349,21 @@ const tableMaterials = {
   trim: new THREE.MeshStandardMaterial({ roughness: 0.22, metalness: 0.85 })
 };
 
+function resolveTablePalette() {
+  const theme = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? null;
+  const wood =
+    (theme && TABLE_WOOD_OPTIONS[theme.woodIndex]) || TABLE_WOOD_OPTIONS[appearance.tableWood] || TABLE_WOOD_OPTIONS[0];
+  const cloth =
+    (theme && TABLE_CLOTH_OPTIONS[theme.clothIndex]) ||
+    TABLE_CLOTH_OPTIONS[appearance.tableCloth] ||
+    TABLE_CLOTH_OPTIONS[0];
+  const base =
+    (theme && TABLE_BASE_OPTIONS[theme.baseIndex]) || TABLE_BASE_OPTIONS[appearance.tableBase] || TABLE_BASE_OPTIONS[0];
+  return { wood, cloth, base };
+}
+
 function updateTableMaterials() {
-  const wood = TABLE_WOOD_OPTIONS[appearance.tableWood] ?? TABLE_WOOD_OPTIONS[0];
+  const { wood, cloth, base } = resolveTablePalette();
   const { preset, grain } = resolveWoodComponents(wood);
   const sharedKey = `domino-wood-${wood?.id ?? preset.id ?? 'default'}`;
   applyWoodTextures(tableMaterials.top, {
@@ -3251,7 +3399,6 @@ function updateTableMaterials() {
   tableMaterials.accent.color.set(wood.accentHex);
   tableMaterials.accent.needsUpdate = true;
 
-  const cloth = TABLE_CLOTH_OPTIONS[appearance.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
   tableMaterials.felt.color.set(0xffffff);
   tableMaterials.felt.emissive.set(cloth.emissive ?? adjustHexColor(cloth.feltTop, 0.2));
   tableMaterials.felt.emissiveIntensity = dimIntensity(cloth.emissiveIntensity ?? 0.34);
@@ -3262,7 +3409,6 @@ function updateTableMaterials() {
   tableMaterials.felt.map.needsUpdate = true;
   tableMaterials.felt.needsUpdate = true;
 
-  const base = TABLE_BASE_OPTIONS[appearance.tableBase] ?? TABLE_BASE_OPTIONS[0];
   tableMaterials.base.color.set(base.base);
   tableMaterials.column.color.set(base.column);
   tableMaterials.trim.color.set(base.trim);
@@ -3964,6 +4110,7 @@ function saveAppearance() {
 function applyAppearanceChange({ refresh = true } = {}) {
   appearance = sanitizeAppearance(appearance);
   clearExistingDominoMeshes();
+  applyEnvironmentOption(HDRI_OPTIONS[appearance.environmentHdri] ?? HDRI_OPTIONS[0]);
   updateTableMaterials();
   applyDominoStyle(DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]);
   applyHighlightStyle(HIGHLIGHT_STYLE_OPTIONS[appearance.highlightStyle] ?? HIGHLIGHT_STYLE_OPTIONS[0]);
@@ -4018,6 +4165,22 @@ function createOptionPreview(key, option) {
   swatch.style.borderRadius = '0.75rem';
   swatch.style.border = '1px solid rgba(255,255,255,0.12)';
   switch (key) {
+    case 'environmentHdri': {
+      const primary = option?.swatches?.[0] ?? '#0b1220';
+      const secondary = option?.swatches?.[1] ?? primary;
+      swatch.style.background = `linear-gradient(135deg, ${primary}, ${secondary})`;
+      break;
+    }
+    case 'tableTheme': {
+      if (option?.thumbnail) {
+        swatch.style.backgroundImage = `url(${option.thumbnail})`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      } else {
+        swatch.style.background = 'linear-gradient(135deg, #1f2937, #0f172a)';
+      }
+      break;
+    }
     case 'tableWood':
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,4 +1,7 @@
-export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+
+const baseDominoOptions = {
   tableWood: [
     { id: 'oakEstate', label: 'Lis Estate' },
     { id: 'teakStudio', label: 'Tik Studio' }
@@ -32,22 +35,65 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'marksmanAmber', label: 'Marksman Amber' },
     { id: 'iceTracer', label: 'Ice Tracer' },
     { id: 'violetPulse', label: 'Violet Pulse' }
-  ],
-  chairTheme: [
-    { id: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
-    { id: 'midnightNavy', label: 'Midnight Blue Chairs' },
-    { id: 'emeraldWave', label: 'Emerald Wave Chairs' },
-    { id: 'onyxShadow', label: 'Onyx Shadow Chairs' },
-    { id: 'royalPlum', label: 'Royal Chestnut Chairs' }
   ]
+};
+
+const dominoChairThemes = [
+  { id: 'crimsonVelvet', label: 'Crimson Velvet Chairs' },
+  { id: 'midnightNavy', label: 'Midnight Blue Chairs' },
+  { id: 'emeraldWave', label: 'Emerald Wave Chairs' },
+  { id: 'onyxShadow', label: 'Onyx Shadow Chairs' },
+  { id: 'royalPlum', label: 'Royal Chestnut Chairs' },
+  ...MURLAN_STOOL_THEMES.map((theme) => ({
+    id: theme.id,
+    label: theme.label,
+    seatColor: theme.seatColor ?? '#d9d9d9',
+    legColor: theme.legColor ?? '#111827',
+    highlight: theme.accentColor ?? theme.seatColor ?? '#e2e8f0'
+  }))
+];
+
+const dominoTableThemes = MURLAN_TABLE_THEMES.map((theme, idx) => ({
+  id: theme.id,
+  label: theme.label,
+  thumbnail: theme.thumbnail,
+  description: theme.description,
+  woodIndex: idx % baseDominoOptions.tableWood.length,
+  clothIndex: (idx + 1) % baseDominoOptions.tableCloth.length,
+  baseIndex: (idx + 2) % baseDominoOptions.tableBase.length
+}));
+
+const dominoHdriOptions = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+  id: variant.id,
+  label: `${variant.name} HDRI`,
+  swatches: variant.swatches,
+  description: variant.description
+}));
+
+export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
+  ...baseDominoOptions,
+  chairTheme: dominoChairThemes,
+  tableTheme: dominoTableThemes,
+  environmentHdri: dominoHdriOptions
 });
 
-export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze(
-  Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
+const buildDominoDefaults = () => {
+  const base = Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
     acc[type] = options.length ? [options[0].id] : [];
     return acc;
-  }, {})
-);
+  }, {});
+  const defaultHdri = DOMINO_ROYAL_OPTION_SETS.environmentHdri.find(
+    (option) => option.id === POOL_ROYALE_DEFAULT_HDRI_ID
+  );
+  const allHdriIds = DOMINO_ROYAL_OPTION_SETS.environmentHdri.map((option) => option.id);
+  if (allHdriIds.length) {
+    const preferredId = defaultHdri?.id ?? allHdriIds[0];
+    base.environmentHdri = Array.from(new Set([preferredId, ...allHdriIds]));
+  }
+  return base;
+};
+
+export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze(buildDominoDefaults());
 
 export const DOMINO_ROYAL_OPTION_LABELS = Object.freeze(
   Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
@@ -109,13 +155,33 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     name: option.label,
     price: 300 + idx * 20,
     description: 'Alternate spectator chair upholstery for the arena.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
+    id: `domino-table-${option.id}`,
+    type: 'tableTheme',
+    optionId: option.id,
+    name: option.label,
+    price: 980 + idx * 40,
+    description: option.description || 'Murlan Royale table variant brought to Domino.'
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.environmentHdri.map((option, idx) => ({
+    id: `domino-hdri-${option.id}`,
+    type: 'environmentHdri',
+    optionId: option.id,
+    name: option.label,
+    price: 1400 + idx * 25,
+    description: option.description || 'HDRI carried over from Murlan Royale.',
+    swatches: option.swatches,
+    previewShape: 'table'
   }))
 ];
 
-export const DOMINO_ROYAL_DEFAULT_LOADOUT = Object.entries(DOMINO_ROYAL_OPTION_SETS).map(
-  ([type, options]) => ({
+export const DOMINO_ROYAL_DEFAULT_LOADOUT = Object.entries(DOMINO_ROYAL_OPTION_SETS).map(([type, options]) => {
+  const preferredId = DOMINO_ROYAL_DEFAULT_UNLOCKS[type]?.[0];
+  const preferredOption = options.find((opt) => opt.id === preferredId) || options[0];
+  return {
     type,
-    optionId: options[0]?.id,
-    label: options[0]?.label
-  })
-);
+    optionId: preferredOption?.id,
+    label: preferredOption?.label
+  };
+});

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -182,7 +182,9 @@ const DOMINO_TYPE_LABELS = {
   tableBase: 'Table Base',
   dominoStyle: 'Domino Styles',
   highlightStyle: 'Highlights',
-  chairTheme: 'Chairs'
+  chairTheme: 'Chairs',
+  tableTheme: 'Table Models',
+  environmentHdri: 'HDR Environments'
 };
 
 const SNAKE_TYPE_LABELS = {

--- a/webapp/src/utils/dominoArena.js
+++ b/webapp/src/utils/dominoArena.js
@@ -693,6 +693,9 @@ export function buildDominoArena({ scene, renderer }) {
 
   const arena = new THREE.Group();
   scene.add(arena);
+  const arenaDecor = new THREE.Group();
+  arenaDecor.visible = false;
+  arena.add(arenaDecor);
 
   const trackedGeometries = new Set();
   const trackedMaterials = new Set();
@@ -719,7 +722,7 @@ export function buildDominoArena({ scene, renderer }) {
   );
   carpet.position.y = -ROOM_DIMENSIONS.carpetThickness / 2;
   carpet.receiveShadow = true;
-  arena.add(carpet);
+  arenaDecor.add(carpet);
 
   const wallMat = new THREE.MeshStandardMaterial({ color: 0xb9ddff, roughness: 0.88, metalness: 0.06 });
 
@@ -727,7 +730,7 @@ export function buildDominoArena({ scene, renderer }) {
     const wall = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), wallMat);
     wall.position.y = height / 2;
     wall.receiveShadow = true;
-    arena.add(wall);
+    arenaDecor.add(wall);
     return wall;
   };
 
@@ -791,7 +794,7 @@ export function buildDominoArena({ scene, renderer }) {
   const cameraOffset = TABLE_DIMENSIONS.outerHalfWidth + 1.3;
   studioCamA.position.set(-cameraOffset, 0, -cameraOffset);
   studioCamB.position.set(cameraOffset, 0, cameraOffset);
-  arena.add(studioCamA, studioCamB);
+  arenaDecor.add(studioCamA, studioCamB);
   [studioCamA, studioCamB].forEach((rig) => {
     rig.traverse((child) => {
       if (child.isMesh) {


### PR DESCRIPTION
## Summary
- hide the legacy Domino arena shell so only the table, chairs, and tiles remain visible
- add Murlan HDRIs, table themes, and chair options into Domino Royal inventories and store listings
- surface the new HDRI and table selections in the Domino setup UI while mapping theme choices onto the table materials

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956304dbdd48329b83d123e9db0aad9)