### PR TITLE
Fix cue ball dot rendering and align spin input mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,8 +123,9 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 1.6;
+  const poleInset = dotRadius * 2.2;
   const angularRadius = (dotRadius / size) * Math.PI;
+  const seamInset = Math.min(0.05, Math.max(0.02, angularRadius / (Math.PI * 2)));
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left
@@ -186,8 +187,8 @@ function drawCueBallDots(ctx, size) {
   dotPositions.forEach(drawDot);
 
   // Back dot spans the seam to keep a full circle.
-  drawDot({ u: 0, v: 0.5 });
-  drawDot({ u: 1, v: 0.5 });
+  drawDot({ u: seamInset, v: 0.5 });
+  drawDot({ u: 1 - seamInset, v: 0.5 });
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Correct visual artifact where three cue ball dots rendered as distorted/triangular due to seam/pole sampling so all six dots appear circular.
- Ensure cue ball spin follows the direction set by the spin controller rather than appearing inverted in gameplay.
- Make the aiming preview (`aim` line) match the actual physics path produced by applied spin.

### Description
- Adjusted cue-dot placement in `webapp/src/utils/ballMaterialFactory.js` by increasing `poleInset`, adding a `seamInset`, and avoiding sampling exactly at `u=0/1` so back seam dots render as full circles.
- Fixed spin sign mapping in `webapp/src/pages/Games/PoolRoyale.jsx` by making `mapSpinForPhysics` use the same `x` sign as the spin controller (removed earlier negation).
- Changes are small and focused to keep rendering and physics inputs consistent across preview and simulation.

### Testing
- No automated unit or integration tests were executed in this environment.
- Manual runtime verification is recommended to confirm cue ball dots now render as circles and that the cue ball and aim line follow controller spin direction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623807bd308329bec9a9f959d338dc)