### PR TITLE
Fix UK pool AI ball-on normalization

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20801,12 +20801,22 @@ const powerRef = useRef(hud.power);
           const assignments = metaState.assignments ?? {};
           const current = metaState.currentPlayer ?? 'A';
           const assigned = assignments[current];
-          if (assigned === 'blue' || assigned === 'yellow') return 'blue';
-          if (assigned === 'red') return 'red';
-          if (assigned === 'black') return 'black';
-          const raw = Array.isArray(frameSnapshot?.ballOn)
-            ? frameSnapshot.ballOn
-            : [];
+          const normalizedAssigned = typeof assigned === 'string'
+            ? assigned.toLowerCase()
+            : null;
+          if (normalizedAssigned) {
+            if (normalizedAssigned.includes('yellow') || normalizedAssigned.includes('blue')) {
+              return 'blue';
+            }
+            if (normalizedAssigned.includes('red')) return 'red';
+            if (normalizedAssigned.includes('black')) return 'black';
+          }
+          const ballOnRaw = frameSnapshot?.ballOn ?? metaState?.ballOn;
+          const raw = Array.isArray(ballOnRaw)
+            ? ballOnRaw
+            : ballOnRaw != null
+              ? [ballOnRaw]
+              : [];
           const normalized = raw
             .map((entry) => (typeof entry === 'string' ? entry.toUpperCase() : ''))
             .filter(Boolean);

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -15438,12 +15438,22 @@ export function PoolRoyaleGame({
           const assignments = metaState.assignments ?? {};
           const current = metaState.currentPlayer ?? 'A';
           const assigned = assignments[current];
-          if (assigned === 'blue' || assigned === 'yellow') return 'blue';
-          if (assigned === 'red') return 'red';
-          if (assigned === 'black') return 'black';
-          const raw = Array.isArray(frameSnapshot?.ballOn)
-            ? frameSnapshot.ballOn
-            : [];
+          const normalizedAssigned = typeof assigned === 'string'
+            ? assigned.toLowerCase()
+            : null;
+          if (normalizedAssigned) {
+            if (normalizedAssigned.includes('yellow') || normalizedAssigned.includes('blue')) {
+              return 'blue';
+            }
+            if (normalizedAssigned.includes('red')) return 'red';
+            if (normalizedAssigned.includes('black')) return 'black';
+          }
+          const ballOnRaw = frameSnapshot?.ballOn ?? metaState?.ballOn;
+          const raw = Array.isArray(ballOnRaw)
+            ? ballOnRaw
+            : ballOnRaw != null
+              ? [ballOnRaw]
+              : [];
           const normalized = raw
             .map((entry) => (typeof entry === 'string' ? entry.toUpperCase() : ''))
             .filter(Boolean);


### PR DESCRIPTION
### Motivation
- The UK AI planner could receive inconsistent `ballOn` assignments (mixed case, missing, or non-array) which caused incorrect shot selection and degraded behaviour after the opening shot. 
- AI sometimes fell back incorrectly when `assignments` or `frameSnapshot.ballOn` were in an unexpected format, producing poor aim directions. 
- The change aims to make the advanced UK AI planning deterministic and robust across both Pool Royale and Snooker Club variants. 

### Description
- Normalize `assignments[current]` with `toLowerCase()` and detect substrings like `yellow`, `blue`, `red`, `black` to accept mixed-case values. 
- Use a unified `ballOnRaw = frameSnapshot?.ballOn ?? metaState?.ballOn` fallback and convert non-array `ballOn` values into a single-element array so the logic handles both array and scalar inputs. 
- Preserve previous uppercase normalization for comparison while returning canonical colour strings (`'blue'|'red'|'black'`) for the AI planner. 
- Applied the same fix in `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/SnookerClubGame.jsx` to keep behavior consistent across variants. 

### Testing
- No automated tests were executed as part of this change. 
- Static checks and runtime integration were not run in CI within this rollout. 
- Recommend running existing unit/integration tests and a short playthrough of UK variant scenarios to verify AI aim consistency. 
- If available, run `npm test` and smoke-play UK variant in the browser to confirm fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613f32fed483298f858f1222b109ad)