### PR TITLE
Align cue aim to cue-ball→camera view to fix inverted cue on opposite rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21984,8 +21984,15 @@ const powerRef = useRef(hud.power);
           if (fallbackAim.lengthSq() < 1e-6) fallbackAim.set(0, 1);
           tmpAim.copy(fallbackAim.normalize());
         } else {
-          camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z).normalize();
+          const cueBall = cueRef.current || cue;
+          const activeCamera = activeRenderCameraRef.current ?? camera;
+          const viewVec = cueBall ? computeCueViewVector(cueBall, activeCamera) : null;
+          if (viewVec && viewVec.lengthSq() > 1e-8) {
+            tmpAim.set(-viewVec.x, -viewVec.y).normalize();
+          } else {
+            camera.getWorldDirection(camFwd);
+            tmpAim.set(camFwd.x, camFwd.z).normalize();
+          }
         }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -16005,8 +16005,15 @@ export function PoolRoyaleGame({
         );
         const subStepScale = frameScale / physicsSubsteps;
         lastStepTime = now;
-        camera.getWorldDirection(camFwd);
-        tmpAim.set(camFwd.x, camFwd.z).normalize();
+        const cueBall = cueRef.current || cue;
+        const activeCamera = activeRenderCameraRef.current ?? camera;
+        const viewVec = cueBall ? computeCueViewVector(cueBall, activeCamera) : null;
+        if (viewVec && viewVec.lengthSq() > 1e-8) {
+          tmpAim.set(-viewVec.x, -viewVec.y).normalize();
+        } else {
+          camera.getWorldDirection(camFwd);
+          tmpAim.set(camFwd.x, camFwd.z).normalize();
+        }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,
           0,


### PR DESCRIPTION
### Motivation

- Players reported the cue stick in Pool Royale behaved inverted when aiming from the opposite rail/side of the table.  
- The intent is to keep the visible cue direction consistent whether the player faces the rack or stands on the rack side.  
- Derive the aiming baseline from the cue-ball ↔ camera relationship to avoid flips caused by camera orientation.  
- Apply the same correction across similar game modes so behaviour is consistent.

### Description

- Use the existing `computeCueViewVector` to compute a cue-ball-to-camera vector and set the temporary aim (`tmpAim`) to `-viewVec` when available, falling back to `camera.getWorldDirection` otherwise.  
- Updated aim computation in `webapp/src/pages/Games/PoolRoyale.jsx` to prefer the cue-ball→camera vector for `tmpAim`.  
- Applied the identical change to `webapp/src/pages/Games/SnookerClubGame.jsx` so both games share the corrected aim behaviour.  
- Change is conservative: it only replaces the code path that computes the base aim vector and preserves existing fallbacks and aim smoothing logic.

### Testing

- No automated tests were executed for this change.  
- No CI or unit test runs were performed as part of this patch.  
- Behavioural validation is expected to be verified in-game (manual QA) to confirm the cue no longer inverts on opposite rails.  
- Existing aim smoothing and fallback paths remain intact to reduce regression risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff92c7f40832985279abcecb1a0af)