### PR TITLE
Ground HDRI to table legs, default to procedural cloth, and align overhead broadcast to replay

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2462,10 +2462,9 @@ const DEFAULT_CLOTH_TEXTURE_KEY =
 const DEFAULT_CLOTH_COLOR_ID = DEFAULT_CLOTH_TEXTURE_KEY;
 const CLOTH_TEXTURE_SOURCE_STORAGE_KEY = 'poolRoyaleClothSource';
 const CLOTH_TEXTURE_SOURCE_OPTIONS = Object.freeze([
-  { id: 'gltf', label: 'GLTF Cloth' },
   { id: 'procedural', label: 'Procedural Cloth' }
 ]);
-const DEFAULT_CLOTH_TEXTURE_SOURCE_ID = 'gltf';
+const DEFAULT_CLOTH_TEXTURE_SOURCE_ID = 'procedural';
 const CLOTH_COLOR_OPTIONS = Object.freeze(
   CLOTH_LIBRARY.map((cloth) => ({
     id: cloth.id,
@@ -11736,6 +11735,7 @@ const powerRef = useRef(hud.power);
   const envSkyboxTextureRef = useRef(null);
   const environmentHdriRef = useRef(environmentHdriId);
   const activeEnvironmentVariantRef = useRef(activeEnvironmentHdri);
+  const environmentFloorRef = useRef(FLOOR_Y);
   const cameraRef = useRef(null);
   const sphRef = useRef(null);
   const initialOrbitRef = useRef(null);
@@ -12945,7 +12945,10 @@ const powerRef = useRef(hud.power);
         const resolvedWorldScale = Number.isFinite(worldScaleFactor) && worldScaleFactor > 0
           ? worldScaleFactor
           : WORLD_SCALE * tableScale;
-        const floorWorldY = FLOOR_Y * resolvedWorldScale + worldOffsetY;
+        const floorLocalY = Number.isFinite(environmentFloorRef.current)
+          ? environmentFloorRef.current
+          : FLOOR_Y;
+        const floorWorldY = floorLocalY * resolvedWorldScale + worldOffsetY;
         const unitsPerMeter = MM_TO_UNITS * 1000 * resolvedWorldScale;
         const cameraHeightMeters = Math.max(
           activeVariant?.cameraHeightM ?? DEFAULT_HDRI_CAMERA_HEIGHT_M,
@@ -12979,6 +12982,13 @@ const powerRef = useRef(hud.power);
             skybox.position.y = floorWorldY + skyboxHeight;
             skybox.rotation.y = hdriRotationY;
             skybox.material.depthWrite = false;
+            skybox.userData = {
+              ...(skybox.userData || {}),
+              baseHeight: skyboxHeight,
+              baseRadius: skyboxRadius,
+              baseFloorY: floorWorldY,
+              baseDistance: null
+            };
             sceneInstance.background = null;
             sceneInstance.add(skybox);
             envSkyboxRef.current = skybox;
@@ -16127,6 +16137,36 @@ const powerRef = useRef(hud.power);
               clothMat.bumpScale = clothMat.userData.bumpScale;
             }
           }
+          const skybox = envSkyboxRef.current;
+          if (skybox && renderCamera) {
+            const focusTarget =
+              lookTarget?.clone?.() ??
+              lastCameraTargetRef.current?.clone?.() ??
+              broadcastArgs.targetWorld?.clone?.() ??
+              null;
+            const distance = focusTarget
+              ? renderCamera.position.distanceTo(focusTarget)
+              : null;
+            if (Number.isFinite(distance)) {
+              const baseDistance = Number.isFinite(skybox.userData?.baseDistance)
+                ? skybox.userData.baseDistance
+                : distance;
+              if (!Number.isFinite(skybox.userData?.baseDistance)) {
+                skybox.userData.baseDistance = baseDistance;
+              }
+              if (Number.isFinite(baseDistance) && baseDistance > 1e-6) {
+                const scaleFactor = THREE.MathUtils.clamp(
+                  distance / baseDistance,
+                  0.6,
+                  1.8
+                );
+                const baseHeight = skybox.userData?.baseHeight ?? 0;
+                const baseFloorY = skybox.userData?.baseFloorY ?? 0;
+                skybox.scale.setScalar(scaleFactor);
+                skybox.position.y = baseFloorY + baseHeight * scaleFactor;
+              }
+            }
+          }
           updateBroadcastCameras(broadcastArgs);
           activeRenderCameraRef.current = renderCamera;
           return renderCamera;
@@ -17113,7 +17153,7 @@ const powerRef = useRef(hud.power);
         const enterTopView = (immediate = false) => {
           topViewRef.current = true;
           topViewLockedRef.current = true;
-          overheadBroadcastVariantRef.current = Math.random() < 0.5 ? 'top' : 'replay';
+          overheadBroadcastVariantRef.current = 'replay';
           const margin = TOP_VIEW_MARGIN;
           fit(margin);
           const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
@@ -17574,6 +17614,26 @@ const powerRef = useRef(hud.power);
         activeTableBase,
         rendererRef.current
       );
+      const updateEnvironmentFloorFromTable = (tableGroup) => {
+        const legMeshes = tableGroup?.userData?.finish?.parts?.legMeshes ?? [];
+        if (!legMeshes.length) return;
+        const legBox = new THREE.Box3();
+        let minLocalY = Infinity;
+        legMeshes.forEach((mesh) => {
+          if (!mesh) return;
+          legBox.setFromObject(mesh);
+          const legBottom = legBox.min.clone();
+          tableGroup.worldToLocal(legBottom);
+          if (Number.isFinite(legBottom.y)) {
+            minLocalY = Math.min(minLocalY, legBottom.y);
+          }
+        });
+        if (Number.isFinite(minLocalY) && minLocalY !== Infinity) {
+          environmentFloorRef.current = minLocalY;
+          updateEnvironmentRef.current?.(activeEnvironmentVariantRef.current);
+        }
+      };
+      updateEnvironmentFloorFromTable(table);
       const SPOTS = spotPositions(baulkZ);
       const longestSide = Math.max(PLAY_W, PLAY_H);
       const secondarySpacingBase =
@@ -24606,31 +24666,6 @@ const powerRef = useRef(hud.power);
                         </button>
                       );
                     })}
-                  </div>
-                  <div className="mt-3">
-                    <h4 className="text-[10px] uppercase tracking-[0.32em] text-emerald-100/70">
-                      Cloth Texture
-                    </h4>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {CLOTH_TEXTURE_SOURCE_OPTIONS.map((option) => {
-                        const active = option.id === clothTextureSourceId;
-                        return (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => setClothTextureSourceId(option.id)}
-                            aria-pressed={active}
-                            className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                              active
-                                ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                                : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                            }`}
-                          >
-                            {option.label}
-                          </button>
-                        );
-                      })}
-                    </div>
                   </div>
                 </div>
               ) : null}


### PR DESCRIPTION
### Motivation

- Make table visuals feel grounded by tying the HDRI skybox floor to the actual table leg base so the table no longer appears to float.
- Ensure HDRI background scales visually with camera distance so overhead/cue camera framing remains consistent.
- Simplify cloth options by removing the GLTF cloth source and defaulting to the procedural pipeline.
- Use replay camera coordinates for overhead broadcast shots to match replay framing.

### Description

- Added `environmentFloorRef` and `updateEnvironmentFloorFromTable` to read table leg geometry and set the HDRI floor from the table's leg bottoms, then reapply the HDRI environment when it changes.
- Create and attach `skybox.userData` and added dynamic skybox scaling in the camera update path so the skybox size/height adjusts based on current camera distance.
- Removed the `gltf` entry from `CLOTH_TEXTURE_SOURCE_OPTIONS`, set `DEFAULT_CLOTH_TEXTURE_SOURCE_ID` to `procedural`, and removed the cloth texture source selector from the table menu UI.
- Force the overhead broadcast variant to use the replay camera by setting `overheadBroadcastVariantRef.current = 'replay'` in the top-view entry path.

### Testing

- Started the dev server with `npm run dev` and the Vite server reported ready, which succeeded.
- Attempted a Playwright-based screenshot of `/games/poolroyale`, but the headless capture timed out and failed; no visual regression screenshots were produced.
- No unit or CI tests were executed as part of this change set.
- Changes were exercised locally in the running dev server (manual run), but automated replay/visual tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610376ac088329beea2973c5fbb1bc)