### PR TITLE
Add PWA glTF prefetching for games

### DIFF
--- a/webapp/public/pwa/gltf-manifest.json
+++ b/webapp/public/pwa/gltf-manifest.json
@@ -1,0 +1,22 @@
+[
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf",
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf",
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb",
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb",
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb",
+  "https://fastly.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb",
+  "https://raw.githubusercontent.com/cx20/gltf-test/master/sampleModels/Chess/glTF-Binary/Chess.glb",
+  "https://cdn.jsdelivr.net/gh/cx20/gltf-test@master/sampleModels/Chess/glTF-Binary/Chess.glb",
+  "https://raw.githubusercontent.com/quaterniusdev/ChessSet/master/Source/GLTF/ChessSet.glb",
+  "https://cdn.jsdelivr.net/gh/quaterniusdev/ChessSet@master/Source/GLTF/ChessSet.glb",
+  "https://raw.githubusercontent.com/KenneyNL/boardgame-kit/main/Models/GLTF/boardgame-kit.glb",
+  "https://cdn.jsdelivr.net/gh/KenneyNL/boardgame-kit@main/Models/GLTF/boardgame-kit.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Binary/Lantern.glb",
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/Lantern/glTF-Binary/Lantern.glb"
+]

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import GamesHallway from '../components/GamesHallway.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
+import { refreshGameCachesInBackground } from '../pwa/preloadGames.js';
 
 export default function Games() {
   useTelegramBackButton();
+  useEffect(() => {
+    refreshGameCachesInBackground();
+  }, []);
   const [showHallway, setShowHallway] = useState(false);
   return (
     <div className="relative space-y-4 text-text">

--- a/webapp/src/pwa/gltfManifest.js
+++ b/webapp/src/pwa/gltfManifest.js
@@ -1,0 +1,28 @@
+const GLTF_MANIFEST_PATH = '/pwa/gltf-manifest.json';
+
+let gltfManifestPromise = null;
+
+const normalizeManifest = (assets = []) =>
+  Array.from(new Set(assets.filter(Boolean))).map((asset) => asset.trim());
+
+export async function loadGltfManifest() {
+  if (gltfManifestPromise) return gltfManifestPromise;
+
+  gltfManifestPromise = (async () => {
+    const response = await fetch(GLTF_MANIFEST_PATH, { cache: 'reload' });
+    if (!response.ok) throw new Error('Unable to load GLTF manifest');
+
+    const assets = await response.json();
+    if (!Array.isArray(assets)) throw new Error('Invalid GLTF manifest format');
+
+    return normalizeManifest(assets);
+  })();
+
+  gltfManifestPromise.catch(() => {
+    gltfManifestPromise = null;
+  });
+
+  return gltfManifestPromise;
+}
+
+export { GLTF_MANIFEST_PATH };

--- a/webapp/src/pwa/preloadGames.js
+++ b/webapp/src/pwa/preloadGames.js
@@ -1,4 +1,6 @@
-const RUNTIME_CACHE_NAME = 'tonplaygram-runtime-v3';
+import { loadGltfManifest } from './gltfManifest.js';
+
+const RUNTIME_CACHE_NAME = 'tonplaygram-runtime-v4';
 
 const GAME_ENTRYPOINTS = [
   '/goal-rush.html',
@@ -21,30 +23,76 @@ const runWhenIdle = cb => {
   return setTimeout(cb, 500);
 };
 
-export function warmGameCaches() {
-  if (!('caches' in window) || !('serviceWorker' in navigator)) return;
+const createRequest = (asset, { forceReload = false } = {}) => {
+  const init = { cache: forceReload ? 'reload' : 'default' };
+  if (/^https?:\/\//.test(asset)) {
+    init.mode = 'cors';
+    init.credentials = 'omit';
+  }
+  return new Request(asset, init);
+};
 
-  runWhenIdle(async () => {
+const prefetchIntoCache = async (cache, assets = [], { forceReload = false } = {}) => {
+  const uniqueAssets = Array.from(new Set(assets));
+  await Promise.all(
+    uniqueAssets.map(async asset => {
+      try {
+        const request = createRequest(asset, { forceReload });
+        const response = await fetch(request);
+        if (response.ok) {
+          await cache.put(request, response.clone());
+        }
+      } catch (err) {
+        console.warn('Skipping prefetch for', asset, err);
+      }
+    })
+  );
+};
+
+export function warmGameCaches({ forceReload = false, immediate = false } = {}) {
+  if (!('caches' in window) || !('serviceWorker' in navigator)) return null;
+
+  const performWarmup = async () => {
     try {
       await navigator.serviceWorker.ready;
       const cache = await caches.open(RUNTIME_CACHE_NAME);
-      await Promise.all(
-        GAME_ENTRYPOINTS.map(async asset => {
-          try {
-            const request = new Request(asset, { cache: 'reload' });
-            const response = await fetch(request);
-            if (response.ok) {
-              await cache.put(request, response.clone());
-            }
-          } catch (err) {
-            console.warn('Skipping prefetch for', asset, err);
-          }
-        })
-      );
+      await prefetchIntoCache(cache, GAME_ENTRYPOINTS, { forceReload });
+      try {
+        const gltfAssets = await loadGltfManifest();
+        await prefetchIntoCache(cache, gltfAssets, { forceReload });
+      } catch (err) {
+        console.warn('Skipping GLTF warmup', err);
+      }
     } catch (err) {
       console.warn('Skipping game warmup', err);
     }
+  };
+
+  if (immediate) {
+    return performWarmup();
+  }
+
+  runWhenIdle(() => {
+    void performWarmup();
   });
+
+  return performWarmup;
+}
+
+export async function refreshGameCachesInBackground() {
+  if (!('serviceWorker' in navigator)) return;
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    if (registration?.update) {
+      registration.update().catch(() => {});
+    }
+    registration.active?.postMessage?.({ type: 'CHECK_FOR_UPDATE' });
+  } catch (err) {
+    console.warn('Unable to force service worker update', err);
+  }
+
+  await warmGameCaches({ forceReload: true, immediate: true });
 }
 
 export { RUNTIME_CACHE_NAME };


### PR DESCRIPTION
## Summary
- add a shared glTF manifest and loader so we can prefetch open-source model sources without shipping binaries
- update the service worker to cache glTF/model requests, bump cache versions, and warm the manifest during installation
- trigger background refreshes when opening the Games page to keep assets and the worker up to date

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958bc04653c8329a87f637977ca6fbb)