### PR TITLE
Fix Snooker Club WebGL renderer fallback

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -10275,11 +10275,34 @@ export function PoolRoyaleGame({
     const cueRackDisposers = [];
     let disposed = false;
     try {
-      const renderer = new THREE.WebGLRenderer({
+      const rendererOptions = {
         antialias: true,
         alpha: false,
         powerPreference: 'high-performance'
-      });
+      };
+      let renderer;
+      try {
+        renderer = new THREE.WebGLRenderer(rendererOptions);
+      } catch (err) {
+        const fallbackCanvas = document.createElement('canvas');
+        const fallbackContext =
+          fallbackCanvas.getContext('webgl', {
+            antialias: rendererOptions.antialias,
+            powerPreference: rendererOptions.powerPreference
+          }) ||
+          fallbackCanvas.getContext('experimental-webgl', {
+            antialias: rendererOptions.antialias,
+            powerPreference: rendererOptions.powerPreference
+          });
+        if (!fallbackContext) {
+          throw err;
+        }
+        renderer = new THREE.WebGLRenderer({
+          ...rendererOptions,
+          canvas: fallbackCanvas,
+          context: fallbackContext
+        });
+      }
       const updatePocketCameraState = (active) => {
         if (pocketCameraStateRef.current === active) return;
         pocketCameraStateRef.current = active;


### PR DESCRIPTION
### Motivation
- The Snooker Club page could show a black screen when `THREE.WebGLRenderer` construction fails (e.g. WebGL2 unavailable), so the renderer needs a robust fallback to WebGL1 without changing the rendering configuration. 
- Preserve the existing renderer options (`antialias`, `alpha`, `powerPreference`) and error messaging/UI when hardware acceleration or WebGL is unavailable.

### Description
- Wrap `THREE.WebGLRenderer` construction in a `try/catch` and fall back to creating a dedicated `<canvas>` and obtaining a WebGL1 context if the direct constructor throws.  
- When falling back, pass the created `canvas` and `context` into the `WebGLRenderer` options to keep behavior consistent.  
- Change is implemented in `webapp/src/pages/Games/SnookerClubGame.jsx` and preserves the existing renderer configuration and context-lost/restored handling.

### Testing
- No automated tests were executed as part of this change.  
- Manual checks are recommended to verify the Snooker Club page now initializes on devices/browsers that fail `THREE.WebGLRenderer` creation and that the existing WebGL availability UI (`isWebGLAvailable`) still appears when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696217dcc4fc8329b47bf6cef20b8381)