### PR TITLE
Add boot loading overlay to Snooker Club to avoid black screen

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -9608,6 +9608,8 @@ export function PoolRoyaleGame({
     applyLightingPreset(lightingId);
   }, [applyLightingPreset, lightingId]);
   const [err, setErr] = useState(null);
+  const [isBooting, setIsBooting] = useState(true);
+  const hasRenderedRef = useRef(false);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
   const sphRef = useRef(null);
@@ -10261,8 +10263,11 @@ export function PoolRoyaleGame({
     const host = mountRef.current;
     if (!host) return;
     setErr(null);
+    setIsBooting(true);
+    hasRenderedRef.current = false;
     if (!isWebGLAvailable()) {
       setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
+      setIsBooting(false);
       return;
     }
     const cueRackDisposers = [];
@@ -16134,6 +16139,10 @@ export function PoolRoyaleGame({
       // Loop
       let lastStepTime = performance.now();
       const step = (now) => {
+        if (!hasRenderedRef.current) {
+          hasRenderedRef.current = true;
+          setIsBooting(false);
+        }
         const playback = replayPlaybackRef.current;
         if (playback) {
           const elapsed = now - playback.startedAt;
@@ -17363,6 +17372,7 @@ export function PoolRoyaleGame({
       } catch (e) {
         console.error(e);
         setErr(e?.message || String(e));
+        setIsBooting(false);
       }
   }, []);
 
@@ -17565,6 +17575,12 @@ export function PoolRoyaleGame({
     >
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
+
+      {isBooting && !err && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/70 text-sm text-white">
+          Loading Snooker Club…
+        </div>
+      )}
 
       {replayBanner && (
         <div className="pointer-events-none absolute top-14 left-1/2 z-50 -translate-x-1/2">


### PR DESCRIPTION
### Motivation
- Users reported a black/blank page when opening the Snooker Club game, indicating the renderer startup was silent without visible feedback.
- Provide clear feedback during the renderer/HDRI/audio boot to avoid confusion and improve onboarding for mobile portrait users.

### Description
- Track boot state with `isBooting` and a `hasRenderedRef` flag to detect when the first frame is rendered and when initialization fails.
- Set `isBooting` to true at the start of initialization and clear it either when the render loop runs the first frame or when initialization errors occur.
- Render a full-screen overlay message `Loading Snooker Club…` while `isBooting` is true and no `err` is present. 
- Changes made in `webapp/src/pages/Games/SnookerClubGame.jsx` to integrate boot-state handling and overlay display.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and received `VITE ready` indicating the app served successfully. (succeeded)
- Attempted to capture a page screenshot with Playwright for `/games/snookerclub?variant=snooker` but the Playwright script timed out. (failed)
- No unit or integration test commands (`npm test`, `jest`, etc.) were executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e06a36848329941bd9648c687a53)