### PR TITLE
Add fallback lighting to Snooker Club renderer

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -13422,7 +13422,92 @@ export function PoolRoyaleGame({
 
       // Lights
       const addMobileLighting = () => {
-        lightingRigRef.current = null;
+        const useHdriOnly = false;
+        if (useHdriOnly) {
+          lightingRigRef.current = null;
+          return;
+        }
+        const lightingRig = new THREE.Group();
+        world.add(lightingRig);
+
+        const lightSpreadBoost = 1.12; // tighten the overhead footprint while keeping enough coverage for mobile
+        const previousLightRigHeight = tableSurfaceY + TABLE.THICK * 7.1; // baseline height used for the prior brightness target
+        const lightRigHeight = tableSurfaceY + TABLE.THICK * 6.6; // lift the rig slightly higher so the fixtures sit further above the felt
+        const brightnessCompensation =
+          ((lightRigHeight ** 2) / (previousLightRigHeight ** 2)) * 1.02; // preserve on-cloth brightness after the height change while keeping intensity stable
+        const lightOffsetX =
+          Math.max(PLAY_W * 0.22, TABLE.THICK * 3.9) * lightSpreadBoost;
+        const lightOffsetZ =
+          Math.max(PLAY_H * 0.2, TABLE.THICK * 3.8) * lightSpreadBoost;
+        const lightLineX = 0; // align fixtures down the center line instead of offsetting per side
+        const lightSpacing = Math.max(lightOffsetZ * 0.36, TABLE.THICK * 2); // pull fixtures closer together while keeping even coverage
+        const lightPositionsZ = [-1.1, -0.34, 0.34, 1.1].map((mult) => mult * lightSpacing);
+        const lightBrightnessTrim = 0.8; // lower the rig intensity a touch for gentler cloth highlights
+        const shadowHalfSpan =
+          Math.max(roomWidth, roomDepth) * 0.82 + TABLE.THICK * 3.5;
+        const targetY = tableSurfaceY + TABLE.THICK * 0.2;
+        const shadowDepth =
+          lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 12;
+
+        const ambient = new THREE.AmbientLight(0xffffff, 0.3 * lightBrightnessTrim);
+        lightingRig.add(ambient);
+
+        const key = new THREE.DirectionalLight(
+          0xffffff,
+          1.68 * brightnessCompensation * lightBrightnessTrim
+        );
+        key.position.set(lightLineX, lightRigHeight, lightPositionsZ[0]);
+        key.target.position.set(0, targetY, 0);
+        key.castShadow = true;
+        key.shadow.mapSize.set(2048, 2048);
+        key.shadow.camera.near = 0.1;
+        key.shadow.camera.far = shadowDepth;
+        key.shadow.camera.left = -shadowHalfSpan;
+        key.shadow.camera.right = shadowHalfSpan;
+        key.shadow.camera.top = shadowHalfSpan;
+        key.shadow.camera.bottom = -shadowHalfSpan;
+        key.shadow.bias = -0.00006;
+        key.shadow.normalBias = 0.0006;
+        key.shadow.camera.updateProjectionMatrix();
+        lightingRig.add(key);
+        lightingRig.add(key.target);
+
+        const fill = new THREE.DirectionalLight(
+          0xffffff,
+          0.84 * brightnessCompensation * lightBrightnessTrim
+        );
+        fill.position.set(-lightLineX, lightRigHeight * 1.01, lightPositionsZ[1]);
+        fill.target.position.set(0, targetY, 0);
+        lightingRig.add(fill);
+        lightingRig.add(fill.target);
+
+        const wash = new THREE.DirectionalLight(
+          0xffffff,
+          0.76 * brightnessCompensation * lightBrightnessTrim
+        );
+        wash.position.set(lightLineX, lightRigHeight * 1.02, lightPositionsZ[2]);
+        wash.target.position.set(0, targetY, 0);
+        lightingRig.add(wash);
+        lightingRig.add(wash.target);
+
+        const rim = new THREE.DirectionalLight(
+          0xffffff,
+          0.68 * brightnessCompensation * lightBrightnessTrim
+        );
+        rim.position.set(-lightLineX, lightRigHeight * 1.03, lightPositionsZ[3]);
+        rim.target.position.set(0, targetY, 0);
+        lightingRig.add(rim);
+        lightingRig.add(rim.target);
+
+        lightingRigRef.current = {
+          group: lightingRig,
+          key,
+          fill,
+          wash,
+          rim,
+          ambient
+        };
+        applyLightingPreset();
       };
 
       addMobileLighting();


### PR DESCRIPTION
### Motivation
- The Snooker Club 3D scene can show a black screen when HDRI environment loading fails, making the table invisible on startup. 
- Provide a minimal, deterministic lighting fallback so the table and balls are visible even without a loaded HDRI. 
- Keep HDRI path available while ensuring a safe default for devices or network failures. 

### Description
- Added a fallback mobile lighting rig inside `addMobileLighting` in `webapp/src/pages/Games/SnookerClubGame.jsx` that creates an ambient plus directional `key`, `fill`, `wash`, and `rim` lights and registers them to `lightingRigRef.current`. 
- Introduced a `useHdriOnly` toggle (set to `false`) so the fallback lights are used alongside HDRI when desired. 
- Configured shadow/map settings, intensity compensation, and called `applyLightingPreset()` to integrate with existing lighting presets. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite served the app successfully (server up). 
- Attempted an automated Playwright screenshot of `/games/snookerclub?mode=ai`, but the Playwright run timed out and did not complete. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961041af798832980e83845d134e678)