### PR TITLE
Handle missing leaderboard data on games page

### DIFF
--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "b06c0c2";
+self.__TONPLAYGRAM_APP_BUILD__ = "9cb212b";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "b06c0c2",
-  "generatedAt": "2026-01-04T14:35:31.328Z"
+  "build": "9cb212b",
+  "generatedAt": "2026-01-04T15:41:51.179Z"
 }

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -96,10 +96,16 @@ export default function LeaderboardCard() {
 
   useEffect(() => {
     function loadLeaderboard() {
-      getLeaderboard(telegramId).then((data) => {
-        setLeaderboard(data.users);
-        setRank(data.rank);
-      });
+      getLeaderboard(telegramId)
+        .then((data) => {
+          const users = Array.isArray(data?.users) ? data.users : [];
+          setLeaderboard(users);
+          setRank(typeof data?.rank === 'number' ? data.rank : null);
+        })
+        .catch(() => {
+          setLeaderboard([]);
+          setRank(null);
+        });
     }
     loadLeaderboard();
     const id = setInterval(loadLeaderboard, 15000);

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "b06c0c2";
-export const APP_BUILD_GENERATED_AT = "2026-01-04T14:35:31.328Z";
+export const APP_BUILD = "9cb212b";
+export const APP_BUILD_GENERATED_AT = "2026-01-04T15:41:51.179Z";


### PR DESCRIPTION
## Summary
- guard the leaderboard fetch so missing or invalid responses default to empty data
- refresh build metadata for the updated web app bundle

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a89e7af148329abc7ca98237eb141)