### PR TITLE
Restore Snooker Club to prior baseline

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -9,7 +9,6 @@ type SnookerSerializedState = {
   redsRemaining: number;
   colorsOnTable: BallColor[];
   colorOnAfterRed: boolean;
-  ballInHand: boolean;
   currentPlayer: 'A' | 'B';
   frameOver: boolean;
   winner: 'A' | 'B' | null;
@@ -85,41 +84,6 @@ type PoolMeta =
     };
 
 const UK_TOTAL_PER_COLOUR = 7;
-const SNOOKER_RED_COUNT = 15;
-
-function buildSnookerBalls(
-  redsRemaining: number,
-  colorsOnTable: Set<BallColor>,
-  cueOnTable = true
-): FrameState['balls'] {
-  const balls: FrameState['balls'] = [];
-  for (let idx = 1; idx <= SNOOKER_RED_COUNT; idx += 1) {
-    const onTable = idx <= redsRemaining;
-    balls.push({
-      id: `RED_${idx}`,
-      color: 'RED',
-      onTable,
-      potted: !onTable
-    });
-  }
-  const orderedColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
-  orderedColors.forEach((color) => {
-    const onTable = colorsOnTable.has(color);
-    balls.push({
-      id: color,
-      color,
-      onTable,
-      potted: !onTable
-    });
-  });
-  balls.push({
-    id: 'CUE',
-    color: 'CUE',
-    onTable: cueOnTable,
-    potted: !cueOnTable
-  });
-  return balls;
-}
 
 function normalizeVariantId(value: string | null | undefined): string {
   if (typeof value !== 'string') return '';
@@ -281,12 +245,12 @@ export class PoolRoyaleRules {
       case 'snooker': {
         const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
         const base: FrameState = {
-          balls: buildSnookerBalls(SNOOKER_RED_COUNT, new Set(colorsOnTable), true),
+          balls: [],
           activePlayer: 'A',
           players: basePlayers(playerA, playerB),
           currentBreak: 0,
           phase: 'REDS_AND_COLORS',
-          redsRemaining: SNOOKER_RED_COUNT,
+          redsRemaining: 15,
           colorOnAfterRed: false,
           ballOn: ['RED'],
           frameOver: false
@@ -294,10 +258,9 @@ export class PoolRoyaleRules {
         base.meta = {
           variant: 'snooker',
           state: {
-            redsRemaining: SNOOKER_RED_COUNT,
+            redsRemaining: 15,
             colorsOnTable,
             colorOnAfterRed: false,
-            ballInHand: false,
             currentPlayer: 'A',
             frameOver: false,
             winner: null
@@ -533,7 +496,6 @@ export class PoolRoyaleRules {
     redsRemaining = Math.max(0, redsRemaining - redPots);
 
     if (foulReason) {
-      colorOnAfterRed = false;
       const foulPoints = Math.max(4, foulValue || 4);
       players[opponent].score = (players[opponent].score ?? 0) + foulPoints;
       activePlayer = opponent;
@@ -564,7 +526,6 @@ export class PoolRoyaleRules {
         redsRemaining,
         colorOnAfterRed,
         ballOn: ballOnNext,
-        balls: buildSnookerBalls(redsRemaining, colorsOnTable, !cueBallPotted),
         frameOver,
         winner,
         foul: {
@@ -577,7 +538,6 @@ export class PoolRoyaleRules {
             redsRemaining,
             colorsOnTable: Array.from(colorsOnTable),
             colorOnAfterRed,
-            ballInHand: cueBallPotted,
             currentPlayer: activePlayer,
             frameOver,
             winner: winner ?? null
@@ -621,7 +581,6 @@ export class PoolRoyaleRules {
     } else {
       activePlayer = opponent;
       currentBreak = 0;
-      colorOnAfterRed = false;
     }
 
     const winner = frameOver
@@ -641,7 +600,6 @@ export class PoolRoyaleRules {
       redsRemaining,
       colorOnAfterRed,
       ballOn: ballOnNext,
-      balls: buildSnookerBalls(redsRemaining, colorsOnTable, true),
       frameOver,
       winner,
       foul: undefined,
@@ -651,7 +609,6 @@ export class PoolRoyaleRules {
           redsRemaining,
           colorsOnTable: Array.from(colorsOnTable),
           colorOnAfterRed,
-          ballInHand: false,
           currentPlayer: activePlayer,
           frameOver,
           winner: winner ?? null

--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -10,7 +10,7 @@ export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['chrome'],
   clothColor: ['freshGreen'],
   cueStyle: [CUE_STYLE_PRESETS[0]?.id],
-  pocketLiner: ['fabric_leather_02'],
+  pocketLiner: ['blackPocket'],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
 });
 
@@ -47,15 +47,7 @@ export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
       acc[preset.id] = preset.label;
       return acc;
     }, {})
-  ),
-  pocketLiner: Object.freeze({
-    fabric_leather_02: 'Fabric Leather 02 Pocket Jaws',
-    fabric_leather_01: 'Fabric Leather 01 Pocket Jaws',
-    brown_leather: 'Brown Leather Pocket Jaws',
-    leather_red_02: 'Leather Red 02 Pocket Jaws',
-    leather_red_03: 'Leather Red 03 Pocket Jaws',
-    leather_white: 'Leather White Pocket Jaws'
-  })
+  )
 });
 
 export const SNOOKER_CLUB_STORE_ITEMS = [
@@ -131,54 +123,6 @@ export const SNOOKER_CLUB_STORE_ITEMS = [
     price: 590,
     description: 'Cool arctic blue cloth with crisp broadcast sheen.'
   },
-  {
-    id: 'snooker-pocket-fabric-leather-02',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    name: 'Fabric Leather 02 Pocket Jaws',
-    price: 520,
-    description: 'Warm stitched leather weave liners for the classic club look.'
-  },
-  {
-    id: 'snooker-pocket-fabric-leather-01',
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_01',
-    name: 'Fabric Leather 01 Pocket Jaws',
-    price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.'
-  },
-  {
-    id: 'snooker-pocket-brown-leather',
-    type: 'pocketLiner',
-    optionId: 'brown_leather',
-    name: 'Brown Leather Pocket Jaws',
-    price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-02',
-    type: 'pocketLiner',
-    optionId: 'leather_red_02',
-    name: 'Leather Red 02 Pocket Jaws',
-    price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.'
-  },
-  {
-    id: 'snooker-pocket-leather-red-03',
-    type: 'pocketLiner',
-    optionId: 'leather_red_03',
-    name: 'Leather Red 03 Pocket Jaws',
-    price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
-  },
-  {
-    id: 'snooker-pocket-leather-white',
-    type: 'pocketLiner',
-    optionId: 'leather_white',
-    name: 'Leather White Pocket Jaws',
-    price: 590,
-    description: 'Bright white leather pockets with crisp seam definition.'
-  },
   ...CUE_STYLE_PRESETS.slice(1).map((preset, idx) => ({
     id: `snooker-cue-${preset.id}`,
     type: 'cueStyle',
@@ -203,11 +147,6 @@ export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
   { type: 'railMarkerColor', optionId: 'chrome', label: 'Chrome Rail Markers' },
   { type: 'clothColor', optionId: 'freshGreen', label: 'Tour Green Cloth' },
   { type: 'cueStyle', optionId: CUE_STYLE_PRESETS[0]?.id, label: CUE_STYLE_PRESETS[0]?.label },
-  {
-    type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    label: 'Fabric Leather 02 Pocket Jaws'
-  },
   {
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -175,7 +175,6 @@ const MURLAN_TYPE_LABELS = {
   cards: 'Card Themes',
   stools: 'Stools & Chairs',
   tables: 'Table Models',
-  tableFinish: 'Table Finish',
   environmentHdri: 'HDR Environments'
 };
 
@@ -203,7 +202,6 @@ const SNAKE_TYPE_LABELS = {
 };
 
 const TEXAS_TYPE_LABELS = {
-  tableFinish: 'Table Finish',
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
   tableBase: 'Table Base',
@@ -304,6 +302,11 @@ const OPTION_SWATCH_OVERRIDES = {
   woodTable001: ['#8f6243', '#a4724f'],
   darkWood: ['#2f241f', '#3d2f2a'],
   rosewoodVeneer01: ['#5b2f26', '#6f3a2f'],
+  rosewoodVeneerAmber: ['#874a29', '#a25d35'],
+  rosewoodVeneerWalnut: ['#523425', '#6a422f'],
+  rosewoodVeneerEbony: ['#1f140f', '#2c1c16'],
+  rosewoodVeneerHoney: ['#ab6b34', '#cd8642'],
+  rosewoodVeneerAsh: ['#6f5f55', '#8b7d72'],
   gold: ['#f59e0b', '#fbbf24'],
   chrome: ['#e5e7eb', '#a1a1aa'],
   pearl: ['#f5f3ff', '#e2e8f0'],

--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -15,12 +15,8 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    try {
-      const stored = window.localStorage.getItem('accountId');
-      if (stored) return stored;
-    } catch (err) {
-      console.warn('Failed to access local storage for account id', err);
-    }
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
   }
   return 'guest';
 };
@@ -38,11 +34,7 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  } catch (err) {
-    console.warn('Failed to write snooker inventory, skipping persist', err);
-  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation
- Restore the Snooker Club game code to the previous baseline to undo recent regressions in rules, inventory and storage handling. 
- Ensure gameplay state (reds count, foul handling and frame progression) matches the prior, stable behavior. 
- Reinstate the original inventory defaults and store items so the in-game store and loadout behave as before. 

### Description
- Reverted snooker rule state and initialization to the prior behavior by removing the `buildSnookerBalls` helper and `SNOOKER_RED_COUNT`, using `redsRemaining: 15`, and removing the `ballInHand` serialized field in `src/rules/SnookerClubRules.ts` so the initial frame and shot resolution mirror the previous baseline. 
- Restored prior foul/turn logic and meta snapshot contents in `src/rules/SnookerClubRules.ts` so computed `meta.state` and `ballOn` calculations match the earlier implementation. 
- Rolled back inventory defaults, option labels and store items in `webapp/src/config/snookerClubInventoryConfig.js` (including `pocketLiner` default and removal of pocket-liner items) and updated the default loadout accordingly. 
- Restored legacy localStorage handling in `webapp/src/utils/snookerClubInventory.js` (direct `localStorage` access for reads/writes and `resolveAccountId`) and adjusted store UI swatches/labels in `webapp/src/pages/Store.jsx`. 

### Testing
- No automated tests were executed for this change. 
- The change set is limited to rule initialization, inventory config and local storage utilities and does not add new automated tests. 
- Existing CI/test suites were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962447a3e5483298d7a9d6920d2fafd)