### PR TITLE
Fix Pool Royale AI target selection logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20258,12 +20258,11 @@ const powerRef = useRef(hud.power);
             activeVariantId === 'american' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);
           const targetOrder = resolveTargetPriorities(state, activeVariantId, activeBalls);
-          const legalTargetsRaw =
-            targetOrder.length > 0
+          const legalTargetsRaw = Array.isArray(state?.ballOn) && state.ballOn.length > 0
+            ? state.ballOn
+            : targetOrder.length > 0
               ? targetOrder
-              : Array.isArray(state?.ballOn)
-                ? state.ballOn
-                : ['RED'];
+              : ['RED'];
           const legalTargets = new Set(
             legalTargetsRaw
               .map((entry) => normalizeTargetId(entry))


### PR DESCRIPTION
### Motivation
- The AI could become inconsistent after the opening shot by using stale priority targets instead of the explicit ruleset, causing poor follow-up decisions.
- The change aims to ensure the AI respects the authoritative `ballOn` list from the frame state when present so shot choice stays legal and stable.

### Description
- Updated the selection order for legal targets in `evaluateShotOptionsBaseline` so `state.ballOn` (when non-empty) is used before the AI-computed `targetOrder`.
- The change is implemented in `webapp/src/pages/Games/PoolRoyale.jsx` by modifying how `legalTargetsRaw` is derived.
- This keeps AI planning aligned with current frame rules and prevents locking onto stale priorities after table state changes.

### Testing
- No automated tests were executed for this change.
- A quick static code review ensured the modified expression uses `Array.isArray(state?.ballOn) && state.ballOn.length > 0` to prefer explicit targets.
- No runtime or CI results are available in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696138a1c6188329be4699be79d59950)