### PR TITLE
Snooker: add HDRI fallback, sync texture anisotropy, and expose Pocket Jaws in setup

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -42,6 +42,7 @@ import {
   DEFAULT_WOOD_TEXTURE_SIZE,
   applyWoodTextures,
   disposeMaterialWithWood,
+  setWoodTextureAnisotropyCap,
 } from '../../utils/woodMaterials.js';
 import { SNOOKER_CLUB_DEFAULT_UNLOCKS } from '../../config/snookerClubInventoryConfig.js';
 import {
@@ -164,6 +165,18 @@ function isWebGLAvailable() {
     return false;
   }
 }
+
+let rendererAnisotropyCap = 16;
+setWoodTextureAnisotropyCap(rendererAnisotropyCap);
+const updateRendererAnisotropyCap = (renderer) => {
+  if (renderer?.capabilities?.getMaxAnisotropy) {
+    const max = renderer.capabilities.getMaxAnisotropy();
+    if (Number.isFinite(max)) {
+      rendererAnisotropyCap = Math.max(rendererAnisotropyCap, max);
+    }
+  }
+  setWoodTextureAnisotropyCap(rendererAnisotropyCap);
+};
 
 let cachedRendererString = null;
 let rendererLookupAttempted = false;
@@ -3660,14 +3673,47 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   }
 }
 
+async function createFallbackHdriEnvironment(renderer) {
+  if (!renderer) return null;
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  pmrem.compileEquirectangularShader();
+  const hemi = new THREE.HemisphereLight(0x94a3b8, 0x0f172a, 1.05);
+  const floor = new THREE.Mesh(
+    new THREE.CircleGeometry(6, 24),
+    new THREE.MeshStandardMaterial({ color: 0x0f172a, roughness: 0.78, metalness: 0.05 })
+  );
+  floor.rotation.x = -Math.PI / 2;
+  const tempScene = new THREE.Scene();
+  tempScene.add(hemi);
+  tempScene.add(floor);
+  const { texture } = pmrem.fromScene(tempScene);
+  texture.name = 'snooker-club-fallback-env';
+  pmrem.dispose();
+  floor.geometry.dispose();
+  floor.material.dispose();
+  return { envMap: texture, skyboxMap: null, url: null };
+}
+
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
   const url = await resolvePolyHavenHdriUrl(config);
+  const resolveFallback = async () => {
+    try {
+      return await createFallbackHdriEnvironment(renderer);
+    } catch (error) {
+      console.warn('Failed to build fallback HDRI environment', error);
+      return null;
+    }
+  };
   const lowerUrl = `${url ?? ''}`.toLowerCase();
   const useExr = lowerUrl.endsWith('.exr');
   const loader = useExr ? new EXRLoader() : new RGBELoader();
   loader.setCrossOrigin?.('anonymous');
   return new Promise((resolve) => {
+    if (!url) {
+      resolveFallback().then(resolve);
+      return;
+    }
     loader.load(
       url,
       (texture) => {
@@ -3683,9 +3729,10 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
         resolve({ envMap, skyboxMap, url });
       },
       undefined,
-      (error) => {
+      async (error) => {
         console.warn('Failed to load Poly Haven HDRI', error);
-        resolve(null);
+        const fallbackEnv = await resolveFallback();
+        resolve(fallbackEnv);
       }
     );
   });
@@ -10117,6 +10164,7 @@ export function PoolRoyaleGame({
       renderer.sortObjects = true;
       renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      updateRendererAnisotropyCap(renderer);
       // Ensure the canvas fills the host element so the table is centered and
       // scaled correctly on all view modes.
       host.appendChild(renderer.domElement);
@@ -17605,15 +17653,51 @@ export function PoolRoyaleGame({
                     Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {availableClothOptions.map((option) => {
-                      const active = option.id === clothColorId;
+              {availableClothOptions.map((option) => {
+                const active = option.id === clothColorId;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setClothColorId(option.id)}
+                    aria-pressed={active}
+                    className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                      active
+                        ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                        : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                  >
+                    <span className="flex items-center justify-center gap-2">
+                      <span
+                        className="h-3.5 w-3.5 rounded-full border border-white/40"
+                        style={{ backgroundColor: toHexColor(option.color) }}
+                        aria-hidden="true"
+                      />
+                      {option.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+              {availablePocketLiners.length > 0 ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Pocket Jaws
+                  </h3>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {availablePocketLiners.map((option) => {
+                      const active = option.id === pocketLinerId;
+                      const swatchColor =
+                        option.jawColor ?? option.rimColor ?? option.sheenColor ?? option.color;
                       return (
                         <button
                           key={option.id}
                           type="button"
-                          onClick={() => setClothColorId(option.id)}
+                          onClick={() => setPocketLinerId(option.id)}
                           aria-pressed={active}
-                          className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          className={`flex-1 min-w-[9rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                             active
                               ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                               : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
@@ -17622,7 +17706,7 @@ export function PoolRoyaleGame({
                           <span className="flex items-center justify-center gap-2">
                             <span
                               className="h-3.5 w-3.5 rounded-full border border-white/40"
-                              style={{ backgroundColor: toHexColor(option.color) }}
+                              style={{ backgroundColor: toHexColor(swatchColor) }}
                               aria-hidden="true"
                             />
                             {option.label}
@@ -17630,9 +17714,9 @@ export function PoolRoyaleGame({
                         </button>
                       );
                     })}
+                  </div>
                 </div>
-              </div>
-            ) : null}
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Rail Markers


### PR DESCRIPTION
### Motivation
- Prevent the Snooker Club from showing a black/blank canvas when HDRI or texture support fails by using the same robust renderer handling used by Pool Royale.
- Ensure GL texture anisotropy settings match Pool Royale so KTX/texture sampling and wood textures render consistently across devices.
- Surface the same table setup options (pocket jaws) the Snooker table needs to match Pool Royale menu parity while keeping Snooker dimensions.
- Improve resilience for environments where PolyHaven HDRI fetches or texture transcode support is unavailable.

### Description
- Add `setWoodTextureAnisotropyCap` usage and an `updateRendererAnisotropyCap` helper, and call it when the WebGL renderer is created so wood/cloth textures get a proper anisotropy cap.
- Add `createFallbackHdriEnvironment(renderer)` and wire a fallback path into `loadPolyHavenHdriEnvironment` so a simple PMREM-based environment is applied when HDRI loading fails or is unavailable.
- Use the fallback environment on missing URLs or loader errors (await the fallback and apply it instead of leaving the scene without an environment).
- Expose Pocket Jaws (pocket liner) options in the Snooker Club table setup panel so the Snooker UI matches Pool Royale options.

### Testing
- Started the dev server (`npm run dev`) to exercise the change and Vite reported ready, indicating the updated module compiled and served (succeeded).
- Attempted an automated Playwright navigation to the Snooker Club page to validate rendering and the config panel, but the navigation failed with `net::ERR_EMPTY_RESPONSE` while capturing a screenshot (failed).
- No unit or integration test suites were run as part of this change (none executed).
- The repository build hooks ran during dev startup and produced build metadata as part of the environment setup (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627e650d4083299804e9785ecd1432)