### PR TITLE
Fix cue ball spin dots and spin-controller alignment for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12032,7 +12032,7 @@ const powerRef = useRef(hud.power);
     const largest = Math.max(maxSide, maxVertical);
     const scaledX = (x * maxSide) / largest;
     const scaledY = (y * maxVertical) / largest;
-    dot.style.left = `${50 + scaledX * 50}%`;
+    dot.style.left = `${50 - scaledX * 50}%`;
     dot.style.top = `${50 + scaledY * 50}%`;
     const magnitude = Math.hypot(x, y);
     const showBlocked = blocked ?? spinLegalityRef.current?.blocked;
@@ -24354,7 +24354,7 @@ const powerRef = useRef(hud.power);
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
       let ny = ((cy - rect.top) / rect.height) * 2 - 1;
-      setSpin(nx, ny);
+      setSpin(-nx, ny);
     };
 
     const scaleBox = (value) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -148,8 +148,9 @@ function drawCueBallDots(ctx, size) {
   const drawDot = ({ u, v }) => {
     const du = angularRadius / (Math.PI * 2);
     const dv = angularRadius / Math.PI;
-    const minU = Math.max(0, u - du);
-    const maxU = Math.min(1, u + du);
+    const poleOverlap = v - dv <= 0 || v + dv >= 1;
+    const minU = poleOverlap ? 0 : Math.max(0, u - du);
+    const maxU = poleOverlap ? 1 : Math.min(1, u + du);
     const minV = Math.max(0, v - dv);
     const maxV = Math.min(1, v + dv);
     const startX = Math.floor(minU * size);


### PR DESCRIPTION
### Motivation
- Top and bottom cue‑ball spin dots were being clipped at the texture poles and rendered as triangular artifacts instead of full circles.  
- The on-screen spin controller input and the cue ball/aim preview were mirrored, causing the aim line and cue spin to disagree with the controller indicator.  
- Improve visual fidelity of the cue ball and make spin input intuitive and consistent with the aiming preview.  

### Description
- Prevent pole clipping in the cue ball texture generator by detecting pole overlap and expanding the horizontal UV sampling to span the seam, updating `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js`.  
- Flip the horizontal mapping for the spin UI so the visible spin dot on the ball and the aiming line match controller input by inverting the X used to position the spin dot in `updateSpinDotPosition` (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Invert the X when converting pointer coordinates to spin values (`setSpin(-nx, ny)`) so dragging the spin control left/right produces the expected left/right spin on the cue ball (`webapp/src/pages/Games/PoolRoyale.jsx`).  

### Testing
- No automated tests were executed for this change.  
- Changes are limited to visual/interaction mapping and were implemented with targeted edits to `drawCueBallDots` and the spin controller mapping; please run the Pool Royale demo or relevant UI smoke tests to validate visuals and input alignment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962557bd2f08329a76b83e1f199eae9)