### PR TITLE
Use Pool Royale wood finish for Murlan default table and expose it in store

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -73,7 +73,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: 'Monochrome slate backs with steel edging.'
   }
 ].concat(
-  MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  MURLAN_TABLE_THEMES.map((theme, idx) => ({
     id: `table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -20,10 +20,10 @@ const DEFAULT_TABLE_BASE_OPTION = Object.freeze({
 });
 
 const DEFAULT_TABLE_WOOD_OPTION = Object.freeze({
-  id: 'oakEstate',
-  label: 'Lis Estate',
+  id: 'peelingPaintWeathered',
+  label: 'Wood Peeling Paint Weathered',
   presetId: 'oak',
-  grainId: 'estateBands'
+  grainId: 'wood_peeling_paint_weathered'
 });
 
 export const DEFAULT_TABLE_CLOTH_OPTION = Object.freeze({
@@ -261,21 +261,29 @@ function applyWoodSelectionToMaterials(topMat, rimMat, option) {
     roughnessVariance: 0.28
   };
   const sharedKey = `murlan-wood-${option?.id ?? preset.id}`;
+  const frameSurface = grain?.frame ?? {};
+  const railSurface = grain?.rail ?? {};
   if (topMat) {
     applyWoodTextures(topMat, {
       ...sharedOptions,
-      repeat: grain?.frame?.repeat ?? grain?.rail?.repeat ?? { x: 0.24, y: 0.38 },
-      rotation: grain?.frame?.rotation ?? 0,
-      textureSize: grain?.frame?.textureSize,
+      repeat: frameSurface.repeat ?? railSurface.repeat ?? { x: 0.24, y: 0.38 },
+      rotation: frameSurface.rotation ?? 0,
+      textureSize: frameSurface.textureSize,
+      mapUrl: frameSurface.mapUrl,
+      roughnessMapUrl: frameSurface.roughnessMapUrl,
+      normalMapUrl: frameSurface.normalMapUrl,
       sharedKey
     });
   }
   if (rimMat) {
     applyWoodTextures(rimMat, {
       ...sharedOptions,
-      repeat: grain?.rail?.repeat ?? grain?.frame?.repeat ?? { x: 0.12, y: 0.62 },
-      rotation: grain?.rail?.rotation ?? 0,
-      textureSize: grain?.rail?.textureSize,
+      repeat: railSurface.repeat ?? frameSurface.repeat ?? { x: 0.12, y: 0.62 },
+      rotation: railSurface.rotation ?? 0,
+      textureSize: railSurface.textureSize,
+      mapUrl: railSurface.mapUrl,
+      roughnessMapUrl: railSurface.roughnessMapUrl,
+      normalMapUrl: railSurface.normalMapUrl,
       sharedKey
     });
   }


### PR DESCRIPTION
### Motivation
- The Murlan Royale default wooden table should match the Pool Royale table finish so visuals (texture, repeat, sharpness) are identical across games. 
- The default Murlan table must be selectable from the store so players can pick the same GLTF/procedural table finish as Pool Royale. 

### Description
- Changed the Murlan default wood option `DEFAULT_TABLE_WOOD_OPTION` to use the Pool Royale peeling paint finish by setting the id to `peelingPaintWeathered` and `grainId` to `wood_peeling_paint_weathered` in `webapp/src/utils/murlanTable.js`. 
- Propagated per-surface external texture fields into the material pipeline by passing `mapUrl`, `roughnessMapUrl`, and `normalMapUrl` (and explicit `repeat`/`rotation`/`textureSize`) for frame and rail surfaces when calling `applyWoodTextures` in `applyWoodSelectionToMaterials`. 
- Included the Murlan default table in the store listing by changing the table list generation to `MURLAN_TABLE_THEMES.map(...)` so the default (`murlan-default`) appears as a `tables` store item in `webapp/src/config/murlanInventoryConfig.js`. 
- Files modified: `webapp/src/utils/murlanTable.js` and `webapp/src/config/murlanInventoryConfig.js`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105fc72d08329be084b671405ebe7)