### PR TITLE
Fix cue stick tip radius when applying spin offsets

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -16205,10 +16205,13 @@ export function PoolRoyaleGame({
             vert,
             perp.z * side
           );
+          const cueTipGap = Math.sqrt(
+            Math.max(0, CUE_TIP_GAP * CUE_TIP_GAP - side * side - vert * vert)
+          );
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + pull + cueTipGap) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + pull + cueTipGap) + spinWorld.z
           );
           const tiltAmount = Math.abs(appliedSpin.y || 0);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
@@ -16218,9 +16221,9 @@ export function PoolRoyaleGame({
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen + pull + cueTipGap) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen + pull + cueTipGap) + spinWorld.z
           );
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -16401,10 +16404,13 @@ export function PoolRoyaleGame({
             }
           }
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
+          const cueTipGap = Math.sqrt(
+            Math.max(0, CUE_TIP_GAP * CUE_TIP_GAP - side * side - vert * vert)
+          );
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + pull + cueTipGap) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + pull + cueTipGap) + spinWorld.z
           );
           const tiltAmount = Math.abs(spinY);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);


### PR DESCRIPTION
### Motivation
- The cue stick tip moved off the intended radius around the cue ball when spin offsets were applied, causing visible misalignment during aiming.
- A consistent visual gap between the cue tip and ball is required so the cue tip stays on the cueball radius regardless of side/vertical spin offsets.
- The change brings manual aiming and AI preview behavior into alignment so the cue butt and tip positions match the corrected radius.

### Description
- Compute a corrected forward gap `cueTipGap = sqrt(max(0, CUE_TIP_GAP * CUE_TIP_GAP - side * side - vert * vert))` to preserve the cue-tip radius under spin offsets.
- Replace uses of the constant `CUE_TIP_GAP` with the computed `cueTipGap` for `cueStick.position` and `TMP_VEC3_BUTT` in manual aiming.
- Apply the same `cueTipGap` correction in the AI aiming branch so the previewed cue stick matches manual aim visuals.
- Modified file: `webapp/src/pages/Games/SnookerClubGame.jsx` to implement the above.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and the Vite server came up successfully (dev server run succeeded).
- Ran an automated Playwright screenshot script against `http://127.0.0.1:4173` which completed and produced a screenshot artifact (succeeded).
- No unit test suite (`npm test`) was executed as part of this change (not run).
- Visual verification via the generated screenshot was used to confirm the cue tip alignment (visual check automated by Playwright script succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eba44b81c8329a719a73124cd9446)