### PR TITLE
Add Murlan table finish option matching Pool Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,6 +1,11 @@
 import { CARD_THEMES } from '../utils/cardThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { MURLAN_OUTFIT_THEMES, MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import {
+  MURLAN_OUTFIT_THEMES,
+  MURLAN_STOOL_THEMES,
+  MURLAN_TABLE_FINISHES,
+  MURLAN_TABLE_THEMES
+} from './murlanThemes.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -15,6 +20,7 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   cards: [CARD_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id].filter(Boolean),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id)
 });
 
@@ -23,6 +29,7 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   tables: mapLabels(MURLAN_TABLE_THEMES),
+  tableFinish: mapLabels(MURLAN_TABLE_FINISHES),
   environmentHdri: mapLabels(
     POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
       id: variant.id,
@@ -73,6 +80,16 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: 'Monochrome slate backs with steel edging.'
   }
 ].concat(
+  MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: `${finish.label} Finish`,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description || `${finish.label} table finish.`,
+    swatches: finish.swatches,
+    previewShape: 'table'
+  })),
   MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `table-${theme.id}`,
     type: 'tables',
@@ -107,6 +124,11 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },
+  {
+    type: 'tableFinish',
+    optionId: MURLAN_TABLE_FINISHES[0]?.id,
+    label: MURLAN_TABLE_FINISHES[0]?.label
+  },
   {
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -77,6 +77,18 @@ const POLYHAVEN_TABLE_THEMES = [
   description: option.description || `${option.label} with preserved Poly Haven materials.`
 }));
 
+export const MURLAN_TABLE_FINISHES = [
+  {
+    id: 'peelingPaintWeathered',
+    label: 'Wood Peeling Paint Weathered',
+    presetId: 'oak',
+    grainId: 'wood_peeling_paint_weathered',
+    price: 980,
+    swatches: ['#a89f95', '#b8b3aa'],
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+  }
+];
+
 export const MURLAN_TABLE_THEMES = [
   {
     id: 'murlan-default',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,6 +175,7 @@ const MURLAN_TYPE_LABELS = {
   cards: 'Card Themes',
   stools: 'Stools & Chairs',
   tables: 'Table Models',
+  tableFinish: 'Table Finishes',
   environmentHdri: 'HDR Environments'
 };
 

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -20,10 +20,10 @@ const DEFAULT_TABLE_BASE_OPTION = Object.freeze({
 });
 
 const DEFAULT_TABLE_WOOD_OPTION = Object.freeze({
-  id: 'oakEstate',
-  label: 'Lis Estate',
+  id: 'peelingPaintWeathered',
+  label: 'Wood Peeling Paint Weathered',
   presetId: 'oak',
-  grainId: 'estateBands'
+  grainId: 'wood_peeling_paint_weathered'
 });
 
 export const DEFAULT_TABLE_CLOTH_OPTION = Object.freeze({


### PR DESCRIPTION
### Motivation
- Expose the same peeling paint wood finish used by Pool Royale as a selectable finish for the Murlan Default table so the Murlan table can match Pool Royale visuals exactly.
- Make the finish available in the Murlan store and default loadout so players can choose it from the customization UI.

### Description
- Add `MURLAN_TABLE_FINISHES` and a `peelingPaintWeathered` entry to `webapp/src/config/murlanThemes.js` to define the finish metadata and swatches.
- Wire the finish into inventory by importing `MURLAN_TABLE_FINISHES` in `webapp/src/config/murlanInventoryConfig.js` and adding store entries, option labels, and a default loadout entry for `tableFinish`.
- Change the procedural default wood option in `webapp/src/utils/murlanTable.js` to use the `peelingPaintWeathered` grain preset so procedural tables use the new finish by default.
- Integrate finish selection into the Murlan UI in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by adding `tableFinish` to appearance/defaults/customization, a preview tile, a `resolveTableFinish` helper, passing the finish to `rebuildTable`, and applying `applyTableMaterials` to update materials when the finish changes; add the type label in `webapp/src/pages/Store.jsx`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (server started successfully). 
- Captured a store page screenshot of `/store/murlanroyale` via a Playwright script to verify the new finish appears in the Murlan store (screenshot artifact created). 
- No unit or CI tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105fc72d08329be084b671405ebe7)