### PR TITLE
Add Murlan table finish matching Pool Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,5 +1,6 @@
 import { CARD_THEMES } from '../utils/cardThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { MURLAN_OUTFIT_THEMES, MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
 const mapLabels = (options) =>
@@ -15,6 +16,7 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   cards: [CARD_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0].id],
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id)
 });
 
@@ -23,6 +25,7 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   tables: mapLabels(MURLAN_TABLE_THEMES),
+  tableFinish: mapLabels(MURLAN_TABLE_FINISHES),
   environmentHdri: mapLabels(
     POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
       id: variant.id,
@@ -32,6 +35,16 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    previewShape: 'table'
+  })),
   {
     id: 'cards-solstice',
     type: 'cards',
@@ -107,6 +120,11 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },
+  {
+    type: 'tableFinish',
+    optionId: MURLAN_TABLE_FINISHES[0].id,
+    label: MURLAN_TABLE_FINISHES[0].label
+  },
   {
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,

--- a/webapp/src/config/murlanTableFinishes.js
+++ b/webapp/src/config/murlanTableFinishes.js
@@ -1,0 +1,15 @@
+export const MURLAN_TABLE_FINISHES = Object.freeze([
+  Object.freeze({
+    id: 'peelingPaintWeathered',
+    label: 'Wood Peeling Paint Weathered Finish',
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.',
+    price: 980,
+    swatches: ['#b8b3aa', '#d6d0c7'],
+    woodOption: Object.freeze({
+      id: 'peelingPaintWeathered',
+      label: 'Wood Peeling Paint Weathered',
+      presetId: 'oak',
+      grainId: 'wood_peeling_paint_weathered'
+    })
+  })
+]);

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,6 +175,7 @@ const MURLAN_TYPE_LABELS = {
   cards: 'Card Themes',
   stools: 'Stools & Chairs',
   tables: 'Table Models',
+  tableFinish: 'Table Finish',
   environmentHdri: 'HDR Environments'
 };
 

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -20,10 +20,10 @@ const DEFAULT_TABLE_BASE_OPTION = Object.freeze({
 });
 
 const DEFAULT_TABLE_WOOD_OPTION = Object.freeze({
-  id: 'oakEstate',
-  label: 'Lis Estate',
+  id: 'peelingPaintWeathered',
+  label: 'Wood Peeling Paint Weathered',
   presetId: 'oak',
-  grainId: 'estateBands'
+  grainId: 'wood_peeling_paint_weathered'
 });
 
 export const DEFAULT_TABLE_CLOTH_OPTION = Object.freeze({
@@ -262,20 +262,28 @@ function applyWoodSelectionToMaterials(topMat, rimMat, option) {
   };
   const sharedKey = `murlan-wood-${option?.id ?? preset.id}`;
   if (topMat) {
+    const frameTexture = grain?.frame ?? {};
     applyWoodTextures(topMat, {
       ...sharedOptions,
-      repeat: grain?.frame?.repeat ?? grain?.rail?.repeat ?? { x: 0.24, y: 0.38 },
-      rotation: grain?.frame?.rotation ?? 0,
-      textureSize: grain?.frame?.textureSize,
+      repeat: frameTexture.repeat ?? grain?.rail?.repeat ?? { x: 0.24, y: 0.38 },
+      rotation: frameTexture.rotation ?? 0,
+      textureSize: frameTexture.textureSize,
+      mapUrl: frameTexture.mapUrl,
+      roughnessMapUrl: frameTexture.roughnessMapUrl,
+      normalMapUrl: frameTexture.normalMapUrl,
       sharedKey
     });
   }
   if (rimMat) {
+    const railTexture = grain?.rail ?? {};
     applyWoodTextures(rimMat, {
       ...sharedOptions,
-      repeat: grain?.rail?.repeat ?? grain?.frame?.repeat ?? { x: 0.12, y: 0.62 },
-      rotation: grain?.rail?.rotation ?? 0,
-      textureSize: grain?.rail?.textureSize,
+      repeat: railTexture.repeat ?? grain?.frame?.repeat ?? { x: 0.12, y: 0.62 },
+      rotation: railTexture.rotation ?? 0,
+      textureSize: railTexture.textureSize,
+      mapUrl: railTexture.mapUrl,
+      roughnessMapUrl: railTexture.roughnessMapUrl,
+      normalMapUrl: railTexture.normalMapUrl,
       sharedKey
     });
   }


### PR DESCRIPTION
### Motivation
- Provide the Murlan Royale default wooden table finish in the store and customization UI so the Murlan table can match the Pool Royale table finish exactly. 
- Reuse the same Poly Haven wood texture and configuration (maps, repeats, IDs) so procedural Murlan tables visually match Pool Royale. 
- Expose the finish as a selectable/store item and include it in the default loadout for new accounts. 

### Description
- Add a new finish definition file `webapp/src/config/murlanTableFinishes.js` containing a `peelingPaintWeathered` finish that references the same grain/asset ids used by Pool Royale. 
- Wire the new finish into inventory and store by updating `webapp/src/config/murlanInventoryConfig.js` so `tableFinish` appears in default unlocks, option labels, store items, and default loadout. 
- Enable selection and application of the finish in the Murlan UI by importing finishes in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, adding a `tableFinish` customization section, resolving the selected finish, rendering a preview swatch, and passing the finish's `woodOption` into `createMurlanStyleTable`. 
- Make procedural Murlan tables use the Pool Royale wood by changing the default wood option and extending `applyWoodSelectionToMaterials` in `webapp/src/utils/murlanTable.js` to pass external `mapUrl`/`roughnessMapUrl`/`normalMapUrl` and texture fields for frame/rail so external Poly Haven textures are applied. 
- Add a `tableFinish` type label to `webapp/src/pages/Store.jsx` so the new items display correctly in the store UI. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev`, which completed and served the app (Vite reported ready). 
- Attempted an automated Playwright script to open the Murlan Royale page and capture the customization UI screenshot, but the Playwright run timed out and did not complete. 
- No unit tests or CI test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105fc72d08329be084b671405ebe7)