### PR TITLE
Add HDRI fallback for Snooker Club rendering

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -3846,14 +3846,47 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   }
 }
 
+async function createFallbackHdriEnvironment(renderer) {
+  if (!renderer) return null;
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  pmrem.compileEquirectangularShader();
+  const hemi = new THREE.HemisphereLight(0x94a3b8, 0x0f172a, 1.05);
+  const floor = new THREE.Mesh(
+    new THREE.CircleGeometry(6, 24),
+    new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.78, metalness: 0.05 })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  const tempScene = new THREE.Scene();
+  tempScene.add(hemi);
+  tempScene.add(floor);
+  const { texture } = pmrem.fromScene(tempScene);
+  texture.name = 'snooker-club-fallback-env';
+  pmrem.dispose();
+  floor.geometry.dispose();
+  floor.material.dispose();
+  return { envMap: texture, skyboxMap: null, url: null };
+}
+
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
   const url = await resolvePolyHavenHdriUrl(config);
+  const resolveFallback = async () => {
+    try {
+      return await createFallbackHdriEnvironment(renderer);
+    } catch (error) {
+      console.warn('Failed to build fallback HDRI environment', error);
+      return null;
+    }
+  };
   const lowerUrl = `${url ?? ''}`.toLowerCase();
   const useExr = lowerUrl.endsWith('.exr');
   const loader = useExr ? new EXRLoader() : new RGBELoader();
   loader.setCrossOrigin?.('anonymous');
   return new Promise((resolve) => {
+    if (!url) {
+      resolveFallback().then(resolve);
+      return;
+    }
     loader.load(
       url,
       (texture) => {
@@ -3869,9 +3902,10 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
         resolve({ envMap, skyboxMap, url });
       },
       undefined,
-      (error) => {
+      async (error) => {
         console.warn('Failed to load Poly Haven HDRI', error);
-        resolve(null);
+        const fallbackEnv = await resolveFallback();
+        resolve(fallbackEnv);
       }
     );
   });


### PR DESCRIPTION
### Motivation
- Snooker Club could render a black screen when the Poly Haven HDRI failed to resolve or load, leaving the scene without an environment map.
- Pool Royale already contains a resilient HDRI loading path; Snooker Club should match that behavior to prevent user-facing black screens.
- Ensure the renderer always receives a valid `environment`/`background` texture so materials and lighting behave predictably.

### Description
- Added `createFallbackHdriEnvironment(renderer)` which builds a small PMREM-based fallback environment and names the texture `snooker-club-fallback-env`.
- Updated `loadPolyHavenHdriEnvironment` to use the fallback when `resolvePolyHavenHdriUrl` returns no URL or when the loader fails, returning the same `{ envMap, skyboxMap, url }` shape.
- The new fallback mirrors the Pool Royale implementation pattern so Snooker Club remains resilient to network or asset issues.

### Testing
- No automated tests were executed as part of this change.
- Manual runtime verification is recommended (load Snooker Club with HDRI network blocked) to confirm the fallback prevents a black screen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696224732e9083299e2090327e09ca23)