### PR TITLE
Restore Snooker Club game baseline (rules, game view, inventory, storage & renderer tweaks)

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -9,7 +9,6 @@ type SnookerSerializedState = {
   redsRemaining: number;
   colorsOnTable: BallColor[];
   colorOnAfterRed: boolean;
-  ballInHand: boolean;
   currentPlayer: 'A' | 'B';
   frameOver: boolean;
   winner: 'A' | 'B' | null;
@@ -85,41 +84,6 @@ type PoolMeta =
     };
 
 const UK_TOTAL_PER_COLOUR = 7;
-const SNOOKER_RED_COUNT = 15;
-
-function buildSnookerBalls(
-  redsRemaining: number,
-  colorsOnTable: Set<BallColor>,
-  cueOnTable = true
-): FrameState['balls'] {
-  const balls: FrameState['balls'] = [];
-  for (let idx = 1; idx <= SNOOKER_RED_COUNT; idx += 1) {
-    const onTable = idx <= redsRemaining;
-    balls.push({
-      id: `RED_${idx}`,
-      color: 'RED',
-      onTable,
-      potted: !onTable
-    });
-  }
-  const orderedColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
-  orderedColors.forEach((color) => {
-    const onTable = colorsOnTable.has(color);
-    balls.push({
-      id: color,
-      color,
-      onTable,
-      potted: !onTable
-    });
-  });
-  balls.push({
-    id: 'CUE',
-    color: 'CUE',
-    onTable: cueOnTable,
-    potted: !cueOnTable
-  });
-  return balls;
-}
 
 function normalizeVariantId(value: string | null | undefined): string {
   if (typeof value !== 'string') return '';
@@ -281,12 +245,12 @@ export class PoolRoyaleRules {
       case 'snooker': {
         const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
         const base: FrameState = {
-          balls: buildSnookerBalls(SNOOKER_RED_COUNT, new Set(colorsOnTable), true),
+          balls: [],
           activePlayer: 'A',
           players: basePlayers(playerA, playerB),
           currentBreak: 0,
           phase: 'REDS_AND_COLORS',
-          redsRemaining: SNOOKER_RED_COUNT,
+          redsRemaining: 15,
           colorOnAfterRed: false,
           ballOn: ['RED'],
           frameOver: false
@@ -294,10 +258,9 @@ export class PoolRoyaleRules {
         base.meta = {
           variant: 'snooker',
           state: {
-            redsRemaining: SNOOKER_RED_COUNT,
+            redsRemaining: 15,
             colorsOnTable,
             colorOnAfterRed: false,
-            ballInHand: false,
             currentPlayer: 'A',
             frameOver: false,
             winner: null
@@ -533,7 +496,6 @@ export class PoolRoyaleRules {
     redsRemaining = Math.max(0, redsRemaining - redPots);
 
     if (foulReason) {
-      colorOnAfterRed = false;
       const foulPoints = Math.max(4, foulValue || 4);
       players[opponent].score = (players[opponent].score ?? 0) + foulPoints;
       activePlayer = opponent;
@@ -564,7 +526,6 @@ export class PoolRoyaleRules {
         redsRemaining,
         colorOnAfterRed,
         ballOn: ballOnNext,
-        balls: buildSnookerBalls(redsRemaining, colorsOnTable, !cueBallPotted),
         frameOver,
         winner,
         foul: {
@@ -577,7 +538,6 @@ export class PoolRoyaleRules {
             redsRemaining,
             colorsOnTable: Array.from(colorsOnTable),
             colorOnAfterRed,
-            ballInHand: cueBallPotted,
             currentPlayer: activePlayer,
             frameOver,
             winner: winner ?? null
@@ -621,7 +581,6 @@ export class PoolRoyaleRules {
     } else {
       activePlayer = opponent;
       currentBreak = 0;
-      colorOnAfterRed = false;
     }
 
     const winner = frameOver
@@ -641,7 +600,6 @@ export class PoolRoyaleRules {
       redsRemaining,
       colorOnAfterRed,
       ballOn: ballOnNext,
-      balls: buildSnookerBalls(redsRemaining, colorsOnTable, true),
       frameOver,
       winner,
       foul: undefined,
@@ -651,7 +609,6 @@ export class PoolRoyaleRules {
           redsRemaining,
           colorsOnTable: Array.from(colorsOnTable),
           colorOnAfterRed,
-          ballInHand: false,
           currentPlayer: activePlayer,
           frameOver,
           winner: winner ?? null

--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -10,7 +10,7 @@ export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['chrome'],
   clothColor: ['freshGreen'],
   cueStyle: [CUE_STYLE_PRESETS[0]?.id],
-  pocketLiner: ['fabric_leather_02'],
+  pocketLiner: ['blackPocket'],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
 });
 
@@ -47,15 +47,7 @@ export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
       acc[preset.id] = preset.label;
       return acc;
     }, {})
-  ),
-  pocketLiner: Object.freeze({
-    fabric_leather_02: 'Fabric Leather 02 Pocket Jaws',
-    fabric_leather_01: 'Fabric Leather 01 Pocket Jaws',
-    brown_leather: 'Brown Leather Pocket Jaws',
-    leather_red_02: 'Leather Red 02 Pocket Jaws',
-    leather_red_03: 'Leather Red 03 Pocket Jaws',
-    leather_white: 'Leather White Pocket Jaws'
-  })
+  )
 });
 
 export const SNOOKER_CLUB_STORE_ITEMS = [
@@ -131,54 +123,6 @@ export const SNOOKER_CLUB_STORE_ITEMS = [
     price: 590,
     description: 'Cool arctic blue cloth with crisp broadcast sheen.'
   },
-  {
-    id: 'snooker-pocket-fabric-leather-02',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    name: 'Fabric Leather 02 Pocket Jaws',
-    price: 520,
-    description: 'Warm stitched leather weave liners for the classic club look.'
-  },
-  {
-    id: 'snooker-pocket-fabric-leather-01',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_01',
-    name: 'Fabric Leather 01 Pocket Jaws',
-    price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.'
-  },
-  {
-    id: 'snooker-pocket-brown-leather',
-    type: 'pocketLiner',
-    optionId: 'brown_leather',
-    name: 'Brown Leather Pocket Jaws',
-    price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-02',
-    type: 'pocketLiner',
-    optionId: 'leather_red_02',
-    name: 'Leather Red 02 Pocket Jaws',
-    price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-03',
-    type: 'pocketLiner',
-    optionId: 'leather_red_03',
-    name: 'Leather Red 03 Pocket Jaws',
-    price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
-  },
-  {
-    id: 'snooker-pocket-leather-white',
-    type: 'pocketLiner',
-    optionId: 'leather_white',
-    name: 'Leather White Pocket Jaws',
-    price: 590,
-    description: 'Bright white leather pockets with crisp seam definition.'
-  },
   ...CUE_STYLE_PRESETS.slice(1).map((preset, idx) => ({
     id: `snooker-cue-${preset.id}`,
     type: 'cueStyle',
@@ -203,11 +147,6 @@ export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
   { type: 'railMarkerColor', optionId: 'chrome', label: 'Chrome Rail Markers' },
   { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
   { type: 'cueStyle', optionId: CUE_STYLE_PRESETS[0]?.id, label: CUE_STYLE_PRESETS[0]?.label },
-  {
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    label: 'Fabric Leather 02 Pocket Jaws'
-  },
   {
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -50,7 +50,6 @@ import {
   snookerClubAccountId
 } from '../../utils/snookerClubInventory.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
-import { safeGetItem, safeSetItem } from '../../utils/storage.js';
 
 function applyTablePhysicsSpec(meta) {
   const cushionAngle = Number.isFinite(meta?.cushionCutAngleDeg)
@@ -1388,9 +1387,6 @@ function deriveInHandFromFrame(frame) {
   if (meta.variant === 'uk' && meta.state) {
     return Boolean(meta.state.mustPlayFromBaulk);
   }
-  if (meta.variant === 'snooker' && meta.state) {
-    return Boolean(meta.state.ballInHand);
-  }
   return false;
 }
 
@@ -2499,204 +2495,6 @@ const POCKET_LINER_PRESETS = Object.freeze([
       repeatY: 2.1,
       seed: 4101
     }
-  }),
-  Object.freeze({
-    id: 'fabric_leather_02',
-    label: 'Fabric Leather 02',
-    type: 'metal',
-    jawColor: 0x4a362d,
-    rimColor: 0x3f2c23,
-    sheenColor: 0x7a5e4f,
-    rimSheenColor: 0x6b5246,
-    sheen: 0.54,
-    sheenRoughness: 0.56,
-    roughness: 0.56,
-    rimRoughness: 0.6,
-    metalness: 0.1,
-    rimMetalness: 0.12,
-    clearcoat: 0.18,
-    clearcoatRoughness: 0.42,
-    envMapIntensity: 0.45,
-    bumpScale: 0.26,
-    rimBumpScale: 0.2,
-    texture: {
-      base: 0x4a362d,
-      highlight: 0x7a5e4f,
-      shadow: 0x2a1d16,
-      density: 0.75,
-      grainSize: 0.8,
-      streakAlpha: 0.2,
-      creaseAlpha: 0.22,
-      seamContrast: 0.24,
-      repeatX: 2.3,
-      repeatY: 2.1,
-      seed: 4211
-    }
-  }),
-  Object.freeze({
-    id: 'fabric_leather_01',
-    label: 'Fabric Leather 01',
-    type: 'metal',
-    jawColor: 0x6c5241,
-    rimColor: 0x5b4335,
-    sheenColor: 0x9b7a62,
-    rimSheenColor: 0x8a6d58,
-    sheen: 0.5,
-    sheenRoughness: 0.6,
-    roughness: 0.6,
-    rimRoughness: 0.65,
-    metalness: 0.08,
-    rimMetalness: 0.1,
-    clearcoat: 0.16,
-    clearcoatRoughness: 0.48,
-    envMapIntensity: 0.4,
-    bumpScale: 0.24,
-    rimBumpScale: 0.18,
-    texture: {
-      base: 0x6c5241,
-      highlight: 0x9b7a62,
-      shadow: 0x3b2a22,
-      density: 0.7,
-      grainSize: 0.85,
-      streakAlpha: 0.18,
-      creaseAlpha: 0.2,
-      seamContrast: 0.22,
-      repeatX: 2.2,
-      repeatY: 2.1,
-      seed: 4313
-    }
-  }),
-  Object.freeze({
-    id: 'brown_leather',
-    label: 'Brown Leather',
-    type: 'metal',
-    jawColor: 0x3f2b21,
-    rimColor: 0x352319,
-    sheenColor: 0x634233,
-    rimSheenColor: 0x56392d,
-    sheen: 0.58,
-    sheenRoughness: 0.52,
-    roughness: 0.52,
-    rimRoughness: 0.56,
-    metalness: 0.12,
-    rimMetalness: 0.14,
-    clearcoat: 0.2,
-    clearcoatRoughness: 0.36,
-    envMapIntensity: 0.48,
-    bumpScale: 0.28,
-    rimBumpScale: 0.22,
-    texture: {
-      base: 0x3f2b21,
-      highlight: 0x634233,
-      shadow: 0x22150d,
-      density: 0.8,
-      grainSize: 0.75,
-      streakAlpha: 0.22,
-      creaseAlpha: 0.24,
-      seamContrast: 0.26,
-      repeatX: 2.2,
-      repeatY: 2.1,
-      seed: 4417
-    }
-  }),
-  Object.freeze({
-    id: 'leather_red_02',
-    label: 'Leather Red 02',
-    type: 'metal',
-    jawColor: 0x6a1c1f,
-    rimColor: 0x57171b,
-    sheenColor: 0x9c3b3d,
-    rimSheenColor: 0x8d3436,
-    sheen: 0.6,
-    sheenRoughness: 0.5,
-    roughness: 0.5,
-    rimRoughness: 0.54,
-    metalness: 0.12,
-    rimMetalness: 0.14,
-    clearcoat: 0.22,
-    clearcoatRoughness: 0.34,
-    envMapIntensity: 0.52,
-    bumpScale: 0.26,
-    rimBumpScale: 0.2,
-    texture: {
-      base: 0x6a1c1f,
-      highlight: 0x9c3b3d,
-      shadow: 0x3a0f12,
-      density: 0.85,
-      grainSize: 0.7,
-      streakAlpha: 0.24,
-      creaseAlpha: 0.24,
-      seamContrast: 0.28,
-      repeatX: 2.1,
-      repeatY: 2.1,
-      seed: 4511
-    }
-  }),
-  Object.freeze({
-    id: 'leather_red_03',
-    label: 'Leather Red 03',
-    type: 'metal',
-    jawColor: 0x4b1013,
-    rimColor: 0x3d0d10,
-    sheenColor: 0x7a2b2d,
-    rimSheenColor: 0x6d2527,
-    sheen: 0.62,
-    sheenRoughness: 0.5,
-    roughness: 0.5,
-    rimRoughness: 0.55,
-    metalness: 0.12,
-    rimMetalness: 0.15,
-    clearcoat: 0.22,
-    clearcoatRoughness: 0.32,
-    envMapIntensity: 0.55,
-    bumpScale: 0.28,
-    rimBumpScale: 0.22,
-    texture: {
-      base: 0x4b1013,
-      highlight: 0x7a2b2d,
-      shadow: 0x24070a,
-      density: 0.9,
-      grainSize: 0.68,
-      streakAlpha: 0.25,
-      creaseAlpha: 0.26,
-      seamContrast: 0.3,
-      repeatX: 2.1,
-      repeatY: 2.1,
-      seed: 4619
-    }
-  }),
-  Object.freeze({
-    id: 'leather_white',
-    label: 'Leather White',
-    type: 'metal',
-    jawColor: 0xd8d2c9,
-    rimColor: 0xc6bfb6,
-    sheenColor: 0xf1ece3,
-    rimSheenColor: 0xe2dbd2,
-    sheen: 0.46,
-    sheenRoughness: 0.62,
-    roughness: 0.7,
-    rimRoughness: 0.75,
-    metalness: 0.04,
-    rimMetalness: 0.05,
-    clearcoat: 0.12,
-    clearcoatRoughness: 0.6,
-    envMapIntensity: 0.36,
-    bumpScale: 0.2,
-    rimBumpScale: 0.16,
-    texture: {
-      base: 0xd8d2c9,
-      highlight: 0xf1ece3,
-      shadow: 0x9b9289,
-      density: 0.6,
-      grainSize: 0.9,
-      streakAlpha: 0.16,
-      creaseAlpha: 0.2,
-      seamContrast: 0.2,
-      repeatX: 2.2,
-      repeatY: 2.1,
-      seed: 4711
-    }
   })
 ]);
 
@@ -2717,9 +2515,7 @@ function resolvePocketLinerTextureColor(value, fallback) {
 }
 
 const DEFAULT_POCKET_LINER_OPTION_ID =
-  POCKET_LINER_PRESETS.find((preset) => preset.id === 'fabric_leather_02')?.id ??
-  POCKET_LINER_PRESETS[0]?.id ??
-  'fabric_leather_02';
+  POCKET_LINER_PRESETS[0]?.id ?? 'walnutPocket';
 
 const POCKET_LINER_OPTIONS = Object.freeze(
   POCKET_LINER_PRESETS.map((config, index) => {
@@ -3846,47 +3642,14 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   }
 }
 
-async function createFallbackHdriEnvironment(renderer) {
-  if (!renderer) return null;
-  const pmrem = new THREE.PMREMGenerator(renderer);
-  pmrem.compileEquirectangularShader();
-  const hemi = new THREE.HemisphereLight(0x94a3b8, 0x0f172a, 1.05);
-  const floor = new THREE.Mesh(
-    new THREE.CircleGeometry(6, 24),
-    new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.78, metalness: 0.05 })
-  );
-  floor.rotation.x = -Math.PI / 2;
-  const tempScene = new THREE.Scene();
-  tempScene.add(hemi);
-  tempScene.add(floor);
-  const { texture } = pmrem.fromScene(tempScene);
-  texture.name = 'snooker-club-fallback-env';
-  pmrem.dispose();
-  floor.geometry.dispose();
-  floor.material.dispose();
-  return { envMap: texture, skyboxMap: null, url: null };
-}
-
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
   const url = await resolvePolyHavenHdriUrl(config);
-  const resolveFallback = async () => {
-    try {
-      return await createFallbackHdriEnvironment(renderer);
-    } catch (error) {
-      console.warn('Failed to build fallback HDRI environment', error);
-      return null;
-    }
-  };
   const lowerUrl = `${url ?? ''}`.toLowerCase();
   const useExr = lowerUrl.endsWith('.exr');
   const loader = useExr ? new EXRLoader() : new RGBELoader();
   loader.setCrossOrigin?.('anonymous');
   return new Promise((resolve) => {
-    if (!url) {
-      resolveFallback().then(resolve);
-      return;
-    }
     loader.load(
       url,
       (texture) => {
@@ -3904,7 +3667,7 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
       undefined,
       (error) => {
         console.warn('Failed to load Poly Haven HDRI', error);
-        resolveFallback().then(resolve);
+        resolve(null);
       }
     );
   });
@@ -8524,8 +8287,8 @@ export function PoolRoyaleGame({
   const resolveStoredSelection = useCallback(
     (type, storageKey, isValid, fallbackId) => {
       const inventory = snookerInventory;
-      if (storageKey) {
-        const stored = safeGetItem(storageKey);
+      if (typeof window !== 'undefined' && storageKey) {
+        const stored = window.localStorage.getItem(storageKey);
         if (
           stored &&
           isValid(stored) &&
@@ -8561,7 +8324,7 @@ export function PoolRoyaleGame({
   });
   const [pocketLinerId, setPocketLinerId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = safeGetItem(POCKET_LINER_STORAGE_KEY);
+      const stored = window.localStorage.getItem(POCKET_LINER_STORAGE_KEY);
       if (stored && POCKET_LINER_OPTIONS.some((opt) => opt?.id === stored)) {
         return stored;
       }
@@ -8570,7 +8333,7 @@ export function PoolRoyaleGame({
   });
   const [railMarkerShapeId, setRailMarkerShapeId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = safeGetItem('poolRailMarkerShape');
+      const stored = window.localStorage.getItem('poolRailMarkerShape');
       if (stored && RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored)) {
         return stored;
       }
@@ -8604,7 +8367,7 @@ export function PoolRoyaleGame({
   });
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = safeGetItem(FRAME_RATE_STORAGE_KEY);
+      const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
       if (stored && FRAME_RATE_OPTIONS.some((opt) => opt.id === stored)) {
         return stored;
       }
@@ -8918,7 +8681,7 @@ export function PoolRoyaleGame({
   const resolveCueIndex = useCallback(() => {
     const paletteLength = CUE_RACK_PALETTE.length || CUE_STYLE_PRESETS.length || 1;
     if (typeof window !== 'undefined') {
-      const stored = safeGetItem(CUE_STYLE_STORAGE_KEY);
+      const stored = window.localStorage.getItem(CUE_STYLE_STORAGE_KEY);
       if (stored != null) {
         const parsed = Number.parseInt(stored, 10);
         if (Number.isFinite(parsed)) {
@@ -9138,7 +8901,10 @@ export function PoolRoyaleGame({
   useEffect(() => {
     cueStyleIndexRef.current = cueStyleIndex;
     if (typeof window !== 'undefined') {
-      safeSetItem(CUE_STYLE_STORAGE_KEY, String(cueStyleIndex));
+      window.localStorage.setItem(
+        CUE_STYLE_STORAGE_KEY,
+        String(cueStyleIndex)
+      );
     }
     applySelectedCueStyle(cueStyleIndex);
   }, [cueStyleIndex, applySelectedCueStyle]);
@@ -9237,15 +9003,15 @@ export function PoolRoyaleGame({
   }, [railMarkerColorId, railMarkerShapeId]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    safeSetItem('poolRailMarkerShape', railMarkerShapeId);
+    window.localStorage.setItem('poolRailMarkerShape', railMarkerShapeId);
   }, [railMarkerShapeId]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    safeSetItem('poolRailMarkerColor', railMarkerColorId);
+    window.localStorage.setItem('poolRailMarkerColor', railMarkerColorId);
   }, [railMarkerColorId]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    safeSetItem(LIGHTING_STORAGE_KEY, lightingId);
+    window.localStorage.setItem(LIGHTING_STORAGE_KEY, lightingId);
   }, [lightingId]);
   useEffect(() => {
     applyRailMarkerStyleRef.current?.(railMarkerStyleRef.current);
@@ -9329,22 +9095,22 @@ export function PoolRoyaleGame({
   const updateEnvironmentRef = useRef(() => {});
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(TABLE_FINISH_STORAGE_KEY, tableFinishId);
+      window.localStorage.setItem(TABLE_FINISH_STORAGE_KEY, tableFinishId);
     }
   }, [tableFinishId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(CLOTH_COLOR_STORAGE_KEY, clothColorId);
+      window.localStorage.setItem(CLOTH_COLOR_STORAGE_KEY, clothColorId);
     }
   }, [clothColorId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(POCKET_LINER_STORAGE_KEY, pocketLinerId);
+      window.localStorage.setItem(POCKET_LINER_STORAGE_KEY, pocketLinerId);
     }
   }, [pocketLinerId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(HDRI_STORAGE_KEY, environmentHdriId);
+      window.localStorage.setItem(HDRI_STORAGE_KEY, environmentHdriId);
     }
     if (typeof updateEnvironmentRef.current === 'function') {
       updateEnvironmentRef.current(activeEnvironmentVariantRef.current);
@@ -9352,17 +9118,17 @@ export function PoolRoyaleGame({
   }, [activeEnvironmentHdri, environmentHdriId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem('poolChromeColor', chromeColorId);
+      window.localStorage.setItem('poolChromeColor', chromeColorId);
     }
   }, [chromeColorId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(FRAME_RATE_STORAGE_KEY, frameRateId);
+      window.localStorage.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
     }
   }, [frameRateId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      safeSetItem(BROADCAST_SYSTEM_STORAGE_KEY, broadcastSystemId);
+      window.localStorage.setItem(BROADCAST_SYSTEM_STORAGE_KEY, broadcastSystemId);
     }
   }, [broadcastSystemId]);
   useEffect(() => {
@@ -9639,7 +9405,6 @@ export function PoolRoyaleGame({
     applyLightingPreset(lightingId);
   }, [applyLightingPreset, lightingId]);
   const [err, setErr] = useState(null);
-  const [webglUnavailable, setWebglUnavailable] = useState(false);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
   const sphRef = useRef(null);
@@ -9682,20 +9447,14 @@ export function PoolRoyaleGame({
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
         ? THREE.MathUtils.clamp(quality.renderScale, 0.75, 1)
         : 1;
-    const fallbackWidth =
-      typeof window !== 'undefined' && typeof window.innerWidth === 'number'
-        ? window.innerWidth
-        : host.clientWidth;
-    const fallbackHeight =
-      typeof window !== 'undefined' && typeof window.innerHeight === 'number'
-        ? window.innerHeight
-        : host.clientHeight;
-    const hostWidth = host.clientWidth || fallbackWidth || 1;
-    const hostHeight = host.clientHeight || fallbackHeight || 1;
     renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
-    renderer.setSize(hostWidth * renderScale, hostHeight * renderScale, false);
-    renderer.domElement.style.width = host.clientWidth ? '100%' : `${hostWidth}px`;
-    renderer.domElement.style.height = host.clientHeight ? '100%' : `${hostHeight}px`;
+    renderer.setSize(
+      host.clientWidth * renderScale,
+      host.clientHeight * renderScale,
+      false
+    );
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
   }, []);
   useEffect(() => {
     applyRendererQuality();
@@ -10299,20 +10058,13 @@ export function PoolRoyaleGame({
     const host = mountRef.current;
     if (!host) return;
     setErr(null);
-    setWebglUnavailable(false);
     if (!isWebGLAvailable()) {
-      setWebglUnavailable(true);
       setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
       return;
     }
     const cueRackDisposers = [];
     let disposed = false;
     try {
-      const renderer = new THREE.WebGLRenderer({
-        antialias: true,
-        alpha: false,
-        powerPreference: 'high-performance'
-      });
       const updatePocketCameraState = (active) => {
         if (pocketCameraStateRef.current === active) return;
         pocketCameraStateRef.current = active;
@@ -10320,6 +10072,12 @@ export function PoolRoyaleGame({
       };
       updatePocketCameraState(false);
       screen.orientation?.lock?.('portrait').catch(() => {});
+      // Renderer
+      const renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: false,
+        powerPreference: 'high-performance'
+      });
       renderer.useLegacyLights = false;
       applyRendererSRGB(renderer);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -10330,15 +10088,9 @@ export function PoolRoyaleGame({
       // Ensure the canvas fills the host element so the table is centered and
       // scaled correctly on all view modes.
       host.appendChild(renderer.domElement);
-      const handleContextLost = (e) => {
-        e.preventDefault();
-        setErr('WebGL context lost. Please reload or enable hardware acceleration.');
-      };
-      const handleContextRestored = () => {
-        setErr('WebGL context restored. Please reload to continue.');
-      };
-      renderer.domElement.addEventListener('webglcontextlost', handleContextLost, false);
-      renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored, false);
+      renderer.domElement.addEventListener('webglcontextlost', (e) =>
+        e.preventDefault()
+      );
       applyRendererQuality();
       renderer.domElement.style.transformOrigin = 'top left';
       rendererRef.current = renderer;
@@ -16453,13 +16205,10 @@ export function PoolRoyaleGame({
             vert,
             perp.z * side
           );
-          const cueTipGap = Math.sqrt(
-            Math.max(0, CUE_TIP_GAP * CUE_TIP_GAP - side * side - vert * vert)
-          );
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + cueTipGap) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + cueTipGap) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
           );
           const tiltAmount = Math.abs(appliedSpin.y || 0);
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount;
@@ -16469,9 +16218,9 @@ export function PoolRoyaleGame({
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           TMP_VEC3_BUTT.set(
-            cue.pos.x - dir.x * (cueLen + pull + cueTipGap) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen + pull + cueTipGap) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen + pull + CUE_TIP_GAP) + spinWorld.z
           );
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
@@ -16652,13 +16401,10 @@ export function PoolRoyaleGame({
             }
           }
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
-          const cueTipGap = Math.sqrt(
-            Math.max(0, CUE_TIP_GAP * CUE_TIP_GAP - side * side - vert * vert)
-          );
           cueStick.position.set(
-            cue.pos.x - dir.x * (cueLen / 2 + pull + cueTipGap) + spinWorld.x,
+            cue.pos.x - dir.x * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.x,
             CUE_Y + spinWorld.y,
-            cue.pos.y - dir.z * (cueLen / 2 + pull + cueTipGap) + spinWorld.z
+            cue.pos.y - dir.z * (cueLen / 2 + pull + CUE_TIP_GAP) + spinWorld.z
           );
           const tiltAmount = Math.abs(spinY);
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
@@ -16717,23 +16463,45 @@ export function PoolRoyaleGame({
                 TMP_VEC2_CURVE.set(-b.spin.y, b.spin.x).multiplyScalar(curveScale);
                 b.vel.add(TMP_VEC2_CURVE);
               }
-              const swerveTravel = isCue && b.spinMode === 'swerve';
-              const rollMultiplier = swerveTravel ? SWERVE_TRAVEL_MULTIPLIER : 1;
-              TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
-                SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-              );
-              b.vel.add(TMP_VEC2_SPIN);
-              if (
-                isCue &&
-                b.spinMode === 'swerve' &&
-                b.pendingSpin &&
-                b.pendingSpin.lengthSq() > 0
-              ) {
-                b.vel.addScaledVector(b.pendingSpin, PRE_IMPACT_SPIN_DRIFT);
-                b.pendingSpin.multiplyScalar(0);
+              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
+              const allowRoll =
+                !isCue || b.impacted || swerveTravel || (isCue && b.spin?.lengthSq() > 1e-8);
+              const preImpact = isCue && !b.impacted;
+              if (allowRoll) {
+                const rollMultiplier = swerveTravel ? SWERVE_TRAVEL_MULTIPLIER : 1;
+                TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
+                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
+                );
+                if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
+                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
+                  const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  b.vel.add(TMP_VEC2_AXIS);
+                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
+                  if (b.spinMode === 'swerve' && b.pendingSpin) {
+                    b.pendingSpin.add(TMP_VEC2_LATERAL);
+                  }
+                  const alignedSpeed = b.vel.dot(launchDir);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
+                  b.vel.copy(TMP_VEC2_AXIS);
+                } else {
+                  b.vel.add(TMP_VEC2_SPIN);
+                  if (
+                    isCue &&
+                    b.spinMode === 'swerve' &&
+                    b.pendingSpin &&
+                    b.pendingSpin.lengthSq() > 0
+                  ) {
+                    b.vel.addScaledVector(b.pendingSpin, PRE_IMPACT_SPIN_DRIFT);
+                    b.pendingSpin.multiplyScalar(0);
+                  }
+                }
+                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
+                b.spin.multiplyScalar(rollDecay);
+              } else {
+                const airDecay = Math.pow(SPIN_AIR_DECAY, stepScale);
+                b.spin.multiplyScalar(airDecay);
               }
-              const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
-              b.spin.multiplyScalar(rollDecay);
               if (b.spin.lengthSq() < 1e-6) {
                 b.spin.set(0, 0);
                 if (b.pendingSpin) b.pendingSpin.set(0, 0);
@@ -17329,8 +17097,6 @@ export function PoolRoyaleGame({
           try {
             host.removeChild(renderer.domElement);
           } catch {}
-          renderer.domElement.removeEventListener('webglcontextlost', handleContextLost, false);
-          renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored, false);
           dom.removeEventListener('mousedown', down);
           dom.removeEventListener('mousemove', move);
           window.removeEventListener('mouseup', up);
@@ -17387,12 +17153,7 @@ export function PoolRoyaleGame({
         };
       } catch (e) {
         console.error(e);
-        const webglAvailable = isWebGLAvailable();
-        const fallbackMessage = webglAvailable
-          ? e?.message || String(e)
-          : 'WebGL is not available on this device. Enable hardware acceleration to play.';
-        setWebglUnavailable(!webglAvailable);
-        setErr(fallbackMessage);
+        setErr(e?.message || String(e));
       }
   }, []);
 
@@ -18091,42 +17852,7 @@ export function PoolRoyaleGame({
         </div>
       )}
 
-      {webglUnavailable && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/90 px-6 text-white">
-          <div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
-            <div className="w-full rounded-3xl border border-emerald-400/40 bg-emerald-950/60 p-5 shadow-[0_24px_48px_rgba(0,0,0,0.6)]">
-              <svg
-                viewBox="0 0 320 200"
-                className="h-36 w-full"
-                role="img"
-                aria-label="Snooker table preview"
-              >
-                <rect x="8" y="24" width="304" height="152" rx="18" fill="#065f46" stroke="#34d399" strokeWidth="6" />
-                <rect x="34" y="50" width="252" height="100" rx="12" fill="#0f766e" />
-                <circle cx="34" cy="50" r="10" fill="#0f172a" />
-                <circle cx="286" cy="50" r="10" fill="#0f172a" />
-                <circle cx="34" cy="150" r="10" fill="#0f172a" />
-                <circle cx="286" cy="150" r="10" fill="#0f172a" />
-                <circle cx="160" cy="50" r="10" fill="#0f172a" />
-                <circle cx="160" cy="150" r="10" fill="#0f172a" />
-                <circle cx="110" cy="100" r="9" fill="#f8fafc" />
-                <circle cx="160" cy="100" r="9" fill="#ef4444" />
-                <circle cx="210" cy="100" r="9" fill="#fbbf24" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-200">
-                WebGL required
-              </p>
-              <p className="mt-2 text-sm text-white/80">
-                Your browser has WebGL disabled, so the 3D table cannot render. Enable hardware acceleration
-                or try another browser to play.
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
-      {err && !webglUnavailable && (
+      {err && (
         <div className="absolute inset-0 bg-black/80 text-white text-xs flex items-center justify-center p-4 z-50">
           Init error: {String(err)}
         </div>

--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -15,12 +15,8 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    try {
-      const stored = window.localStorage.getItem('accountId');
-      if (stored) return stored;
-    } catch (err) {
-      console.warn('Failed to access local storage for account id', err);
-    }
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
   }
   return 'guest';
 };
@@ -38,11 +34,7 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  } catch (err) {
-    console.warn('Failed to write snooker inventory, skipping persist', err);
-  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation
- Restore the Snooker Club feature to the stable baseline from ~5 days ago to undo recent changes that caused renderer/startup/inventory inconsistencies.
- Keep the scope limited to the Snooker Club files so other game modes are unaffected.
- Re-establish the expected snooker rule serialization and table/visual defaults so gameplay and UI behave predictably.
- Simplify inventory persistence paths to avoid noisy storage error handling regressions.

### Description
- Reverted snooker rules to the prior serialized state shape and initialization (adjusted `SnookerSerializedState`, removed `ballInHand` usage, set initial `redsRemaining` to `15`, and restored related `meta.state` handling) in `src/rules/SnookerClubRules.ts`.
- Restored Snooker Club scene/table configuration, renderer sizing, cue placement/tilt and spin/physics pre-impact behavior fixes, and WebGL initialization adjustments in `webapp/src/pages/Games/SnookerClubGame.jsx` (including switching from `safeGetItem`/`safeSetItem` to direct `window.localStorage` calls and ensuring canvas fills host via 100% sizing).
- Reinstated the snooker inventory defaults/loadout and simplified option list (changed default pocket liner, removed several pocket-liner options from the store list) in `webapp/src/config/snookerClubInventoryConfig.js`.
- Simplified inventory persistence and normalization code in `webapp/src/utils/snookerClubInventory.js` (direct `localStorage` reads/writes, keep `normalizeInventory`/`getSnookerClubInventory` and event dispatch behavior intact).

### Testing
- No automated tests were executed as part of this change.
- No CI/lint or unit test runs were performed locally for these files.
- Manual verification was not recorded in this rollout message.
- Recommend running the existing unit tests and a smoke playthrough of the Snooker Club scene before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962390b65888329a02212dc9d195e0c)