### PR TITLE
Fix Pool Royale cue ball pole dots and invert side-spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
+  x: -(spin?.x ?? 0),
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,7 +123,7 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
+  const poleInset = dotRadius * 1.1;
   const angularRadius = (dotRadius / size) * Math.PI;
   const seamInset = 0;
   const dotPositions = [


### PR DESCRIPTION
### Motivation

- The cue ball top/bottom pole marks were rendering as distorted/triangular shapes instead of circular highlights on the sphere texture. 
- The cue ball spin and the aiming preview were showing opposite side-spin directions compared to the spin controller input. 
- These visual and input mismatches degrade player feedback for spin and aiming on Pool Royale. 

### Description

- Move the cue ball pole dot positions closer to the poles by changing the `poleInset` multiplier in `drawCueBallDots` inside `webapp/src/utils/ballMaterialFactory.js` (reduce from `dotRadius * 2.2` to `dotRadius * 1.1`) so the top/bottom dots render as full circles. 
- Invert the side-spin mapping passed to the physics layer by negating the X component in `mapSpinForPhysics` inside `webapp/src/pages/Games/PoolRoyale.jsx` so physics/aim preview now match the spin controller direction. 
- Adjustments are localized to `drawCueBallDots` (texture generation) and `mapSpinForPhysics` (spin mapping) and do not change other spin logic or UI code. 

### Testing

- No automated tests were run as part of this change. 
- Visual/functional verification was not executed in CI during this edit. 
- Manual playtesting is recommended to validate that top/bottom cue dots now appear circular and that side-spin/aim preview directions match controller input.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962557bd2f08329a76b83e1f199eae9)