### PR TITLE
Fix cue alignment and butt clearance; sharpen cloth/texture patterns; add 16K HDRI/cloth option

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -454,7 +454,7 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '6k', '4k', '2k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['16k', '8k', '6k', '4k', '2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3966,11 +3966,12 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 }
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '6k', '4k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['16k', '8k', '6k', '4k']);
 const HDRI_RESOLUTION_STORAGE_KEY = 'poolHdriResolution';
 const DEFAULT_HDRI_RESOLUTION_MODE = 'auto';
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: 'auto', label: 'Match Table' },
+  { id: '16k', label: '16K' },
   { id: '8k', label: '8K' },
   { id: '6k', label: '6K' },
   { id: '4k', label: '4K' },


### PR DESCRIPTION
### Motivation
- Correct cue aiming visuals so the cue tip stays precisely on the cue ball radius and the butt lifts slightly to avoid clipping nearby balls. 
- Expose higher-resolution environment/cloth options for ultra-high-refresh displays (120 Hz) and allow larger, sharper cloth detail. 
- Make cue and pocket-liner textures visibly larger and clearer by increasing pattern scale and bump intensity. 
- Keep changes localized to rendering/aiming/texture generation subsystems to preserve physics and game rules.

### Description
- Cue alignment and butt clearance: aligned the cue tip to the cue ball center by setting `CUE_Y` and defining `CUE_TIP_GAP`, introduced `tipOffset` on the cue model and added `computeCueButtClearanceTilt` to lift the butt when the rear section would intersect nearby balls, and wired this into aim/animation math so the front tip remains fixed while the butt tilts. (changes in `SnookerClubGame.jsx` around cue constants, tip/tipOffset, aim and animation code). 
- Texture pattern scaling: increased cloth pattern intensity/ bump (`CLOTH_TEXTURE_INTENSITY`, `CLOTH_BUMP_INTENSITY`), adjusted thread pitch and pattern upscaling to make cloth weave larger and sharper, and reduced soft blend to emphasize detail; scaled down cue wood/ebony canvas repeats and pocket-liner repeat via `POCKET_LINER_REPEAT_SCALE` so their visible patterns appear ~3× larger. (changes in `SnookerClubGame.jsx` cues/textures and pocket liner code). 
- Cloth resolution control & caching: added a cloth texture size override API (`setClothTextureSizeOverride`, `resolveClothTextureSize`) and keyed the cloth texture cache by `(presetId:textureSize)` so cloth textures can be regenerated at 16K when requested. (changes in `SnookerClubGame.jsx` `createClothTextures` and related callers). 
- 16K HDRI / UI integration: added `16k` support to the HDRI resolution stacks and UI options and added `clothTextureSize: 16384` to the `uhd120` frame-rate profile, plus plumbing to apply the cloth texture size override when the frame rate/profile changes or when the table is created. (changes in `poolRoyaleInventoryConfig.js`, `PoolRoyale.jsx`, and `SnookerClubGame.jsx`).

### Testing
- Automated tests: none were run as part of this change. 
- Local validation: code was updated and committed; runtime verification on-device/engine was not executed here. 
- No unit or integration test suites were executed by this PR. 
- Recommend running the graphics smoke tests and in-game aiming/interaction playtests after merging to validate visual alignment and performance on 120 Hz / 16K targets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec674e65c83299e61fd955e78aa16)