### PR TITLE
Refine Pool Royale camera and cue strike handling

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -9,6 +9,8 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
+      onStart,
+      onRelease,
       theme = 'default',
       labels = false
     } = opts;
@@ -21,6 +23,8 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
+    this.onStart = onStart;
+    this.onRelease = onRelease;
     this.locked = false;
 
     this.el = document.createElement('div');
@@ -202,6 +206,7 @@ export class PowerSlider {
   _pointerDown(e) {
     if (this.locked) return;
     e.preventDefault();
+    if (typeof this.onStart === 'function') this.onStart();
     this.dragging = true;
     this.dragMoved = false;
     this.dragStartValue = this.value;
@@ -227,6 +232,7 @@ export class PowerSlider {
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
+    if (typeof this.onRelease === 'function') this.onRelease(this.value);
     const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
     if (!moved) {
       this.set(this.dragStartValue, { animate: true });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1230,6 +1230,11 @@ const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
+const SHOT_LINEAR_SPEED_MAX = SHOT_BASE_SPEED * 1.45; // peak linear launch speed at full power
+const SHOT_ANGULAR_SPEED_MAX = 140; // rad/s equivalent for the simplified spin vector system
+const SHOT_SPIN_TORQUE_SCALE = BALL_R * 18; // how strongly the contact offset converts to spin
+const SHOT_SPIN_SIDE_SCALE = BALL_R * 0.95;
+const SHOT_SPIN_VERTICAL_SCALE = BALL_R * 0.95;
 const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
 const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
@@ -4991,18 +4996,18 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.12;
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.04;
-const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI + 0.02, CAMERA.minPhi * 0.55);
-const TOP_VIEW_RADIUS_SCALE = 1.06;
+const TOP_VIEW_MARGIN = 1.14;
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const TOP_VIEW_PHI = CAMERA_ABS_MIN_PHI; // keep the 2D view level (no downward tilt)
+const TOP_VIEW_RADIUS_SCALE = 1.12; // lift slightly to keep both near pockets visible on portrait
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: 0, // center the table for the classic top-down framing
-  z: 0 // keep the 2D view aligned with the original overhead composition
+  z: BALL_R * 0.35 // nudge upward on screen to expose the lower rail pockets fully
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
-const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI + 0.12;
+const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI + 0.08;
 const BROADCAST_MARGIN_WIDTH = (PLAY_W / 2) * (TOP_VIEW_MARGIN - 1);
 const BROADCAST_MARGIN_LENGTH = (PLAY_H / 2) * (TOP_VIEW_MARGIN - 1);
 const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) => {
@@ -5217,6 +5222,7 @@ const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
 const TMP_VEC3_TOP_VIEW = new THREE.Vector3();
 const TMP_VEC3_CAM_DIR = new THREE.Vector3();
 const TMP_VEC3_CUE_DIR = new THREE.Vector3();
+const TMP_VEC3_TORQUE = new THREE.Vector3();
 const CORNER_SIGNS = [
   { sx: -1, sy: -1 },
   { sx: 1, sy: -1 },
@@ -5251,7 +5257,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
-const SPIN_INPUT_DEAD_ZONE = 0.06;
+const SPIN_UI_RADIUS = 0.85;
+const SPIN_INPUT_DEAD_ZONE = 0.05;
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
 
 const clampToUnitCircle = (x, y) => {
@@ -10849,6 +10856,7 @@ const [hud, setHud] = useState({
   inHand: initialHudInHand,
   over: false
 });
+const [shotPhase, setShotPhase] = useState('AIMING'); // AIMING -> CHARGING -> STRIKING -> BALLS_MOVING
 const [turnCycle, setTurnCycle] = useState(0);
 const [pottedBySeat, setPottedBySeat] = useState({ A: [], B: [] });
 const lastPottedBySeatRef = useRef({ A: null, B: null });
@@ -12232,6 +12240,7 @@ const powerRef = useRef(hud.power);
         if (shooting === value) return;
         shooting = value;
         shotStartedAt = shooting ? getNow() : 0;
+        setShotPhase(value ? 'BALLS_MOVING' : 'AIMING');
         if (!shooting) {
           maxPowerLiftTriggered = false;
         }
@@ -18481,6 +18490,7 @@ const powerRef = useRef(hud.power);
           setHud((prev) => ({ ...prev, inHand: false }));
         }
         const shotStartTime = performance.now();
+        setShotPhase('STRIKING');
         const forcedCueView = aiShotCueViewRef.current;
         setAiShotCueViewActive(false);
         setAiShotPreviewActive(false);
@@ -18722,26 +18732,42 @@ const powerRef = useRef(hud.power);
           }
           const appliedSpin = applySpinConstraints(aimDir, true);
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = powerScale;
-          const baseSide = appliedSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = -appliedSpin.y * (ranges.forward ?? 0) * powerSpinScale;
-          if (appliedSpin.y > 0) {
-            spinTop *= BACKSPIN_MULTIPLIER;
-          } else if (appliedSpin.y < 0) {
-            spinTop *= TOPSPIN_MULTIPLIER;
-          }
           const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(
-              perp.x * spinSide + aimDir.x * spinTop,
-              perp.y * spinSide + aimDir.y * spinTop
+          const contactOffset = perp
+            .clone()
+            .multiplyScalar((appliedSpin.x || 0) * SHOT_SPIN_SIDE_SCALE)
+            .add(
+              aimDir
+                .clone()
+                .multiplyScalar(-(appliedSpin.y || 0) * SHOT_SPIN_VERTICAL_SCALE)
             );
+          const impulseMag = clampedPower * SHOT_LINEAR_SPEED_MAX;
+          const spinBudget = Math.hypot(appliedSpin.x || 0, appliedSpin.y || 0);
+          const energyBudget = 1 - Math.min(0.35, spinBudget * 0.28);
+          const impulseVec2 = aimDir.clone().multiplyScalar(impulseMag * energyBudget);
+          cue.vel.copy(impulseVec2);
+          const impulse3 = new THREE.Vector3(impulseVec2.x, 0, impulseVec2.y);
+          const contact3 = new THREE.Vector3(contactOffset.x, 0, contactOffset.y);
+          TMP_VEC3_TORQUE.crossVectors(contact3, impulse3);
+          const torqueMag = THREE.MathUtils.clamp(
+            TMP_VEC3_TORQUE.length() * SHOT_SPIN_TORQUE_SCALE,
+            0,
+            SHOT_ANGULAR_SPEED_MAX
+          );
+          const angularDir = perp
+            .clone()
+            .multiplyScalar(appliedSpin.x || 0)
+            .add(aimDir.clone().multiplyScalar(-(appliedSpin.y || 0)));
+          if (angularDir.lengthSq() > 1e-8) angularDir.normalize();
+          const spinStrength = torqueMag;
+          if (cue.spin) {
+            cue.spin.copy(angularDir.multiplyScalar(spinStrength));
           }
           if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
           cue.spinMode =
-            spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
+            spinAppliedRef.current?.mode === 'swerve' && spinBudget >= SWERVE_THRESHOLD
+              ? 'swerve'
+              : 'standard';
           resetSpinRef.current?.();
           cue.impacted = false;
           cue.launchDir = aimDir.clone().normalize();
@@ -22415,8 +22441,15 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onStart: () => setShotPhase('CHARGING'),
+      onRelease: () => {
+        if (!shootingRef.current) {
+          setShotPhase('AIMING');
+        }
+      },
       onChange: (v) => applyPower(v / 100),
       onCommit: () => {
+        setShotPhase('STRIKING');
         fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
@@ -22430,7 +22463,7 @@ const powerRef = useRef(hud.power);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, showPowerSlider]);
+  }, [applyPower, applySliderLock, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;
@@ -22446,7 +22479,10 @@ const powerRef = useRef(hud.power);
   const isOpponentTurn = hud.turn === 1;
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
   const showSpinController =
-    !hud.over && !replayActive && (isPlayerTurn || aiTakingShot);
+    !hud.over &&
+    !replayActive &&
+    (isPlayerTurn || aiTakingShot) &&
+    (shotPhase === 'AIMING' || shotPhase === 'CHARGING');
 
   // Spin controller interactions
   useEffect(() => {
@@ -22479,8 +22515,20 @@ const powerRef = useRef(hud.power);
       };
     };
 
+    const normalizeSpinInput = (nx, ny) => {
+      const rawX = clamp(nx, -SPIN_UI_RADIUS, SPIN_UI_RADIUS);
+      const rawY = clamp(ny, -SPIN_UI_RADIUS, SPIN_UI_RADIUS);
+      const mag = Math.hypot(rawX, rawY);
+      if (mag < SPIN_INPUT_DEAD_ZONE) return { x: 0, y: 0 };
+      const scale = SPIN_UI_RADIUS > 1e-6 ? 1 / SPIN_UI_RADIUS : 1;
+      return {
+        x: clamp(rawX * scale, -1, 1),
+        y: clamp(rawY * scale, -1, 1)
+      };
+    };
+
     const setSpin = (nx, ny) => {
-      const normalized = clampToUnitCircle(nx, ny);
+      const normalized = normalizeSpinInput(nx, ny);
       spinRequestRef.current = normalized;
       const limited = clampToLimits(normalized.x, normalized.y);
       spinRef.current = limited;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -429,13 +429,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Rosewood Veneer 01',
     source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
     rail: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.65, y: 0.65 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.65, y: 0.65 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')


### PR DESCRIPTION
## Summary
- flatten and raise the 2D/top view framing to keep all pockets visible
- enlarge the Rosewood Veneer 01 wood grain repeat for a bolder pattern
- introduce an explicit AIMING→CHARGING→STRIKING→BALLS_MOVING shot state, with pull-and-release power, spin UI deadzone, and impulse/torque-based cueball launch

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591fe8dbd88329b13e713626f6c4ca)