### PR TITLE
Improve Pool Royale cue feedback and decor textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1050,12 +1050,12 @@ const SIDE_POCKET_GUARD_RADIUS =
   SIDE_POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.08; // use the middle-pocket bowl to gate reflections
 const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
-  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.08
+  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.05
 );
 const SIDE_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.52 * POCKET_VISUAL_EXPANSION; // reduce the invisible pocket wall so rail-first cuts fall naturally
 const SIDE_POCKET_SPAN =
-  SIDE_POCKET_RADIUS * 0.9 * POCKET_VISUAL_EXPANSION + BALL_R * 0.52; // tune the middle lane to the real mouth width
+  SIDE_POCKET_RADIUS * 0.96 * POCKET_VISUAL_EXPANSION + BALL_R * 0.58; // tune the middle lane to the real mouth width
 const CLOTH_THICKNESS = TABLE.THICK * 0.12; // match snooker cloth profile so cushions blend seamlessly
 const PLYWOOD_ENABLED = false; // fully disable any plywood underlay beneath the cloth
 const PLYWOOD_THICKNESS = 0; // remove the plywood bed so no underlayment renders beneath the cloth
@@ -1295,7 +1295,7 @@ const SPIN_DOT_DIAMETER_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // middle pocket cushion cuts are sharpened to a 29° cut to align the side-rail cushions with the updated spec
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 34;
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 32;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -4173,6 +4173,7 @@ const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const MIN_HDRI_RADIUS = 24;
 const HDRI_GROUNDED_RESOLUTION = 96;
+const DECOR_WOOD_TEXTURE_SIZE_2K = 2048;
 
 function resolveHdriResolutionForTable(tableSizeMeta) {
   const widthMm = tableSizeMeta?.playfield?.widthMm;
@@ -9600,6 +9601,36 @@ function applyTableFinishToTable(table, finish) {
   finishInfo.clothDetail = resolvedFinish?.clothDetail ?? null;
 }
 
+function shouldUseDecorTextureBudget(environmentId) {
+  return environmentId === 'musicHall02' || environmentId === 'oldHall';
+}
+
+function retileTableWoodTextures(table, textureSize) {
+  if (!table || !Number.isFinite(textureSize)) return;
+  const finish = table.userData?.finish;
+  const parts = finish?.parts;
+  const woodSurfaces = parts?.woodSurfaces;
+  if (!parts || !woodSurfaces) return;
+  const repeatScale = parts.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE;
+  const applySurface = (meshes, surface, fallback) => {
+    if (!Array.isArray(meshes) || meshes.length === 0) return;
+    const targetSurface = surface || fallback;
+    if (!targetSurface) return;
+    const nextSurface = {
+      ...targetSurface,
+      textureSize,
+      woodRepeatScale: repeatScale
+    };
+    meshes.forEach((mesh) => {
+      if (!mesh?.material) return;
+      applyWoodTextureToMaterial(mesh.material, nextSurface);
+    });
+  };
+  applySurface(parts.railMeshes, woodSurfaces.rail, woodSurfaces.frame);
+  applySurface(parts.frameMeshes, woodSurfaces.frame, woodSurfaces.rail);
+  applySurface(parts.legMeshes, woodSurfaces.frame, woodSurfaces.rail);
+}
+
 // --------------------------------------------------
 // NEW Engine (no globals). Camera feels like standing at the side.
 // --------------------------------------------------
@@ -11283,7 +11314,7 @@ const powerRef = useRef(hud.power);
     const buffer = audioBuffersRef.current.cue;
     if (!ctx || !buffer || muteRef.current) return;
     const power = clamp(vol, 0, 1);
-    const scaled = clamp(volumeRef.current * 1.2 * (0.35 + power * 0.75), 0, 1);
+    const scaled = clamp(volumeRef.current * 1.4 * (0.42 + power * 0.78), 0, 1);
     if (scaled <= 0 || !Number.isFinite(buffer.duration)) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
@@ -16679,6 +16710,12 @@ const powerRef = useRef(hud.power);
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
+      if (shouldUseDecorTextureBudget(environmentHdriRef.current)) {
+        retileTableWoodTextures(
+          secondaryTableRef.current,
+          DECOR_WOOD_TEXTURE_SIZE_2K
+        );
+      }
       const resolveSnookerScale = () => {
         const poolWidth = tableSizeMeta?.playfield?.widthMm ?? 2540;
         const snookerWidth = resolveSnookerTableSize()?.playfield?.widthMm ?? 3556;
@@ -16896,6 +16933,9 @@ const powerRef = useRef(hud.power);
         tableGroup.rotation.y = rotationY;
         markDecorativeTable(tableGroup);
         applyTableFinishToTable(tableGroup, finishForLayout);
+        if (shouldUseDecorTextureBudget(environmentHdriRef.current)) {
+          retileTableWoodTextures(tableGroup, DECOR_WOOD_TEXTURE_SIZE_2K);
+        }
         const decor = buildDecorGroup({ table: tableGroup, variant });
         decorativeTablesRef.current.push({
           group: tableGroup,
@@ -17095,10 +17135,19 @@ const powerRef = useRef(hud.power);
         }
         if (secondaryTableRef.current && nextFinish) {
           applyTableFinishToTable(secondaryTableRef.current, nextFinish);
+          if (shouldUseDecorTextureBudget(environmentHdriRef.current)) {
+            retileTableWoodTextures(
+              secondaryTableRef.current,
+              DECOR_WOOD_TEXTURE_SIZE_2K
+            );
+          }
         }
         decorativeTablesRef.current.forEach((entry) => {
           if (entry?.group && nextFinish) {
             applyTableFinishToTable(entry.group, nextFinish);
+            if (shouldUseDecorTextureBudget(environmentHdriRef.current)) {
+              retileTableWoodTextures(entry.group, DECOR_WOOD_TEXTURE_SIZE_2K);
+            }
           }
         });
       };
@@ -21506,7 +21555,11 @@ const powerRef = useRef(hud.power);
               b.launchDir = null;
             }
             const railImpact = reflectRails(b);
-            if (railImpact && b.id === 'cue') b.impacted = true;
+            const cueRailContact = railImpact && b.id === 'cue';
+            if (cueRailContact && b.spin?.lengthSq() > 0 && !b.impacted) {
+              applySpinImpulse(b, 0.9);
+            }
+            if (cueRailContact) b.impacted = true;
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;
             }


### PR DESCRIPTION
## Summary
- raise cue hit gain while playing the trimmed 7–8.6s segment so the strike reads clearly when the shot triggers
- tune middle-pocket cushion cuts, guard spacing, and rail spin handling so spin transfers on first cushion contact and angles behave more naturally
- keep the playable table resolution user-configurable while forcing 2K wood textures on secondary/decor tables in the Music Hall 02 and Old Hall HDRIs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957947a57788329bc4f1af6478a7380)