### PR TITLE
Fix snooker renderer sizing fallback

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -9650,14 +9650,20 @@ export function PoolRoyaleGame({
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
         ? THREE.MathUtils.clamp(quality.renderScale, 0.75, 1)
         : 1;
+    const fallbackWidth =
+      typeof window !== 'undefined' && typeof window.innerWidth === 'number'
+        ? window.innerWidth
+        : host.clientWidth;
+    const fallbackHeight =
+      typeof window !== 'undefined' && typeof window.innerHeight === 'number'
+        ? window.innerHeight
+        : host.clientHeight;
+    const hostWidth = host.clientWidth || fallbackWidth || 1;
+    const hostHeight = host.clientHeight || fallbackHeight || 1;
     renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
-    renderer.setSize(
-      host.clientWidth * renderScale,
-      host.clientHeight * renderScale,
-      false
-    );
-    renderer.domElement.style.width = '100%';
-    renderer.domElement.style.height = '100%';
+    renderer.setSize(hostWidth * renderScale, hostHeight * renderScale, false);
+    renderer.domElement.style.width = host.clientWidth ? '100%' : `${hostWidth}px`;
+    renderer.domElement.style.height = host.clientHeight ? '100%' : `${hostHeight}px`;
   }, []);
   useEffect(() => {
     applyRendererQuality();


### PR DESCRIPTION
### Motivation
- The Snooker Club scene could render a blank/black page when the canvas host reported zero dimensions, causing the WebGL renderer to be sized to 0×0. 
- Ensure the renderer still gets a usable size during initialization and on resizes so the table and UI become visible. 

### Description
- Added fallback dimension logic inside `applyRendererQuality` in `webapp/src/pages/Games/SnookerClubGame.jsx` to use `window.innerWidth`/`innerHeight` when the host `clientWidth`/`clientHeight` are zero. 
- Compute `hostWidth`/`hostHeight` and call `renderer.setSize(hostWidth * renderScale, hostHeight * renderScale, false)` to avoid 0×0 canvas sizes. 
- Update the canvas CSS sizing so `renderer.domElement.style.width`/`height` use the fallback pixel values when the host reports no client size. 

### Testing
- No automated tests were run for this change. 
- Manual verification was used during development to confirm the renderer no longer sizes to 0×0 in situations where the mount reports zero dimensions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e06a36848329941bd9648c687a53)