### PR TITLE
Prefer rules engine currentPlayer for AI target selection

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20170,7 +20170,8 @@ const powerRef = useRef(hud.power);
             if (!order.includes(normalized)) order.push(normalized);
           };
           const metaState = frameSnapshot?.meta?.state ?? null;
-          const shooterSeat = frameSnapshot?.activePlayer === 'B' ? 'B' : 'A';
+          const activeSeat = metaState?.currentPlayer ?? frameSnapshot?.activePlayer;
+          const shooterSeat = activeSeat === 'B' ? 'B' : 'A';
           const assignments = metaState?.assignments ?? {};
           const assignmentTargets = mapAssignmentToTargets(
             shooterSeat ? assignments[shooterSeat] : null,


### PR DESCRIPTION
### Motivation
- AI shot logic used the frame's `activePlayer` when resolving target priorities which can diverge from the rules engine's authoritative `currentPlayer` and produce inconsistent AI behavior after the first shot.
- The change aims to make AI planning use the authoritative player from the rules meta so target priorities and assignments remain consistent across turns.
- Keep a safe fallback to the frame snapshot when rules metadata is unavailable to preserve compatibility.

### Description
- Updated `resolveTargetPriorities` in `webapp/src/pages/Games/PoolRoyale.jsx` to compute `activeSeat` from `metaState?.currentPlayer` with fallback to `frameSnapshot?.activePlayer`.
- Replaced the prior `shooterSeat` assignment logic to derive from the new `activeSeat` so assignment lookups and last-potted logic reference the rules engine player.
- The change is a small, localized modification (two insertions, one deletion) and preserves existing behavior when metadata is missing.

### Testing
- No automated tests were run as part of this change.
- The change compiles and the single-file edit was committed locally without running test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611c13028c8329a60faa0b9f5e1ce9)