### PR TITLE
Add TON wallet login support

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -24,6 +24,7 @@ import {
   shouldUseMemoryUserStore,
   deleteMemoryUser
 } from '../utils/memoryUserStore.js';
+import { normalizeAddress } from '../utils/ton.js';
 
 const router = Router();
 
@@ -36,7 +37,9 @@ router.post('/create', async (req, res) => {
     googleEmail,
     firstName,
     lastName,
-    photo
+    photo,
+    walletAddress,
+    walletPublicKey
   } = req.body;
   const useMemoryStore = shouldUseMemoryUserStore();
 
@@ -51,11 +54,20 @@ router.post('/create', async (req, res) => {
     const removeUser = async (payload) =>
       useMemoryStore ? deleteMemoryUser(payload?.accountId) : payload?.deleteOne?.();
 
+    const normalizedWallet = walletAddress ? normalizeAddress(walletAddress) : null;
+    if (walletAddress && !normalizedWallet) {
+      return res.status(400).json({ error: 'invalid walletAddress' });
+    }
+
     const existingByAccountId = accountId ? await findUser({ accountId }) : null;
     const existingByTelegram = telegramId ? await findUser({ telegramId }) : null;
     const existingByGoogle = googleId ? await findUser({ googleId }) : null;
+    const existingByWallet = normalizedWallet
+      ? await findUser({ walletAddress: normalizedWallet })
+      : null;
 
-    const primaryExisting = existingByAccountId || existingByTelegram || existingByGoogle;
+    const primaryExisting =
+      existingByAccountId || existingByTelegram || existingByGoogle || existingByWallet;
 
     if (telegramId) {
       try {
@@ -66,7 +78,9 @@ router.post('/create', async (req, res) => {
 
       user = existingByTelegram || primaryExisting;
       if (!user) {
-        const wallet = await generateWalletAddress();
+        const wallet = normalizedWallet
+          ? { address: normalizedWallet, publicKey: walletPublicKey || '' }
+          : await generateWalletAddress();
         const baseData = {
           telegramId,
           accountId: accountId || uuidv4(),
@@ -107,9 +121,15 @@ router.post('/create', async (req, res) => {
           updated = true;
         }
         if (!user.walletAddress) {
-          const wallet = await generateWalletAddress();
+          const wallet = normalizedWallet
+            ? { address: normalizedWallet, publicKey: walletPublicKey || '' }
+            : await generateWalletAddress();
           user.walletAddress = wallet.address;
           user.walletPublicKey = wallet.publicKey;
+          updated = true;
+        } else if (normalizedWallet && user.walletAddress !== normalizedWallet) {
+          user.walletAddress = normalizedWallet;
+          if (walletPublicKey) user.walletPublicKey = walletPublicKey;
           updated = true;
         }
         if (telegramProfile) {
@@ -131,7 +151,9 @@ router.post('/create', async (req, res) => {
     } else if (googleId) {
       user = existingByGoogle || primaryExisting;
       if (!user) {
-        const wallet = await generateWalletAddress();
+        const wallet = normalizedWallet
+          ? { address: normalizedWallet, publicKey: walletPublicKey || '' }
+          : await generateWalletAddress();
         const baseData = {
           googleId,
           googleEmail: googleEmail || '',
@@ -168,9 +190,15 @@ router.post('/create', async (req, res) => {
           updated = true;
         }
         if (!user.walletAddress) {
-          const wallet = await generateWalletAddress();
+          const wallet = normalizedWallet
+            ? { address: normalizedWallet, publicKey: walletPublicKey || '' }
+            : await generateWalletAddress();
           user.walletAddress = wallet.address;
           user.walletPublicKey = wallet.publicKey;
+          updated = true;
+        } else if (normalizedWallet && user.walletAddress !== normalizedWallet) {
+          user.walletAddress = normalizedWallet;
+          if (walletPublicKey) user.walletPublicKey = walletPublicKey;
           updated = true;
         }
         if (googleEmail && user.googleEmail !== googleEmail) {
@@ -191,20 +219,56 @@ router.post('/create', async (req, res) => {
         }
         if (updated) await persistUser(user);
       }
+    } else if (normalizedWallet) {
+      user = existingByWallet || primaryExisting;
+      const baseData = {
+        accountId: accountId || user?.accountId || uuidv4(),
+        walletAddress: normalizedWallet,
+        walletPublicKey: walletPublicKey || user?.walletPublicKey,
+        referralCode: user?.referralCode || normalizedWallet
+      };
+
+      if (!user) {
+        user = useMemoryStore
+          ? createMemoryUser(baseData)
+          : new User(baseData);
+        if (!useMemoryStore) await user.save();
+      } else {
+        let updated = false;
+        if (!user.accountId) {
+          user.accountId = baseData.accountId;
+          updated = true;
+        }
+        if (!user.walletAddress || user.walletAddress !== normalizedWallet) {
+          user.walletAddress = normalizedWallet;
+          updated = true;
+        }
+        if (walletPublicKey && user.walletPublicKey !== walletPublicKey) {
+          user.walletPublicKey = walletPublicKey;
+          updated = true;
+        }
+        if (!user.referralCode) {
+          user.referralCode = baseData.referralCode;
+          updated = true;
+        }
+        if (updated) await persistUser(user);
+      }
     } else {
       const wallet = await generateWalletAddress();
       const id = uuidv4();
-      user = useMemoryStore ? createMemoryUser({
-        accountId: id,
-        referralCode: id,
-        walletAddress: wallet.address,
-        walletPublicKey: wallet.publicKey
-      }) : new User({
-        accountId: id,
-        referralCode: id,
-        walletAddress: wallet.address,
-        walletPublicKey: wallet.publicKey
-      });
+      user = useMemoryStore
+        ? createMemoryUser({
+            accountId: id,
+            referralCode: id,
+            walletAddress: wallet.address,
+            walletPublicKey: wallet.publicKey
+          })
+        : new User({
+            accountId: id,
+            referralCode: id,
+            walletAddress: wallet.address,
+            walletPublicKey: wallet.publicKey
+          });
       if (!useMemoryStore) await user.save();
     }
 

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -3,9 +3,12 @@ import { socket } from '../utils/socket.js';
 import { createAccount } from '../utils/api.js';
 import { ensureAccountId } from '../utils/telegram.js';
 import { loadGoogleProfile } from '../utils/google.js';
+import { useTonAddress, useTonWallet } from '@tonconnect/ui-react';
 
 export default function useTelegramAuth() {
   const [googleProfile, setGoogleProfile] = useState(() => loadGoogleProfile());
+  const tonAddress = useTonAddress(true);
+  const tonWallet = useTonWallet();
 
   useEffect(() => {
     const refresh = () => setGoogleProfile(loadGoogleProfile());
@@ -31,7 +34,10 @@ export default function useTelegramAuth() {
         const accountId = acc || (await ensureAccountId());
         socket.emit('register', { playerId: accountId });
         try {
-          const res = await createAccount(undefined, googleProfile);
+          const res = await createAccount(undefined, googleProfile, undefined, {
+            address: tonAddress || undefined,
+            publicKey: tonWallet?.account?.publicKey
+          });
           if (res?.accountId) {
             localStorage.setItem('accountId', res.accountId);
           }
@@ -55,5 +61,5 @@ export default function useTelegramAuth() {
     if (user) {
       localStorage.setItem('telegramUserData', JSON.stringify(user));
     }
-  }, [googleProfile?.id]);
+  }, [googleProfile?.id, tonAddress, tonWallet?.account?.publicKey]);
 }

--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { createAccount, getAccountBalance, getTonBalance } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
-import { useTonAddress } from '@tonconnect/ui-react';
+import { useTonAddress, useTonWallet } from '@tonconnect/ui-react';
 import { loadGoogleProfile } from '../utils/google.js';
 
 export default function useTokenBalances() {
@@ -18,12 +18,16 @@ export default function useTokenBalances() {
   const [tpcWalletBalance, setTpcWalletBalance] = useState(null);
 
   const walletAddress = useTonAddress(true);
+  const tonWallet = useTonWallet();
 
   useEffect(() => {
     async function loadTpc() {
-      if (!telegramId && !googleProfile?.id) return;
+      if (!telegramId && !googleProfile?.id && !walletAddress) return;
       try {
-        const acc = await createAccount(telegramId, googleProfile);
+        const acc = await createAccount(telegramId, googleProfile, undefined, {
+          address: walletAddress || undefined,
+          publicKey: tonWallet?.account?.publicKey
+        });
         if (acc?.error) throw new Error(acc.error);
         if (acc.walletAddress) {
           localStorage.setItem('walletAddress', acc.walletAddress);
@@ -37,7 +41,7 @@ export default function useTokenBalances() {
       }
     }
     loadTpc();
-  }, [telegramId, googleProfile?.id]);
+  }, [telegramId, googleProfile?.id, walletAddress, tonWallet?.account?.publicKey]);
 
   useEffect(() => {
     if (telegramId) return undefined;

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -33,6 +33,7 @@ import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import { loadGoogleProfile, clearGoogleProfile } from '../utils/google.js';
 import useProfileLock from '../hooks/useProfileLock.js';
 import ProfileLockOverlay from '../components/ProfileLockOverlay.jsx';
+import { useTonAddress, useTonWallet } from '@tonconnect/ui-react';
 
 import { FiCopy } from 'react-icons/fi';
 
@@ -88,7 +89,9 @@ export default function MyAccount() {
   const [lockMessage, setLockMessage] = useState('');
   const [lockMessageTone, setLockMessageTone] = useState('info');
   const [showRecoveryCodes, setShowRecoveryCodes] = useState([]);
-  const requiresAuth = !telegramId && !googleProfile?.id;
+  const tonAddress = useTonAddress();
+  const tonWallet = useTonWallet();
+  const requiresAuth = !telegramId && !googleProfile?.id && !tonAddress;
 
   useEffect(() => {
     setGoogleLinked(Boolean(googleProfile?.id));
@@ -127,7 +130,10 @@ export default function MyAccount() {
     async function load() {
       setLoadingProfile(true);
       setLoadError('');
-      const accountPayload = await createAccount(telegramId, googleProfile);
+      const accountPayload = await createAccount(telegramId, googleProfile, undefined, {
+        address: tonAddress || undefined,
+        publicKey: tonWallet?.account?.publicKey
+      });
       if (accountPayload?.error || !accountPayload?.accountId) {
         throw new Error(accountPayload?.error || 'Unable to load your TPC account. Please try again.');
       }
@@ -224,7 +230,7 @@ export default function MyAccount() {
       if (timerRef.current) clearTimeout(timerRef.current);
       cancelled = true;
     };
-  }, [telegramId, googleProfile?.id, requiresAuth, reloadNonce]);
+  }, [telegramId, googleProfile?.id, requiresAuth, reloadNonce, tonAddress, tonWallet?.account?.publicKey]);
 
   useEffect(() => {
     if (!telegramId && googleProfile?.photo) {

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -17,6 +17,7 @@ import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { loadGoogleProfile } from '../utils/google.js';
 import LoginOptions from '../components/LoginOptions.jsx';
+import { useTonAddress, useTonWallet } from '@tonconnect/ui-react';
 
 const urlParams = new URLSearchParams(window.location.search);
 const DEV_ACCOUNT_ID =
@@ -58,7 +59,9 @@ export default function Wallet({ hideClaim = false }) {
     telegramId = undefined;
   }
   const [googleProfile, setGoogleProfile] = useState(() => (telegramId ? null : loadGoogleProfile()));
-  if (!telegramId && !googleProfile?.id) {
+  const tonAddress = useTonAddress(true);
+  const tonWallet = useTonWallet();
+  if (!telegramId && !googleProfile?.id && !tonAddress) {
     return <LoginOptions onAuthenticated={setGoogleProfile} />;
   }
 
@@ -102,7 +105,10 @@ export default function Wallet({ hideClaim = false }) {
     if (id) {
       acc = { accountId: id };
     } else {
-      acc = await createAccount(telegramId, googleProfile);
+      acc = await createAccount(telegramId, googleProfile, undefined, {
+        address: tonAddress || undefined,
+        publicKey: tonWallet?.account?.publicKey
+      });
       if (acc?.error) {
         console.error('Failed to load account:', acc.error);
         return null;
@@ -143,7 +149,7 @@ export default function Wallet({ hideClaim = false }) {
         }
       }
     });
-  }, []);
+  }, [tonAddress, tonWallet?.account?.publicKey]);
 
   useEffect(() => {
     if (DEV_ACCOUNTS.includes(accountId)) {

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -552,13 +552,15 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId, googleProfile, accountId) {
+export function createAccount(telegramId, googleProfile, accountId, tonWallet) {
   const body = {};
   if (telegramId) body.telegramId = telegramId;
   const existingAccountId =
     accountId ||
     (typeof window !== 'undefined' ? localStorage.getItem('accountId') : null);
   if (existingAccountId) body.accountId = existingAccountId;
+  if (tonWallet?.address) body.walletAddress = tonWallet.address;
+  if (tonWallet?.publicKey) body.walletPublicKey = tonWallet.publicKey;
   const profile =
     typeof googleProfile === 'string'
       ? { id: googleProfile }


### PR DESCRIPTION
## Summary
- add a TON wallet login option in the web app alongside existing Telegram and Google flows
- propagate TON wallet details through account creation and profile loading to link accounts to connected wallets
- enhance backend account creation to accept and normalize wallet addresses and public keys

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a4611702083298e50b4e0fe2016eb)