### PR TITLE
Fix cue ball dot distortion on textures

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,7 +123,7 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 1.25;
+  const poleInset = dotRadius * 1.6;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left
@@ -132,24 +132,23 @@ function drawCueBallDots(ctx, size) {
     { u: 0.5, v: 1 - poleInset / size } // bottom
   ];
 
-  ctx.save();
-  ctx.fillStyle = '#dc2626';
-  dotPositions.forEach(({ u, v }) => {
+  const drawDot = ({ u, v }) => {
+    const latitude = (0.5 - v) * Math.PI;
+    const cosLatitude = Math.cos(latitude);
+    const correctedRadiusX = dotRadius / Math.max(0.6, cosLatitude);
     ctx.beginPath();
-    ctx.arc(u * size, v * size, dotRadius, 0, Math.PI * 2);
+    ctx.ellipse(u * size, v * size, correctedRadiusX, dotRadius, 0, 0, Math.PI * 2);
     ctx.closePath();
     ctx.fill();
-  });
+  };
+
+  ctx.save();
+  ctx.fillStyle = '#dc2626';
+  dotPositions.forEach(drawDot);
 
   // Back dot spans the seam to keep a full circle.
-  ctx.beginPath();
-  ctx.arc(0, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
-  ctx.beginPath();
-  ctx.arc(size, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
+  drawDot({ u: 0, v: 0.5 });
+  drawDot({ u: 1, v: 0.5 });
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Red spin dots on the cue ball were rendered as egg-shaped rather than true circles due to equirectangular/UV compression on the sphere texture.
- Dots needed to match the cue tip sizing so visual spin indicators stay consistent and legible.
- The seam dots must render as full circles across the texture seam.

### Description
- Updated `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to increase the pole inset and keep dot sizing tied to `CUE_TIP_RADIUS_RATIO`.
- Added a `drawDot` helper that computes the sphere latitude and corrects horizontal radius to counter UV compression, and switched from `ctx.arc` to `ctx.ellipse` for drawing.
- Replaced manual seam arc code with calls to `drawDot({ u: 0, v: 0.5 })` and `drawDot({ u: 1, v: 0.5 })` so seam dots remain circular.

### Testing
- Started the dev server with `npm --prefix webapp run dev` which completed and reported Vite ready (succeeded).
- Ran an automated Playwright screenshot script loading the root page `/` which produced a screenshot artifact `artifacts/pool-royale-cue-ball.png` (succeeded).
- Attempts to load `/games/poolroyale` via Playwright timed out during earlier runs (failed/timeout).
- No unit test suite (`npm test`) was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962268242f083298698389076dc1228)