### PR TITLE
Fix Pool Royale cue ball spin visuals and spin direction

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
+  x: -(spin?.x ?? 0),
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {
@@ -12032,8 +12032,10 @@ const powerRef = useRef(hud.power);
     const largest = Math.max(maxSide, maxVertical);
     const scaledX = (x * maxSide) / largest;
     const scaledY = (y * maxVertical) / largest;
-    dot.style.left = `${50 + scaledX * 50}%`;
-    dot.style.top = `${50 + scaledY * 50}%`;
+    const dotInset = (SPIN_DOT_DIAMETER_PX / SPIN_CONTROL_DIAMETER_PX) * 50;
+    const maxOffset = 50 - dotInset;
+    dot.style.left = `${50 + scaledX * maxOffset}%`;
+    dot.style.top = `${50 + scaledY * maxOffset}%`;
     const magnitude = Math.hypot(x, y);
     const showBlocked = blocked ?? spinLegalityRef.current?.blocked;
     dot.style.backgroundColor = showBlocked

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,7 +123,7 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
+  const poleInset = dotRadius * 1.1;
   const angularRadius = (dotRadius / size) * Math.PI;
   const seamInset = Math.min(0.05, Math.max(0.02, angularRadius / (Math.PI * 2)));
   const dotPositions = [


### PR DESCRIPTION
### Motivation
- Correct cue ball pole dot placement so the top/bottom dot renders on the visible top surface instead of appearing misplaced. 
- Align side-spin mapping so the visible aiming/preview and physics use the same lateral spin direction. 
- Prevent the spin UI indicator from clipping at the edge of the circular spin control to avoid visual artifacts. 

### Description
- Move the cue-ball pole inset calculation from `dotRadius * 2.2` to `dotRadius * 1.1` in `webapp/src/utils/ballMaterialFactory.js` to place the pole dots correctly on the sphere texture. 
- Flip the side-spin sign in `mapSpinForPhysics` by negating `x` in `webapp/src/pages/Games/PoolRoyale.jsx` so physics receives the corrected lateral direction. 
- Constrain the spin control dot to the control bounds by computing a `dotInset` and using `maxOffset` when setting `dot.style.left`/`top` in `webapp/src/pages/Games/PoolRoyale.jsx` to avoid clipping. 

### Testing
- No automated tests were executed for these changes in this rollout. 
- The change was committed locally as part of the patch update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962434c7d5c8329bb78576da52f42ba)