### PR TITLE
Improve Pool Royale audio feedback and texture clarity

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11244,7 +11244,8 @@ const powerRef = useRef(hud.power);
       const buffer = audioBuffersRef.current.cue;
       if (!ctx || !buffer || muteRef.current) return;
       const power = clamp(vol, 0, 1);
-      const scaled = clamp((0.18 + power * 0.82) * volumeRef.current, 0, 1);
+      const boosted = (0.32 + power * 0.9) * volumeRef.current * 1.1;
+      const scaled = clamp(boosted, 0, 1);
       if (scaled <= 0) return;
       ctx.resume().catch(() => {});
       const source = ctx.createBufferSource();
@@ -16954,24 +16955,6 @@ const powerRef = useRef(hud.power);
           outerShortRailZ + serviceGap * 1.1,
           farInteriorZ
         );
-        const chairSpread = toHospitalityUnits(0.44) * hospitalityUpscale;
-        const chairDepth = toHospitalityUnits(0.64) * hospitalityUpscale;
-        const facingCenter = Math.atan2(0, -placementZ);
-        createChessLoungeSet({
-            chairOffsets: [
-              [-chairSpread, -chairDepth],
-              [chairSpread, -chairDepth]
-            ],
-            position: [0, placementZ],
-            rotationY: facingCenter
-          })
-          .then((group) => {
-            if (!group || hospitalityLayoutRunRef.current !== runToken) return;
-            addHospitalityGroup(group);
-          })
-          .catch((error) => {
-            console.warn('Failed to add chess lounge hospitality set', error);
-          });
         const dartboardZ = Math.min(
           farInteriorZ,
           Math.max(
@@ -21431,9 +21414,8 @@ const powerRef = useRef(hud.power);
                 const shotScale = 0.35 + 0.65 * lastShotPower;
                 const baseVol = speed / RAIL_HIT_SOUND_REFERENCE_SPEED;
                 const railVolume = clamp(baseVol * shotScale, 0, 1);
-                if (railVolume > 0) {
-                  // Cushion contacts should remain silent so only ball collisions
-                  // trigger impact audio cues. Leave the cooldown updates intact.
+                if (b.id === 'cue' && lastShotPower >= 0.5 && railVolume > 0) {
+                  playCueHit(Math.max(railVolume, 0.6));
                 }
                 railSoundTimeRef.current.set(b.id, nowRail);
               }

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -30,7 +30,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
   return (nx + ny + nxy + 3) / 6; // normalize to [0,1]
 };
 
-const WOOD_TEXTURE_ANISOTROPY = 12;
+const WOOD_TEXTURE_ANISOTROPY = 32;
 
 const woodTextureLoader = new THREE.TextureLoader();
 woodTextureLoader.setCrossOrigin?.('anonymous');


### PR DESCRIPTION
## Summary
- Boost cue hit volume and trigger the cue sound on strong cushion impacts for Pool Royale.
- Increase wood texture sampling anisotropy to sharpen table finish glTF textures.
- Remove the chess lounge hospitality set so the small table and chairs no longer appear.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d2932fa48329a94335eb821cf42b)