### PR TITLE
Enlarge cue wood grain tiling and enhance cloth texture detail

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1437,7 +1437,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Match cue grain scale to the table finish
-const CUE_WOOD_REPEAT_SCALE = 1 / 3;
+const CUE_WOOD_REPEAT_SCALE = 1 / 9;
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // enlarge grain 3× so rails, skirts, and legs read at table scale; push pattern larger for the new finish pass
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
@@ -1790,10 +1790,10 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 1.32;
-const CLOTH_HAIR_INTENSITY = 1.02;
-const CLOTH_BUMP_INTENSITY = 1.38;
-const CLOTH_SOFT_BLEND = 0.5;
+const CLOTH_TEXTURE_INTENSITY = 1.58;
+const CLOTH_HAIR_INTENSITY = 1.24;
+const CLOTH_BUMP_INTENSITY = 1.7;
+const CLOTH_SOFT_BLEND = 0.42;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {


### PR DESCRIPTION
### Motivation
- Enlarge the visible wood pattern on cue shafts so the cue stick patterns read roughly 3× larger without altering the peeling/painted weathered finish behavior.  
- Make table cloth patterns richer and more visible by increasing procedural texture intensity and bump/hair detail so the felt reads more realistic on-screen.

### Description
- Reduce `CUE_WOOD_REPEAT_SCALE` from `1/3` to `1/9` to increase the apparent size of the cue wood grain in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Increase cloth detail by raising `CLOTH_TEXTURE_INTENSITY`, `CLOTH_HAIR_INTENSITY`, and `CLOTH_BUMP_INTENSITY`, and adjust `CLOTH_SOFT_BLEND` to tune the resulting look in the same file.  
- Changes are limited to rendering/texture tuning and do not modify gameplay or physics systems.  

### Testing
- Launched the local dev server with `npm --prefix webapp run dev` and Vite reported the site was ready.  
- Attempted an automated visual capture via Playwright to verify in-viewport appearance but the screenshot step timed out.  
- No unit or integration tests were run because the changes are visual/material-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8b9931e08329b453afb00eb1f916)