### PR TITLE
Handle snooker inventory storage failures gracefully

### DIFF
--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -15,8 +15,12 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    const stored = window.localStorage.getItem('accountId');
-    if (stored) return stored;
+    try {
+      const stored = window.localStorage.getItem('accountId');
+      if (stored) return stored;
+    } catch (err) {
+      console.warn('Failed to access local storage for account id', err);
+    }
   }
   return 'guest';
 };
@@ -34,7 +38,11 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.warn('Failed to write snooker inventory, skipping persist', err);
+  }
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes during Snooker Club game load caused by exceptions when accessing `localStorage` on restricted environments.
- Make inventory lookup and persistence resilient so the game can fall back to a `guest` inventory when storage is unavailable.

### Description
- Wrapped `localStorage.getItem('accountId')` inside a `try/catch` in `resolveAccountId` to guard against access errors and log a warning on failure.
- Wrapped `localStorage.setItem(STORAGE_KEY, ...)` inside a `try/catch` in `writeAllInventories` to skip persistence when writes fail and log a warning.
- Ensured `getSnookerClubInventory` continues to return a normalized inventory and falls back to `'guest'` when storage is inaccessible.
- Changes are confined to `webapp/src/utils/snookerClubInventory.js` and do not alter inventory semantics.

### Testing
- No automated tests were run for this change.
- Existing functionality should continue to work in environments where `localStorage` is available and will now gracefully degrade where it is not.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69620306ebf48329b580f2d2010e8f43)