### PR TITLE
Adjust Pool Royale max power audio cues and remove deprecated HDRIs

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2003,8 +2003,6 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
     environmentIntensity: 1.12,
     backgroundIntensity: 1.06
   },
-  { id: 'adamsBridge', name: 'Adams Bridge', assetId: 'adams_place_bridge', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.02 },
-  { id: 'ballroomHall', name: 'Ballroom Hall', assetId: 'ballroom', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.15, environmentIntensity: 1.16, backgroundIntensity: 1.08 },
   { id: 'christmasPhotoStudio04', name: 'Christmas Photo Studio 04', assetId: 'christmas_photo_studio_04', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.04 },
   { id: 'colorfulStudio', name: 'Colorful Studio', assetId: 'colorful_studio', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.02, environmentIntensity: 0.92, backgroundIntensity: 0.92 },
   { id: 'dancingHall', name: 'Dancing Hall', assetId: 'dancing_hall', preferredResolutions: ['4k', '2k'], fallbackResolution: '4k', exposure: 1.12, environmentIntensity: 1.08, backgroundIntensity: 1.04 },

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -7,20 +7,6 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundResolution: 120,
     arenaScale: 1.1
   },
-  adamsBridge: {
-    cameraHeightM: 1.68,
-    groundRadiusMultiplier: 6.5,
-    groundResolution: 112,
-    arenaScale: 1.35,
-    rotationY: 0
-  },
-  ballroomHall: {
-    cameraHeightM: 1.58,
-    groundRadiusMultiplier: 5.1,
-    groundResolution: 112,
-    arenaScale: 1.3,
-    rotationY: Math.PI / 2
-  },
   christmasPhotoStudio04: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.9,
@@ -186,32 +172,6 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1.06,
     swatches: ['#0ea5e9', '#8b5cf6'],
     description: 'Vibrant cyber studio wrap with strong rim accents.'
-  },
-  {
-    id: 'adamsBridge',
-    name: 'Adams Bridge',
-    assetId: 'adams_place_bridge',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1520,
-    exposure: 1.12,
-    environmentIntensity: 1.08,
-    backgroundIntensity: 1.02,
-    swatches: ['#1d4ed8', '#0ea5e9'],
-    description: 'Cool twilight bridge lighting with crisp specular pickup.'
-  },
-  {
-    id: 'ballroomHall',
-    name: 'Ballroom Hall',
-    assetId: 'ballroom',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    price: 1640,
-    exposure: 1.15,
-    environmentIntensity: 1.16,
-    backgroundIntensity: 1.08,
-    swatches: ['#fef3c7', '#a16207'],
-    description: 'Grand hall ambience with chandeliers for polished highlights.'
   },
   {
     id: 'christmasPhotoStudio04',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1031,7 +1031,7 @@ const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up ca
 const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const STUCK_SHOT_TIMEOUT_MS = 4500; // auto-resolve shots if motion stops but the turn never clears
 const MAX_POWER_BOUNCE_THRESHOLD = 0.98;
-const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 0.95;
+const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 1.1;
 const MAX_POWER_BOUNCE_GRAVITY = BALL_R * 3.2;
 const MAX_POWER_BOUNCE_DAMPING = 0.86;
 const MAX_POWER_LANDING_SOUND_COOLDOWN_MS = 240;
@@ -1266,7 +1266,7 @@ const CUE_FOLLOW_SPEED_MIN = BALL_R * 12;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 24;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.02; // align the tip closer to the cue-ball equator so the contact reads front-and-centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
-const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 5.2;
+const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 5.8;
 const CUE_BUTT_LIFT = BALL_R * 0.64; // keep the butt elevated for clearance while keeping the tip level with the cue-ball centre
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(8.5);
@@ -16655,7 +16655,6 @@ const powerRef = useRef(hud.power);
         };
         if (
           environmentId === 'oldHall' ||
-          environmentId === 'adamsBridge' ||
           environmentId === 'emptyPlayRoom'
         ) {
           placeSideLayout();
@@ -21115,7 +21114,8 @@ const powerRef = useRef(hud.power);
                     0,
                     1
                   );
-                  playBallHit(Math.max(0.35, landingVol * 0.85));
+                  const cueLandingVol = Math.max(0.45, landingVol * 0.95);
+                  playCueHit(cueLandingVol);
                   liftLandingTimeRef.current.set(b.id, nowLanding);
                 }
               }
@@ -21321,6 +21321,8 @@ const powerRef = useRef(hud.power);
                   const bounceStrength = THREE.MathUtils.clamp(lastShotPower, 0, 1);
                   const liftBoost = 1.2;
                   maxPowerLiftTriggered = true;
+                  const liftSoundVol = Math.max(0.7, bounceStrength * 0.95);
+                  playCueHit(liftSoundVol);
                   cueBall.lift = Math.max(
                     cueBall.lift ?? 0,
                     Math.min(MAX_POWER_LIFT_HEIGHT * liftBoost, MAX_POWER_BOUNCE_IMPULSE * 0.65)


### PR DESCRIPTION
## Summary
- reuse the existing cue-hit sound effect for max-power lift and landing events while slightly boosting jump height
- remove the Adams Bridge and Ballroom Hall HDRI variants from Pool Royale configuration and sample HTML data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569ca556a08329a2d968fa46ac0d24)