### PR TITLE
Fix cue ball spin direction and cue-dot placement in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
+  x: -(spin?.x ?? 0),
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {
@@ -19655,7 +19655,8 @@ const powerRef = useRef(hud.power);
         const offsetVertical = ranges?.offsetVertical ?? 0;
         const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
         const hasSpin = magnitude > 1e-4;
-        let side = hasSpin ? spin.x * offsetSide : 0;
+        const sideInput = -(spin?.x ?? 0);
+        let side = hasSpin ? sideInput * offsetSide : 0;
         let vert = hasSpin ? -spin.y * offsetVertical : 0;
         if (hasSpin) {
           vert = THREE.MathUtils.clamp(vert, -MAX_SPIN_VISUAL_LIFT, MAX_SPIN_VISUAL_LIFT);

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -123,15 +123,16 @@ function drawPoolNumberBadge(ctx, size, number) {
 
 function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
-  const poleInset = dotRadius * 2.2;
   const angularRadius = (dotRadius / size) * Math.PI;
+  const poleOffset = angularRadius * 1.35;
+  const poleV = Math.min(0.5, Math.max(0, poleOffset / Math.PI));
   const seamInset = 0;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
     { u: 0.25, v: 0.5 }, // left
     { u: 0.75, v: 0.5 }, // right
-    { u: 0.5, v: poleInset / size }, // top
-    { u: 0.5, v: 1 - poleInset / size } // bottom
+    { u: 0.5, v: poleV }, // top
+    { u: 0.5, v: 1 - poleV } // bottom
   ];
 
   const uvToVec3 = (u, v) => {


### PR DESCRIPTION
### Motivation
- Top and bottom cue-ball dots on the cue ball texture were rendering as distorted/triangular shapes instead of circular poles and needed corrected UV placement.
- The cue ball and aiming visuals were rotating opposite to the spin controller input, so the physics/visuals and the on-screen spin dot were inconsistent.
- Ensure the cue-tip offset and aiming preview use the same spin sign so the aim line, cue stick visuals, and resulting physics match controller input.
- Keep changes small and local to ball texture generation and spin mapping so other systems remain unaffected.

### Description
- Adjusted pole placement math in `drawCueBallDots` (`webapp/src/utils/ballMaterialFactory.js`) to compute top/bottom dot UVs from an angular offset (`poleOffset / poleV`) so the pole dots remain circular across the sphere projection.
- Inverted lateral spin mapping by negating the X component in `mapSpinForPhysics` in `webapp/src/pages/Games/PoolRoyale.jsx` so physics uses the same left/right sign as the spin controller (`x: -(spin?.x ?? 0)`).
- Applied the same lateral inversion when computing visual cue-tip spin offsets in `computeSpinOffsets` so the cue stick and aim preview align with the controller input.
- Changes are limited to `webapp/src/utils/ballMaterialFactory.js` and `webapp/src/pages/Games/PoolRoyale.jsx` and should reconcile controller, aim-line, cue visuals, and resulting spin behaviour.

### Testing
- No automated tests were executed against these changes.
- Interactive/manual QA was not included in this PR; recommend running the app and verifying that the spin controller left/right matches the cueball roll and that the top/bottom cue-ball dots render as circular poles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962557bd2f08329a76b83e1f199eae9)