### PR TITLE
Improve security lock UX and resilience

### DIFF
--- a/webapp/src/components/ProfileLockOverlay.jsx
+++ b/webapp/src/components/ProfileLockOverlay.jsx
@@ -1,124 +1,240 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+
+function getErrorMessage(code) {
+  switch (code) {
+    case 'password_too_short':
+      return 'Password must be at least 8 characters.';
+    case 'pin_too_short':
+      return 'PIN/pattern must be at least 4 characters.';
+    case 'hash_failed':
+      return 'Could not secure your secret. Please try again.';
+    case 'device_unsupported':
+      return 'This device or browser does not support passkeys/biometrics.';
+    case 'device_failed':
+      return 'We could not complete biometric unlock on this device.';
+    case 'secret_invalid':
+      return 'That PIN/password did not unlock your profile.';
+    case 'recovery_invalid':
+      return 'Recovery code not recognized or already used.';
+    default:
+      return 'Something went wrong. Please try again.';
+  }
+}
 
 export default function ProfileLockOverlay({
   locked,
   onUnlockSecret,
   onUnlockDevice,
+  onUnlockRecovery,
   onDisable,
   onConfigureSecret,
-  onConfigureDevice
+  onConfigureDevice,
+  deviceSupported = true,
+  issuedRecoveryCodes = [],
+  lastError
 }) {
   const [mode, setMode] = useState('pin');
   const [value, setValue] = useState('');
-  const [error, setError] = useState('');
+  const [recoveryValue, setRecoveryValue] = useState('');
+  const [localError, setLocalError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const currentError = useMemo(() => localError || (lastError ? getErrorMessage(lastError) : ''), [localError, lastError]);
 
   if (!locked) return null;
 
   const submitUnlock = async (evt) => {
     evt.preventDefault();
-    setError('');
+    setLocalError('');
+    setSuccess('');
     const ok = await onUnlockSecret(value);
-    if (!ok) setError('That secret did not unlock your profile.');
+    if (!ok) setLocalError('secret_invalid');
     setValue('');
+  };
+
+  const submitRecovery = async (evt) => {
+    evt.preventDefault();
+    setLocalError('');
+    setSuccess('');
+    const ok = await onUnlockRecovery(recoveryValue);
+    if (!ok) setLocalError('recovery_invalid');
+    else setSuccess('Recovered access. Update your lock next.');
+    setRecoveryValue('');
   };
 
   const configure = async (evt) => {
     evt.preventDefault();
-    setError('');
+    setLocalError('');
+    setSuccess('');
     if (!value || value.length < 4) {
-      setError('Choose a PIN/pattern/password with at least 4 characters.');
+      setLocalError('pin_too_short');
       return;
     }
-    const ok = await onConfigureSecret({
+    const result = await onConfigureSecret({
       method: mode === 'pattern' ? 'pin' : mode,
       secret: value
     });
-    if (ok) {
+    if (result.ok) {
       setValue('');
-      setError('');
+      setSuccess('Lock updated. Save your recovery codes below.');
     } else {
-      setError('Could not save your lock. Try again.');
+      setLocalError(result.error || 'unknown');
+    }
+  };
+
+  const useDevice = async () => {
+    setLocalError('');
+    setSuccess('');
+    const result = await onUnlockDevice();
+    if (!result?.ok) {
+      setLocalError(result?.error || 'device_failed');
+    } else {
+      setSuccess('Unlocked with your device.');
+    }
+  };
+
+  const registerDevice = async () => {
+    setLocalError('');
+    setSuccess('');
+    const result = await onConfigureDevice();
+    if (result?.ok) {
+      setSuccess('Device lock added. Use biometrics next time.');
+    } else {
+      setLocalError(result?.error || 'device_failed');
     }
   };
 
   return (
     <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/80 backdrop-blur px-4">
-      <div className="max-w-xl w-full space-y-4 bg-surface border border-border rounded-2xl p-5 shadow-lg">
-        <h3 className="text-xl font-bold text-white text-center">Protect your profile</h3>
+      <div className="max-w-4xl w-full space-y-4 bg-surface border border-border rounded-2xl p-5 shadow-lg">
+        <h3 className="text-2xl font-bold text-white text-center">Protect your profile</h3>
         <p className="text-sm text-subtext text-center">
-          Unlock to view sensitive info, or set a stronger lock that works across browsers. Choose PIN, pattern, password,
-          or device biometrics/passkey where available.
+          Unlock to view sensitive info, or set a stronger lock that works across browsers. Use PIN, pattern, password, device
+          biometrics/passkey, and keep recovery codes handy.
         </p>
 
-        <form className="space-y-3" onSubmit={submitUnlock}>
-          <label className="text-sm text-white">Enter your PIN / password</label>
-          <input
-            type="password"
-            className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder="Unlock secret"
-          />
-          <button type="submit" className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2">
-            Unlock
-          </button>
-        </form>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-3 rounded-xl border border-border bg-background/40 p-4">
+            <h4 className="font-semibold text-white">Unlock access</h4>
+            <form className="space-y-3" onSubmit={submitUnlock}>
+              <label className="text-xs text-subtext">PIN / password</label>
+              <input
+                type="password"
+                className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder="Enter your secret"
+                autoComplete="current-password"
+              />
+              <button
+                type="submit"
+                className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2"
+              >
+                Unlock with secret
+              </button>
+            </form>
 
-        <div className="space-y-2">
-          <p className="text-sm text-white">Or use your device</p>
-          <button
-            type="button"
-            className="w-full border border-border rounded py-2 text-white"
-            onClick={onUnlockDevice}
-          >
-            Unlock with biometrics/passkey
-          </button>
-        </div>
+            <div className="space-y-2">
+              <p className="text-xs text-subtext">Recovery code</p>
+              <form onSubmit={submitRecovery} className="flex flex-col gap-2 sm:flex-row">
+                <input
+                  type="text"
+                  className="flex-1 rounded border border-border bg-background px-3 py-2 text-sm text-text"
+                  value={recoveryValue}
+                  onChange={(e) => setRecoveryValue(e.target.value)}
+                  placeholder="XXXX-XXXX"
+                  autoComplete="one-time-code"
+                />
+                <button
+                  type="submit"
+                  className="w-full sm:w-40 bg-surface text-white border border-border rounded py-2 text-sm"
+                >
+                  Use recovery
+                </button>
+              </form>
+            </div>
 
-        <div className="space-y-3 border-t border-border pt-3">
-          <p className="text-sm text-white">Set or change your lock</p>
-          <div className="grid grid-cols-2 gap-2 text-sm">
-            {['pin', 'pattern', 'password'].map((option) => (
+            <div className="space-y-2">
+              <p className="text-xs text-subtext">Device unlock</p>
               <button
                 type="button"
-                key={option}
-                onClick={() => setMode(option)}
-                className={`rounded border px-2 py-1 capitalize ${
-                  mode === option ? 'bg-primary text-black' : 'text-white border-border'
-                }`}
+                className="w-full border border-border rounded py-2 text-white disabled:opacity-50"
+                onClick={useDevice}
+                disabled={!deviceSupported}
               >
-                {option}
+                Unlock with biometrics/passkey
               </button>
-            ))}
-            <button
-              type="button"
-              onClick={onConfigureDevice}
-              className="col-span-2 rounded border border-border px-2 py-1 text-white"
-            >
-              Use device biometrics/passkey
-            </button>
+              {!deviceSupported && (
+                <p className="text-xs text-amber-300">
+                  Your current browser does not support passkeys. Try a modern mobile browser.
+                </p>
+              )}
+            </div>
           </div>
-          <form onSubmit={configure} className="space-y-2">
-            <input
-              type={mode === 'password' ? 'password' : 'text'}
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
-              placeholder={mode === 'password' ? 'New password (min 8 chars)' : 'New PIN / pattern'}
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-            />
-            <button type="submit" className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2">
-              Save lock
-            </button>
-          </form>
+
+          <div className="space-y-3 rounded-xl border border-border bg-background/40 p-4">
+            <h4 className="font-semibold text-white">Update your lock</h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {['pin', 'pattern', 'password'].map((option) => (
+                <button
+                  type="button"
+                  key={option}
+                  onClick={() => setMode(option)}
+                  className={`rounded border px-2 py-2 capitalize ${
+                    mode === option ? 'bg-primary text-black' : 'text-white border-border'
+                  }`}
+                >
+                  {option}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={registerDevice}
+                className="col-span-2 rounded border border-border px-2 py-2 text-white disabled:opacity-50"
+                disabled={!deviceSupported}
+              >
+                Add device biometrics/passkey
+              </button>
+            </div>
+            <form onSubmit={configure} className="space-y-2">
+              <input
+                type={mode === 'password' ? 'password' : 'text'}
+                className="w-full rounded border border-border bg-background px-3 py-2 text-sm text-text"
+                placeholder={mode === 'password' ? 'New password (min 8 chars)' : 'New PIN / pattern'}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                autoComplete="new-password"
+              />
+              <button
+                type="submit"
+                className="w-full bg-primary hover:bg-primary-hover text-black font-semibold rounded py-2"
+              >
+                Save lock
+              </button>
+            </form>
+            {issuedRecoveryCodes.length > 0 && (
+              <div className="rounded border border-border bg-black/30 p-3 space-y-1">
+                <p className="text-xs text-amber-200">Save these one-time recovery codes:</p>
+                <div className="flex flex-wrap gap-2 text-sm text-white font-mono">
+                  {issuedRecoveryCodes.map((code) => (
+                    <span key={code} className="px-2 py-1 rounded bg-surface/80 border border-border">
+                      {code}
+                    </span>
+                  ))}
+                </div>
+                <p className="text-[11px] text-subtext">Codes disappear after you leave this screen. Store them safely.</p>
+              </div>
+            )}
+          </div>
         </div>
 
-        <div className="text-sm text-subtext text-center">
-          <button type="button" className="underline" onClick={onDisable}>
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <button type="button" className="underline text-white" onClick={onDisable}>
             Disable profile lock
           </button>
+          {success && <span className="text-green-400">{success}</span>}
+          {currentError && <span className="text-red-400">{getErrorMessage(currentError)}</span>}
         </div>
-
-        {error && <p className="text-center text-red-400 text-sm">{error}</p>}
       </div>
     </div>
   );

--- a/webapp/src/hooks/useProfileLock.js
+++ b/webapp/src/hooks/useProfileLock.js
@@ -7,6 +7,7 @@ import {
   markUnlockedSession,
   setSecretLock,
   storeDeviceCredentialId,
+  verifyRecoveryCode,
   verifySecret
 } from '../utils/profileLock.js';
 
@@ -30,11 +31,21 @@ function base64urlFromBuffer(buffer) {
 export default function useProfileLock() {
   const [config, setConfig] = useState(() => loadLockConfig());
   const [status, setStatus] = useState(() => (isUnlocked() || !config ? 'unlocked' : 'locked'));
+  const [issuedRecoveryCodes, setIssuedRecoveryCodes] = useState([]);
+  const [lastError, setLastError] = useState('');
+  const [deviceSupported, setDeviceSupported] = useState(
+    typeof window !== 'undefined' && !!window.PublicKeyCredential
+  );
   const locked = status === 'locked';
 
   useEffect(() => {
     setConfig(loadLockConfig());
     setStatus(isUnlocked() || !loadLockConfig() ? 'unlocked' : 'locked');
+    if (typeof window !== 'undefined' && window.PublicKeyCredential?.isUserVerifyingPlatformAuthenticatorAvailable) {
+      window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+        .then((available) => setDeviceSupported(Boolean(available)))
+        .catch(() => setDeviceSupported(false));
+    }
   }, []);
 
   const unlockWithSecret = useCallback(async (secret) => {
@@ -42,44 +53,78 @@ export default function useProfileLock() {
     if (ok) {
       markUnlockedSession();
       setStatus('unlocked');
+      setLastError('');
+    } else {
+      setLastError('secret_invalid');
+    }
+    return ok;
+  }, []);
+
+  const unlockWithRecovery = useCallback(async (code) => {
+    const ok = await verifyRecoveryCode(code);
+    if (ok) {
+      markUnlockedSession();
+      setStatus('unlocked');
+      setLastError('');
+    } else {
+      setLastError('recovery_invalid');
     }
     return ok;
   }, []);
 
   const unlockWithDevice = useCallback(async () => {
     const id = getDeviceCredentialId();
-    if (!id || !window.PublicKeyCredential) return false;
+    if (!id || !window.PublicKeyCredential) {
+      setLastError('device_unsupported');
+      return { ok: false, error: 'device_unsupported' };
+    }
     try {
       const assertion = await navigator.credentials.get({
         publicKey: {
           challenge: crypto.getRandomValues(new Uint8Array(32)),
           allowCredentials: [{ id: bufferFromBase64url(id), type: 'public-key' }],
-          userVerification: 'preferred'
+          userVerification: 'required',
+          timeout: 60000
         }
       });
       if (assertion) {
         markUnlockedSession();
         setStatus('unlocked');
-        return true;
+        setLastError('');
+        return { ok: true };
       }
     } catch (err) {
       console.error('Device unlock failed', err);
+      setLastError('device_failed');
+      return { ok: false, error: err?.name || 'device_failed' };
     }
-    return false;
+    return { ok: false, error: 'device_failed' };
   }, []);
 
   const enableSecretLock = useCallback(async ({ method, secret }) => {
-    const ok = await setSecretLock({ method, secret });
-    if (ok) {
+    const result = await setSecretLock({ method, secret });
+    if (result.ok) {
       setConfig(loadLockConfig());
       setStatus('locked');
+      setIssuedRecoveryCodes(result.recoveryCodes || []);
+      setLastError('');
+    } else {
+      setLastError(result.error || 'unknown');
     }
-    return ok;
+    return result;
   }, []);
 
   const enableDeviceLock = useCallback(async () => {
-    if (!window.PublicKeyCredential) return false;
+    if (!window.PublicKeyCredential) {
+      setLastError('device_unsupported');
+      return { ok: false, error: 'device_unsupported' };
+    }
     try {
+      const authenticatorAvailable = await window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable?.();
+      if (authenticatorAvailable === false) {
+        setLastError('device_unsupported');
+        return { ok: false, error: 'device_unsupported' };
+      }
       const credential = await navigator.credentials.create({
         publicKey: {
           challenge: crypto.getRandomValues(new Uint8Array(32)),
@@ -90,25 +135,31 @@ export default function useProfileLock() {
             displayName: 'TonPlaygram user'
           },
           pubKeyCredParams: [{ alg: -7, type: 'public-key' }],
-          authenticatorSelection: { authenticatorAttachment: 'platform', userVerification: 'preferred' }
+          authenticatorSelection: { authenticatorAttachment: 'platform', userVerification: 'required' },
+          timeout: 60000
         }
       });
       if (credential?.rawId) {
         storeDeviceCredentialId(base64urlFromBuffer(credential.rawId));
         setConfig(loadLockConfig());
         setStatus('locked');
-        return true;
+        setLastError('');
+        return { ok: true };
       }
     } catch (err) {
       console.error('Failed to register device lock', err);
+      setLastError(err?.name || 'device_failed');
+      return { ok: false, error: err?.name || 'device_failed' };
     }
-    return false;
+    setLastError('device_failed');
+    return { ok: false, error: 'device_failed' };
   }, []);
 
   const disableLock = useCallback(() => {
     clearLockConfig();
     setConfig(null);
     setStatus('unlocked');
+    setLastError('');
   }, []);
 
   return useMemo(
@@ -118,9 +169,13 @@ export default function useProfileLock() {
       status,
       unlockWithSecret,
       unlockWithDevice,
+      unlockWithRecovery,
       enableSecretLock,
       enableDeviceLock,
-      disableLock
+      disableLock,
+      issuedRecoveryCodes,
+      lastError,
+      deviceSupported
     }),
     [
       config,
@@ -128,9 +183,13 @@ export default function useProfileLock() {
       status,
       unlockWithSecret,
       unlockWithDevice,
+      unlockWithRecovery,
       enableSecretLock,
       enableDeviceLock,
-      disableLock
+      disableLock,
+      issuedRecoveryCodes,
+      lastError,
+      deviceSupported
     ]
   );
 }

--- a/webapp/src/utils/profileLock.js
+++ b/webapp/src/utils/profileLock.js
@@ -2,6 +2,7 @@ const LOCK_CONFIG_KEY = 'tpc-profile-lock';
 const UNLOCKED_FLAG = 'tpc-profile-lock-unlocked';
 
 const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+const CONFIG_VERSION = 2;
 
 async function sha256(text) {
   if (!textEncoder || !crypto?.subtle) return null;
@@ -16,11 +17,25 @@ async function sha256(text) {
   }
 }
 
+function normalizeConfig(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    method: raw.method || null,
+    salt: raw.salt || '',
+    hash: raw.hash || '',
+    credentialId: raw.credentialId || null,
+    recoveryCodes: Array.isArray(raw.recoveryCodes) ? raw.recoveryCodes : [],
+    lastUpdated: raw.lastUpdated || Date.now(),
+    deviceInfo: raw.deviceInfo || null,
+    version: raw.version || CONFIG_VERSION
+  };
+}
+
 export function loadLockConfig() {
   if (typeof window === 'undefined') return null;
   try {
     const raw = localStorage.getItem(LOCK_CONFIG_KEY);
-    return raw ? JSON.parse(raw) : null;
+    return raw ? normalizeConfig(JSON.parse(raw)) : null;
   } catch {
     return null;
   }
@@ -61,19 +76,48 @@ function generateSalt() {
     .join('');
 }
 
+function generateRecoveryCodes(count = 3) {
+  const codes = [];
+  for (let i = 0; i < count; i++) {
+    const chunk = Array.from(crypto?.getRandomValues?.(new Uint8Array(8)) || [])
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    codes.push(chunk.slice(0, 4) + '-' + chunk.slice(4, 8));
+  }
+  return codes;
+}
+
 export async function setSecretLock({ method, secret }) {
-  if (!method || !secret) return false;
+  if (!method || !secret) return { ok: false, error: 'missing_fields' };
+  const trimmed = secret.trim();
+  if (method === 'password' && trimmed.length < 8) {
+    return { ok: false, error: 'password_too_short' };
+  }
+  if ((method === 'pin' || method === 'pattern') && trimmed.length < 4) {
+    return { ok: false, error: 'pin_too_short' };
+  }
   const salt = generateSalt();
-  const hashed = await sha256(`${salt}:${secret}`);
-  if (!hashed) return false;
-  if (typeof window === 'undefined') return false;
-  const payload = { method, salt, hash: hashed };
+  const hashed = await sha256(`${salt}:${trimmed}`);
+  if (!hashed) return { ok: false, error: 'hash_failed' };
+  if (typeof window === 'undefined') return { ok: false, error: 'unavailable' };
+  const recoveryCodes = generateRecoveryCodes();
+  const recoveryHashes = await Promise.all(
+    recoveryCodes.map(async (code) => sha256(`${salt}:${code}`))
+  );
+  const payload = {
+    method,
+    salt,
+    hash: hashed,
+    recoveryCodes: recoveryHashes.filter(Boolean),
+    lastUpdated: Date.now(),
+    version: CONFIG_VERSION
+  };
   try {
     localStorage.setItem(LOCK_CONFIG_KEY, JSON.stringify(payload));
     sessionStorage.removeItem(UNLOCKED_FLAG);
-    return true;
+    return { ok: true, recoveryCodes };
   } catch {
-    return false;
+    return { ok: false, error: 'storage_failed' };
   }
 }
 
@@ -84,6 +128,24 @@ export async function verifySecret(secret) {
   return Boolean(hashed && hashed === cfg.hash);
 }
 
+export async function verifyRecoveryCode(code) {
+  const cfg = loadLockConfig();
+  if (!cfg?.recoveryCodes?.length || !cfg?.salt) return false;
+  const hashed = await sha256(`${cfg.salt}:${code.trim()}`);
+  if (!hashed) return false;
+  const match = cfg.recoveryCodes.includes(hashed);
+  if (match) {
+    try {
+      const remaining = cfg.recoveryCodes.filter((h) => h !== hashed);
+      const updated = { ...cfg, recoveryCodes: remaining, lastUpdated: Date.now() };
+      localStorage.setItem(LOCK_CONFIG_KEY, JSON.stringify(updated));
+    } catch {
+      // best effort
+    }
+  }
+  return match;
+}
+
 export function storeDeviceCredentialId(id) {
   if (!id || typeof window === 'undefined') return;
   try {
@@ -92,6 +154,9 @@ export function storeDeviceCredentialId(id) {
     cfg.credentialId = id;
     cfg.salt = cfg.salt || generateSalt();
     cfg.hash = cfg.hash || '';
+    cfg.lastUpdated = Date.now();
+    cfg.deviceInfo = { userAgent: navigator?.userAgent || 'unknown', platform: navigator?.platform };
+    cfg.version = CONFIG_VERSION;
     localStorage.setItem(LOCK_CONFIG_KEY, JSON.stringify(cfg));
     sessionStorage.removeItem(UNLOCKED_FLAG);
   } catch {


### PR DESCRIPTION
## Summary
- add recovery codes, clearer messaging, and improved layout for profile locking with biometrics, PIN, password, and passkeys
- strengthen profile lock hook and validation for device support, recovery unlock, and passkey enrollment feedback
- harden server reliability by logging unhandled errors and retrying database connections without crashing the bot

## Testing
- npm run build --prefix webapp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a20489bc08329af59b7d7be459bbe)