### PR TITLE
Fix cue ball dot distortion

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -131,25 +131,25 @@ function drawCueBallDots(ctx, size) {
     { u: 0.5, v: poleInset / size }, // top
     { u: 0.5, v: 1 - poleInset / size } // bottom
   ];
+  const minLatitudeCos = 0.25;
+
+  const drawDot = ({ u, v }) => {
+    const latitude = (0.5 - v) * Math.PI;
+    const latitudeCos = Math.abs(Math.cos(latitude));
+    const horizontalRadius = dotRadius / Math.max(latitudeCos, minLatitudeCos);
+    ctx.beginPath();
+    ctx.ellipse(u * size, v * size, horizontalRadius, dotRadius, 0, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.fill();
+  };
 
   ctx.save();
   ctx.fillStyle = '#dc2626';
-  dotPositions.forEach(({ u, v }) => {
-    ctx.beginPath();
-    ctx.arc(u * size, v * size, dotRadius, 0, Math.PI * 2);
-    ctx.closePath();
-    ctx.fill();
-  });
+  dotPositions.forEach(drawDot);
 
   // Back dot spans the seam to keep a full circle.
-  ctx.beginPath();
-  ctx.arc(0, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
-  ctx.beginPath();
-  ctx.arc(size, size * 0.5, dotRadius, 0, Math.PI * 2);
-  ctx.closePath();
-  ctx.fill();
+  drawDot({ u: 0, v: 0.5 });
+  drawDot({ u: 1, v: 0.5 });
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Cue-ball red markers were rendering as ovals on the spherical UV map and needed to appear circular and consistent in size.
- The visible dot diameter should match the cue tip radius visually across the sphere.
- Compensate for equirectangular latitude stretch so dots remain circular near poles and seams.
- Keep rendering simple and robust on canvas texture generation used for ball materials.

### Description
- Modified `webapp/src/utils/ballMaterialFactory.js` `drawCueBallDots` to compute a latitude-based horizontal radius and draw with `ctx.ellipse` instead of `ctx.arc`.
- Added a `minLatitudeCos` clamp to avoid extreme horizontal scaling near the poles.
- Replaced ad-hoc seam arcs with the same `drawDot` helper to keep back/seam dots consistent.
- Change keeps the dot size tied to the existing `CUE_TIP_RADIUS_RATIO` so visual size matches the blue cue tip.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite served the app successfully at the local URL (succeeded).
- Attempted an automated Playwright screenshot to visually confirm the fix but the screenshot timed out (failed).
- No unit tests or linters were executed as part of this change (not run).
- The change was committed (`git commit`) and is ready for review and further visual QA.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962268242f083298698389076dc1228)