### PR TITLE
Clamp cue butt above cushion top in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1401,6 +1401,7 @@ const CUE_FOLLOW_MAX_MS = 420;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 12;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 24;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.085; // rest the cue a touch lower so the tip lines up with the cue-ball centre on portrait screens
+const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.18; // keep the cue butt above the cushion top when aiming from the baulk end
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
 const CUE_BUTT_LIFT = BALL_R * 0.52; // keep the butt elevated for clearance while keeping the tip level with the cue-ball centre
@@ -18332,6 +18333,24 @@ const powerRef = useRef(hud.power);
         cueStick.position.copy(tipTarget).sub(TMP_VEC3_CUE_TIP_OFFSET);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
+      const resolveCueButtMinimumHeight = () => {
+        const cushionTop = table?.userData?.cushionTopWorld;
+        if (!Number.isFinite(cushionTop)) return null;
+        return cushionTop + CUE_BUTT_CUSHION_CLEARANCE;
+      };
+      const clampCueButtAboveCushion = (tipTarget, extraTilt) => {
+        const minButtY = resolveCueButtMinimumHeight();
+        if (!Number.isFinite(minButtY)) return;
+        if (TMP_VEC3_BUTT.y >= minButtY - 1e-4) return;
+        const desiredTilt = Math.asin(
+          THREE.MathUtils.clamp((tipTarget.y - minButtY) / cueLen, -1, 1)
+        );
+        const currentTilt = cueStick.rotation.x;
+        if (desiredTilt >= currentTilt - 1e-4) return;
+        const adjustedExtra = extraTilt + (desiredTilt - currentTilt);
+        applyCueButtTilt(cueStick, adjustedExtra);
+        applyCueStickTransform(tipTarget);
+      };
       const resolveCueObstructionTilt = (strength) => {
         const obstructionTilt = strength * CUE_OBSTRUCTION_TILT;
         const obstructionLift = strength * CUE_OBSTRUCTION_LIFT;
@@ -22239,16 +22258,15 @@ const powerRef = useRef(hud.power);
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
-          applyCueButtTilt(
-            cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
-          );
+          const totalExtraTilt = extraTilt + obstructionTilt + obstructionTiltFromLift;
+          applyCueButtTilt(cueStick, totalExtraTilt);
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
           applyCueStickTransform(tipTarget);
+          clampCueButtAboveCushion(tipTarget, totalExtraTilt);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -22448,16 +22466,15 @@ const powerRef = useRef(hud.power);
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
-          applyCueButtTilt(
-            cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
-          );
+          const totalExtraTilt = extraTilt + obstructionTilt + obstructionTiltFromLift;
+          applyCueButtTilt(cueStick, totalExtraTilt);
           cueStick.rotation.y = Math.atan2(baseDir.x, baseDir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           const tipTarget = resolveCueTipTarget(baseDir, visualPull, spinWorld);
           applyCueStickTransform(tipTarget);
+          clampCueButtAboveCushion(tipTarget, totalExtraTilt);
           cueStick.visible = true;
           updateChalkVisibility(null);
           if (targetDir && targetBall) {
@@ -22547,16 +22564,15 @@ const powerRef = useRef(hud.power);
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
-          applyCueButtTilt(
-            cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
-          );
+          const totalExtraTilt = extraTilt + obstructionTilt + obstructionTiltFromLift;
+          applyCueButtTilt(cueStick, totalExtraTilt);
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
           applyCueStickTransform(tipTarget);
+          clampCueButtAboveCushion(tipTarget, totalExtraTilt);
           cueStick.visible = true;
         } else {
           aimFocusRef.current = null;


### PR DESCRIPTION
### Motivation
- Prevent the cue butt from dipping below the top of the cushions when the camera/aim is looking from the rack/baulk end. 
- Keep existing cue-tip behavior unchanged while ensuring the back of the cue never intersects or visually sinks into the cushion/rail geometry. 
- Fix inconsistent cue pose across local, remote and AI aim previews where the butt could be lowered too far. 
- Improve aiming UX on portrait/rail-facing views by enforcing a minimum butt clearance above the cushion.

### Description
- Added a new clearance constant `CUE_BUTT_CUSHION_CLEARANCE` and helper `resolveCueButtMinimumHeight()` to compute the world-space minimum butt Y based on `table.userData.cushionTopWorld` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Implemented `clampCueButtAboveCushion(tipTarget, extraTilt)` which adjusts the cue butt tilt and reapplies the transform so the butt stays above the cushion while preserving the tip target.
- Centralized the computed tilt into `totalExtraTilt` and applied the clamp immediately after `applyCueStickTransform(...)` in the player, remote, and AI aiming flows so all aim modes respect the butt clearance.
- Changed only the aiming transform/tilt logic; the cue-tip placement and forward stroke animation remain unchanged.

### Testing
- No automated tests were executed for this change.
- The change was implemented in `webapp/src/pages/Games/PoolRoyale.jsx` and committed locally.
- Manual runtime verification was not performed as part of this patch (3D runtime not executed).
- Recommend running the app and visually testing player, remote, and AI aim views (especially from the baulk/rack end) to confirm the butt no longer intersects the cushions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe60323b48329ab9fb69296c6f08d)