### PR TITLE
Configure Android release signing and launcher delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ webapp/android/app/src/main/res/mipmap-*/ic_launcher_round.png
 webapp/android/app/src/main/res/mipmap-*/ic_launcher_foreground.png
 webapp/android/app/src/main/res/drawable*/splash_logo.png
 webapp/public/assets/icons/generated/
+webapp/public/tonplaygram-launcher.apk
+webapp/android/keystore.properties
+webapp/android/*.keystore
+webapp/android/*.jks
+webapp/android/keystores/
 
 # Environment files
 twitter.env

--- a/webapp/android/RELEASE.md
+++ b/webapp/android/RELEASE.md
@@ -1,0 +1,16 @@
+# Android release process (no binaries in git)
+
+1) Prepare signing
+   - Copy `keystore.properties.example` to `webapp/android/keystore.properties`.
+   - Fill `storeFile`, `storePassword`, `keyAlias`, `keyPassword` with your release keystore values.
+
+2) Fetch the launcher APK (kept out of git)
+   - Export `LAUNCHER_URL` to the hosted, signed `tonplaygram-launcher.apk` (and optionally `LAUNCHER_SHA256`).
+   - Run `npm run fetch:launcher` from `webapp/` to place the file at `public/tonplaygram-launcher.apk` (ignored by git).
+
+3) Build a signed release
+   - From `webapp/android`, run `./gradlew assembleRelease` (or `bundleRelease`) to generate `app-release.apk/aab`.
+
+4) Publish and wire the download link
+   - Upload the generated `app-release.apk` to your CDN/object storage.
+   - Set `VITE_LAUNCHER_URL` in the web deployment environment to the new URL so `Home.jsx` links to the latest launcher without committing binaries.

--- a/webapp/android/app/build.gradle
+++ b/webapp/android/app/build.gradle
@@ -1,4 +1,19 @@
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.util.Properties
+
 apply plugin: 'com.android.application'
+
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('keystore.properties')
+def isReleaseTask = gradle.startParameter.taskNames.any { name ->
+    def lowered = name.toLowerCase()
+    lowered.contains('release') || lowered.contains('bundle')
+}
+
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 android {
     namespace "com.tonplaygram.app"
@@ -7,8 +22,8 @@ android {
         applicationId "com.tonplaygram.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,9 +31,26 @@ android {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            } else if (isReleaseTask) {
+                throw new FileNotFoundException("keystore.properties missing; copy keystore.properties.example and fill release signing values.")
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
+            if (keystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.release
+            } else if (isReleaseTask) {
+                throw new FileNotFoundException("Release signing requires keystore.properties. Populate it using keystore.properties.example.")
+            }
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/webapp/android/keystore.properties.example
+++ b/webapp/android/keystore.properties.example
@@ -1,0 +1,4 @@
+storeFile=/absolute/path/to/tonplaygram.keystore
+storePassword=CHANGE_ME
+keyAlias=tonplaygram
+keyPassword=CHANGE_ME

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview",
     "generate:native-assets": "node scripts/generate-native-assets.mjs",
     "fetch:gradle-wrapper": "node scripts/fetch-gradle-wrapper.mjs",
+    "fetch:launcher": "node scripts/fetch-launcher.mjs",
     "postinstall": "npm run generate:native-assets && npm run fetch:gradle-wrapper"
   },
   "type": "module",

--- a/webapp/public/tonplaygram-launcher.apk
+++ b/webapp/public/tonplaygram-launcher.apk
@@ -1,9 +1,0 @@
-TonPlaygram Android Launcher (preview)
-
-This .apk file acts as a placeholder for downloading the full Android application.
-It currently includes text only to validate the download endpoint without sensitive code
-or closed binaries. Replace it with the signed official build as soon as it is ready.
-
-- Contains no keys or private data.
-- Can be shared publicly to test the download flow.
-- Keep the filename so existing links continue to work.

--- a/webapp/scripts/fetch-launcher.mjs
+++ b/webapp/scripts/fetch-launcher.mjs
@@ -1,0 +1,46 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { createHash } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const outputPath = path.join(projectRoot, 'public', 'tonplaygram-launcher.apk');
+
+const launcherUrl = process.env.LAUNCHER_URL || process.env.VITE_LAUNCHER_URL;
+const expectedSha = (process.env.LAUNCHER_SHA256 || '').trim().toLowerCase();
+
+if (!launcherUrl) {
+  console.error('Set LAUNCHER_URL (or VITE_LAUNCHER_URL) to the signed launcher APK before running this script.');
+  process.exitCode = 1;
+  process.exit();
+}
+
+async function main() {
+  console.info(`Downloading launcher from ${launcherUrl}…`);
+  const response = await fetch(launcherUrl);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download launcher: ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  if (expectedSha) {
+    const hash = createHash('sha256').update(buffer).digest('hex');
+    if (hash !== expectedSha) {
+      throw new Error(`SHA-256 mismatch. Expected ${expectedSha} but got ${hash}`);
+    }
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, buffer);
+  const sizeMb = (buffer.length / (1024 * 1024)).toFixed(2);
+  console.info(`Saved launcher to ${outputPath} (${sizeMb} MiB).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -42,6 +42,10 @@ export default function Home() {
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const baseUrl = useMemo(() => import.meta.env.BASE_URL || '/', []);
+  const launcherUrl = useMemo(
+    () => import.meta.env.VITE_LAUNCHER_URL || `${baseUrl}tonplaygram-launcher.apk`,
+    [baseUrl]
+  );
   const [pwaDownloadStatus, setPwaDownloadStatus] = useState({ state: 'idle', message: '' });
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
@@ -303,13 +307,15 @@ export default function Home() {
             <p>1) Tap the browser menu and choose &quot;Add to Home screen&quot; to pin the web app like an app.</p>
             <p>2) On Android, you can also install the lightweight launcher APK for faster opening:</p>
             <a
-              href={`${baseUrl}tonplaygram-launcher.apk`}
+              href={launcherUrl}
               className="text-primary font-semibold underline"
               download
             >
               Download launcher APK
             </a>
-            <p className="italic text-[11px] text-subtext">No new binaries are added; this uses the existing launcher file.</p>
+            <p className="italic text-[11px] text-subtext">
+              The APK link updates automatically when a new signed launcher is published.
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add release signing configuration driven by keystore.properties and bump the Android versionCode/versionName
- externalize the launcher APK via a configurable download URL and fetch script instead of committing binaries
- document the Android release flow so the web link can point at the latest signed launcher

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8999f0e4832983f207ad7b7d627f)