### PR TITLE
Handle task API errors gracefully

### DIFF
--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -6,6 +6,7 @@ import {
   adminUpdateTask,
   adminDeleteTask
 } from '../utils/api.js';
+import { normalizeTasksResponse } from '../utils/taskUtils.js';
 import { FiEdit, FiTrash2 } from 'react-icons/fi';
 
 export default function DevTasksModal({ open, onClose }) {
@@ -18,7 +19,7 @@ export default function DevTasksModal({ open, onClose }) {
 
   const load = async () => {
     const data = await adminListTasks();
-    if (!data.error) setTasks(data.tasks || data);
+    if (!data.error) setTasks(normalizeTasksResponse(data));
   };
 
   useEffect(() => {

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -13,6 +13,7 @@ import {
   getProfile,
 } from '../utils/api.js';
 import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
+import { normalizeTasksResponse } from '../utils/taskUtils.js';
 import LoginOptions from './LoginOptions.jsx';
 
 
@@ -93,7 +94,7 @@ export default function TasksCard() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    const tasksList = (data.tasks || data).filter((t) => !t.hideOnHome);
+    const tasksList = normalizeTasksResponse(data).filter((t) => !t.hideOnHome);
     setTasks(tasksList);
     if (data.version) {
       const seen = localStorage.getItem('tasksVersion');

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -14,6 +14,7 @@ import {
   submitInfluencerVideo,
   myInfluencerVideos,
 } from '../utils/api.js';
+import { normalizeTasksResponse } from '../utils/taskUtils.js';
 
 import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
 import LoginOptions from '../components/LoginOptions.jsx';
@@ -74,7 +75,7 @@ export default function Tasks() {
 
   const load = async () => {
     const data = await listTasks(telegramId);
-    const tasksList = data.tasks || data;
+    const tasksList = normalizeTasksResponse(data);
     setTasks(tasksList);
     if (data.version) {
       const seen = localStorage.getItem('tasksVersion');

--- a/webapp/src/utils/taskUtils.js
+++ b/webapp/src/utils/taskUtils.js
@@ -1,0 +1,6 @@
+export function normalizeTasksResponse(data) {
+  if (!data || data.error) return [];
+  if (Array.isArray(data?.tasks)) return data.tasks;
+  if (Array.isArray(data)) return data;
+  return [];
+}


### PR DESCRIPTION
## Summary
- add a helper to normalize task API responses
- guard task loading in the Tasks card, Tasks page, and dev tasks modal so missing or errored responses do not crash the UI

## Testing
- npm run build
- Playwright smoke load against dev server (expecting 404s without backend but no JS crashes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a195155fc832997b5c2915138f84a)