### PR TITLE
Remove unwanted Murlan Royale table themes

### DIFF
--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -47,10 +47,7 @@ const POLYHAVEN_CHAIR_THEMES = [
 
 const POLYHAVEN_TABLE_THEMES = [
   { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
-  { id: 'WoodenTable_01', label: 'Wooden Table 01' },
   { id: 'WoodenTable_02', label: 'Wooden Table 02' },
-  { id: 'WoodenTable_03', label: 'Wooden Table 03' },
-  { id: 'chinese_console_table', label: 'Chinese Console Table' },
   { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
   { id: 'coffee_table_round_01', label: 'Coffee Table Round 01' },
   { id: 'gallinera_table', label: 'Gallinera Table' },
@@ -59,14 +56,12 @@ const POLYHAVEN_TABLE_THEMES = [
   { id: 'modern_coffee_table_01', label: 'Modern Coffee Table 01' },
   { id: 'modern_coffee_table_02', label: 'Modern Coffee Table 02' },
   { id: 'outdoor_table_chair_set_01', label: 'Outdoor Table Chair Set 01' },
-  { id: 'painted_wooden_table', label: 'Painted Wooden Table' },
   { id: 'round_wooden_table_01', label: 'Round Wooden Table 01' },
   { id: 'round_wooden_table_02', label: 'Round Wooden Table 02' },
   { id: 'side_table_01', label: 'Side Table 01' },
   { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
   { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' },
-  { id: 'wooden_picnic_table', label: 'Wooden Picnic Table' },
-  { id: 'wooden_table_02', label: 'Wooden Table 02 (Alt)' }
+  { id: 'wooden_picnic_table', label: 'Wooden Picnic Table' }
 ].map((option, index) => ({
   ...option,
   assetId: option.id,
@@ -83,7 +78,7 @@ export const MURLAN_TABLE_THEMES = [
     label: 'Murlan Default Table',
     source: 'procedural',
     price: 0,
-    thumbnail: POLYHAVEN_THUMB('WoodenTable_01'),
+    thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
     description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
   },
   ...POLYHAVEN_TABLE_THEMES


### PR DESCRIPTION
### Motivation

- Remove several table assets from the Murlan Royale selection to match the requested asset removals (Wooden Table 01, Wooden Table 03, Chinese Console Table, Painted Wooden Table, Wooden Table 02 Alt). 
- Prevent references to removed thumbnails by switching the default table preview to an existing Poly Haven asset. 
- Keep the themes list consistent and avoid exposing deprecated/removed table options in the UI.

### Description

- Deleted the entries for `WoodenTable_01`, `WoodenTable_03`, `chinese_console_table`, `painted_wooden_table`, and `wooden_table_02` from the `POLYHAVEN_TABLE_THEMES` array in `webapp/src/config/murlanThemes.js`.
- Adjusted the `MURLAN_TABLE_THEMES` default `thumbnail` from `POLYHAVEN_THUMB('WoodenTable_01')` to `POLYHAVEN_THUMB('CoffeeTable_01')` to point at a remaining asset.
- Kept `wooden_picnic_table` and other remaining table themes intact and preserved existing mapping logic for `POLYHAVEN_TABLE_THEMES`.
- Modified file: `webapp/src/config/murlanThemes.js`.

### Testing

- No automated tests were run for this change.
- No CI/build verification was executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962089fc1e08329acc5889b43c8ce0d)