### PR TITLE
Fix cue stick lift near obstructions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18248,11 +18248,11 @@ const powerRef = useRef(hud.power);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
       const resolveCueObstructionTilt = (strength) => {
-        const obstructionTilt = -strength * CUE_OBSTRUCTION_TILT;
+        const obstructionTilt = strength * CUE_OBSTRUCTION_TILT;
         const obstructionLift = strength * CUE_OBSTRUCTION_LIFT;
         const liftDivisor = cueLen * 0.55;
         const obstructionTiltFromLift =
-          obstructionLift > 0 ? -Math.atan2(obstructionLift, liftDivisor) : 0;
+          obstructionLift > 0 ? Math.atan2(obstructionLift, liftDivisor) : 0;
         return { obstructionTilt, obstructionLift, obstructionTiltFromLift };
       };
 


### PR DESCRIPTION
### Motivation
- Fix a visual/animation bug where the cue butt was being lowered (instead of lifting) when cushions or balls obstruct the back of the cue during aiming and pull animations. 
- The incorrect sign in the obstruction-to-tilt math caused the cue to rotate the wrong way under obstruction influence, producing unintuitive visuals when aiming near rails or other balls.

### Description
- Adjusted `resolveCueObstructionTilt` in `webapp/src/pages/Games/PoolRoyale.jsx` to compute `obstructionTilt` as `strength * CUE_OBSTRUCTION_TILT` (previously negated) so the butt tilts upward when strength increases. 
- Changed `obstructionTiltFromLift` to use a positive `Math.atan2` for the tilt contribution from lift so lift produces a matching tilt direction. 
- This is a small deterministic math fix (2 lines changed) that affects how `applyCueButtTilt` composes final cue rotation for rendering the cue stick.

### Testing
- No automated tests were run against this change. 
- The change is limited to client-side rendering math in `PoolRoyale.jsx` and intended to be verified visually in the game.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5c6a1af88329b8bb8846980219ef)