### PR TITLE
Boost cue strike audio and raise top view camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1237,6 +1237,7 @@ const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
 const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
+const CUE_STRIKE_VOLUME_MULTIPLIER = 1.5; // set cue strikes to 150% loudness for clearer feedback
 const POCKET_SOUND_TAIL = 1;
 // Pool Royale now raises the stance; extend the legs so the playfield sits higher
 const LEG_SCALE = 6.2;
@@ -4997,7 +4998,7 @@ const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
 const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
-const TOP_VIEW_RADIUS_SCALE = 1.14; // lift the 2D top view a bit higher to keep the full field comfortably in frame
+const TOP_VIEW_RADIUS_SCALE = 1.18; // lift the 2D top view a touch higher to keep the full field comfortably in frame
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: 0, // center the table for the classic top-down framing
@@ -11341,7 +11342,8 @@ const powerRef = useRef(hud.power);
       volumeRef.current *
       1.2 *
       1.5 *
-      1.5 * // boost cue strike loudness by 50%
+      1.5 *
+      CUE_STRIKE_VOLUME_MULTIPLIER * // set cue strike playback to 150% for a crisper hit
       (0.35 + power * 0.75);
     const scaled = clamp(baseGain, 0, 3);
     if (scaled <= 0 || !Number.isFinite(buffer.duration)) return;


### PR DESCRIPTION
## Summary
- set cue strike playback gain to 150% for clearer impact feedback
- slightly raise the 2D top view camera height to give a roomier overhead framing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595c0bb5e08329a14ef6400f4c20e8)