### PR TITLE
Add jump and masse tuning to cue physics

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -20,7 +20,16 @@ public static class PhysicsConstants
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
     public const double JumpStopVelocity = 0.2;        // m/s below which vertical motion stops
     public const double AirborneHeightThreshold = BallRadius * 0.25; // height before ignoring cushions/balls
-    public const double MaxCueElevationDegrees = 70.0; // WPA jump cue elevations top out near this range
+    public const double JumpVelocityThreshold = 0.9;   // minimum vertical speed to treat as a hop
+    public const double JumpTipOffsetBoost = 0.35;     // reduces jump threshold as tip offset increases
+    public const double LandingHorizontalDamping = 0.85; // horizontal speed retained on landing
+    public const double LandingSpinDamping = 0.8;      // spin retained on landing
+    public const double MasseAngleMin = 25.0;          // degrees where masse starts to show
+    public const double MasseAngleMax = 75.0;          // degrees where masse reaches full strength
+    public const double MasseSwerveBoost = 2.0;        // multiplier for swerve at max masse
+    public const double SwerveSpeedCutoff = 2.5;       // m/s after which swerve fades out
+    public const double SwerveSpeedFadeRange = 4.0;    // fade distance for swerve cutoff
+    public const double MaxCueElevationDegrees = 85.0; // clamp to UI upper bound
     public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%


### PR DESCRIPTION
### Motivation

- Provide tunable parameters to better model jump/hop behavior and masse (curved) shots in the cue-ball physics.
- Make masse strength depend smoothly on cue elevation and tip offset while preventing small elevation inputs from producing unintended hops.
- Reduce on-recontact energy and spin to match expected landing behavior and to allow further calibration.
- Expose swerve fade at high speeds so spin-induced lateral acceleration behaves plausibly across speed ranges.

### Description

- Added new constants in `billiards/PhysicsConstants.cs` (`JumpVelocityThreshold`, `JumpTipOffsetBoost`, `LandingHorizontalDamping`, `LandingSpinDamping`, `MasseAngleMin`, `MasseAngleMax`, `MasseSwerveBoost`, `SwerveSpeedCutoff`, `SwerveSpeedFadeRange`) and updated `MaxCueElevationDegrees` to `85.0` for UI clamping.
- Added `MasseFactor` to `BilliardsSolver.Ball` and computed it in `CreateCueBall` using a `Smoothstep` blend between `MasseAngleMin`/`MasseAngleMax` to scale masse swerve.
- Implemented jump gating in `CreateCueBall` so `VerticalVelocity` is zeroed unless it exceeds a tip-offset adjusted `JumpVelocityThreshold` and introduced a speed-based `swerve` fade inside `ApplySpinForces` that multiplies by `MasseFactor`.
- On landing (in `StepVertical`) apply `LandingHorizontalDamping` and `LandingSpinDamping` when the ball returns from height to ground, and added a `Smoothstep` helper for angle blending.

### Testing

- No automated tests were executed as part of this change.
- Existing unit tests are present under `billiards.Tests` but were not run in this rollout.
- Changes were compiled and committed locally (no CI run recorded).
- Manual playtesting and further tuning recommended before merging to mainline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962765a95dc8329a0d9af89951ee861)