### PR TITLE
Align cue-ball swerve to aim preview, simplify spin UI, add cue-ball red dots

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -133,6 +133,26 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     ctx.fillRect(0, stripeY, size, stripeHeight);
   }
 
+  if (pattern === 'cue') {
+    const tipRadiusRatio = 0.1714;
+    const dotRadius = (size * 0.5) * tipRadiusRatio;
+    const edgeMargin = dotRadius + size * 0.02;
+    const mid = size * 0.5;
+    ctx.fillStyle = '#d71b1b';
+    const drawDot = (x, y) => {
+      ctx.beginPath();
+      ctx.arc(x, y, dotRadius, 0, Math.PI * 2);
+      ctx.fill();
+    };
+    drawDot(mid, edgeMargin); // top
+    drawDot(mid, size - edgeMargin); // bottom
+    drawDot(mid, mid); // front
+    drawDot(size * 0.25, mid); // left
+    drawDot(size * 0.75, mid); // right
+    drawDot(0, mid); // back seam (left edge)
+    drawDot(size, mid); // back seam (right edge)
+  }
+
   if (Number.isFinite(number)) {
     drawPoolNumberBadge(ctx, size, number);
   }


### PR DESCRIPTION
### Motivation

- Make the actual cue-ball pre-impact swerve match the visual aiming guide so shots that show a curved aim line produce the same swerve in physics.  
- Remove distracting markings from the spin controller and keep only the red spin dot for a simpler, clearer control.  
- Add six red reference dots on cue balls (top, bottom, front, back, left, right) matching the blue tip radius so players can see spin orientation.  

### Description

- Implemented a new `applySwerveSteering` helper that applies pre-impact lateral steering to balls based on stored shot spin/power/lift to better match `buildSwerveAimLinePoints` preview behavior.  
- Stored shot swerve inputs on balls (`swerveSpin`, `swervePower`, `swerveLift`) at shot time and reset them when spin decays or the ball stops.  
- Replaced the spin controller decoration by removing the ring/gradient elements and leaving only the red `spinDot` element in the UI (`spinBox`/`spinDot`).  
- Added rendering for six filled red dots to the cue-ball texture in `drawPoolBallTexture` when `pattern === 'cue'`, sized relative to the cue tip radius to match the requested visual.  

### Testing

- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (local server started successfully).  
- Attempted an automated Playwright screenshot to validate visuals but the Chromium process crashed in this environment so the capture failed.  
- No unit or integration test suite (e.g. `npm test`) was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621f8d3f8c8329b81847ef1543bf2b)