### PR TITLE
Add Murlan Royale tables as Pool Royale bases

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -501,6 +501,48 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     name: 'Gothic Coffee Table Base',
     description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
     swatches: ['#8f4a2b', '#3b2a1f']
+  },
+  {
+    id: 'murlanDefaultTable',
+    name: 'Murlan Default Table Base',
+    description: 'Scaled version of the Murlan Royale default table supporting the pool deck.',
+    swatches: ['#9b7350', '#d7b594']
+  },
+  {
+    id: 'woodenTable02',
+    name: 'Wooden Table 02 Base',
+    description: 'Poly Haven Wooden Table 02 adapted to the Pool Royale frame proportions.',
+    swatches: ['#7d5a3c', '#c7a27d']
+  },
+  {
+    id: 'chineseTeaTable',
+    name: 'Chinese Tea Table Base',
+    description: 'Low-profile Chinese tea table from Murlan Royale fitted beneath the pool table.',
+    swatches: ['#70452f', '#d1a573']
+  },
+  {
+    id: 'woodenTable02Alt',
+    name: 'Wooden Table 02 Alt Base',
+    description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
+    swatches: ['#6f5140', '#caa07a']
+  },
+  {
+    id: 'sideTableTall01',
+    name: 'Side Table Tall 01 Base',
+    description: 'Extended tall side table scaled to lift the pool platform.',
+    swatches: ['#5b4634', '#b68a64']
+  },
+  {
+    id: 'roundWoodenTable01',
+    name: 'Round Wooden Table 01 Base',
+    description: 'Circular wooden base with generous footprint for the pool layout.',
+    swatches: ['#805b3a', '#c99f72']
+  },
+  {
+    id: 'modernCoffeeTable02',
+    name: 'Modern Coffee Table 02 Base',
+    description: 'Modern coffee table form-factor re-used as a contemporary pool base.',
+    swatches: ['#3f3f3f', '#b0a08b']
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9172,6 +9172,60 @@ function Table3D(
       topInsetScale: 0.98,
       materialKey: 'rail',
       matchTableFootprint: true
+    }),
+    murlanDefaultTable: createPolyhavenTableBaseBuilder('WoodenTable_01', {
+      footprintScale: 1.06,
+      footprintDepthScale: 1.08,
+      heightFill: 0.9,
+      topInsetScale: 0.96,
+      materialKey: 'rail',
+      matchTableFootprint: true
+    }),
+    woodenTable02: createPolyhavenTableBaseBuilder('WoodenTable_02', {
+      footprintScale: 1.05,
+      footprintDepthScale: 1.08,
+      heightFill: 0.92,
+      topInsetScale: 0.95,
+      materialKey: 'rail',
+      matchTableFootprint: true
+    }),
+    chineseTeaTable: createPolyhavenTableBaseBuilder('chinese_tea_table', {
+      footprintScale: 1.12,
+      footprintDepthScale: 1.08,
+      heightFill: 0.86,
+      topInsetScale: 0.92,
+      materialKey: 'rail'
+    }),
+    woodenTable02Alt: createPolyhavenTableBaseBuilder('wooden_table_02', {
+      footprintScale: 1.06,
+      footprintDepthScale: 1.1,
+      heightFill: 0.9,
+      topInsetScale: 0.95,
+      materialKey: 'rail',
+      matchTableFootprint: true
+    }),
+    sideTableTall01: createPolyhavenTableBaseBuilder('side_table_tall_01', {
+      footprintScale: 1.28,
+      footprintDepthScale: 1.22,
+      heightFill: 0.94,
+      topInsetScale: 0.9,
+      materialKey: 'rail',
+      matchTableFootprint: true
+    }),
+    roundWoodenTable01: createPolyhavenTableBaseBuilder('round_wooden_table_01', {
+      footprintScale: 1.18,
+      footprintDepthScale: 1.18,
+      heightFill: 0.88,
+      topInsetScale: 0.9,
+      materialKey: 'trim'
+    }),
+    modernCoffeeTable02: createPolyhavenTableBaseBuilder('modern_coffee_table_02', {
+      footprintScale: 1.07,
+      footprintDepthScale: 1.1,
+      heightFill: 0.86,
+      topInsetScale: 0.94,
+      materialKey: 'rail',
+      matchTableFootprint: true
     })
   };
 


### PR DESCRIPTION
## Summary
- add Murlan Royale table bases to the Pool Royale inventory and store
- wire new Poly Haven base builders sized to the pool table footprint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958fa131a088329a894d6781a0161b1)