### PR TITLE
Create mobile-first games hub and pool variant entrypoints

### DIFF
--- a/webapp/src/components/GameCard.jsx
+++ b/webapp/src/components/GameCard.jsx
@@ -1,35 +1,73 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
 
-export default function GameCard({ title, description, link, icon }) {
+export default function GameCard({
+  title,
+  description,
+  link,
+  icon,
+  genre,
+  meta = [],
+  features = [],
+  inlineActions
+}) {
   let iconNode = null;
   if (icon) {
     iconNode =
       typeof icon === 'string'
-        ? <img src={icon} alt="" className="h-8 w-8 mx-auto" />
+        ? <img src={icon} alt="" className="h-10 w-10 object-contain mx-auto drop-shadow" />
         : React.isValidElement(icon)
           ? icon
           : <span className="text-3xl text-accent">{icon}</span>;
   }
 
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 shadow-lg space-y-2 text-center overflow-hidden wide-card">
-      {iconNode}
-      <h3
-        className="text-lg font-bold text-yellow-400"
-        style={{ WebkitTextStroke: '1px black' }}
-      >
-        {title}
-      </h3>
-      {description && <p className="text-subtext text-sm">{description}</p>}
-      {link && (
-        <Link
-          to={link}
-          className="inline-block mt-1 px-3 py-1 bg-primary rounded hover:bg-primary-hover text-white-shadow"
-        >
-          Open
-        </Link>
+    <div className="relative bg-surface border border-border rounded-2xl p-4 shadow-lg space-y-3 overflow-hidden wide-card">
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 w-12 h-12 rounded-xl bg-black/40 border border-border flex items-center justify-center">
+          {iconNode}
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-bold text-yellow-400" style={{ WebkitTextStroke: '1px black' }}>
+            {title}
+          </h3>
+          {genre && <p className="text-xs uppercase tracking-wide text-subtext">{genre}</p>}
+          {description && <p className="text-subtext text-sm leading-snug">{description}</p>}
+        </div>
+      </div>
+
+      {meta?.length > 0 && (
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          {meta.map(({ label, value }) => (
+            <div key={`${label}-${value}`} className="rounded-lg border border-border/60 bg-background/40 px-2 py-2">
+              <p className="text-[11px] uppercase tracking-wide text-subtext">{label}</p>
+              <p className="font-semibold">{value}</p>
+            </div>
+          ))}
+        </div>
       )}
+
+      {features?.length > 0 && (
+        <ul className="list-disc list-inside space-y-1 text-sm text-subtext">
+          {features.map((item) => (
+            <li key={item} className="leading-snug">{item}</li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center justify-between gap-2">
+        {inlineActions}
+        {link && (
+          <Link
+            to={link}
+            className="ml-auto inline-flex items-center gap-2 px-3 py-2 bg-primary hover:bg-primary-hover rounded-full text-black text-sm font-semibold shadow-lg shadow-primary/40"
+          >
+            Open lobby
+            <ArrowRight size={16} />
+          </Link>
+        )}
+      </div>
     </div>
   );
 }

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,19 +1,180 @@
 const gamesCatalog = [
-  { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
-  { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
-  { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
-  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
-  { name: 'Goal Rush', route: '/games/goalrush/lobby' },
-  { name: 'Air Hockey', route: '/games/airhockey/lobby' },
-  { name: 'Snake & Ladder', route: '/games/snake/lobby' },
-  { name: 'Murlan Royale', route: '/games/murlanroyale/lobby' },
-  { name: 'Chess Battle Royal', route: '/games/chessbattleroyal/lobby' },
-  { name: 'Ludo Battle Royal', route: '/games/ludobattleroyal/lobby' }
+  {
+    name: 'Pool Royale',
+    slug: 'poolroyale',
+    route: '/games/poolroyale/lobby',
+    icon: '/assets/icons/pool-royale.svg',
+    genre: 'Cue sports • 1v1 / tournaments',
+    summary: 'Three billiards rule-sets with precision physics, touch-friendly aim and optional stakes.',
+    meta: [
+      { label: 'Modes', value: 'AI, Online, Tournament' },
+      { label: 'Average rack', value: '5–7 minutes' },
+      { label: 'Variants', value: '8 Pool UK, American, 9-Ball' }
+    ],
+    features: [
+      'TPC escrow for online stakes with anti-tilt timers.',
+      'Training tables, cloth presets, and cue personalization.',
+      'Supports left/right handed cueing with auto camera assist.'
+    ]
+  },
+  {
+    name: "Texas Hold'em",
+    slug: 'texasholdem',
+    route: '/games/texasholdem/lobby',
+    icon: '/assets/icons/texas-holdem.svg',
+    genre: 'Cards • 2-6 players',
+    summary: 'Fast-paced poker with sit & go style stacks and table cosmetics.',
+    meta: [
+      { label: 'Stakes', value: 'TPC blinds or practice chips' },
+      { label: 'Playstyle', value: 'Turbo hands, emoji tells' }
+    ],
+    features: [
+      'Supports avatars and emotes per hand.',
+      'Table selector keeps lobbies balanced by blinds.',
+      'Designed for portrait play with one-hand controls.'
+    ]
+  },
+  {
+    name: 'Domino Royal 3D',
+    slug: 'domino-royal',
+    route: '/games/domino-royal/lobby',
+    icon: '/assets/icons/domino-royal.svg',
+    genre: 'Board • Up to 4 players',
+    summary: 'Immersive double-six domino tables with local, AI, and online seats.',
+    meta: [
+      { label: 'Pot', value: 'Up to TPC stake you set' },
+      { label: 'Modes', value: 'Local pass & play, AI, Online' }
+    ],
+    features: [
+      'Save and reuse your avatar, flags, and frame rate presets.',
+      'Quick seat fills for AI opponents to keep tables active.',
+      'Optimized camera for portrait taps and drags.'
+    ]
+  },
+  {
+    name: 'Snooker Club',
+    slug: 'snookerclub',
+    route: '/games/snookerclub/lobby',
+    icon: '/assets/icons/pool-royale.svg',
+    genre: 'Cue sports • Tactical',
+    summary: 'Long-table snooker with touch safeties and crisp physics.',
+    meta: [
+      { label: 'Frames', value: 'Race-to formats' },
+      { label: 'Focus', value: 'Safety play + long pots' }
+    ],
+    features: [
+      'Best for players who enjoy methodical cue sports.',
+      'Practice-friendly pacing tuned for mobile accuracy.',
+      'Shared cue/cloth unlocks with Pool Royale.'
+    ]
+  },
+  {
+    name: 'Goal Rush',
+    slug: 'goalrush',
+    route: '/games/goalrush/lobby',
+    icon: '/assets/icons/goal_rush_card_1200x675.webp',
+    genre: 'Sports • Football skill shots',
+    summary: 'Arcade free-kicks with curved shots, walls, and tournaments.',
+    meta: [
+      { label: 'Modes', value: 'Solo training & brackets' },
+      { label: 'Avg run', value: '3–5 minutes' }
+    ],
+    features: [
+      'Swipe-to-curve shooting tuned for portrait play.',
+      'Bracket view for multi-round play.',
+      'Works with controller-like touch regions.'
+    ]
+  },
+  {
+    name: 'Air Hockey',
+    slug: 'airhockey',
+    route: '/games/airhockey/lobby',
+    icon: '/assets/icons/pool-royale.svg',
+    genre: 'Arcade • 1v1',
+    summary: 'Lightning-fast air hockey with tactile rebounds.',
+    meta: [
+      { label: 'Pacing', value: 'First to 7 goals' },
+      { label: 'Modes', value: 'AI & Online' }
+    ],
+    features: [
+      'Lag-tolerant input for quick swipes.',
+      'Compact rink sizing for portrait reachability.',
+      'Glow trails for clearer puck tracking.'
+    ]
+  },
+  {
+    name: 'Snake & Ladder',
+    slug: 'snake',
+    route: '/games/snake/lobby',
+    icon: '/assets/icons/snakes_and_ladders.webp',
+    genre: 'Board • Casual',
+    summary: 'Family-friendly rolls with animated ladders and snakes.',
+    meta: [
+      { label: 'Players', value: '1–4 (AI or friends)' },
+      { label: 'Session', value: '5–10 minutes' }
+    ],
+    features: [
+      'Online matchmaking plus pass-and-play.',
+      'Tilted 3D board with simple tap controls.',
+      'Clear turn indicators to keep things moving.'
+    ]
+  },
+  {
+    name: 'Murlan Royale',
+    slug: 'murlanroyale',
+    route: '/games/murlanroyale/lobby',
+    icon: '/assets/icons/murlan-royale.svg',
+    genre: 'Cards • Set progression',
+    summary: 'Classic Murlan flow with simultaneous drops and combo scoring.',
+    meta: [
+      { label: 'Room sizes', value: '2–4 players' },
+      { label: 'Modes', value: 'AI & Online' }
+    ],
+    features: [
+      'Smart hints help onboard new players.',
+      'Quick rematch flow to keep friends together.',
+      'Supports TPC stakes with escrow when online.'
+    ]
+  },
+  {
+    name: 'Chess Battle Royal',
+    slug: 'chessbattleroyal',
+    route: '/games/chessbattleroyal/lobby',
+    icon: '/assets/icons/pool-royale.svg',
+    genre: 'Board • 1v1 / survival',
+    summary: 'Arcade chess with power-ups and arena-style eliminations.',
+    meta: [
+      { label: 'Pacing', value: 'Rapid timers' },
+      { label: 'Mode', value: 'Battle royale twist' }
+    ],
+    features: [
+      'Friendly for both chess vets and arcade players.',
+      'Power-ups surface clearly for mobile screens.',
+      'Tournament-friendly brackets for streams.'
+    ]
+  },
+  {
+    name: 'Ludo Battle Royal',
+    slug: 'ludobattleroyal',
+    route: '/games/ludobattleroyal/lobby',
+    icon: '/assets/icons/pool-royale.svg',
+    genre: 'Board • Party',
+    summary: 'Fast Ludo with arena visuals and easy invites.',
+    meta: [
+      { label: 'Players', value: '2–4' },
+      { label: 'Session', value: '6–10 minutes' }
+    ],
+    features: [
+      'Auto-roll timers to keep turns moving.',
+      'Invite flow built for Telegram groups.',
+      'Vibrant board skin tuned for mobile contrast.'
+    ]
+  }
 ];
 
 export default gamesCatalog;
 
-export const catalogWithSlugs = gamesCatalog.map((game) => {
-  const [, , slug] = game.route.split('/');
-  return { ...game, slug };
-});
+export const catalogWithSlugs = gamesCatalog.map((game) => ({
+  ...game,
+  slug: game.slug || game.route.split('/').filter(Boolean).pop()
+}));

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,37 +1,119 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
-import GamesHallway from '../components/GamesHallway.jsx';
+import GameCard from '../components/GameCard.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
+
+const poolVariants = [
+  { id: 'uk', label: '8 Pool UK', note: 'Classic reds & yellows', route: '/games/poolroyale/lobby?variant=uk' },
+  { id: 'american', label: 'American', note: 'Solids & stripes visuals', route: '/games/poolroyale/lobby?variant=american' },
+  { id: '9ball', label: '9-Ball', note: 'Texas Express rules', route: '/games/poolroyale/lobby?variant=9ball' }
+];
 
 export default function Games() {
   useTelegramBackButton();
-  const [showHallway, setShowHallway] = useState(false);
+
+  const poolRoyale = useMemo(() => gamesCatalog.find((g) => g.slug === 'poolroyale'), []);
+  const otherGames = useMemo(() => gamesCatalog.filter((g) => g.slug !== 'poolroyale'), []);
+
   return (
-    <div className="relative space-y-4 text-text">
-      <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
-      <p className="text-center text-sm text-subtext">Online games are under construction and will be available soon.</p>
-      <div className="space-y-4">
-        <div className="relative bg-surface border border-border rounded-xl p-6 shadow-lg overflow-hidden wide-card space-y-4 text-center">
-          <div className="space-y-2">
-            <h3 className="text-lg font-semibold">3D Hallway Experience</h3>
-            <p className="text-sm text-subtext">
-              Explore the luxury hallway and pick your favorite game by stepping through its golden door or tapping the illuminated sign.
-            </p>
+    <div className="relative space-y-5 text-text pb-16">
+      <div className="relative mt-4 overflow-hidden rounded-2xl border border-border bg-gradient-to-br from-primary/20 via-background to-surface shadow-xl">
+        <div className="p-5 space-y-3">
+          <p className="text-xs uppercase tracking-[0.2em] text-subtext">Main gamer hub</p>
+          <h2 className="text-2xl font-extrabold leading-tight">
+            Pick a game, enter its lobby, and play instantly.
+          </h2>
+          <p className="text-sm text-subtext leading-snug">
+            Designed for portrait play on your phone: responsive controls, quick onboarding, and crisp UI that stays readable on the go.
+          </p>
+          <div className="flex flex-wrap gap-2 text-xs">
+            {['One-hand friendly', 'Low latency', 'TPC stakes ready', 'Touch + swipe tuned'].map((tag) => (
+              <span key={tag} className="rounded-full border border-border bg-black/40 px-3 py-1">{tag}</span>
+            ))}
           </div>
-          <button
-            type="button"
-            onClick={() => setShowHallway(true)}
-            className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-base font-semibold text-black shadow-lg shadow-primary/40"
-          >
-            Enter Games
-          </button>
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="rounded-xl border border-border/60 bg-background/60 px-3 py-2">
+              <p className="text-[11px] uppercase tracking-wide text-subtext">Online players</p>
+              <p className="text-lg font-semibold">Live lobbies</p>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background/60 px-3 py-2">
+              <p className="text-[11px] uppercase tracking-wide text-subtext">Game modes</p>
+              <p className="text-lg font-semibold">Solo • 1v1 • Tournaments</p>
+            </div>
+          </div>
         </div>
       </div>
+
+      {poolRoyale && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-subtext">Featured</p>
+              <h3 className="text-xl font-bold">Pool Royale variants</h3>
+              <p className="text-sm text-subtext leading-snug">Choose a rule-set and jump straight into its lobby.</p>
+            </div>
+            <Link
+              to={poolRoyale.route}
+              className="shrink-0 rounded-full border border-border bg-primary px-4 py-2 text-black text-sm font-semibold shadow-lg shadow-primary/40"
+            >
+              Open Pool Royale lobby
+            </Link>
+          </div>
+          <GameCard
+            title={poolRoyale.name}
+            description={poolRoyale.summary}
+            link={poolRoyale.route}
+            icon={poolRoyale.icon}
+            genre={poolRoyale.genre}
+            meta={poolRoyale.meta}
+            features={poolRoyale.features}
+            inlineActions={(
+              <div className="flex flex-wrap gap-2">
+                {poolVariants.map((variant) => (
+                  <Link
+                    key={variant.id}
+                    to={variant.route}
+                    className="rounded-full border border-border bg-background/70 px-3 py-2 text-sm font-semibold hover:border-primary"
+                  >
+                    {variant.label}
+                    <span className="block text-[11px] font-normal text-subtext">{variant.note}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          />
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-subtext">All games</p>
+            <h3 className="text-xl font-bold">Jump into any lobby</h3>
+          </div>
+          <Link to="/games/transactions" className="text-sm text-primary underline">View game history</Link>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {otherGames.map((game) => (
+            <GameCard
+              key={game.route}
+              title={game.name}
+              description={game.summary}
+              link={game.route}
+              icon={game.icon}
+              genre={game.genre}
+              meta={game.meta}
+              features={game.features}
+            />
+          ))}
+        </div>
+      </div>
+
       <GameTransactionsCard />
       <LeaderboardCard />
-      {showHallway && <GamesHallway games={gamesCatalog} onClose={() => setShowHallway(false)} />}
     </div>
   );
 }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -113,7 +113,6 @@ export default function DominoRoyalLobby() {
       params.set('avatars', 'flags');
       if (aiFlagSelection.length) params.set('flags', aiFlagSelection.join(','));
     }
-    params.set('entry', 'hallway');
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     const initData = window.Telegram?.WebApp?.initData;

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -33,7 +33,10 @@ export default function PoolRoyaleLobby() {
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
-  const [variant, setVariant] = useState('uk');
+  const [variant, setVariant] = useState(() => {
+    const requestedVariant = (searchParams.get('variant') || '').toLowerCase();
+    return ['uk', 'american', '9ball'].includes(requestedVariant) ? requestedVariant : 'uk';
+  });
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
@@ -90,6 +93,14 @@ export default function PoolRoyaleLobby() {
       setUkBallSet('uk');
     }
   }, [variant]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const requestedVariant = (params.get('variant') || '').toLowerCase();
+    if (['uk', 'american', '9ball'].includes(requestedVariant) && requestedVariant !== variant) {
+      setVariant(requestedVariant);
+    }
+  }, [search, variant]);
 
   const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
     const selfId = accountId || accountIdRef.current;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -262,7 +262,6 @@ const TYPE_SWATCHES = {
   goals: ['#f97316', '#fb923c'],
   tableWood: ['#4b3621', '#9a7b4f'],
   tableCloth: ['#0f172a', '#34d399'],
-  tableBase: ['#0f172a', '#1f2937'],
   tableTheme: ['#0f172a', '#e5e7eb'],
   tables: ['#0f172a', '#94a3b8'],
   stools: ['#111827', '#eab308'],
@@ -361,7 +360,6 @@ const PREVIEW_BY_TYPE = {
   tableBase: 'table',
   tableWood: 'table',
   tableCloth: 'table',
-  tableBase: 'table',
   tableTheme: 'table',
   chairTheme: 'chair',
   tables: 'table'


### PR DESCRIPTION
## Summary
- Replace the hallway overlay with a mobile-first Games hub that lists every title with metadata and direct lobby entry points.
- Spotlight Pool Royale with per-variant quick links (8 Pool UK, American, 9-Ball) and richer catalog copy for all games.
- Parse lobby variant params, drop the hallway entry flag for Domino, and clean duplicate store swatches to keep builds healthy.

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956448792e483298fa8e0e435138615)