### PR TITLE
Add Snooker Club loading overlay to avoid black screen

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -9426,6 +9426,8 @@ export function PoolRoyaleGame({
     applyLightingPreset(lightingId);
   }, [applyLightingPreset, lightingId]);
   const [err, setErr] = useState(null);
+  const [sceneReady, setSceneReady] = useState(false);
+  const hasRenderedRef = useRef(false);
   const fireRef = useRef(() => {}); // set from effect so slider can trigger fire()
   const cameraRef = useRef(null);
   const sphRef = useRef(null);
@@ -10079,6 +10081,8 @@ export function PoolRoyaleGame({
     const host = mountRef.current;
     if (!host) return;
     setErr(null);
+    setSceneReady(false);
+    hasRenderedRef.current = false;
     if (!isWebGLAvailable()) {
       setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
       return;
@@ -17062,9 +17066,13 @@ export function PoolRoyaleGame({
             const edge = Math.min(1, Math.max(edgeX, edgeY) / 5);
             fit(1 + edge * 0.08);
           }
-          const frameCamera = updateCamera();
-          renderer.render(scene, frameCamera ?? camera);
-          rafRef.current = requestAnimationFrame(step);
+        const frameCamera = updateCamera();
+        renderer.render(scene, frameCamera ?? camera);
+        if (!hasRenderedRef.current) {
+          hasRenderedRef.current = true;
+          setSceneReady(true);
+        }
+        rafRef.current = requestAnimationFrame(step);
         };
         step(performance.now());
 
@@ -17876,6 +17884,14 @@ export function PoolRoyaleGame({
       {err && (
         <div className="absolute inset-0 bg-black/80 text-white text-xs flex items-center justify-center p-4 z-50">
           Init error: {String(err)}
+        </div>
+      )}
+      {!sceneReady && !err && (
+        <div className="absolute inset-0 z-40 flex items-center justify-center bg-gradient-to-b from-[#0b1324] via-[#070f1f] to-black text-white">
+          <div className="flex flex-col items-center gap-3 rounded-2xl border border-emerald-400/30 bg-black/60 px-6 py-5 text-center text-xs uppercase tracking-[0.35em] shadow-[0_24px_48px_rgba(0,0,0,0.45)] backdrop-blur">
+            <span className="text-[11px] text-emerald-200/80">Snooker Club</span>
+            <span className="text-[10px] text-white/60">Loading table...</span>
+          </div>
         </div>
       )}
       {hud?.inHand && (


### PR DESCRIPTION
### Motivation
- The Snooker Club 3D scene could show a black page while the WebGL scene is building and before the first frame is rendered.  
- Provide clear feedback during the initial scene boot to avoid a confusing blank/black screen.  
- Ensure the loading state is reset on each game init so the overlay doesn't persist across re-inits.  

### Description
- Added a `sceneReady` React state and a `hasRenderedRef` ref to track when the first `renderer.render` has occurred.  
- Reset `sceneReady` and `hasRenderedRef` at scene initialization so loading state is fresh for each mount (`useEffect` that initializes the renderer).  
- On the first successful render loop iteration set `hasRenderedRef.current = true` and `setSceneReady(true)`.  
- Render a small branded loading overlay (gated by `!sceneReady && !err`) in `webapp/src/pages/Games/SnookerClubGame.jsx` to show a friendly "Loading table..." screen while the 3D scene boots.  

### Testing
- Started the dev server with `npm --prefix webapp run dev` to load the app locally (Vite reported ready).  
- Attempted a Playwright screenshot navigation to `/games/snookerclub` to validate the overlay, but the scripted headless run timed out before completion.  
- No unit tests were run as this is a UI-only change.  
- Manual smoke: code includes guards for `WebGL` availability and preserves existing `err` handling so the loading overlay only shows when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ac4abcc832989e169e094814c6d)