### PR TITLE
Bump Android version and refresh launcher link

### DIFF
--- a/webapp/android/app/build.gradle
+++ b/webapp/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.tonplaygram.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -42,6 +42,10 @@ export default function Home() {
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const baseUrl = useMemo(() => import.meta.env.BASE_URL || '/', []);
+  const launcherDownloadUrl = useMemo(
+    () => `${baseUrl}tonplaygram-launcher.apk?v=1.0.1`,
+    [baseUrl]
+  );
   const [pwaDownloadStatus, setPwaDownloadStatus] = useState({ state: 'idle', message: '' });
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
@@ -303,13 +307,15 @@ export default function Home() {
             <p>1) Tap the browser menu and choose &quot;Add to Home screen&quot; to pin the web app like an app.</p>
             <p>2) On Android, you can also install the lightweight launcher APK for faster opening:</p>
             <a
-              href={`${baseUrl}tonplaygram-launcher.apk`}
+              href={launcherDownloadUrl}
               className="text-primary font-semibold underline"
               download
             >
-              Download launcher APK
+              Download launcher APK (v1.0.1)
             </a>
-            <p className="italic text-[11px] text-subtext">No new binaries are added; this uses the existing launcher file.</p>
+            <p className="italic text-[11px] text-subtext">
+              The APK link targets the refreshed launcher build (drop the signed file at public/tonplaygram-launcher.apk outside this PR).
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- bump the Android app versionCode to 2 and versionName to 1.0.1 for the next launcher release
- update the Home page launcher download link to point at the refreshed APK with cache-busting version metadata
- document that the signed launcher APK should be dropped at public/tonplaygram-launcher.apk outside this PR

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a851e5fc08329aabbb736652dd399)