### PR TITLE
Add Murlan assets to Texas Hold'em table setup

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,7 +1,8 @@
 import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
-import { TEXAS_CHAIR_COLOR_OPTIONS } from './texasHoldemOptions.js';
+import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from './texasHoldemOptions.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 
 const reduceLabels = (items) =>
   items.reduce((acc, option) => {
@@ -9,22 +10,38 @@ const reduceLabels = (items) =>
     return acc;
   }, {});
 
+export const TEXAS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+  ...variant,
+  label: `${variant.name} HDRI`
+}));
+
+const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID));
+
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
   tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
-  chairColor: [TEXAS_CHAIR_COLOR_OPTIONS[0]?.id],
+  chairTheme: [TEXAS_CHAIR_THEME_OPTIONS[0]?.id],
+  tableTheme: [TEXAS_TABLE_THEME_OPTIONS[0]?.id],
   tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
-  cards: [CARD_THEMES[0]?.id]
+  cards: [CARD_THEMES[0]?.id],
+  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
 });
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
   tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
   tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
   tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
-  chairColor: Object.freeze(reduceLabels(TEXAS_CHAIR_COLOR_OPTIONS)),
+  chairTheme: Object.freeze(reduceLabels(TEXAS_CHAIR_THEME_OPTIONS)),
+  tableTheme: Object.freeze(reduceLabels(TEXAS_TABLE_THEME_OPTIONS)),
   tableShape: Object.freeze(reduceLabels(TABLE_SHAPE_OPTIONS)),
-  cards: Object.freeze(reduceLabels(CARD_THEMES))
+  cards: Object.freeze(reduceLabels(CARD_THEMES)),
+  environmentHdri: Object.freeze(
+    TEXAS_HDRI_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  )
 });
 
 export const TEXAS_HOLDEM_STORE_ITEMS = [
@@ -52,13 +69,31 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     price: 420 + idx * 35,
     description: 'Upgrade the pedestal finish beneath your Hold\'em surface.'
   })),
-  ...TEXAS_CHAIR_COLOR_OPTIONS.slice(1).map((option, idx) => ({
+  ...TEXAS_CHAIR_THEME_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-chair-${option.id}`,
-    type: 'chairColor',
+    type: 'chairTheme',
     optionId: option.id,
-    name: `${option.label} Chairs`,
-    price: 340 + idx * 30,
-    description: 'Unlock an additional lounge chair palette for the poker ring.'
+    name: option.label,
+    price: option.price ?? 340 + idx * 30,
+    description: option.description || 'Unlock a premium lounge chair model from Murlan Royale.'
+  })),
+  ...TEXAS_TABLE_THEME_OPTIONS.slice(1).map((option, idx) => ({
+    id: `texas-table-${option.id}`,
+    type: 'tableTheme',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 980 + idx * 45,
+    description: option.description || `${option.label} table model from the Murlan Royale set.`,
+    thumbnail: option.thumbnail
+  })),
+  ...TEXAS_HDRI_OPTIONS.map((variant, idx) => ({
+    id: `texas-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: variant.label,
+    price: variant.price ?? 1400 + idx * 25,
+    description: variant.description || 'Poly Haven HDRI environment used in Murlan Royale.',
+    swatches: variant.swatches
   })),
   ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-shape-${option.id}`,
@@ -82,7 +117,13 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
   { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
-  { type: 'chairColor', optionId: TEXAS_CHAIR_COLOR_OPTIONS[0]?.id, label: `${TEXAS_CHAIR_COLOR_OPTIONS[0]?.label} Chairs` },
+  { type: 'chairTheme', optionId: TEXAS_CHAIR_THEME_OPTIONS[0]?.id, label: TEXAS_CHAIR_THEME_OPTIONS[0]?.label },
+  { type: 'tableTheme', optionId: TEXAS_TABLE_THEME_OPTIONS[0]?.id, label: TEXAS_TABLE_THEME_OPTIONS[0]?.label },
   { type: 'tableShape', optionId: TABLE_SHAPE_OPTIONS[0]?.id, label: TABLE_SHAPE_OPTIONS[0]?.label },
-  { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` }
+  { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` },
+  {
+    type: 'environmentHdri',
+    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
+    label: TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[POOL_ROYALE_DEFAULT_HDRI_ID] || TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
+  }
 ];

--- a/webapp/src/config/texasHoldemOptions.js
+++ b/webapp/src/config/texasHoldemOptions.js
@@ -1,8 +1,5 @@
-export const TEXAS_CHAIR_COLOR_OPTIONS = Object.freeze([
-  { id: 'ruby', label: 'Ruby', primary: '#8b0000', accent: '#8b0000', highlight: '#b22222', legColor: '#1f1f1f' },
-  { id: 'slate', label: 'Slate', primary: '#374151', accent: '#374151', highlight: '#6b7280', legColor: '#0f172a' },
-  { id: 'teal', label: 'Teal', primary: '#0f766e', accent: '#0f766e', highlight: '#38b2ac', legColor: '#082f2a' },
-  { id: 'amber', label: 'Amber', primary: '#b45309', accent: '#b45309', highlight: '#f59e0b', legColor: '#2f2410' },
-  { id: 'violet', label: 'Violet', primary: '#7c3aed', accent: '#7c3aed', highlight: '#c084fc', legColor: '#2b1059' },
-  { id: 'frost', label: 'Ice', primary: '#1f2937', accent: '#1f2937', highlight: '#9ca3af', legColor: '#0f172a' }
-]);
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+
+export const TEXAS_CHAIR_THEME_OPTIONS = Object.freeze(MURLAN_STOOL_THEMES);
+export const TEXAS_TABLE_THEME_OPTIONS = Object.freeze(MURLAN_TABLE_THEMES);
+export const TEXAS_CHAIR_COLOR_OPTIONS = TEXAS_CHAIR_THEME_OPTIONS;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -205,9 +205,11 @@ const TEXAS_TYPE_LABELS = {
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
-  chairColor: 'Chairs',
+  chairTheme: 'Chairs',
+  tableTheme: 'Table Models',
   tableShape: 'Table Shape',
-  cards: 'Cards'
+  cards: 'Cards',
+  environmentHdri: 'HDR Environments'
 };
 
 const TPC_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';


### PR DESCRIPTION
## Summary
- add Texas Hold'em inventory support for Murlan chair/table themes and Poly Haven HDRI environments
- update the store UI to surface the new Texas chair, table, and HDRI item types with appropriate previews
- load Poly Haven tables, chairs, and HDRI lighting in the Texas Hold'em arena while removing the old base, wall, and carpet geometry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695693465e4083298b04182b09e4dd83)