### PR TITLE
Render circular cue-ball dots and remove pre-impact swerve gating

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -16684,45 +16684,23 @@ export function PoolRoyaleGame({
                 TMP_VEC2_CURVE.set(-b.spin.y, b.spin.x).multiplyScalar(curveScale);
                 b.vel.add(TMP_VEC2_CURVE);
               }
-              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
-              const allowRoll =
-                !isCue || b.impacted || swerveTravel || (isCue && b.spin?.lengthSq() > 1e-8);
-              const preImpact = isCue && !b.impacted;
-              if (allowRoll) {
-                const rollMultiplier = swerveTravel ? SWERVE_TRAVEL_MULTIPLIER : 1;
-                TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
-                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-                );
-                if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
-                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
-                  b.vel.add(TMP_VEC2_AXIS);
-                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
-                  if (b.spinMode === 'swerve' && b.pendingSpin) {
-                    b.pendingSpin.add(TMP_VEC2_LATERAL);
-                  }
-                  const alignedSpeed = b.vel.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
-                  b.vel.copy(TMP_VEC2_AXIS);
-                } else {
-                  b.vel.add(TMP_VEC2_SPIN);
-                  if (
-                    isCue &&
-                    b.spinMode === 'swerve' &&
-                    b.pendingSpin &&
-                    b.pendingSpin.lengthSq() > 0
-                  ) {
-                    b.vel.addScaledVector(b.pendingSpin, PRE_IMPACT_SPIN_DRIFT);
-                    b.pendingSpin.multiplyScalar(0);
-                  }
-                }
-                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
-                b.spin.multiplyScalar(rollDecay);
-              } else {
-                const airDecay = Math.pow(SPIN_AIR_DECAY, stepScale);
-                b.spin.multiplyScalar(airDecay);
+              const swerveTravel = isCue && b.spinMode === 'swerve';
+              const rollMultiplier = swerveTravel ? SWERVE_TRAVEL_MULTIPLIER : 1;
+              TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
+                SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
+              );
+              b.vel.add(TMP_VEC2_SPIN);
+              if (
+                isCue &&
+                b.spinMode === 'swerve' &&
+                b.pendingSpin &&
+                b.pendingSpin.lengthSq() > 0
+              ) {
+                b.vel.addScaledVector(b.pendingSpin, PRE_IMPACT_SPIN_DRIFT);
+                b.pendingSpin.multiplyScalar(0);
               }
+              const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
+              b.spin.multiplyScalar(rollDecay);
               if (b.spin.lengthSq() < 1e-6) {
                 b.spin.set(0, 0);
                 if (b.pendingSpin) b.pendingSpin.set(0, 0);


### PR DESCRIPTION
### Motivation
- Cue-ball red spin dots were appearing stretched/egg-shaped due to equirectangular UV compression and needed to remain true circles across latitudes and the texture seam.  
- Dot sizing should match the cue-tip sizing so visual spin indicators remain consistent and legible.  
- The seam must render full circular dots when wrapping the spherical UV.  
- The physics contained code that prevented the cue ball from curving from spin before contact, which blocked natural pre-impact behavior and must be removed.

### Description
- Rewrote `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to compute spherical coordinates (`uvToVec3`) and rasterize dots by sampling the sphere (`angularRadius`, `drawDot`) so dots remain circular on the equirectangular texture and across the seam.  
- Replaced prior 2D arc/ellipse draws with per-pixel spherical inclusion tests and updated pole inset/radius math to better match `CUE_TIP_RADIUS_RATIO`.  
- Removed the pre-impact `!b.impacted` gating and simplified the spin application paths in `webapp/src/pages/Games/PoolRoyale.jsx` to let `b.spin` and `b.pendingSpin` influence `b.vel` immediately, and applied the same change in `webapp/src/pages/Games/SnookerClubGame.jsx`.  
- Kept spin decay handling (`SPIN_ROLL_DECAY`) and pendingSpin consumption while enabling immediate swerve behavior.

### Testing
- Started the dev server with `npm --prefix webapp run dev`, which completed and reported Vite ready (succeeded).  
- Ran a Playwright screenshot script targeting the site root and produced `artifacts/pool-royale-root.png` (succeeded).  
- A Playwright run that loaded `/games/poolroyale` timed out during the session (failed/timeout).  
- No unit test suite (`npm test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962268242f083298698389076dc1228)