### PR TITLE
Restore Pool Royale state from earlier snapshot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1304,7 +1304,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
-const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3, 0.44 / 3); // enlarge grain 3× so rails, skirts, and legs read at table scale
+const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 2.4, 0.44 / 2.4); // shrink grain slightly so rail and skirt wood reads tighter
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
@@ -1737,10 +1737,10 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 1.04;
-const CLOTH_HAIR_INTENSITY = 0.82;
-const CLOTH_BUMP_INTENSITY = 1.18;
-const CLOTH_SOFT_BLEND = 0.36;
+const CLOTH_TEXTURE_INTENSITY = 0.97;
+const CLOTH_HAIR_INTENSITY = 0.78;
+const CLOTH_BUMP_INTENSITY = 1.12;
+const CLOTH_SOFT_BLEND = 0.42;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
@@ -2012,6 +2012,9 @@ const POOL_ROYALE_WOOD_SURFACE_PROPS = Object.freeze({
   roughnessBase: 0.16,
   roughnessVariance: 0.22
 });
+
+const LONG_RAIL_WOOD_TILING = 1.18;
+const SHORT_RAIL_WOOD_TILING = 1.18;
 
 const applySnookerStyleWoodPreset = (materials, finishId) => {
   if (!WOOD_TEXTURES_ENABLED) return;
@@ -3062,7 +3065,7 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.92; // enlarge the pattern footprint for higher visibility without losing weave definition
+const CLOTH_PATTERN_SCALE = 0.76; // tighten the pattern footprint so the scan resolves more clearly
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1 / 3;
 const POLYHAVEN_ANISOTROPY_BOOST = 2.6;
@@ -3653,22 +3656,18 @@ function updateClothTexturesForFinish (finishInfo, textureKey = DEFAULT_CLOTH_TE
     finishInfo.clothMat.userData?.repeatRatio ?? finishInfo.clothBase?.repeatRatio ?? 1;
   const baseRepeatValue = baseRepeatRaw * textureScale;
   const fallbackRepeat = new THREE.Vector2(baseRepeatValue, baseRepeatValue * repeatRatioValue);
-  replaceMaterialTexture(finishInfo.clothMat, 'map', textures.map, fallbackRepeat, {
-    preserveExisting: true
-  });
+  replaceMaterialTexture(finishInfo.clothMat, 'map', textures.map, fallbackRepeat);
   replaceMaterialTexture(
     finishInfo.clothMat,
     'normalMap',
     textures.normal,
-    fallbackRepeat,
-    { preserveExisting: true }
+    fallbackRepeat
   );
   replaceMaterialTexture(
     finishInfo.clothMat,
     'roughnessMap',
     textures.roughness,
-    fallbackRepeat,
-    { preserveExisting: true }
+    fallbackRepeat
   );
   if (textures.normal) {
     finishInfo.clothMat.normalScale = CLOTH_NORMAL_SCALE.clone();
@@ -3698,22 +3697,18 @@ function updateClothTexturesForFinish (finishInfo, textureKey = DEFAULT_CLOTH_TE
     finishInfo.clothMat.userData.farRepeat = baseRepeatValue * 0.44;
   }
   if (finishInfo.cushionMat) {
-    replaceMaterialTexture(finishInfo.cushionMat, 'map', textures.map, fallbackRepeat, {
-      preserveExisting: true
-    });
+    replaceMaterialTexture(finishInfo.cushionMat, 'map', textures.map, fallbackRepeat);
     replaceMaterialTexture(
       finishInfo.cushionMat,
       'normalMap',
       textures.normal,
-      fallbackRepeat,
-      { preserveExisting: true }
+      fallbackRepeat
     );
     replaceMaterialTexture(
       finishInfo.cushionMat,
       'roughnessMap',
       textures.roughness,
-      fallbackRepeat,
-      { preserveExisting: true }
+      fallbackRepeat
     );
     if (textures.normal) {
       finishInfo.cushionMat.normalScale = CLOTH_NORMAL_SCALE.clone();
@@ -8830,7 +8825,10 @@ function Table3D(
     resolvedWoodOption?.rail ?? baseFrameFallback
   );
   const synchronizedWoodSurface = {
-    repeat: new THREE.Vector2(woodFrameSurface.repeat.x, woodFrameSurface.repeat.y),
+    repeat: new THREE.Vector2(
+      woodFrameSurface.repeat.x * LONG_RAIL_WOOD_TILING,
+      woodFrameSurface.repeat.y * SHORT_RAIL_WOOD_TILING
+    ),
     rotation: woodFrameSurface.rotation,
     textureSize: woodFrameSurface.textureSize,
     mapUrl: woodFrameSurface.mapUrl,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -301,11 +301,11 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const polyHavenTextureSet = (assetId) => {
-  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/${assetId}/${assetId}`;
+  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}`;
   return {
-    mapUrl: `${base}_diff_4k.jpg`,
-    roughnessMapUrl: `${base}_rough_4k.jpg`,
-    normalMapUrl: `${base}_nor_gl_4k.jpg`
+    mapUrl: `${base}_diff_2k.jpg`,
+    roughnessMapUrl: `${base}_rough_2k.jpg`,
+    normalMapUrl: `${base}_nor_gl_2k.jpg`
   };
 };
 
@@ -345,15 +345,15 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Wood Peeling Paint Weathered',
     source: 'Poly Haven — Wood Peeling Paint Weathered (CC0)',
     rail: {
-      repeat: { x: 1.45, y: 1.45 },
-      rotation: Math.PI / 2,
-      textureSize: 4096,
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     },
     frame: {
-      repeat: { x: 1.32, y: 1.32 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     }
   }),
@@ -364,13 +364,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('oak_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('oak_veneer_01')
     }
   }),
@@ -381,13 +381,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('wood_table_001')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('wood_table_001')
     }
   }),
@@ -398,13 +398,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('dark_wood')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('dark_wood')
     }
   }),
@@ -415,13 +415,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     }
   }),
@@ -432,13 +432,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('kitchen_wood')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('kitchen_wood')
     }
   }),
@@ -449,13 +449,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 4096,
+      textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
     }
   })
@@ -470,8 +470,8 @@ export const WOOD_GRAIN_OPTIONS_BY_ID = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_WOOD_TEXTURE_SIZE = 4096;
-export const DEFAULT_WOOD_ROUGHNESS_SIZE = 4096;
+export const DEFAULT_WOOD_TEXTURE_SIZE = 1024;
+export const DEFAULT_WOOD_ROUGHNESS_SIZE = 512;
 
 export const shiftLightness = (light, delta) => clamp01(light + delta);
 export const shiftSaturation = (sat, delta) => clamp01(sat + delta);


### PR DESCRIPTION
## Summary
- revert Pool Royale cloth and wood tuning to the state from two hours ago
- return wood materials to 2k sources with prior repeat/tiling defaults
- restore cloth intensity, pattern scaling, and texture application logic to the earlier baseline

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f28cb4048329b31f76d767eb66c1)