### PR TITLE
Enable cross-platform onboarding and profile lock

### DIFF
--- a/bot/utils/memoryUserStore.js
+++ b/bot/utils/memoryUserStore.js
@@ -55,3 +55,8 @@ export const ensureMemoryUser = (user) => {
   memoryUsers.set(accountId, merged);
   return memoryUsers.get(accountId);
 };
+
+export const deleteMemoryUser = (accountId) => {
+  if (!accountId) return false;
+  return memoryUsers.delete(accountId);
+};

--- a/webapp/src/components/ProfileLockOverlay.jsx
+++ b/webapp/src/components/ProfileLockOverlay.jsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+
+export default function ProfileLockOverlay({
+  locked,
+  onUnlockSecret,
+  onUnlockDevice,
+  onDisable,
+  onConfigureSecret,
+  onConfigureDevice
+}) {
+  const [mode, setMode] = useState('pin');
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  if (!locked) return null;
+
+  const submitUnlock = async (evt) => {
+    evt.preventDefault();
+    setError('');
+    const ok = await onUnlockSecret(value);
+    if (!ok) setError('That secret did not unlock your profile.');
+    setValue('');
+  };
+
+  const configure = async (evt) => {
+    evt.preventDefault();
+    setError('');
+    if (!value || value.length < 4) {
+      setError('Choose a PIN/pattern/password with at least 4 characters.');
+      return;
+    }
+    const ok = await onConfigureSecret({
+      method: mode === 'pattern' ? 'pin' : mode,
+      secret: value
+    });
+    if (ok) {
+      setValue('');
+      setError('');
+    } else {
+      setError('Could not save your lock. Try again.');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/80 backdrop-blur px-4">
+      <div className="max-w-xl w-full space-y-4 bg-surface border border-border rounded-2xl p-5 shadow-lg">
+        <h3 className="text-xl font-bold text-white text-center">Protect your profile</h3>
+        <p className="text-sm text-subtext text-center">
+          Unlock to view sensitive info, or set a stronger lock that works across browsers. Choose PIN, pattern, password,
+          or device biometrics/passkey where available.
+        </p>
+
+        <form className="space-y-3" onSubmit={submitUnlock}>
+          <label className="text-sm text-white">Enter your PIN / password</label>
+          <input
+            type="password"
+            className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Unlock secret"
+          />
+          <button type="submit" className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2">
+            Unlock
+          </button>
+        </form>
+
+        <div className="space-y-2">
+          <p className="text-sm text-white">Or use your device</p>
+          <button
+            type="button"
+            className="w-full border border-border rounded py-2 text-white"
+            onClick={onUnlockDevice}
+          >
+            Unlock with biometrics/passkey
+          </button>
+        </div>
+
+        <div className="space-y-3 border-t border-border pt-3">
+          <p className="text-sm text-white">Set or change your lock</p>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            {['pin', 'pattern', 'password'].map((option) => (
+              <button
+                type="button"
+                key={option}
+                onClick={() => setMode(option)}
+                className={`rounded border px-2 py-1 capitalize ${
+                  mode === option ? 'bg-primary text-black' : 'text-white border-border'
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={onConfigureDevice}
+              className="col-span-2 rounded border border-border px-2 py-1 text-white"
+            >
+              Use device biometrics/passkey
+            </button>
+          </div>
+          <form onSubmit={configure} className="space-y-2">
+            <input
+              type={mode === 'password' ? 'password' : 'text'}
+              className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
+              placeholder={mode === 'password' ? 'New password (min 8 chars)' : 'New PIN / pattern'}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+            <button type="submit" className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2">
+              Save lock
+            </button>
+          </form>
+        </div>
+
+        <div className="text-sm text-subtext text-center">
+          <button type="button" className="underline" onClick={onDisable}>
+            Disable profile lock
+          </button>
+        </div>
+
+        {error && <p className="text-center text-red-400 text-sm">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/hooks/useProfileLock.js
+++ b/webapp/src/hooks/useProfileLock.js
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  clearLockConfig,
+  getDeviceCredentialId,
+  isUnlocked,
+  loadLockConfig,
+  markUnlockedSession,
+  setSecretLock,
+  storeDeviceCredentialId,
+  verifySecret
+} from '../utils/profileLock.js';
+
+function bufferFromBase64url(value) {
+  const padding = '='.repeat((4 - (value.length % 4)) % 4);
+  const base64 = (value + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) view[i] = raw.charCodeAt(i);
+  return buffer;
+}
+
+function base64urlFromBuffer(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export default function useProfileLock() {
+  const [config, setConfig] = useState(() => loadLockConfig());
+  const [status, setStatus] = useState(() => (isUnlocked() || !config ? 'unlocked' : 'locked'));
+  const locked = status === 'locked';
+
+  useEffect(() => {
+    setConfig(loadLockConfig());
+    setStatus(isUnlocked() || !loadLockConfig() ? 'unlocked' : 'locked');
+  }, []);
+
+  const unlockWithSecret = useCallback(async (secret) => {
+    const ok = await verifySecret(secret);
+    if (ok) {
+      markUnlockedSession();
+      setStatus('unlocked');
+    }
+    return ok;
+  }, []);
+
+  const unlockWithDevice = useCallback(async () => {
+    const id = getDeviceCredentialId();
+    if (!id || !window.PublicKeyCredential) return false;
+    try {
+      const assertion = await navigator.credentials.get({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          allowCredentials: [{ id: bufferFromBase64url(id), type: 'public-key' }],
+          userVerification: 'preferred'
+        }
+      });
+      if (assertion) {
+        markUnlockedSession();
+        setStatus('unlocked');
+        return true;
+      }
+    } catch (err) {
+      console.error('Device unlock failed', err);
+    }
+    return false;
+  }, []);
+
+  const enableSecretLock = useCallback(async ({ method, secret }) => {
+    const ok = await setSecretLock({ method, secret });
+    if (ok) {
+      setConfig(loadLockConfig());
+      setStatus('locked');
+    }
+    return ok;
+  }, []);
+
+  const enableDeviceLock = useCallback(async () => {
+    if (!window.PublicKeyCredential) return false;
+    try {
+      const credential = await navigator.credentials.create({
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          rp: { name: 'TonPlaygram Profile' },
+          user: {
+            id: crypto.getRandomValues(new Uint8Array(32)),
+            name: `tpc-${Date.now()}`,
+            displayName: 'TonPlaygram user'
+          },
+          pubKeyCredParams: [{ alg: -7, type: 'public-key' }],
+          authenticatorSelection: { authenticatorAttachment: 'platform', userVerification: 'preferred' }
+        }
+      });
+      if (credential?.rawId) {
+        storeDeviceCredentialId(base64urlFromBuffer(credential.rawId));
+        setConfig(loadLockConfig());
+        setStatus('locked');
+        return true;
+      }
+    } catch (err) {
+      console.error('Failed to register device lock', err);
+    }
+    return false;
+  }, []);
+
+  const disableLock = useCallback(() => {
+    clearLockConfig();
+    setConfig(null);
+    setStatus('unlocked');
+  }, []);
+
+  return useMemo(
+    () => ({
+      config,
+      locked,
+      status,
+      unlockWithSecret,
+      unlockWithDevice,
+      enableSecretLock,
+      enableDeviceLock,
+      disableLock
+    }),
+    [
+      config,
+      locked,
+      status,
+      unlockWithSecret,
+      unlockWithDevice,
+      enableSecretLock,
+      enableDeviceLock,
+      disableLock
+    ]
+  );
+}

--- a/webapp/src/pwa/registerServiceWorker.js
+++ b/webapp/src/pwa/registerServiceWorker.js
@@ -1,4 +1,4 @@
-const TELEGRAM_ONLY = true;
+const TELEGRAM_ONLY = false;
 const REFRESH_FLAG_KEY = 'tonplaygram-sw-refreshed';
 const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const SERVICE_WORKER_URL = '/service-worker.js';

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -295,8 +295,14 @@ export function verifyInfluencer(id, status, views) {
   });
 }
 
-export function getProfile(telegramId) {
-  return post('/api/profile/get', { telegramId });
+export function getProfile(telegramId, accountId) {
+  const payload = {};
+  if (telegramId != null) payload.telegramId = telegramId;
+  const storedAccount =
+    accountId ||
+    (typeof window !== 'undefined' ? localStorage.getItem('accountId') : null);
+  if (storedAccount) payload.accountId = storedAccount;
+  return post('/api/profile/get', payload);
 }
 
 export function updateProfile(data) {
@@ -546,9 +552,13 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId, googleProfile) {
+export function createAccount(telegramId, googleProfile, accountId) {
   const body = {};
   if (telegramId) body.telegramId = telegramId;
+  const existingAccountId =
+    accountId ||
+    (typeof window !== 'undefined' ? localStorage.getItem('accountId') : null);
+  if (existingAccountId) body.accountId = existingAccountId;
   const profile =
     typeof googleProfile === 'string'
       ? { id: googleProfile }

--- a/webapp/src/utils/profileLock.js
+++ b/webapp/src/utils/profileLock.js
@@ -1,0 +1,105 @@
+const LOCK_CONFIG_KEY = 'tpc-profile-lock';
+const UNLOCKED_FLAG = 'tpc-profile-lock-unlocked';
+
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+
+async function sha256(text) {
+  if (!textEncoder || !crypto?.subtle) return null;
+  try {
+    const data = textEncoder.encode(text);
+    const digest = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  } catch {
+    return null;
+  }
+}
+
+export function loadLockConfig() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(LOCK_CONFIG_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLockConfig() {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(LOCK_CONFIG_KEY);
+    sessionStorage.removeItem(UNLOCKED_FLAG);
+  } catch {
+    // ignore
+  }
+}
+
+export function markUnlockedSession() {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(UNLOCKED_FLAG, '1');
+  } catch {
+    // ignore
+  }
+}
+
+export function isUnlocked() {
+  if (typeof window === 'undefined') return false;
+  try {
+    return sessionStorage.getItem(UNLOCKED_FLAG) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function generateSalt() {
+  if (!crypto?.getRandomValues) return Math.random().toString(36).slice(2);
+  return Array.from(crypto.getRandomValues(new Uint8Array(12)))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function setSecretLock({ method, secret }) {
+  if (!method || !secret) return false;
+  const salt = generateSalt();
+  const hashed = await sha256(`${salt}:${secret}`);
+  if (!hashed) return false;
+  if (typeof window === 'undefined') return false;
+  const payload = { method, salt, hash: hashed };
+  try {
+    localStorage.setItem(LOCK_CONFIG_KEY, JSON.stringify(payload));
+    sessionStorage.removeItem(UNLOCKED_FLAG);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifySecret(secret) {
+  const cfg = loadLockConfig();
+  if (!cfg?.hash || !cfg?.salt) return false;
+  const hashed = await sha256(`${cfg.salt}:${secret}`);
+  return Boolean(hashed && hashed === cfg.hash);
+}
+
+export function storeDeviceCredentialId(id) {
+  if (!id || typeof window === 'undefined') return;
+  try {
+    const cfg = loadLockConfig() || { method: 'device' };
+    cfg.method = 'device';
+    cfg.credentialId = id;
+    cfg.salt = cfg.salt || generateSalt();
+    cfg.hash = cfg.hash || '';
+    localStorage.setItem(LOCK_CONFIG_KEY, JSON.stringify(cfg));
+    sessionStorage.removeItem(UNLOCKED_FLAG);
+  } catch {
+    // ignore
+  }
+}
+
+export function getDeviceCredentialId() {
+  const cfg = loadLockConfig();
+  return cfg?.credentialId || null;
+}

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -132,3 +132,19 @@ export function parseTelegramPostLink(link) {
     messageId: m && m[2] ? Number(m[2]) : undefined,
   };
 }
+
+export function clearTelegramCache() {
+  if (typeof window === 'undefined') return;
+  try {
+    [
+      'telegramId',
+      'telegramUsername',
+      'telegramFirstName',
+      'telegramLastName',
+      'telegramUserData',
+      'telegramPhotoUrl'
+    ].forEach((key) => localStorage.removeItem(key));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- Allow service worker and web onboarding outside Telegram while preserving existing flows
- Unify account creation across Telegram, Google, and guest sessions using shared account IDs and cleanup helpers
- Add profile lock overlay with PIN/password/passkey options plus sign-out controls on the account page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a0ee9e1408329b618ea7374d67cc7)