### PR TITLE
Add Chrome and TON Connect signup options to profile

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
-import { createAccount } from '../utils/api.js';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { createAccount, registerWallet } from '../utils/api.js';
 import { ensureAccountId } from '../utils/telegram.js';
 import LinkGoogleButton from './LinkGoogleButton.jsx';
 import { loadGoogleProfile } from '../utils/google.js';
@@ -8,6 +9,18 @@ export default function LoginOptions({ onAuthenticated }) {
   const [googleProfile, setGoogleProfile] = useState(() => loadGoogleProfile());
   const [status, setStatus] = useState('initializing');
   const [ctaMessage, setCtaMessage] = useState('');
+  const [tonStatus, setTonStatus] = useState('idle');
+  const [tonError, setTonError] = useState('');
+
+  const walletAddress = useTonAddress();
+  const [tonConnectUI] = useTonConnectUI();
+
+  const isChrome = useMemo(() => {
+    if (typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    const isChromium = /Chrome\/\d+/i.test(ua) && !/Edg|OPR|Brave/i.test(ua);
+    return isChromium;
+  }, []);
 
   const handleAuthenticated = (profile) => {
     setGoogleProfile(profile);
@@ -61,6 +74,61 @@ export default function LoginOptions({ onAuthenticated }) {
     }
   }, [googleProfile, onAuthenticated]);
 
+  useEffect(() => {
+    if (!walletAddress) {
+      setTonStatus('idle');
+      setTonError('');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        setTonStatus('linking');
+        setTonError('');
+        const res = await registerWallet(walletAddress);
+        if (cancelled) return;
+        if (res?.accountId) {
+          localStorage.setItem('accountId', res.accountId);
+        }
+        localStorage.setItem('walletAddress', walletAddress);
+        const accountRes = await createAccount(undefined, undefined, res?.accountId);
+        if (cancelled) return;
+        if (accountRes?.accountId) {
+          localStorage.setItem('accountId', accountRes.accountId);
+        }
+        setTonStatus('connected');
+      } catch (err) {
+        console.error('Ton Connect setup failed', err);
+        if (!cancelled) {
+          setTonStatus('error');
+          setTonError('We could not link your TON wallet. Please try again.');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  const handleTonConnect = async () => {
+    if (!tonConnectUI) return;
+    try {
+      setTonStatus('connecting');
+      await tonConnectUI.openModal();
+      setTonStatus((prev) => (prev === 'connecting' ? 'idle' : prev));
+    } catch (err) {
+      console.error('Failed to open TON Connect', err);
+      setTonStatus('error');
+      setTonError('Unable to open TON Connect. Please try again.');
+    }
+  };
+
+  const tonCtaLabel = tonStatus === 'connecting' || tonStatus === 'linking'
+    ? 'Connecting to TON…'
+    : walletAddress
+      ? 'TON Wallet Connected'
+      : 'Sign up with TON Connect';
+
   return (
     <div className="p-6 text-text space-y-4 max-w-3xl mx-auto">
       <div className="space-y-2">
@@ -70,7 +138,7 @@ export default function LoginOptions({ onAuthenticated }) {
           TPC profile so you can access the full site, stake, and sync rewards anywhere.
         </p>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-start">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 items-start">
         <div className="rounded-xl border border-border bg-surface/60 p-4 space-y-3">
           <p className="text-sm font-semibold text-white">Login with Telegram</p>
           <p className="text-xs text-subtext">
@@ -88,13 +156,19 @@ export default function LoginOptions({ onAuthenticated }) {
         <div className="rounded-xl border border-border bg-surface/60 p-4 space-y-3">
           <p className="text-sm font-semibold text-white">Login with Google</p>
           <p className="text-xs text-subtext">
-            Ideal for desktop browsers. We&apos;ll link your Google profile to a new TPC account if you don&apos;t have one.
+            Ideal for Google Chrome on desktop. We&apos;ll link your Google profile to a new TPC account if you don&apos;t have one.
           </p>
-          <LinkGoogleButton
-            telegramId={null}
-            label="Continue with Google"
-            onAuthenticated={handleAuthenticated}
-          />
+          {isChrome ? (
+            <LinkGoogleButton
+              telegramId={null}
+              label="Continue with Google"
+              onAuthenticated={handleAuthenticated}
+            />
+          ) : (
+            <p className="text-[11px] text-amber-200">
+              Switch to Google Chrome to unlock sign up with your Google account.
+            </p>
+          )}
           {googleProfile?.email && (
             <p className="text-green-400 text-xs">
               Signed in as {googleProfile.email}. Completing your TPC profile…
@@ -103,6 +177,26 @@ export default function LoginOptions({ onAuthenticated }) {
           {status === 'error' && (
             <p className="text-red-400 text-xs">We couldn&apos;t finish setup. Try again in a moment.</p>
           )}
+        </div>
+
+        <div className="rounded-xl border border-border bg-surface/60 p-4 space-y-3">
+          <p className="text-sm font-semibold text-white">Sign up with TON Connect</p>
+          <p className="text-xs text-subtext">
+            Use the TON Connect wallet flow from the home page to create or link your TPC account with your TON wallet.
+          </p>
+          <button
+            onClick={handleTonConnect}
+            disabled={tonStatus === 'connecting' || tonStatus === 'linking' || tonStatus === 'connected'}
+            className="w-full px-3 py-2 bg-[#0098ea] hover:bg-[#007ac0] text-white rounded font-semibold disabled:opacity-50"
+          >
+            {tonCtaLabel}
+          </button>
+          {walletAddress && (
+            <p className="text-green-400 text-xs">
+              Connected wallet: {walletAddress.slice(0, 6)}…{walletAddress.slice(-4)}
+            </p>
+          )}
+          {tonError && <p className="text-red-400 text-xs">{tonError}</p>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- detect Google Chrome visitors to present the Google signup button for TPC account creation
- add TON Connect signup flow on the profile login options, linking connected wallets to a TPC account
- expand the login options layout and messaging to cover Telegram, Google, and TON wallet entry points

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a4fee5d808329833330f6690e50a0)