### PR TITLE
Adjust Pool Royale audio, spin, and environment quality

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -475,13 +475,30 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
 ];
 
 const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
+export const HDRI_RESOLUTION_OVERRIDES = Object.freeze({
+  musicHall02: {
+    preferredResolutions: Object.freeze(['6k']),
+    fallbackResolution: '6k'
+  },
+  oldHall: {
+    preferredResolutions: Object.freeze(['6k']),
+    fallbackResolution: '6k'
+  }
+});
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
-  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-    ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
-  }))
+  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => {
+    const override = HDRI_RESOLUTION_OVERRIDES[variant.id] || null;
+    const preferredResolutions = override?.preferredResolutions || HDRI_RESOLUTION_STACK;
+    const fallbackResolution =
+      override?.fallbackResolution || variant.fallbackResolution || HDRI_RESOLUTION_STACK[0];
+    return {
+      ...variant,
+      preferredResolutions,
+      fallbackResolution,
+      ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
+    };
+  })
 );
 
 export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(


### PR DESCRIPTION
## Summary
- tighten cue impact audio timing by scheduling the trimmed 7–8.6s segment louder at strike time
- ensure rail spin response applies pending cue-ball spin immediately and widen side-pocket cut capture for truer bounce angles
- lock Music Hall 02 and Old Hall HDRIs to 6K while capping background/decor textures to 2K for those scenes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695781dbe71883299bd2f5d6e6ee5ea9)