### PR TITLE
Improve hallway asset prefetching

### DIFF
--- a/webapp/public/pwa/hallway-assets.json
+++ b/webapp/public/pwa/hallway-assets.json
@@ -1,0 +1,11 @@
+[
+  "https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/water.jpg",
+  "https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/checker.png",
+  "https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/wood/mahogany_diffuse.jpg",
+  "https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/metal/Brass_Albedo.jpg",
+  "https://cdn.jsdelivr.net/gh/mrdoob/three.js@r150/examples/textures/uv_grid_opengl.jpg",
+  "https://api.polyhaven.com/files/marble_01",
+  "https://api.polyhaven.com/files/potted_plant_01",
+  "https://api.polyhaven.com/files/potted_plant_02",
+  "https://api.polyhaven.com/files/potted_plant_04"
+]


### PR DESCRIPTION
## Summary
- add hallway asset manifest and prewarm logic so service worker caches hallway textures alongside game assets
- allow remote hallway asset caching with updated cache versions and install/activate warmup hooks
- trigger hallway warmup from client preload helpers and reuse shared runtime cache version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958c5e6e0588329bd338391d909829b)