### PR TITLE
Improve Pool Royale camera framing and aim precision

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4933,20 +4933,20 @@ function applySnookerScaling({
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
 const STANDING_VIEW_PHI = 0.86; // raise the standing orbit a touch for a clearer overview
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
+const STANDING_VIEW_MARGIN = 0.0009; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.1;
 const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.14; // let the cue view drop to the same rail-hugging height used by AI shots while staying above the cue
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0165; // pull the player orbit nearer to the cloth while keeping the frame airy
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0155; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
-const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
+const BROADCAST_DISTANCE_MULTIPLIER = 0.055;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 1.0013;
-const STANDING_VIEW_MARGIN_PORTRAIT = 1.0011;
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.001;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.0009;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5038,7 +5038,7 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 1.38; // pull the rail overhead broadcast he
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.024; // tighten cue camera distance so the cue ball and object ball appear larger
+const CUE_VIEW_RADIUS_RATIO = 0.021; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
@@ -19739,11 +19739,11 @@ const powerRef = useRef(hud.power);
           };
           const isPlayablePlan = (plan, { allowCushion = true } = {}) => {
             if (!plan) return false;
-            const qualityOk = (plan.quality ?? 0) >= 0.12;
+            const qualityOk = (plan.quality ?? 0) >= 0.2;
             if (!qualityOk) return false;
             if (!allowCushion && plan.viaCushion) return false;
             if (isAimLaneBlocked(plan)) return false;
-            if (measureLaneClearance(plan) < 0.6) return false;
+            if (measureLaneClearance(plan) < 0.75) return false;
             if (detectScratchRisk(plan)) return false;
             return true;
           };
@@ -20083,17 +20083,19 @@ const powerRef = useRef(hud.power);
                 .length <= 2
                 ? 0.06
                 : 0;
-            const laneBonus = Math.max(0, Math.min((laneClearance - 0.6) / 0.8, 1));
+            const laneBonus = Math.max(0, Math.min((laneClearance - 0.75) / 0.6, 1));
+            const directBonus = plan.viaCushion ? -0.18 : 0.12;
             return (
               quality * 0.48 +
-              difficultyEase * 0.18 +
+              difficultyEase * 0.2 +
               pocketEase * 0.1 +
               cueEase * 0.08 +
               priorityBonus * 0.1 +
               routeEase * 0.06 +
-              laneBonus * 0.08 +
+              laneBonus * 0.12 +
               finishBonus -
-              cushionPenalty
+              cushionPenalty +
+              directBonus
             );
           };
           const scoredPots = potShots
@@ -20614,18 +20616,22 @@ const powerRef = useRef(hud.power);
             suggestionAimKeyRef.current = key;
             return true;
           };
-          const preferAutoAim = autoAimRequestRef.current;
-          if (preferAutoAim) {
-            let autoDir = resolveAutoAimDirection();
-            if (!autoDir && plan?.targetBall && cue?.pos) {
+          const resolveDirectAim = () => {
+            let directDir = resolveAutoAimDirection();
+            if (!directDir && plan?.targetBall && cue?.pos) {
               const manualDir = new THREE.Vector2(
                 plan.targetBall.pos.x - cue.pos.x,
                 plan.targetBall.pos.y - cue.pos.y
               );
               if (manualDir.lengthSq() > 1e-6) {
-                autoDir = manualDir.normalize();
+                directDir = manualDir.normalize();
               }
             }
+            return directDir;
+          };
+          const preferAutoAim = autoAimRequestRef.current || plan?.viaCushion;
+          if (preferAutoAim) {
+            const autoDir = resolveDirectAim();
             suggestionAimKeyRef.current = null;
             if (applyAimDirection(autoDir, null)) {
               return;
@@ -20646,6 +20652,8 @@ const powerRef = useRef(hud.power);
             suggestionAimKeyRef.current = null;
           } else {
             suggestionAimKeyRef.current = null;
+            const fallbackDir = resolveDirectAim();
+            applyAimDirection(fallbackDir, null);
           }
         };
         stopAiThinkingRef.current = stopAiThinking;


### PR DESCRIPTION
## Summary
- Pull cue and standing camera framing in closer while keeping existing angles and safety margins for portrait play
- Tighten AI pot selection to prioritize clear direct lanes and higher-quality shots
- Force user aim suggestions to lock onto player balls directly instead of cushion-first lines, including after pots

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8a02113c8329bd78cc8e349e431c)