### PR TITLE
Add Pool Royale table finishes to Murlan store and restrict finish UI to default table

### DIFF
--- a/webapp/src/config/murlanTableFinishes.js
+++ b/webapp/src/config/murlanTableFinishes.js
@@ -11,5 +11,57 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
       presetId: 'oak',
       grainId: 'wood_peeling_paint_weathered'
     })
+  }),
+  Object.freeze({
+    id: 'oakVeneer01',
+    label: 'Oak Veneer 01 Finish',
+    description: 'Warm oak veneer rails with smooth satin polish.',
+    price: 990,
+    swatches: ['#b9854e', '#c89a64'],
+    woodOption: Object.freeze({
+      id: 'oakVeneer01',
+      label: 'Oak Veneer 01',
+      presetId: 'oak',
+      grainId: 'oak_veneer_01'
+    })
+  }),
+  Object.freeze({
+    id: 'woodTable001',
+    label: 'Wood Table 001 Finish',
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.',
+    price: 1000,
+    swatches: ['#8f6243', '#a4724f'],
+    woodOption: Object.freeze({
+      id: 'woodTable001',
+      label: 'Wood Table 001',
+      presetId: 'walnut',
+      grainId: 'wood_table_001'
+    })
+  }),
+  Object.freeze({
+    id: 'darkWood',
+    label: 'Dark Wood Finish',
+    description: 'Deep espresso rails with strong grain contrast.',
+    price: 1010,
+    swatches: ['#2f241f', '#3d2f2a'],
+    woodOption: Object.freeze({
+      id: 'darkWood',
+      label: 'Dark Wood',
+      presetId: 'smokedOak',
+      grainId: 'dark_wood'
+    })
+  }),
+  Object.freeze({
+    id: 'rosewoodVeneer01',
+    label: 'Rosewood Veneer 01 Finish',
+    description: 'Rosewood veneer rails with rich, reddish undertones.',
+    price: 1020,
+    swatches: ['#5b2f26', '#6f3a2f'],
+    woodOption: Object.freeze({
+      id: 'rosewoodVeneer01',
+      label: 'Rosewood Veneer 01',
+      presetId: 'cherry',
+      grainId: 'rosewood_veneer_01'
+    })
   })
 ]);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -612,6 +612,7 @@ const DEFAULT_APPEARANCE = {
   tableFinish: DEFAULT_TABLE_FINISH_INDEX,
   environmentHdri: DEFAULT_HDRI_INDEX
 };
+const DEFAULT_TABLE_THEME_ID = 'murlan-default';
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
 const CUSTOMIZATION_SECTIONS = [
@@ -1213,16 +1214,26 @@ export default function MurlanRoyaleArena({ search }) {
     });
     return map;
   }, [seatAnchors]);
+  const isDefaultTableSelected = useMemo(
+    () => (TABLE_THEMES[appearance.tables]?.id ?? DEFAULT_TABLE_THEME_ID) === DEFAULT_TABLE_THEME_ID,
+    [appearance.tables]
+  );
 
   const customizationSections = useMemo(
     () =>
-      CUSTOMIZATION_SECTIONS.map((section) => ({
-        ...section,
-        options: section.options
-          .map((option, idx) => ({ ...option, idx }))
-          .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
-      })).filter((section) => section.options.length > 0),
-    [murlanInventory]
+      CUSTOMIZATION_SECTIONS.map((section) => {
+        const isTableFinish = section.key === 'tableFinish';
+        if (isTableFinish && !isDefaultTableSelected) {
+          return { ...section, options: [] };
+        }
+        return {
+          ...section,
+          options: section.options
+            .map((option, idx) => ({ ...option, idx }))
+            .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
+        };
+      }).filter((section) => section.options.length > 0),
+    [isDefaultTableSelected, murlanInventory]
   );
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Make the Pool Royale wood finishes available in the Murlan Royale store so the default wooden table gains the full set of finishes. 
- Ensure those finishes only apply to the default procedural Murlan table model and not to arbitrary imported PolyHaven table models.

### Description
- Added Pool Royale finish entries (`oakVeneer01`, `woodTable001`, `darkWood`, `rosewoodVeneer01`) to `webapp/src/config/murlanTableFinishes.js` with `price`, `swatches`, and `woodOption` metadata. 
- Added `DEFAULT_TABLE_THEME_ID` and `isDefaultTableSelected` logic in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to detect when the default procedural table is selected. 
- Modified `CUSTOMIZATION_SECTIONS` generation to hide the `tableFinish` options when a non-default table model is active so finishes remain usable only with the default wooden table. 

### Testing
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0` and the server started successfully. 
- Ran an automated Playwright script that navigated to `/games/murlanroyale`, opened the table customization panel, and produced `artifacts/murlan-table-finish.png`, confirming the UI shows finishes (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f7539d30832996d028cd685d888d)