### PR TITLE
Fix Pool Royale break detection

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -55,6 +55,7 @@ type PoolMeta =
       state: UkSerializedState;
       totals: { blue: number; red: number };
       hud: HudInfo;
+      breakInProgress?: boolean;
     }
   | {
       variant: 'american';
@@ -245,7 +246,8 @@ export class PoolRoyaleRules {
           variant: 'uk',
           state: snapshot,
           totals: { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR },
-          hud
+          hud,
+          breakInProgress: true
         } satisfies PoolMeta;
         return base;
       }
@@ -364,6 +366,14 @@ export class PoolRoyaleRules {
       phase: snapshot.isOpenTable ? 'open' : 'groups',
       scores: playerScores
     };
+    const shooter = state.activePlayer === 'B' ? 'B' : 'A';
+    const scorerDelta =
+      playerScores[shooter] - (state.players?.[shooter]?.score ?? 0);
+    const retainsTable = game.state.currentPlayer === shooter;
+    const currentBreak =
+      !shotResult.foul && retainsTable && scorerDelta > 0 && !game.state.frameOver
+        ? Math.max(0, state.currentBreak ?? 0) + scorerDelta
+        : 0;
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
@@ -371,6 +381,7 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: playerScores.A },
         B: { ...state.players.B, score: playerScores.B }
       },
+      currentBreak,
       ballOn,
       frameOver: game.state.frameOver,
       winner: game.state.winner ?? undefined,
@@ -384,7 +395,8 @@ export class PoolRoyaleRules {
         variant: 'uk',
         state: snapshot,
         totals,
-        hud
+        hud,
+        breakInProgress: false
       } satisfies PoolMeta
     };
     return nextState;
@@ -479,6 +491,14 @@ export class PoolRoyaleRules {
       else if (snapshot.scores.B > snapshot.scores.A) winner = 'B';
       else winner = 'TIE';
     }
+    const shooter = state.activePlayer === 'B' ? 'B' : 'A';
+    const scorerDelta =
+      snapshot.scores[shooter] - (state.players?.[shooter]?.score ?? 0);
+    const retainsTable = game.state.currentPlayer === shooter;
+    const currentBreak =
+      !result.foul && retainsTable && scorerDelta > 0 && !frameOver
+        ? Math.max(0, state.currentBreak ?? 0) + scorerDelta
+        : 0;
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
@@ -486,6 +506,7 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: snapshot.scores.A },
         B: { ...state.players.B, score: snapshot.scores.B }
       },
+      currentBreak,
       ballOn: lowest != null && !frameOver ? [`BALL_${lowest}`] : [],
       frameOver,
       winner,
@@ -544,6 +565,13 @@ export class PoolRoyaleRules {
       phase: snapshot.gameOver ? 'complete' : 'run',
       scores: { A: 0, B: 0 }
     };
+    const shooter = state.activePlayer === 'B' ? 'B' : 'A';
+    const retainsTable = game.state.currentPlayer === shooter;
+    const scoredBalls = result.foul ? 0 : potted.filter((id) => id !== 0).length;
+    const currentBreak =
+      retainsTable && scoredBalls > 0 && !game.state.gameOver
+        ? Math.max(0, state.currentBreak ?? 0) + scoredBalls
+        : 0;
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
@@ -551,6 +579,7 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: 0 },
         B: { ...state.players.B, score: 0 }
       },
+      currentBreak,
       ballOn: lowest != null && !snapshot.gameOver ? [`BALL_${lowest}`] : [],
       frameOver: game.state.gameOver,
       winner: game.state.winner ?? undefined,

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -10,6 +10,7 @@ describe('PoolRoyaleRules', () => {
     expect(initialMeta?.variant).toBe('uk');
     expect(initialMeta?.hud?.next).toBe('open table');
     expect(initialMeta?.state?.isOpenTable).toBe(true);
+    expect(initialMeta?.breakInProgress).toBe(true);
 
     const assignEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 'red', ballId: 'RED' },
@@ -28,6 +29,8 @@ describe('PoolRoyaleRules', () => {
     expect(assigned.ballOn).toEqual(['RED']);
     expect(assignedMeta?.hud?.next).toBe('red');
     expect(assignedMeta?.hud?.phase).toBe('groups');
+    expect(assignedMeta?.breakInProgress).toBe(false);
+    expect(assigned.currentBreak).toBe(1);
 
     const foulEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 'black', ballId: 'BLACK' },
@@ -71,6 +74,7 @@ describe('PoolRoyaleRules', () => {
     expect(cleared.ballOn).toEqual(['BALL_3']);
     expect(clearedMeta?.hud?.next).toBe('ball 3');
     expect(cleared.players.A.score).toBe(3);
+    expect(cleared.currentBreak).toBe(3);
 
     const scratchEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 3, ballId: 3 },
@@ -85,6 +89,7 @@ describe('PoolRoyaleRules', () => {
     expect(scratch.activePlayer).toBe('B');
     expect(scratch.ballOn).toEqual(['BALL_3']);
     expect(scratchMeta?.hud?.phase).toBe('rotation');
+    expect(scratch.currentBreak).toBe(0);
   });
 
   test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {
@@ -119,5 +124,6 @@ describe('PoolRoyaleRules', () => {
     expect(recoveryMeta?.state?.ballInHand).toBe(false);
     expect(recoveryState.ballOn).toEqual(['BALL_2']);
     expect(recoveryMeta?.hud?.next).toBe('ball 2');
+    expect(recoveryState.currentBreak).toBe(1);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18949,7 +18949,7 @@ const powerRef = useRef(hud.power);
           const preferZoomReplay =
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
-          const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
+          const isBreakShot = isBreakInProgress(frameStateCurrent);
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = aimDir
@@ -20314,7 +20314,7 @@ const powerRef = useRef(hud.power);
             Math.max(AI_MIN_AIM_PREVIEW_MS, windowDuration - AI_MIN_AIM_PREVIEW_MS)
           );
           const deadline = started + thinkingBudget;
-          const think = () => {
+            const think = () => {
             if (shooting || hudRef.current?.turn !== 1) {
               setAiPlanning(null);
               aiPlanRef.current = null;
@@ -20345,6 +20345,13 @@ const powerRef = useRef(hud.power);
             }
           };
           think();
+        };
+        const isBreakInProgress = (frameSnapshot) => {
+          const meta = frameSnapshot?.meta;
+          if (meta && typeof meta === 'object' && 'breakInProgress' in meta) {
+            return Boolean(meta.breakInProgress);
+          }
+          return (frameSnapshot?.currentBreak ?? 0) === 0;
         };
         const resolveAutoAimDirection = () => {
           if (!cue?.active) return null;
@@ -20400,7 +20407,7 @@ const powerRef = useRef(hud.power);
             }, null);
 
           let targetBall = null;
-          if ((frameSnapshot?.currentBreak ?? 0) === 0) {
+          if (isBreakInProgress(frameSnapshot)) {
             targetBall = findRackApex();
           }
 


### PR DESCRIPTION
## Summary
- track break progress and currentBreak across Pool Royale variants, including the UK frame meta
- use the break-in-progress flag on the client to avoid treating every AI shot as the opening break
- add regression coverage to confirm break state resets and scoring runs are recorded

## Testing
- npm test -- poolRoyaleRules.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b68c8d1808329b1837b21f1ac0769)