### PR TITLE
Update Pool Royale cue strike audio and jump physics

### DIFF
--- a/webapp/public/pwa/offline-assets.json
+++ b/webapp/public/pwa/offline-assets.json
@@ -163,7 +163,7 @@
   "/assets/sounds/Ancient_Egyptian_Music__The_Nile_River.mp3",
   "/assets/sounds/Callraischip.mp3",
   "/assets/sounds/Chinese_Gong_Meme_Sound_Effect.mp3",
-  "/assets/sounds/Control_the_Cue_Ball_Control_the_Black_snooker_billiard_tipsandtrick.mp3",
+  "/assets/sounds/Trim_Control_the_Cue_Ball_Control_the_Black_snooker_billiard_tipsandtrick_1.mp3",
   "/assets/sounds/EnglandLeader.mp3",
   "/assets/sounds/FranceLeader.mp3",
   "/assets/sounds/Haha.mp3",


### PR DESCRIPTION
## Summary
- replace the cue strike sound with the trimmed asset and boost playback while keeping cushions silent
- refresh offline asset caching to cover the new cue sound
- increase max-power lift strength and let spin-driven jumps carry more height and sideways drift

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594efa02448329b66a361bb01b6663)