### PR TITLE
Align Pool Royale pocket holders with reference

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1179,6 +1179,7 @@ const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as 
 const POCKET_NET_RING_VERTICAL_OFFSET = -BALL_R * 0.02; // sit the ring directly against the bottom of the woven net
 const POCKET_GUIDE_RADIUS = BALL_R * 0.09;
 const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 5.6); // stretch the holder run so it comfortably fits 5 balls
+const POCKET_GUIDE_ENTRY_DROP = BALL_R * 0.62; // force a vertical drop through the net before the rails begin
 const POCKET_GUIDE_DROP = BALL_R * 0.28;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.32;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.22; // start the chrome rails just outside the ring to keep the mouth open
@@ -7252,7 +7253,7 @@ function Table3D(
   const pocketNetGeo = new THREE.LatheGeometry(pocketNetProfile, POCKET_NET_SEGMENTS);
   const pocketGuideMaterial = trimMat;
   const pocketGuideRingRadius = POCKET_BOTTOM_R * POCKET_NET_RING_RADIUS_SCALE;
-  const pocketStrapLength = Math.max(POCKET_GUIDE_LENGTH * 0.62, BALL_DIAMETER * 5.4);
+  const pocketStrapHeight = Math.max(POCKET_GUIDE_LENGTH * 0.2, BALL_DIAMETER * 1.6);
   const pocketStrapWidth = BALL_R * 1.2;
   const pocketStrapThickness = BALL_R * 0.12;
   const pocketRingGeometry = new THREE.TorusGeometry(
@@ -7330,11 +7331,16 @@ function Table3D(
       const middleSway = isMiddlePocket ? POCKET_MIDDLE_HOLDER_SWAY * (pocketId === 'TM' ? -1 : 1) : 0;
       const lateralOffset = (i - 1) * POCKET_GUIDE_SPREAD + middleSway * (i - 1);
       const isCenterGuide = i === 1;
-      const start = ringAnchor
+      const ringExit = ringAnchor
         .clone()
-        .addScaledVector(outwardDir, railStartOffset)
-        .addScaledVector(sideDir, lateralOffset)
+        .addScaledVector(sideDir, lateralOffset);
+      const entryDrop = ringExit.clone().add(new THREE.Vector3(0, -POCKET_GUIDE_ENTRY_DROP, 0));
+      buildGuideSegment(ringExit, entryDrop);
+      const start = entryDrop
+        .clone()
+        .addScaledVector(outwardDir, -railStartOffset)
         .add(new THREE.Vector3(0, isCenterGuide ? -POCKET_GUIDE_FLOOR_DROP : 0, 0));
+      buildGuideSegment(entryDrop, start);
       const stemEnd = start.clone().add(new THREE.Vector3(0, -POCKET_GUIDE_STEM_DEPTH, 0));
       const runEnd = stemEnd
         .clone()
@@ -7352,17 +7358,27 @@ function Table3D(
     if (strapOrigin && strapEnd) {
       const strapGeom = new THREE.BoxGeometry(
         pocketStrapWidth,
-        pocketStrapThickness,
-        pocketStrapLength
+        pocketStrapHeight,
+        pocketStrapThickness
       );
       const strap = new THREE.Mesh(strapGeom, pocketJawMat);
-      const strapMid = strapOrigin
+      const strapNormal = strapDir.clone().normalize();
+      const strapSide = new THREE.Vector3()
+        .crossVectors(new THREE.Vector3(0, 1, 0), strapNormal)
+        .normalize();
+      if (strapSide.lengthSq() < MICRO_EPS) {
+        strapSide.set(1, 0, 0);
+      }
+      const strapUp = new THREE.Vector3()
+        .crossVectors(strapNormal, strapSide)
+        .normalize();
+      const strapBasis = new THREE.Matrix4().makeBasis(strapSide, strapUp, strapNormal);
+      const strapMid = strapEnd
         .clone()
-        .add(strapEnd)
-        .multiplyScalar(0.5);
-      strapMid.y -= pocketStrapThickness * 0.5;
+        .addScaledVector(strapNormal, pocketStrapThickness * 0.5)
+        .addScaledVector(strapUp, -pocketStrapHeight * 0.5);
       strap.position.copy(strapMid);
-      strap.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), strapDir);
+      strap.quaternion.setFromRotationMatrix(strapBasis);
       strap.castShadow = true;
       strap.receiveShadow = true;
       table.add(strap);


### PR DESCRIPTION
### Motivation

- Match the Pocket/Pool Royale reference so potted balls fall vertically through the net/ring before entering the chrome cradle rails.
- Ensure the three chrome holder rails sit on the far side of the ring and run smoothly so balls naturally roll to the leather strap rest.
- Orient the leather strap as a vertical end-stop below the playfield and keep the chrome/strap geometry visually trimmed beneath the table.

### Description

- Added `POCKET_GUIDE_ENTRY_DROP` and reworked the pocket guide build so each guide now starts with a vertical `ringExit -> entryDrop` segment before the outward rail run in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added an extra `buildGuideSegment(entryDrop, start)` and adjusted the guide start calculation to force a vertical drop through the net/ring prior to the rail segments.
- Replaced `pocketStrapLength` with `pocketStrapHeight` and updated the strap geometry/midpoint math and orientation by constructing a local basis matrix to rotate the leather strap into a vertical end-stop.
- Kept existing stem/run segments and resting calculations but updated strap sizing and placement to align with the new holder routing.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ceffccfc88329bf16f36f0f763395)