### PR TITLE
PoolRoyale: camera-aware cue obstruction, AI first-contact checks, and pocket strap texture fix

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6938,6 +6938,9 @@ function Table3D(
         pocketStrapThickness
       );
       const strap = new THREE.Mesh(strapGeom, pocketJawMat);
+      applyPocketLeatherTextureDefaults(strap.material?.map, { isColor: true });
+      applyPocketLeatherTextureDefaults(strap.material?.normalMap);
+      applyPocketLeatherTextureDefaults(strap.material?.roughnessMap);
       const strapBase = strapEnd.clone();
       const strapTopLimit = pocketTopY - TABLE.THICK * 0.08;
       const strapBaseY = Math.min(
@@ -19638,7 +19641,11 @@ const powerRef = useRef(hud.power);
             cuePerp.z * contactSide
           );
           clampCueTipOffset(spinWorld);
-          const obstructionStrength = resolveCueObstruction(dir, pull);
+          const obstructionStrength = resolveCueObstruction(
+            dir,
+            pull,
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera
+          );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
           const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
@@ -20182,6 +20189,20 @@ const powerRef = useRef(hud.power);
             if (plan.targetBall?.id != null) ignore.add(plan.targetBall.id);
             return !isPathClear(cuePos, aimTarget, ignore);
           };
+          const isFirstContactLegal = (plan) => {
+            if (!plan?.aimDir) return false;
+            if (plan.viaCushion) return true;
+            const contact = calcTarget(cueBall, plan.aimDir, activeBalls);
+            const hitBall = contact?.targetBall ?? null;
+            if (!hitBall) return false;
+            if (plan.targetBall) {
+              return String(hitBall.id) === String(plan.targetBall.id);
+            }
+            if (plan.target) {
+              return matchesTargetId(hitBall, plan.target);
+            }
+            return true;
+          };
           const measureLaneClearance = (plan) => {
             if (!plan?.aimDir || !plan?.cueToTarget || !cuePos) return 1;
             const aimTarget = cuePos.clone().add(
@@ -20215,6 +20236,7 @@ const powerRef = useRef(hud.power);
             const qualityOk = (plan.quality ?? 0) >= 0.12;
             if (!qualityOk) return false;
             if (!allowCushion && plan.viaCushion) return false;
+            if (!isFirstContactLegal(plan)) return false;
             if (isAimLaneBlocked(plan)) return false;
             const clearanceTarget = isRotationVariant ? 0.7 : 0.6;
             if (measureLaneClearance(plan) < clearanceTarget) return false;
@@ -20522,6 +20544,7 @@ const powerRef = useRef(hud.power);
           const scorePotPlan = (plan) => {
             if (!plan) return -Infinity;
             if (plan.targetBall && !plan.targetBall.active) return -Infinity;
+            if (!isFirstContactLegal(plan)) return -Infinity;
             if (detectScratchRisk(plan)) return -Infinity;
             if (isAimLaneBlocked(plan)) return -Infinity;
             const laneClearance = measureLaneClearance(plan);
@@ -20867,6 +20890,12 @@ const powerRef = useRef(hud.power);
         };
         const startAiThinking = () => {
           stopAiThinking();
+          if (!allStopped(balls)) {
+            aiPlanRef.current = null;
+            setAiPlanning(null);
+            aiThinkingHandle = requestAnimationFrame(startAiThinking);
+            return;
+          }
           if (!cue?.active) {
             setAiPlanning(null);
             return;
@@ -21176,6 +21205,13 @@ const powerRef = useRef(hud.power);
               }, 250);
               return;
             }
+          }
+          if (!allStopped(balls)) {
+            aiRetryTimeoutRef.current = window.setTimeout(() => {
+              aiRetryTimeoutRef.current = null;
+              aiShoot.current();
+            }, 200);
+            return;
           }
           if (currentHud?.over || currentHud?.inHand || shooting) return;
           try {
@@ -21905,16 +21941,27 @@ const powerRef = useRef(hud.power);
           isOnlineMatch &&
           currentHud?.turn === 1 &&
           remoteAimFresh;
-        function resolveCueObstruction(dirVec3, pullDistance = cuePullTargetRef.current ?? 0) {
+        function resolveCueObstruction(
+          dirVec3,
+          pullDistance = cuePullTargetRef.current ?? 0,
+          viewCamera = null
+        ) {
           if (!cue?.pos || !dirVec3) return 0;
+          if (viewCamera?.getWorldDirection) {
+            viewCamera.getWorldDirection(TMP_VEC3_CAM_DIR);
+            TMP_VEC3_CAM_DIR.y = 0;
+            if (TMP_VEC3_CAM_DIR.lengthSq() > 1e-8) {
+              TMP_VEC3_CAM_DIR.normalize();
+              if (TMP_VEC3_CAM_DIR.dot(dirVec3) < -0.15) {
+                return 0;
+              }
+            }
+          }
           const backward = new THREE.Vector2(-dirVec3.x, -dirVec3.z);
           if (backward.lengthSq() < 1e-8) return 0;
           backward.normalize();
           const origin = new THREE.Vector2(cue.pos.x, cue.pos.y);
-          const reach = Math.max(
-            CUE_OBSTRUCTION_RANGE,
-            cueLen + pullDistance + CUE_TIP_GAP
-          );
+          const reach = cueLen + pullDistance + CUE_TIP_GAP;
           const clearanceSq = CUE_OBSTRUCTION_CLEARANCE * CUE_OBSTRUCTION_CLEARANCE;
           let strength = 0;
           const applyRailObstruction = (railPos, axis) => {
@@ -22319,7 +22366,11 @@ const powerRef = useRef(hud.power);
           );
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
-          const obstructionStrength = resolveCueObstruction(baseDir, pull);
+          const obstructionStrength = resolveCueObstruction(
+            baseDir,
+            pull,
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera
+          );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
@@ -22414,7 +22465,11 @@ const powerRef = useRef(hud.power);
           );
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
-          const obstructionStrength = resolveCueObstruction(dir, pull);
+          const obstructionStrength = resolveCueObstruction(
+            dir,
+            pull,
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera
+          );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;


### PR DESCRIPTION
### Motivation
- Fix inconsistent cue-stick lowering when viewing the table from the opposite side so the visual behaviour matches facing the rack.  
- Ensure the AI re-evaluates shots after ball motion and avoids selecting plans that would foul by striking an opponent ball or potting the cue ball.  
- Make pocket strap leather pattern display consistent with pocket jaw leather patterns.  

### Description
- Add a camera-aware `resolveCueObstruction` parameter and early-exit check so the cue is not visually lowered when the camera looks from the opposite side, and use the active render camera when calling it.  
- Change obstruction reach calculation to use the cue length plus pull and tip gap instead of a max clamp to better match visual placement.  
- Add `isFirstContactLegal` and integrate it into `evaluateShotOptions`/`isPlayablePlan`/`scorePotPlan` so AI plans are rejected if the predicted first contact would hit an illegal/opponent ball.  
- Defer AI planning and firing until balls are stopped (with short retry timeouts), and add small retry scheduling so AI waits for motion to finish before choosing or executing a shot.  
- Re-apply `applyPocketLeatherTextureDefaults` to the pocket strap mesh so GLTF leather pattern scaling and texture defaults match the pocket jaw materials.  

### Testing
- No automated unit or integration tests were executed for these changes.  
- Changes were implemented in `webapp/src/pages/Games/PoolRoyale.jsx` and committed; CI should run existing test suites on merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc22f504c83299525d51d88ca3230)