### PR TITLE
Enable universal PWA install and add download options

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
-import { registerTelegramServiceWorker } from './pwa/registerServiceWorker.js';
+import { registerServiceWorker } from './pwa/registerServiceWorker.js';
 import { warmGameCaches } from './pwa/preloadGames.js';
 
 // Prevent Telegram in-app browser swipe-down from closing the game
@@ -10,8 +10,8 @@ if (window.Telegram?.WebApp?.disableVerticalSwipes) {
   window.Telegram.WebApp.disableVerticalSwipes();
 }
 
-// Register a Telegram-friendly service worker for instant updates
-void registerTelegramServiceWorker().finally(warmGameCaches);
+// Register a PWA-friendly service worker for instant updates
+void registerServiceWorker().finally(warmGameCaches);
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -9,7 +9,9 @@ import DailyCheckIn from '../components/DailyCheckIn.jsx';
 import {
   FaArrowUp,
   FaArrowDown,
-  FaWallet
+  FaWallet,
+  FaAndroid,
+  FaApple
 } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
@@ -47,6 +49,32 @@ export default function Home() {
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
+  const downloadButtons = useMemo(
+    () => [
+      {
+        label: 'Android APK',
+        href: `${baseUrl}tonplaygram-launcher.apk`,
+        icon: <FaAndroid className="w-5 h-5 text-primary" />,
+        description: 'Install the lightweight Android launcher to pin TonPlaygram like a native app.',
+        props: { download: true }
+      },
+      {
+        label: 'iOS PWA',
+        href: `${baseUrl}manifest.webmanifest`,
+        icon: <FaApple className="w-5 h-5 text-primary" />,
+        description: 'Open in Safari, then use Share → Add to Home Screen for an app-like experience.',
+        props: { target: '_blank', rel: 'noreferrer' }
+      },
+      {
+        label: 'Telegram mini app',
+        href: 'https://t.me/TonPlaygramBot',
+        icon: <RiTelegramFill className="w-5 h-5 text-sky-400" />,
+        description: 'Open the bot and add TonPlaygram to your Telegram menu for quick access.',
+        props: { target: '_blank', rel: 'noreferrer' }
+      }
+    ],
+    [baseUrl]
+  );
 
   const handlePwaDownload = useCallback(async (autoTriggered = false) => {
     setPwaDownloadStatus({
@@ -74,7 +102,7 @@ export default function Home() {
       setPwaDownloadStatus({
         state: 'error',
         message:
-          'Offline download is unavailable right now. Please try again from the Telegram in-app browser after reloading.'
+          'Offline download is unavailable right now. Please try again after reloading.'
       });
     }
   }, [baseUrl]);
@@ -264,6 +292,34 @@ export default function Home() {
         >
           <IoLogoTiktok className="text-pink-500 w-6 h-6" />
         </a>
+      </div>
+
+      <div className="mt-4 bg-surface border border-border rounded-xl p-4 space-y-3">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-white text-center">Download TonPlaygram anywhere</h3>
+          <p className="text-sm text-subtext text-center">
+            Choose the install path that fits your device and keep the web app pinned like Android or iOS apps.
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {downloadButtons.map(({ label, href, icon, description, props }) => (
+            <a
+              key={label}
+              href={href}
+              className="flex items-start gap-3 rounded-xl border border-border bg-background/60 px-3 py-3 text-left shadow-sm hover:border-accent/60 transition"
+              {...props}
+            >
+              <div className="mt-1">{icon}</div>
+              <div className="space-y-1">
+                <p className="text-white font-semibold leading-tight">{label}</p>
+                <p className="text-xs text-subtext leading-snug">{description}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+        <p className="text-[11px] text-subtext text-center">
+          Tip: iOS users should open in Safari, then tap Share → Add to Home Screen to keep TonPlaygram handy.
+        </p>
       </div>
 
       <div className="mt-4 bg-surface border border-border rounded-xl p-4 space-y-3">

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,14 +1,14 @@
-const TELEGRAM_ONLY = true;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
 const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
-const SERVICE_WORKER_URL = '/service-worker.js';
+const BASE_URL = (import.meta.env.BASE_URL || '/').replace(/\/+$/, '/');
+const SERVICE_WORKER_URL = `${BASE_URL}service-worker.js`;
+const SERVICE_WORKER_SCOPE = BASE_URL;
 
-function shouldRegisterForTelegram() {
+function shouldRegisterServiceWorker() {
   if (!('serviceWorker' in navigator)) return false;
   const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
-  if (isLocalhost) return true;
-  if (TELEGRAM_ONLY && !window.Telegram?.WebApp) return false;
-  return true;
+  if (!window.isSecureContext && !isLocalhost) return false;
+  return isLocalhost || window.location.protocol === 'https:';
 }
 
 function markRefreshed() {
@@ -80,13 +80,13 @@ function setupUpdatePolling(registration) {
   window.addEventListener('online', runUpdate);
 }
 
-export async function registerTelegramServiceWorker() {
-  if (!shouldRegisterForTelegram()) return;
+export async function registerServiceWorker() {
+  if (!shouldRegisterServiceWorker()) return;
 
   try {
     const hadController = Boolean(navigator.serviceWorker.controller);
     const registration = await navigator.serviceWorker.register(SERVICE_WORKER_URL, {
-      scope: '/',
+      scope: SERVICE_WORKER_SCOPE,
       updateViaCache: 'none'
     });
 


### PR DESCRIPTION
## Summary
- register the service worker for all secure contexts using the configured base URL so the PWA works outside Telegram
- add a home page download card with Android, iOS, and Telegram install links plus updated offline install guidance
- soften the offline cache error copy so non-Telegram browsers aren’t blocked by Telegram-only messaging

## Testing
- npm run build --prefix webapp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a04e9cf50832994f50103d73a4a21)