### PR TITLE
Guard Telegram storage access to prevent Snooker Club load crashes

### DIFF
--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -1,4 +1,5 @@
 import { fetchTelegramInfo } from "./api.js";
+import { safeGetItem, safeRemoveItem, safeSetItem } from './storage.js';
 
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
@@ -17,7 +18,7 @@ export function getTelegramId() {
     const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
     const telegramId = parseTelegramId(tgId);
     if (telegramId != null) {
-      localStorage.setItem('telegramId', telegramId);
+      safeSetItem('telegramId', telegramId);
       return telegramId;
     }
     const params = new URLSearchParams(window.location.search);
@@ -25,16 +26,16 @@ export function getTelegramId() {
     if (urlId) {
       const parsed = parseTelegramId(urlId);
       if (parsed != null) {
-        localStorage.setItem('telegramId', parsed);
+        safeSetItem('telegramId', parsed);
         return parsed;
       }
-      localStorage.removeItem('telegramId');
+      safeRemoveItem('telegramId');
     }
-    const stored = localStorage.getItem('telegramId');
+    const stored = safeGetItem('telegramId');
     if (stored) {
       const parsed = parseTelegramId(stored);
       if (parsed != null) return parsed;
-      localStorage.removeItem('telegramId');
+      safeRemoveItem('telegramId');
     }
   }
   return null;
@@ -52,10 +53,10 @@ function generateAccountId() {
 
 export function getPlayerId() {
   if (typeof window === 'undefined') return null;
-  let id = localStorage.getItem('accountId');
+  let id = safeGetItem('accountId');
   if (!id) {
     id = generateAccountId();
-    if (id) localStorage.setItem('accountId', id);
+    if (id) safeSetItem('accountId', id);
   }
   return id;
 }
@@ -69,7 +70,7 @@ export function getTelegramUsername() {
   if (typeof window !== 'undefined') {
     const name = window?.Telegram?.WebApp?.initDataUnsafe?.user?.username;
     if (name) return name;
-    const stored = localStorage.getItem('telegramUsername');
+    const stored = safeGetItem('telegramUsername');
     if (stored) return stored;
   }
   return '';
@@ -79,7 +80,7 @@ export function getTelegramFirstName() {
   if (typeof window !== 'undefined') {
     const first = window?.Telegram?.WebApp?.initDataUnsafe?.user?.first_name;
     if (first) return first;
-    const stored = localStorage.getItem('telegramFirstName');
+    const stored = safeGetItem('telegramFirstName');
     if (stored) return stored;
   }
   return '';
@@ -89,7 +90,7 @@ export function getTelegramLastName() {
   if (typeof window !== 'undefined') {
     const last = window?.Telegram?.WebApp?.initDataUnsafe?.user?.last_name;
     if (last) return last;
-    const stored = localStorage.getItem('telegramLastName');
+    const stored = safeGetItem('telegramLastName');
     if (stored) return stored;
   }
   return '';
@@ -99,7 +100,7 @@ export function getTelegramUserData() {
   if (typeof window !== 'undefined') {
     const user = window?.Telegram?.WebApp?.initDataUnsafe?.user;
     if (user) return user;
-    const stored = localStorage.getItem('telegramUserData');
+    const stored = safeGetItem('telegramUserData');
     if (stored) {
       try {
         return JSON.parse(stored);
@@ -115,17 +116,17 @@ export function getTelegramPhotoUrl() {
   if (typeof window !== 'undefined') {
     const photo = window?.Telegram?.WebApp?.initDataUnsafe?.user?.photo_url;
     if (photo) {
-      localStorage.setItem('telegramPhotoUrl', photo);
+      safeSetItem('telegramPhotoUrl', photo);
       return photo;
     }
-    const stored = localStorage.getItem('telegramPhotoUrl');
+    const stored = safeGetItem('telegramPhotoUrl');
     if (stored) return stored;
     const id = getTelegramId();
     if (id) {
       fetchTelegramInfo(id)
         .then((info) => {
           if (info?.photoUrl) {
-            localStorage.setItem('telegramPhotoUrl', info.photoUrl);
+            safeSetItem('telegramPhotoUrl', info.photoUrl);
             window.dispatchEvent(new Event('profilePhotoUpdated'));
           }
         })
@@ -153,7 +154,7 @@ export function clearTelegramCache() {
       'telegramLastName',
       'telegramUserData',
       'telegramPhotoUrl'
-    ].forEach((key) => localStorage.removeItem(key));
+    ].forEach((key) => safeRemoveItem(key));
   } catch {
     // ignore
   }


### PR DESCRIPTION
### Motivation
- The Snooker Club game could crash on startup when `localStorage` was unavailable, causing the game to fail to load.
- Telegram identity and cached profile reads/writes are performed during game initialization and must not throw when storage is disabled in some WebView contexts.
- Guarding storage access ensures the game can start reliably in environments with restricted or failing storage.

### Description
- Replaced direct `localStorage` usage in `webapp/src/utils/telegram.js` with the safe helpers `safeGetItem`, `safeSetItem`, and `safeRemoveItem` imported from `webapp/src/utils/storage.js`.
- Updated `getTelegramId`, `getPlayerId`, `getTelegramUsername`, `getTelegramFirstName`, `getTelegramLastName`, `getTelegramUserData`, `getTelegramPhotoUrl`, and `clearTelegramCache` to use the safe APIs.
- This change prevents exceptions when reading or writing cached Telegram/player data during Snooker Club initialization.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69620306ebf48329b580f2d2010e8f43)