### PR TITLE
Add TON Connect signup and Chrome Google CTA

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -552,7 +552,7 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 // ----- Account based wallet -----
 
-export function createAccount(telegramId, googleProfile, accountId) {
+export function createAccount(telegramId, googleProfile, accountId, walletAddress) {
   const body = {};
   if (telegramId) body.telegramId = telegramId;
   const existingAccountId =
@@ -569,6 +569,9 @@ export function createAccount(telegramId, googleProfile, accountId) {
     if (profile.firstName) body.firstName = profile.firstName;
     if (profile.lastName) body.lastName = profile.lastName;
     if (profile.photo) body.photo = profile.photo;
+  }
+  if (walletAddress) {
+    body.walletAddress = walletAddress;
   }
   return post('/api/account/create', body);
 }


### PR DESCRIPTION
## Summary
- add a Chrome CTA for Google sign up and expose a TON Connect sign-up option in the login options
- allow My Account and Wallet flows to treat TON wallet connections as authentication and persist wallet addresses during account creation
- extend account creation API calls to accept a wallet address

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a4fee5d808329833330f6690e50a0)