### PR TITLE
Add HDRI fallback for Snooker Club environment

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -3846,14 +3846,51 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   }
 }
 
+async function createFallbackHdriEnvironment(renderer) {
+  if (!renderer) return null;
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  pmrem.compileEquirectangularShader();
+  const hemi = new THREE.HemisphereLight(0x94a3b8, 0x0f172a, 1.05);
+  const floor = new THREE.Mesh(
+    new THREE.CircleGeometry(6, 24),
+    new THREE.MeshStandardMaterial({
+      color: 0x0f172a,
+      roughness: 0.78,
+      metalness: 0.05
+    })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  const tempScene = new THREE.Scene();
+  tempScene.add(hemi);
+  tempScene.add(floor);
+  const { texture } = pmrem.fromScene(tempScene);
+  texture.name = 'snooker-fallback-env';
+  pmrem.dispose();
+  floor.geometry.dispose();
+  floor.material.dispose();
+  return { envMap: texture, skyboxMap: null, url: null };
+}
+
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
   const url = await resolvePolyHavenHdriUrl(config);
+  const resolveFallback = async () => {
+    try {
+      return await createFallbackHdriEnvironment(renderer);
+    } catch (error) {
+      console.warn('Failed to build fallback HDRI environment', error);
+      return null;
+    }
+  };
   const lowerUrl = `${url ?? ''}`.toLowerCase();
   const useExr = lowerUrl.endsWith('.exr');
   const loader = useExr ? new EXRLoader() : new RGBELoader();
   loader.setCrossOrigin?.('anonymous');
   return new Promise((resolve) => {
+    if (!url) {
+      resolveFallback().then(resolve);
+      return;
+    }
     loader.load(
       url,
       (texture) => {
@@ -3869,9 +3906,10 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
         resolve({ envMap, skyboxMap, url });
       },
       undefined,
-      (error) => {
+      async (error) => {
         console.warn('Failed to load Poly Haven HDRI', error);
-        resolve(null);
+        const fallbackEnv = await resolveFallback();
+        resolve(fallbackEnv);
       }
     );
   });


### PR DESCRIPTION
### Motivation
- The Snooker Club game could render a black scene when HDRI fetches or loads fail, reducing playability compared to the working Pool Royale build. 
- Provide a resilient, local lighting fallback so the table remains lit even if external HDRI resolution or loading fails. 
- Match the Pool Royale behavior of creating a stable environment when external assets are unavailable. 
- Reduce occurrences of a blank/black screen caused by missing environment textures.

### Description
- Added a new helper `createFallbackHdriEnvironment(renderer)` that builds a simple PMREM-based environment using a hemisphere light and a small floor and returns `{ envMap, skyboxMap: null, url: null }` in `webapp/src/pages/Games/SnookerClubGame.jsx`.
- Integrated a `resolveFallback` path into `loadPolyHavenHdriEnvironment(renderer, config)` so the fallback is used when the resolved HDRI `url` is missing or when the loader errors during fetch/load. 
- Ensured proper PMREM generation and disposal and named the fallback texture `snooker-fallback-env` to match existing naming conventions. 
- Preserved existing HDRI loading logic and only fall back when necessary, so behavior matches Pool Royale when HDRIs are available.

### Testing
- No automated tests were executed as part of this change. 
- The patch contains only additions and small control-flow changes inside `loadPolyHavenHdriEnvironment` and a new helper function. 
- Static verification (lint/build) was not run automatically during this change. 
- Recommend running the app in a browser and simulating HDRI failures to validate fallback behavior in a follow-up test pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696224732e9083299e2090327e09ca23)