### PR TITLE
Fix Pool Royale aim direction, spin mapping, and cue ball dot placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,8 +5017,8 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
-  y: spin?.y ?? 0
+  x: -(spin?.x ?? 0),
+  y: -(spin?.y ?? 0)
 });
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
@@ -17651,7 +17651,7 @@ const powerRef = useRef(hud.power);
                 ? CHALK_PRECISION_SLOW_MULTIPLIER
                 : 1;
             const precisionScale = basePrecisionScale * slowScale;
-            sph.theta -= dx * 0.0026 * precisionScale;
+            sph.theta += dx * 0.0026 * precisionScale;
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const phiDelta = dy * 0.0019 * precisionScale;
             const blendDelta =
@@ -17714,9 +17714,9 @@ const powerRef = useRef(hud.power);
               : 1;
           const step = baseStep * slowScale;
           if (e.code === 'ArrowLeft') {
-            sph.theta += step;
-          } else if (e.code === 'ArrowRight') {
             sph.theta -= step;
+          } else if (e.code === 'ArrowRight') {
+            sph.theta += step;
           } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
             const phiRange = CAMERA.maxPhi - CAMERA.minPhi;
             const dir = e.code === 'ArrowUp' ? -1 : 1;

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,7 +123,7 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
+  const poleInset = dotRadius * 1.05;
   const angularRadius = (dotRadius / size) * Math.PI;
   const seamInset = Math.min(0.05, Math.max(0.02, angularRadius / (Math.PI * 2)));
   const dotPositions = [


### PR DESCRIPTION
### Motivation
- Fix the cue ball visual artefact where the top dot rendered with an incorrect shape/position on the sphere surface.  
- Make player input for aiming and spin match the on-table responses so the cue ball no longer spins or aims in the opposite direction.  
- Keep camera/pointer rotation consistent with the control mapping so drag/arrow rotations feel natural.  

### Description
- Adjust `drawCueBallDots` pole inset so the top/bottom dot positions are calculated closer to the pole (`webapp/src/utils/ballMaterialFactory.js`).  
- Invert the spin-to-physics mapping by negating `x` and `y` in `mapSpinForPhysics` so spin input applies in the expected direction (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Flip pointer drag horizontal rotation sign and swap `ArrowLeft`/`ArrowRight` key handling so camera/aim rotation matches drag direction (`webapp/src/pages/Games/PoolRoyale.jsx`).  

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962434c7d5c8329bb78576da52f42ba)