### PR TITLE
Fix Pool Royale cloth rendering and powered cue audio

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1213,6 +1213,8 @@ const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
 const POCKET_SOUND_TAIL = 1;
+const POWERED_CUE_SOUND_THRESHOLD = 0.5;
+const POWERED_CUE_VOLUME_BOOST = 1.3;
 // Pool Royale now raises the stance; extend the legs so the playfield sits higher
 const LEG_SCALE = 6.2;
 const LEG_HEIGHT_FACTOR = 4;
@@ -4876,8 +4878,8 @@ const TOP_VIEW_PHI = CAMERA_ABS_MIN_PHI + 0.02;
 const TOP_VIEW_RADIUS_SCALE = 0.82;
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -BALL_R * 0.85, // nudge the table slightly left in top-down framing
-  z: -BALL_R * 7 // push the table downward in 2D view so the lower rail gains space and top/bottom padding is balanced as requested
+  x: 0, // center the table for the classic top-down framing
+  z: 0 // keep the 2D view aligned with the original overhead composition
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -6485,6 +6487,8 @@ function Table3D(
   }
   clothMat.userData = {
     ...(clothMat.userData || {}),
+    clothLike: true,
+    materialRole: 'cloth',
     baseRepeatRaw: baseRepeat,
     baseRepeat: baseRepeatApplied,
     repeatRatio,
@@ -6497,10 +6501,12 @@ function Table3D(
   };
 
   const cushionMat = clothMat.clone();
+  cushionMat.userData = { ...(clothMat.userData || {}), ...(cushionMat.userData || {}) };
   cushionMat.color.copy(cushionColor);
   cushionMat.emissive.copy(cushionColor.clone().multiplyScalar(0.045));
   cushionMat.side = THREE.DoubleSide;
   const clothEdgeMat = clothMat.clone();
+  clothEdgeMat.userData = { ...(clothMat.userData || {}), ...(clothEdgeMat.userData || {}) };
   clothEdgeMat.color.copy(clothColor);
   clothEdgeMat.emissive.set(0x000000);
   clothEdgeMat.map = null;
@@ -11272,6 +11278,7 @@ const powerRef = useRef(hud.power);
   const audioContextRef = useRef(null);
   const audioBuffersRef = useRef({
     cue: null,
+    rail: null,
     ball: null,
     pocket: null,
     knock: null,
@@ -11341,10 +11348,19 @@ const powerRef = useRef(hud.power);
 
   const playCueHit = useCallback((vol = 1) => {
     const ctx = audioContextRef.current;
-    const buffer = audioBuffersRef.current.cue;
-    if (!ctx || !buffer || muteRef.current) return;
     const power = clamp(vol, 0, 1);
-    const scaled = clamp(volumeRef.current * 1.35 * (0.48 + power * 0.78), 0, 1);
+    const usePoweredCueSound =
+      power >= POWERED_CUE_SOUND_THRESHOLD && audioBuffersRef.current.rail;
+    const buffer = usePoweredCueSound
+      ? audioBuffersRef.current.rail
+      : audioBuffersRef.current.cue;
+    if (!ctx || !buffer || muteRef.current) return;
+    const baseScaled = volumeRef.current * 1.35 * (0.48 + power * 0.78);
+    const scaled = clamp(
+      usePoweredCueSound ? baseScaled * POWERED_CUE_VOLUME_BOOST : baseScaled,
+      0,
+      1
+    );
     if (scaled <= 0 || !Number.isFinite(buffer.duration)) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
@@ -11353,6 +11369,10 @@ const powerRef = useRef(hud.power);
     gain.gain.value = scaled;
     source.connect(gain);
     routeAudioNode(gain);
+    if (usePoweredCueSound) {
+      source.start(0);
+      return;
+    }
     const clipStart = THREE.MathUtils.clamp(7, 0, Math.max(buffer.duration - 0.1, 0));
     const clipEnd = THREE.MathUtils.clamp(8.6, clipStart, buffer.duration);
     const playbackDuration = Math.max(0, clipEnd - clipStart);
@@ -11569,6 +11589,7 @@ const powerRef = useRef(hud.power);
     (async () => {
       const entries = [
         ['cue', '/assets/sounds/Control_the_Cue_Ball_Control_the_Black_snooker_billiard_tipsandtrick.mp3'],
+        ['rail', '/assets/sounds/billiard-sound-05-288416.mp3'],
         ['ball', '/assets/sounds/billiard-sound newhit.mp3'],
         ['pocket', '/assets/sounds/billiard-sound-6-288417.mp3'],
         ['knock', '/assets/sounds/wooden-door-knock-102902.mp3'],
@@ -11594,6 +11615,7 @@ const powerRef = useRef(hud.power);
       stopActiveCrowdSound();
       audioBuffersRef.current = {
         cue: null,
+        rail: null,
         ball: null,
         pocket: null,
         knock: null,
@@ -17156,6 +17178,9 @@ const powerRef = useRef(hud.power);
               : [child.material];
             materials.forEach((mat) => {
               if (!mat || typeof mat !== 'object') return;
+              if (mat.userData?.clothLike || mat.userData?.materialRole === 'cloth') {
+                return;
+              }
               mat.envMap = envMap || null;
               mat.needsUpdate = true;
             });


### PR DESCRIPTION
## Summary
- restore the classic centered 2D top-down framing
- keep cloth/cushion materials from picking up 2K decor HDRI env maps on Music Hall/Old Hall tables so the green cloth stays visible
- reuse the cushion-hit sample for powered cue strikes at +30% gain while leaving cushion impacts silent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579b6b03208329ba1912f81f3a9e71)