### PR TITLE
Pool Royale: scale cue/leather patterns, thicken & lift pocket nets, recalibrate drop anchors, tweak brand plates & chalks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -223,7 +223,7 @@ const updateRendererAnisotropyCap = (renderer) => {
 const resolveTextureAnisotropy = (fallback = 1) =>
   Math.max(rendererAnisotropyCap, Number.isFinite(fallback) ? fallback : 1);
 
-const POCKET_NET_LINE_THICKNESS_SCALE = 1.6;
+const POCKET_NET_LINE_THICKNESS_SCALE = 4.8;
 
 const createPocketNetTexture = (size = 256, repeat = POCKET_NET_HEX_REPEAT) => {
   if (typeof document === 'undefined') return null;
@@ -1170,7 +1170,7 @@ const POCKET_DROP_SPEED_REFERENCE = 1.4;
 const POCKET_HOLDER_SLIDE = BALL_R * 1.2; // horizontal drift as the ball rolls toward the leather strap
 const POCKET_HOLDER_TILT_RAD = THREE.MathUtils.degToRad(9); // slight angle so potted balls settle against the strap
 const POCKET_LEATHER_TEXTURE_ID = 'fabric_leather_02';
-const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({ x: 0.45, y: 0.45 });
+const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({ x: 0.15, y: 0.15 });
 const POCKET_LEATHER_TEXTURE_ANISOTROPY = 8;
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84 * POCKET_VISUAL_EXPANSION; // trim the cloth aperture to match the smaller chrome + rail cuts
 const POCKET_CLOTH_BOTTOM_RADIUS = POCKET_CLOTH_TOP_RADIUS * 0.62;
@@ -1181,12 +1181,13 @@ const POCKET_BOTTOM_R = POCKET_TOP_R * 0.7;
 const POCKET_WALL_OPEN_TRIM = TABLE.THICK * 0.18;
 const POCKET_WALL_HEIGHT = TABLE.THICK * 0.7 - POCKET_WALL_OPEN_TRIM;
 const POCKET_NET_DEPTH = TABLE.THICK * 2.26;
+const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.26;
 const POCKET_NET_SEGMENTS = 64;
 const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 0.9; // drop nearly the full net depth so potted balls clear the rim
 const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall slightly above the ring/strap junction
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
-const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
+const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.14; // lift the ring so the holder assembly sits higher
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
@@ -1200,8 +1201,8 @@ const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form t
 const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.2; // wider spacing so potted balls line up without overlapping on the holder rails
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 1.15; // stop the lead ball right against the leather strap without letting it bury the backstop
-const POCKET_HOLDER_REST_DROP = BALL_R * 1.85; // drop the resting spot so potted balls settle lower on the chrome rails
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 1.6; // stop the lead ball right against the leather strap without letting it bury the backstop
+const POCKET_HOLDER_REST_DROP = BALL_R * 0.6; // lower the resting spot just enough for the balls to sit on the holder rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
@@ -1431,7 +1432,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(1, 5.5); // Mirror the cue butt wood repeat for table finishes
-const CUE_WOOD_REPEAT_SCALE = 1.15; // enlarge cue grain slightly without affecting table rail tiling
+const CUE_WOOD_REPEAT_SCALE = 0.38; // enlarge cue grain 3x by reducing the repeat scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // enlarge grain 3× so rails, skirts, and legs read at table scale; push pattern larger for the new finish pass
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
@@ -6770,7 +6771,7 @@ function Table3D(
     new THREE.Vector2(POCKET_BOTTOM_R * 0.94, -POCKET_NET_DEPTH * 0.16),
     new THREE.Vector2(POCKET_BOTTOM_R * 0.82, -POCKET_NET_DEPTH * 0.45),
     new THREE.Vector2(POCKET_BOTTOM_R * 0.66, -POCKET_NET_DEPTH * 0.74),
-    new THREE.Vector2(POCKET_BOTTOM_R * 0.62, -POCKET_NET_DEPTH * 1.06)
+    new THREE.Vector2(pocketGuideRingRadius, -POCKET_NET_DEPTH * 1.06)
   ];
   const pocketNetGeo = new THREE.LatheGeometry(pocketNetProfile, POCKET_NET_SEGMENTS);
   const pocketGuideMaterial = trimMat;
@@ -6784,6 +6785,7 @@ function Table3D(
     28
   );
   const pocketMeshes = [];
+  const pocketDropAnchors = new Map();
   pocketCenters().forEach((p, index) => {
     const pocketId = POCKET_IDS[index] ?? null;
     const isMiddlePocket = index >= 4;
@@ -6799,7 +6801,7 @@ function Table3D(
     const net = new THREE.Mesh(pocketNetGeo, pocketNetMaterial);
     net.position.set(
       p.x,
-      pocketTopY - POCKET_WALL_HEIGHT - POCKET_WALL_OPEN_TRIM + pocketLift,
+      pocketTopY - POCKET_WALL_HEIGHT - POCKET_WALL_OPEN_TRIM + pocketLift + POCKET_NET_VERTICAL_LIFT,
       p.y
     );
     net.castShadow = false;
@@ -6907,7 +6909,11 @@ function Table3D(
       table.add(strap);
       finishParts.pocketJawMeshes.push(strap);
     }
+    const holderSurfaceY =
+      ringAnchor.y - POCKET_GUIDE_VERTICAL_DROP - POCKET_GUIDE_FLOOR_DROP + POCKET_GUIDE_RADIUS + BALL_R;
+    pocketDropAnchors.set(pocketId, { ringAnchor: ringAnchor.clone(), holderSurfaceY });
   });
+  table.userData.pocketDropAnchors = pocketDropAnchors;
 
   const railH = RAIL_HEIGHT;
   const railsTopY = frameTopY + railH;
@@ -8395,11 +8401,11 @@ function Table3D(
     return mat;
   };
   const brandPlateThickness = chromePlateThickness;
-  const brandPlateDepth = Math.min(endRailW * 0.54, TABLE.THICK * 0.78);
-  const brandPlateWidth = Math.min(PLAY_W * 0.36, Math.max(BALL_R * 11, PLAY_W * 0.28));
+  const brandPlateDepth = Math.min(endRailW * 0.48, TABLE.THICK * 0.72);
+  const brandPlateWidth = Math.min(PLAY_W * 0.4, Math.max(BALL_R * 12, PLAY_W * 0.32));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.2;
+  const brandPlateOutwardShift = endRailW * 0.26;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -8652,28 +8658,40 @@ function Table3D(
       tangent: new THREE.Vector3(0, 0, 1),
       defaultOffset: chalkLongAxisOffset,
       offsetLimits: { min: -chalkLongOffsetLimit, max: chalkLongOffsetLimit },
-      rotationY: Math.PI / 2
+      rotationY: Math.PI / 2,
+      rotationX: 0
+    },
+    {
+      basePosition: new THREE.Vector3(-sideRailCenterX - chalkSideRailOffset, chalkBaseY, 0),
+      tangent: new THREE.Vector3(0, 0, 1),
+      defaultOffset: -chalkLongAxisOffset,
+      offsetLimits: { min: -chalkLongOffsetLimit, max: chalkLongOffsetLimit },
+      rotationY: Math.PI / 2,
+      rotationX: 0
     },
     {
       basePosition: new THREE.Vector3(sideRailCenterX + chalkSideRailOffset, chalkBaseY, 0),
       tangent: new THREE.Vector3(0, 0, -1),
       defaultOffset: chalkLongAxisOffset,
       offsetLimits: { min: -chalkLongOffsetLimit, max: chalkLongOffsetLimit },
-      rotationY: -Math.PI / 2
+      rotationY: -Math.PI / 2,
+      rotationX: 0
     },
     {
-      basePosition: new THREE.Vector3(0, chalkBaseY, -endRailCenterZ - chalkEndRailOffset),
+      basePosition: new THREE.Vector3(0, railsTopY + chalkSize / 2, -endRailCenterZ - chalkEndRailOffset),
       tangent: new THREE.Vector3(-1, 0, 0),
       defaultOffset: -chalkShortAxisOffset,
       offsetLimits: { min: -chalkShortOffsetLimit, max: chalkShortOffsetLimit },
-      rotationY: 0
+      rotationY: 0,
+      rotationX: Math.PI / 2
     },
     {
-      basePosition: new THREE.Vector3(0, chalkBaseY, endRailCenterZ + chalkEndRailOffset),
+      basePosition: new THREE.Vector3(0, railsTopY + chalkSize / 2, endRailCenterZ + chalkEndRailOffset),
       tangent: new THREE.Vector3(1, 0, 0),
       defaultOffset: chalkShortAxisOffset,
       offsetLimits: { min: -chalkShortOffsetLimit, max: chalkShortOffsetLimit },
-      rotationY: Math.PI
+      rotationY: Math.PI,
+      rotationX: Math.PI / 2
     }
   ];
   chalkSlots.forEach((slot, index) => {
@@ -8681,7 +8699,7 @@ function Table3D(
     mesh.position
       .copy(slot.basePosition)
       .addScaledVector(slot.tangent, slot.defaultOffset ?? 0);
-    mesh.rotation.set(0, slot.rotationY, 0);
+    mesh.rotation.set(slot.rotationX ?? 0, slot.rotationY ?? 0, 0);
     mesh.castShadow = true;
     mesh.receiveShadow = true;
     mesh.visible = true;
@@ -22875,16 +22893,15 @@ const powerRef = useRef(hud.power);
               if (b.id === 'cue') b.impacted = false;
               const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               const dropStart = performance.now();
-              const fromX = b.pos.x;
-              const fromZ = b.pos.y;
               const holderDir = resolvePocketHolderDirection(c, pocketId);
               const pocketRestIndex =
                 pocketRestIndexRef.current.get(pocketId) ?? 0;
-              const ringAnchor = new THREE.Vector3(
-                c.x,
-                BALL_CENTER_Y - POCKET_DROP_DEPTH * 0.5,
-                c.y
-              );
+              const pocketDropAnchor = table?.userData?.pocketDropAnchors?.get(pocketId) ?? null;
+              const ringAnchor = pocketDropAnchor?.ringAnchor?.clone()
+                ?? new THREE.Vector3(c.x, BALL_CENTER_Y - POCKET_DROP_DEPTH * 0.5, c.y);
+              const holderSurfaceY = Number.isFinite(pocketDropAnchor?.holderSurfaceY)
+                ? pocketDropAnchor.holderSurfaceY
+                : BALL_CENTER_Y - POCKET_DROP_DEPTH;
               const holderSpacing = POCKET_HOLDER_REST_SPACING;
               const railStartDistance =
                 POCKET_NET_RING_RADIUS_SCALE * POCKET_BOTTOM_R +
@@ -22922,13 +22939,12 @@ const powerRef = useRef(hud.power);
                     0
                   )
                 );
+              const dropStartY = ringAnchor.y + BALL_R * 0.65;
               const dropEntry = {
                 start: dropStart,
-                fromY: BALL_CENTER_Y,
-                currentY: BALL_CENTER_Y,
-                targetY:
-                  BALL_CENTER_Y -
-                  (POCKET_DROP_DEPTH + POCKET_HOLDER_REST_DROP + tiltDrop),
+                fromY: dropStartY,
+                currentY: dropStartY,
+                targetY: holderSurfaceY - POCKET_HOLDER_REST_DROP - tiltDrop,
                 fromX: ringAnchor.x,
                 fromZ: ringAnchor.z,
                 toX: targetX,
@@ -22954,7 +22970,7 @@ const powerRef = useRef(hud.power);
               };
               b.mesh.visible = true;
               b.mesh.scale.set(1, 1, 1);
-              b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
+              b.mesh.position.set(ringAnchor.x, dropStartY, ringAnchor.z);
               pocketDropRef.current.set(b.id, dropEntry);
               const mappedColor = toBallColorId(b.id);
               const colorId =


### PR DESCRIPTION
### Motivation
- Make cue and pocket leather patterns visually larger (3×) so materials read correctly at mobile portrait scale. 
- Thicken and lift the pocket net and ring so potted balls pass through the ring, roll on the chrome guides and stop reliably on the leather straps. 
- Slightly adjust branding plates to sit more outward and change sizing so they match the visual reference. 
- Reposition and add chalk models so two are rotated to show the blue face and one extra chalk is present while preserving spacing.

### Description
- Increased pocket net line thickness by setting `POCKET_NET_LINE_THICKNESS_SCALE` from `1.6` to `4.8` and added `POCKET_NET_VERTICAL_LIFT` to raise the net mesh. 
- Enlarged cue/leather pattern scale by reducing `CUE_WOOD_REPEAT_SCALE` and `POCKET_LEATHER_TEXTURE_REPEAT` so visual patterns read ~3× larger. 
- Recalibrated pocket drop anchors and flow: created `pocketDropAnchors` and use it to compute `ringAnchor`, `dropStartY`, and `targetY` so potted balls land on the chrome guides and rest against leather straps; adjusted `POCKET_NET_RING_VERTICAL_OFFSET`, `POCKET_HOLDER_REST_PULLBACK`, and `POCKET_HOLDER_REST_DROP`. 
- Adjusted brand plate geometry/placement (`brandPlateWidth`, `brandPlateDepth`, `brandPlateOutwardShift`) and updated `chalkSlots` (added an extra chalk entry, rotated two chalks to expose their top/blue faces and set `rotationX`/`rotationY`) so chalk display and spacing match the new layout.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and confirmed Vite reported a successful startup (local + network URLs). (succeeded) 
- Ran a Playwright script to open the running app at portrait viewport `430x932` and captured a screenshot (`artifacts/pool-royale.png`) to visually verify changes. (succeeded) 
- No unit test (`npm test`) or CI runs were executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4ab96f0883299c949e253d75a70d)