### PR TITLE
Refine cue obstruction lift/tilt and clamp spin input before legality check

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1408,9 +1408,9 @@ const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear secti
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_FRONT_SECTION_RATIO = 0.28;
 const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 1.6;
-const CUE_OBSTRUCTION_RANGE = BALL_R * 9;
-const CUE_OBSTRUCTION_LIFT = BALL_R * 0.9;
-const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(10);
+const CUE_OBSTRUCTION_RANGE = BALL_R * 7.5;
+const CUE_OBSTRUCTION_LIFT = BALL_R * 0.38;
+const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(6);
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * 0.85;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -17129,7 +17129,14 @@ const powerRef = useRef(hud.power);
               x: 0,
               y: 0
             };
-            legality = checkSpinLegality2D(cueBall, requested, ballsList, {
+            const normalizedRequested = normalizeSpinInput(requested);
+            spinRef.current = normalizedRequested;
+            const limited = clampSpinToLimits();
+            const normalized = normalizeSpinInput(limited);
+            if (normalized.x !== limited.x || normalized.y !== limited.y) {
+              spinRef.current = normalized;
+            }
+            legality = checkSpinLegality2D(cueBall, normalized, ballsList, {
               axes,
               view: viewVec
                 ? { x: viewVec.x, y: viewVec.y }
@@ -17139,10 +17146,7 @@ const powerRef = useRef(hud.power);
           }
           const applied = clampSpinToLimits();
           const normalized = normalizeSpinInput(applied);
-          if (
-            normalized.x !== applied.x ||
-            normalized.y !== applied.y
-          ) {
+          if (normalized.x !== applied.x || normalized.y !== applied.y) {
             spinRef.current = normalized;
           }
           if (updateUi) {


### PR DESCRIPTION
### Motivation
- Reduce unintended cue-stick lowering/over-lift near rails by making obstruction lift and tilt subtler. 
- Ensure the cue tip visual position does not jump or exceed legal spin areas when the spin control (red dot) is used. 
- Make spin legality checks reflect the clamped/normalized spin actually applied to the cue so UI and physics match. 
- Improve consistency between the spin controller dot and the 3D cue-tip placement around blocked/edge cases. 

### Description
- Tuned obstruction constants by changing `CUE_OBSTRUCTION_RANGE`, `CUE_OBSTRUCTION_LIFT`, and `CUE_OBSTRUCTION_TILT` to reduce how much the cue is lifted/tilted when near rails. 
- Updated `applySpinConstraints` to normalize the requested spin, store it to `spinRef.current`, clamp to computed `spinLimitsRef.current`, then normalize again and use that clamped/normalized value for `checkSpinLegality2D` so checks run on the spin that will actually be applied. 
- Ensured `spinRef.current` is kept in sync when clamping/normalizing so the spin dot UI and internal state match the effective spin. 
- Small ordering/flow changes prevent the spin legality check from using an un-clamped/raw request that could cause visual mismatch. 

### Testing
- No automated tests were run for this change. 
- Manual playtesting was assumed but not recorded as part of this PR. 
- Unit or integration tests for spin/aiming systems were not executed. 
- Lint/build steps were not run by the automated rollout process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7e99c620832982d02ca18d59382a)