### PR TITLE
Add Chrome Google and TON wallet signup options to account

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -37,11 +37,22 @@ router.post('/register-wallet', async (req, res) => {
   if (!normalized) {
     return res.status(400).json({ error: 'invalid walletAddress' });
   }
+  const accountId = uuidv4();
   const user = await User.findOneAndUpdate(
     { walletAddress: normalized },
-    { $setOnInsert: { walletAddress: normalized, referralCode: normalized } },
+    {
+      $setOnInsert: {
+        walletAddress: normalized,
+        referralCode: normalized,
+        accountId
+      }
+    },
     { upsert: true, new: true, setDefaultsOnInsert: true }
   );
+  if (!user.accountId) {
+    user.accountId = accountId;
+    await user.save();
+  }
   res.json(sanitizeUser(user));
 });
 

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -58,11 +58,26 @@ export default function Wallet({ hideClaim = false }) {
     telegramId = undefined;
   }
   const [googleProfile, setGoogleProfile] = useState(() => (telegramId ? null : loadGoogleProfile()));
-  if (!telegramId && !googleProfile?.id) {
-    return <LoginOptions onAuthenticated={setGoogleProfile} />;
+  const [accountId, setAccountId] = useState(() => localStorage.getItem('accountId') || '');
+  const [walletAddress, setWalletAddress] = useState(() => localStorage.getItem('walletAddress') || '');
+  if (!telegramId && !googleProfile?.id && !accountId) {
+    return (
+      <LoginOptions
+        onAuthenticated={setGoogleProfile}
+        onAccountReady={({ accountId, walletAddress }) => {
+          if (accountId) {
+            setAccountId(accountId);
+            localStorage.setItem('accountId', accountId);
+          }
+          if (walletAddress) {
+            setWalletAddress(walletAddress);
+            localStorage.setItem('walletAddress', walletAddress);
+          }
+        }}
+      />
+    );
   }
 
-  const [accountId, setAccountId] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
   const [receiver, setReceiver] = useState('');
   const [amount, setAmount] = useState('');
@@ -110,6 +125,7 @@ export default function Wallet({ hideClaim = false }) {
       localStorage.setItem('accountId', acc.accountId);
       if (acc.walletAddress) {
         localStorage.setItem('walletAddress', acc.walletAddress);
+        setWalletAddress(acc.walletAddress);
       }
       id = acc.accountId;
     }


### PR DESCRIPTION
## Summary
- add a Chrome-focused Google sign-up prompt and a TON Connect wallet sign-up path to the login options
- allow the account and wallet pages to load using stored account IDs from TON wallet registration
- ensure wallet registration assigns an account ID on the server when creating a TPC profile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a4fee5d808329833330f6690e50a0)