### PR TITLE
Refine cue hit audio timing and rail rounding

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1100,7 +1100,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops furthe
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep the exterior wooden rails straight with no rounding
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.12; // round the exterior wooden rails while leaving the playfield-facing edges crisp
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_ANIMATION_MS = 420;
@@ -11276,6 +11276,8 @@ const powerRef = useRef(hud.power);
   const volumeRef = useRef(getGameVolume());
   const railSoundTimeRef = useRef(new Map());
   const liftLandingTimeRef = useRef(new Map());
+  const cueStrikePendingRef = useRef(false);
+  const cueStrikeVolumeRef = useRef(0);
   const powerImpactHoldRef = useRef(0);
   const [player, setPlayer] = useState({ name: '', avatar: '' });
   const playerInfoRef = useRef(player);
@@ -11334,7 +11336,9 @@ const powerRef = useRef(hud.power);
     const buffer = audioBuffersRef.current.cue;
     if (!ctx || !buffer || muteRef.current) return;
     const power = clamp(vol, 0, 1);
-    const scaled = clamp(volumeRef.current * 1.2 * 1.5 * (0.35 + power * 0.75), 0, 1);
+    const baseVolume = volumeRef.current * 1.2 * 1.5 * (0.35 + power * 0.75);
+    const boosted = baseVolume * 1.5;
+    const scaled = clamp(boosted, 0, 1.5);
     if (scaled <= 0 || !Number.isFinite(buffer.duration)) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
@@ -12233,6 +12237,8 @@ const powerRef = useRef(hud.power);
         shooting = value;
         shotStartedAt = shooting ? getNow() : 0;
         if (!shooting) {
+          cueStrikePendingRef.current = false;
+          cueStrikeVolumeRef.current = 0;
           maxPowerLiftTriggered = false;
         }
         if (shotCameraHoldTimeoutRef.current) {
@@ -18582,7 +18588,8 @@ const powerRef = useRef(hud.power);
           const shouldRecordReplay = true;
           const preferZoomReplay =
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
-          playCueHit(clampedPower * 0.6);
+          cueStrikePendingRef.current = true;
+          cueStrikeVolumeRef.current = Math.max(0, clampedPower * 0.6);
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
@@ -21442,6 +21449,15 @@ const powerRef = useRef(hud.power);
             const isCue = b.id === 'cue';
             const hasSpin = b.spin?.lengthSq() > 1e-6;
             const hasLift = (b.lift ?? 0) > 1e-6 || Math.abs(b.liftVel ?? 0) > 1e-6;
+            if (
+              shooting &&
+              cueStrikePendingRef.current &&
+              isCue &&
+              b.vel.lengthSq() > STOP_EPS * STOP_EPS
+            ) {
+              playCueHit(Math.max(0, cueStrikeVolumeRef.current ?? 0));
+              cueStrikePendingRef.current = false;
+            }
             if (hasLift) {
               const dampedVel = (b.liftVel ?? 0) * Math.pow(MAX_POWER_BOUNCE_DAMPING, stepScale);
               const nextLift = Math.max(0, (b.lift ?? 0) + dampedVel * stepScale);


### PR DESCRIPTION
## Summary
- boost the cue strike audio mix and trigger it when the cue ball actually starts moving
- round the outer edges of the wooden rails to match the frame rounding without touching the playfield side

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695935be5a548329bec7eac8a00e31a7)