### PR TITLE
Fix Pool Royale spin direction mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5017,7 +5017,7 @@ const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 const mapSpinForPhysics = (spin) => ({
-  x: -(spin?.x ?? 0),
+  x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
 const normalizeCueLift = (liftAngle = 0) => {
@@ -19655,7 +19655,7 @@ const powerRef = useRef(hud.power);
         const offsetVertical = ranges?.offsetVertical ?? 0;
         const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
         const hasSpin = magnitude > 1e-4;
-        const sideInput = -(spin?.x ?? 0);
+        const sideInput = spin?.x ?? 0;
         let side = hasSpin ? sideInput * offsetSide : 0;
         let vert = hasSpin ? -spin.y * offsetVertical : 0;
         if (hasSpin) {


### PR DESCRIPTION
### Motivation
- The on-screen spin controller (red dot) was producing the opposite side-spin effect to the cue stick, aiming line and resulting cue-ball motion.
- Players expect the visual spin input to map directly to both aiming feedback and physics so the cue and cueball move in the same direction as the controller.

### Description
- Removed the inverted sign on the side-spin mapping by updating `mapSpinForPhysics` so the physics x component uses `spin.x` instead of `-spin.x`.
- Made the cue-tip / aim visual use the same side-spin sign by changing the `sideInput` in `computeSpinOffsets` to `spin.x` (no negation).
- The single modified file is `webapp/src/pages/Games/PoolRoyale.jsx` and the change affects how spin is converted for physics and visuals.

### Testing
- No automated tests were executed in this rollout.
- Manual verification is recommended in the Pool Royale scene to confirm the cue stick, aiming line and cue-ball motion now follow the spin controller direction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696280799ff48329a2d3797f739774a1)