### PR TITLE
Add production webapp env and wire CI secrets

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -6,6 +6,16 @@ on:
 jobs:
   android:
     runs-on: ubuntu-latest
+    env:
+      VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+      VITE_SOCKET_URL: ${{ secrets.VITE_SOCKET_URL }}
+      VITE_SOCKET_PATH: ${{ secrets.VITE_SOCKET_PATH }}
+      VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+      VITE_DEV_ACCOUNT_ID: ${{ secrets.VITE_DEV_ACCOUNT_ID }}
+      VITE_DEV_ACCOUNT_ID_1: ${{ secrets.VITE_DEV_ACCOUNT_ID_1 }}
+      VITE_DEV_ACCOUNT_ID_2: ${{ secrets.VITE_DEV_ACCOUNT_ID_2 }}
+      VITE_API_AUTH_TOKEN: ${{ secrets.VITE_API_AUTH_TOKEN }}
+      VITE_LAUNCHER_URL: ${{ secrets.VITE_LAUNCHER_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,6 +58,16 @@ jobs:
 
   ios:
     runs-on: macos-latest
+    env:
+      VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+      VITE_SOCKET_URL: ${{ secrets.VITE_SOCKET_URL }}
+      VITE_SOCKET_PATH: ${{ secrets.VITE_SOCKET_PATH }}
+      VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+      VITE_DEV_ACCOUNT_ID: ${{ secrets.VITE_DEV_ACCOUNT_ID }}
+      VITE_DEV_ACCOUNT_ID_1: ${{ secrets.VITE_DEV_ACCOUNT_ID_1 }}
+      VITE_DEV_ACCOUNT_ID_2: ${{ secrets.VITE_DEV_ACCOUNT_ID_2 }}
+      VITE_API_AUTH_TOKEN: ${{ secrets.VITE_API_AUTH_TOKEN }}
+      VITE_LAUNCHER_URL: ${{ secrets.VITE_LAUNCHER_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,0 +1,9 @@
+VITE_API_BASE_URL=https://api.tonplaygram.com
+VITE_SOCKET_URL=https://api.tonplaygram.com
+VITE_SOCKET_PATH=/socket.io
+VITE_GOOGLE_CLIENT_ID=1080581969180-2rmpxhzwd67l6hx0n5zti37ya15dyc95.apps.googleusercontent.com
+VITE_DEV_ACCOUNT_ID=5ffe7c43-c0ae-48f6-ab8c-9e065ca95466
+VITE_DEV_ACCOUNT_ID_1=
+VITE_DEV_ACCOUNT_ID_2=
+VITE_API_AUTH_TOKEN=ccfccc16b9ae23319ea1b6d06ccca1dfc777456b0de1e061d6e0e552fbe7386e
+VITE_LAUNCHER_URL=https://cdn.tonplaygram.com/tonplaygram-launcher.apk


### PR DESCRIPTION
## Summary
- add a populated `webapp/.env` with production API/socket endpoints, Google client ID, developer account IDs, API auth token, and launcher URL
- expose the same webapp environment variables to the Android and iOS native build workflow via repository secrets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aaa9d384483298f07750e51eb4b37)