### PR TITLE
Handle invalid Telegram IDs in account creation

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -30,6 +30,12 @@ function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function normalizeTelegramId(rawId) {
+  const parsed =
+    typeof rawId === 'number' ? rawId : rawId != null ? Number(rawId) : NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 async function fetchWithRetry(url, options = {}, retries = 3, backoff = 500) {
   try {
     const res = await fetch(url, options);
@@ -554,7 +560,8 @@ export function registerWalletPasskey(telegramId, passkeyId, publicKey) {
 
 export function createAccount(telegramId, googleProfile, accountId, walletAddress) {
   const body = {};
-  if (telegramId) body.telegramId = telegramId;
+  const normalizedTelegramId = normalizeTelegramId(telegramId);
+  if (normalizedTelegramId != null) body.telegramId = normalizedTelegramId;
   const existingAccountId =
     accountId ||
     (typeof window !== 'undefined' ? localStorage.getItem('accountId') : null);

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -5,27 +5,37 @@ export function isTelegramWebView() {
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
   return Boolean(window.Telegram?.WebApp || ua.includes('Telegram'));
 }
+
+function parseTelegramId(value) {
+  if (value == null) return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function getTelegramId() {
   if (typeof window !== 'undefined') {
     const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
-    if (tgId) {
-      localStorage.setItem('telegramId', tgId);
-      return tgId;
+    const telegramId = parseTelegramId(tgId);
+    if (telegramId != null) {
+      localStorage.setItem('telegramId', telegramId);
+      return telegramId;
     }
     const params = new URLSearchParams(window.location.search);
     const urlId = params.get('tg') || params.get('telegramId');
     if (urlId) {
-      localStorage.setItem('telegramId', urlId);
-      const n = Number(urlId);
-      return Number.isNaN(n) ? urlId : n;
+      const parsed = parseTelegramId(urlId);
+      if (parsed != null) {
+        localStorage.setItem('telegramId', parsed);
+        return parsed;
+      }
+      localStorage.removeItem('telegramId');
     }
     const stored = localStorage.getItem('telegramId');
     if (stored) {
-      const n = Number(stored);
-      return Number.isNaN(n) ? stored : n;
+      const parsed = parseTelegramId(stored);
+      if (parsed != null) return parsed;
+      localStorage.removeItem('telegramId');
     }
-    const acc = localStorage.getItem('accountId');
-    if (acc) return acc;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- sanitize Telegram IDs before sending account creation requests to avoid backend cast errors
- drop invalid cached Telegram IDs rather than treating arbitrary values as Telegram logins

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a5644e6948329af6924c96c39956a)