### PR TITLE
Refine Pool Royale table frame and textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -483,7 +483,7 @@ const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 0; // keep the wooden rail corners crisp with no rounding on the frame
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 1; // round the exterior wooden rail corners to match the photographed reference radius
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
@@ -1078,7 +1078,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops furthe
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep the exterior wooden rails straight with no rounding
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.24; // softly round only the exterior wooden rail edges while leaving the playfield cuts sharp
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_ANIMATION_MS = 420;
@@ -1238,7 +1238,8 @@ const LEG_ROOM_HEIGHT =
   (LEG_ROOM_HEIGHT_RAW + LEG_HEIGHT_OFFSET) * LEG_LENGTH_SCALE - LEG_HEIGHT_OFFSET;
 const LEG_ELEVATION_DELTA = LEG_ROOM_HEIGHT - BASE_LEG_ROOM_HEIGHT;
 const LEG_TOP_OVERLAP = TABLE.THICK * 0.25; // sink legs slightly into the apron so they appear connected
-const SKIRT_DROP_MULTIPLIER = 1.36; // halve the apron drop to slim the skirt while keeping the tabletop level
+const SKIRT_DROP_MULTIPLIER = 1.36; // apron depth reference used to keep the tabletop height while redistributing mass downward
+const SKIRT_ENABLED = false; // hide the skirt/apron and extend the main wooden frame downward instead
 const SKIRT_SIDE_OVERHANG = 0; // keep the lower base flush with the rail footprint (no horizontal flare)
 const SKIRT_RAIL_GAP_FILL = TABLE.THICK * 0.072; // raise the apron further so it fully meets the lowered rails
 const BASE_HEIGHT_FILL = 0.94; // grow bases upward so the stance stays consistent with the shorter skirt
@@ -4098,8 +4099,21 @@ function projectRailUVs(geometry, bounds) {
     const absY = Math.abs(faceNormal.y);
     const absZ = Math.abs(faceNormal.z);
     const dominantZ = absZ >= Math.max(absX, absY);
-    const uAxis = dominantZ ? 'x' : absX >= absY ? 'y' : 'x';
-    const vAxis = dominantZ ? 'y' : 'z';
+    const alignWithLongRail = Math.abs(center.y) > Math.abs(center.x);
+    const uAxis = dominantZ
+      ? alignWithLongRail
+        ? 'x'
+        : 'y'
+      : absX >= absY
+        ? 'z'
+        : 'x';
+    const vAxis = dominantZ
+      ? alignWithLongRail
+        ? 'y'
+        : 'x'
+      : absX >= absY
+        ? 'y'
+        : 'z';
 
     verts.forEach((v, idx) => {
       const u = (v[uAxis] + extents[uAxis] / 2) / extents[uAxis];
@@ -7028,6 +7042,9 @@ function Table3D(
   const frameWidthLong = frameWidthEnd; // force side rails to carry the same exterior thickness as the short rails
   const outerHalfW = halfW + 2 * longRailW + frameWidthLong;
   const outerHalfH = halfH + 2 * endRailW + frameWidthEnd;
+  const skirtDepth = TABLE_H * 0.68 * SKIRT_DROP_MULTIPLIER;
+  const railDrop = SKIRT_ENABLED ? 0 : skirtDepth;
+  const effectiveRailH = railH + railDrop;
   finishParts.dimensions = { outerHalfW, outerHalfH, railH, frameTopY };
   // Force the table rails to reuse the exact cue butt wood scale so the grain
   // is just as visible as it is on the stick finish in cue view.
@@ -8184,18 +8201,21 @@ function Table3D(
   });
 
   let railsGeom = new THREE.ExtrudeGeometry(railsOuter, {
-    depth: railH,
+    depth: effectiveRailH,
     bevelEnabled: false,
     curveSegments: 128
   });
-  railsGeom = softenOuterExtrudeEdges(railsGeom, railH, RAIL_OUTER_EDGE_RADIUS_RATIO, {
+  railsGeom = softenOuterExtrudeEdges(railsGeom, effectiveRailH, RAIL_OUTER_EDGE_RADIUS_RATIO, {
     innerBounds: {
       halfWidth: Math.max(cushionInnerX, 0),
       halfHeight: Math.max(cushionInnerZ, 0),
       padding: TABLE.THICK * 0.04
     }
   });
-  railsGeom = projectRailUVs(railsGeom, { outerHalfW, outerHalfH, railH });
+  if (railDrop > MICRO_EPS) {
+    railsGeom.translate(0, 0, -railDrop);
+  }
+  railsGeom = projectRailUVs(railsGeom, { outerHalfW, outerHalfH, railH: effectiveRailH });
   const railsMesh = new THREE.Mesh(railsGeom, railMat);
   railsMesh.rotation.x = -Math.PI / 2;
   railsMesh.position.y = frameTopY;
@@ -8660,120 +8680,122 @@ function Table3D(
 
   const frameOuterX = outerHalfW;
   const frameOuterZ = outerHalfH;
-  const skirtH = TABLE_H * 0.68 * SKIRT_DROP_MULTIPLIER;
+  const skirtH = SKIRT_ENABLED ? skirtDepth : 0;
   const baseRailWidth = endRailW;
   const baseOverhang = baseRailWidth * SKIRT_SIDE_OVERHANG;
-  const skirtShape = new THREE.Shape();
   const outW = frameOuterX + baseOverhang;
   const outZ = frameOuterZ + baseOverhang;
   const skirtOuterRadius = hasRoundedRailCorners
     ? Math.min(outerCornerRadius + baseOverhang * 0.4, Math.min(outW, outZ))
     : 0;
-  if (skirtOuterRadius > MICRO_EPS) {
-    skirtShape.moveTo(outW, -outZ + skirtOuterRadius);
-    skirtShape.lineTo(outW, outZ - skirtOuterRadius);
-    skirtShape.absarc(
-      outW - skirtOuterRadius,
-      outZ - skirtOuterRadius,
-      skirtOuterRadius,
-      0,
-      Math.PI / 2,
-      false
-    );
-    skirtShape.lineTo(-outW + skirtOuterRadius, outZ);
-    skirtShape.absarc(
-      -outW + skirtOuterRadius,
-      outZ - skirtOuterRadius,
-      skirtOuterRadius,
-      Math.PI / 2,
-      Math.PI,
-      false
-    );
-    skirtShape.lineTo(-outW, -outZ + skirtOuterRadius);
-    skirtShape.absarc(
-      -outW + skirtOuterRadius,
-      -outZ + skirtOuterRadius,
-      skirtOuterRadius,
-      Math.PI,
-      1.5 * Math.PI,
-      false
-    );
-    skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
-    skirtShape.absarc(
-      outW - skirtOuterRadius,
-      -outZ + skirtOuterRadius,
-      skirtOuterRadius,
-      -Math.PI / 2,
-      0,
-      false
-    );
-  } else {
-    skirtShape.moveTo(outW, -outZ);
-    skirtShape.lineTo(outW, outZ);
-    skirtShape.lineTo(-outW, outZ);
-    skirtShape.lineTo(-outW, -outZ);
-    skirtShape.lineTo(outW, -outZ);
+  if (SKIRT_ENABLED && skirtH > MICRO_EPS) {
+    const skirtShape = new THREE.Shape();
+    if (skirtOuterRadius > MICRO_EPS) {
+      skirtShape.moveTo(outW, -outZ + skirtOuterRadius);
+      skirtShape.lineTo(outW, outZ - skirtOuterRadius);
+      skirtShape.absarc(
+        outW - skirtOuterRadius,
+        outZ - skirtOuterRadius,
+        skirtOuterRadius,
+        0,
+        Math.PI / 2,
+        false
+      );
+      skirtShape.lineTo(-outW + skirtOuterRadius, outZ);
+      skirtShape.absarc(
+        -outW + skirtOuterRadius,
+        outZ - skirtOuterRadius,
+        skirtOuterRadius,
+        Math.PI / 2,
+        Math.PI,
+        false
+      );
+      skirtShape.lineTo(-outW, -outZ + skirtOuterRadius);
+      skirtShape.absarc(
+        -outW + skirtOuterRadius,
+        -outZ + skirtOuterRadius,
+        skirtOuterRadius,
+        Math.PI,
+        1.5 * Math.PI,
+        false
+      );
+      skirtShape.lineTo(outW - skirtOuterRadius, -outZ);
+      skirtShape.absarc(
+        outW - skirtOuterRadius,
+        -outZ + skirtOuterRadius,
+        skirtOuterRadius,
+        -Math.PI / 2,
+        0,
+        false
+      );
+    } else {
+      skirtShape.moveTo(outW, -outZ);
+      skirtShape.lineTo(outW, outZ);
+      skirtShape.lineTo(-outW, outZ);
+      skirtShape.lineTo(-outW, -outZ);
+      skirtShape.lineTo(outW, -outZ);
+    }
+    const inner = new THREE.Path();
+    const skirtInnerRadius = Math.max(outerCornerRadius - baseOverhang, 0);
+    if (skirtInnerRadius > 1e-4) {
+      inner.moveTo(frameOuterX, -frameOuterZ + skirtInnerRadius);
+      inner.lineTo(frameOuterX, frameOuterZ - skirtInnerRadius);
+      inner.absarc(
+        frameOuterX - skirtInnerRadius,
+        frameOuterZ - skirtInnerRadius,
+        skirtInnerRadius,
+        0,
+        Math.PI / 2,
+        false
+      );
+      inner.lineTo(-frameOuterX + skirtInnerRadius, frameOuterZ);
+      inner.absarc(
+        -frameOuterX + skirtInnerRadius,
+        frameOuterZ - skirtInnerRadius,
+        skirtInnerRadius,
+        Math.PI / 2,
+        Math.PI,
+        false
+      );
+      inner.lineTo(-frameOuterX, -frameOuterZ + skirtInnerRadius);
+      inner.absarc(
+        -frameOuterX + skirtInnerRadius,
+        -frameOuterZ + skirtInnerRadius,
+        skirtInnerRadius,
+        Math.PI,
+        1.5 * Math.PI,
+        false
+      );
+      inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
+      inner.absarc(
+        frameOuterX - skirtInnerRadius,
+        -frameOuterZ + skirtInnerRadius,
+        skirtInnerRadius,
+        -Math.PI / 2,
+        0,
+        false
+      );
+    } else {
+      inner.moveTo(frameOuterX, -frameOuterZ);
+      inner.lineTo(frameOuterX, frameOuterZ);
+      inner.lineTo(-frameOuterX, frameOuterZ);
+      inner.lineTo(-frameOuterX, -frameOuterZ);
+      inner.lineTo(frameOuterX, -frameOuterZ);
+    }
+    skirtShape.holes.push(inner);
+    const skirtGeo = new THREE.ExtrudeGeometry(skirtShape, {
+      depth: skirtH,
+      bevelEnabled: false
+    });
+    projectRailUVs(skirtGeo, { outerHalfW: outW, outerHalfH: outZ, railH: skirtH });
+    const skirt = new THREE.Mesh(skirtGeo, frameMat);
+    skirt.rotation.x = -Math.PI / 2;
+    skirt.position.y = frameTopY - skirtH + SKIRT_RAIL_GAP_FILL + MICRO_EPS * 0.5;
+    skirt.castShadow = true;
+    skirt.receiveShadow = true;
+    table.add(skirt);
+    finishParts.frameMeshes.push(skirt);
   }
-  const inner = new THREE.Path();
-  const skirtInnerRadius = Math.max(outerCornerRadius - baseOverhang, 0);
-  if (skirtInnerRadius > 1e-4) {
-    inner.moveTo(frameOuterX, -frameOuterZ + skirtInnerRadius);
-    inner.lineTo(frameOuterX, frameOuterZ - skirtInnerRadius);
-    inner.absarc(
-      frameOuterX - skirtInnerRadius,
-      frameOuterZ - skirtInnerRadius,
-      skirtInnerRadius,
-      0,
-      Math.PI / 2,
-      false
-    );
-    inner.lineTo(-frameOuterX + skirtInnerRadius, frameOuterZ);
-    inner.absarc(
-      -frameOuterX + skirtInnerRadius,
-      frameOuterZ - skirtInnerRadius,
-      skirtInnerRadius,
-      Math.PI / 2,
-      Math.PI,
-      false
-    );
-    inner.lineTo(-frameOuterX, -frameOuterZ + skirtInnerRadius);
-    inner.absarc(
-      -frameOuterX + skirtInnerRadius,
-      -frameOuterZ + skirtInnerRadius,
-      skirtInnerRadius,
-      Math.PI,
-      1.5 * Math.PI,
-      false
-    );
-    inner.lineTo(frameOuterX - skirtInnerRadius, -frameOuterZ);
-    inner.absarc(
-      frameOuterX - skirtInnerRadius,
-      -frameOuterZ + skirtInnerRadius,
-      skirtInnerRadius,
-      -Math.PI / 2,
-      0,
-      false
-    );
-  } else {
-    inner.moveTo(frameOuterX, -frameOuterZ);
-    inner.lineTo(frameOuterX, frameOuterZ);
-    inner.lineTo(-frameOuterX, frameOuterZ);
-    inner.lineTo(-frameOuterX, -frameOuterZ);
-    inner.lineTo(frameOuterX, -frameOuterZ);
-  }
-  skirtShape.holes.push(inner);
-  const skirtGeo = new THREE.ExtrudeGeometry(skirtShape, {
-    depth: skirtH,
-    bevelEnabled: false
-  });
-  projectRailUVs(skirtGeo, { outerHalfW: outW, outerHalfH: outZ, railH: skirtH });
-  const skirt = new THREE.Mesh(skirtGeo, frameMat);
-  skirt.rotation.x = -Math.PI / 2;
-  skirt.position.y = frameTopY - skirtH + SKIRT_RAIL_GAP_FILL + MICRO_EPS * 0.5;
-  skirt.castShadow = true;
-  skirt.receiveShadow = true;
-  table.add(skirt);
-  finishParts.frameMeshes.push(skirt);
 
   if (PLYWOOD_ENABLED && plywoodDepth > MICRO_EPS) {
     const plywoodShape = buildSurfaceShape(PLYWOOD_HOLE_R, -baseOverhang);
@@ -8873,6 +8895,7 @@ function Table3D(
     mesh.castShadow = true;
     mesh.receiveShadow = true;
   });
+  const skirtClearance = SKIRT_ENABLED ? skirtH : railDrop;
 
   const clearBaseMeshes = () => {
     finishParts.baseMeshes.forEach((mesh) => {
@@ -8903,7 +8926,7 @@ function Table3D(
     trimMat,
     halfW,
     halfH,
-    skirtH,
+    skirtH: skirtClearance,
     baseRailWidth
   };
 
@@ -9241,7 +9264,7 @@ function Table3D(
     });
     if (bounds.isEmpty()) return;
     const availableBottom = baseContext.floorY + MICRO_EPS;
-    const availableTop = baseContext.frameTopY - baseContext.skirtH * 0.1;
+    const availableTop = baseContext.frameTopY - baseContext.skirtH * 0.9;
     let height = Math.max(bounds.max.y - bounds.min.y, MICRO_EPS);
     const offsetToFloor = availableBottom - bounds.min.y;
     if (Math.abs(offsetToFloor) > 1e-6) {


### PR DESCRIPTION
## Summary
- Rounded the Pool Royale rail corners and softened exterior edges while extending the rail geometry downward in place of the apron.
- Synced rail UV projection so wood grain follows the long-rail direction across the top and sides to match the finish.
- Adjusted base clearance to account for the deeper rail body and keep supporting meshes aligned.

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582227d13083299d607fd317600c1d)