### PR TITLE
Update Pool Royale bases and pockets

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -497,12 +497,6 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     swatches: ['#8f4a2b', '#3b2a1f']
   },
   {
-    id: 'murlanDefaultTable',
-    name: 'Murlan Default Table Base',
-    description: 'Scaled version of the Murlan Royale default table supporting the pool deck.',
-    swatches: ['#9b7350', '#d7b594']
-  },
-  {
     id: 'woodenTable02Alt',
     name: 'Wooden Table 02 Alt Base',
     description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',


### PR DESCRIPTION
## Summary
- remove the Murlan default base option and keep available table bases focused on pool-ready supports
- move cylinder and portal leg placements inward and shrink the Wooden Table 02 Alt footprint to clear pocket space
- trim pocket walls and add lathed pocket nets with a procedural mesh texture so pockets look realistic and unobstructed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c09e1502c8329892e12d441ef5d2f)