### PR TITLE
Improve Pool Royale AI aiming consistency

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -186,6 +186,17 @@ function aimPointForCandidate (candidate, state, cueBall) {
   if (candidate.bankAnchor) {
     return { x: candidate.bankAnchor.x, y: candidate.bankAnchor.y }
   }
+  // For virtually straight pots, aim at the object ball's center rather than
+  // offsetting to a ghost contact point. This keeps dead-straight shots on
+  // line and matches how a real player would strike the ball head‑on.
+  const STRAIGHT_AIM_EPSILON = Math.PI / 90 // ~2°
+  if (
+    candidate.targetBall &&
+    typeof candidate.angle === 'number' &&
+    candidate.angle <= STRAIGHT_AIM_EPSILON
+  ) {
+    return { x: candidate.targetBall.x, y: candidate.targetBall.y }
+  }
   const ghost = contactPointTowardsPocket(
     candidate.targetBall,
     candidate.pocket,
@@ -735,6 +746,10 @@ function chooseBestAction (state, colour) {
 
   if (candidates.length === 0) {
     candidates = kicks
+  } else if (directPots.length === 0 && kicks.length > 0) {
+    // When straight looks are blocked, consider kick safeties before
+    // defaulting to gentle roll-ups so the AI actively seeks cushion escapes.
+    candidates = candidates.concat(kicks)
   }
 
   if (directPots.length === 0) {


### PR DESCRIPTION
## Summary
- aim straight pot calculations at the object-ball center to keep perfect-line shots on track
- prefer kick-based safeties when direct pots are blocked so the AI stays logical after the break

## Testing
- `npm test -- poolUkAdvancedAi.test.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b68c8d1808329b1837b21f1ac0769)