### PR TITLE
Tighten cue lift and spin clearance in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1409,8 +1409,8 @@ const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_FRONT_SECTION_RATIO = 0.28;
 const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 1.6;
 const CUE_OBSTRUCTION_RANGE = BALL_R * 9;
-const CUE_OBSTRUCTION_LIFT = BALL_R * 0.9;
-const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(10);
+const CUE_OBSTRUCTION_LIFT = BALL_R * 0.35;
+const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(4);
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * 0.85;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -1419,7 +1419,7 @@ const MAX_SPIN_VERTICAL = BALL_R * 0.75;
 const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so the cue stays just above the ball surface
 const SPIN_RING_RATIO = THREE.MathUtils.clamp(SWERVE_THRESHOLD, 0, 1);
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
-const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
+const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.15;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.3;
@@ -19647,7 +19647,7 @@ const powerRef = useRef(hud.power);
             0,
             Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
           );
-          const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
@@ -22117,7 +22117,7 @@ const powerRef = useRef(hud.power);
           const obstructionStrength = resolveCueObstruction(dir, pull);
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,


### PR DESCRIPTION
### Motivation

- Cue elevation during aiming and stroking was too aggressive in places and sometimes lowered the tip when it should not, making fine aim/spin alignment unreliable.
- Backspin and topspin both contributed to butt tilt which caused the cue to lift unnecessarily for topspin strokes.
- The visible cue tip travel did not match the spin UI dot range near rails, reducing precision when setting spin.

### Description

- Reduced obstruction lift and tilt constants to keep the cue closer to the cloth by changing `CUE_OBSTRUCTION_LIFT` to `BALL_R * 0.35` and `CUE_OBSTRUCTION_TILT` to `THREE.MathUtils.degToRad(4)` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Narrowed the spin tip margin by setting `SPIN_TIP_MARGIN` to `CUE_TIP_RADIUS * 1.15` so the visual tip travel better matches the spin control.
- Restricted butt-tilt to backspin only by replacing `Math.abs(appliedSpin.y)` with `Math.max(0, appliedSpin.y)` where `tiltAmount` is computed, preventing topspin from raising the butt.
- Changes affect aiming, pull/warmup, and stroke animation paths where `applyCueButtTilt`, `resolveCueObstruction`, and `computeSpinOffsets` are used.

### Testing

- No automated tests were executed as part of this change.
- The file `webapp/src/pages/Games/PoolRoyale.jsx` was updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7e99c620832982d02ca18d59382a)