### PR TITLE
Tighten Pool Royale cameras and upgrade AI aiming

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -27,21 +27,21 @@ public class CameraController : MonoBehaviour
     // Minimum distance the camera should maintain when hugging the table so the
     // framing ends up closer to the cue ball without drifting toward the butt of
     // the cue stick.
-    public float minimumCueViewDistance = 1.25f;
+    public float minimumCueViewDistance = 1.05f;
     // How far above the rails the camera is allowed to travel.
     public float maxHeightAboveTable = 2.05f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 2.7f;
+    public float distanceFromCenter = 2.45f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 1.55f;
+    public float minDistanceFromCenter = 1.35f;
     // Extra distance the camera is allowed to shed as it hugs the table so the
     // cue ball fills more of the view during low-angle aiming.
-    public float lowHeightDistanceReduction = 0.9f;
+    public float lowHeightDistanceReduction = 1.05f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
-    public float zoomOutWhenRaised = 0.12f;
+    public float zoomOutWhenRaised = 0.08f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
     public float railBuffer = 0.012f;

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -25,14 +25,14 @@ public class CueCamera : MonoBehaviour
 
     [Header("Cue aim view")]
     // Distance from the cue ball when the camera is fully raised above the cue.
-    public float cueRaisedDistanceFromBall = 0.68f;
+    public float cueRaisedDistanceFromBall = 0.6f;
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.05f;
+    public float cueLoweredDistanceFromBall = 0.035f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
-    public float cueDistancePullIn = 0.48f;
+    public float cueDistancePullIn = 0.52f;
     // Minimum separation we allow once the pull-in is applied. Prevents the
     // camera from intersecting the cue or cloth when the player drops in tight.
     public float cueMinimumDistance = 0.02f;
@@ -90,11 +90,11 @@ public class CueCamera : MonoBehaviour
     // Scale applied to the cue distance when the camera is raised. Values below
     // 1 slide the camera closer to the cloth even before the player lowers it.
     [Range(0.1f, 1f)]
-    public float cueRaisedDistanceScale = 0.78f;
+    public float cueRaisedDistanceScale = 0.7f;
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.45f;
+    public float cueLoweredDistanceScale = 0.4f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -40,6 +40,8 @@
 const LOOKAHEAD_DEPTH = 2
 const LOOKAHEAD_CANDIDATES = 3
 const MONTE_CARLO_BASE_SAMPLES = 28
+const MIN_RELIABLE_POT_CHANCE = 0.18
+const SCRATCH_CLEARANCE = 1.2
 
 function dist (a, b) {
   const dx = a.x - b.x
@@ -65,6 +67,64 @@ function pathBlocked (a, b, balls, ignoreIds, radius, margin = 1) {
       !ignoreIds.includes(ball.id) &&
       lineIntersectsBall(a, b, ball, radius * margin)
   )
+}
+
+function cueLineNearPocket (start, end, pockets, radius, maxTravel) {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const len = Math.hypot(dx, dy)
+  if (len < Number.EPSILON) return false
+  const nx = dx / len
+  const ny = dy / len
+  const travel = Math.min(len, maxTravel ?? len)
+  const clearanceSq = (radius * SCRATCH_CLEARANCE) * (radius * SCRATCH_CLEARANCE)
+  return pockets.some((p) => {
+    const px = p.x - start.x
+    const py = p.y - start.y
+    const proj = px * nx + py * ny
+    if (proj <= 0 || proj >= travel) return false
+    const closest = { x: start.x + nx * proj, y: start.y + ny * proj }
+    const distSq = (closest.x - p.x) ** 2 + (closest.y - p.y) ** 2
+    return distSq < clearanceSq
+  })
+}
+
+function findCushionRedirect (cue, ghost, balls, ignoreIds, radius, state) {
+  const inset = radius * 1.1
+  const walls = [
+    { axis: 'x', value: inset },
+    { axis: 'x', value: state.width - inset },
+    { axis: 'y', value: inset },
+    { axis: 'y', value: state.height - inset }
+  ]
+  for (const wall of walls) {
+    const mirrored = { ...ghost }
+    if (wall.axis === 'x') {
+      mirrored.x = wall.value + (wall.value - ghost.x)
+    } else {
+      mirrored.y = wall.value + (wall.value - ghost.y)
+    }
+    const dir = { x: mirrored.x - cue.x, y: mirrored.y - cue.y }
+    const len = Math.hypot(dir.x, dir.y)
+    if (len < radius * 2) continue
+    const t = wall.axis === 'x'
+      ? (wall.value - cue.x) / dir.x
+      : (wall.value - cue.y) / dir.y
+    if (t <= 0 || t >= 1) continue
+    const cushionPoint = { x: cue.x + dir.x * t, y: cue.y + dir.y * t }
+    if (
+      cushionPoint.x < inset ||
+      cushionPoint.x > state.width - inset ||
+      cushionPoint.y < inset ||
+      cushionPoint.y > state.height - inset
+    ) {
+      continue
+    }
+    if (pathBlocked(cue, cushionPoint, balls, ignoreIds, radius, 1.05)) continue
+    if (pathBlocked(cushionPoint, ghost, balls, ignoreIds, radius, 1.05)) continue
+    return cushionPoint
+  }
+  return null
 }
 
 function pocketNormal (pocket, width, height) {
@@ -368,6 +428,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
     y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
   }
+  let aimTarget = ghost
+  let viaCushion = false
+  let cushionPoint = null
   // if ghost lies outside playable area, shot is impossible
   if (
     ghost.x < r ||
@@ -377,15 +440,28 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
+  const ignore = [0, target.id]
+  const cueToGhostBlocked = pathBlocked(cue, ghost, balls, ignore, r, 1.1)
+  if (cueToGhostBlocked) {
+    cushionPoint = findCushionRedirect(cue, ghost, balls, ignore, r, req.state)
+    if (!cushionPoint) return null
+    aimTarget = cushionPoint
+    viaCushion = true
+  }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
+    pathBlocked(target, entry, balls, ignore, r) ||
     balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
+  if (cueLineNearPocket(cue, aimTarget, req.state.pockets, r, dist(cue, aimTarget))) {
+    return null
+  }
   const maxD = Math.hypot(req.state.width, req.state.height)
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls)
+  if (potChance < MIN_RELIABLE_POT_CHANCE && strict) {
+    return null
+  }
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
@@ -399,7 +475,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
-  const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
+  let centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const viewAngle = Math.atan2(r * 2, dist(target, entry))
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
@@ -413,13 +489,17 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
   }
+  if (viaCushion) {
+    // cushion shots are harder; dampen their influence unless no other options exist
+    centerAlign *= 0.9
+  }
   const lookaheadDepth = Number.isFinite(options.lookaheadDepth)
     ? Math.max(0, options.lookaheadDepth)
     : LOOKAHEAD_DEPTH
   const runoutPotential = options.skipLookahead
     ? 0
     : estimateRunoutPotential(req, cueAfter, target.id, balls, lookaheadDepth)
-  const quality = Math.max(
+  let quality = Math.max(
     0,
     Math.min(
       1,
@@ -430,19 +510,29 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
         0.06 * nearHole +
         0.08 * runoutPotential -
         0.15 * risk -
-        difficultyPenalty
+        difficultyPenalty -
+        (viaCushion ? 0.12 : 0)
     )
   )
-  const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
+  if (!viaCushion && potChance < MIN_RELIABLE_POT_CHANCE) {
+    // Steer away from visually red (low probability) lines unless nothing else exists.
+    quality *= 0.6
+  }
+  const aimVec = { x: aimTarget.x - cue.x, y: aimTarget.y - cue.y }
+  const angle = Math.atan2(aimVec.y, aimVec.x)
   return {
     angleRad: angle,
     power,
     spin,
     targetBallId: target.id,
     targetPocket: entry,
-    aimPoint: ghost,
+    aimPoint: viaCushion ? cushionPoint : ghost,
+    contactPoint: ghost,
+    viaCushion,
+    cushionPoint: viaCushion ? cushionPoint : undefined,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
+    potChance,
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)} cushion=${viaCushion}`,
     nextScore,
     hasNext
   }

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -40,6 +40,8 @@
 const LOOKAHEAD_DEPTH = 2
 const LOOKAHEAD_CANDIDATES = 3
 const MONTE_CARLO_BASE_SAMPLES = 28
+const MIN_RELIABLE_POT_CHANCE = 0.18
+const SCRATCH_CLEARANCE = 1.2
 
 function dist (a, b) {
   const dx = a.x - b.x
@@ -65,6 +67,64 @@ function pathBlocked (a, b, balls, ignoreIds, radius, margin = 1) {
       !ignoreIds.includes(ball.id) &&
       lineIntersectsBall(a, b, ball, radius * margin)
   )
+}
+
+function cueLineNearPocket (start, end, pockets, radius, maxTravel) {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const len = Math.hypot(dx, dy)
+  if (len < Number.EPSILON) return false
+  const nx = dx / len
+  const ny = dy / len
+  const travel = Math.min(len, maxTravel ?? len)
+  const clearanceSq = (radius * SCRATCH_CLEARANCE) * (radius * SCRATCH_CLEARANCE)
+  return pockets.some((p) => {
+    const px = p.x - start.x
+    const py = p.y - start.y
+    const proj = px * nx + py * ny
+    if (proj <= 0 || proj >= travel) return false
+    const closest = { x: start.x + nx * proj, y: start.y + ny * proj }
+    const distSq = (closest.x - p.x) ** 2 + (closest.y - p.y) ** 2
+    return distSq < clearanceSq
+  })
+}
+
+function findCushionRedirect (cue, ghost, balls, ignoreIds, radius, state) {
+  const inset = radius * 1.1
+  const walls = [
+    { axis: 'x', value: inset },
+    { axis: 'x', value: state.width - inset },
+    { axis: 'y', value: inset },
+    { axis: 'y', value: state.height - inset }
+  ]
+  for (const wall of walls) {
+    const mirrored = { ...ghost }
+    if (wall.axis === 'x') {
+      mirrored.x = wall.value + (wall.value - ghost.x)
+    } else {
+      mirrored.y = wall.value + (wall.value - ghost.y)
+    }
+    const dir = { x: mirrored.x - cue.x, y: mirrored.y - cue.y }
+    const len = Math.hypot(dir.x, dir.y)
+    if (len < radius * 2) continue
+    const t = wall.axis === 'x'
+      ? (wall.value - cue.x) / dir.x
+      : (wall.value - cue.y) / dir.y
+    if (t <= 0 || t >= 1) continue
+    const cushionPoint = { x: cue.x + dir.x * t, y: cue.y + dir.y * t }
+    if (
+      cushionPoint.x < inset ||
+      cushionPoint.x > state.width - inset ||
+      cushionPoint.y < inset ||
+      cushionPoint.y > state.height - inset
+    ) {
+      continue
+    }
+    if (pathBlocked(cue, cushionPoint, balls, ignoreIds, radius, 1.05)) continue
+    if (pathBlocked(cushionPoint, ghost, balls, ignoreIds, radius, 1.05)) continue
+    return cushionPoint
+  }
+  return null
 }
 
 function pocketNormal (pocket, width, height) {
@@ -368,6 +428,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
     y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
   }
+  let aimTarget = ghost
+  let viaCushion = false
+  let cushionPoint = null
   // if ghost lies outside playable area, shot is impossible
   if (
     ghost.x < r ||
@@ -377,15 +440,28 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
+  const ignore = [0, target.id]
+  const cueToGhostBlocked = pathBlocked(cue, ghost, balls, ignore, r, 1.1)
+  if (cueToGhostBlocked) {
+    cushionPoint = findCushionRedirect(cue, ghost, balls, ignore, r, req.state)
+    if (!cushionPoint) return null
+    aimTarget = cushionPoint
+    viaCushion = true
+  }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
+    pathBlocked(target, entry, balls, ignore, r) ||
     balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
+  if (cueLineNearPocket(cue, aimTarget, req.state.pockets, r, dist(cue, aimTarget))) {
+    return null
+  }
   const maxD = Math.hypot(req.state.width, req.state.height)
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls)
+  if (potChance < MIN_RELIABLE_POT_CHANCE && strict) {
+    return null
+  }
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
@@ -399,7 +475,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
-  const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
+  let centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const viewAngle = Math.atan2(r * 2, dist(target, entry))
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
@@ -413,13 +489,17 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
   }
+  if (viaCushion) {
+    // cushion shots are harder; dampen their influence unless no other options exist
+    centerAlign *= 0.9
+  }
   const lookaheadDepth = Number.isFinite(options.lookaheadDepth)
     ? Math.max(0, options.lookaheadDepth)
     : LOOKAHEAD_DEPTH
   const runoutPotential = options.skipLookahead
     ? 0
     : estimateRunoutPotential(req, cueAfter, target.id, balls, lookaheadDepth)
-  const quality = Math.max(
+  let quality = Math.max(
     0,
     Math.min(
       1,
@@ -430,19 +510,29 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
         0.06 * nearHole +
         0.08 * runoutPotential -
         0.15 * risk -
-        difficultyPenalty
+        difficultyPenalty -
+        (viaCushion ? 0.12 : 0)
     )
   )
-  const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
+  if (!viaCushion && potChance < MIN_RELIABLE_POT_CHANCE) {
+    // Steer away from visually red (low probability) lines unless nothing else exists.
+    quality *= 0.6
+  }
+  const aimVec = { x: aimTarget.x - cue.x, y: aimTarget.y - cue.y }
+  const angle = Math.atan2(aimVec.y, aimVec.x)
   return {
     angleRad: angle,
     power,
     spin,
     targetBallId: target.id,
     targetPocket: entry,
-    aimPoint: ghost,
+    aimPoint: viaCushion ? cushionPoint : ghost,
+    contactPoint: ghost,
+    viaCushion,
+    cushionPoint: viaCushion ? cushionPoint : undefined,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
+    potChance,
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)} cushion=${viaCushion}`,
     nextScore,
     hasNext
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20539,11 +20539,14 @@ const powerRef = useRef(hud.power);
           }
 
           if (targetBall && !isDirectLaneOpen(targetBall)) {
-            const rerouted =
+            const rescueTarget =
               pickDirectPreferredBall(combinedTargets) ||
-              pickPreferredBall(combinedTargets, activeBalls, cuePos) ||
               pickFallbackBall();
-            if (rerouted) targetBall = rerouted;
+            if (rescueTarget && isDirectLaneOpen(rescueTarget)) {
+              targetBall = rescueTarget;
+            } else {
+              return null;
+            }
           }
 
           if (!targetBall) return null;


### PR DESCRIPTION
## Summary
- Pull the cue and standing camera defaults closer to the action while keeping existing framing logic intact.
- Strengthen Pool AI shot selection with scratch avoidance, cushion redirects when direct lanes are blocked, and better weighting toward reliable pots across rule sets.
- Keep auto-aim suggestions pointed at player balls instead of cushion lines for user turns.

## Testing
- npm test -- poolAi.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b80d08b1c83299c90b48764718107)