### PR TITLE
Align cue side-spin direction with controller input

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- Fix a direction-mismatch where left/right side-spin from the controller did not match the physics input to the cue ball.
- Respect the UX principle of not inverting user directions so controller input maps visually and physically as expected.
- Keep UI and aiming visuals unchanged while correcting the physics mapping.

### Description
- Updated `mapSpinForPhysics` in `webapp/src/pages/Games/PoolRoyale.jsx` to stop negating the X (side) component so side-spin sign matches controller input.
- Replaced `x: -(spin?.x ?? 0)` with `x: spin?.x ?? 0` and left `y` mapping and spin clamping logic untouched.
- Change only affects the physics mapping layer and does not modify UI, aim line, or controller visuals.

### Testing
- No automated tests were executed for this change.
- Manual verification should ensure left/right input now produces corresponding left/right cue-ball spin (not part of automated run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626c51d0f48329a3ae301f27945123)