### PR TITLE
Fix cue stick obstruction tilt

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18248,11 +18248,11 @@ const powerRef = useRef(hud.power);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
       const resolveCueObstructionTilt = (strength) => {
-        const obstructionTilt = -strength * CUE_OBSTRUCTION_TILT;
+        const obstructionTilt = strength * CUE_OBSTRUCTION_TILT;
         const obstructionLift = strength * CUE_OBSTRUCTION_LIFT;
         const liftDivisor = cueLen * 0.55;
         const obstructionTiltFromLift =
-          obstructionLift > 0 ? -Math.atan2(obstructionLift, liftDivisor) : 0;
+          obstructionLift > 0 ? Math.atan2(obstructionLift, liftDivisor) : 0;
         return { obstructionTilt, obstructionLift, obstructionTiltFromLift };
       };
 


### PR DESCRIPTION
### Motivation
- The cue butt was being lowered instead of lifted when the cue is obstructed by cushions or nearby balls due to inverted tilt math. 
- The lift-derived tilt calculation also used the opposite sign and therefore produced incorrect compensation. 

### Description
- Corrected `resolveCueObstructionTilt` so `obstructionTilt` uses `strength * CUE_OBSTRUCTION_TILT` instead of the inverted sign. 
- Made the lift-derived tilt use `Math.atan2(obstructionLift, liftDivisor)` (positive) to align its direction with the primary tilt. 
- Changes applied in `webapp/src/pages/Games/PoolRoyale.jsx` inside the cue stick / obstruction handling code. 

### Testing
- No automated tests were run against this change. 
- Manual visual verification is recommended to confirm the cue butt now lifts near cushions/balls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5c6a1af88329b8bb8846980219ef)