### PR TITLE
Guard screen orientation lock in Snooker Club to avoid init crash

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -10274,7 +10274,12 @@ export function PoolRoyaleGame({
         setPocketCameraActive(active);
       };
       updatePocketCameraState(false);
-      screen.orientation?.lock?.('portrait').catch(() => {});
+      const orientationLock = typeof screen !== 'undefined'
+        ? screen.orientation?.lock?.('portrait')
+        : null;
+      if (orientationLock && typeof orientationLock.catch === 'function') {
+        orientationLock.catch(() => {});
+      }
       // Renderer
       const renderer = new THREE.WebGLRenderer({
         antialias: true,


### PR DESCRIPTION
### Motivation
- Prevent the Snooker Club game from failing to initialize when `screen.orientation.lock` is unavailable and producing a black page.
- Avoid unhandled promise rejections during initialization that can block renderer creation.
- Improve robustness for browsers and WebView environments where the orientation API is absent.
- Maintain existing behaviour of attempting to lock orientation when supported.

### Description
- Replace the direct call to `screen.orientation?.lock('portrait').catch(...)` with a guarded call that checks `screen` and the returned `orientationLock` before invoking `.catch`.
- The change is in `webapp/src/pages/Games/SnookerClubGame.jsx` inside the main initialization `useEffect` block.
- This preserves the attempt to lock orientation when available while preventing exceptions when the API is missing.
- No other gameplay or rendering logic was modified.

### Testing
- No automated tests were executed for this change.
- The project test suite and CI were not triggered during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e06a36848329941bd9648c687a53)