### PR TITLE
Fix cue ball dot placement and align spin direction with controller

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -125,7 +125,11 @@ function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
   const angularRadius = (dotRadius / size) * Math.PI;
   const poleOffset = angularRadius * 1.35;
-  const poleV = Math.min(0.5, Math.max(0, poleOffset / Math.PI));
+  const polePadding = angularRadius / Math.PI;
+  const poleV = Math.min(
+    0.5,
+    Math.max(polePadding, poleOffset / Math.PI)
+  );
   const seamInset = 0;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front


### PR DESCRIPTION
### Motivation
- Ensure the red cue-ball dots (including top and bottom poles) render identically to the other dots by preventing texture-edge clipping.  
- Make the cue ball spin direction match the spin control and aiming line so visual and physics inputs are consistent.  

### Description
- Adjusted the cue-ball dot placement math in `webapp/src/utils/ballMaterialFactory.js` by adding a pole padding and clamping `poleV` so top/bottom dots remain inside the texture bounds.  
- Removed the lateral inversion in the physics mapping by changing `mapSpinForPhysics` in `webapp/src/pages/Games/PoolRoyale.jsx` from `x: -(spin?.x ?? 0)` to `x: spin?.x ?? 0` so applied spin now matches the controller direction.  
- Changes are limited to visual cue-ball texture generation and the spin mapping used when converting UI spin to physics spin.  

### Testing
- No automated tests were executed as part of this change.  
- A code formatting/lint step was not run automatically in this rollout.  
- Manual visual verification is recommended in the game to confirm top/bottom dots match other dots and that cue ball rotation follows the aiming line.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962633a94d48329ab4b2ee51f65069f)