### PR TITLE
Fix Pool Royale side spin direction mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- Players reported the cue ball spinning the opposite direction from the spin control (left input produced right spin), so side-spin visually and physically disagreed with the aiming UI.
- The intent is to make cue-ball side spin match the existing aiming line and spin controller without changing those systems.

### Description
- Replaced the sign inversion in `mapSpinForPhysics` so the physics receives side spin with the same sign as the controller by changing `x: -(spin?.x ?? 0)` to `x: spin?.x ?? 0`.
- The change is a single-line update in `webapp/src/pages/Games/PoolRoyale.jsx` and does not modify the aiming line or spin controller code.

### Testing
- No automated tests were run for this change.
- Manual verification is expected during QA to confirm left/right spin now matches the aiming UI (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626c51d0f48329a3ae301f27945123)