### PR TITLE
Consistently lift cue tip near obstructions and restrict butt-tilt to backspin

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1409,8 +1409,8 @@ const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_FRONT_SECTION_RATIO = 0.28;
 const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 1.6;
 const CUE_OBSTRUCTION_RANGE = BALL_R * 9;
-const CUE_OBSTRUCTION_LIFT = BALL_R * 0.9;
-const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(10);
+const CUE_OBSTRUCTION_LIFT = BALL_R * 0.35;
+const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(4);
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * 0.85;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -1419,7 +1419,7 @@ const MAX_SPIN_VERTICAL = BALL_R * 0.75;
 const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so the cue stays just above the ball surface
 const SPIN_RING_RATIO = THREE.MathUtils.clamp(SWERVE_THRESHOLD, 0, 1);
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
-const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.6;
+const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.15;
 const SIDE_SPIN_MULTIPLIER = 1.25;
 const BACKSPIN_MULTIPLIER = 1.7 * 1.25 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.3;
@@ -18278,12 +18278,15 @@ const powerRef = useRef(hud.power);
       };
       const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
       const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
-      const resolveCueTipTarget = (dir, pullAmount, spinWorld) =>
-        TMP_VEC3_CUE_TIP_TARGET.set(
+      const resolveCueTipTarget = (dir, pullAmount, spinWorld, lift = 0) => {
+        const baseY = CUE_Y + spinWorld.y;
+        const minY = CUE_Y + CUE_CLEARANCE_PADDING;
+        return TMP_VEC3_CUE_TIP_TARGET.set(
           cue.pos.x - dir.x * (CUE_TIP_GAP + pullAmount) + spinWorld.x,
-          CUE_Y + spinWorld.y,
+          Math.max(baseY, minY) + lift,
           cue.pos.y - dir.z * (CUE_TIP_GAP + pullAmount) + spinWorld.z
         );
+      };
       const applyCueStickTransform = (tipTarget) => {
         TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
         TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
@@ -19639,7 +19642,7 @@ const powerRef = useRef(hud.power);
           );
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(dir, pull);
-          const { obstructionTilt, obstructionTiltFromLift } =
+          const { obstructionTilt, obstructionTiltFromLift, obstructionLift } =
             resolveCueObstructionTilt(obstructionStrength);
           const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
           const minVisibleGap = Math.max(MIN_PULLBACK_GAP, visualPull * 0.08);
@@ -19647,7 +19650,7 @@ const powerRef = useRef(hud.power);
             0,
             Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
           );
-          const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
@@ -19660,7 +19663,12 @@ const powerRef = useRef(hud.power);
           TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
           TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
           const buildCuePosition = (pullAmount = visualPull) => {
-            const tipTarget = resolveCueTipTarget(dir, pullAmount, spinWorld);
+            const tipTarget = resolveCueTipTarget(
+              dir,
+              pullAmount,
+              spinWorld,
+              obstructionLift
+            );
             return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
@@ -22115,9 +22123,9 @@ const powerRef = useRef(hud.power);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(dir, pull);
-          const { obstructionTilt, obstructionTiltFromLift } =
+          const { obstructionTilt, obstructionTiltFromLift, obstructionLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.abs(appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
           applyCueButtTilt(
             cueStick,
@@ -22127,7 +22135,12 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
+          const tipTarget = resolveCueTipTarget(
+            dir,
+            visualPull,
+            spinWorld,
+            obstructionLift
+          );
           applyCueStickTransform(tipTarget);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -22320,9 +22333,9 @@ const powerRef = useRef(hud.power);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(baseDir, pull);
-          const { obstructionTilt, obstructionTiltFromLift } =
+          const { obstructionTilt, obstructionTiltFromLift, obstructionLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
@@ -22332,7 +22345,12 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(baseDir, visualPull, spinWorld);
+          const tipTarget = resolveCueTipTarget(
+            baseDir,
+            visualPull,
+            spinWorld,
+            obstructionLift
+          );
           applyCueStickTransform(tipTarget);
           cueStick.visible = true;
           updateChalkVisibility(null);
@@ -22415,9 +22433,9 @@ const powerRef = useRef(hud.power);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(dir, pull);
-          const { obstructionTilt, obstructionTiltFromLift } =
+          const { obstructionTilt, obstructionTiltFromLift, obstructionLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
           applyCueButtTilt(
             cueStick,
@@ -22427,7 +22445,12 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
+          const tipTarget = resolveCueTipTarget(
+            dir,
+            visualPull,
+            spinWorld,
+            obstructionLift
+          );
           applyCueStickTransform(tipTarget);
           cueStick.visible = true;
         } else {


### PR DESCRIPTION
### Motivation

- Fix inconsistent cue elevation where one half of the table showed the tip dipping instead of lifting near obstructions, reducing aiming precision. 
- Ensure the visual cue tip never goes below the cloth clearance line so spin placement and rail interactions are reliable. 
- Keep butt-tilt behaviour limited to backspin to avoid unintended cue lifting during topspin strokes. 
- Make the obstruction lift calculation available to all aim and stroke codepaths for consistent behaviour.

### Description

- Add a `lift` parameter to `resolveCueTipTarget` and clamp the tip Y to at least `CUE_Y + CUE_CLEARANCE_PADDING` before applying `lift`. 
- Reduce `CUE_OBSTRUCTION_LIFT` and `CUE_OBSTRUCTION_TILT` and narrow `SPIN_TIP_MARGIN` to tighten clearance and tip travel precision. 
- Return `obstructionLift` from `resolveCueObstructionTilt` and thread it into all calls to `resolveCueTipTarget` in the stroke, aiming, remote-aim, and AI aim paths. 
- Use `Math.max(0, spinY)` (i.e. backspin-only) when computing `tiltAmount` instead of `Math.abs(...)` to avoid topspin raising the butt.

### Testing

- No automated tests were executed for this change. 
- Changes were compiled and committed locally via the normal workflow but no CI job was run in this environment. 
- Manual inspection of modified call sites was performed to ensure `obstructionLift` is passed to `resolveCueTipTarget`. 
- No runtime/gameplay verification was performed here due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7e99c620832982d02ca18d59382a)