### PR TITLE
Fix HDRI fallback URL and use renderer-aware GLTF loader for chairs

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -921,7 +921,10 @@ function pickPolyHavenHdriUrl(fileMap, preferredResolutions = PREFERRED_HDRI_RES
 }
 
 async function resolvePolyHavenHdriUrl(config = {}, preferred = PREFERRED_HDRI_RESOLUTIONS) {
-  const fallbackUrl = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/${config?.assetId || 'neon_photostudio'}.hdr`;
+  const fallbackRes =
+    (Array.isArray(preferred) && preferred[0]) || config?.fallbackResolution || '4k';
+  const fallbackAsset = config?.assetId || 'neon_photostudio';
+  const fallbackUrl = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${fallbackAsset}_${fallbackRes}.hdr`;
   if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
   try {
     const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
@@ -1208,8 +1211,8 @@ function extractChairMaterials(model) {
   };
 }
 
-async function loadGltfChair() {
-  const loader = createConfiguredGLTFLoader();
+async function loadGltfChair(renderer) {
+  const loader = createConfiguredGLTFLoader(renderer);
 
   let gltf = null;
   let lastError = null;
@@ -1322,7 +1325,7 @@ async function buildChairTemplate(theme, renderer) {
       }
       return { chairTemplate: model, materials, preserveOriginal: preserveMaterials };
     }
-    const gltfChair = await loadGltfChair();
+    const gltfChair = await loadGltfChair(renderer);
     if (rotationY && gltfChair?.chairTemplate) {
       gltfChair.chairTemplate.rotation.y += rotationY;
     }


### PR DESCRIPTION
### Motivation
- HDRI backgrounds could fail to appear because the Poly Haven fallback URL lacked resolution segments and filename suffixes. 
- glTF chair models sometimes missed renderer-specific features (KTX2 support / correct texture handling) because the loader wasn’t created with the active `renderer`.
- Provide deterministic fallback behavior and ensure chair materials/textures respect renderer capabilities for consistent visuals.

### Description
- Update `resolvePolyHavenHdriUrl` to build a resolution-aware fallback URL using the first `preferred` resolution, `config.fallbackResolution`, and include the asset/resolution filename suffix (e.g. `.../hdr/4k/name_4k.hdr`).
- Change `loadGltfChair` to accept a `renderer` parameter and construct the GLTF loader via `createConfiguredGLTFLoader(renderer)` so KTX2/renderer detection is applied.
- Pass the `renderer` through from `buildChairTemplate` when calling `loadGltfChair`, preserving existing material preparation and SRGB handling.
- Minor: keep existing behavior of selecting Poly Haven assets first and falling back to procedural chairs when loads fail.

### Testing
- No automated tests were run for this change.
- The change is limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and was committed after local edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961176f6c588329bba231eb8b9c6f4c)