### PR TITLE
Add HDRI fallback for Snooker Club rendering

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -3846,14 +3846,47 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   }
 }
 
+async function createFallbackHdriEnvironment(renderer) {
+  if (!renderer) return null;
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  pmrem.compileEquirectangularShader();
+  const hemi = new THREE.HemisphereLight(0x94a3b8, 0x0f172a, 1.05);
+  const floor = new THREE.Mesh(
+    new THREE.CircleGeometry(6, 24),
+    new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.78, metalness: 0.05 })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  const tempScene = new THREE.Scene();
+  tempScene.add(hemi);
+  tempScene.add(floor);
+  const { texture } = pmrem.fromScene(tempScene);
+  texture.name = 'snooker-club-fallback-env';
+  pmrem.dispose();
+  floor.geometry.dispose();
+  floor.material.dispose();
+  return { envMap: texture, skyboxMap: null, url: null };
+}
+
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
   const url = await resolvePolyHavenHdriUrl(config);
+  const resolveFallback = async () => {
+    try {
+      return await createFallbackHdriEnvironment(renderer);
+    } catch (error) {
+      console.warn('Failed to build fallback HDRI environment', error);
+      return null;
+    }
+  };
   const lowerUrl = `${url ?? ''}`.toLowerCase();
   const useExr = lowerUrl.endsWith('.exr');
   const loader = useExr ? new EXRLoader() : new RGBELoader();
   loader.setCrossOrigin?.('anonymous');
   return new Promise((resolve) => {
+    if (!url) {
+      resolveFallback().then(resolve);
+      return;
+    }
     loader.load(
       url,
       (texture) => {
@@ -3871,7 +3904,7 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
       undefined,
       (error) => {
         console.warn('Failed to load Poly Haven HDRI', error);
-        resolve(null);
+        resolveFallback().then(resolve);
       }
     );
   });


### PR DESCRIPTION
### Motivation
- Prevent the Snooker Club 3D view from going black when Poly Haven HDRI resolution or network loads fail. 
- Match the robustness of the Pool Royale renderer by providing an internal HDRI fallback so environment lighting is always available. 
- Reduce dependency on remote HDRI assets for initial scene lighting on devices with flaky network or unsupported formats. 
- Keep table lighting and reflections consistent even if the configured HDRI cannot be resolved or loaded.

### Description
- Added `createFallbackHdriEnvironment(renderer)` to `webapp/src/pages/Games/SnookerClubGame.jsx`, which builds a small PMREM-based environment (hemisphere light + floor) and returns an `envMap` texture named `snooker-club-fallback-env`.
- Updated `loadPolyHavenHdriEnvironment(renderer, config)` to use the fallback when `resolvePolyHavenHdriUrl` returns no URL or when the HDRI `loader.load` call errors, by calling the new `createFallbackHdriEnvironment` and resolving with its result.
- Preserves existing behavior when a valid HDRI is available while ensuring a fallback `envMap` is provided on failure to avoid an empty or black scene.
- Changes are isolated to `webapp/src/pages/Games/SnookerClubGame.jsx` and do not alter the public API surface.

### Testing
- No automated tests were run for this change.
- (Manual/functional verification not listed here because only automated test results should be reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696224732e9083299e2090327e09ca23)