### PR TITLE
Improve Pool Royale audio and environment cleanup

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11244,7 +11244,7 @@ const powerRef = useRef(hud.power);
       const buffer = audioBuffersRef.current.cue;
       if (!ctx || !buffer || muteRef.current) return;
       const power = clamp(vol, 0, 1);
-      const scaled = clamp((0.18 + power * 0.82) * volumeRef.current, 0, 1);
+      const scaled = clamp((0.32 + power * 0.92) * volumeRef.current, 0, 1);
       if (scaled <= 0) return;
       ctx.resume().catch(() => {});
       const source = ctx.createBufferSource();
@@ -16954,24 +16954,27 @@ const powerRef = useRef(hud.power);
           outerShortRailZ + serviceGap * 1.1,
           farInteriorZ
         );
-        const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
-        const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
-        const facingCenter = Math.atan2(0, -placementZ);
-        createChessLoungeSet({
-            chairOffsets: [
-              [-chairSpread, -chairDepth],
-              [chairSpread, -chairDepth]
-            ],
-            position: [0, placementZ],
-            rotationY: facingCenter
-          })
-          .then((group) => {
-            if (!group || hospitalityLayoutRunRef.current !== runToken) return;
-            addHospitalityGroup(group);
-          })
-          .catch((error) => {
-            console.warn('Failed to add chess lounge hospitality set', error);
-          });
+        const shouldShowChessLounge = false;
+        if (shouldShowChessLounge) {
+          const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
+          const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
+          const facingCenter = Math.atan2(0, -placementZ);
+          createChessLoungeSet({
+              chairOffsets: [
+                [-chairSpread, -chairDepth],
+                [chairSpread, -chairDepth]
+              ],
+              position: [0, placementZ],
+              rotationY: facingCenter
+            })
+            .then((group) => {
+              if (!group || hospitalityLayoutRunRef.current !== runToken) return;
+              addHospitalityGroup(group);
+            })
+            .catch((error) => {
+              console.warn('Failed to add chess lounge hospitality set', error);
+            });
+        }
         const dartboardZ = Math.min(
           farInteriorZ,
           Math.max(
@@ -21431,9 +21434,13 @@ const powerRef = useRef(hud.power);
                 const shotScale = 0.35 + 0.65 * lastShotPower;
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
-                if (railVolume > 0) {
-                  // Cushion contacts should remain silent so only ball collisions
-                  // trigger impact audio cues. Leave the cooldown updates intact.
+                if (railVolume > 0 && b.id === 'cue' && lastShotPower >= 0.5) {
+                  const boosted = clamp(
+                    Math.max(railVolume, 0.55) * (0.8 + lastShotPower * 0.35),
+                    0,
+                    1
+                  );
+                  playCueHit(boosted);
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -30,7 +30,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
   return (nx + ny + nxy + 3) / 6; // normalize to [0,1]
 };
 
-const WOOD_TEXTURE_ANISOTROPY = 12;
+const WOOD_TEXTURE_ANISOTROPY = 32;
 
 const woodTextureLoader = new THREE.TextureLoader();
 woodTextureLoader.setCrossOrigin?.('anonymous');
@@ -95,7 +95,7 @@ const loadExternalTexture = (url, isColor, anisotropy, onError) => {
   return texture;
 };
 
-const getExternalWoodTextures = (urls, anisotropy = 16, fallbacks = null) => {
+const getExternalWoodTextures = (urls, anisotropy = WOOD_TEXTURE_ANISOTROPY, fallbacks = null) => {
   if (!urls?.mapUrl) return null;
   const cacheKey = [urls.mapUrl, urls.roughnessMapUrl, urls.normalMapUrl]
     .filter(Boolean)
@@ -233,7 +233,7 @@ const makeSlabTexture = (width, height, hue, sat, light, contrast) => {
 
   const texture = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(texture);
-  texture.anisotropy = 16;
+  texture.anisotropy = WOOD_TEXTURE_ANISOTROPY;
   return texture;
 };
 
@@ -615,7 +615,7 @@ export const applyWoodTextures = (
   if (mapUrl) {
     const external = getExternalWoodTextures(
       { mapUrl, roughnessMapUrl, normalMapUrl },
-      16,
+      WOOD_TEXTURE_ANISOTROPY,
       fallbackTextures
     );
     baseTextures = {


### PR DESCRIPTION
## Summary
- Boost cue impact volume and play the cue strike sound on high-power cushion hits
- Increase wood texture sampling anisotropy to sharpen table finishes that were appearing blurry
- Remove the chess lounge prop from the music hall layout to clear the side space

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d2932fa48329a94335eb821cf42b)