### PR TITLE
Improve pool camera framing and AI shot selection

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -244,7 +244,15 @@ function generatePotCandidates (state, colour) {
       if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
       const angle = cutAngle(cue, ball, entry)
       const d = dist(ball, entry)
-      const view = Math.atan2(state.ballRadius * 2, d)
+      const toPocket = { x: entry.x - ball.x, y: entry.y - ball.y }
+      const toPocketLen = Math.hypot(toPocket.x, toPocket.y) || 1
+      const toPocketDir = { x: toPocket.x / toPocketLen, y: toPocket.y / toPocketLen }
+      const tableCenter = { x: state.width / 2, y: state.height / 2 }
+      const pocketFacing = { x: tableCenter.x - entry.x, y: tableCenter.y - entry.y }
+      const pocketFacingLen = Math.hypot(pocketFacing.x, pocketFacing.y) || 1
+      const pocketNormal = { x: pocketFacing.x / pocketFacingLen, y: pocketFacing.y / pocketFacingLen }
+      const entranceFacing = Math.max(0, toPocketDir.x * pocketNormal.x + toPocketDir.y * pocketNormal.y)
+      const view = Math.atan2(state.ballRadius * 2.4, d) + entranceFacing * 0.4
       if (
         view > bestView + 1e-6 ||
         (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
@@ -264,7 +272,7 @@ function generatePotCandidates (state, colour) {
       state.ballRadius,
       1.4
     )
-    if (laneClearance < 0.55) continue
+    if (laneClearance < 0.65) continue
     const angle = bestAngle
     const distCT = dist(cue, ball)
     const distTP = bestDist
@@ -499,21 +507,23 @@ function generateSafeties (state, colour) {
 // ----------------- evaluation heuristics -----------------
 function estimatePotProbability (shot, state) {
   const angleDeg = shot.angle * 180 / Math.PI
-  const pocketViewDeg = Math.atan2(state.ballRadius * 2, shot.distTP || 1) * 180 / Math.PI
+  const pocketViewDeg = Math.atan2(state.ballRadius * 2.2, shot.distTP || 1) * 180 / Math.PI
   const cutRatio = angleDeg / (pocketViewDeg + 1e-6)
   const maxD = Math.hypot(state.width, state.height)
   const distScore = 1 - Math.min((shot.distCT + shot.distTP) / maxD, 1)
   const cueBall = state.balls.find(b => b.colour === 'cue')
-  const laneClearance = clearanceMargin(
-    cueBall,
-    shot.targetBall,
-    state.balls,
-    [shot.targetBall.id, cueBall.id],
-    state.ballRadius,
-    1.6
-  )
-  if (laneClearance < 0.45) return 0
-  const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.6) / 0.8))
+  const laneClearance = typeof shot.laneClearance === 'number'
+    ? shot.laneClearance
+    : clearanceMargin(
+        cueBall,
+        shot.targetBall,
+        state.balls,
+        [shot.targetBall.id, cueBall.id],
+        state.ballRadius,
+        1.6
+      )
+  if (laneClearance < 0.6) return 0
+  const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.65) / 0.7))
 
   // sharper lines receive a steeper falloff to mimic pro precision
   const eliteStraightWindow = 0.65
@@ -525,7 +535,8 @@ function estimatePotProbability (shot, state) {
   }
 
   // combine distance, angle, and lane cleanliness with stronger emphasis on accuracy
-  let P = angleScore * 0.52 + distScore * 0.22 + clearanceScore * 0.26
+  const entranceBonus = Math.max(0, Math.min(1, pocketViewDeg / 55))
+  let P = angleScore * 0.5 + distScore * 0.18 + clearanceScore * 0.24 + entranceBonus * 0.08
 
   if (shot.isKick) {
     P *= 0.9
@@ -547,9 +558,15 @@ function estimatePotProbability (shot, state) {
   if (target && (Math.min(target.x, state.width - target.x) < state.ballRadius * 2 || Math.min(target.y, state.height - target.y) < state.ballRadius * 2)) {
     P -= 0.08
   }
-  P -= foulRisk(shot, state) * 0.45
+  const scratchRisk = foulRisk(shot, state)
+  if (scratchRisk > 0.65) return 0
+  P -= scratchRisk * 0.6
 
   if (state.shotsRemaining && state.shotsRemaining > 1) P += 0.05 // under pressure bonus
+  const ownRemaining = shot?.targetBall
+    ? state.balls.filter(b => b.colour === shot.targetBall.colour && !b.pocketed).length
+    : 0
+  if (ownRemaining > 0 && ownRemaining <= 2) P += 0.06 // end-game focus
 
   // bonus for near-straight shots
   const straightBonus = Math.max(0, (12 - angleDeg) / 120)
@@ -703,6 +720,8 @@ function evaluateCandidates (state, colour, candidates) {
     if (c.actionType === 'safety') {
       EV = safetyEV(state, colour)
     } else {
+      const risk = foulRisk(c, state)
+      if (risk > 0.65) continue
       const Ppot = estimatePotProbability(c, state)
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
@@ -717,7 +736,6 @@ function evaluateCandidates (state, colour, candidates) {
         if (EV2 > nextBest) nextBest = EV2
       }
       const baseValue = 1.05
-      const risk = foulRisk(c, state)
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.25
       const shapeWindow = nextShapeWindow(nextState, colour)
@@ -735,7 +753,8 @@ function chooseBestAction (state, colour) {
   // explored when every straight look is blocked so the AI plays bank/kick
   // shots as a last resort rather than by default.
   const directPots = generatePotCandidates(state, colour)
-  let candidates = [...directPots]
+  const cleanDirect = directPots.filter(c => (c.laneClearance ?? 1) >= 0.7)
+  let candidates = cleanDirect.length > 0 ? [...cleanDirect] : [...directPots]
   const kicks = generateKickCandidates(state, colour, 4)
 
   if (candidates.length === 0) {


### PR DESCRIPTION
## Summary
- Bring cue and broadcast camera distances in closer while keeping existing orbit logic and aspect-aware zoom profiles
- Increase shot power and cue-ball hop response, and normalize cue impact audio to game volume
- Tighten shot planning: prefer clear pocket views, reduce cushion reliance for player aim assist, and add scratch-averse advanced AI heuristics

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba4c8879c832983384cc0c1584b72)