### PR TITLE
Adjust cue ball dot size and seam placement

### DIFF
--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -7,7 +7,7 @@ import { applySRGBColorSpace } from './colorSpace.js';
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
-const CUE_TIP_RADIUS_RATIO = 0.1714285714;
+const CUE_TIP_RADIUS_RATIO = 0.155;
 
 function clamp01(value) {
   return Math.min(1, Math.max(0, value));
@@ -125,7 +125,7 @@ function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
   const poleInset = dotRadius * 2.2;
   const angularRadius = (dotRadius / size) * Math.PI;
-  const seamInset = Math.min(0.05, Math.max(0.02, angularRadius / (Math.PI * 2)));
+  const seamInset = 0;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left


### PR DESCRIPTION
### Motivation

- Fix visual mismatch where the cue ball red dots were larger than the cue tip and an extra side dot appeared near the seam. 
- Make the six cue-ball dots perfectly circular and better match the radius of the front blue cue tip. 
- Keep rendering logic simple and deterministic so the seam-spanning dot does not produce a stray visible dot. 

### Description

- Reduced the cue-dot sizing constant by updating `CUE_TIP_RADIUS_RATIO` from `0.1714285714` to `0.155` in `webapp/src/utils/ballMaterialFactory.js`. 
- Removed the computed seam inset and set `seamInset` to `0` so the back seam dot is anchored on the texture seam and avoids producing an extra visible side dot. 
- Left the existing spherical UV sampling and seam draw calls in place so dots remain circular on the equirectangular texture. 
- Change recorded in a commit with message `Adjust cue ball dots`.

### Testing

- No automated tests were executed for this visual change. 
- Visual verification in a running client is recommended to confirm dot size and seam behaviour on the cue ball texture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624f00da1c83299b29ce5d23cc4b17)