### PR TITLE
Regenerate native assets for iOS app icons

### DIFF
--- a/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -7,16 +7,10 @@
       "size": "20x20"
     },
     {
-      "filename": "app-icon-29x29@2x.png",
-      "idiom": "iphone",
-      "scale": "2x",
-      "size": "29x29"
-    },
-    {
-      "filename": "app-icon-20x20@3x.png",
+      "filename": "app-icon-29x29@3x.png",
       "idiom": "iphone",
       "scale": "3x",
-      "size": "20x20"
+      "size": "29x29"
     },
     {
       "filename": "app-icon-40x40@2x.png",
@@ -25,16 +19,16 @@
       "size": "40x40"
     },
     {
-      "filename": "app-icon-29x29@3x.png",
+      "filename": "app-icon-29x29@2x.png",
       "idiom": "iphone",
-      "scale": "3x",
+      "scale": "2x",
       "size": "29x29"
     },
     {
-      "filename": "app-icon-20x20@1x.png",
-      "idiom": "ipad",
-      "scale": "1x",
-      "size": "20x20"
+      "filename": "app-icon-60x60@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "60x60"
     },
     {
       "filename": "app-icon-40x40@3x.png",
@@ -49,15 +43,15 @@
       "size": "20x20"
     },
     {
-      "filename": "app-icon-60x60@2x.png",
+      "filename": "app-icon-60x60@3x.png",
       "idiom": "iphone",
-      "scale": "2x",
+      "scale": "3x",
       "size": "60x60"
     },
     {
-      "filename": "app-icon-29x29@2x.png",
+      "filename": "app-icon-29x29@1x.png",
       "idiom": "ipad",
-      "scale": "2x",
+      "scale": "1x",
       "size": "29x29"
     },
     {
@@ -67,9 +61,15 @@
       "size": "40x40"
     },
     {
-      "filename": "app-icon-29x29@1x.png",
+      "filename": "app-icon-20x20@1x.png",
       "idiom": "ipad",
       "scale": "1x",
+      "size": "20x20"
+    },
+    {
+      "filename": "app-icon-29x29@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
       "size": "29x29"
     },
     {
@@ -79,10 +79,22 @@
       "size": "40x40"
     },
     {
-      "filename": "app-icon-60x60@3x.png",
+      "filename": "app-icon-76x76@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "76x76"
+    },
+    {
+      "filename": "app-icon-20x20@3x.png",
       "idiom": "iphone",
       "scale": "3x",
-      "size": "60x60"
+      "size": "20x20"
+    },
+    {
+      "filename": "app-icon-83.5x83.5@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "83.5x83.5"
     },
     {
       "filename": "app-icon-76x76@1x.png",
@@ -95,18 +107,6 @@
       "idiom": "ios-marketing",
       "scale": "1x",
       "size": "1024x1024"
-    },
-    {
-      "filename": "app-icon-76x76@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "76x76"
-    },
-    {
-      "filename": "app-icon-83.5x83.5@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "83.5x83.5"
     }
   ],
   "info": {


### PR DESCRIPTION
## Summary
- regenerated iOS app icon catalog via `npm --prefix webapp run generate:native-assets`
- ensured native asset definitions are up to date for iOS builds

## Testing
- npm --prefix webapp run generate:native-assets

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aae143c708329bb024dcdb8e36db4)