### PR TITLE
Fix cue ball pole dots and side-spin alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19950,11 +19950,12 @@ const powerRef = useRef(hud.power);
             spinTop *= TOPSPIN_MULTIPLIER;
           }
           const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
+          const appliedSideSpin = -spinSide;
           cue.vel.copy(base);
           if (cue.spin) {
             cue.spin.set(
-              perp.x * spinSide + aimDir.x * spinTop,
-              perp.y * spinSide + aimDir.y * spinTop
+              perp.x * appliedSideSpin + aimDir.x * spinTop,
+              perp.y * appliedSideSpin + aimDir.y * spinTop
             );
           }
           if (cue.pendingSpin) cue.pendingSpin.set(0, 0);

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,15 +123,16 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
-  const angularRadius = (dotRadius / size) * Math.PI;
+  const poleDotRadius = dotRadius * 0.75;
+  const poleLatitudeDeg = 78;
+  const poleV = 0.5 - poleLatitudeDeg / 180;
   const seamInset = 0;
   const dotPositions = [
-    { u: 0.5, v: 0.5 }, // front
-    { u: 0.25, v: 0.5 }, // left
-    { u: 0.75, v: 0.5 }, // right
-    { u: 0.5, v: poleInset / size }, // top
-    { u: 0.5, v: 1 - poleInset / size } // bottom
+    { u: 0.5, v: 0.5, radius: dotRadius }, // front
+    { u: 0.25, v: 0.5, radius: dotRadius }, // left
+    { u: 0.75, v: 0.5, radius: dotRadius }, // right
+    { u: 0.5, v: poleV, radius: poleDotRadius }, // top
+    { u: 0.5, v: 1 - poleV, radius: poleDotRadius } // bottom
   ];
 
   const uvToVec3 = (u, v) => {
@@ -145,7 +146,8 @@ function drawCueBallDots(ctx, size) {
     };
   };
 
-  const drawDot = ({ u, v }) => {
+  const drawDot = ({ u, v, radius }) => {
+    const angularRadius = (radius / size) * Math.PI;
     const du = angularRadius / (Math.PI * 2);
     const dv = angularRadius / Math.PI;
     const minU = Math.max(0, u - du);
@@ -187,8 +189,8 @@ function drawCueBallDots(ctx, size) {
   dotPositions.forEach(drawDot);
 
   // Back dot spans the seam to keep a full circle.
-  drawDot({ u: seamInset, v: 0.5 });
-  drawDot({ u: 1 - seamInset, v: 0.5 });
+  drawDot({ u: seamInset, v: 0.5, radius: dotRadius });
+  drawDot({ u: 1 - seamInset, v: 0.5, radius: dotRadius });
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Top and bottom cue-ball markers were rendering as clipped/triangular shapes instead of round pole dots on the equirectangular texture. 
- The shot preview/aiming guide showed spin in the opposite direction to the actual applied cue-ball spin, causing controller feedback to disagree with physics. 
- Make the cue texture and physics mapping consistent so the visual spin indicator matches the resulting shot. 

### Description
- Adjusted `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to use per-dot radii and a fixed pole latitude so the top/bottom dots draw as proper circular marks on the sphere texture. 
- Reworked the dot sampling to compute an `angularRadius` per dot and pass `radius` through `drawDot` so seam and pole dots keep correct shape and size. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` flipped the applied lateral spin sign by introducing `appliedSideSpin = -spinSide` before writing into `cue.spin.set(...)` so the physical cue-ball spin matches the controller/preview orientation. 

### Testing
- No automated tests were run for these changes. 
- Changes were implemented as source edits to the rendering (`ballMaterialFactory`) and shot application (`PoolRoyale.jsx`) code paths and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962557bd2f08329a76b83e1f199eae9)