### PR TITLE
Fix Pool Royale pocket drop behavior and add pocket holder rings

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5668,10 +5668,9 @@ const resolvePocketHolderDirection = (center, pocketId = null) => {
   const absZ = Math.abs(center?.y ?? 0);
   const isMiddlePocket = pocketId === 'TM' || pocketId === 'BM' || absZ < BALL_R * 0.6;
   if (isMiddlePocket) {
-    const towardTop = pocketId === 'TM';
-    const towardBottom = pocketId === 'BM';
-    const zDir = towardTop ? -1 : towardBottom ? 1 : Math.sign(center?.x || 1);
-    return new THREE.Vector3(0, 0, zDir || 1);
+    const xDir = Math.sign(center?.x || (pocketId === 'BM' ? 1 : -1)) || 1;
+    const zBias = pocketId === 'TM' ? -0.35 : pocketId === 'BM' ? 0.35 : 0;
+    return new THREE.Vector3(xDir, 0, zBias).normalize();
   }
   if (absX >= absZ) {
     return new THREE.Vector3(Math.sign(center?.x || 1), 0, 0);
@@ -7225,6 +7224,7 @@ function Table3D(
   const pocketStrapWidth = BALL_R * 1.35;
   const pocketStrapThickness = BALL_R * 0.18;
   const pocketMeshes = [];
+  pocketHolderTargetsRef.current.clear();
   pocketCenters().forEach((p, index) => {
     const pocketId = POCKET_IDS[index] ?? null;
     const isMiddlePocket = index >= 4;
@@ -7249,19 +7249,48 @@ function Table3D(
     table.add(net);
     finishParts.pocketNetMeshes.push(net);
 
-    // Add chrome cradle rails and holders beneath the pocket net to catch potted balls.
     const netBottomY = net.position.y - POCKET_NET_DEPTH * 0.96;
+    const holderTiltRad = isMiddlePocket ? POCKET_HOLDER_TILT_RAD * 1.22 : POCKET_HOLDER_TILT_RAD;
+    const holderEntry = new THREE.Vector3(p.x, netBottomY, p.y);
     const outwardDir = resolvePocketHolderDirection(p, pocketId);
+
+    const netRingRadius = POCKET_BOTTOM_R * 1.04;
+    const netRingTube = Math.max(pocketGuideRadius * 1.05, BALL_R * 0.22);
+    const netRing = new THREE.Mesh(
+      new THREE.TorusGeometry(netRingRadius, netRingTube * 0.72, 16, 28),
+      pocketGuideMaterial
+    );
+    netRing.position.set(holderEntry.x, holderEntry.y - netRingTube * 0.35, holderEntry.z);
+    netRing.rotation.x = Math.PI / 2;
+    netRing.castShadow = true;
+    netRing.receiveShadow = true;
+    table.add(netRing);
+    finishParts.pocketBaseMeshes.push(netRing);
+
+    const holderReach = pocketGuideLength * 0.86;
+    const holderDrop = pocketGuideDrop * 0.92;
+    const holderRest = holderEntry
+      .clone()
+      .addScaledVector(outwardDir, holderReach)
+      .add(new THREE.Vector3(0, -holderDrop, 0))
+      .add(new THREE.Vector3(0, -Math.tan(holderTiltRad) * holderReach, 0));
+    pocketHolderTargetsRef.current.set(pocketId, {
+      entry: holderEntry.clone(),
+      rest: holderRest.clone(),
+      tilt: holderTiltRad
+    });
+
+    // Add chrome cradle rails and holders beneath the pocket net to catch potted balls.
     const sideDir = new THREE.Vector3().crossVectors(outwardDir, new THREE.Vector3(0, 1, 0)).normalize();
-    const strapDir = outwardDir.clone().setY(-Math.tan(POCKET_HOLDER_TILT_RAD)).normalize();
+    const strapDir = outwardDir.clone().setY(-Math.tan(holderTiltRad)).normalize();
     for (let i = 0; i < 3; i += 1) {
       const lateralOffset = (i - 1) * pocketGuideSpread;
-      const start = new THREE.Vector3(p.x, netBottomY, p.y).addScaledVector(sideDir, lateralOffset);
+      const start = holderEntry.clone().addScaledVector(sideDir, lateralOffset);
       const end = start
         .clone()
         .addScaledVector(outwardDir, pocketGuideLength)
         .add(new THREE.Vector3(0, -pocketGuideDrop, 0))
-        .add(new THREE.Vector3(0, -Math.tan(POCKET_HOLDER_TILT_RAD) * pocketGuideLength, 0));
+        .add(new THREE.Vector3(0, -Math.tan(holderTiltRad) * pocketGuideLength, 0));
       const delta = end.clone().sub(start);
       const guideGeom = new THREE.CylinderGeometry(
         pocketGuideRadius,
@@ -11645,6 +11674,7 @@ const powerRef = useRef(hud.power);
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
   const pocketDropRef = useRef(new Map());
+  const pocketHolderTargetsRef = useRef(new Map());
   const captureBallSnapshotRef = useRef(null);
   const applyBallSnapshotRef = useRef(null);
   const pendingLayoutRef = useRef(null);
@@ -22765,16 +22795,19 @@ const powerRef = useRef(hud.power);
               const fromX = b.pos.x;
               const fromZ = b.pos.y;
               const holderDir = resolvePocketHolderDirection(c, pocketId);
-              const strapOffset = holderDir
-                .clone()
-                .multiplyScalar(POCKET_HOLDER_SLIDE);
-              const targetX = c.x + strapOffset.x;
-              const targetZ = c.y + strapOffset.z;
+              const strapOffset = holderDir.clone().multiplyScalar(POCKET_HOLDER_SLIDE);
+              const holderTargets = pocketHolderTargetsRef.current;
+              const pocketHolder = holderTargets.get(pocketId);
+              const targetX = pocketHolder?.rest?.x ?? c.x + strapOffset.x;
+              const targetZ = pocketHolder?.rest?.z ?? c.y + strapOffset.z;
+              const targetY =
+                pocketHolder?.rest?.y ?? BALL_CENTER_Y - POCKET_DROP_STRAP_DEPTH;
+              const fromY = BALL_CENTER_Y;
               const dropEntry = {
                 start: dropStart,
-                fromY: BALL_CENTER_Y,
-                currentY: BALL_CENTER_Y,
-                targetY: BALL_CENTER_Y - POCKET_DROP_STRAP_DEPTH,
+                fromY,
+                currentY: fromY,
+                targetY,
                 fromX,
                 fromZ,
                 toX: targetX,
@@ -23041,6 +23074,7 @@ const powerRef = useRef(hud.power);
           updatePocketCameraState(false);
           pocketCamerasRef.current.clear();
           pocketDropRef.current.clear();
+          pocketHolderTargetsRef.current.clear();
           captureBallSnapshotRef.current = null;
           applyBallSnapshotRef.current = null;
           pendingLayoutRef.current = null;


### PR DESCRIPTION
### Motivation
- Potted balls were remaining visible at the pocket mouth instead of falling into the holder cradle beneath the nets.  
- Middle-pocket leather straps needed a different tilt/orientation so balls settle naturally against them.  
- A visible chrome/gold ring is required to visually connect the net base to the cradle rails and allow balls to pass through.

### Description
- Adjusted middle-pocket direction logic in `resolvePocketHolderDirection` to provide a biased outward direction (`x` + small `z` bias) so middle-pocket holders sit at a slight angle.  
- Added `pocketHolderTargetsRef` and compute per-pocket `entry` and `rest` positions plus a `tilt` when building pockets, and clear this map during init and teardown.  
- Placed a torus ring mesh (`netRing`) at each pocket net base and stored holder rest targets, and moved the cradle guide starts to use the new `holderEntry` and `holderTiltRad` so rails / straps align with the ring and holder path.  
- Updated the pocket-drop animation to read `pocketHolderTargetsRef` for `toX`, `toZ` and `targetY` so dropped balls move into the holder rest position instead of lingering at the pocket mouth.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c976ad6f08329b5f796a821139e1e)