### PR TITLE
Align Pool Royale pocket ring, holder, and strap to photographic reference

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1174,11 +1174,11 @@ const POCKET_NET_DEPTH = TABLE.THICK * 2.1;
 const POCKET_NET_SEGMENTS = 48;
 const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 0.9; // drop nearly the full net depth so potted balls clear the rim
 const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.82; // stop the fall slightly above the ring/strap junction
-const POCKET_NET_RING_RADIUS_SCALE = 0.94; // size the ring to the lower pocket bowl so balls clear the opening
+const POCKET_NET_RING_RADIUS_SCALE = 0.62; // match the ring diameter to the net's lowest hoop so the net and chrome line up exactly
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
 const POCKET_NET_RING_VERTICAL_OFFSET = -BALL_R * 0.02; // sit the ring directly against the bottom of the woven net
 const POCKET_GUIDE_RADIUS = BALL_R * 0.09;
-const POCKET_GUIDE_LENGTH = POCKET_NET_DEPTH * 1.35;
+const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 5.6); // stretch the holder run so it comfortably fits 5 balls
 const POCKET_GUIDE_DROP = BALL_R * 0.28;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.32;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.22; // start the chrome rails just outside the ring to keep the mouth open
@@ -1189,7 +1189,7 @@ const POCKET_HOLDER_REST_DROP = BALL_R * 0.38; // keep the resting spot visibly 
 const POCKET_MIDDLE_HOLDER_SWAY = 0.32; // add a slight diagonal so middle-pocket holders angle like the reference photos
 const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.08; // push the cloth sleeve past the felt base so it meets the pocket walls cleanly
 const POCKET_HOLDER_L_LEG = BALL_R * 0.42; // small connector that links the ring to the holder tray
-const POCKET_HOLDER_L_SPAN = POCKET_GUIDE_LENGTH * 0.42; // longer tray section that actually holds the balls
+const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
 const POCKET_BOARD_TOUCH_OFFSET = 0; // lock the pocket rim directly against the cloth wrap with no gap
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -5690,6 +5690,20 @@ const resolvePocketHolderDirection = (center, pocketId = null) => {
     const xDir = Math.sign(center?.x || 1) || 1;
     return new THREE.Vector3(xDir, 0, 0);
   }
+  const middlePocketTargets = pocketCenters().slice(4);
+  let closest = null;
+  let shortest = Infinity;
+  for (const target of middlePocketTargets) {
+    const delta = target.clone().sub(center);
+    const distance = delta.lengthSq();
+    if (distance < shortest && distance > MICRO_EPS) {
+      shortest = distance;
+      closest = delta;
+    }
+  }
+  if (closest) {
+    return new THREE.Vector3(closest.x, 0, closest.y).normalize();
+  }
   if (absX >= absZ) {
     return new THREE.Vector3(Math.sign(center?.x || 1), 0, 0);
   }
@@ -7233,7 +7247,7 @@ function Table3D(
   const pocketNetGeo = new THREE.LatheGeometry(pocketNetProfile, POCKET_NET_SEGMENTS);
   const pocketGuideMaterial = trimMat;
   const pocketGuideRingRadius = POCKET_BOTTOM_R * POCKET_NET_RING_RADIUS_SCALE;
-  const pocketStrapLength = POCKET_GUIDE_LENGTH * 0.62;
+  const pocketStrapLength = Math.max(POCKET_GUIDE_LENGTH * 0.62, BALL_DIAMETER * 5.4);
   const pocketStrapWidth = BALL_R * 1.35;
   const pocketStrapThickness = BALL_R * 0.18;
   const pocketRingGeometry = new THREE.TorusGeometry(
@@ -7340,7 +7354,7 @@ function Table3D(
         .clone()
         .addScaledVector(
           strapDirNormalized,
-          pocketStrapLength * 0.4
+          pocketStrapLength * 0.78
         )
         .add(new THREE.Vector3(0, -POCKET_GUIDE_DROP * 0.35, 0));
       strap.position.copy(strapMid);


### PR DESCRIPTION
### Motivation
- Ensure the pocket chrome ring lines up exactly with the net opening so the net and ring share the same visual diameter. 
- Make the pocket holder and strap long enough to visibly contain at least five balls without clipping. 
- Reorient corner-pocket holders so their long side sits toward the middle-pocket edge to match reference photos. 
- Preserve existing Polyhaven glTF usage for environment and assets while updating geometry and sizing.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to change `POCKET_NET_RING_RADIUS_SCALE` from `0.94` to `0.62` so the ring diameter matches the net hoop. 
- Guaranteed holder and strap length by setting `POCKET_GUIDE_LENGTH`, `POCKET_HOLDER_L_SPAN`, and `pocketStrapLength` to `Math.max(...)` with `BALL_DIAMETER * <n>` thresholds so they comfortably fit five balls. 
- Increased the strap placement offset by adjusting the strap mid multiplier from `0.4` to `0.78` so the leather strap sits toward the far end of the holder. 
- Added logic to `resolvePocketHolderDirection` to bias corner-holder orientation toward the nearest middle-pocket targets so corner holders point the long side at middle pockets rather than always along a fixed axis.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ca9b823548329bc9c904889685bcc)