### PR TITLE
Fix cue stick tip radius alignment in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19208,6 +19208,17 @@ const powerRef = useRef(hud.power);
         }
         return vec;
       };
+      const resolveCueTipForwardOffset = (spinWorld, baseDistance) => {
+        const targetDistance = Number.isFinite(baseDistance)
+          ? Math.max(baseDistance, 0)
+          : 0;
+        const spinMagnitude = spinWorld?.length?.() ?? 0;
+        if (spinMagnitude <= 1e-6) {
+          return targetDistance;
+        }
+        const squared = targetDistance * targetDistance - spinMagnitude * spinMagnitude;
+        return Math.sqrt(Math.max(0, squared));
+      };
       const computeSpinOffsets = (spin, ranges) => {
         const offsetSide = ranges?.offsetSide ?? 0;
         const offsetVertical = ranges?.offsetVertical ?? 0;
@@ -22040,15 +22051,17 @@ const powerRef = useRef(hud.power);
           const { side, vert, hasSpin } = computeSpinOffsets(appliedSpin, ranges);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
+          const tipDistance = CUE_TIP_GAP + visualPull;
+          const forwardOffset = resolveCueTipForwardOffset(spinWorld, tipDistance);
           const obstructionStrength = resolveCueObstruction(dir, pull);
           const obstructionTilt = obstructionStrength * CUE_OBSTRUCTION_TILT;
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + forwardOffset) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + forwardOffset) + spinWorld.z
           );
           const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
@@ -22064,9 +22077,9 @@ const powerRef = useRef(hud.power);
           const buttTiltInfo = cueStick.userData?.buttTilt;
           const buttHeightOffset = buttTiltInfo?.buttHeightOffset ?? 0;
           TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + visualPull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen + forwardOffset) + spinWorld.x,
             CUE_Y + spinWorld.y + buttHeightOffset,
-            cue.pos.y - dir.z * (cueLen + visualPull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen + forwardOffset) + spinWorld.z
           );
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -22258,15 +22271,17 @@ const powerRef = useRef(hud.power);
           );
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
+          const tipDistance = CUE_TIP_GAP + visualPull;
+          const forwardOffset = resolveCueTipForwardOffset(spinWorld, tipDistance);
           const obstructionStrength = resolveCueObstruction(baseDir, pull);
           const obstructionTilt = obstructionStrength * CUE_OBSTRUCTION_TILT;
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
           cueStick.position.set(
-            cue.pos.x - baseDir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - baseDir.x * (cueLen / 2 + forwardOffset) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - baseDir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - baseDir.z * (cueLen / 2 + forwardOffset) + spinWorld.z
           );
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
@@ -22359,15 +22374,17 @@ const powerRef = useRef(hud.power);
           );
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
+          const tipDistance = CUE_TIP_GAP + visualPull;
+          const forwardOffset = resolveCueTipForwardOffset(spinWorld, tipDistance);
           const obstructionStrength = resolveCueObstruction(dir, pull);
           const obstructionTilt = obstructionStrength * CUE_OBSTRUCTION_TILT;
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + forwardOffset) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + forwardOffset) + spinWorld.z
           );
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);


### PR DESCRIPTION
### Motivation
- Cue stick tip was drifting off the intended radius when lateral/vertical spin was applied, producing an unnatural visual offset. 
- Ensure the cue tip remains visually constrained to the correct distance from the cue ball while preserving spin offsets. 

### Description
- Added `resolveCueTipForwardOffset` which computes a forward offset so the cue-tip stays on the target radius when lateral/vertical spin displacement is present. 
- Replaced uses of `cueLen/2 + visualPull + CUE_TIP_GAP` with the computed forward offset in player, remote, and AI aiming/animation flows to keep the tip alignment consistent. 
- Applied the forward offset to both the cue stick `position` and the butt reference (`TMP_VEC3_BUTT`) calculations in `webapp/src/pages/Games/PoolRoyale.jsx`. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eba44b81c8329a719a73124cd9446)