### PR TITLE
Improve Pool Royale finish options and leg assets

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,4 +1,8 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import {
+  DEFAULT_POOL_ROYALE_TABLE_FINISH_ID,
+  POOL_ROYALE_TABLE_FINISH_VARIANTS
+} from './poolRoyaleTableFinishes.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -501,7 +505,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
   {
     id: 'chessCastleLegs',
     name: 'Chess Castle Legs',
-    description: 'Four Chess Battle Royale rooks turned into sculpted corner legs.',
+    description: 'Chess Battle Royale rook GLTF legs with the original materials intact.',
     swatches: ['#e5e7eb', '#0ea5e9']
   },
   {
@@ -537,7 +541,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
   {
     id: 'chessBishopLegs',
     name: 'Chess Bishop Legs',
-    description: 'Bishop silhouettes from Chess Battle Royale recast as tapered legs.',
+    description: 'Chess Battle Royale bishop GLTF legs carrying the native textures.',
     swatches: ['#cbd5e1', '#1f2937']
   },
   {
@@ -551,7 +555,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
-  tableFinish: ['peelingPaintWeathered'],
+  tableFinish: [DEFAULT_POOL_ROYALE_TABLE_FINISH_ID],
   chromeColor: ['gold'],
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
@@ -569,11 +573,10 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   tableFinish: Object.freeze({
-    peelingPaintWeathered: 'Wood Peeling Paint Weathered',
-    oakVeneer01: 'Oak Veneer 01',
-    woodTable001: 'Wood Table 001',
-    darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    ...POOL_ROYALE_TABLE_FINISH_VARIANTS.reduce((acc, finish) => {
+      acc[finish.id] = finish.label;
+      return acc;
+    }, {})
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -617,47 +620,20 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
   })
 });
 
+const POOL_ROYALE_TABLE_FINISH_STORE_ITEMS = POOL_ROYALE_TABLE_FINISH_VARIANTS.map(
+  (finish, idx) => ({
+    id: `finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: 980 + idx * 10,
+    description: `${finish.label} with preserved ${finish.woodTextureId?.replace(/_/g, ' ') || 'wood'} grain.`,
+    swatches: finish.swatches
+  })
+);
+
 export const POOL_ROYALE_STORE_ITEMS = [
-  {
-    id: 'finish-peelingPaintWeathered',
-    type: 'tableFinish',
-    optionId: 'peelingPaintWeathered',
-    name: 'Wood Peeling Paint Weathered Finish',
-    price: 980,
-    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
-  },
-  {
-    id: 'finish-oakVeneer01',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01',
-    name: 'Oak Veneer 01 Finish',
-    price: 990,
-    description: 'Warm oak veneer rails with smooth satin polish.'
-  },
-  {
-    id: 'finish-woodTable001',
-    type: 'tableFinish',
-    optionId: 'woodTable001',
-    name: 'Wood Table 001 Finish',
-    price: 1000,
-    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
-  },
-  {
-    id: 'finish-darkWood',
-    type: 'tableFinish',
-    optionId: 'darkWood',
-    name: 'Dark Wood Finish',
-    price: 1010,
-    description: 'Deep espresso rails with strong grain contrast.'
-  },
-  {
-    id: 'finish-rosewoodVeneer01',
-    type: 'tableFinish',
-    optionId: 'rosewoodVeneer01',
-    name: 'Rosewood Veneer 01 Finish',
-    price: 1020,
-    description: 'Rosewood veneer rails with rich, reddish undertones.'
-  },
+  ...POOL_ROYALE_TABLE_FINISH_STORE_ITEMS,
   {
     id: 'chrome-chrome',
     type: 'chromeColor',
@@ -815,8 +791,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
 export const POOL_ROYALE_DEFAULT_LOADOUT = [
   {
     type: 'tableFinish',
-    optionId: 'peelingPaintWeathered',
-    label: 'Wood Peeling Paint Weathered Finish'
+    optionId: DEFAULT_POOL_ROYALE_TABLE_FINISH_ID,
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish[DEFAULT_POOL_ROYALE_TABLE_FINISH_ID]
   },
   { type: 'chromeColor', optionId: 'gold', label: 'Gold Chrome Plates' },
   { type: 'railMarkerColor', optionId: 'gold', label: 'Gold Diamond Markers' },

--- a/webapp/src/config/poolRoyaleTableFinishes.js
+++ b/webapp/src/config/poolRoyaleTableFinishes.js
@@ -1,0 +1,232 @@
+export const POOL_ROYALE_TABLE_FINISH_VARIANTS = Object.freeze([
+  Object.freeze({
+    id: 'peelingPaintWeathered-driftwood',
+    baseId: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered — Driftwood',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    rail: 0xb8b3aa,
+    base: 0xa89f95,
+    trim: 0xd6d0c7,
+    woodRepeatScale: 1,
+    swatches: ['#a89f95', '#d6d0c7']
+  }),
+  Object.freeze({
+    id: 'peelingPaintWeathered-seaGlass',
+    baseId: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered — Sea Glass',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    rail: 0xa5b5b1,
+    base: 0x91a59c,
+    trim: 0xc3d6d0,
+    woodRepeatScale: 1,
+    swatches: ['#91a59c', '#c3d6d0']
+  }),
+  Object.freeze({
+    id: 'peelingPaintWeathered-sandbar',
+    baseId: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered — Sandbar',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    rail: 0xcdbba3,
+    base: 0xbfa78a,
+    trim: 0xe8d8c0,
+    woodRepeatScale: 1,
+    swatches: ['#bfa78a', '#e8d8c0']
+  }),
+  Object.freeze({
+    id: 'peelingPaintWeathered-storm',
+    baseId: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered — Storm',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    rail: 0x9aa3b1,
+    base: 0x828b9a,
+    trim: 0xc2cad9,
+    woodRepeatScale: 1,
+    swatches: ['#828b9a', '#c2cad9']
+  }),
+  Object.freeze({
+    id: 'peelingPaintWeathered-ember',
+    baseId: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered — Ember',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    rail: 0xb79b84,
+    base: 0xa08066,
+    trim: 0xd8b79a,
+    woodRepeatScale: 1,
+    swatches: ['#a08066', '#d8b79a']
+  }),
+  Object.freeze({
+    id: 'oakVeneer01-amber',
+    baseId: 'oakVeneer01',
+    label: 'Oak Veneer — Amber',
+    woodTextureId: 'oak_veneer_01',
+    rail: 0xc89a64,
+    base: 0xb9854e,
+    trim: 0xe0bb7a,
+    woodRepeatScale: 1,
+    swatches: ['#b9854e', '#e0bb7a']
+  }),
+  Object.freeze({
+    id: 'oakVeneer01-honey',
+    baseId: 'oakVeneer01',
+    label: 'Oak Veneer — Honey',
+    woodTextureId: 'oak_veneer_01',
+    rail: 0xd7ad72,
+    base: 0xc7975a,
+    trim: 0xefd3a0,
+    woodRepeatScale: 1,
+    swatches: ['#c7975a', '#efd3a0']
+  }),
+  Object.freeze({
+    id: 'oakVeneer01-rye',
+    baseId: 'oakVeneer01',
+    label: 'Oak Veneer — Rye',
+    woodTextureId: 'oak_veneer_01',
+    rail: 0xbb905c,
+    base: 0xa97a46,
+    trim: 0xd7b280,
+    woodRepeatScale: 1,
+    swatches: ['#a97a46', '#d7b280']
+  }),
+  Object.freeze({
+    id: 'oakVeneer01-moss',
+    baseId: 'oakVeneer01',
+    label: 'Oak Veneer — Moss',
+    woodTextureId: 'oak_veneer_01',
+    rail: 0xa88d6a,
+    base: 0x947651,
+    trim: 0xc9b08a,
+    woodRepeatScale: 1,
+    swatches: ['#947651', '#c9b08a']
+  }),
+  Object.freeze({
+    id: 'oakVeneer01-charcoal',
+    baseId: 'oakVeneer01',
+    label: 'Oak Veneer — Charcoal',
+    woodTextureId: 'oak_veneer_01',
+    rail: 0x8f7356,
+    base: 0x7a5d42,
+    trim: 0xab8a6c,
+    woodRepeatScale: 1,
+    swatches: ['#7a5d42', '#ab8a6c']
+  }),
+  Object.freeze({
+    id: 'woodTable001-heritage',
+    baseId: 'woodTable001',
+    label: 'Wood Table — Heritage',
+    woodTextureId: 'wood_table_001',
+    rail: 0xa4724f,
+    base: 0x8f6243,
+    trim: 0xc89a64,
+    woodRepeatScale: 1,
+    swatches: ['#8f6243', '#c89a64']
+  }),
+  Object.freeze({
+    id: 'woodTable001-ember',
+    baseId: 'woodTable001',
+    label: 'Wood Table — Ember',
+    woodTextureId: 'wood_table_001',
+    rail: 0xb06f50,
+    base: 0x9a5b3d,
+    trim: 0xd59a6d,
+    woodRepeatScale: 1,
+    swatches: ['#9a5b3d', '#d59a6d']
+  }),
+  Object.freeze({
+    id: 'woodTable001-dune',
+    baseId: 'woodTable001',
+    label: 'Wood Table — Dune',
+    woodTextureId: 'wood_table_001',
+    rail: 0x967a63,
+    base: 0x80644f,
+    trim: 0xb89c83,
+    woodRepeatScale: 1,
+    swatches: ['#80644f', '#b89c83']
+  }),
+  Object.freeze({
+    id: 'woodTable001-moss',
+    baseId: 'woodTable001',
+    label: 'Wood Table — Moss',
+    woodTextureId: 'wood_table_001',
+    rail: 0x7f6a52,
+    base: 0x6a553f,
+    trim: 0xa4886d,
+    woodRepeatScale: 1,
+    swatches: ['#6a553f', '#a4886d']
+  }),
+  Object.freeze({
+    id: 'woodTable001-noir',
+    baseId: 'woodTable001',
+    label: 'Wood Table — Noir',
+    woodTextureId: 'wood_table_001',
+    rail: 0x5c4436,
+    base: 0x4b3428,
+    trim: 0x8a6b55,
+    woodRepeatScale: 1,
+    swatches: ['#4b3428', '#8a6b55']
+  }),
+  Object.freeze({
+    id: 'darkWood-obsidian',
+    baseId: 'darkWood',
+    label: 'Dark Wood — Obsidian',
+    woodTextureId: 'dark_wood',
+    rail: 0x3d2f2a,
+    base: 0x2f241f,
+    trim: 0x6a5a52,
+    woodRepeatScale: 1,
+    swatches: ['#2f241f', '#6a5a52']
+  }),
+  Object.freeze({
+    id: 'darkWood-ember',
+    baseId: 'darkWood',
+    label: 'Dark Wood — Ember',
+    woodTextureId: 'dark_wood',
+    rail: 0x4a322b,
+    base: 0x3a2721,
+    trim: 0x7b5c52,
+    woodRepeatScale: 1,
+    swatches: ['#3a2721', '#7b5c52']
+  }),
+  Object.freeze({
+    id: 'darkWood-slate',
+    baseId: 'darkWood',
+    label: 'Dark Wood — Slate',
+    woodTextureId: 'dark_wood',
+    rail: 0x3a3c3f,
+    base: 0x2d2f32,
+    trim: 0x6b6e73,
+    woodRepeatScale: 1,
+    swatches: ['#2d2f32', '#6b6e73']
+  }),
+  Object.freeze({
+    id: 'darkWood-cocoa',
+    baseId: 'darkWood',
+    label: 'Dark Wood — Cocoa',
+    woodTextureId: 'dark_wood',
+    rail: 0x4f3b30,
+    base: 0x3f2d24,
+    trim: 0x7e6151,
+    woodRepeatScale: 1,
+    swatches: ['#3f2d24', '#7e6151']
+  }),
+  Object.freeze({
+    id: 'darkWood-forest',
+    baseId: 'darkWood',
+    label: 'Dark Wood — Forest',
+    woodTextureId: 'dark_wood',
+    rail: 0x3f352d,
+    base: 0x312821,
+    trim: 0x6b5a4f,
+    woodRepeatScale: 1,
+    swatches: ['#312821', '#6b5a4f']
+  })
+]);
+
+export const POOL_ROYALE_TABLE_FINISH_MAP = Object.freeze(
+  POOL_ROYALE_TABLE_FINISH_VARIANTS.reduce((acc, finish) => {
+    acc[finish.id] = finish;
+    return acc;
+  }, {})
+);
+
+export const DEFAULT_POOL_ROYALE_TABLE_FINISH_ID =
+  POOL_ROYALE_TABLE_FINISH_VARIANTS[0]?.id;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -8,6 +8,7 @@ import {
   POOL_ROYALE_BASE_VARIANTS
 } from '../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../config/poolRoyaleClothPresets.js';
+import { POOL_ROYALE_TABLE_FINISH_VARIANTS } from '../config/poolRoyaleTableFinishes.js';
 import {
   SNOOKER_CLUB_DEFAULT_LOADOUT,
   SNOOKER_CLUB_OPTION_LABELS,
@@ -295,13 +296,16 @@ const POOL_CLOTH_SWATCHES = POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, cloth) => {
   return acc;
 }, {});
 
+const POOL_FINISH_SWATCHES = POOL_ROYALE_TABLE_FINISH_VARIANTS.reduce((acc, finish) => {
+  if (finish?.swatches?.length) {
+    acc[finish.id] = finish.swatches;
+  }
+  return acc;
+}, {});
+
 const OPTION_SWATCH_OVERRIDES = {
   ...POOL_CLOTH_SWATCHES,
-  peelingPaintWeathered: ['#a89f95', '#b8b3aa'],
-  oakVeneer01: ['#b9854e', '#c89a64'],
-  woodTable001: ['#8f6243', '#a4724f'],
-  darkWood: ['#2f241f', '#3d2f2a'],
-  rosewoodVeneer01: ['#5b2f26', '#6f3a2f'],
+  ...POOL_FINISH_SWATCHES,
   gold: ['#f59e0b', '#fbbf24'],
   chrome: ['#e5e7eb', '#a1a1aa'],
   pearl: ['#f5f3ff', '#e2e8f0'],

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -30,7 +30,7 @@ const tileableNoise = (x, y, width, height, scale, seed = 1) => {
   return (nx + ny + nxy + 3) / 6; // normalize to [0,1]
 };
 
-const WOOD_TEXTURE_ANISOTROPY = 12;
+const WOOD_TEXTURE_ANISOTROPY = 24;
 
 const woodTextureLoader = new THREE.TextureLoader();
 woodTextureLoader.setCrossOrigin?.('anonymous');
@@ -301,11 +301,11 @@ export const WOOD_FINISH_PRESETS = Object.freeze([
 const LARGE_SLAB_REPEAT_X = 0.009;
 const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const polyHavenTextureSet = (assetId) => {
-  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${assetId}/${assetId}`;
+  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/${assetId}/${assetId}`;
   return {
-    mapUrl: `${base}_diff_2k.jpg`,
-    roughnessMapUrl: `${base}_rough_2k.jpg`,
-    normalMapUrl: `${base}_nor_gl_2k.jpg`
+    mapUrl: `${base}_diff_4k.jpg`,
+    roughnessMapUrl: `${base}_rough_4k.jpg`,
+    normalMapUrl: `${base}_nor_gl_4k.jpg`
   };
 };
 
@@ -347,13 +347,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_peeling_paint_weathered')
     }
   }),
@@ -364,13 +364,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('oak_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('oak_veneer_01')
     }
   }),
@@ -381,13 +381,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_table_001')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('wood_table_001')
     }
   }),
@@ -398,13 +398,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('dark_wood')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('dark_wood')
     }
   }),
@@ -415,13 +415,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     rail: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
       repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
+      textureSize: 4096,
       ...polyHavenTextureSet('rosewood_veneer_01')
     }
   }),


### PR DESCRIPTION
## Summary
- preserve Poly Haven texture sharpness for wood and cloth assets and replace the skirt with a rail-aligned frame wrap
- add twenty single-color table finish variants (removing rose veneer) and wire them through defaults, store items, and swatches
- reuse Chess Battle Royale GLTF bishop/rook pieces for table legs with asynchronous base rebuilds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958b2576f848329a8453736e15da106)