### PR TITLE
Fix cue aim direction when aiming from rack side

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21984,8 +21984,25 @@ const powerRef = useRef(hud.power);
           if (fallbackAim.lengthSq() < 1e-6) fallbackAim.set(0, 1);
           tmpAim.copy(fallbackAim.normalize());
         } else {
-          camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z).normalize();
+          const cueBall = cueRef.current || cue;
+          if (cueBall?.pos && camera?.position) {
+            tmpAim.set(
+              cueBall.pos.x - camera.position.x,
+              cueBall.pos.y - camera.position.z
+            );
+            if (tmpAim.lengthSq() < 1e-8) {
+              camera.getWorldDirection(camFwd);
+              tmpAim.set(camFwd.x, camFwd.z);
+            }
+          } else {
+            camera.getWorldDirection(camFwd);
+            tmpAim.set(camFwd.x, camFwd.z);
+          }
+          if (tmpAim.lengthSq() < 1e-8) {
+            tmpAim.set(0, 1);
+          } else {
+            tmpAim.normalize();
+          }
         }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,


### PR DESCRIPTION
### Motivation
- Players reported the cue stick rotates incorrectly when aiming from the side near the rack, producing the opposite aim direction to what’s expected. 
- The aim fallback used the camera forward vector which can invert the intended cue direction when the camera is positioned near the rack. 
- The goal is to keep cue behavior consistent whether aiming from the front of the rack or from the side. 

### Description
- Compute the default aiming vector using the cue-to-camera vector instead of always using the camera forward vector in the main update loop by changing `tmpAim` computation in `PoolRoyale.jsx`.
- If the computed cue-to-camera vector is degenerate, fall back to `camera.getWorldDirection(...)` as before and still normalize/guard against zero length. 
- Added length checks and normalization to ensure a stable, non-zero `tmpAim` in all camera/cue configurations. 

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff92c7f40832985279abcecb1a0af)