### PR TITLE
Add Pool Royale table finishes to Murlan Royale and conditionally show finish option

### DIFF
--- a/webapp/src/config/murlanTableFinishes.js
+++ b/webapp/src/config/murlanTableFinishes.js
@@ -1,15 +1,69 @@
+import { POOL_ROYALE_OPTION_LABELS } from './poolRoyaleInventoryConfig.js';
+
 export const MURLAN_TABLE_FINISHES = Object.freeze([
   Object.freeze({
     id: 'peelingPaintWeathered',
-    label: 'Wood Peeling Paint Weathered Finish',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.peelingPaintWeathered,
     description: 'Weathered peeling paint wood rails with a reclaimed finish.',
     price: 980,
-    swatches: ['#b8b3aa', '#d6d0c7'],
+    swatches: ['#a89f95', '#b8b3aa'],
     woodOption: Object.freeze({
       id: 'peelingPaintWeathered',
-      label: 'Wood Peeling Paint Weathered',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.peelingPaintWeathered,
       presetId: 'oak',
       grainId: 'wood_peeling_paint_weathered'
+    })
+  }),
+  Object.freeze({
+    id: 'oakVeneer01',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.oakVeneer01,
+    description: 'Warm oak veneer rails with smooth satin polish.',
+    price: 990,
+    swatches: ['#b9854e', '#c89a64'],
+    woodOption: Object.freeze({
+      id: 'oakVeneer01',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.oakVeneer01,
+      presetId: 'oak',
+      grainId: 'oak_veneer_01'
+    })
+  }),
+  Object.freeze({
+    id: 'woodTable001',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.woodTable001,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.',
+    price: 1000,
+    swatches: ['#8f6243', '#a4724f'],
+    woodOption: Object.freeze({
+      id: 'woodTable001',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.woodTable001,
+      presetId: 'walnut',
+      grainId: 'wood_table_001'
+    })
+  }),
+  Object.freeze({
+    id: 'darkWood',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.darkWood,
+    description: 'Deep espresso rails with strong grain contrast.',
+    price: 1010,
+    swatches: ['#2f241f', '#3d2f2a'],
+    woodOption: Object.freeze({
+      id: 'darkWood',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.darkWood,
+      presetId: 'smokedOak',
+      grainId: 'dark_wood'
+    })
+  }),
+  Object.freeze({
+    id: 'rosewoodVeneer01',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.rosewoodVeneer01,
+    description: 'Rosewood veneer rails with rich, reddish undertones.',
+    price: 1020,
+    swatches: ['#5b2f26', '#6f3a2f'],
+    woodOption: Object.freeze({
+      id: 'rosewoodVeneer01',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.rosewoodVeneer01,
+      presetId: 'cherry',
+      grainId: 'rosewood_veneer_01'
     })
   })
 ]);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1214,16 +1214,18 @@ export default function MurlanRoyaleArena({ search }) {
     return map;
   }, [seatAnchors]);
 
-  const customizationSections = useMemo(
-    () =>
-      CUSTOMIZATION_SECTIONS.map((section) => ({
-        ...section,
-        options: section.options
-          .map((option, idx) => ({ ...option, idx }))
-          .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
-      })).filter((section) => section.options.length > 0),
-    [murlanInventory]
-  );
+  const customizationSections = useMemo(() => {
+    const tableTheme = TABLE_THEMES[appearance.tables] ?? TABLE_THEMES[0];
+    const allowTableFinish = tableTheme?.source === 'procedural';
+    return CUSTOMIZATION_SECTIONS.map((section) => ({
+      ...section,
+      options: section.options
+        .map((option, idx) => ({ ...option, idx }))
+        .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
+    }))
+      .filter((section) => section.options.length > 0)
+      .filter((section) => (section.key === 'tableFinish' ? allowTableFinish : true));
+  }, [appearance.tables, murlanInventory]);
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);


### PR DESCRIPTION
### Motivation
- Reuse the Pool Royale wood finish set for the Murlan Royale default wooden table so players get the same finish options across games.
- Ensure table finishes only apply to the procedural (default wooden) Murlan table and not to imported PolyHaven table models.

### Description
- Expanded `MURLAN_TABLE_FINISHES` in `webapp/src/config/murlanTableFinishes.js` to include the Pool Royale finishes and mapped labels via `POOL_ROYALE_OPTION_LABELS` with matching `woodOption` presets and swatches.
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the `customizationSections` `useMemo` checks the selected table theme and hides the `tableFinish` section unless the theme `source === 'procedural'`.
- The finish options remain gated by ownership via `isMurlanOptionUnlocked` and now the customization UI only shows finishes when applicable to the selected table model.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported the app ready at the local URL, which succeeded.
- Ran an automated Playwright script that loaded `/games/murlanroyale`, opened the table customization panel, and captured a screenshot, which completed successfully.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f7539d30832996d028cd685d888d)