### PR TITLE
Boost cue strike audio and raise 2D camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1237,7 +1237,8 @@ const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
 const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
-const CUE_STRIKE_VOLUME_MULTIPLIER = 2; // set cue strikes to 200% loudness for clearer feedback
+const CUE_STRIKE_VOLUME_MULTIPLIER = 3; // boost cue strikes to 300% loudness to compensate for the quieter recording
+const CUE_STRIKE_MAX_GAIN = 9; // allow the louder cue strike to pass through without clipping to the previous 3x cap
 const POCKET_SOUND_TAIL = 1;
 // Pool Royale now raises the stance; extend the legs so the playfield sits higher
 const LEG_SCALE = 6.2;
@@ -4998,7 +4999,7 @@ const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
 const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
-const TOP_VIEW_RADIUS_SCALE = 1.22; // lift the 2D top view a bit higher to keep the full field comfortably in frame
+const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: 0, // center the table for the classic top-down framing
@@ -11343,9 +11344,9 @@ const powerRef = useRef(hud.power);
       1.2 *
       1.5 *
       1.5 *
-      CUE_STRIKE_VOLUME_MULTIPLIER * // set cue strike playback to 150% for a crisper hit
+      CUE_STRIKE_VOLUME_MULTIPLIER * // amplify cue strike playback for a clearer hit
       (0.35 + power * 0.75);
-    const scaled = clamp(baseGain, 0, 3);
+    const scaled = clamp(baseGain, 0, CUE_STRIKE_MAX_GAIN);
     if (scaled <= 0 || !Number.isFinite(buffer.duration)) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();


### PR DESCRIPTION
## Summary
- increase Pool Royale cue strike gain to make the quieter recording audible
- lift the 2D top-down camera slightly to clear the rails in portrait

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596300d7f08329afe6e6cbc413ea4d)