### PR TITLE
Fix Pool Royale online flow tests for Jest

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -1,5 +1,3 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
 import { EventEmitter } from 'events';
 import { setTimeout as delay } from 'timers/promises';
 import { runPoolRoyaleOnlineFlow } from '../webapp/src/pages/Games/poolRoyaleOnlineFlow.js';
@@ -75,123 +73,125 @@ function createRefs() {
   };
 }
 
-test.after(() => {
+afterAll(() => {
   realSocket?.disconnect?.();
   realSocket?.close?.();
 });
 
-test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async () => {
-  const mockSocket = new MockSocket();
-  const refs = createRefs();
-  const state = createState();
-  const addCalls = [];
-  const started = [];
+describe('runPoolRoyaleOnlineFlow', () => {
+  test('debits once and keeps stake for game start', async () => {
+    const mockSocket = new MockSocket();
+    const refs = createRefs();
+    const state = createState();
+    const addCalls = [];
+    const started = [];
 
-  const deps = {
-    ensureAccountId: () => Promise.resolve('acct-1'),
-    getAccountBalance: () => Promise.resolve({ balance: 200 }),
-    addTransaction: (...args) => {
-      addCalls.push(args);
-      return Promise.resolve();
-    },
-    getTelegramId: () => 'tg-1',
-    getTelegramFirstName: () => 'Alice',
-    socket: mockSocket
-  };
+    const deps = {
+      ensureAccountId: () => Promise.resolve('acct-1'),
+      getAccountBalance: () => Promise.resolve({ balance: 200 }),
+      addTransaction: (...args) => {
+        addCalls.push(args);
+        return Promise.resolve();
+      },
+      getTelegramId: () => 'tg-1',
+      getTelegramFirstName: () => 'Alice',
+      socket: mockSocket
+    };
 
-  await runPoolRoyaleOnlineFlow({
-    stake: { token: 'TPC', amount: 100 },
-    variant: 'uk',
-    ballSet: 'american',
-    playType: 'regular',
-    mode: 'online',
-    tableSize: 'medium',
-    avatar: 'me.png',
-    deps,
-    state,
-    refs,
-    timeouts: { seat: 50, matchmaking: 200 },
-    onGameStart: (payload) => started.push(payload)
+    await runPoolRoyaleOnlineFlow({
+      stake: { token: 'TPC', amount: 100 },
+      variant: 'uk',
+      ballSet: 'american',
+      playType: 'regular',
+      mode: 'online',
+      tableSize: 'medium',
+      avatar: 'me.png',
+      deps,
+      state,
+      refs,
+      timeouts: { seat: 50, matchmaking: 200 },
+      onGameStart: (payload) => started.push(payload)
+    });
+
+    expect(mockSocket.seatRequests).toHaveLength(1);
+    const seatPayload = mockSocket.seatRequests[0].payload;
+    expect(seatPayload.ballSet).toBe('american');
+    expect(seatPayload.variant).toBe('uk');
+    expect(seatPayload.mode).toBe('online');
+    expect(seatPayload.tableSize).toBe('medium');
+    expect(seatPayload.playType).toBe('regular');
+    const seatCb = mockSocket.seatRequests[0].cb;
+    seatCb({
+      success: true,
+      tableId: 'tbl-1',
+      players: [
+        { id: 'acct-1', name: 'Alice' },
+        { id: 'acct-2', name: 'Bob' }
+      ],
+      ready: ['acct-1']
+    });
+
+    mockSocket.emit('gameStart', {
+      tableId: 'tbl-1',
+      players: [
+        { id: 'acct-1', name: 'Alice' },
+        { id: 'acct-2', name: 'Bob' }
+      ]
+    });
+
+    await delay(0);
+
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0][1]).toBe(-100);
+    expect(addCalls[0][2]).toBe('stake');
+    expect(started).toHaveLength(1);
+    expect(started[0].tableId).toBe('tbl-1');
+    expect(refs.stakeDebitRef.current).toBeNull();
   });
 
-  assert.equal(mockSocket.seatRequests.length, 1);
-  const seatPayload = mockSocket.seatRequests[0].payload;
-  assert.equal(seatPayload.ballSet, 'american');
-  assert.equal(seatPayload.variant, 'uk');
-  assert.equal(seatPayload.mode, 'online');
-  assert.equal(seatPayload.tableSize, 'medium');
-  assert.equal(seatPayload.playType, 'regular');
-  const seatCb = mockSocket.seatRequests[0].cb;
-  seatCb({
-    success: true,
-    tableId: 'tbl-1',
-    players: [
-      { id: 'acct-1', name: 'Alice' },
-      { id: 'acct-2', name: 'Bob' }
-    ],
-    ready: ['acct-1']
+  test('refunds when matchmaking times out', async () => {
+    const mockSocket = new MockSocket();
+    const refs = createRefs();
+    const state = createState();
+    const addCalls = [];
+
+    const deps = {
+      ensureAccountId: () => Promise.resolve('acct-9'),
+      getAccountBalance: () => Promise.resolve({ balance: 200 }),
+      addTransaction: (...args) => {
+        addCalls.push(args);
+        return Promise.resolve();
+      },
+      getTelegramId: () => 'tg-9',
+      getTelegramFirstName: () => 'Alex',
+      socket: mockSocket
+    };
+
+    await runPoolRoyaleOnlineFlow({
+      stake: { token: 'TPC', amount: 75 },
+      variant: 'uk',
+      ballSet: 'uk',
+      playType: 'regular',
+      mode: 'online',
+      tableSize: 'medium',
+      avatar: 'me.png',
+      deps,
+      state,
+      refs,
+      timeouts: { seat: 50, matchmaking: 80 }
+    });
+
+    expect(mockSocket.seatRequests).toHaveLength(1);
+    const seatCb = mockSocket.seatRequests[0].cb;
+    seatCb({ success: true, tableId: 'tbl-timeout', players: [], ready: [] });
+
+    await delay(120);
+
+    expect(addCalls).toHaveLength(2);
+    expect(addCalls[0][1]).toBe(-75);
+    expect(addCalls[1][1]).toBe(75);
+    expect(addCalls[1][2]).toBe('stake_refund');
+    expect(state.snapshot.matchingError).toContain('timed out');
+    expect(refs.pendingTableRef.current).toBe('');
   });
-
-  mockSocket.emit('gameStart', {
-    tableId: 'tbl-1',
-    players: [
-      { id: 'acct-1', name: 'Alice' },
-      { id: 'acct-2', name: 'Bob' }
-    ]
-  });
-
-  await delay(0);
-
-  assert.equal(addCalls.length, 1, 'should only debit once');
-  assert.equal(addCalls[0][1], -100);
-  assert.equal(addCalls[0][2], 'stake');
-  assert.equal(started.length, 1);
-  assert.equal(started[0].tableId, 'tbl-1');
-  assert.equal(refs.stakeDebitRef.current, null, 'stake cleared after start');
-});
-
-test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
-  const mockSocket = new MockSocket();
-  const refs = createRefs();
-  const state = createState();
-  const addCalls = [];
-
-  const deps = {
-    ensureAccountId: () => Promise.resolve('acct-9'),
-    getAccountBalance: () => Promise.resolve({ balance: 200 }),
-    addTransaction: (...args) => {
-      addCalls.push(args);
-      return Promise.resolve();
-    },
-    getTelegramId: () => 'tg-9',
-    getTelegramFirstName: () => 'Alex',
-    socket: mockSocket
-  };
-
-  await runPoolRoyaleOnlineFlow({
-    stake: { token: 'TPC', amount: 75 },
-    variant: 'uk',
-    ballSet: 'uk',
-    playType: 'regular',
-    mode: 'online',
-    tableSize: 'medium',
-    avatar: 'me.png',
-    deps,
-    state,
-    refs,
-    timeouts: { seat: 50, matchmaking: 80 }
-  });
-
-  assert.equal(mockSocket.seatRequests.length, 1);
-  const seatCb = mockSocket.seatRequests[0].cb;
-  seatCb({ success: true, tableId: 'tbl-timeout', players: [], ready: [] });
-
-  await delay(120);
-
-  assert.equal(addCalls.length, 2, 'should debit then refund');
-  assert.equal(addCalls[0][1], -75);
-  assert.equal(addCalls[1][1], 75);
-  assert.equal(addCalls[1][2], 'stake_refund');
-  assert.ok(state.snapshot.matchingError.includes('timed out'));
-  assert.equal(refs.pendingTableRef.current, '');
 });


### PR DESCRIPTION
## Summary
- switch the Pool Royale online flow tests to Jest APIs and expectations instead of node:test
- keep the socket cleanup while using Jest hooks

## Testing
- npm test -- poolRoyale

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695800f308f48329abd2957f6f9b18cb)