### PR TITLE
Align cue swerve with aim guide, add cue-ball red dots, simplify spin controller

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -7,6 +7,7 @@ import { applySRGBColorSpace } from './colorSpace.js';
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
+const CUE_TIP_RADIUS_RATIO = 0.1714285714;
 
 function clamp01(value) {
   return Math.min(1, Math.max(0, value));
@@ -120,6 +121,38 @@ function drawPoolNumberBadge(ctx, size, number) {
   ctx.restore();
 }
 
+function drawCueBallDots(ctx, size) {
+  const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
+  const poleInset = dotRadius * 1.25;
+  const dotPositions = [
+    { u: 0.5, v: 0.5 }, // front
+    { u: 0.25, v: 0.5 }, // left
+    { u: 0.75, v: 0.5 }, // right
+    { u: 0.5, v: poleInset / size }, // top
+    { u: 0.5, v: 1 - poleInset / size } // bottom
+  ];
+
+  ctx.save();
+  ctx.fillStyle = '#dc2626';
+  dotPositions.forEach(({ u, v }) => {
+    ctx.beginPath();
+    ctx.arc(u * size, v * size, dotRadius, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.fill();
+  });
+
+  // Back dot spans the seam to keep a full circle.
+  ctx.beginPath();
+  ctx.arc(0, size * 0.5, dotRadius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(size, size * 0.5, dotRadius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
 function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
   const baseHex = toHexString(baseColor);
 
@@ -131,6 +164,10 @@ function drawPoolBallTexture(ctx, size, baseColor, pattern, number) {
     const stripeHeight = size * 0.45;
     const stripeY = (size - stripeHeight) / 2;
     ctx.fillRect(0, stripeY, size, stripeHeight);
+  }
+
+  if (pattern === 'cue') {
+    drawCueBallDots(ctx, size);
   }
 
   if (Number.isFinite(number)) {


### PR DESCRIPTION
### Motivation
- Match the cue-ball motion to the on-screen aiming line by making swerve depend on shot power so the visual guide and physics line up.  
- Remove the extra markings in the 2D spin controller UI and keep only the red dot to simplify the control visuals.  
- Add six filled red dots to the cue ball (top, bottom, front, back, left, right) sized to the cue tip radius so players can see spin orientation on the sphere.  

### Description
- Added `CUE_TIP_RADIUS_RATIO` and a new `drawCueBallDots` routine and call path in `webapp/src/utils/ballMaterialFactory.js` so cue-ball textures render six filled red markers when `pattern === 'cue'`.  
- Simplified the spin controller UI in `webapp/src/pages/Games/PoolRoyale.jsx` by removing the radial threshold ring and spin-ring elements, leaving only the `#spinDot` red indicator.  
- Introduced a `swervePowerStrength` field on ball objects and the cue and set `cue.swervePowerStrength = clampedPower` when firing, then scaled existing swerve calculations by this power (`swervePowerScale`) so pre-impact swerve matches the aim preview.  
- Reset `swervePowerStrength` alongside other spin/swerve state on impacts, stops, pocket captures, replays and in-hand placement to keep behavior deterministic.  

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and the Vite dev server came up successfully.  
- Attempted an automated Playwright screenshot of `/games/poolroyale` at mobile portrait size but the script timed out (screenshot run failed).  
- No unit test suite (`jest`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621f8d3f8c8329b81847ef1543bf2b)