### PR TITLE
Add Murlan table bases and lower chess leg supports

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -545,6 +545,24 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     name: 'Rustic Cross',
     description: 'Industrial X-trestle stance with plank stretcher.',
     swatches: ['#8b5f39', '#1f2937']
+  },
+  {
+    id: 'coffeeTable01',
+    name: 'Coffee Table 01 Base',
+    description: 'Poly Haven Coffee Table 01 from Murlan Royale sized to support the pool deck.',
+    swatches: ['#8b7355', '#d6c1a3']
+  },
+  {
+    id: 'coffeeTableRound01',
+    name: 'Coffee Table Round 01 Base',
+    description: 'Rounded Poly Haven coffee table legs tucked beneath the pool table.',
+    swatches: ['#c5a47e', '#7a5534']
+  },
+  {
+    id: 'gothicCoffeeTable',
+    name: 'Gothic Coffee Table Base',
+    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
+    swatches: ['#8f4a2b', '#3b2a1f']
   }
 ]);
 


### PR DESCRIPTION
## Summary
- shorten the Chess Battle Royale bishop and castle-style bases so their tops tuck under the pool frame without raising the ground
- add Coffee Table 01, Coffee Table Round 01, and Gothic Coffee Table bases from the Murlan Royale set, loading the Poly Haven assets and fitting them under the pool table deck

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cee9957c8329979fd79edea3f9ae)