### PR TITLE
Fix cue alignment, sharpen textures, and improve AI shot selection in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1171,8 +1171,8 @@ const POCKET_HOLDER_SLIDE = BALL_R * 1.2; // horizontal drift as the ball rolls 
 const POCKET_HOLDER_TILT_RAD = THREE.MathUtils.degToRad(9); // slight angle so potted balls settle against the strap
 const POCKET_LEATHER_TEXTURE_ID = 'fabric_leather_02';
 const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({
-  x: 0.08 / 9 * 0.7,
-  y: 0.44 / 9 * 0.7
+  x: 0.08 / 27 * 0.7,
+  y: 0.44 / 27 * 0.7
 });
 const POCKET_LEATHER_TEXTURE_ANISOTROPY = 8;
 const POCKET_LEATHER_NORMAL_SCALE = new THREE.Vector2(1.35, 1.35);
@@ -1437,7 +1437,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
 const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Match cue grain scale to the table finish
-const CUE_WOOD_REPEAT_SCALE = 1 / 3;
+const CUE_WOOD_REPEAT_SCALE = 1 / 9; // enlarge cue wood grain 3× so the pattern reads more clearly at table scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // enlarge grain 3× so rails, skirts, and legs read at table scale; push pattern larger for the new finish pass
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
@@ -1790,9 +1790,9 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 1.32;
-const CLOTH_HAIR_INTENSITY = 1.02;
-const CLOTH_BUMP_INTENSITY = 1.38;
+const CLOTH_TEXTURE_INTENSITY = 1.6;
+const CLOTH_HAIR_INTENSITY = 1.2;
+const CLOTH_BUMP_INTENSITY = 1.8;
 const CLOTH_SOFT_BLEND = 0.5;
 
 const CLOTH_QUALITY = (() => {
@@ -2779,7 +2779,7 @@ const CLOTH_PATTERN_SCALE = 0.76; // tighten the pattern footprint so the scan r
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1 / 3;
 const POLYHAVEN_ANISOTROPY_BOOST = 2.6;
-const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.55, 0.72);
+const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -4905,6 +4905,9 @@ const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_VEC3_A = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
+const TMP_VEC3_CUE_TIP_OFFSET = new THREE.Vector3();
+const TMP_VEC3_CUE_BUTT_OFFSET = new THREE.Vector3();
+const TMP_VEC3_CUE_TIP_TARGET = new THREE.Vector3();
 const TMP_VEC3_CHALK = new THREE.Vector3();
 const TMP_VEC3_CHALK_DELTA = new THREE.Vector3();
 const TMP_VEC3_TOP_VIEW = new THREE.Vector3();
@@ -18210,19 +18213,15 @@ const powerRef = useRef(hud.power);
       const buttTilt = Math.asin(
         Math.min(1, buttLift / Math.max(cueLen, 1e-4))
       );
-      const applyCueButtTilt = (group, extraTilt = 0, anchorY = null) => {
+      const applyCueButtTilt = (group, extraTilt = 0) => {
         if (!group) return;
         const info = group.userData?.buttTilt;
         const baseTilt = info?.angle ?? buttTilt;
         const len = info?.length ?? cueLen;
         const totalTilt = -(baseTilt + extraTilt);
         group.rotation.x = totalTilt;
-        const tipComp = -Math.sin(totalTilt) * len * 0.5;
-        const baseY = anchorY ?? group.position.y;
-        group.position.y = baseY + tipComp;
         if (info) {
-          info.baseAnchor = baseY;
-          info.tipCompensation = tipComp;
+          info.tipCompensation = -Math.sin(totalTilt) * len * 0.5;
           info.current = totalTilt;
           info.extra = extraTilt;
           info.buttHeightOffset = -Math.sin(totalTilt) * len;
@@ -18233,6 +18232,20 @@ const powerRef = useRef(hud.power);
         tipCompensation: -Math.sin(-buttTilt) * cueLen * 0.5,
         buttHeightOffset: -Math.sin(-buttTilt) * cueLen,
         length: cueLen
+      };
+      const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
+      const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
+      const resolveCueTipTarget = (dir, pullAmount, spinWorld) =>
+        TMP_VEC3_CUE_TIP_TARGET.set(
+          cue.pos.x - dir.x * (CUE_TIP_GAP + pullAmount) + spinWorld.x,
+          CUE_Y + spinWorld.y,
+          cue.pos.y - dir.z * (CUE_TIP_GAP + pullAmount) + spinWorld.z
+        );
+      const applyCueStickTransform = (tipTarget) => {
+        TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
+        TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
+        cueStick.position.copy(tipTarget).sub(TMP_VEC3_CUE_TIP_OFFSET);
+        TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
 
       const paletteLength = CUE_FINISH_PALETTE.length || CUE_FINISH_OPTIONS.length || 1;
@@ -18426,7 +18439,7 @@ const powerRef = useRef(hud.power);
       cueBody.add(stripeOverlay);
 
       cueStick.position.set(cue.pos.x, CUE_Y, cue.pos.y + 1.2 * SCALE);
-      applyCueButtTilt(cueStick, 0, CUE_Y);
+      applyCueButtTilt(cueStick, 0);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
@@ -19579,32 +19592,33 @@ const powerRef = useRef(hud.power);
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
-          const buildCuePosition = (pullAmount = visualPull) =>
-            new THREE.Vector3(
-              cue.pos.x - dir.x * (cueLen / 2 + pullAmount + CUE_TIP_GAP) + spinWorld.x,
-              CUE_Y + spinWorld.y,
-              cue.pos.y - dir.z * (cueLen / 2 + pullAmount + CUE_TIP_GAP) + spinWorld.z
-            );
           const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
           const minVisibleGap = Math.max(MIN_PULLBACK_GAP, visualPull * 0.08);
           const warmupPull = Math.max(
             0,
             Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
           );
-          const startPos = buildCuePosition(visualPull);
-          const warmupPos = buildCuePosition(warmupPull);
           const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift,
-            CUE_Y + spinWorld.y + obstructionLift * 0.25
+            extraTilt + obstructionTilt + obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
+          TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
+          TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
+          const buildCuePosition = (pullAmount = visualPull) => {
+            const tipTarget = resolveCueTipTarget(dir, pullAmount, spinWorld);
+            return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
+              .sub(TMP_VEC3_CUE_TIP_OFFSET);
+          };
+          const startPos = buildCuePosition(visualPull);
+          const warmupPos = buildCuePosition(warmupPull);
           cueStick.position.copy(warmupPos);
+          TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const topSpinWeight = Math.max(0, -(appliedSpin.y || 0));
           const backSpinWeight = Math.max(0, appliedSpin.y || 0);
@@ -20038,6 +20052,8 @@ const powerRef = useRef(hud.power);
           if (!cue?.active) return { bestPot: null, bestSafety: null };
           const state = frameRef.current ?? frameState;
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
+          const isRotationVariant =
+            activeVariantId === 'american' || activeVariantId === '9ball';
           const activeBalls = balls.filter((b) => b.active);
           const targetOrder = resolveTargetPriorities(state, activeVariantId, activeBalls);
           const legalTargetsRaw =
@@ -20148,7 +20164,8 @@ const powerRef = useRef(hud.power);
             if (!qualityOk) return false;
             if (!allowCushion && plan.viaCushion) return false;
             if (isAimLaneBlocked(plan)) return false;
-            if (measureLaneClearance(plan) < 0.6) return false;
+            const clearanceTarget = isRotationVariant ? 0.7 : 0.6;
+            if (measureLaneClearance(plan) < clearanceTarget) return false;
             if (detectScratchRisk(plan)) return false;
             return true;
           };
@@ -20452,6 +20469,7 @@ const powerRef = useRef(hud.power);
           }
           const scorePotPlan = (plan) => {
             if (!plan) return -Infinity;
+            if (plan.targetBall && !plan.targetBall.active) return -Infinity;
             if (detectScratchRisk(plan)) return -Infinity;
             if (isAimLaneBlocked(plan)) return -Infinity;
             const laneClearance = measureLaneClearance(plan);
@@ -20482,7 +20500,8 @@ const powerRef = useRef(hud.power);
             );
             const priorityBonus =
               priorityIndex >= 0 ? 1 - Math.min(priorityIndex * 0.18, 0.72) : 0;
-            const cushionPenalty = plan.viaCushion ? 0.18 : 0;
+            const priorityWeight = isRotationVariant ? 0.16 : 0.1;
+            const cushionPenalty = plan.viaCushion ? (isRotationVariant ? 0.28 : 0.18) : 0;
             const finishBonus =
               activeBalls.filter((ball) => ball.active && matchesTargetId(ball, plan.target))
                 .length <= 2
@@ -20494,7 +20513,7 @@ const powerRef = useRef(hud.power);
               difficultyEase * 0.18 +
               pocketEase * 0.1 +
               cueEase * 0.08 +
-              priorityBonus * 0.1 +
+              priorityBonus * priorityWeight +
               routeEase * 0.06 +
               laneBonus * 0.08 +
               finishBonus -
@@ -22045,29 +22064,18 @@ const powerRef = useRef(hud.power);
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
-          cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
-            CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
-          );
           const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift,
-            CUE_Y + spinWorld.y + obstructionLift * 0.25
+            extraTilt + obstructionTilt + obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const buttTiltInfo = cueStick.userData?.buttTilt;
-          const buttHeightOffset = buttTiltInfo?.buttHeightOffset ?? 0;
-          TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + visualPull + CUE_TIP_GAP) + spinWorld.x,
-            CUE_Y + spinWorld.y + buttHeightOffset,
-            cue.pos.y - dir.z * (cueLen + visualPull + CUE_TIP_GAP) + spinWorld.z
-          );
+          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
+          applyCueStickTransform(tipTarget);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -22263,22 +22271,18 @@ const powerRef = useRef(hud.power);
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
-          cueStick.position.set(
-            cue.pos.x - baseDir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
-            CUE_Y + spinWorld.y,
-            cue.pos.y - baseDir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
-          );
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift,
-            CUE_Y + spinWorld.y + obstructionLift * 0.25
+            extraTilt + obstructionTilt + obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(baseDir.x, baseDir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
+          const tipTarget = resolveCueTipTarget(baseDir, visualPull, spinWorld);
+          applyCueStickTransform(tipTarget);
           cueStick.visible = true;
           updateChalkVisibility(null);
           if (targetDir && targetBall) {
@@ -22364,22 +22368,18 @@ const powerRef = useRef(hud.power);
           const obstructionLift = obstructionStrength * CUE_OBSTRUCTION_LIFT;
           const obstructionTiltFromLift =
             obstructionLift > 0 ? Math.atan2(obstructionLift, cueLen) : 0;
-          cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.x,
-            CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + visualPull + CUE_TIP_GAP) + spinWorld.z
-          );
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift,
-            CUE_Y + spinWorld.y
+            extraTilt + obstructionTilt + obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
+          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
+          applyCueStickTransform(tipTarget);
           cueStick.visible = true;
         } else {
           aimFocusRef.current = null;


### PR DESCRIPTION
### Motivation

- Anchor the visible cue tip precisely to the cue-ball strike point so the blue tip and controller dot remain aligned while letting the butt lift for obstructions and spin. 
- Improve AI shot consistency so the opponent selects better, more stable plans across variants (notably American / 9-ball). 
- Make table cloth, cue wood, and pocket leather patterns larger/sharper so materials read clearly on phone screens. 
- Reduce visual mismatch where the rear of the cue moved away from the expected butt/tilt behaviour during obstruction/animation.

### Description

- Reworked cue transform to compute a tip target with `resolveCueTipTarget` and apply the full stick transform via `applyCueStickTransform`, and removed the previous `anchorY` handling in `applyCueButtTilt` so the tip is anchored while butt tilt still updates. 
- Added temporary vectors (`TMP_VEC3_CUE_TIP_OFFSET`, `TMP_VEC3_CUE_BUTT_OFFSET`, `TMP_VEC3_CUE_TIP_TARGET`) and centralized tip/butt math so all branches (player, remote, AI preview) position the stick from the tip target. 
- Tuned AI evaluation by introducing `isRotationVariant` (American/9-ball), raising lane-clearance gating for those variants, rejecting plans that reference inactive `targetBall`, and adjusting `priorityWeight`/`cushionPenalty` to prefer more consistent professional choices. 
- Increased visual detail by changing `CUE_WOOD_REPEAT_SCALE` to `1/9`, boosting `CLOTH_TEXTURE_INTENSITY`, `CLOTH_HAIR_INTENSITY`, `CLOTH_BUMP_INTENSITY`, updating `CLOTH_NORMAL_SCALE`, and reducing `POCKET_LEATHER_TEXTURE_REPEAT` to scale leather patterns up.

### Testing

- Started the dev server with `npm --prefix webapp run dev` and Vite reported the site serving at `http://localhost:4173/` (succeeded). 
- Attempted an automated headless rendering/screenshot with Playwright to validate visuals but the browser process crashed in the container (failed). 
- No unit or integration test suites were run as part of this change (none executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f35f91f508329ab322a33850de4d0)