### PR TITLE
Fix Pool Royale online flow tests

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -1,4 +1,3 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'events';
 import { setTimeout as delay } from 'timers/promises';
@@ -75,7 +74,7 @@ function createRefs() {
   };
 }
 
-test.after(() => {
+afterAll(() => {
   realSocket?.disconnect?.();
   realSocket?.close?.();
 });


### PR DESCRIPTION
## Summary
- switch Pool Royale online flow tests to Jest lifecycle cleanup instead of node:test hooks
- keep real socket cleanups after all tests to avoid runtime errors

## Testing
- npm test -- poolRoyaleOnlineFlow.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695800f308f48329abd2957f6f9b18cb)