### PR TITLE
Improve Pool Royale cue sync and environment fidelity

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -477,11 +477,17 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
 const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
-  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-    ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
-  }))
+  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => {
+    const prefer6k = variant.id === 'musicHall02' || variant.id === 'oldHall';
+    const preferredResolutions = prefer6k ? ['6k', '4k', '2k'] : HDRI_RESOLUTION_STACK;
+    const fallbackResolution = prefer6k ? '6k' : variant.fallbackResolution;
+    return {
+      ...variant,
+      preferredResolutions,
+      fallbackResolution: fallbackResolution || preferredResolutions[0],
+      ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
+    };
+  })
 );
 
 export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(


### PR DESCRIPTION
## Summary
- align the cue hit sound to the stroke impact using the trimmed 7–8.6s clip with a louder gain envelope
- apply spin throw on the first cushion contact by folding pending spin into rail responses and adjusting middle-pocket normals for more natural cuts
- force 6K HDRI for the Music Hall 02 and Old Hall scenes while keeping background pool/chess props at a 2K texture size without altering the main table quality controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695787a09f1c83299136901fd3559b24)