### PR TITLE
Attempt WebGL renderer init before marking Snooker Club unavailable

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -10267,11 +10267,6 @@ export function PoolRoyaleGame({
     if (!host) return;
     setErr(null);
     setWebglUnavailable(false);
-    if (!isWebGLAvailable()) {
-      setWebglUnavailable(true);
-      setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
-      return;
-    }
     const cueRackDisposers = [];
     let disposed = false;
     try {


### PR DESCRIPTION
### Motivation
- The Snooker Club page could show a black/blocked UI because initialization was short-circuited when `isWebGLAvailable()` returned false, preventing the renderer from attempting fallback handling. 
- Allow the renderer to try to initialize so existing `try/catch` and context-loss handlers can surface a clearer error or recover gracefully. 

### Description
- Removed the early WebGL availability short‑circuit that returned before renderer creation in `webapp/src/pages/Games/SnookerClubGame.jsx`. 
- The renderer is now constructed and the existing fallback/error handling (context lost/restored handlers and `try/catch` path that sets `err`/`webglUnavailable`) will handle failures. 
- Kept the `webglUnavailable` state and the user-facing messages intact so the UI still informs the user when WebGL cannot be used. 

### Testing
- No automated tests were executed for this change. 
- The change is limited to initialization flow in `webapp/src/pages/Games/SnookerClubGame.jsx` and relies on existing runtime error handlers to report WebGL faults.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696217dcc4fc8329b47bf6cef20b8381)