### PR TITLE
Adjust Snooker Club error overlay presentation

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -17900,8 +17900,11 @@ export function PoolRoyaleGame({
       )}
 
       {err && (
-        <div className="absolute inset-0 bg-black/80 text-white text-xs flex items-center justify-center p-4 z-50">
-          Init error: {String(err)}
+        <div className="pointer-events-none absolute left-1/2 top-4 z-50 -translate-x-1/2 px-4">
+          <div className="pointer-events-auto flex max-w-xl items-center gap-2 rounded-2xl border border-red-400/50 bg-red-900/85 px-4 py-3 text-xs font-semibold text-white shadow-[0_16px_34px_rgba(0,0,0,0.5)] backdrop-blur">
+            <span className="text-red-200">Init issue:</span>
+            <span className="text-white/90">{String(err)}</span>
+          </div>
         </div>
       )}
       {hud?.inHand && (


### PR DESCRIPTION
### Motivation
- The full-screen init error overlay in the Snooker Club UI was blocking the power slider, aiming line and other HUD elements, preventing gameplay from being visible.
- Provide a less intrusive way to surface initialization errors while keeping the interactive UI visible and accessible.

### Description
- Replaced the full-screen error overlay in `webapp/src/pages/Games/SnookerClubGame.jsx` with a compact, centered toast-style banner so it no longer covers the canvas or controls.
- The new banner is rendered as a non-blocking wrapper (`pointer-events-none`) with an inner `pointer-events-auto` toast element and styled with a red error palette and rounded container.
- Kept the original error content but moved to a compact layout that matches existing HUD/toast patterns used elsewhere in the app.
- Changes were committed to the repository (`git commit` performed) and the modified file is `webapp/src/pages/Games/SnookerClubGame.jsx`.

### Testing
- No automated tests were executed for this change.
- This is a UI-only change intended to be verified visually during manual or smoke testing.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962642be630832990f94e5e847f92a0)