### PR TITLE
Fix cue stick tilt direction in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18294,6 +18294,7 @@ const powerRef = useRef(hud.power);
       const cueBody = new THREE.Group();
       cueStick.add(cueBody);
       cueStick.userData.body = cueBody;
+      cueStick.rotation.order = 'YXZ';
       cueBodyRef.current = cueBody;
       const buttLift = Math.min(CUE_BUTT_LIFT, cueLen);
       const buttTilt = Math.asin(


### PR DESCRIPTION
### Motivation
- Players reported the cue stick tilting the wrong way when aiming from the far side of the rack, causing the tip to lower instead of lifting. 
- The cue butt pitch needed to be applied in cue-local rotation order so pitch (X) does not get mixed with global yaw/pan.

### Description
- Set the rotation order on the cue stick to apply pitch in local space by assigning `cueStick.rotation.order = 'YXZ'` when the `cueStick` group is created in `webapp/src/pages/Games/PoolRoyale.jsx`.
- This change ensures the X-rotation (tilt) behaves consistently regardless of camera/aim direction.

### Testing
- No automated tests were run as part of this change.
- Manual visual verification was intended for cue orientation behavior (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608a402538832995786d82faef7ce8)