### PR TITLE
Fix cue ball dot rendering so red dots are circular and match cue tip size

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -132,24 +132,24 @@ function drawCueBallDots(ctx, size) {
     { u: 0.5, v: 1 - poleInset / size } // bottom
   ];
 
-  ctx.save();
-  ctx.fillStyle = '#dc2626';
-  dotPositions.forEach(({ u, v }) => {
+  const drawCompensatedDot = ({ u, v }) => {
+    const latitude = (0.5 - v) * Math.PI;
+    const cosLat = Math.max(0.35, Math.cos(latitude));
+    const stretchX = dotRadius / cosLat;
+
     ctx.beginPath();
-    ctx.arc(u * size, v * size, dotRadius, 0, Math.PI * 2);
+    ctx.ellipse(u * size, v * size, stretchX, dotRadius, 0, 0, Math.PI * 2);
     ctx.closePath();
     ctx.fill();
-  });
+  };
+
+  ctx.save();
+  ctx.fillStyle = '#dc2626';
+  dotPositions.forEach(drawCompensatedDot);
 
   // Back dot spans the seam to keep a full circle.
-  ctx.beginPath();
-  ctx.arc(0, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
-  ctx.beginPath();
-  ctx.arc(size, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
+  drawCompensatedDot({ u: 0, v: 0.5 });
+  drawCompensatedDot({ u: 1, v: 0.5 });
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Dots on the cue ball were appearing stretched/egg-shaped due to latitude compression on the spherical texture.
- The dots must render as circles with a diameter matching the cue tip (`CUE_TIP_RADIUS_RATIO`) for visual consistency.
- Seam dots must remain visually complete across the texture seam.

### Description
- Added a helper `drawCompensatedDot` that computes a `latitude` and uses `cos(latitude)` to derive an `stretchX` factor to offset texture latitude distortion.
- Replaced per-dot `ctx.arc` calls with `ctx.ellipse(u*size, v*size, stretchX, dotRadius, 0, 0, Math.PI*2)` so dots appear circular on the mapped sphere.
- Clamped the cosine factor with `Math.max(0.35, Math.cos(latitude))` to avoid extreme horizontal stretching at poles.
- Applied the compensation to the seam/back dots so the dot spanning the texture edges remains a full circle.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962268242f083298698389076dc1228)