### PR TITLE
Fix cue ball dots and spin direction in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -124,70 +124,32 @@ function drawPoolNumberBadge(ctx, size, number) {
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
   const poleInset = dotRadius * 1.6;
-  const angularRadius = (dotRadius / size) * Math.PI;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left
     { u: 0.75, v: 0.5 }, // right
     { u: 0.5, v: poleInset / size }, // top
-    { u: 0.5, v: 1 - poleInset / size } // bottom
+    { u: 0.5, v: 1 - poleInset / size }, // bottom
+    { u: 0, v: 0.5 } // back (wrap across seam)
   ];
-
-  const uvToVec3 = (u, v) => {
-    const longitude = (u - 0.5) * Math.PI * 2;
-    const latitude = (0.5 - v) * Math.PI;
-    const cosLat = Math.cos(latitude);
-    return {
-      x: Math.sin(longitude) * cosLat,
-      y: Math.sin(latitude),
-      z: Math.cos(longitude) * cosLat
+  const dotFill = '#dc2626';
+  const drawCircle = (u, v) => {
+    const cx = u * size;
+    const cy = v * size;
+    const drawAt = (x) => {
+      ctx.beginPath();
+      ctx.arc(x, cy, dotRadius, 0, Math.PI * 2);
+      ctx.closePath();
+      ctx.fill();
     };
-  };
-
-  const drawDot = ({ u, v }) => {
-    const du = angularRadius / (Math.PI * 2);
-    const dv = angularRadius / Math.PI;
-    const minU = Math.max(0, u - du);
-    const maxU = Math.min(1, u + du);
-    const minV = Math.max(0, v - dv);
-    const maxV = Math.min(1, v + dv);
-    const startX = Math.floor(minU * size);
-    const endX = Math.ceil(maxU * size);
-    const startY = Math.floor(minV * size);
-    const endY = Math.ceil(maxV * size);
-    const width = Math.max(1, endX - startX);
-    const height = Math.max(1, endY - startY);
-    const imageData = ctx.getImageData(startX, startY, width, height);
-    const data = imageData.data;
-    const center = uvToVec3(u, v);
-    const cosRadius = Math.cos(angularRadius);
-
-    for (let y = 0; y < height; y += 1) {
-      const vSample = (startY + y + 0.5) / size;
-      for (let x = 0; x < width; x += 1) {
-        const uSample = (startX + x + 0.5) / size;
-        const point = uvToVec3(uSample, vSample);
-        const dot =
-          center.x * point.x + center.y * point.y + center.z * point.z;
-        if (dot >= cosRadius) {
-          const idx = (y * width + x) * 4;
-          data[idx] = 220;
-          data[idx + 1] = 38;
-          data[idx + 2] = 38;
-          data[idx + 3] = 255;
-        }
-      }
-    }
-
-    ctx.putImageData(imageData, startX, startY);
+    drawAt(cx);
+    if (cx - dotRadius < 0) drawAt(cx + size);
+    if (cx + dotRadius > size) drawAt(cx - size);
   };
 
   ctx.save();
-  dotPositions.forEach(drawDot);
-
-  // Back dot spans the seam to keep a full circle.
-  drawDot({ u: 0, v: 0.5 });
-  drawDot({ u: 1, v: 0.5 });
+  ctx.fillStyle = dotFill;
+  dotPositions.forEach(({ u, v }) => drawCircle(u, v));
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Correct visual defect where only three cue-ball dots rendered as circles while the other three appeared triangular by ensuring all cue-ball measle dots are circular and seam-safe.
- Fix inversion of side-spin so the cue ball actually moves in the direction the spin controller indicates and the aiming preview matches the physics.

### Description
- Reworked `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to draw six consistent circular dots and added seam wrapping for the back dot instead of the previous spherical sampling routine.
- Updated spin mapping in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `mapSpinForPhysics` so the side spin `x` is passed through (removed the previous negation) so controller input matches physics and preview.
- Kept spin normalization and limits logic intact while ensuring applied spin flows through to cue state and aim preview consistently via existing code paths like `applySpinConstraints` and `mapSpinForPhysics`.

### Testing
- No automated tests were run for this change in the rollout environment.
- Manual runtime QA was not executed in this environment (game client not launched as part of the patch run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623807bd308329bec9a9f959d338dc)