### PR TITLE
Fix cue aim inversion when aiming from rack side

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21984,8 +21984,17 @@ const powerRef = useRef(hud.power);
           if (fallbackAim.lengthSq() < 1e-6) fallbackAim.set(0, 1);
           tmpAim.copy(fallbackAim.normalize());
         } else {
-          camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z).normalize();
+          const cueBall = cueRef.current || cue;
+          const activeCamera = activeRenderCameraRef.current ?? camera;
+          const viewVec = cueBall?.active
+            ? computeCueViewVector(cueBall, activeCamera)
+            : null;
+          if (viewVec) {
+            tmpAim.set(-viewVec.x, -viewVec.y).normalize();
+          } else {
+            activeCamera.getWorldDirection(camFwd);
+            tmpAim.set(camFwd.x, camFwd.z).normalize();
+          }
         }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,


### PR DESCRIPTION
### Motivation

- Players reported the cue stick pointing the wrong way when aiming from the table side near the rack toward the baulk/white line, causing inverted visual aim feedback.
- The aim direction should remain consistent whether the camera is behind or in front of the cue ball so the cue butt always points away from the camera as expected.

### Description

- Updated the aim vector calculation in `webapp/src/pages/Games/PoolRoyale.jsx` to prefer the cue-to-camera view vector by calling `computeCueViewVector(cueBall, activeCamera)` when the cue ball is active. 
- When a valid view vector is available the code now sets `tmpAim` to `-viewVec` (so the aim faces away from the camera), and falls back to `activeCamera.getWorldDirection(camFwd)` when the view vector is not available. 
- The change only affects the branch used when not in the locked top view so existing `topView` behavior is preserved. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff92c7f40832985279abcecb1a0af)