### PR TITLE
Fix cue ball dot rendering and align roll direction with spin controls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23287,7 +23287,7 @@ const powerRef = useRef(hud.power);
             const liftAmount = b.lift ?? 0;
             b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
             if (scaledSpeed > 0) {
-              const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
+              const axis = new THREE.Vector3(-b.vel.y, 0, b.vel.x).normalize();
               const angle = scaledSpeed / BALL_R;
               b.mesh.rotateOnWorldAxis(axis, angle);
             }

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -125,7 +125,8 @@ function drawCueBallDots(ctx, size) {
   const dotRadius = size * 0.5 * CUE_TIP_RADIUS_RATIO;
   const angularRadius = (dotRadius / size) * Math.PI;
   const poleOffset = angularRadius * 1.35;
-  const poleV = Math.min(0.5, Math.max(0, poleOffset / Math.PI));
+  const minPoleV = angularRadius / Math.PI;
+  const poleV = Math.min(0.5, Math.max(minPoleV, poleOffset / Math.PI));
   const seamInset = 0;
   const dotPositions = [
     { u: 0.5, v: 0.5 }, // front
@@ -147,7 +148,9 @@ function drawCueBallDots(ctx, size) {
   };
 
   const drawDot = ({ u, v }) => {
-    const du = angularRadius / (Math.PI * 2);
+    const latitude = (0.5 - v) * Math.PI;
+    const cosLat = Math.cos(latitude);
+    const du = angularRadius / (Math.PI * 2 * Math.max(0.12, Math.abs(cosLat)));
     const dv = angularRadius / Math.PI;
     const minU = Math.max(0, u - du);
     const maxU = Math.min(1, u + du);


### PR DESCRIPTION
### Motivation
- Make the cue ball top/bottom red dots render identical to the other dots by fixing the UV/projection math. 
- Ensure the visual roll direction of the cue ball matches the aiming line and spin controller so the spin looks correct. 
- Keep all other ball markings and the spin controller behaviour unchanged. 

### Description
- Adjust `drawCueBallDots` in `webapp/src/utils/ballMaterialFactory.js` to clamp the pole V coordinate and compensate for latitude compression so pole dots keep full circular shape. 
- Modify the sample radius calculation in `drawCueBallDots` to scale `du` by latitude (`cos(latitude)`) to avoid stretched sampling near poles. 
- Flip the roll axis used for rotating the mesh in `webapp/src/pages/Games/PoolRoyale.jsx` so `b.mesh.rotateOnWorldAxis` uses `new THREE.Vector3(-b.vel.y, 0, b.vel.x)` and the cue ball visually spins to match the aim/spin input. 

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready and serving at `http://localhost:4173/`. 
- Attempted to capture an in-game screenshot with Playwright to visually verify the change, but the screenshot attempt timed out. 
- No automated unit tests were run as part of this change (no `jest`/`vitest` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962633a94d48329ab4b2ee51f65069f)