### PR TITLE
Sync spin controller dot with cue-stick visuals (Pool Royale & Snooker)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11729,14 +11729,8 @@ const powerRef = useRef(hud.power);
     if (!dot) return;
     const x = clamp(value.x ?? 0, -1, 1);
     const y = clamp(value.y ?? 0, -1, 1);
-    const ranges = spinRangeRef.current || {};
-    const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 1e-6);
-    const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 1e-6);
-    const largest = Math.max(maxSide, maxVertical);
-    const scaledX = (x * maxSide) / largest;
-    const scaledY = (y * maxVertical) / largest;
-    dot.style.left = `${50 + scaledX * 50}%`;
-    dot.style.top = `${50 + scaledY * 50}%`;
+    dot.style.left = `${50 + x * 50}%`;
+    dot.style.top = `${50 + y * 50}%`;
     const magnitude = Math.hypot(x, y);
     const showBlocked = blocked ?? spinLegalityRef.current?.blocked;
     dot.style.backgroundColor = showBlocked
@@ -19174,17 +19168,26 @@ const powerRef = useRef(hud.power);
         }
         return vec;
       };
+      const getSpinVisualRadius = (ranges = {}) => {
+        const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 0);
+        const maxVertical = Math.max(
+          ranges.offsetVertical ?? MAX_SPIN_VERTICAL,
+          0
+        );
+        const radius = Math.min(maxSide, maxVertical);
+        if (radius > 1e-6) return radius;
+        return Math.max(maxSide, maxVertical, 1e-6);
+      };
       const computeSpinOffsets = (spin, ranges) => {
-        const offsetSide = ranges?.offsetSide ?? 0;
-        const offsetVertical = ranges?.offsetVertical ?? 0;
+        const visualRadius = getSpinVisualRadius(ranges);
         const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
         const hasSpin = magnitude > 1e-4;
-        let side = hasSpin ? spin.x * offsetSide : 0;
-        let vert = hasSpin ? -spin.y * offsetVertical : 0;
+        let side = hasSpin ? (spin.x ?? 0) * visualRadius : 0;
+        let vert = hasSpin ? -(spin.y ?? 0) * visualRadius : 0;
         if (hasSpin) {
           vert = THREE.MathUtils.clamp(vert, -MAX_SPIN_VISUAL_LIFT, MAX_SPIN_VISUAL_LIFT);
         }
-        const maxContactOffset = MAX_SPIN_CONTACT_OFFSET;
+        const maxContactOffset = visualRadius;
         if (hasSpin && maxContactOffset > 1e-6) {
           const combined = Math.hypot(side, vert);
           if (combined > maxContactOffset) {

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -9504,14 +9504,8 @@ export function PoolRoyaleGame({
     if (!dot) return;
     const x = clamp(value.x ?? 0, -1, 1);
     const y = clamp(value.y ?? 0, -1, 1);
-    const ranges = spinRangeRef.current || {};
-    const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 1e-6);
-    const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 1e-6);
-    const largest = Math.max(maxSide, maxVertical);
-    const scaledX = (x * maxSide) / largest;
-    const scaledY = (y * maxVertical) / largest;
-    dot.style.left = `${50 + scaledX * 50}%`;
-    dot.style.top = `${50 + scaledY * 50}%`;
+    dot.style.left = `${50 + x * 50}%`;
+    dot.style.top = `${50 + y * 50}%`;
     const magnitude = Math.hypot(x, y);
     const showBlocked = blocked ?? spinLegalityRef.current?.blocked;
     dot.style.backgroundColor = showBlocked
@@ -9521,6 +9515,13 @@ export function PoolRoyaleGame({
         : '#dc2626';
     dot.dataset.blocked = showBlocked ? '1' : '0';
   }, []);
+  const getSpinVisualRadius = (ranges = {}) => {
+    const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 0);
+    const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 0);
+    const radius = Math.min(maxSide, maxVertical);
+    if (radius > 1e-6) return radius;
+    return Math.max(maxSide, maxVertical, 1e-6);
+  };
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
   const pocketDropRef = useRef(new Map());
@@ -16181,11 +16182,10 @@ export function PoolRoyaleGame({
             CUE_PULL_SMOOTHING
           );
           cuePullCurrentRef.current = pull;
-          const offsetSide = ranges.offsetSide ?? 0;
-          const offsetVertical = ranges.offsetVertical ?? 0;
-          let side = appliedSpin.x * offsetSide;
-          let vert = -appliedSpin.y * offsetVertical;
-          const maxContactOffset = MAX_SPIN_CONTACT_OFFSET;
+          const visualRadius = getSpinVisualRadius(ranges);
+          let side = (appliedSpin.x ?? 0) * visualRadius;
+          let vert = -(appliedSpin.y ?? 0) * visualRadius;
+          const maxContactOffset = visualRadius;
           if (maxContactOffset > 1e-6) {
             const combined = Math.hypot(side, vert);
             if (combined > maxContactOffset) {
@@ -16384,14 +16384,13 @@ export function PoolRoyaleGame({
             CUE_PULL_SMOOTHING
           );
           cuePullCurrentRef.current = pull;
-          const offsetSide = ranges.offsetSide ?? 0;
-          const offsetVertical = ranges.offsetVertical ?? 0;
+          const visualRadius = getSpinVisualRadius(ranges);
           const planSpin = activeAiPlan.spin ?? spinRef.current ?? { x: 0, y: 0 };
           const spinX = THREE.MathUtils.clamp(planSpin.x ?? 0, -1, 1);
           const spinY = THREE.MathUtils.clamp(planSpin.y ?? 0, -1, 1);
-          let side = spinX * offsetSide;
-          let vert = -spinY * offsetVertical;
-          const maxContactOffset = MAX_SPIN_CONTACT_OFFSET;
+          let side = spinX * visualRadius;
+          let vert = -spinY * visualRadius;
+          const maxContactOffset = visualRadius;
           if (maxContactOffset > 1e-6) {
             const combined = Math.hypot(side, vert);
             if (combined > maxContactOffset) {


### PR DESCRIPTION
### Motivation

- The cue stick visual offsets were not matching the spin controller dot, causing perceived top-spin at break and inconsistent cue placement near balls. 
- The spin UI previously scaled the dot using independent range extents which could desync the controller and cue tip movement. 
- We need the cue tip to follow the same normalized spin input and remain clamped to a consistent visual radius so it never intersects cushions/balls.

### Description

- Map the spin controller dot directly to the normalized spin values by setting the dot position using the raw `x`/`y` values instead of separate scaled ranges (`updateSpinDotPosition`).
- Introduce `getSpinVisualRadius` and apply a unified `visualRadius` so cue-tip offsets (`side`/`vert`) use the same scale the controller visual uses (`computeSpinOffsets`).
- Replace previous per-axis scaling with the unified visual radius and clamp the resulting cue-tip offsets to the same contact limit so visuals stay on the intended radius.
- Changes applied to `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/SnookerClubGame.jsx` to keep both player and AI cue visuals consistent with the controller.

### Testing

- Started the dev webapp with `npm --prefix webapp run dev` and Vite reported "ready" which indicates the app built and served successfully. (succeeded)
- Attempted an automated Playwright screenshot of the running dev server to verify visual alignment, but the Playwright run timed out while loading and did not complete. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e754831c88329a62abc177b6f3d46)