### PR TITLE
Refine Pool Royale pocket visuals, strap geometry and capture handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -908,10 +908,10 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.016; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 1.02; // push the jaw bodies further down so the underside reaches the pocket floor
+const POCKET_JAW_DEPTH_SCALE = 0.9; // trim the jaw bodies so the underside finishes closer to the cloth plane
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114; // lower the visible rim slightly more so the pocket lips sit nearer the cloth plane
-const POCKET_JAW_BOTTOM_CLEARANCE = 0; // allow the jaw extrusion to run right down to the pocket base without a visible gap
-const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.12; // align the jaw underside to the same height as the pocket base plate
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.06; // stop the jaw extrusion at the cloth surface so no extra lip hangs below
+const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.22; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.22; // hold the thicker centre section longer before easing toward the chrome trim
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.12; // thin the outer lips more aggressively while leaving the centre crown unchanged
@@ -1108,17 +1108,17 @@ const MAX_POWER_CAMERA_HOLD_MS = 2000;
 const MAX_POWER_SPIN_LATERAL_THROW = BALL_R * 0.42; // let max-power jumps inherit a strong sideways release from active side spin
 const MAX_POWER_SPIN_LIFT_BONUS = BALL_R * 0.28; // spin adds extra hop height when the cue ball is driven at full power
 const POCKET_INTERIOR_CAPTURE_R =
-  POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION * 0.992; // tighten capture so balls fall only once they reach the pocket throat
+  POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // match capture radius directly to the pocket bowl opening
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
-  SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION * 0.996; // narrow the middle capture to stop pre-pocket drops while keeping center-line forgiveness
-const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the interior bowl so balls fall at the throat
-const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R; // middle pocket capture now matches the bowl opening instead of scaling from corners
-const POCKET_GUARD_RADIUS = POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.06; // align the rail guard to the playable capture bowl instead of the visual rim
+  SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
+const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the true bowl opening
+const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R; // middle pocket capture now mirrors the bowl radius
+const POCKET_GUARD_RADIUS = Math.max(0, POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.04); // align the rail guard to the playable capture bowl instead of the visual rim
 const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.08); // keep a slim safety margin so clean entries aren't rejected
 const CORNER_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.58 * POCKET_VISUAL_EXPANSION; // clamp corner reflections to the actual pocket depth
 const SIDE_POCKET_GUARD_RADIUS =
-  SIDE_POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.08; // use the middle-pocket bowl to gate reflections
+  SIDE_POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.06; // use the middle-pocket bowl to gate reflections with a tighter inset
 const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.08
@@ -1135,10 +1135,10 @@ const PLYWOOD_EXTRA_DROP = 0;
 const PLYWOOD_SURFACE_COLOR = 0xd8c29b; // fallback plywood tone when a finish color is unavailable
 const PLYWOOD_HOLE_SCALE = 1.05; // plywood pocket cutouts should be 5% larger than the pocket bowls for clearance
 const PLYWOOD_HOLE_R = POCKET_VIS_R * PLYWOOD_HOLE_SCALE * POCKET_VISUAL_EXPANSION;
-const CLOTH_EDGE_GAP_FILL = TABLE.THICK * 0.32; // drive the cloth sleeve deeper so it seals the exposed gap left by the removed plywood
+const CLOTH_EDGE_GAP_FILL = TABLE.THICK * 0.46; // drive the cloth sleeve deeper so it seals the exposed gap left by the removed plywood
 const CLOTH_EXTENDED_DEPTH = CLOTH_THICKNESS + CLOTH_EDGE_GAP_FILL; // wrap enough felt to close the plywood gap while keeping the surface profile unchanged
 const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening slightly so the pocket lip picks up a soft round-over
-const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.012; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
+const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.04; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
 const CLOTH_EDGE_CURVE_INTENSITY = 0.012; // shallow easing that rounds the cloth sleeve as it transitions from lip to throat
 const CLOTH_EDGE_TEXTURE_HEIGHT_SCALE = 1.2; // boost vertical tiling so the wrapped cloth reads with tighter, more realistic fibres
 const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt tone so they don't glow around the cuts
@@ -7253,8 +7253,8 @@ function Table3D(
   const pocketGuideMaterial = trimMat;
   const pocketGuideRingRadius = POCKET_BOTTOM_R * POCKET_NET_RING_RADIUS_SCALE;
   const pocketStrapLength = Math.max(POCKET_GUIDE_LENGTH * 0.62, BALL_DIAMETER * 5.4);
-  const pocketStrapWidth = BALL_R * 1.35;
-  const pocketStrapThickness = BALL_R * 0.18;
+  const pocketStrapWidth = BALL_R * 1.2;
+  const pocketStrapThickness = BALL_R * 0.12;
   const pocketRingGeometry = new THREE.TorusGeometry(
     pocketGuideRingRadius,
     POCKET_NET_RING_TUBE_RADIUS,
@@ -7350,21 +7350,19 @@ function Table3D(
     }
 
     if (strapOrigin && strapEnd) {
-      const strapFacing = outwardDir.clone().setY(0);
-      if (strapFacing.lengthSq() <= MICRO_EPS) strapFacing.set(0, 0, 1);
-      strapFacing.normalize();
       const strapGeom = new THREE.BoxGeometry(
         pocketStrapWidth,
-        pocketStrapLength,
-        pocketStrapThickness
+        pocketStrapThickness,
+        pocketStrapLength
       );
       const strap = new THREE.Mesh(strapGeom, pocketJawMat);
-      const strapMid = strapEnd
+      const strapMid = strapOrigin
         .clone()
-        .add(new THREE.Vector3(0, pocketStrapLength * 0.5, 0))
-        .addScaledVector(strapFacing, -pocketStrapThickness * 0.5);
+        .add(strapEnd)
+        .multiplyScalar(0.5);
+      strapMid.y -= pocketStrapThickness * 0.5;
       strap.position.copy(strapMid);
-      strap.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), strapFacing);
+      strap.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), strapDir);
       strap.castShadow = true;
       strap.receiveShadow = true;
       table.add(strap);
@@ -22268,6 +22266,11 @@ const powerRef = useRef(hud.power);
           if (!ball) return;
           const dropEntry = pocketDropRef.current.get(ball.id);
           const dropping = Boolean(dropEntry);
+          if (ball.active && dropEntry) {
+            pocketDropRef.current.delete(ball.id);
+            ball.mesh.visible = true;
+            if (ball.shadow) ball.shadow.visible = true;
+          }
           if (!ball.active) {
             if (dropEntry) {
               ball.mesh.visible = true;


### PR DESCRIPTION
### Motivation
- Make the leather strap/holder and chrome rails sit under the cloth so the leather/rails do not show above the playing surface.
- Extend and tighten the cloth sleeve around pocket apertures so felt meets pocket hardware cleanly.
- Make pocket capture behaviour match the physical bowl mouth so balls only fall when they truly reach the throat.
- Prevent a frozen/visible pocket-drop state when balls return to play by clearing stale drop entries.

### Description
- Adjusted pocket jaw & floor constants (`POCKET_JAW_DEPTH_SCALE`, `POCKET_JAW_BOTTOM_CLEARANCE`, `POCKET_JAW_FLOOR_CONTACT_LIFT`) so jaws are trimmed and finish flush with the cloth plane.
- Aligned capture radii to the actual bowl opening by changing `POCKET_INTERIOR_CAPTURE_R` / `SIDE_POCKET_INTERIOR_CAPTURE_R` and tightened guard radii (`POCKET_GUARD_RADIUS`, `SIDE_POCKET_GUARD_RADIUS`).
- Deepened the cloth sleeve (`CLOTH_EDGE_GAP_FILL`, `CLOTH_EDGE_BOTTOM_RADIUS_SCALE`) and resized/reoriented the pocket leather strap (`pocketStrapWidth`, `pocketStrapThickness`) and its geometry/placement to ensure the strap sits beneath the cloth & chrome guides.
- Fixed pocket-drop state handling by clearing `pocketDropRef` entries when a ball becomes active again so stale drop animations cannot freeze the scene.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd948d86083299114fc5aa140db7f)