### PR TITLE
Adjust Pool Royale audio cues and remove table logos

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1239,6 +1239,10 @@ const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
 const CUE_STRIKE_VOLUME_MULTIPLIER = 1.5; // boost cue strikes to 150% loudness for clearer feedback
 const CUE_STRIKE_MAX_GAIN = 9; // allow the louder cue strike to pass through without clipping to the previous cap
+const CUE_STRIKE_LEAD_SECONDS = 0.5; // trim the cue strike to start 0.5s earlier than the current onset
+const CUE_STRIKE_NOISE_HIGH_CUTOFF = 4200; // low-pass to tame hiss from the cue strike sample
+const CUE_STRIKE_NOISE_LOW_CUTOFF = 180; // high-pass to filter out low-end rumble on the cue strike
+const RAIL_LOGOS_ENABLED = false;
 const POCKET_SOUND_TAIL = 1;
 // Pool Royale now raises the stance; extend the legs so the playfield sits higher
 const LEG_SCALE = 6.2;
@@ -6312,6 +6316,7 @@ function createAccentMesh(accent, dims) {
 const TABLE_LOGO_TEXTURE_URL = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
 let cachedTableLogoTexture = null;
 function getTableLogoTexture() {
+  if (!RAIL_LOGOS_ENABLED) return null;
   if (cachedTableLogoTexture) return cachedTableLogoTexture;
   const loader = new THREE.TextureLoader();
   loader.setCrossOrigin?.('anonymous');
@@ -6340,6 +6345,7 @@ function applyLogoMaterialStyling(material, railMat) {
 }
 
 function ensureRailLogoMaterial(finishParts, railMat) {
+  if (!RAIL_LOGOS_ENABLED) return null;
   if (!finishParts) return null;
   const logoTexture = getTableLogoTexture();
   if (!logoTexture) return null;
@@ -6363,6 +6369,7 @@ function ensureRailLogoMaterial(finishParts, railMat) {
 }
 
 function addRailLogosToTable(targetGroup, finishParts, railMat, options = {}) {
+  if (!RAIL_LOGOS_ENABLED) return;
   if (!targetGroup || !finishParts?.dimensions) return;
   if (!Array.isArray(finishParts.logoMeshes)) {
     finishParts.logoMeshes = [];
@@ -11337,7 +11344,6 @@ const powerRef = useRef(hud.power);
   const spinDotElRef = useRef(null);
   const spinSwerveHotspotRef = useRef(null);
   const spinModeUiRef = useRef('standard');
-  const lastSwerveSoundRef = useRef(0);
   const spinLegalityRef = useRef({ blocked: false, reason: '' });
   const cuePullTargetRef = useRef(0);
   const cuePullCurrentRef = useRef(0);
@@ -11470,13 +11476,22 @@ const powerRef = useRef(hud.power);
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
     source.buffer = buffer;
+    const highpass = ctx.createBiquadFilter();
+    highpass.type = 'highpass';
+    highpass.frequency.value = CUE_STRIKE_NOISE_LOW_CUTOFF;
+    const lowpass = ctx.createBiquadFilter();
+    lowpass.type = 'lowpass';
+    lowpass.frequency.value = CUE_STRIKE_NOISE_HIGH_CUTOFF;
     const gain = ctx.createGain();
     gain.gain.value = scaled;
-    source.connect(gain);
+    source.connect(highpass);
+    highpass.connect(lowpass);
+    lowpass.connect(gain);
     routeAudioNode(gain);
     const playbackDuration = Math.min(buffer.duration ?? 0, 4.5);
     if (playbackDuration > 0 && Number.isFinite(playbackDuration)) {
-      source.start(0, 0, playbackDuration);
+      const startAt = Math.max(ctx.currentTime - CUE_STRIKE_LEAD_SECONDS, 0);
+      source.start(startAt, 0, playbackDuration);
     }
   }, []);
 
@@ -22703,15 +22718,8 @@ const powerRef = useRef(hud.power);
       spinLegalityRef.current = legality;
       const magnitude = Math.hypot(limited.x ?? 0, limited.y ?? 0);
       const mode = !legality.blocked && magnitude >= SWERVE_THRESHOLD ? 'swerve' : 'standard';
-      const previousMode = spinModeUiRef.current;
       updateSpinDotPosition(limited, legality.blocked);
       if (!legality.blocked) {
-        const now = performance.now();
-        const lastPlay = lastSwerveSoundRef.current ?? 0;
-        if (mode === 'swerve' && previousMode !== 'swerve' && now - lastPlay > 220) {
-          playSwerveApply();
-          lastSwerveSoundRef.current = now;
-        }
         spinModeUiRef.current = mode;
       } else {
         spinModeUiRef.current = 'standard';


### PR DESCRIPTION
## Summary
- reduce swerve control noise by only playing the swerve sound when the shot fires
- clean up the cue strike audio with noise filters and a small lead time
- disable the engraved rail logos on the Pool Royale table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f42f85488329930103bd941f28d5)