### PR TITLE
Update Pool Royale HDRI layouts and music hall lounge

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2005,7 +2005,6 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
   },
   { id: 'adamsBridge', name: 'Adams Bridge', assetId: 'adams_place_bridge', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.02 },
   { id: 'ballroomHall', name: 'Ballroom Hall', assetId: 'ballroom', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.15, environmentIntensity: 1.16, backgroundIntensity: 1.08 },
-  { id: 'emptyPlayRoom', name: 'Empty Play Room', assetId: 'empty_play_room', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.09, environmentIntensity: 1.04, backgroundIntensity: 1 },
   { id: 'christmasPhotoStudio04', name: 'Christmas Photo Studio 04', assetId: 'christmas_photo_studio_04', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.04 },
   { id: 'colorfulStudio', name: 'Colorful Studio', assetId: 'colorful_studio', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.02, environmentIntensity: 0.92, backgroundIntensity: 0.92 },
   { id: 'dancingHall', name: 'Dancing Hall', assetId: 'dancing_hall', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.04 },

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -21,13 +21,6 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     arenaScale: 1.3,
     rotationY: Math.PI / 2
   },
-  emptyPlayRoom: {
-    cameraHeightM: 1.5,
-    groundRadiusMultiplier: 3.9,
-    groundResolution: 120,
-    arenaScale: 1.15,
-    rotationY: 0
-  },
   christmasPhotoStudio04: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.9,
@@ -219,19 +212,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.08,
     swatches: ['#fef3c7', '#a16207'],
     description: 'Grand hall ambience with chandeliers for polished highlights.'
-  },
-  {
-    id: 'emptyPlayRoom',
-    name: 'Empty Play Room',
-    assetId: 'empty_play_room',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1760,
-    exposure: 1.09,
-    environmentIntensity: 1.04,
-    backgroundIntensity: 1,
-    swatches: ['#a855f7', '#22c55e'],
-    description: 'Quiet game room ambience with even indoor bounce.'
   },
   {
     id: 'christmasPhotoStudio04',


### PR DESCRIPTION
## Summary
- remove the Empty Play Room HDRI variant from the inventory config and demo HTML
- align Adams Bridge and Old Hall decorative table layouts with the side-by-side pool/snooker arrangement while keeping table finishes applied
- rebuild the Music Hall lounge using the Chess Battle Royale assets, keep it between the short rail and back wall, and reposition the dartboard so it is visible

## Testing
- npm run build (warnings about existing duplicate `tableBase` keys)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695690cddd688329bec8515d1a4cdbbd)