### PR TITLE
Add customizable Pool Royale bases

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -552,8 +552,19 @@ export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
 );
 
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
+export const POOL_ROYALE_TABLE_BASE_OPTIONS = Object.freeze([
+  { id: 'classicSkirt', name: 'Classic Skirt' },
+  { id: 'loopPedestal', name: 'Loop Pedestal' },
+  { id: 'zPedestal', name: 'Z Pedestal' },
+  { id: 'arcBridge', name: 'Arc Bridge' },
+  { id: 'modernBridge', name: 'Modern Bridge' },
+  { id: 'arcadeBlock', name: 'Arcade Block' },
+  { id: 'heritageCarved', name: 'Heritage Carved' },
+  { id: 'timberCross', name: 'Timber Cross' }
+]);
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
+  tableBase: POOL_ROYALE_TABLE_BASE_OPTIONS.map((variant) => variant.id),
   tableFinish: ['peelingPaintWeathered'],
   chromeColor: ['gold'],
   railMarkerColor: ['gold'],
@@ -579,6 +590,12 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     kitchenWood: 'Kitchen Wood',
     japaneseSycamore: 'Japanese Sycamore'
   }),
+  tableBase: Object.freeze(
+    POOL_ROYALE_TABLE_BASE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.name;
+      return acc;
+    }, {})
+  ),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
     gold: 'Gold'
@@ -819,6 +836,11 @@ export const POOL_ROYALE_STORE_ITEMS = [
 ];
 
 export const POOL_ROYALE_DEFAULT_LOADOUT = [
+  {
+    type: 'tableBase',
+    optionId: POOL_ROYALE_TABLE_BASE_OPTIONS[0].id,
+    label: POOL_ROYALE_TABLE_BASE_OPTIONS[0].name
+  },
   {
     type: 'tableFinish',
     optionId: 'peelingPaintWeathered',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -115,6 +115,7 @@ import { getAccountBalance, sendAccountTpc } from '../utils/api.js';
 import { DEV_INFO } from '../utils/constants.js';
 
 const TYPE_LABELS = {
+  tableBase: 'Table Bases',
   tableFinish: 'Table Finishes',
   chromeColor: 'Chrome Fascias',
   railMarkerColor: 'Rail Markers',


### PR DESCRIPTION
## Summary
- add unlockable Pool Royale table base presets and surface labels
- render multiple under-table base geometries and allow switching from the table setup panel
- surface the new base type in store metadata and defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695633ae02788329a8fc18f18112e292)