### PR TITLE
Require hardware-accelerated WebGL for Snooker Club (detect and block software renderers)

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -216,6 +216,22 @@ function classifyRendererTier(rendererString) {
   return 'unknown';
 }
 
+function isSoftwareRenderer(rendererString) {
+  if (typeof rendererString !== 'string' || rendererString.length === 0) {
+    return false;
+  }
+  const signature = rendererString.toLowerCase();
+  return (
+    signature.includes('swiftshader') ||
+    signature.includes('llvmpipe') ||
+    signature.includes('software') ||
+    signature.includes('mesa') ||
+    signature.includes('virtualbox') ||
+    signature.includes('basic render') ||
+    signature.includes('angle (software')
+  );
+}
+
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return 'balanced60';
@@ -10267,6 +10283,17 @@ export function PoolRoyaleGame({
     if (!host) return;
     setErr(null);
     setWebglUnavailable(false);
+    const rendererLabel = readGraphicsRendererString();
+    const softwareRenderer = isSoftwareRenderer(rendererLabel);
+    if (!isWebGLAvailable() || softwareRenderer) {
+      setWebglUnavailable(true);
+      setErr(
+        softwareRenderer
+          ? 'Hardware-accelerated WebGL is disabled. Enable GPU acceleration to play.'
+          : 'WebGL is not available on this device. Enable hardware acceleration to play.'
+      );
+      return;
+    }
     const cueRackDisposers = [];
     let disposed = false;
     try {


### PR DESCRIPTION
### Motivation
- Players reported a black screen when the game ran with a software WebGL backend or when GPU acceleration was disabled, so initialization must fail early with a clear message instead of creating a renderer that won't produce a usable view.
- Provide a deterministic preflight check to avoid entering the heavy renderer setup when the environment uses SwiftShader/llvmpipe/other software renderers.

### Description
- Added an `isSoftwareRenderer` helper that checks the `readGraphicsRendererString()` result for signatures like `swiftshader`, `llvmpipe`, `mesa`, and `angle (software`.
- Added a preflight in the Snooker `useEffect` which calls `readGraphicsRendererString()` and `isWebGLAvailable()` and aborts renderer creation when WebGL is missing or software-rendered.
- When blocked, the code sets `webglUnavailable` and `err` with a clear instruction to enable hardware acceleration instead of showing a black canvas.
- Change is contained in `webapp/src/pages/Games/SnookerClubGame.jsx` and prevents creating `new THREE.WebGLRenderer(...)` in unsupported environments.

### Testing
- No automated tests were run for this change.
- Manual runtime verification is recommended on devices/VMs with software WebGL (e.g., Chrome with SwiftShader) and on hardware-accelerated devices to confirm correct behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f6c5a8b08329b4d174b2ac36e084)