### PR TITLE
Improve Pool Royale audio and visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -44,6 +44,7 @@ import {
   DEFAULT_WOOD_GRAIN_ID,
   DEFAULT_WOOD_TEXTURE_SIZE,
   applyWoodTextures,
+  setWoodTextureAnisotropy,
   disposeMaterialWithWood,
 } from '../../utils/woodMaterials.js';
 import {
@@ -11244,7 +11245,7 @@ const powerRef = useRef(hud.power);
       const buffer = audioBuffersRef.current.cue;
       if (!ctx || !buffer || muteRef.current) return;
       const power = clamp(vol, 0, 1);
-      const scaled = clamp((0.18 + power * 0.82) * volumeRef.current, 0, 1);
+      const scaled = clamp((0.42 + power * 0.9) * volumeRef.current, 0, 1);
       if (scaled <= 0) return;
       ctx.resume().catch(() => {});
       const source = ctx.createBufferSource();
@@ -16584,6 +16585,7 @@ const powerRef = useRef(hud.power);
       };
 
       addMobileLighting();
+      setWoodTextureAnisotropy(resolveTextureAnisotropy());
 
       // Table
       const finishForScene = tableFinishRef.current;
@@ -16954,24 +16956,6 @@ const powerRef = useRef(hud.power);
           outerShortRailZ + serviceGap * 1.1,
           farInteriorZ
         );
-        const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
-        const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
-        const facingCenter = Math.atan2(0, -placementZ);
-        createChessLoungeSet({
-            chairOffsets: [
-              [-chairSpread, -chairDepth],
-              [chairSpread, -chairDepth]
-            ],
-            position: [0, placementZ],
-            rotationY: facingCenter
-          })
-          .then((group) => {
-            if (!group || hospitalityLayoutRunRef.current !== runToken) return;
-            addHospitalityGroup(group);
-          })
-          .catch((error) => {
-            console.warn('Failed to add chess lounge hospitality set', error);
-          });
         const dartboardZ = Math.min(
           farInteriorZ,
           Math.max(
@@ -18463,7 +18447,7 @@ const powerRef = useRef(hud.power);
           const shouldRecordReplay = true;
           const preferZoomReplay =
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
-          playCueHit(clampedPower * 0.6);
+          playCueHit(clampedPower);
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
@@ -21431,9 +21415,9 @@ const powerRef = useRef(hud.power);
                 const shotScale = 0.35 + 0.65 * lastShotPower;
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
-                if (railVolume > 0) {
-                  // Cushion contacts should remain silent so only ball collisions
-                  // trigger impact audio cues. Leave the cooldown updates intact.
+                if (railVolume > 0 && b.id === 'cue' && lastShotPower >= 0.5) {
+                  const cushionVol = Math.max(0.55, railVolume);
+                  playCueHit(cushionVol);
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }


### PR DESCRIPTION
## Summary
- Boost cue hit audio volume and trigger the same cue sound on high-power cushion impacts
- Sharpen table finish textures by aligning wood texture anisotropy with the renderer capabilities
- Remove the chess lounge table and chairs from the Pool Royale hospitality layout

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d2932fa48329a94335eb821cf42b)