### PR TITLE
Document launcher APK hosting workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@
      Leave empty to reuse the API origin automatically.
    - `VITE_SOCKET_PATH` – (optional) socket.io path (defaults to `/socket.io`).
    - `VITE_GOOGLE_CLIENT_ID` – OAuth client ID for Google sign-in.
-  - `VITE_DEV_ACCOUNT_ID` – account ID that receives the developer share
-    (10% by default).
-  - `VITE_DEV_ACCOUNT_ID_1` – (optional) secondary developer account. When set,
-    the main account receives 9% and this account receives 1%.
-  - `VITE_DEV_ACCOUNT_ID_2` – (optional) additional developer account. When set,
-    the main account receives 9% and this account receives 2%.
-  - `VITE_API_AUTH_TOKEN` – (optional) token used when calling privileged API
-    endpoints outside Telegram.
+   - `VITE_DEV_ACCOUNT_ID` – account ID that receives the developer share
+     (10% by default).
+   - `VITE_DEV_ACCOUNT_ID_1` – (optional) secondary developer account. When set,
+     the main account receives 9% and this account receives 1%.
+   - `VITE_DEV_ACCOUNT_ID_2` – (optional) additional developer account. When set,
+     the main account receives 9% and this account receives 2%.
+   - `VITE_API_AUTH_TOKEN` – (optional) token used when calling privileged API
+     endpoints outside Telegram.
+   - `VITE_LAUNCHER_URL` – HTTPS link to the signed `tonplaygram-launcher.apk` hosted on your CDN/object storage so `Home.jsx` links to the correct binary.
 
    This value is required for the Google button to appear on the login and
    profile pages. When provided, the webapp lets users sign in with Google and
@@ -93,6 +94,7 @@ The server honors a few extra environment variables when building or serving the
 - `WEBAPP_API_BASE_URL` – overrides the API base used during the webapp build. Set this when the bot API is hosted on another domain or port. If left empty the webapp assumes it is served from the same origin.
 - `SKIP_WEBAPP_BUILD` – set to any value to skip the automatic webapp build that normally runs when `npm start` is executed. Useful if you built the assets manually.
 - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io when serving the API. Separate multiple origins with commas.
+- `LAUNCHER_URL` / `LAUNCHER_SHA256` – (optional) set these before running `npm --prefix webapp run fetch:launcher` to download the signed launcher APK into `webapp/public/tonplaygram-launcher.apk` without committing binaries. `LAUNCHER_SHA256` is verified when provided.
 
 5. Copy `scripts/.env.example` to `scripts/.env` and set:
    - `MNEMONIC` – wallet seed phrase used to deploy the Jetton

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -9,3 +9,6 @@ VITE_DEV_ACCOUNT_ID=5ffe7c43-c0ae-48f6-ab8c-9e065ca95466
 VITE_DEV_ACCOUNT_ID_1=
 VITE_DEV_ACCOUNT_ID_2=
 VITE_API_AUTH_TOKEN=
+VITE_LAUNCHER_URL=https://cdn.prod-domain.tld/tonplaygram-launcher.apk
+# Optional: if set, `npm --prefix webapp run fetch:launcher` can read LAUNCHER_URL/LAUNCHER_SHA256
+# to download a signed launcher APK into webapp/public without committing the binary.

--- a/webapp/android/RELEASE.md
+++ b/webapp/android/RELEASE.md
@@ -6,7 +6,7 @@
 
 2) Fetch the launcher APK (kept out of git)
    - Export `LAUNCHER_URL` to the hosted, signed `tonplaygram-launcher.apk` (and optionally `LAUNCHER_SHA256`).
-   - Run `npm run fetch:launcher` from `webapp/` to place the file at `public/tonplaygram-launcher.apk` (ignored by git).
+   - Run `npm --prefix webapp run fetch:launcher` to place the file at `webapp/public/tonplaygram-launcher.apk` (ignored by git).
 
 3) Build a signed release
    - From `webapp/android`, run `./gradlew assembleRelease` (or `bundleRelease`) to generate `app-release.apk/aab`.


### PR DESCRIPTION
## Summary
- add VITE_LAUNCHER_URL to the webapp environment example for linking the hosted launcher APK
- document the LAUNCHER_URL/LAUNCHER_SHA256 variables and fetch command in the repository README
- update the Android release guide to use the root-level fetch launcher command and path

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa3ad096c8329b937ea0458b110e5)