### PR TITLE
Pool Royale: smarter AI power/spin & swerve + pocket/finish adjustments

### DIFF
--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -97,6 +97,16 @@ function clearanceMargin (a, b, balls, ignoreIds, radius, multiplier = 1.35) {
   return Math.min(Math.max(ratio, 0), 2)
 }
 
+function clampPower (value, min = 0.35, max = 0.98) {
+  if (!Number.isFinite(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+function clampRange (value, min = -1, max = 1) {
+  if (!Number.isFinite(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
 function scratchRiskAlongLine (cue, aimPoint, pockets, radius) {
   const dir = { x: aimPoint.x - cue.x, y: aimPoint.y - cue.y }
   const len = Math.hypot(dir.x, dir.y) || 1
@@ -142,6 +152,90 @@ function pocketAlignment (pocket, target, width, height) {
   const len = Math.hypot(approach.x, approach.y) || 1
   const normal = pocketNormal(pocket, width, height)
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
+}
+
+function buildPowerCandidates (req, cuePos, target, pocket, nextTargets = []) {
+  const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+  const shotLength = dist(cuePos, target)
+  const pocketLength = dist(target, entry)
+  const tableScale = Math.max(req.state.width, req.state.height) || 1
+  const shotDir = { x: target.x - cuePos.x, y: target.y - cuePos.y }
+  const shotLen = Math.hypot(shotDir.x, shotDir.y) || 1
+  shotDir.x /= shotLen
+  shotDir.y /= shotLen
+  const potDir = { x: entry.x - target.x, y: entry.y - target.y }
+  const potLen = Math.hypot(potDir.x, potDir.y) || 1
+  potDir.x /= potLen
+  potDir.y /= potLen
+  let cutAngle = Math.abs(Math.atan2(potDir.y, potDir.x) - Math.atan2(shotDir.y, shotDir.x))
+  if (cutAngle > Math.PI) cutAngle = Math.abs(cutAngle - Math.PI * 2)
+  const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
+  let base =
+    (shotLength + pocketLength * 0.55) /
+    (tableScale * (1.08 + cutSeverity * 0.22))
+  base = clampPower(base + cutSeverity * 0.06)
+  const candidates = new Set([
+    base,
+    clampPower(base * 0.9),
+    clampPower(base * 1.08)
+  ])
+  if (nextTargets.length > 0) {
+    const next = nextTargets[0]
+    const cueAfter = estimateCueAfterShot(
+      cuePos,
+      target,
+      entry,
+      base,
+      { top: 0, side: 0, back: 0 },
+      req.state
+    )
+    const distToNext = dist(cueAfter, next)
+    const baseline = Math.min(dist(cuePos, next) / tableScale, 1)
+    if (distToNext > baseline * tableScale) {
+      candidates.add(clampPower(base + 0.07))
+    } else {
+      candidates.add(clampPower(base - 0.07))
+    }
+  }
+  return Array.from(candidates).sort((a, b) => a - b)
+}
+
+function buildSpinCandidates (req, cuePos, target, pocket, basePower, nextTargets = []) {
+  const spins = [
+    { top: 0, side: 0, back: 0 },
+    { top: 0.25, side: 0, back: 0 },
+    { top: -0.25, side: 0, back: 0 },
+    { top: 0, side: 0.2, back: 0 },
+    { top: 0, side: -0.2, back: 0 }
+  ]
+  if (nextTargets.length === 0) return spins
+  const next = nextTargets[0]
+  const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+  const cueAfter = estimateCueAfterShot(
+    cuePos,
+    target,
+    entry,
+    basePower,
+    { top: 0, side: 0, back: 0 },
+    req.state
+  )
+  const shotDir = { x: target.x - cuePos.x, y: target.y - cuePos.y }
+  const shotLen = Math.hypot(shotDir.x, shotDir.y) || 1
+  shotDir.x /= shotLen
+  shotDir.y /= shotLen
+  const lateral = { x: -shotDir.y, y: shotDir.x }
+  const toNext = { x: next.x - cueAfter.x, y: next.y - cueAfter.y }
+  const tableScale = Math.max(req.state.width, req.state.height) || 1
+  const sideBias = clampRange(
+    (toNext.x * lateral.x + toNext.y * lateral.y) / (tableScale * 0.45),
+    -0.35,
+    0.35
+  )
+  if (Math.abs(sideBias) > 0.04) {
+    spins.push({ top: 0.15, side: sideBias, back: 0 })
+    spins.push({ top: 0, side: sideBias * 0.85, back: 0.2 })
+  }
+  return spins
 }
 
 function currentGroup (state) {
@@ -287,9 +381,15 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
   const len = Math.hypot(dir.x, dir.y) || 1
 
+  const shotDir = { x: toTarget.x / (Math.hypot(toTarget.x, toTarget.y) || 1), y: toTarget.y / (Math.hypot(toTarget.x, toTarget.y) || 1) }
+  const potDir = { x: toPocket.x / (Math.hypot(toPocket.x, toPocket.y) || 1), y: toPocket.y / (Math.hypot(toPocket.x, toPocket.y) || 1) }
+  const alignment = Math.max(0, shotDir.x * potDir.x + shotDir.y * potDir.y)
+  const tableScale = Math.max(table.width, table.height) || 1
+  const distFactor = Math.min(dist(cue, target) / tableScale, 1)
+  const carryScale = 0.38 + 0.32 * alignment + 0.2 * distFactor
   // Base travel of the cue ball after striking the target – this is the
   // straight path with no spin influence. Power only affects distance.
-  const baseDist = (power * 120) / len
+  const baseDist = power * tableScale * carryScale
   const result = {
     x: target.x + dir.x * baseDist,
     y: target.y + dir.y * baseDist
@@ -301,8 +401,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   result.x += dir.x * baseDist * (distScale - 1)
   result.y += dir.y * baseDist * (distScale - 1)
 
-  const tableScale = Math.max(table.width, table.height) * 0.04
-  const sideOffset = spin.side * power * tableScale
+  const sideScale = Math.max(table.width, table.height) * 0.045
+  const sideOffset = spin.side * power * sideScale
   const perp = { x: -dir.y / len, y: dir.x / len }
   result.x += perp.x * sideOffset
   result.y += perp.y * sideOffset
@@ -587,15 +687,6 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
-  const spins = [
-    { top: 0, side: 0, back: 0 },
-    { top: 0.3, side: 0, back: -0.3 },
-    { top: -0.3, side: 0.3, back: 0 },
-    { top: -0.3, side: -0.3, back: 0 },
-    { top: 0, side: 0.3, back: 0 }
-  ]
-
   // first, gather candidate target/pocket pairs meeting strict criteria
   let candidatePairs = clearShotCandidates(req)
   if (candidatePairs.length === 0) {
@@ -651,14 +742,19 @@ export function planShot (req) {
         const balls = req.state.balls.map(b =>
           b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
+        const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
+        const powers = buildPowerCandidates(req, cuePos, target, pocket, nextTargets)
+        const basePower = powers[Math.floor(powers.length / 2)] ?? 0.65
+        const spins = buildSpinCandidates(req, cuePos, target, pocket, basePower, nextTargets)
+        const baseSpin = spins[0] ?? { top: 0, side: 0, back: 0 }
 
         const baseCand = evaluate(
           req,
           cuePos,
           target,
           pocket,
-          powers[0],
-          spins[0],
+          basePower,
+          baseSpin,
           balls,
           strict,
           { lookaheadDepth: LOOKAHEAD_DEPTH, rng }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1193,20 +1193,21 @@ const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass clean
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
 const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
 const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.16; // raise the net so the weave sits higher on screen
+const POCKET_NET_TOP_LIFT = BALL_R * 0.16; // extend the net upward without moving the bottom
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
 const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.6); // stretch the holder run so it comfortably fits 7 balls
 const POCKET_GUIDE_DROP = BALL_R * 0.12;
-const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
+const POCKET_GUIDE_SPREAD = BALL_R * 0.56;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
 const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
-const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.18; // drop the centre rail slightly lower to form the floor of the holder
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.04; // raise the short L segments closer to the ring
 const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
-const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
+const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.05; // ease spacing so balls sit a touch farther apart on the holders
 const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.78; // keep the ball rest point unchanged while the chrome guides extend
 const POCKET_HOLDER_REST_DROP = BALL_R * 2.18; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
@@ -1218,6 +1219,7 @@ const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section 
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
 const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so it meets the raised holder rails
+const POCKET_STRAP_HEIGHT_SCALE = 1.04; // stretch the leather strap slightly downward
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -1321,6 +1323,7 @@ const RAIL_SPIN_THROW_SCALE = BALL_R * 0.24; // let cushion contacts inherit not
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to keep the cue ball rolling after rebounds
 const SWERVE_THRESHOLD = 0.7; // outer 30% of the spin control activates swerve behaviour
+const SWERVE_CURVE_STRENGTH = 0.55; // add visible pre-impact curve when swerve spin is set
 const SWERVE_TRAVEL_MULTIPLIER = 0.86; // let swerve-driven roll carry more lateral energy while staying believable
 const PRE_IMPACT_SPIN_DRIFT = 0.1; // reapply stored sideways swerve once the cue ball is rolling after impact
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
@@ -1444,7 +1447,7 @@ const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Ma
 const CUE_WOOD_REPEAT_SCALE = 1 / 9; // enlarge cue wood grain 3× so the pattern reads more clearly at table scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
 const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // enlarge grain 3× so rails, skirts, and legs read at table scale; push pattern larger for the new finish pass
-const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
+const FIXED_WOOD_REPEAT_SCALE = 2; // shrink finish patterns 50% so the table grain reads tighter
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
@@ -6804,6 +6807,7 @@ function Table3D(
   });
   const pocketGuideRingRadius = POCKET_BOTTOM_R * POCKET_NET_RING_RADIUS_SCALE;
   const pocketNetProfile = [
+    new THREE.Vector2(pocketGuideRingRadius, POCKET_NET_TOP_LIFT),
     new THREE.Vector2(pocketGuideRingRadius, 0),
     new THREE.Vector2(POCKET_BOTTOM_R * 0.94, -POCKET_NET_DEPTH * 0.16),
     new THREE.Vector2(POCKET_BOTTOM_R * 0.82, -POCKET_NET_DEPTH * 0.45),
@@ -6928,7 +6932,8 @@ function Table3D(
     }
 
     if (strapOrigin && strapEnd) {
-      const strapHeight = Math.max(BALL_DIAMETER * 2.6, pocketStrapLength * 0.72);
+      const strapHeight =
+        Math.max(BALL_DIAMETER * 2.6, pocketStrapLength * 0.72) * POCKET_STRAP_HEIGHT_SCALE;
       const strapGeom = new THREE.BoxGeometry(
         pocketStrapWidth,
         strapHeight,
@@ -22894,6 +22899,9 @@ const powerRef = useRef(hud.power);
                   const alignedSpeed = b.vel.dot(launchDir);
                   TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
                   b.vel.copy(TMP_VEC2_AXIS);
+                  if (isCue && b.spinMode === 'swerve') {
+                    b.vel.addScaledVector(TMP_VEC2_LATERAL, SWERVE_CURVE_STRENGTH);
+                  }
                 } else {
                   b.vel.add(TMP_VEC2_SPIN);
                   if (


### PR DESCRIPTION
### Motivation
- Improve AI shot selection so the bot chooses power and spin to both pot and leave the cue ball in a useful position for the next shot.  
- Add natural swerve/curve behavior when high side-spin (swerve) is used so pre-impact cues visibly curve.  
- Tweak pocket holder geometry, strap height, and net top so potted-ball visuals match reference photos and feel more natural.  
- Reduce visible wood/cloth finish pattern scale so table textures read finer on-screen (50% smaller appearance).  

### Description
- Enhanced planning in `webapp/public/lib/poolAi.js` by adding `clampPower`/`clampRange`, `buildPowerCandidates`, and `buildSpinCandidates`, and using them in `planShot` to produce dynamic power/spin candidates per candidate shot.  
- Refined cue-ball travel estimation in `estimateCueAfterShot` to weight alignment and distance so power choices produce more accurate positional estimates.  
- Added swerve pre-impact curve tuning (`SWERVE_CURVE_STRENGTH`) and applied a lateral velocity injection for swerve-mode cueballs in `webapp/src/pages/Games/PoolRoyale.jsx` to make the cue ball swerve before impact.  
- Adjusted pocket/net/holder parameters in `PoolRoyale.jsx` (net top lift, guide spread, floor/vertical drops, holder spacing, strap height scale) and tightened the table finish repeat scale (`FIXED_WOOD_REPEAT_SCALE`) to produce the requested visual/layout changes.  

### Testing
- Launched the dev site with the Vite dev server for the web app (`npm --prefix webapp run dev`) and the server came up (Vite reported ready).  
- Attempted an automated Playwright capture of the Pool Royale page to verify visuals but the screenshot run timed out and failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696152387b448329afeb4a78cb4753a6)