### PR TITLE
Refine Pool Royale camera and shot handling

### DIFF
--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -429,13 +429,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Rosewood Veneer 01',
     source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
     rail: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.7, y: 0.7 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.7, y: 0.7 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')


### PR DESCRIPTION
## Summary
- Flatten the 2D/top-down camera angle and raise framing so all pockets stay visible while preserving portrait composition.
- Add configurable shot physics constants, pull/release state handling, and spin UI deadzone/radius clamping to keep spin and power application stable.
- Upscale the Rosewood Veneer 01 wood grain repeat to make the pattern read larger on rails and frame.

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591fe8dbd88329b13e713626f6c4ca)