### PR TITLE
Enhance cue ball swerve, spin and jump physics

### DIFF
--- a/billiards/AimPreview.cs
+++ b/billiards/AimPreview.cs
@@ -17,20 +17,41 @@ public static class AimPreview
     public static Result Build(BilliardsSolver solver, Vec2 cueStart, Vec2 dir, double speed, List<BilliardsSolver.Ball> others)
     {
         var preview = solver.PreviewShot(cueStart, dir, speed, others);
-        var impact = solver.SimulateFirstImpact(cueStart, dir, speed, others);
 
-        List<Vec2> path = new List<Vec2> { cueStart, impact.Point };
-        if (impact.CueVelocity.Length > PhysicsConstants.Epsilon)
+        List<Vec2> path = preview.Path.Count > 0 ? preview.Path : new List<Vec2> { cueStart };
+        if (preview.CuePostVelocity.Length > PhysicsConstants.Epsilon)
         {
-            path.Add(impact.Point + impact.CueVelocity.Normalized() * PhysicsConstants.BallRadius);
+            var endPoint = preview.ContactPoint;
+            path.Add(endPoint + preview.CuePostVelocity.Normalized() * PhysicsConstants.BallRadius);
         }
 
         return new Result
         {
             Path = path.ToArray(),
-            ContactPoint = impact.Point,
-            CuePostVelocity = impact.CueVelocity,
-            TargetPostVelocity = impact.TargetVelocity ?? preview.TargetPostVelocity
+            ContactPoint = preview.ContactPoint,
+            CuePostVelocity = preview.CuePostVelocity,
+            TargetPostVelocity = preview.TargetPostVelocity
+        };
+    }
+
+    /// <summary>Preview with explicit spin and cue elevation inputs.</summary>
+    public static Result Build(BilliardsSolver solver, Vec2 cueStart, BilliardsSolver.ShotParams shot, List<BilliardsSolver.Ball> others)
+    {
+        var preview = solver.PreviewShot(shot, cueStart, others);
+
+        List<Vec2> path = preview.Path.Count > 0 ? preview.Path : new List<Vec2> { cueStart };
+        if (preview.CuePostVelocity.Length > PhysicsConstants.Epsilon)
+        {
+            var endPoint = preview.ContactPoint;
+            path.Add(endPoint + preview.CuePostVelocity.Normalized() * PhysicsConstants.BallRadius);
+        }
+
+        return new Result
+        {
+            Path = path.ToArray(),
+            ContactPoint = preview.ContactPoint,
+            CuePostVelocity = preview.CuePostVelocity,
+            TargetPostVelocity = preview.TargetPostVelocity
         };
     }
 }

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -11,6 +11,18 @@ public static class PhysicsConstants
     // pocket edges fully absorb balls (no bounce)
     public const double PocketRestitution = 0.0;
     public const double Mu = 0.2;                      // linear damping (m/s^2)
+    public const double Gravity = 9.81;                // m/s^2
+    public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
+    public const double SpinDecay = 2.0;               // per-second decay for on-table spin
+    public const double AirSpinDecay = 0.6;            // per-second decay while airborne
+    public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
+    public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
+    public const double JumpRestitution = 0.1;         // vertical energy retained on landing
+    public const double JumpStopVelocity = 0.2;        // m/s below which vertical motion stops
+    public const double AirborneHeightThreshold = BallRadius * 0.25; // height before ignoring cushions/balls
+    public const double MaxCueElevationDegrees = 70.0; // WPA jump cue elevations top out near this range
+    public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
+    public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
     public const double TableHeight = 1.3135;
     public const double FixedDt = 1.0 / 120.0;         // simulation step


### PR DESCRIPTION
### Motivation

- Improve realism of cue-ball behavior by modeling side/top/back spin, swerve, and airborne (jump) motion so aim previews match simulated paths.  
- Provide tunable physics parameters to allow calibration to WPA-style rules and to balance stability vs realism.  
- Generate curved aiming previews that reflect spin-induced lateral motion and post-impact cue direction.  
- Keep solver deterministic and modular so the new mechanics can be used from both native and preview code paths.

### Description

- Added new tuning values to `billiards/PhysicsConstants.cs` such as `Gravity`, `AirDrag`, `SpinDecay`, `SwerveCoefficient`, `RollAcceleration`, jump-related constants, and preview spacing.  
- Extended `billiards/BilliardsSolver.cs` to track per-ball `SideSpin`, `ForwardSpin`, `Height`, and `VerticalVelocity`, and added `ShotSpin` / `ShotParams` types and a `ClampSpin` helper for safe tip offsets.  
- Implemented spin + swerve forces (`ApplySpinForces`), vertical integration (`StepVertical`), airborne drag handling, and linear drag switching so on-table and in-air behaviour differ, and updated collision/step logic to respect airborne threshold.  
- Reworked preview and impact APIs: new `PreviewShot(ShotParams...)` and `SimulateFirstImpact(ShotParams...)` paths, a CCD `TryFindImpact` helper, curved sampling (`AppendPathPoint`) for aim lines, and `AimPreview` overloads to consume the spin/elevation-aware preview.

### Testing

- No automated tests were executed for this change.  
- No unit or integration test runs were performed as part of this rollout.  
- Compiling and runtime validation are recommended (run the existing test suite and smoke the billiards demo).  
- Manual playtesting should be performed to tune the new `PhysicsConstants` values and confirm aim preview vs simulation alignment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621768b0108329a1dd38a3965b5bf7)