### PR TITLE
Align Pool Royale spin direction

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {
@@ -19655,7 +19655,7 @@ const powerRef = useRef(hud.power);
         const offsetVertical = ranges?.offsetVertical ?? 0;
         const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
         const hasSpin = magnitude > 1e-4;
-        const sideInput = -(spin?.x ?? 0);
+        const sideInput = spin?.x ?? 0;
         let side = hasSpin ? sideInput * offsetSide : 0;
         let vert = hasSpin ? -spin.y * offsetVertical : 0;
         if (hasSpin) {


### PR DESCRIPTION
### Motivation
- Fix a sign mismatch between the spin controller (red dot), the visible cue stick/aiming line, and the physics so the visual direction matches the user input. 
- Make cue-tip offsets and cueball lateral motion follow the same spin sign so shots behave naturally and intuitively. 
- Reduce confusion where the aiming guide and actual ball trajectory appeared inverted relative to the spin control. 

### Description
- Removed the lateral inversion in the spin->physics mapping by changing `mapSpinForPhysics` to keep the spin x component sign. 
- Removed the negation of the spin x input used for cue-tip offset calculation by changing `computeSpinOffsets` to use `spin.x` directly. 
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing normalization/clamping logic. 

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the Vite server reported ready and accessible locally. 
- Attempted an automated visual check using Playwright to capture a screenshot, but the headless Chromium run failed (browser crash / timeout) so visual verification could not be completed. 
- No unit tests were executed as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696280799ff48329a2d3797f739774a1)