### PR TITLE
Refine Pool Royale pocket hardware, cloth fit and jaw materials

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -908,10 +908,10 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.016; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 0.9; // trim the jaw bodies so the underside finishes closer to the cloth plane
+const POCKET_JAW_DEPTH_SCALE = 0.82; // trim the jaw bodies so the underside finishes closer to the cloth plane
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114; // lower the visible rim slightly more so the pocket lips sit nearer the cloth plane
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.06; // stop the jaw extrusion at the cloth surface so no extra lip hangs below
-const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.22; // keep the underside tight to the cloth depth instead of the deeper pocket floor
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.12; // stop the jaw extrusion right at the cloth surface so no extra lip hangs below
+const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.18; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.22; // hold the thicker centre section longer before easing toward the chrome trim
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.12; // thin the outer lips more aggressively while leaving the centre crown unchanged
@@ -1196,7 +1196,7 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_BOARD_TOUCH_OFFSET = -TABLE.THICK * 0.05; // lift the pocket bowls slightly so they cover the cloth edge without needing an extra sleeve
+const POCKET_BOARD_TOUCH_OFFSET = 0; // extend the cloth sleeve down until it kisses the pocket bowls without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_BASE_MIN_OUTSIDE =
@@ -5697,9 +5697,15 @@ const resolvePocketHolderDirection = (center, pocketId = null) => {
       pocketId === 'TM'
         ? -1
         : pocketId === 'BM'
-          ? 1
+        ? 1
           : Math.sign(center?.y || 1) || 1;
     return new THREE.Vector3(0, 0, zDir);
+  }
+  const zDir = -Math.sign(center?.y || 1) || -1;
+  const sidePull = Math.sign(center?.x || 1) * 0.2;
+  const towardMiddlePocketSide = new THREE.Vector3(sidePull, 0, zDir);
+  if (towardMiddlePocketSide.lengthSq() > MICRO_EPS * MICRO_EPS) {
+    return towardMiddlePocketSide.normalize();
   }
   const outward = new THREE.Vector3(center?.x ?? 0, 0, center?.y ?? 0);
   if (outward.lengthSq() > MICRO_EPS * MICRO_EPS) {
@@ -6520,6 +6526,7 @@ function Table3D(
   const baulkLineZ = -PLAY_H / 2 + BAULK_FROM_BAULK;
   const frameTopY = FRAME_TOP_Y;
   const clothPlaneLocal = CLOTH_TOP_LOCAL + CLOTH_LIFT;
+  const clothSurfaceY = clothPlaneLocal - CLOTH_DROP;
 
   const resolvedFinish =
     (finish && typeof finish === 'object')
@@ -6563,6 +6570,9 @@ function Table3D(
   const trimMat = rawMaterials.trim ?? getFallbackMaterial('trim');
   const pocketJawMat = rawMaterials.pocketJaw ?? getFallbackMaterial('pocketJaw');
   const pocketRimMat = rawMaterials.pocketRim ?? getFallbackMaterial('pocketRim');
+  applyPocketLeatherTextureDefaults(pocketJawMat.map, { isColor: true });
+  applyPocketLeatherTextureDefaults(pocketJawMat.normalMap);
+  applyPocketLeatherTextureDefaults(pocketJawMat.roughnessMap);
   const gapStripeMat =
     rawMaterials.gapStripe ||
     new THREE.MeshPhysicalMaterial({
@@ -8269,6 +8279,10 @@ function Table3D(
     if (Number.isFinite(maxJawDepth)) {
       const limitedDepth = Math.max(MICRO_EPS, maxJawDepth - MICRO_EPS * 0.5);
       jawDepth = Math.min(jawDepth, limitedDepth);
+    }
+    const clothAlignedDepth = jawTopY - clothSurfaceY;
+    if (Number.isFinite(clothAlignedDepth)) {
+      jawDepth = Math.min(jawDepth, Math.max(MICRO_EPS, clothAlignedDepth));
     }
     const jawGeom = new THREE.ExtrudeGeometry(jawShape, {
       depth: jawDepth,


### PR DESCRIPTION
### Motivation
- Align pocket hardware and leather straps so potted balls roll along the chrome holder rails and the holder orientation matches the photographic reference.
- Remove the visible gap between the cloth sleeve and pocket bowls by extending the cloth down to meet the pockets.
- Lower and trim pocket jaws so their bottoms sit flush with the cloth surface for visual correctness and to avoid geometry poking below the cloth plane.
- Restore proper PolyHaven `Fabric_Leather_02` mapping/settings on pocket jaws and straps so the leather grain and mapping look correct.

### Description
- Adjusted pocket jaw geometry constants: `POCKET_JAW_DEPTH_SCALE` reduced to `0.82`, `POCKET_JAW_BOTTOM_CLEARANCE` increased to `TABLE.THICK * 0.12`, and `POCKET_JAW_FLOOR_CONTACT_LIFT` changed to `TABLE.THICK * 0.18` to limit jaw extrusion and bring bottoms to the cloth plane.
- Extended cloth to touch pocket bowls by setting `POCKET_BOARD_TOUCH_OFFSET = 0` and computed `clothSurfaceY` to clamp jaw depth to the cloth plane inside the jaw build routine.
- Reoriented pocket holders toward the middle-pocket sides by changing `resolvePocketHolderDirection` to bias holder direction with a small side pull so rails and straps sit on the side of the middle pockets.
- Reapplied leather texture defaults to the runtime pocket jaw material maps via `applyPocketLeatherTextureDefaults(pocketJawMat.map, { isColor: true })` and equivalents for normal/roughness so the PolyHaven leather texture mapping/space settings are enforced.

### Testing
- Ran `npm test -- poolRoyalInventoryRoutes.test.js --runInBand`; the test suite completed and the single targeted test passed (`PASS test/poolRoyalInventoryRoutes.test.js`).
- Note: `mongodb-memory-server` download from `fastdl.mongodb.org` failed during setup (invalid `Content-Length`), the test runner continued without an in-memory DB and tests still passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d11722ce08329808d36cb17328611)