### PR TITLE
Fix cue butt lift direction near obstructions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18248,11 +18248,11 @@ const powerRef = useRef(hud.power);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
       const resolveCueObstructionTilt = (strength) => {
-        const obstructionTilt = -strength * CUE_OBSTRUCTION_TILT;
+        const obstructionTilt = strength * CUE_OBSTRUCTION_TILT;
         const obstructionLift = strength * CUE_OBSTRUCTION_LIFT;
         const liftDivisor = cueLen * 0.55;
         const obstructionTiltFromLift =
-          obstructionLift > 0 ? -Math.atan2(obstructionLift, liftDivisor) : 0;
+          obstructionLift > 0 ? Math.atan2(obstructionLift, liftDivisor) : 0;
         return { obstructionTilt, obstructionLift, obstructionTiltFromLift };
       };
 
@@ -19608,7 +19608,7 @@ const powerRef = useRef(hud.power);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
+            extraTilt - obstructionTilt - obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
@@ -22072,7 +22072,7 @@ const powerRef = useRef(hud.power);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
+            extraTilt - obstructionTilt - obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
@@ -22277,7 +22277,7 @@ const powerRef = useRef(hud.power);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
+            extraTilt - obstructionTilt - obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(baseDir.x, baseDir.z) + Math.PI;
           if (tipGroupRef.current) {
@@ -22372,7 +22372,7 @@ const powerRef = useRef(hud.power);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
+            extraTilt - obstructionTilt - obstructionTiltFromLift
           );
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {


### PR DESCRIPTION
### Motivation
- Users observed the cue butt lowering instead of lifting when cushions or balls obstruct the cue during aiming and pull animations, producing unintuitive visuals.
- The obstruction-to-tilt composition had inconsistent signs between `resolveCueObstructionTilt` and how the tilt contributions were applied to the cue butt.

### Description
- Updated all `applyCueButtTilt` call sites to subtract obstruction contributions instead of adding them by changing `extraTilt + obstructionTilt + obstructionTiltFromLift` to `extraTilt - obstructionTilt - obstructionTiltFromLift` in the pull/aim/remote code paths.
- Ensured `resolveCueObstructionTilt` returns a positive `obstructionTilt` and a positive `obstructionTiltFromLift` (via `Math.atan2`) so lift produces an upward tilt visually.
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and affect client-side rendering math for cue stick orientation.

### Testing
- No automated tests were run for this change.
- Visual verification is recommended to confirm cue butt now lifts when obstructions are present during aim and pull animations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5c6a1af88329b8bb8846980219ef)