### PR TITLE
Enhance Pool Royale table textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1737,9 +1737,9 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 0.97;
+const CLOTH_TEXTURE_INTENSITY = 1.05;
 const CLOTH_HAIR_INTENSITY = 0.78;
-const CLOTH_BUMP_INTENSITY = 1.12;
+const CLOTH_BUMP_INTENSITY = 1.2;
 const CLOTH_SOFT_BLEND = 0.42;
 
 const CLOTH_QUALITY = (() => {
@@ -3062,11 +3062,11 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.76; // tighten the pattern footprint so the scan resolves more clearly
-const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
+const CLOTH_PATTERN_SCALE = 0.68; // enlarge the weave so cloth scans stay bolder and easier to read
+const CLOTH_TEXTURE_REPEAT_HINT = 1.32;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1 / 3;
 const POLYHAVEN_ANISOTROPY_BOOST = 2.6;
-const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.35, 0.55);
+const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.45, 0.64);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -301,11 +301,11 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const polyHavenTextureSet = (assetId) => {
-  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}`;
+  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/${assetId}/${assetId}`;
   return {
-    mapUrl: `${base}_diff_2k.jpg`,
-    roughnessMapUrl: `${base}_rough_2k.jpg`,
-    normalMapUrl: `${base}_nor_gl_2k.jpg`
+    mapUrl: `${base}_diff_4k.jpg`,
+    roughnessMapUrl: `${base}_rough_4k.jpg`,
+    normalMapUrl: `${base}_nor_gl_4k.jpg`
   };
 };
 
@@ -345,15 +345,15 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Wood Peeling Paint Weathered',
     source: 'Poly Haven — Wood Peeling Paint Weathered (CC0)',
     rail: {
-      repeat: { x: 1, y: 1 },
-      rotation: 0,
-      textureSize: 2048,
+      repeat: { x: 1.35, y: 1.35 },
+      rotation: Math.PI / 2,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     },
     frame: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 1.35, y: 1.35 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     }
   }),
@@ -364,13 +364,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('oak_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('oak_veneer_01')
     }
   }),
@@ -381,13 +381,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_table_001')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_table_001')
     }
   }),
@@ -398,13 +398,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('dark_wood')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('dark_wood')
     }
   }),
@@ -415,13 +415,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('rosewood_veneer_01')
     }
   }),
@@ -432,13 +432,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('kitchen_wood')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('kitchen_wood')
     }
   }),
@@ -449,13 +449,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('japanese_sycamore')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('japanese_sycamore')
     }
   })


### PR DESCRIPTION
## Summary
- default table finishes now pull 4K wood textures and the weathered peeling paint rail grain is rotated for contrast
- tightened wood peeling paint tiling to reduce pattern size while keeping skirts aligned differently from rails
- enlarged and sharpened cloth texture patterns so GLTF cloth weaves read more clearly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e253bc8883298bf627677d7b56a7)