### PR TITLE
Handle task list errors gracefully

### DIFF
--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -16,6 +16,7 @@ import {
 } from '../utils/api.js';
 
 import { getTelegramId, parseTelegramPostLink } from '../utils/telegram.js';
+import { extractTasksError, extractTasksVersion, normalizeTasksResponse } from '../utils/tasks.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 
 import { IoLogoTiktok } from 'react-icons/io5';
@@ -52,6 +53,7 @@ export default function Tasks() {
   }
 
   const [tasks, setTasks] = useState(null);
+  const [tasksError, setTasksError] = useState('');
   const [adCount, setAdCount] = useState(0);
   const [showAd, setShowAd] = useState(false);
   const [showQuestAd, setShowQuestAd] = useState(false);
@@ -73,34 +75,45 @@ export default function Tasks() {
   });
 
   const load = async () => {
-    const data = await listTasks(telegramId);
-    const tasksList = data.tasks || data;
-    setTasks(tasksList);
-    if (data.version) {
-      const seen = localStorage.getItem('tasksVersion');
-      if (seen !== String(data.version)) {
-        setShowNew(true);
-        localStorage.setItem('tasksVersion', String(data.version));
-      }
-    }
-    const ad = await getAdStatus(telegramId);
-    if (!ad.error) setAdCount(ad.count);
-    const quest = await getQuestStatus(telegramId);
-    if (!quest.error) setQuestTime(quest.remaining || 0);
     try {
-      const prof = await getProfile(telegramId);
-      setProfile(prof);
-      if (prof.dailyStreak) setStreak(prof.dailyStreak);
-      const serverTs = prof.lastCheckIn
-        ? new Date(prof.lastCheckIn).getTime()
-        : null;
-      const localTs = lastCheck || 0;
-      const ts = Math.max(serverTs || 0, localTs);
-      if (ts) {
-        setLastCheck(ts);
-        localStorage.setItem('lastCheckIn', String(ts));
+      const data = await listTasks(telegramId);
+      const tasksList = normalizeTasksResponse(data);
+      setTasks(tasksList);
+
+      const version = extractTasksVersion(data);
+      if (version) {
+        const seen = localStorage.getItem('tasksVersion');
+        if (seen !== String(version)) {
+          setShowNew(true);
+          localStorage.setItem('tasksVersion', String(version));
+        }
       }
-    } catch {}
+
+      setTasksError(extractTasksError(data));
+
+      const ad = await getAdStatus(telegramId);
+      if (!ad.error) setAdCount(ad.count);
+      const quest = await getQuestStatus(telegramId);
+      if (!quest.error) setQuestTime(quest.remaining || 0);
+      try {
+        const prof = await getProfile(telegramId);
+        setProfile(prof);
+        if (prof.dailyStreak) setStreak(prof.dailyStreak);
+        const serverTs = prof.lastCheckIn
+          ? new Date(prof.lastCheckIn).getTime()
+          : null;
+        const localTs = lastCheck || 0;
+        const ts = Math.max(serverTs || 0, localTs);
+        if (ts) {
+          setLastCheck(ts);
+          localStorage.setItem('lastCheckIn', String(ts));
+        }
+      } catch {}
+    } catch (err) {
+      console.error('Failed to load tasks', err);
+      setTasks([]);
+      setTasksError('Unable to load tasks right now. Please try again later.');
+    }
   };
 
   const loadInfluencer = async () => {
@@ -251,6 +264,9 @@ export default function Tasks() {
 
     <div className="relative p-4 space-y-2 text-text flex flex-col items-center wide-card">
       <h2 className="text-xl font-bold">Tasks</h2>
+      {tasksError && (
+        <p className="text-sm text-red-400 text-center">{tasksError}</p>
+      )}
       <div className="flex justify-center space-x-2">
         {['TonPlaygram', 'Influencer', 'Partners'].map((c) => (
           <button

--- a/webapp/src/utils/tasks.js
+++ b/webapp/src/utils/tasks.js
@@ -1,0 +1,23 @@
+function isTaskContainer(data) {
+  return Boolean(data) && typeof data === 'object' && !Array.isArray(data);
+}
+
+export function normalizeTasksResponse(data) {
+  if (Array.isArray(data?.tasks)) return data.tasks;
+  if (Array.isArray(data)) return data;
+  return [];
+}
+
+export function extractTasksVersion(data) {
+  if (isTaskContainer(data) && data.version) {
+    return data.version;
+  }
+  return null;
+}
+
+export function extractTasksError(data) {
+  if (isTaskContainer(data) && typeof data.error === 'string') {
+    return data.error;
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary
- add helpers to normalize task list responses and safely reuse metadata
- guard task fetching in Tasks and TasksCard to avoid runtime crashes when APIs return errors
- show a friendly tasks error message instead of breaking the UI

## Testing
- npm --prefix webapp run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a195155fc832997b5c2915138f84a)