### PR TITLE
Fix cue aim inversion when camera faces opposite rail

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21985,7 +21985,27 @@ const powerRef = useRef(hud.power);
           tmpAim.copy(fallbackAim.normalize());
         } else {
           camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z).normalize();
+          tmpAim.set(camFwd.x, camFwd.z);
+          if (tmpAim.lengthSq() > 1e-6) {
+            tmpAim.normalize();
+          } else {
+            tmpAim.set(0, 1);
+          }
+          if (cue?.pos) {
+            const scale = Number.isFinite(worldScaleFactor)
+              ? worldScaleFactor
+              : WORLD_SCALE;
+            const cueToCamera = new THREE.Vector2(
+              camera.position.x / scale - cue.pos.x,
+              camera.position.z / scale - cue.pos.y
+            );
+            if (cueToCamera.lengthSq() > 1e-6) {
+              cueToCamera.normalize();
+              if (tmpAim.dot(cueToCamera) > 0) {
+                tmpAim.multiplyScalar(-1);
+              }
+            }
+          }
         }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,


### PR DESCRIPTION
### Motivation
- Players observed the cue stick aiming inverted when standing on the side of the table by the rack (camera looking from the opposite rail). 
- The aim vector was derived directly from the camera forward vector and could point toward the cue ball, producing the reversed visual/aim behavior.

### Description
- Update aim computation in `webapp/src/pages/Games/PoolRoyale.jsx` to build `tmpAim` from `camera.getWorldDirection` with a safe non-zero normalization fallback to `new THREE.Vector2(0, 1)`.
- Compute a scaled `cueToCamera` vector from the cue ball to the camera and normalize it, then flip `tmpAim` when the camera-forward projection points toward the cue (dot product > 0) to preserve correct aiming direction.
- Add guards to avoid normalizing zero-length vectors and keep the previous aim lerp behavior intact.
- Changes are confined to `PoolRoyale.jsx` where aiming and camera logic is resolved.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff92c7f40832985279abcecb1a0af)