### PR TITLE
Tune Pool Royale finishes and bases

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -527,22 +527,10 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     swatches: ['#6f5140', '#caa07a']
   },
   {
-    id: 'sideTableTall01',
-    name: 'Side Table Tall 01 Base',
-    description: 'Extended tall side table scaled to lift the pool platform.',
-    swatches: ['#5b4634', '#b68a64']
-  },
-  {
     id: 'roundWoodenTable01',
     name: 'Round Wooden Table 01 Base',
     description: 'Circular wooden base with generous footprint for the pool layout.',
     swatches: ['#805b3a', '#c99f72']
-  },
-  {
-    id: 'modernCoffeeTable02',
-    name: 'Modern Coffee Table 02 Base',
-    description: 'Modern coffee table form-factor re-used as a contemporary pool base.',
-    swatches: ['#3f3f3f', '#b0a08b']
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2205,54 +2205,54 @@ const TABLE_FINISHES = Object.freeze({
   rosewoodVeneer01: createStandardWoodFinish({
     id: 'rosewoodVeneer01',
     label: 'Rosewood Veneer 01',
-    rail: 0x6f3a2f,
-    base: 0x5b2f26,
-    trim: 0x9b5a44,
+    rail: 0x7c402f,
+    base: 0x643127,
+    trim: 0xa56146,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
   rosewoodVeneerAmber: createStandardWoodFinish({
     id: 'rosewoodVeneerAmber',
     label: 'Rosewood Veneer Amber',
-    rail: 0x8b4a2f,
-    base: 0x733b26,
-    trim: 0xbf6f4a,
+    rail: 0x9f5b33,
+    base: 0x834829,
+    trim: 0xd68545,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
   rosewoodVeneerWalnut: createStandardWoodFinish({
     id: 'rosewoodVeneerWalnut',
     label: 'Rosewood Veneer Walnut',
-    rail: 0x5a372a,
-    base: 0x452a20,
-    trim: 0x7c503b,
+    rail: 0x5e3f2d,
+    base: 0x493125,
+    trim: 0x875d42,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
   rosewoodVeneerEbony: createStandardWoodFinish({
     id: 'rosewoodVeneerEbony',
     label: 'Rosewood Veneer Ebony',
-    rail: 0x2a1c18,
-    base: 0x1f1512,
-    trim: 0x4b3329,
+    rail: 0x2c1d18,
+    base: 0x1f1411,
+    trim: 0x51362c,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
   rosewoodVeneerHoney: createStandardWoodFinish({
     id: 'rosewoodVeneerHoney',
     label: 'Rosewood Veneer Honey',
-    rail: 0xb36b3f,
-    base: 0x945732,
-    trim: 0xcf8a56,
+    rail: 0xc67d3b,
+    base: 0xa2652f,
+    trim: 0xe3a65c,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
   rosewoodVeneerAsh: createStandardWoodFinish({
     id: 'rosewoodVeneerAsh',
     label: 'Rosewood Veneer Ash',
-    rail: 0x7a5c4d,
-    base: 0x5f463a,
-    trim: 0x9a7b67,
+    rail: 0x8b7769,
+    base: 0x6f5a4e,
+    trim: 0xb19b89,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   })
@@ -9174,16 +9174,16 @@ function Table3D(
       matchTableFootprint: true
     }),
     murlanDefaultTable: createPolyhavenTableBaseBuilder('WoodenTable_01', {
-      footprintScale: 1.06,
-      footprintDepthScale: 1.08,
+      footprintScale: 0.98,
+      footprintDepthScale: 1.02,
       heightFill: 0.9,
       topInsetScale: 0.96,
       materialKey: 'rail',
       matchTableFootprint: true
     }),
     woodenTable02: createPolyhavenTableBaseBuilder('WoodenTable_02', {
-      footprintScale: 1.05,
-      footprintDepthScale: 1.08,
+      footprintScale: 0.98,
+      footprintDepthScale: 1,
       heightFill: 0.92,
       topInsetScale: 0.95,
       materialKey: 'rail',
@@ -9197,35 +9197,19 @@ function Table3D(
       materialKey: 'rail'
     }),
     woodenTable02Alt: createPolyhavenTableBaseBuilder('wooden_table_02', {
-      footprintScale: 1.06,
-      footprintDepthScale: 1.1,
+      footprintScale: 0.98,
+      footprintDepthScale: 1,
       heightFill: 0.9,
       topInsetScale: 0.95,
       materialKey: 'rail',
       matchTableFootprint: true
     }),
-    sideTableTall01: createPolyhavenTableBaseBuilder('side_table_tall_01', {
-      footprintScale: 1.28,
-      footprintDepthScale: 1.22,
-      heightFill: 0.94,
-      topInsetScale: 0.9,
-      materialKey: 'rail',
-      matchTableFootprint: true
-    }),
     roundWoodenTable01: createPolyhavenTableBaseBuilder('round_wooden_table_01', {
-      footprintScale: 1.18,
-      footprintDepthScale: 1.18,
+      footprintScale: 1.08,
+      footprintDepthScale: 1.08,
       heightFill: 0.88,
       topInsetScale: 0.9,
       materialKey: 'trim'
-    }),
-    modernCoffeeTable02: createPolyhavenTableBaseBuilder('modern_coffee_table_02', {
-      footprintScale: 1.07,
-      footprintDepthScale: 1.1,
-      heightFill: 0.86,
-      topInsetScale: 0.94,
-      materialKey: 'rail',
-      matchTableFootprint: true
     })
   };
 


### PR DESCRIPTION
## Summary
- Adjusted rosewood veneer finish palettes to give each variant a distinct color tone while keeping the shared texture
- Removed unused Pool Royale base variants and tightened base footprints to shrink specific tables without altering their heights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959016bbc748329bed8124ebb14c03f)