### PR TITLE
Enhance Pool Royale cue audio and texture clarity

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11244,7 +11244,7 @@ const powerRef = useRef(hud.power);
       const buffer = audioBuffersRef.current.cue;
       if (!ctx || !buffer || muteRef.current) return;
       const power = clamp(vol, 0, 1);
-      const scaled = clamp((0.18 + power * 0.82) * volumeRef.current, 0, 1);
+      const scaled = clamp((0.35 + power * 0.85) * volumeRef.current, 0, 1);
       if (scaled <= 0) return;
       ctx.resume().catch(() => {});
       const source = ctx.createBufferSource();
@@ -16954,10 +16954,12 @@ const powerRef = useRef(hud.power);
           outerShortRailZ + serviceGap * 1.1,
           farInteriorZ
         );
-        const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
-        const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
-        const facingCenter = Math.atan2(0, -placementZ);
-        createChessLoungeSet({
+        const enableChessLounge = false;
+        if (enableChessLounge) {
+          const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
+          const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
+          const facingCenter = Math.atan2(0, -placementZ);
+          createChessLoungeSet({
             chairOffsets: [
               [-chairSpread, -chairDepth],
               [chairSpread, -chairDepth]
@@ -16965,13 +16967,14 @@ const powerRef = useRef(hud.power);
             position: [0, placementZ],
             rotationY: facingCenter
           })
-          .then((group) => {
-            if (!group || hospitalityLayoutRunRef.current !== runToken) return;
-            addHospitalityGroup(group);
-          })
-          .catch((error) => {
-            console.warn('Failed to add chess lounge hospitality set', error);
-          });
+            .then((group) => {
+              if (!group || hospitalityLayoutRunRef.current !== runToken) return;
+              addHospitalityGroup(group);
+            })
+            .catch((error) => {
+              console.warn('Failed to add chess lounge hospitality set', error);
+            });
+        }
         const dartboardZ = Math.min(
           farInteriorZ,
           Math.max(
@@ -21431,9 +21434,9 @@ const powerRef = useRef(hud.power);
                 const shotScale = 0.35 + 0.65 * lastShotPower;
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
-                if (railVolume > 0) {
-                  // Cushion contacts should remain silent so only ball collisions
-                  // trigger impact audio cues. Leave the cooldown updates intact.
+                if (railVolume > 0 && b.id === 'cue' && lastShotPower >= 0.5) {
+                  const cushionHitVol = Math.max(0.55, railVolume * 0.9);
+                  playCueHit(cushionHitVol);
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -30,7 +30,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
   return (nx + ny + nxy + 3) / 6; // normalize to [0,1]
 };
 
-const WOOD_TEXTURE_ANISOTROPY = 12;
+const WOOD_TEXTURE_ANISOTROPY = 24;
 
 const woodTextureLoader = new THREE.TextureLoader();
 woodTextureLoader.setCrossOrigin?.('anonymous');
@@ -95,7 +95,7 @@ const loadExternalTexture = (url, isColor, anisotropy, onError) => {
   return texture;
 };
 
-const getExternalWoodTextures = (urls, anisotropy = 16, fallbacks = null) => {
+const getExternalWoodTextures = (urls, anisotropy = WOOD_TEXTURE_ANISOTROPY, fallbacks = null) => {
   if (!urls?.mapUrl) return null;
   const cacheKey = [urls.mapUrl, urls.roughnessMapUrl, urls.normalMapUrl]
     .filter(Boolean)
@@ -233,7 +233,7 @@ const makeSlabTexture = (width, height, hue, sat, light, contrast) => {
 
   const texture = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(texture);
-  texture.anisotropy = 16;
+  texture.anisotropy = WOOD_TEXTURE_ANISOTROPY;
   return texture;
 };
 
@@ -615,7 +615,7 @@ export const applyWoodTextures = (
   if (mapUrl) {
     const external = getExternalWoodTextures(
       { mapUrl, roughnessMapUrl, normalMapUrl },
-      16,
+      WOOD_TEXTURE_ANISOTROPY,
       fallbackTextures
     );
     baseTextures = {


### PR DESCRIPTION
## Summary
- raise the cue strike mix and mirror that sound on strong cue-ball cushion impacts
- disable the chess lounge prop so the extra side table, chairs, and chess set no longer appear
- increase wood texture sampling quality to sharpen the Pool Royale table finishes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d2932fa48329a94335eb821cf42b)