### PR TITLE
Track and update currentBreak in Pool Royale rules (UK/American/9-ball)

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -355,6 +355,7 @@ export class PoolRoyaleRules {
       noCushionAfterContact: Boolean(context.noCushionAfterContact),
       placedFromHand: Boolean(context.placedFromHand)
     });
+    const pottedCount = potted.filter((colour) => colour !== 'cue').length;
     const snapshot = serializeUkState(game.state);
     const totals = previous ? previous.totals : { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR };
     const playerScores = this.computeUkScores(snapshot, totals);
@@ -364,6 +365,11 @@ export class PoolRoyaleRules {
       phase: snapshot.isOpenTable ? 'open' : 'groups',
       scores: playerScores
     };
+    const isFoul = Boolean(shotResult.foul);
+    const shooter = state.activePlayer ?? game.state.currentPlayer;
+    const sameShooter = shooter === game.state.currentPlayer;
+    const currentBreak =
+      !isFoul && sameShooter && pottedCount > 0 ? (state.currentBreak ?? 0) + pottedCount : 0;
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
@@ -371,6 +377,7 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: playerScores.A },
         B: { ...state.players.B, score: playerScores.B }
       },
+      currentBreak,
       ballOn,
       frameOver: game.state.frameOver,
       winner: game.state.winner ?? undefined,
@@ -455,6 +462,7 @@ export class PoolRoyaleRules {
       placedFromHand: Boolean(context.placedFromHand),
       noCushionAfterContact: Boolean(context.noCushionAfterContact)
     });
+    const pottedCount = potted.filter((id) => id !== 0).length;
     const snapshot = serializeAmericanState(game.state);
     const lowest = lowestBall(snapshot.ballsOnTable);
     const tableClear = snapshot.ballsOnTable.length === 0;
@@ -486,6 +494,10 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: snapshot.scores.A },
         B: { ...state.players.B, score: snapshot.scores.B }
       },
+      currentBreak:
+        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
+          ? (state.currentBreak ?? 0) + pottedCount
+          : 0,
       ballOn: lowest != null && !frameOver ? [`BALL_${lowest}`] : [],
       frameOver,
       winner,
@@ -537,6 +549,7 @@ export class PoolRoyaleRules {
       placedFromHand: Boolean(context.placedFromHand),
       noCushionAfterContact: Boolean(context.noCushionAfterContact)
     });
+    const pottedCount = potted.filter((id) => id !== 0).length;
     const snapshot = serializeNineState(game.state);
     const lowest = lowestBall(snapshot.ballsOnTable);
     const hud: HudInfo = {
@@ -551,6 +564,10 @@ export class PoolRoyaleRules {
         A: { ...state.players.A, score: 0 },
         B: { ...state.players.B, score: 0 }
       },
+      currentBreak:
+        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
+          ? (state.currentBreak ?? 0) + pottedCount
+          : 0,
       ballOn: lowest != null && !snapshot.gameOver ? [`BALL_${lowest}`] : [],
       frameOver: game.state.gameOver,
       winner: game.state.winner ?? undefined,


### PR DESCRIPTION
### Motivation
- The AI was treating many shots as opening breaks because frame break progress was not reliably tracked across shot resolution. 
- Preserve accurate break state so AI planning and shot selection remain consistent after the first shot. 
- Keep break counting consistent across variants (UK, American, 9-ball) and reset it on fouls, misses, or turn changes.

### Description
- Update `src/rules/PoolRoyaleRules.ts` to compute `pottedCount` for each shot and fold it into `currentBreak` when the shot is legal and the shooter remains the same. 
- Apply the same break-tracking logic to `applyUkShot`, `applyAmericanShot`, and `applyNineBallShot`, resetting `currentBreak` on fouls or when the turn changes. 
- Use the existing shot result (`shotResult` / `result`) to detect fouls and the game state (`game.state.currentPlayer`) to determine whether the shooter stayed the same. 
- Return `currentBreak` as part of the updated `FrameState` so downstream AI planning uses the correct break context.

### Testing
- Automated tests: none were executed for this change.
- Recommend running the existing unit/CI suite after review (e.g., `npm test` / project CI) to confirm behavior across variants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696138a1c6188329be4699be79d59950)