### PR TITLE
Restore Snooker Club to prior-week baseline

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -9,7 +9,6 @@ type SnookerSerializedState = {
   redsRemaining: number;
   colorsOnTable: BallColor[];
   colorOnAfterRed: boolean;
-  ballInHand: boolean;
   currentPlayer: 'A' | 'B';
   frameOver: boolean;
   winner: 'A' | 'B' | null;
@@ -85,41 +84,6 @@ type PoolMeta =
     };
 
 const UK_TOTAL_PER_COLOUR = 7;
-const SNOOKER_RED_COUNT = 15;
-
-function buildSnookerBalls(
-  redsRemaining: number,
-  colorsOnTable: Set<BallColor>,
-  cueOnTable = true
-): FrameState['balls'] {
-  const balls: FrameState['balls'] = [];
-  for (let idx = 1; idx <= SNOOKER_RED_COUNT; idx += 1) {
-    const onTable = idx <= redsRemaining;
-    balls.push({
-      id: `RED_${idx}`,
-      color: 'RED',
-      onTable,
-      potted: !onTable
-    });
-  }
-  const orderedColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
-  orderedColors.forEach((color) => {
-    const onTable = colorsOnTable.has(color);
-    balls.push({
-      id: color,
-      color,
-      onTable,
-      potted: !onTable
-    });
-  });
-  balls.push({
-    id: 'CUE',
-    color: 'CUE',
-    onTable: cueOnTable,
-    potted: !cueOnTable
-  });
-  return balls;
-}
 
 function normalizeVariantId(value: string | null | undefined): string {
   if (typeof value !== 'string') return '';
@@ -281,12 +245,12 @@ export class PoolRoyaleRules {
       case 'snooker': {
         const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
         const base: FrameState = {
-          balls: buildSnookerBalls(SNOOKER_RED_COUNT, new Set(colorsOnTable), true),
+          balls: [],
           activePlayer: 'A',
           players: basePlayers(playerA, playerB),
           currentBreak: 0,
           phase: 'REDS_AND_COLORS',
-          redsRemaining: SNOOKER_RED_COUNT,
+          redsRemaining: 15,
           colorOnAfterRed: false,
           ballOn: ['RED'],
           frameOver: false
@@ -294,10 +258,9 @@ export class PoolRoyaleRules {
         base.meta = {
           variant: 'snooker',
           state: {
-            redsRemaining: SNOOKER_RED_COUNT,
+            redsRemaining: 15,
             colorsOnTable,
             colorOnAfterRed: false,
-            ballInHand: false,
             currentPlayer: 'A',
             frameOver: false,
             winner: null
@@ -533,7 +496,6 @@ export class PoolRoyaleRules {
     redsRemaining = Math.max(0, redsRemaining - redPots);
 
     if (foulReason) {
-      colorOnAfterRed = false;
       const foulPoints = Math.max(4, foulValue || 4);
       players[opponent].score = (players[opponent].score ?? 0) + foulPoints;
       activePlayer = opponent;
@@ -564,7 +526,6 @@ export class PoolRoyaleRules {
         redsRemaining,
         colorOnAfterRed,
         ballOn: ballOnNext,
-        balls: buildSnookerBalls(redsRemaining, colorsOnTable, !cueBallPotted),
         frameOver,
         winner,
         foul: {
@@ -577,7 +538,6 @@ export class PoolRoyaleRules {
             redsRemaining,
             colorsOnTable: Array.from(colorsOnTable),
             colorOnAfterRed,
-            ballInHand: cueBallPotted,
             currentPlayer: activePlayer,
             frameOver,
             winner: winner ?? null
@@ -621,7 +581,6 @@ export class PoolRoyaleRules {
     } else {
       activePlayer = opponent;
       currentBreak = 0;
-      colorOnAfterRed = false;
     }
 
     const winner = frameOver
@@ -641,7 +600,6 @@ export class PoolRoyaleRules {
       redsRemaining,
       colorOnAfterRed,
       ballOn: ballOnNext,
-      balls: buildSnookerBalls(redsRemaining, colorsOnTable, true),
       frameOver,
       winner,
       foul: undefined,
@@ -651,7 +609,6 @@ export class PoolRoyaleRules {
           redsRemaining,
           colorsOnTable: Array.from(colorsOnTable),
           colorOnAfterRed,
-          ballInHand: false,
           currentPlayer: activePlayer,
           frameOver,
           winner: winner ?? null

--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -10,7 +10,7 @@ export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['chrome'],
   clothColor: ['freshGreen'],
   cueStyle: [CUE_STYLE_PRESETS[0]?.id],
-  pocketLiner: ['fabric_leather_02'],
+  pocketLiner: ['blackPocket'],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
 });
 
@@ -47,15 +47,7 @@ export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
       acc[preset.id] = preset.label;
       return acc;
     }, {})
-  ),
-  pocketLiner: Object.freeze({
-    fabric_leather_02: 'Fabric Leather 02 Pocket Jaws',
-    fabric_leather_01: 'Fabric Leather 01 Pocket Jaws',
-    brown_leather: 'Brown Leather Pocket Jaws',
-    leather_red_02: 'Leather Red 02 Pocket Jaws',
-    leather_red_03: 'Leather Red 03 Pocket Jaws',
-    leather_white: 'Leather White Pocket Jaws'
-  })
+  )
 });
 
 export const SNOOKER_CLUB_STORE_ITEMS = [
@@ -131,54 +123,6 @@ export const SNOOKER_CLUB_STORE_ITEMS = [
     price: 590,
     description: 'Cool arctic blue cloth with crisp broadcast sheen.'
   },
-  {
-    id: 'snooker-pocket-fabric-leather-02',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    name: 'Fabric Leather 02 Pocket Jaws',
-    price: 520,
-    description: 'Warm stitched leather weave liners for the classic club look.'
-  },
-  {
-    id: 'snooker-pocket-fabric-leather-01',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_01',
-    name: 'Fabric Leather 01 Pocket Jaws',
-    price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.'
-  },
-  {
-    id: 'snooker-pocket-brown-leather',
-    type: 'pocketLiner',
-    optionId: 'brown_leather',
-    name: 'Brown Leather Pocket Jaws',
-    price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-02',
-    type: 'pocketLiner',
-    optionId: 'leather_red_02',
-    name: 'Leather Red 02 Pocket Jaws',
-    price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-03',
-    type: 'pocketLiner',
-    optionId: 'leather_red_03',
-    name: 'Leather Red 03 Pocket Jaws',
-    price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
-  },
-  {
-    id: 'snooker-pocket-leather-white',
-    type: 'pocketLiner',
-    optionId: 'leather_white',
-    name: 'Leather White Pocket Jaws',
-    price: 590,
-    description: 'Bright white leather pockets with crisp seam definition.'
-  },
   ...CUE_STYLE_PRESETS.slice(1).map((preset, idx) => ({
     id: `snooker-cue-${preset.id}`,
     type: 'cueStyle',
@@ -203,11 +147,6 @@ export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
   { type: 'railMarkerColor', optionId: 'chrome', label: 'Chrome Rail Markers' },
   { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
   { type: 'cueStyle', optionId: CUE_STYLE_PRESETS[0]?.id, label: CUE_STYLE_PRESETS[0]?.label },
-  {
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    label: 'Fabric Leather 02 Pocket Jaws'
-  },
   {
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,

--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -15,12 +15,8 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    try {
-      const stored = window.localStorage.getItem('accountId');
-      if (stored) return stored;
-    } catch (err) {
-      console.warn('Failed to access local storage for account id', err);
-    }
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
   }
   return 'guest';
 };
@@ -38,11 +34,7 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  } catch (err) {
-    console.warn('Failed to write snooker inventory, skipping persist', err);
-  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation

- Revert recent changes so the Snooker Club game matches the known-good state from one week ago.
- Preserve the previous snooker rules serialization and foul/ball flow behavior to avoid regressions in gameplay.
- Restore the inventory defaults and store items to the prior configuration used by Snooker Club.
- Reinstate the earlier localStorage persistence behavior for snooker inventory to match the previous baseline.

### Description

- Reverted snooker rules/state changes in `src/rules/SnookerClubRules.ts`, removing the `ballInHand` field from `SnookerSerializedState` and restoring the simpler snooker meta/state flow (also removed the `buildSnookerBalls` helper and `SNOOKER_RED_COUNT` constant uses and replaced with the prior numeric defaults and empty `balls` initialization). 
- Restored initial frame setup and foul/turn handling to the previous baseline so `redsRemaining` and `colorOnAfterRed` behavior match the earlier implementation. 
- Rolled back inventory configuration in `webapp/src/config/snookerClubInventoryConfig.js`, including the `pocketLiner` default change and removal of pocket-liner store entries so defaults and store items match the earlier set. 
- Reinstated the previous persistence logic in `webapp/src/utils/snookerClubInventory.js` by simplifying `resolveAccountId` (removed guarded try/catch around `localStorage` read) and making `writeAllInventories` write directly to `localStorage` again.

### Testing

- No automated tests were run for this change.
- Changes were staged and committed locally as part of the restore operation.
- Recommended follow-up: run the repository's unit and integration test suites plus a quick Snooker Club smoke test in-browser to validate gameplay and inventory persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962447a3e5483298d7a9d6920d2fafd)