### PR TITLE
Refine Pool Royale branding plates, pocket nets, and pocket-holder geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -224,31 +224,48 @@ const updateRendererAnisotropyCap = (renderer) => {
 const resolveTextureAnisotropy = (fallback = 1) =>
   Math.max(rendererAnisotropyCap, Number.isFinite(fallback) ? fallback : 1);
 
-const POCKET_NET_LINE_THICKNESS_SCALE = 1.45;
+const POCKET_NET_LINE_THICKNESS_SCALE = 1.1;
 
-const createPocketNetTexture = (size = 256, repeat = 2) => {
+const createPocketNetTexture = (size = 256, repeat = POCKET_NET_HEX_REPEAT) => {
   if (typeof document === 'undefined') return null;
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
   const ctx = canvas.getContext('2d');
   if (!ctx) return null;
   ctx.clearRect(0, 0, size, size);
-  const spacing = size / 8;
-  const lineWidth = Math.max(1, (size / 96) * POCKET_NET_LINE_THICKNESS_SCALE);
+  const lineWidth = Math.max(1, (size / 128) * POCKET_NET_LINE_THICKNESS_SCALE);
   ctx.lineWidth = lineWidth;
   ctx.strokeStyle = 'rgba(255,255,255,0.9)';
-  for (let x = 0; x <= size; x += spacing) {
+  const drawHex = (cx, cy, r) => {
     ctx.beginPath();
-    ctx.moveTo(x + lineWidth / 2, 0);
-    ctx.lineTo(x + lineWidth / 2, size);
+    for (let i = 0; i < 6; i += 1) {
+      const angle = Math.PI / 3 * i;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
     ctx.stroke();
+  };
+  const radius = Math.max(4, size * POCKET_NET_HEX_RADIUS_RATIO);
+  const verticalStep = Math.sqrt(3) * radius;
+  const horizontalStep = radius * 1.5;
+  ctx.save();
+  ctx.translate(size / 2, size / 2);
+  for (let row = -Math.ceil(size / verticalStep); row <= Math.ceil(size / verticalStep); row += 1) {
+    const y = row * verticalStep;
+    const offset = row % 2 === 0 ? 0 : horizontalStep / 2;
+    for (
+      let col = -Math.ceil(size / horizontalStep);
+      col <= Math.ceil(size / horizontalStep);
+      col += 1
+    ) {
+      const x = col * horizontalStep + offset;
+      drawHex(x, y, radius - lineWidth * 0.35);
+    }
   }
-  for (let y = 0; y <= size; y += spacing) {
-    ctx.beginPath();
-    ctx.moveTo(0, y + lineWidth / 2);
-    ctx.lineTo(size, y + lineWidth / 2);
-    ctx.stroke();
-  }
+  ctx.restore();
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(repeat, repeat);
@@ -1171,23 +1188,26 @@ const POCKET_BOTTOM_R = POCKET_TOP_R * 0.7;
 const POCKET_WALL_OPEN_TRIM = TABLE.THICK * 0.18;
 const POCKET_WALL_HEIGHT = TABLE.THICK * 0.7 - POCKET_WALL_OPEN_TRIM;
 const POCKET_NET_DEPTH = TABLE.THICK * 2.1;
-const POCKET_NET_SEGMENTS = 48;
+const POCKET_NET_SEGMENTS = 64;
 const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 0.9; // drop nearly the full net depth so potted balls clear the rim
 const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.82; // stop the fall slightly above the ring/strap junction
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
 const POCKET_NET_RING_VERTICAL_OFFSET = -BALL_R * 0.02; // sit the ring directly against the bottom of the woven net
+const POCKET_NET_HEX_REPEAT = 3;
+const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
 const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 5.6); // stretch the holder run so it comfortably fits 5 balls
 const POCKET_GUIDE_DROP = BALL_R * 0.28;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.32;
-const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.22; // start the chrome rails just outside the ring to keep the mouth open
+const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.16; // start the chrome rails just outside the ring to keep the mouth open
+const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 0.6; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 0.72; // lengthen the elbow so each rail meets the ring with a ball-length guide
-const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.24; // drop the centre rail to form the floor of the holder
+const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.3; // drop the centre rail to form the floor of the holder
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.12; // wider spacing so potted balls line up without overlapping on the holder rails
 const POCKET_HOLDER_REST_PULLBACK = BALL_R * 1.05; // stop the lead ball right against the leather strap without letting it bury the backstop
-const POCKET_HOLDER_REST_DROP = BALL_R * 0.52; // keep the resting spot visibly below the pocket throat
+const POCKET_HOLDER_REST_DROP = BALL_R * 0.7; // keep the resting spot visibly below the pocket throat
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
@@ -7313,7 +7333,10 @@ function Table3D(
     const outwardDir = resolvePocketHolderDirection(p, pocketId);
     const sideDir = new THREE.Vector3().crossVectors(outwardDir, new THREE.Vector3(0, 1, 0)).normalize();
     const strapDir = outwardDir.clone().setY(-Math.tan(POCKET_HOLDER_TILT_RAD)).normalize();
-    const railStartOffset = pocketGuideRingRadius + POCKET_GUIDE_RING_CLEARANCE;
+    const railStartOffset = Math.max(
+      MICRO_EPS,
+      pocketGuideRingRadius + POCKET_GUIDE_RING_CLEARANCE - POCKET_GUIDE_RING_OVERLAP
+    );
     const buildGuideSegment = (start, end) => {
       const delta = end.clone().sub(start);
       const length = delta.length();
@@ -7910,12 +7933,12 @@ function Table3D(
   })();
 
   const createCarbonLabelTexture = ({
-    width = 1024,
-    height = 256,
+    width = 2048,
+    height = 512,
     lines = [],
-    borderWidth = 18,
-    padding = 48,
-    studScale = 0.16
+    borderWidth = 22,
+    padding = 64,
+    studScale = 0.18
   } = {}) => {
     if (typeof document === 'undefined') return null;
     const canvas = document.createElement('canvas');
@@ -7953,18 +7976,44 @@ function Table3D(
     if (studRadius > 0) {
       const studGradient = (x, y) => {
         const g = ctx.createRadialGradient(
-          x - studRadius * 0.35,
-          y - studRadius * 0.35,
-          studRadius * 0.25,
+          x - studRadius * 0.32,
+          y - studRadius * 0.34,
+          studRadius * 0.14,
           x,
           y,
-          studRadius * 1.15
+          studRadius * 1.12
         );
-        g.addColorStop(0, '#fff4c2');
-        g.addColorStop(0.42, '#f1cf64');
-        g.addColorStop(0.72, '#c99c2e');
-        g.addColorStop(1, '#8a641a');
+        g.addColorStop(0, '#fff9e6');
+        g.addColorStop(0.3, '#f6e1ac');
+        g.addColorStop(0.58, '#d5a634');
+        g.addColorStop(1, '#6f5016');
         return g;
+      };
+      const studHighlight = (x, y) => {
+        const h = ctx.createRadialGradient(
+          x - studRadius * 0.18,
+          y - studRadius * 0.3,
+          0,
+          x - studRadius * 0.18,
+          y - studRadius * 0.3,
+          studRadius * 0.55
+        );
+        h.addColorStop(0, 'rgba(255,255,255,0.95)');
+        h.addColorStop(1, 'rgba(255,255,255,0)');
+        return h;
+      };
+      const studRim = (x, y) => {
+        const rim = ctx.createRadialGradient(
+          x,
+          y,
+          studRadius * 0.6,
+          x,
+          y,
+          studRadius * 1.08
+        );
+        rim.addColorStop(0, 'rgba(64,42,8,0.35)');
+        rim.addColorStop(1, 'rgba(28,18,4,0.9)');
+        return rim;
       };
       const studPadding = Math.max(padding * 0.5, studRadius * 2.4);
       const studs = [
@@ -7974,13 +8023,23 @@ function Table3D(
         [studPadding, canvas.height - studPadding]
       ];
       studs.forEach(([x, y]) => {
+        ctx.save();
+        ctx.shadowColor = 'rgba(0,0,0,0.35)';
+        ctx.shadowBlur = studRadius * 0.6;
+        ctx.shadowOffsetY = studRadius * 0.14;
         ctx.fillStyle = studGradient(x, y);
         ctx.beginPath();
         ctx.arc(x, y, studRadius, 0, Math.PI * 2);
         ctx.fill();
-        ctx.lineWidth = Math.max(2, studRadius * 0.25);
-        ctx.strokeStyle = '#5a3e10';
+        ctx.shadowBlur = 0;
+        ctx.fillStyle = studHighlight(x, y);
+        ctx.beginPath();
+        ctx.arc(x, y, studRadius * 0.62, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.lineWidth = Math.max(2, studRadius * 0.22);
+        ctx.strokeStyle = studRim(x, y);
         ctx.stroke();
+        ctx.restore();
       });
     }
 
@@ -8023,6 +8082,9 @@ function Table3D(
 
     const texture = new THREE.CanvasTexture(canvas);
     applySRGBColorSpace(texture);
+    texture.generateMipmaps = true;
+    texture.minFilter = THREE.LinearMipmapLinearFilter;
+    texture.magFilter = THREE.LinearFilter;
     texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
     texture.wrapS = THREE.ClampToEdgeWrapping;
     texture.wrapT = THREE.ClampToEdgeWrapping;
@@ -8738,12 +8800,12 @@ function Table3D(
 
   const brandPlateTexture =
     createCarbonLabelTexture({
-      width: 1200,
-      height: 360,
+      width: 2048,
+      height: 512,
       lines: [{ text: 'TonPlaygram', size: 0.34, weight: '800' }],
-      borderWidth: Math.max(TABLE.THICK * 6, 18),
-      padding: 110,
-      studScale: 0.22
+      borderWidth: Math.max(TABLE.THICK * 5.5, 20),
+      padding: 140,
+      studScale: 0.2
     }) || null;
   const brandPlateTopMaterial = brandPlateTexture
     ? new THREE.MeshPhysicalMaterial({
@@ -8777,12 +8839,12 @@ function Table3D(
     mat.sheenRoughness = Math.min(mat.sheenRoughness ?? 0.6, 0.6);
     return mat;
   };
-  const brandPlateThickness = Math.max(TABLE.THICK * 0.12, railH * 0.16);
-  const brandPlateDepth = Math.min(endRailW * 0.7, TABLE.THICK * 0.96);
+  const brandPlateThickness = chromePlateThickness;
+  const brandPlateDepth = Math.min(endRailW * 0.62, TABLE.THICK * 0.86);
   const brandPlateWidth = Math.min(PLAY_W * 0.34, Math.max(BALL_R * 10, PLAY_W * 0.26));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateZOffset = endRailW * 0.1;
+  const brandPlateOutwardShift = endRailW * 0.12;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -8798,7 +8860,7 @@ function Table3D(
       createBrandSideMaterial()
     ];
     const plate = new THREE.Mesh(brandPlateGeom, materials);
-    plate.position.set(0, brandPlateY, dirZ * (shortRailCenterZ - brandPlateZOffset));
+    plate.position.set(0, brandPlateY, dirZ * (shortRailCenterZ + brandPlateOutwardShift));
     plate.castShadow = true;
     plate.receiveShadow = true;
     plate.renderOrder = CHROME_PLATE_RENDER_ORDER + 0.2;


### PR DESCRIPTION
### Motivation
- Update the Pool Royale table visuals to match reference: thin and slightly outward TonPlaygram branding plates, higher-resolution label, and Domino-style rounded studs. 
- Improve pocket visuals and ball routing so potted balls sit lower and visibly contact the chrome holder rails. 
- Make pocket nets visually finer with smaller hexagonal holes and smoother geometry. 
- Nudge the chrome guide geometry so the thin L-shaped holders slightly extend past the ring but do not block the pocket mouth. 

### Description
- Reworked branding plate creation: set plate thickness to `chromePlateThickness`, increased label texture size via `createCarbonLabelTexture` defaults (`width`/`height`), enabled mipmaps and filtering, and moved plates outward using `brandPlateOutwardShift`. 
- Replaced grid net texture with a hexagonal weave by changing `createPocketNetTexture` to draw hexagons, introduced `POCKET_NET_HEX_REPEAT` and `POCKET_NET_HEX_RADIUS_RATIO`, and increased `POCKET_NET_SEGMENTS` from `48` to `64`. 
- Adjusted pocket/holder geometry and timing: decreased `POCKET_GUIDE_RING_CLEARANCE`, added `POCKET_GUIDE_RING_OVERLAP`, guarded `railStartOffset` with `Math.max(MICRO_EPS, ...)`, increased `POCKET_GUIDE_FLOOR_DROP`, and raised resting offset `POCKET_HOLDER_REST_DROP` so potted balls sit lower and touch holders. 
- Minor visual/styling tweaks for studs (rounded highlights/rims) inside `createCarbonLabelTexture` to better match Domino-style spheric look. 

### Testing
- No automated tests were executed as part of this change. 
- Basic linting/build checks were not run in this rollout. 
- Visual inspection is recommended in the running app (open `PoolRoyale` scene) to verify plate placement, net density, and pocket-holder interactions. 
- If available, run the existing UI/render smoke tests and `npm --prefix webapp run build` to validate runtime asset generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d53a33720832989df148357d0f3fc)