### PR TITLE
Fix cue ball dot placement and spin direction in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
+  x: -(spin?.x ?? 0),
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,15 +123,15 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
   const angularRadius = (dotRadius / size) * Math.PI;
   const seamInset = Math.min(0.05, Math.max(0.02, angularRadius / (Math.PI * 2)));
+  const poleInset = Math.max(seamInset, angularRadius / Math.PI);
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left
     { u: 0.75, v: 0.5 }, // right
-    { u: 0.5, v: poleInset / size }, // top
-    { u: 0.5, v: 1 - poleInset / size } // bottom
+    { u: 0.5, v: poleInset }, // top
+    { u: 0.5, v: 1 - poleInset } // bottom
   ];
 
   const uvToVec3 = (u, v) => {


### PR DESCRIPTION
### Motivation
- The cue ball top dot was appearing distorted and misplaced on the front seam of the texture, producing a triangular artifact instead of a pole-centered dot.  
- Cue-ball spin and the aiming/curve were running in the opposite lateral direction from player input, making controls feel inverted.  
- These changes restore correct visual placement of cue-ball dots and make spin mapping consistent with the aiming UI.

### Description
- Adjusted `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to compute `poleInset` from the spherical angular radius and use normalized `v` coordinates so the top/bottom dots are placed at the poles.  
- Inverted side-spin mapping in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `mapSpinForPhysics` to `x: -(spin?.x ?? 0)` so physics receives the correct lateral spin direction.  
- Changes are limited to texture dot placement and the spin → physics mapping and do not modify other game systems.

### Testing
- No automated tests were executed for these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962434c7d5c8329bb78576da52f42ba)