### PR TITLE
Snooker: add pocket liner customization and tighten rules/respot logic

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -84,6 +84,8 @@ type PoolMeta =
     };
 
 const UK_TOTAL_PER_COLOUR = 7;
+const SNOOKER_RED_COUNT = 15;
+const SNOOKER_COLORS: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
 
 function normalizeVariantId(value: string | null | undefined): string {
   if (typeof value !== 'string') return '';
@@ -220,6 +222,32 @@ function lowestBall(balls: Iterable<number>): number | null {
   return lowest;
 }
 
+function buildSnookerBalls(
+  redsRemaining: number,
+  colorsOnTable: Set<BallColor>
+): FrameState['balls'] {
+  const balls: FrameState['balls'] = [];
+  for (let i = 0; i < SNOOKER_RED_COUNT; i += 1) {
+    const onTable = i < redsRemaining;
+    balls.push({
+      id: `RED_${i + 1}`,
+      color: 'RED',
+      onTable,
+      potted: !onTable
+    });
+  }
+  SNOOKER_COLORS.forEach((color) => {
+    const onTable = colorsOnTable.has(color);
+    balls.push({
+      id: color.toLowerCase(),
+      color,
+      onTable,
+      potted: !onTable
+    });
+  });
+  return balls;
+}
+
 export class PoolRoyaleRules {
   private readonly variant: PoolVariantId;
 
@@ -243,14 +271,14 @@ export class PoolRoyaleRules {
   getInitialFrame(playerA: string, playerB: string): FrameState {
     switch (this.variant) {
       case 'snooker': {
-        const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+        const colorsOnTable: BallColor[] = [...SNOOKER_COLORS];
         const base: FrameState = {
-          balls: [],
+          balls: buildSnookerBalls(SNOOKER_RED_COUNT, new Set(colorsOnTable)),
           activePlayer: 'A',
           players: basePlayers(playerA, playerB),
           currentBreak: 0,
           phase: 'REDS_AND_COLORS',
-          redsRemaining: 15,
+          redsRemaining: SNOOKER_RED_COUNT,
           colorOnAfterRed: false,
           ballOn: ['RED'],
           frameOver: false
@@ -424,12 +452,12 @@ export class PoolRoyaleRules {
   }
 
   private applySnookerShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const defaultColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+    const defaultColors: BallColor[] = [...SNOOKER_COLORS];
     const meta = (state.meta ?? {}) as PoolMeta;
     const previous: SnookerSerializedState | null =
       meta.variant === 'snooker' && meta.state ? (meta.state as SnookerSerializedState) : null;
 
-    let redsRemaining = Number.isFinite(state.redsRemaining) ? state.redsRemaining : 15;
+    let redsRemaining = Number.isFinite(state.redsRemaining) ? state.redsRemaining : SNOOKER_RED_COUNT;
     let colorOnAfterRed = Boolean(state.colorOnAfterRed);
     let phase: FrameState['phase'] = state.phase === 'COLORS_ORDER' ? 'COLORS_ORDER' : 'REDS_AND_COLORS';
     const colorsOnTable = new Set<BallColor>(previous?.colorsOnTable ?? defaultColors);
@@ -464,7 +492,20 @@ export class PoolRoyaleRules {
       }
     }
 
-    const ballOnValue = Math.max(...Array.from(ballOnSet).map((b) => this.ballValue(b)), 0);
+    const resolveBallOnValue = () => {
+      if (ballOnSet.size === 1) {
+        return this.ballValue(Array.from(ballOnSet)[0]);
+      }
+      if (firstContact && ballOnSet.has(firstContact)) {
+        return this.ballValue(firstContact);
+      }
+      const pottedOn = potted.filter((colour) => ballOnSet.has(colour));
+      if (pottedOn.length > 0) {
+        return Math.max(...pottedOn.map((colour) => this.ballValue(colour)), 0);
+      }
+      return Math.max(...Array.from(ballOnSet).map((b) => this.ballValue(b)), 0);
+    };
+    const ballOnValue = resolveBallOnValue();
     let foulReason: string | null = null;
     let foulValue = ballOnValue;
 
@@ -475,6 +516,17 @@ export class PoolRoyaleRules {
     } else if (!ballOnSet.has(firstContact)) {
       foulReason = `Incorrect first contact (${firstContact.toLowerCase()})`;
       foulValue = Math.max(foulValue, this.ballValue(firstContact));
+    }
+
+    if (!foulReason && colorOnAfterRed) {
+      const colorsPotted = potted.filter((colour) => colour !== 'RED');
+      if (colorsPotted.length > 1) {
+        foulReason = 'Multiple colors potted';
+        foulValue = Math.max(
+          foulValue,
+          ...colorsPotted.map((colour) => this.ballValue(colour))
+        );
+      }
     }
 
     const illegalPot = potted.find((c) => !ballOnSet.has(c));
@@ -517,8 +569,10 @@ export class PoolRoyaleRules {
             ? 'A'
             : 'B'
         : undefined;
+      const nextBalls = buildSnookerBalls(redsRemaining, colorsOnTable);
       return {
         ...state,
+        balls: nextBalls,
         activePlayer,
         players,
         currentBreak,
@@ -591,8 +645,10 @@ export class PoolRoyaleRules {
           : 'B'
       : undefined;
 
+    const nextBalls = buildSnookerBalls(redsRemaining, colorsOnTable);
     return {
       ...state,
+      balls: nextBalls,
       activePlayer,
       players,
       currentBreak,

--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -1,7 +1,8 @@
 import { CUE_STYLE_PRESETS } from './cueStyles.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_OPTION_LABELS
 } from './poolRoyaleInventoryConfig.js';
 
 export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
@@ -41,6 +42,10 @@ export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
     freshGreen: 'Tour Green',
     graphite: 'Arcadia Graphite',
     arcticBlue: 'Arctic Blue'
+  }),
+  pocketLiner: Object.freeze({
+    blackPocket: 'Black Pocket Jaws',
+    ...POOL_ROYALE_OPTION_LABELS.pocketLiner
   }),
   cueStyle: Object.freeze(
     CUE_STYLE_PRESETS.reduce((acc, preset) => {
@@ -123,6 +128,54 @@ export const SNOOKER_CLUB_STORE_ITEMS = [
     price: 590,
     description: 'Cool arctic blue cloth with crisp broadcast sheen.'
   },
+  {
+    id: 'snooker-pocket-fabric-leather-02',
+    type: 'pocketLiner',
+    optionId: 'fabric_leather_02',
+    name: 'Fabric Leather 02 Pocket Jaws',
+    price: 520,
+    description: 'Warm stitched leather weave liners for the classic Pool Royale look.'
+  },
+  {
+    id: 'snooker-pocket-fabric-leather-01',
+    type: 'pocketLiner',
+    optionId: 'fabric_leather_01',
+    name: 'Fabric Leather 01 Pocket Jaws',
+    price: 530,
+    description: 'Soft-grain leather weave liners with a mellow brown finish.'
+  },
+  {
+    id: 'snooker-pocket-brown-leather',
+    type: 'pocketLiner',
+    optionId: 'brown_leather',
+    name: 'Brown Leather Pocket Jaws',
+    price: 540,
+    description: 'Deep brown leather pockets with natural creases and aged texture.'
+  },
+  {
+    id: 'snooker-pocket-leather-red-02',
+    type: 'pocketLiner',
+    optionId: 'leather_red_02',
+    name: 'Leather Red 02 Pocket Jaws',
+    price: 560,
+    description: 'Bold red leather liners with pronounced seams and worn highlights.'
+  },
+  {
+    id: 'snooker-pocket-leather-red-03',
+    type: 'pocketLiner',
+    optionId: 'leather_red_03',
+    name: 'Leather Red 03 Pocket Jaws',
+    price: 570,
+    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
+  },
+  {
+    id: 'snooker-pocket-leather-white',
+    type: 'pocketLiner',
+    optionId: 'leather_white',
+    name: 'Leather White Pocket Jaws',
+    price: 590,
+    description: 'Bright white leather pockets with crisp seam definition and clean grain.'
+  },
   ...CUE_STYLE_PRESETS.slice(1).map((preset, idx) => ({
     id: `snooker-cue-${preset.id}`,
     type: 'cueStyle',
@@ -146,6 +199,7 @@ export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
   { type: 'chromeColor', optionId: 'chrome', label: 'Chrome Fascias' },
   { type: 'railMarkerColor', optionId: 'chrome', label: 'Chrome Rail Markers' },
   { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
+  { type: 'pocketLiner', optionId: 'blackPocket', label: 'Black Pocket Jaws' },
   { type: 'cueStyle', optionId: CUE_STYLE_PRESETS[0]?.id, label: CUE_STYLE_PRESETS[0]?.label },
   {
     type: 'environmentHdri',

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -2495,6 +2495,132 @@ const POCKET_LINER_PRESETS = Object.freeze([
       repeatY: 2.1,
       seed: 4101
     }
+  }),
+  Object.freeze({
+    id: 'fabric_leather_02',
+    label: 'Fabric Leather 02 Pocket Jaws',
+    type: 'leather',
+    jawColor: 0xc08b5a,
+    rimColor: 0x704c2d,
+    sheenColor: 0xd6b18a,
+    texture: {
+      base: 0xc79a6d,
+      highlight: 0xe1c3a0,
+      shadow: 0x7a4b2c,
+      density: 1.1,
+      grainSize: 0.9,
+      streakAlpha: 0.22,
+      creaseAlpha: 0.3,
+      seamContrast: 0.32,
+      repeatX: 2.6,
+      repeatY: 2.3,
+      seed: 4521
+    }
+  }),
+  Object.freeze({
+    id: 'fabric_leather_01',
+    label: 'Fabric Leather 01 Pocket Jaws',
+    type: 'leather',
+    jawColor: 0xb07a4b,
+    rimColor: 0x6a3f23,
+    sheenColor: 0xcda47f,
+    texture: {
+      base: 0xb88459,
+      highlight: 0xd4b08a,
+      shadow: 0x6b3f23,
+      density: 1,
+      grainSize: 0.95,
+      streakAlpha: 0.21,
+      creaseAlpha: 0.28,
+      seamContrast: 0.3,
+      repeatX: 2.5,
+      repeatY: 2.2,
+      seed: 4629
+    }
+  }),
+  Object.freeze({
+    id: 'brown_leather',
+    label: 'Brown Leather Pocket Jaws',
+    type: 'leather',
+    jawColor: 0x7a4a2a,
+    rimColor: 0x4e2c18,
+    sheenColor: 0x9a6a45,
+    texture: {
+      base: 0x6d4023,
+      highlight: 0x8b5a36,
+      shadow: 0x3f2414,
+      density: 1.05,
+      grainSize: 1.02,
+      streakAlpha: 0.2,
+      creaseAlpha: 0.34,
+      seamContrast: 0.34,
+      repeatX: 2.7,
+      repeatY: 2.3,
+      seed: 4809
+    }
+  }),
+  Object.freeze({
+    id: 'leather_red_02',
+    label: 'Leather Red 02 Pocket Jaws',
+    type: 'leather',
+    jawColor: 0x9a3c3c,
+    rimColor: 0x642020,
+    sheenColor: 0xc05c5c,
+    texture: {
+      base: 0x8f2f2f,
+      highlight: 0xb75858,
+      shadow: 0x4a1b1b,
+      density: 1.08,
+      grainSize: 0.98,
+      streakAlpha: 0.2,
+      creaseAlpha: 0.33,
+      seamContrast: 0.34,
+      repeatX: 2.6,
+      repeatY: 2.25,
+      seed: 4907
+    }
+  }),
+  Object.freeze({
+    id: 'leather_red_03',
+    label: 'Leather Red 03 Pocket Jaws',
+    type: 'leather',
+    jawColor: 0x7d2029,
+    rimColor: 0x4a1116,
+    sheenColor: 0xa63b43,
+    texture: {
+      base: 0x751821,
+      highlight: 0xa63f47,
+      shadow: 0x3a0c11,
+      density: 1.12,
+      grainSize: 0.96,
+      streakAlpha: 0.21,
+      creaseAlpha: 0.36,
+      seamContrast: 0.36,
+      repeatX: 2.7,
+      repeatY: 2.3,
+      seed: 5003
+    }
+  }),
+  Object.freeze({
+    id: 'leather_white',
+    label: 'Leather White Pocket Jaws',
+    type: 'leather',
+    jawColor: 0xe5e0d6,
+    rimColor: 0x9f988f,
+    sheenColor: 0xffffff,
+    texture: {
+      base: 0xede7dc,
+      highlight: 0xffffff,
+      shadow: 0xb9b2a8,
+      density: 0.85,
+      grainSize: 1.05,
+      streakAlpha: 0.18,
+      creaseAlpha: 0.26,
+      seamContrast: 0.25,
+      repeatX: 2.4,
+      repeatY: 2.1,
+      seed: 5121
+    }
   })
 ]);
 
@@ -2571,10 +2697,12 @@ const POCKET_LINER_OPTIONS = Object.freeze(
         }
       });
     }
-    if (config.type === 'metal') {
+    if (config.type === 'metal' || config.type === 'leather') {
       const jawHex = config.jawColor ?? 0x6d7177;
       const rimHex = config.rimColor ?? jawHex;
-      const sheenHex = config.sheenColor ?? mixHexColors(jawHex, 0xffffff, 0.35);
+      const sheenHex =
+        config.sheenColor ??
+        mixHexColors(jawHex, 0xffffff, config.type === 'leather' ? 0.2 : 0.35);
       const rimSheenHex =
         config.rimSheenColor ?? mixHexColors(rimHex, 0xffffff, 0.28);
       const highlightHex =
@@ -2582,6 +2710,7 @@ const POCKET_LINER_OPTIONS = Object.freeze(
       const shadowHex =
         config.shadowColor ?? mixHexColors(jawHex, 0x111111, 0.4);
       const textureConfig = config.texture ?? {};
+      const resolvedMetalness = config.metalness ?? (config.type === 'leather' ? 0.06 : 0.72);
       return Object.freeze({
         id: config.id,
         label: config.label,
@@ -2590,17 +2719,18 @@ const POCKET_LINER_OPTIONS = Object.freeze(
         rimColor: rimHex,
         sheenColor: sheenHex,
         rimSheenColor: rimSheenHex,
-        sheen: config.sheen ?? 0.72,
-        sheenRoughness: config.sheenRoughness ?? 0.36,
-        roughness: config.roughness ?? 0.32,
-        rimRoughness: config.rimRoughness ?? 0.36,
-        metalness: config.metalness ?? 0.72,
-        rimMetalness: config.rimMetalness ?? config.metalness ?? 0.72,
-        clearcoat: config.clearcoat ?? 0.32,
-        clearcoatRoughness: config.clearcoatRoughness ?? 0.18,
-        envMapIntensity: config.envMapIntensity ?? 0.9,
-        bumpScale: config.bumpScale ?? 0.2,
-        rimBumpScale: config.rimBumpScale ?? 0.16,
+        sheen: config.sheen ?? (config.type === 'leather' ? 0.38 : 0.72),
+        sheenRoughness: config.sheenRoughness ?? (config.type === 'leather' ? 0.56 : 0.36),
+        roughness: config.roughness ?? (config.type === 'leather' ? 0.78 : 0.32),
+        rimRoughness: config.rimRoughness ?? (config.type === 'leather' ? 0.86 : 0.36),
+        metalness: resolvedMetalness,
+        rimMetalness: config.rimMetalness ?? resolvedMetalness,
+        clearcoat: config.clearcoat ?? (config.type === 'leather' ? 0.18 : 0.32),
+        clearcoatRoughness:
+          config.clearcoatRoughness ?? (config.type === 'leather' ? 0.55 : 0.18),
+        envMapIntensity: config.envMapIntensity ?? (config.type === 'leather' ? 0.3 : 0.9),
+        bumpScale: config.bumpScale ?? (config.type === 'leather' ? 0.34 : 0.2),
+        rimBumpScale: config.rimBumpScale ?? (config.type === 'leather' ? 0.28 : 0.16),
         texture: {
           base: resolvePocketLinerTextureColor(
             textureConfig.base,
@@ -2614,11 +2744,24 @@ const POCKET_LINER_OPTIONS = Object.freeze(
             textureConfig.shadow,
             config.shadowColor ?? shadowHex
           ),
-          density: textureConfig.density ?? config.textureDensity ?? 0.5,
-          grainSize: textureConfig.grainSize ?? config.grainSize ?? 0.7,
-          streakAlpha: textureConfig.streakAlpha ?? config.streakAlpha ?? 0.14,
-          creaseAlpha: textureConfig.creaseAlpha ?? config.creaseAlpha ?? 0.12,
-          seamContrast: textureConfig.seamContrast ?? config.seamContrast ?? 0.2,
+          density:
+            textureConfig.density ??
+            config.textureDensity ??
+            (config.type === 'leather' ? 1 : 0.5),
+          grainSize:
+            textureConfig.grainSize ?? config.grainSize ?? (config.type === 'leather' ? 1 : 0.7),
+          streakAlpha:
+            textureConfig.streakAlpha ??
+            config.streakAlpha ??
+            (config.type === 'leather' ? 0.2 : 0.14),
+          creaseAlpha:
+            textureConfig.creaseAlpha ??
+            config.creaseAlpha ??
+            (config.type === 'leather' ? 0.28 : 0.12),
+          seamContrast:
+            textureConfig.seamContrast ??
+            config.seamContrast ??
+            (config.type === 'leather' ? 0.28 : 0.2),
           repeatX: textureConfig.repeatX ?? config.repeatX ?? 2.1,
           repeatY: textureConfig.repeatY ?? config.repeatY ?? 2.1,
           seed: textureConfig.seed ?? config.seed ?? 4103 + index * 211


### PR DESCRIPTION
### Motivation
- Bring Snooker Club customization parity with Pool Royale by exposing the same pocket liner options and default loadout entries so players can style pockets the same way as Pool Royale.  
- Improve snooker rules fidelity to better reflect official behaviour for scoring, fouls and respotting so gameplay follows authentic tournament logic.  
- Surface ball state in game frames so the UI and replay/respot logic can reliably restore ball positions and visibility after shots.  

### Description
- Added pocket liner labels, store items and a default loadout entry in `webapp/src/config/snookerClubInventoryConfig.js` so pocket liners mirror `POOL_ROYALE` options and appear in the Snooker Club store (`pocketLiner` keys and items).  
- Extended `POCKET_LINER_PRESETS` in `webapp/src/pages/Games/SnookerClubGame.jsx` with leather/fabric variants and adjusted material generation to support `leather` types and tuned material/texture parameters for those variants.  
- Enhanced rule engine in `src/rules/SnookerClubRules.ts` by adding `SNOOKER_RED_COUNT`, `SNOOKER_COLORS`, a `buildSnookerBalls()` helper, and updates to `applySnookerShot()` to compute `ballOn` value more robustly, detect multi-color fouls, adjust foul valuation, update `redsRemaining`, and return an updated `FrameState.balls` snapshot for accurate respotting.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d293b34c8329801491c7be5501af)