### PR TITLE
Guard Snooker Club polygon clipping to prevent startup crash

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -52,6 +52,29 @@ import {
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { safeGetItem, safeSetItem } from '../../utils/storage.js';
 
+function safePolygonUnion(...parts) {
+  const valid = parts.filter(Boolean);
+  if (!valid.length) return [];
+  try {
+    return polygonClipping.union(...valid);
+  } catch (err) {
+    console.error('Snooker Club polygon union failed', err);
+    return valid[0];
+  }
+}
+
+function safePolygonDifference(subject, ...clips) {
+  const validSubject = subject || [];
+  const validClips = clips.filter(Boolean);
+  if (!validSubject?.length || !validClips.length) return validSubject;
+  try {
+    return polygonClipping.difference(validSubject, ...validClips);
+  } catch (err) {
+    console.error('Snooker Club polygon difference failed', err);
+    return validSubject;
+  }
+}
+
 function applyTablePhysicsSpec(meta) {
   const cushionAngle = Number.isFinite(meta?.cushionCutAngleDeg)
     ? meta.cushionCutAngleDeg
@@ -635,7 +658,7 @@ function buildChromePlateGeometry({
           baseRing.push([baseRing[0][0], baseRing[0][1]]);
         }
         const baseMP = [[baseRing]];
-        const clipped = polygonClipping.difference(baseMP, notchMP);
+        const clipped = safePolygonDifference(baseMP, notchMP);
         const clippedShapes = multiPolygonToShapes(clipped);
         if (clippedShapes.length) {
           shapesToExtrude = clippedShapes;
@@ -6136,7 +6159,7 @@ function Table3D(
 
     let shapeMP = baseMP;
     if (pocketSectors.length) {
-      shapeMP = polygonClipping.difference(baseMP, ...pocketSectors);
+      shapeMP = safePolygonDifference(baseMP, ...pocketSectors);
     }
     const shapes = multiPolygonToShapes(shapeMP);
     if (shapes.length === 1) {
@@ -6718,7 +6741,7 @@ function Table3D(
         ]
       ]);
     }
-    const union = polygonClipping.union(...unionParts);
+    const union = safePolygonUnion(...unionParts);
     const adjusted = adjustCornerNotchDepth(union, cz, sz);
     if (CHROME_CORNER_NOTCH_EXPANSION_SCALE === 1) {
       return adjusted;
@@ -6752,7 +6775,7 @@ function Table3D(
       throatRadius,
       192
     );
-    const union = polygonClipping.union(circle, throat);
+    const union = safePolygonUnion(circle, throat);
     return adjustSideNotchDepth(union);
   };
 
@@ -7402,12 +7425,12 @@ function Table3D(
   }
 
   // Rail openings simply reuse the chrome plate cuts; wood never dictates alternate pocket sizing.
-  let openingMP = polygonClipping.union(
+  let openingMP = safePolygonUnion(
     rectPoly(innerHalfW * 2, innerHalfH * 2),
     ...scaleWoodRailSidePocketCut(sideNotchMP(-1), -1),
     ...scaleWoodRailSidePocketCut(sideNotchMP(1), 1)
   );
-  openingMP = polygonClipping.union(
+  openingMP = safePolygonUnion(
     openingMP,
     ...translatePocketCutMP(
       scaleWoodRailCornerPocketCut(cornerNotchMP(1, 1)),


### PR DESCRIPTION
### Motivation

- The Snooker Club game could crash while generating table geometry due to uncaught errors from `polygon-clipping` operations during rail/pocket/notch construction. 
- Crashes during startup prevent players from loading the game, so the geometry pipeline must fail safely. 

### Description

- Add `safePolygonUnion` and `safePolygonDifference` helpers that wrap `polygonClipping.union` and `polygonClipping.difference` with try/catch and error logging. 
- Replace direct calls to `polygonClipping.union` / `polygonClipping.difference` in `webapp/src/pages/Games/SnookerClubGame.jsx` with the new `safe*` helpers for rail, pocket and notch construction. 
- Helpers return a safe fallback (original input or first valid part) when clipping fails so geometry generation continues instead of throwing. 

### Testing

- No automated tests were run for this change. 
- The change was limited to `webapp/src/pages/Games/SnookerClubGame.jsx` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69620306ebf48329b580f2d2010e8f43)