### PR TITLE
Add selectable table base styles for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -552,9 +552,28 @@ export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
 );
 
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
+export const POOL_ROYALE_BASE_OPTIONS = Object.freeze([
+  { id: 'classicColumns', name: 'Classic Cylinders' },
+  { id: 'loopPedestal', name: 'Loop Pedestal' },
+  { id: 'zSculpt', name: 'Z Pedestal' },
+  { id: 'archBridge', name: 'Arc Bridge' },
+  { id: 'openTrestle', name: 'Open Trestle' },
+  { id: 'coinOpClassic', name: 'Coin-Op Taper' },
+  { id: 'modernPedestal', name: 'Sculpted Pedestal' },
+  { id: 'industrialX', name: 'Industrial X-Frame' },
+  { id: 'heritageClaw', name: 'Heritage Claw Legs' }
+]);
+export const POOL_ROYALE_BASE_OPTION_MAP = Object.freeze(
+  POOL_ROYALE_BASE_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
+export const POOL_ROYALE_DEFAULT_BASE_ID = POOL_ROYALE_BASE_OPTIONS[0].id;
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['peelingPaintWeathered'],
+  tableBase: POOL_ROYALE_BASE_OPTIONS.map((option) => option.id),
   chromeColor: ['gold'],
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
@@ -588,6 +607,12 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     pearl: 'Pearl',
     gold: 'Gold'
   }),
+  tableBase: Object.freeze(
+    POOL_ROYALE_BASE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.name;
+      return acc;
+    }, {})
+  ),
   clothColor: Object.freeze(
     POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
       acc[variant.id] = variant.name;
@@ -823,6 +848,11 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
     type: 'tableFinish',
     optionId: 'peelingPaintWeathered',
     label: 'Wood Peeling Paint Weathered Finish'
+  },
+  {
+    type: 'tableBase',
+    optionId: POOL_ROYALE_DEFAULT_BASE_ID,
+    label: POOL_ROYALE_OPTION_LABELS.tableBase[POOL_ROYALE_DEFAULT_BASE_ID]
   },
   { type: 'chromeColor', optionId: 'gold', label: 'Gold Chrome Plates' },
   { type: 'railMarkerColor', optionId: 'gold', label: 'Gold Diamond Markers' },


### PR DESCRIPTION
## Summary
- add new table base options (loop pedestal, Z pedestal, arches, trestles, coin-op, pedestal, industrial X, and heritage claws) and unlock them by default
- expose table base selection in the Pool Royale setup menu with persisted choices
- rebuild table base geometry via the new style switcher while keeping existing wood and chrome finish updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695633ae02788329a8fc18f18112e292)