### PR TITLE
Align cue side-spin direction with spin controller (PoolRoyale.jsx)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- Fix a bug where applying left spin caused the cue ball to spin right so physics matches the spin controller input.
- Keep the aiming line and spin controller visuals unchanged and only adjust the physics mapping.
- Improve player control fidelity by making input direction and ball response consistent.

### Description
- Updated `mapSpinForPhysics` in `webapp/src/pages/Games/PoolRoyale.jsx` to stop negating the X (side) component so the side-spin sign matches the controller input.
- The one-line change replaces `x: -(spin?.x ?? 0)` with `x: spin?.x ?? 0` and leaves `y` mapping and other spin clamping logic untouched.
- Only physics mapping was modified; UI and spin controller code were not changed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626c51d0f48329a3ae301f27945123)