### PR TITLE
Enhance Pool Royale audio and lounge

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -264,7 +264,6 @@ const TYPE_SWATCHES = {
   goals: ['#f97316', '#fb923c'],
   tableWood: ['#4b3621', '#9a7b4f'],
   tableCloth: ['#0f172a', '#34d399'],
-  tableBase: ['#0f172a', '#1f2937'],
   tableTheme: ['#0f172a', '#e5e7eb'],
   tables: ['#0f172a', '#94a3b8'],
   stools: ['#111827', '#eab308'],
@@ -363,7 +362,6 @@ const PREVIEW_BY_TYPE = {
   tableBase: 'table',
   tableWood: 'table',
   tableCloth: 'table',
-  tableBase: 'table',
   tableTheme: 'table',
   chairTheme: 'chair',
   tables: 'table'


### PR DESCRIPTION
## Summary
- update Pool Royale cue strike to use the new sound excerpt with power-based gain and add chalk press feedback
- preserve GLTF material settings while scaling and relocating the chess lounge to match the Chess Battle assets and sit along the far short rail
- remove duplicate store swatch keys to unblock the build

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c9bd238c8329955fb4fe220aa6ef)