### PR TITLE
Adjust cue stick obstruction near rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21827,6 +21827,29 @@ const powerRef = useRef(hud.power);
           );
           const clearanceSq = CUE_OBSTRUCTION_CLEARANCE * CUE_OBSTRUCTION_CLEARANCE;
           let strength = 0;
+          const applyRailObstruction = (railPos, axis) => {
+            const axisPos = axis === 'x' ? origin.x : origin.y;
+            const axisDir = axis === 'x' ? backward.x : backward.y;
+            const distance = Math.abs(axisPos - railPos);
+            if (distance > CUE_OBSTRUCTION_CLEARANCE) return;
+            let closestT = 0;
+            if (Math.abs(axisDir) > 1e-6) {
+              const tAtRail = (railPos - axisPos) / axisDir;
+              closestT = THREE.MathUtils.clamp(tAtRail, 0, reach);
+            }
+            const depth = THREE.MathUtils.clamp(1 - closestT / reach, 0, 1);
+            const proximity = THREE.MathUtils.clamp(
+              1 - distance / CUE_OBSTRUCTION_CLEARANCE,
+              0,
+              1
+            );
+            const influence = Math.max(proximity, 0.6 * proximity + 0.4 * depth);
+            strength = Math.max(strength, influence);
+          };
+          applyRailObstruction(RAIL_LIMIT_X, 'x');
+          applyRailObstruction(-RAIL_LIMIT_X, 'x');
+          applyRailObstruction(RAIL_LIMIT_Y, 'y');
+          applyRailObstruction(-RAIL_LIMIT_Y, 'y');
           balls.forEach((b) => {
             if (!b?.active || b === cue) return;
             const delta = b.pos.clone().sub(origin);


### PR DESCRIPTION
### Motivation
- The cue stick behaved differently when hugging the short rail on the rack side versus other rails, causing inconsistent lift/tilt visuals.
- Match the rail-side behavior to the rack-side behavior so cue lift and obstruction feel uniform around the table.

### Description
- Update `resolveCueObstruction` in `webapp/src/pages/Games/PoolRoyale.jsx` to factor table rails into obstruction strength calculations.
- Add an `applyRailObstruction` helper that samples proximity and reach against `RAIL_LIMIT_X`, `-RAIL_LIMIT_X`, `RAIL_LIMIT_Y`, and `-RAIL_LIMIT_Y` and blends proximity/depth into the `strength` metric.
- Reuse the same proximity/depth influence blend used for ball obstructions so rail influence integrates smoothly with existing logic.

### Testing
- No automated tests were run against this change.
- Manual runtime verification is expected as part of playtesting (not included in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8121bfbc8329af40e143688584a3)