### PR TITLE
Revamp games catalog layout

### DIFF
--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,19 +1,195 @@
 const gamesCatalog = [
-  { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
-  { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
-  { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
-  { name: 'Snooker Club', route: '/games/snookerclub/lobby' },
-  { name: 'Goal Rush', route: '/games/goalrush/lobby' },
-  { name: 'Air Hockey', route: '/games/airhockey/lobby' },
-  { name: 'Snake & Ladder', route: '/games/snake/lobby' },
-  { name: 'Murlan Royale', route: '/games/murlanroyale/lobby' },
-  { name: 'Chess Battle Royal', route: '/games/chessbattleroyal/lobby' },
-  { name: 'Ludo Battle Royal', route: '/games/ludobattleroyal/lobby' }
+  {
+    id: 'pool-uk',
+    name: 'Pool Royale',
+    variant: '8 Pool UK',
+    slug: 'poolroyale',
+    lobbyPath: '/games/poolroyale/lobby',
+    playPath: '/games/poolroyale',
+    params: { variant: 'uk' },
+    tagline: 'Classic pub rules with compact tables for mobile touch play.',
+    tags: ['AI & Online', 'TPC stakes', 'Table size presets'],
+    accent: 'from-emerald-400/25 via-cyan-400/20 to-blue-500/10',
+    stats: [
+      { label: 'Mode', value: 'AI & 1v1 Online' },
+      { label: 'Visuals', value: 'Yellow/Red or Solids' }
+    ],
+    emoji: '🎱'
+  },
+  {
+    id: 'pool-american',
+    name: 'Pool Royale',
+    variant: 'American Billiards',
+    slug: 'poolroyale',
+    lobbyPath: '/games/poolroyale/lobby',
+    playPath: '/games/poolroyale',
+    params: { variant: 'american' },
+    tagline: 'Solids & Stripes physics tuned for U.S. table specs.',
+    tags: ['TPC stakes', 'Ranked-ready', 'Cinematic intro'],
+    accent: 'from-purple-500/25 via-fuchsia-500/20 to-sky-500/10',
+    stats: [
+      { label: 'Mode', value: 'AI & 1v1 Online' },
+      { label: 'Skill', value: 'American break & run' }
+    ],
+    emoji: '🎱'
+  },
+  {
+    id: 'pool-9ball',
+    name: 'Pool Royale',
+    variant: '9-Ball',
+    slug: 'poolroyale',
+    lobbyPath: '/games/poolroyale/lobby',
+    playPath: '/games/poolroyale',
+    params: { variant: '9ball' },
+    tagline: 'Fast racks with 9-ball order, ideal for speedruns.',
+    tags: ['Race format', 'Pro cue ball', 'TPC optional'],
+    accent: 'from-amber-400/25 via-orange-500/20 to-rose-500/10',
+    stats: [
+      { label: 'Mode', value: 'AI practice' },
+      { label: 'Focus', value: 'Call shots, combos' }
+    ],
+    emoji: '🎱'
+  },
+  {
+    id: 'domino-royal',
+    name: 'Domino Royal 3D',
+    slug: 'domino-royal',
+    lobbyPath: '/games/domino-royal/lobby',
+    playPath: '/games/domino-royal',
+    tagline: 'Double-six domino arena with cinematic lighting and AI seats.',
+    tags: ['2-4 players', 'Flag avatars', 'TPC stakes'],
+    accent: 'from-cyan-500/20 via-sky-500/10 to-indigo-500/10',
+    stats: [
+      { label: 'Mode', value: 'Local AI & stake' },
+      { label: 'Seats', value: 'Up to 4' }
+    ],
+    emoji: '🁫'
+  },
+  {
+    id: 'texas-holdem',
+    name: "Texas Hold'em",
+    slug: 'texasholdem',
+    lobbyPath: '/games/texasholdem/lobby',
+    playPath: '/games/texasholdem',
+    tagline: 'Tournament-ready poker tables with crisp card animations.',
+    tags: ['Stake ready', 'Fast hands'],
+    accent: 'from-red-500/25 via-rose-500/20 to-orange-500/10',
+    stats: [
+      { label: 'Mode', value: 'Online-ready' },
+      { label: 'Pace', value: 'Turbo hands' }
+    ],
+    emoji: '🃏'
+  },
+  {
+    id: 'snooker-club',
+    name: 'Snooker Club',
+    slug: 'snookerclub',
+    lobbyPath: '/games/snookerclub/lobby',
+    playPath: '/games/snookerclub',
+    tagline: 'Precision snooker tables with aim training overlays.',
+    tags: ['Practice', 'Cinematic'],
+    accent: 'from-green-500/25 via-emerald-500/15 to-slate-600/10',
+    stats: [
+      { label: 'Mode', value: 'Cue training' },
+      { label: 'Tables', value: 'Full-size cloth' }
+    ],
+    emoji: '🎱'
+  },
+  {
+    id: 'goal-rush',
+    name: 'Goal Rush',
+    slug: 'goalrush',
+    lobbyPath: '/games/goalrush/lobby',
+    playPath: '/games/goalrush',
+    tagline: 'Arcade football flicks with lobby-based matchmaking.',
+    tags: ['Arcade', 'Skill shots'],
+    accent: 'from-emerald-400/25 via-lime-400/20 to-sky-400/10',
+    stats: [
+      { label: 'Mode', value: 'Lobby to pitch' },
+      { label: 'Pace', value: 'Quick kicks' }
+    ],
+    emoji: '⚽'
+  },
+  {
+    id: 'air-hockey',
+    name: 'Air Hockey',
+    slug: 'airhockey',
+    lobbyPath: '/games/airhockey/lobby',
+    playPath: '/games/airhockey',
+    tagline: 'Slick air hockey duels with neon rails.',
+    tags: ['1v1', 'Reflex'],
+    accent: 'from-sky-500/25 via-blue-500/15 to-indigo-500/10',
+    stats: [
+      { label: 'Mode', value: 'Arcade duel' },
+      { label: 'Physics', value: 'Glide-tuned' }
+    ],
+    emoji: '🥅'
+  },
+  {
+    id: 'snake-ladder',
+    name: 'Snake & Ladder',
+    slug: 'snake',
+    lobbyPath: '/games/snake',
+    playPath: '/games/snake',
+    tagline: 'Instant board start with multiplayer and results views.',
+    tags: ['Board', 'Multiplayer'],
+    accent: 'from-yellow-400/25 via-orange-400/20 to-rose-500/10',
+    stats: [
+      { label: 'Mode', value: 'Solo & MP' },
+      { label: 'Scene', value: '3D board' }
+    ],
+    emoji: '🎲'
+  },
+  {
+    id: 'murlan-royale',
+    name: 'Murlan Royale',
+    slug: 'murlanroyale',
+    lobbyPath: '/games/murlanroyale/lobby',
+    playPath: '/games/murlanroyale',
+    tagline: 'Card climbing battles with Royale pacing.',
+    tags: ['Cards', 'Quick rounds'],
+    accent: 'from-indigo-500/20 via-purple-500/15 to-fuchsia-500/10',
+    stats: [
+      { label: 'Mode', value: 'Lobby linked' },
+      { label: 'Pace', value: 'Royale turns' }
+    ],
+    emoji: '🂮'
+  },
+  {
+    id: 'chess-battle-royal',
+    name: 'Chess Battle Royal',
+    slug: 'chessbattleroyal',
+    lobbyPath: '/games/chessbattleroyal/lobby',
+    playPath: '/games/chessbattleroyal',
+    tagline: 'Blitz chess battles with royale field and flags.',
+    tags: ['Blitz', 'Flags'],
+    accent: 'from-slate-500/25 via-blue-500/15 to-cyan-400/10',
+    stats: [
+      { label: 'Mode', value: 'Lobby + battle' },
+      { label: 'Board', value: 'Royale grid' }
+    ],
+    emoji: '♟️'
+  },
+  {
+    id: 'ludo-battle-royal',
+    name: 'Ludo Battle Royal',
+    slug: 'ludobattleroyal',
+    lobbyPath: '/games/ludobattleroyal/lobby',
+    playPath: '/games/ludobattleroyal',
+    tagline: 'High-tempo Ludo arenas with animated tokens.',
+    tags: ['Board', 'Party'],
+    accent: 'from-teal-400/20 via-cyan-500/15 to-indigo-500/10',
+    stats: [
+      { label: 'Mode', value: 'Lobby linked' },
+      { label: 'Players', value: 'Battle-royal' }
+    ],
+    emoji: '🎯'
+  }
 ];
 
 export default gamesCatalog;
 
-export const catalogWithSlugs = gamesCatalog.map((game) => {
-  const [, , slug] = game.route.split('/');
-  return { ...game, slug };
-});
+export const catalogWithSlugs = gamesCatalog.map((game) => ({
+  ...game,
+  slug: game.slug || (game.lobbyPath || game.playPath || game.route || '').split('/')[2] || game.id
+}));

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,37 +1,107 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
-import GamesHallway from '../components/GamesHallway.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 
 export default function Games() {
   useTelegramBackButton();
-  const [showHallway, setShowHallway] = useState(false);
-  return (
-    <div className="relative space-y-4 text-text">
-      <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
-      <p className="text-center text-sm text-subtext">Online games are under construction and will be available soon.</p>
-      <div className="space-y-4">
-        <div className="relative bg-surface border border-border rounded-xl p-6 shadow-lg overflow-hidden wide-card space-y-4 text-center">
-          <div className="space-y-2">
-            <h3 className="text-lg font-semibold">3D Hallway Experience</h3>
-            <p className="text-sm text-subtext">
-              Explore the luxury hallway and pick your favorite game by stepping through its golden door or tapping the illuminated sign.
-            </p>
-          </div>
+  const navigate = useNavigate();
+
+  const catalog = useMemo(
+    () =>
+      gamesCatalog.map((game) => ({
+        ...game,
+        primaryActionLabel: 'Play',
+        secondaryActionLabel: game.lobbyPath && game.lobbyPath !== game.playPath ? 'Lobby' : 'Details'
+      })),
+    []
+  );
+
+  const goTo = (path, params = {}) => {
+    if (!path) return;
+    const query = new URLSearchParams();
+    Object.entries(params || {}).forEach(([key, value]) => {
+      if (value != null) query.set(key, value);
+    });
+    const suffix = query.toString();
+    navigate(suffix ? `${path}?${query.toString()}` : path);
+  };
+
+  const renderCard = (game) => (
+    <div
+      key={game.id}
+      className={`relative rounded-2xl border border-border/70 bg-gradient-to-br ${game.accent || 'from-primary/20 to-primary/5'} p-4 shadow-lg backdrop-blur-md flex flex-col gap-3`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-subtext">{game.variant || game.slug}</p>
+          <h3 className="text-lg font-bold leading-tight">{game.name}</h3>
+        </div>
+        <span className="text-2xl">{game.emoji || '🎮'}</span>
+      </div>
+      {game.tagline && <p className="text-sm text-subtext leading-relaxed">{game.tagline}</p>}
+      {Array.isArray(game.tags) && game.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {game.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-black/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-subtext border border-border/70"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      {Array.isArray(game.stats) && game.stats.length > 0 && (
+        <div className="grid grid-cols-2 gap-2 text-xs text-subtext">
+          {game.stats.map((stat) => (
+            <div key={stat.label} className="rounded-lg border border-border/60 bg-black/20 px-3 py-2">
+              <p className="uppercase tracking-wide text-[10px]">{stat.label}</p>
+              <p className="font-semibold text-sm text-text">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2 pt-1">
+        {game.playPath && (
           <button
             type="button"
-            onClick={() => setShowHallway(true)}
-            className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-base font-semibold text-black shadow-lg shadow-primary/40"
+            onClick={() => goTo(game.playPath, game.params)}
+            className="flex-1 rounded-xl bg-primary px-4 py-2 text-black font-semibold shadow-md shadow-primary/40"
           >
-            Enter Games
+            {game.primaryActionLabel}
           </button>
-        </div>
+        )}
+        {game.lobbyPath && (
+          <button
+            type="button"
+            onClick={() => goTo(game.lobbyPath, game.params)}
+            className="flex-1 rounded-xl border border-border bg-background/60 px-4 py-2 text-sm font-semibold text-text"
+          >
+            {game.secondaryActionLabel}
+          </button>
+        )}
       </div>
+    </div>
+  );
+
+  return (
+    <div className="relative space-y-4 text-text">
+      <div className="rounded-2xl border border-border bg-surface p-5 shadow-xl text-center space-y-2">
+        <h2 className="text-2xl font-bold">Play Games</h2>
+        <p className="text-sm text-subtext">
+          Pick a game, hop into its lobby, and jump straight into the match. Built for mobile portrait flow.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {catalog.map(renderCard)}
+      </div>
+
       <GameTransactionsCard />
       <LeaderboardCard />
-      {showHallway && <GamesHallway games={gamesCatalog} onClose={() => setShowHallway(false)} />}
     </div>
   );
 }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -113,7 +113,6 @@ export default function DominoRoyalLobby() {
       params.set('avatars', 'flags');
       if (aiFlagSelection.length) params.set('flags', aiFlagSelection.join(','));
     }
-    params.set('entry', 'hallway');
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
     const initData = window.Telegram?.WebApp?.initData;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -250,7 +250,6 @@ const TYPE_SWATCHES = {
   tableFinish: ['#3b2f2f', '#8b5a2b'],
   chromeColor: ['#f5f5f5', '#d4d4d8'],
   railMarkerColor: ['#9ca3af', '#fef3c7'],
-  tableBase: ['#0f172a', '#1f2937'],
   clothColor: ['#0f766e', '#22c55e'],
   cueStyle: ['#0f172a', '#1e293b'],
   environmentHdri: ['#0ea5e9', '#312e81'],
@@ -262,7 +261,6 @@ const TYPE_SWATCHES = {
   goals: ['#f97316', '#fb923c'],
   tableWood: ['#4b3621', '#9a7b4f'],
   tableCloth: ['#0f172a', '#34d399'],
-  tableBase: ['#0f172a', '#1f2937'],
   tableTheme: ['#0f172a', '#e5e7eb'],
   tables: ['#0f172a', '#94a3b8'],
   stools: ['#111827', '#eab308'],
@@ -361,7 +359,6 @@ const PREVIEW_BY_TYPE = {
   tableBase: 'table',
   tableWood: 'table',
   tableCloth: 'table',
-  tableBase: 'table',
   tableTheme: 'table',
   chairTheme: 'chair',
   tables: 'table'


### PR DESCRIPTION
## Summary
- replace hallway entry with a mobile-friendly games hub showcasing each title and Pool Royale variants
- expand games catalog metadata for dedicated play/lobby links and variant details
- remove hallway entry flag from Domino Royal lobby and fix store swatch duplicates

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956448792e483298fa8e0e435138615)