### PR TITLE
Refine Pool Royale camera, shot controls, and textures

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -10,7 +10,9 @@ export class PowerSlider {
       onChange,
       onCommit,
       theme = 'default',
-      labels = false
+      labels = false,
+      onStart,
+      onEnd
     } = opts;
 
     if (!mount) throw new Error('mount required');
@@ -21,6 +23,8 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
+    this.onStart = onStart;
+    this.onEnd = onEnd;
     this.locked = false;
 
     this.el = document.createElement('div');
@@ -202,6 +206,9 @@ export class PowerSlider {
   _pointerDown(e) {
     if (this.locked) return;
     e.preventDefault();
+    if (typeof this.onStart === 'function') {
+      this.onStart(this.value);
+    }
     this.dragging = true;
     this.dragMoved = false;
     this.dragStartValue = this.value;
@@ -228,11 +235,12 @@ export class PowerSlider {
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
+    const committed = moved;
     if (!moved) {
       this.set(this.dragStartValue, { animate: true });
-      return;
     }
-    if (typeof this.onCommit === 'function') this.onCommit(this.value);
+    if (typeof this.onEnd === 'function') this.onEnd({ value: this.value, committed });
+    if (committed && typeof this.onCommit === 'function') this.onCommit(this.value);
   }
 
   _wheel(e) {

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -429,13 +429,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Rosewood Veneer 01',
     source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
     rail: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.7, y: 0.7 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.7, y: 0.7 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')


### PR DESCRIPTION
## Summary
- flatten and lift the 2D top view camera to keep all pockets visible
- add a configurable shot impulse/torque model with explicit AIMING→CHARGING→STRIKING→BALLS_MOVING state handling tied to the pull-and-release slider and spin UI
- enlarge the Rosewood Veneer 01 rail/frame texture tiling to make the pattern read bigger

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591fe8dbd88329b13e713626f6c4ca)