### PR TITLE
Fix cue butt tilt direction and obstruction tilt signs in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18218,19 +18218,19 @@ const powerRef = useRef(hud.power);
         const info = group.userData?.buttTilt;
         const baseTilt = info?.angle ?? buttTilt;
         const len = info?.length ?? cueLen;
-        const totalTilt = -(baseTilt + extraTilt);
+        const totalTilt = baseTilt + extraTilt;
         group.rotation.x = totalTilt;
         if (info) {
-          info.tipCompensation = -Math.sin(totalTilt) * len * 0.5;
+          info.tipCompensation = Math.sin(totalTilt) * len * 0.5;
           info.current = totalTilt;
           info.extra = extraTilt;
-          info.buttHeightOffset = -Math.sin(totalTilt) * len;
+          info.buttHeightOffset = Math.sin(totalTilt) * len;
         }
       };
       cueStick.userData.buttTilt = {
         angle: buttTilt,
-        tipCompensation: -Math.sin(-buttTilt) * cueLen * 0.5,
-        buttHeightOffset: -Math.sin(-buttTilt) * cueLen,
+        tipCompensation: Math.sin(buttTilt) * cueLen * 0.5,
+        buttHeightOffset: Math.sin(buttTilt) * cueLen,
         length: cueLen
       };
       const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
@@ -18248,11 +18248,11 @@ const powerRef = useRef(hud.power);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
       const resolveCueObstructionTilt = (strength) => {
-        const obstructionTilt = -strength * CUE_OBSTRUCTION_TILT;
+        const obstructionTilt = strength * CUE_OBSTRUCTION_TILT;
         const obstructionLift = strength * CUE_OBSTRUCTION_LIFT;
         const liftDivisor = cueLen * 0.55;
         const obstructionTiltFromLift =
-          obstructionLift > 0 ? -Math.atan2(obstructionLift, liftDivisor) : 0;
+          obstructionLift > 0 ? Math.atan2(obstructionLift, liftDivisor) : 0;
         return { obstructionTilt, obstructionLift, obstructionTiltFromLift };
       };
 


### PR DESCRIPTION
### Motivation
- Fix a visual/animation bug where the cue butt lowered instead of lifting when cushions or balls obstruct the back of the cue during aiming and pull animations. 
- Align Pool Royale cue tilt math with the snooker implementation so obstruction and lift produce consistent upward butt movement. 
- Ensure tilt compensation values used for positioning and tip/butt offsets match the new tilt sign convention.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` changed `applyCueButtTilt` to compute `totalTilt = baseTilt + extraTilt` instead of negating the sum. 
- Updated `info.tipCompensation` and `info.buttHeightOffset` to use `Math.sin(totalTilt)` (positive) and adjusted the initial `cueStick.userData.buttTilt` `tipCompensation` and `buttHeightOffset` to `Math.sin(buttTilt)`. 
- Adjusted `resolveCueObstructionTilt` so `obstructionTilt = strength * CUE_OBSTRUCTION_TILT` and `obstructionTiltFromLift` uses a positive `Math.atan2(...)` so lift contributes an upward tilt. 
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and affect rendering/offset math for the cue stick.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev` and Vite started successfully. 
- Attempted an automated Playwright screenshot of the running app, but the Playwright run timed out and no screenshot was captured. 
- No unit or integration test suites were executed as part of this change. 
- The file changes were committed locally after the edits (`Adjust cue butt tilt direction`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5c6a1af88329b8bb8846980219ef)