### PR TITLE
Align Domino Royal seating scale and textures with Ludo

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -756,8 +756,9 @@ scene.background = null;
 const LIGHT_INTENSITY_FACTOR = 1;
 const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
-const MODEL_SCALE = 0.75;
-const TABLE_SCALE = 0.85;
+const ARENA_SCALE = 0.85;
+const MODEL_SCALE = 0.75 * ARENA_SCALE;
+const TABLE_SCALE = 1;
 const ARENA_GROWTH = 1.45;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
@@ -3548,6 +3549,10 @@ function updateTableMaterials() {
     tableMaterials.felt.map.dispose();
   }
   tableMaterials.felt.map = makeClothTexture({ top: cloth.feltTop, bottom: cloth.feltBottom, border: cloth.border });
+  if (tableMaterials.felt.map) {
+    tableMaterials.felt.map.colorSpace = THREE.SRGBColorSpace;
+    tableMaterials.felt.map.anisotropy = renderer.capabilities.getMaxAnisotropy?.() ?? 8;
+  }
   tableMaterials.felt.map.needsUpdate = true;
   tableMaterials.felt.needsUpdate = true;
 

--- a/webapp/src/utils/dominoArena.js
+++ b/webapp/src/utils/dominoArena.js
@@ -1,6 +1,42 @@
 import * as THREE from 'three';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import { makeRoughClothTexture, DEFAULT_TABLE_CLOTH_OPTION } from './murlanTable.js';
+import {
+  applyWoodTextures,
+  DEFAULT_WOOD_GRAIN_ID,
+  WOOD_FINISH_PRESETS,
+  WOOD_GRAIN_OPTIONS,
+  WOOD_GRAIN_OPTIONS_BY_ID
+} from './woodMaterials.js';
+
+const ARENA_SCALE = 0.85;
+const MODEL_SCALE = 0.75 * ARENA_SCALE;
+const TABLE_SCALE = 1;
+const STOOL_SCALE = 1.5 * 1.3;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
+const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
+const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
+const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE;
+const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
+const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
+const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
+const ARM_DEPTH = SEAT_DEPTH * 0.75;
+const COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
+const BASE_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
+const COLUMN_RADIUS_TOP = 0.2 * MODEL_SCALE;
+const COLUMN_RADIUS_BOTTOM = 0.26 * MODEL_SCALE;
+const BASE_RADIUS = 0.72 * MODEL_SCALE;
+const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
+const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
+const CHAIR_GAP = 0.12 * MODEL_SCALE;
+const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
+const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
+const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE * TABLE_SCALE;
+const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
+const TABLE_TOP_DEPTH = 0.06 * MODEL_SCALE * TABLE_SCALE;
+const TABLE_BASE_Y = TABLE_HEIGHT - TABLE_TOP_DEPTH;
 
 const ROOM_DIMENSIONS = Object.freeze({
   width: 6.2,
@@ -11,32 +47,32 @@ const ROOM_DIMENSIONS = Object.freeze({
 });
 
 const TABLE_DIMENSIONS = Object.freeze({
-  baseY: 0.64,
-  outerHalfWidth: 0.95,
-  innerHalfWidth: 0.76,
-  clothHalfWidth: 0.7,
-  rimThickness: 0.07,
-  clothRise: 0.022,
+  baseY: TABLE_BASE_Y,
+  outerHalfWidth: TABLE_RADIUS,
+  innerHalfWidth: TABLE_RADIUS * 0.84,
+  clothHalfWidth: TABLE_RADIUS * 0.72,
+  rimThickness: 0.08 * MODEL_SCALE,
+  clothRise: TABLE_HEIGHT - TABLE_BASE_Y,
   baseSkirtInset: 0.05,
-  skirtHeight: 0.6
+  skirtHeight: 0.6 * MODEL_SCALE
 });
 
 const CHAIR_DIMENSIONS = Object.freeze({
-  seatWidth: 0.72,
-  seatDepth: 0.72,
-  seatThickness: 0.12,
-  backHeight: 0.78,
-  backThickness: 0.08,
-  armHeight: 0.36,
-  armThickness: 0.1,
-  armDepth: 0.76,
-  columnHeight: 0.46,
-  baseThickness: 0.08,
-  columnRadiusTop: 0.11,
-  columnRadiusBottom: 0.15,
-  baseRadius: 0.46,
-  footRingRadius: 0.34,
-  footRingTube: 0.03
+  seatWidth: SEAT_WIDTH,
+  seatDepth: SEAT_DEPTH,
+  seatThickness: SEAT_THICKNESS,
+  backHeight: BACK_HEIGHT,
+  backThickness: BACK_THICKNESS,
+  armHeight: ARM_HEIGHT,
+  armThickness: ARM_THICKNESS,
+  armDepth: ARM_DEPTH,
+  columnHeight: COLUMN_HEIGHT,
+  baseThickness: BASE_THICKNESS,
+  columnRadiusTop: COLUMN_RADIUS_TOP,
+  columnRadiusBottom: COLUMN_RADIUS_BOTTOM,
+  baseRadius: BASE_RADIUS,
+  footRingRadius: FOOT_RING_RADIUS,
+  footRingTube: FOOT_RING_TUBE
 });
 
 const DEFAULT_CHAIR_OPTION = Object.freeze({
@@ -46,13 +82,20 @@ const DEFAULT_CHAIR_OPTION = Object.freeze({
   legColor: '#151515'
 });
 
+const DEFAULT_WOOD_FINISH =
+  WOOD_FINISH_PRESETS.find((preset) => preset.id === 'oak') ?? WOOD_FINISH_PRESETS[0];
+const DEFAULT_WOOD_GRAIN =
+  WOOD_GRAIN_OPTIONS_BY_ID[DEFAULT_WOOD_GRAIN_ID] ??
+  WOOD_GRAIN_OPTIONS.find(Boolean) ??
+  null;
+
 const CAMERA_CONFIG = Object.freeze({
   fov: 56,
   near: 0.05,
   far: 100,
-  minRadius: 1.1,
-  maxRadius: 4,
-  targetY: 0.64,
+  minRadius: Math.max(1.1, TABLE_RADIUS * 0.55),
+  maxRadius: TABLE_RADIUS * 2,
+  targetY: TABLE_HEIGHT,
   maxPolarAngle: Math.PI * 0.49
 });
 
@@ -519,8 +562,37 @@ function buildDominoTable(renderer) {
   const tableY = TABLE_DIMENSIONS.baseY;
   const clothTop = tableY + TABLE_DIMENSIONS.clothRise;
 
-  const woodMat = new THREE.MeshStandardMaterial({ color: '#5a3a19', roughness: 0.55, metalness: 0.08 });
-  const woodDark = new THREE.MeshStandardMaterial({ color: '#4a3115', roughness: 0.7, metalness: 0.05 });
+  const woodMat = new THREE.MeshStandardMaterial({ roughness: 0.55, metalness: 0.12 });
+  const woodDark = new THREE.MeshStandardMaterial({ roughness: 0.65, metalness: 0.12 });
+  const woodPreset = DEFAULT_WOOD_FINISH;
+  const woodGrain = DEFAULT_WOOD_GRAIN;
+  const sharedWoodKey = 'domino-table-wood';
+  applyWoodTextures(woodMat, {
+    hue: woodPreset?.hue,
+    sat: woodPreset?.sat,
+    light: woodPreset?.light,
+    contrast: woodPreset?.contrast,
+    repeat: woodGrain?.frame?.repeat ?? woodGrain?.rail?.repeat ?? { x: 0.24, y: 0.38 },
+    rotation: woodGrain?.frame?.rotation ?? 0,
+    textureSize: woodGrain?.frame?.textureSize,
+    sharedKey: `${sharedWoodKey}-top`
+  });
+  applyWoodTextures(woodDark, {
+    hue: woodPreset?.hue,
+    sat: woodPreset?.sat,
+    light: woodPreset?.light,
+    contrast: woodPreset?.contrast,
+    repeat: woodGrain?.rail?.repeat ?? woodGrain?.frame?.repeat ?? { x: 0.14, y: 0.6 },
+    rotation: woodGrain?.rail?.rotation ?? 0,
+    textureSize: woodGrain?.rail?.textureSize,
+    sharedKey: `${sharedWoodKey}-rim`
+  });
+  if (!woodMat.map) {
+    woodMat.color.set('#5a3a19');
+  }
+  if (!woodDark.map) {
+    woodDark.color.set('#4a3115');
+  }
   const clothOption = DEFAULT_TABLE_CLOTH_OPTION;
   const feltMat = new THREE.MeshStandardMaterial({
     color: '#ffffff',
@@ -531,7 +603,7 @@ function buildDominoTable(renderer) {
       ? clothOption.emissiveIntensity
       : 0.08
   });
-  const baseMat = new THREE.MeshStandardMaterial({ color: '#0f3e2d', roughness: 0.85, metalness: 0.05 });
+  const baseMat = new THREE.MeshStandardMaterial({ color: '#0f3e2d', roughness: 0.85, metalness: 0.08 });
 
   const feltTexture = makeRoughClothTexture(
     1024,
@@ -540,6 +612,9 @@ function buildDominoTable(renderer) {
     renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
   );
   feltMat.map = feltTexture;
+  if (feltMat.map) {
+    feltMat.map.colorSpace = THREE.SRGBColorSpace;
+  }
   feltMat.needsUpdate = true;
 
   disposables.push(woodMat, woodDark, feltMat, baseMat, feltTexture);
@@ -769,9 +844,9 @@ export function buildDominoArena({ scene, renderer }) {
     if (material) trackedMaterials.add(material);
   });
 
-  const chairRadius = TABLE_DIMENSIONS.outerHalfWidth + 0.55;
-  const chairHeight =
-    CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness;
+  const chairRadius =
+    TABLE_DIMENSIONS.outerHalfWidth + CHAIR_DIMENSIONS.seatDepth / 2 + CHAIR_GAP;
+  const chairHeight = STOOL_HEIGHT + BACK_HEIGHT * 0.5;
   const lookTarget = new THREE.Vector3(0, chairHeight, 0);
   const dominoFacing = new THREE.Vector3(1, 0, 0);
   const chairs = [


### PR DESCRIPTION
## Summary
- match the Domino Royal table and chair scale to the Ludo Battle Royal baseline so seating/layout sizes align
- apply wood and cloth texture configuration so Domino table materials render with the same fidelity as Ludo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695652831624832995fe04b74028e762)