### PR TITLE
Fix cue spin/swerve direction and remove power-based spin scaling (PoolRoyale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5798,7 +5798,8 @@ function resolveSpinFrame(ball) {
 function resolveSpinWorldVector(ball, output) {
   if (!ball?.spin) return null;
   const { forward, lateral } = resolveSpinFrame(ball);
-  const sideSpin = ball.spin.x || 0;
+  const sideSpin =
+    ball.spinMode === 'swerve' ? -(ball.spin.x || 0) : (ball.spin.x || 0);
   const forwardSpin = ball.spin.y || 0;
   const target = output ?? TMP_VEC2_SPIN;
   target.copy(lateral).multiplyScalar(sideSpin).addScaledVector(forward, forwardSpin);
@@ -5938,8 +5939,9 @@ function resolveSwerveAimDir(
     (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
   const powerScale = 4 + powerStrength * 6;
   const swerveScale = 0.6 + swerve.intensity * 0.9;
+  const sideSpin = -swerve.sideSpin;
   const adjust =
-    swerve.sideSpin *
+    sideSpin *
     swerve.intensity *
     curveBase *
     powerScale *
@@ -5969,7 +5971,7 @@ function buildSwerveAimLinePoints(
     swerveActive,
     liftStrength
   );
-  const sideSpin = swerve.sideSpin;
+  const sideSpin = -swerve.sideSpin;
   const travel = start.distanceTo(end);
   if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
     points.length = 2;
@@ -19989,7 +19991,7 @@ const powerRef = useRef(hud.power);
           const liftStrength = normalizeCueLift(liftAngle);
           const physicsSpin = mapSpinForPhysics(appliedSpin);
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = powerScale;
+          const powerSpinScale = 1;
           const baseSide = physicsSpin.x * (ranges.side ?? 0);
           let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
           let spinTop = -physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;


### PR DESCRIPTION
### Motivation

- Players reported that small top/back spin combined with power produced inverted results and that side spin swerve was applied to the opposite side.  
- The intent is to make the spin controller map 1:1 to physics so that applied spin and swerve match user input.  
- Also ensure shot `power` does not unintentionally reduce the effective applied spin.  

### Description

- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to flip the swerve-side sign when resolving world-space spin in `resolveSpinWorldVector`.  
- Negated side spin used for aiming previews in `resolveSwerveAimDir` and `buildSwerveAimLinePoints` so previewed swerve matches the control direction.  
- Removed power-based scaling of the cue spin by setting `powerSpinScale = 1` when computing `spinSide`/`spinTop` so spin strength is driven by the controller value only.  

### Testing

- No automated tests were executed for this change.  
- The change was limited to `webapp/src/pages/Games/PoolRoyale.jsx` and focused on spin/swerve sign and a single scale constant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696294b8426083298caee016a3a36548)