### PR TITLE
Normalize cut-angle wraparound in Pool AI evaluation

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -451,7 +451,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
-  const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+  let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+  if (cutAngle > Math.PI) cutAngle = Math.abs(cutAngle - Math.PI * 2)
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const viewAngle = Math.atan2(r * 2, dist(target, entry))

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -451,7 +451,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
-  const cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+  let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+  if (cutAngle > Math.PI) cutAngle = Math.abs(cutAngle - Math.PI * 2)
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
   const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
   const viewAngle = Math.atan2(r * 2, dist(target, entry))


### PR DESCRIPTION
### Motivation
- The pool AI was computing cut angles as a raw absolute difference which can wrap around the ±π boundary and misreport severe cuts, causing inconsistent shot scoring and poor AI decisions.  
- The intent is to make angle comparisons robust so candidate shots near the angle boundary are evaluated correctly across runtimes.

### Description
- Normalize the computed cut angle in the shot `evaluate` routine by wrapping values > π back into the [-π, π] range in `lib/poolAi.js`.  
- Mirror the same normalization change in the web runtime copy at `webapp/public/lib/poolAi.js` to keep shared and client logic consistent.

### Testing
- No automated tests were run as part of this change.  
- There are existing AI unit tests (e.g. `test/poolAi.test.js`) that exercise `planShot`/`evaluate` which should be run in CI to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696138a1c6188329be4699be79d59950)