### PR TITLE
Align side-spin input with spin controller (fix inverted spin direction)

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -14679,7 +14679,8 @@ export function PoolRoyaleGame({
           }
           const appliedSpin = applySpinConstraints(aimDir, true);
           const ranges = spinRangeRef.current || {};
-          const baseSide = appliedSpin.x * (ranges.side ?? 0);
+          const spinSideInput = -(appliedSpin.x ?? 0);
+          const baseSide = spinSideInput * (ranges.side ?? 0);
           let spinSide = baseSide * SIDE_SPIN_MULTIPLIER;
           let spinTop = -appliedSpin.y * (ranges.forward ?? 0);
           if (appliedSpin.y > 0) {
@@ -16057,6 +16058,7 @@ export function PoolRoyaleGame({
           aimDir.lerp(tmpAim, aimLerpFactor);
         }
         const appliedSpin = applySpinConstraints(aimDir, true);
+        const spinSideInput = -(appliedSpin.x ?? 0);
         const ranges = spinRangeRef.current || {};
         const newCollisions = new Set();
         let shouldSlowAim = false;
@@ -16160,7 +16162,7 @@ export function PoolRoyaleGame({
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const spinSideInfluence = (appliedSpin.x || 0) * (0.4 + 0.42 * powerStrength);
+          const spinSideInfluence = spinSideInput * (0.4 + 0.42 * powerStrength);
           const spinVerticalInfluence = (appliedSpin.y || 0) * (0.68 + 0.45 * powerStrength);
           const cueFollowDirSpinAdjusted = cueFollowDir
             .clone()
@@ -16216,7 +16218,7 @@ export function PoolRoyaleGame({
           cuePullCurrentRef.current = pull;
           const offsetSide = ranges.offsetSide ?? 0;
           const offsetVertical = ranges.offsetVertical ?? 0;
-          let side = appliedSpin.x * offsetSide;
+          let side = spinSideInput * offsetSide;
           let vert = -appliedSpin.y * offsetVertical;
           const maxContactOffset = MAX_SPIN_CONTACT_OFFSET;
           if (maxContactOffset > 1e-6) {
@@ -16422,7 +16424,8 @@ export function PoolRoyaleGame({
           const planSpin = activeAiPlan.spin ?? spinRef.current ?? { x: 0, y: 0 };
           const spinX = THREE.MathUtils.clamp(planSpin.x ?? 0, -1, 1);
           const spinY = THREE.MathUtils.clamp(planSpin.y ?? 0, -1, 1);
-          let side = spinX * offsetSide;
+          const spinSideInput = -spinX;
+          let side = spinSideInput * offsetSide;
           let vert = -spinY * offsetVertical;
           const maxContactOffset = MAX_SPIN_CONTACT_OFFSET;
           if (maxContactOffset > 1e-6) {


### PR DESCRIPTION
### Motivation
- The cue stick, aiming line and resulting cue-ball motion were opposing the spin controller's red dot direction, indicating the side-spin input was inverted relative to visuals.
- Make the visual spin controller, AI previews and physics application all use the same side-spin orientation so aim/preview matches the shot result.

### Description
- Inverted the side-spin component by introducing `spinSideInput = -(appliedSpin.x ?? 0)` and using it when computing side-spin contributions to shot physics and visuals. 
- Updated cue-spin assignment and cue-follow/aim preview calculations to apply `spinSideInput` for `cue.spin`, `cueAfter`/aim visuals and `cueStick` placement. 
- Applied the same inversion to AI preview code paths so AI cue previews use the corrected side-spin orientation. 
- Changes are localized to `webapp/src/pages/Games/SnookerClubGame.jsx` and adjust how `appliedSpin.x` is translated into world/visual offsets.

### Testing
- No automated unit or integration tests were executed for this change.
- The change was committed and compiled locally as a code edit (no test failures reported by automated suites because they were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696280799ff48329a2d3797f739774a1)