### PR TITLE
Pool Royale: scale spin by power, stabilize spin controller, and fix cue-ball roll

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5020,6 +5020,8 @@ const mapSpinForPhysics = (spin) => ({
   x: spin?.x ?? 0,
   y: spin?.y ?? 0
 });
+const resolvePowerSpinScale = (powerStrength = 0) =>
+  THREE.MathUtils.clamp(0.35 + powerStrength * 0.65, 0.35, 1);
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
   return THREE.MathUtils.clamp(liftAngle / CUE_LIFT_MAX_TILT, 0, 1);
@@ -19991,10 +19993,14 @@ const powerRef = useRef(hud.power);
           const liftStrength = normalizeCueLift(liftAngle);
           const physicsSpin = mapSpinForPhysics(appliedSpin);
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 1;
-          const baseSide = physicsSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = -physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+          const powerSpinScale = resolvePowerSpinScale(clampedPower);
+          const scaledSpin = {
+            x: physicsSpin.x * powerSpinScale,
+            y: physicsSpin.y * powerSpinScale
+          };
+          const baseSide = scaledSpin.x * (ranges.side ?? 0);
+          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER;
+          let spinTop = -scaledSpin.y * (ranges.forward ?? 0);
           if (physicsSpin.y > 0) {
             spinTop *= BACKSPIN_MULTIPLIER;
           } else if (physicsSpin.y < 0) {
@@ -20008,7 +20014,7 @@ const powerRef = useRef(hud.power);
           cue.spinMode =
             spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
           const swerveSettings = resolveSwerveSettings(
-            physicsSpin,
+            scaledSpin,
             clampedPower,
             cue.spinMode === 'swerve',
             liftStrength
@@ -22647,10 +22653,15 @@ const powerRef = useRef(hud.power);
             1
           );
           const swerveActive = spinAppliedRef.current?.mode === 'swerve';
+          const powerSpinScale = resolvePowerSpinScale(powerStrength);
+          const scaledPhysicsSpin = {
+            x: physicsSpin.x * powerSpinScale,
+            y: physicsSpin.y * powerSpinScale
+          };
           const aimDir2D = new THREE.Vector2(baseAimDir.x, baseAimDir.z);
           const guideAimDir2D = resolveSwerveAimDir(
             aimDir2D,
-            physicsSpin,
+            scaledPhysicsSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -22675,7 +22686,7 @@ const powerRef = useRef(hud.power);
             end,
             dir,
             perp,
-            physicsSpin,
+            scaledPhysicsSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -22750,8 +22761,10 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const spinSideInfluence = (physicsSpin.x || 0) * (0.4 + 0.42 * powerStrength);
-          const spinVerticalInfluence = -(physicsSpin.y || 0) * (0.68 + 0.45 * powerStrength);
+          const spinSideInfluence =
+            (scaledPhysicsSpin.x || 0) * (0.4 + 0.42 * powerStrength);
+          const spinVerticalInfluence =
+            -(scaledPhysicsSpin.y || 0) * (0.68 + 0.45 * powerStrength);
           const cueFollowDirSpinAdjusted = cueFollowDir
             .clone()
             .add(perp.clone().multiplyScalar(spinSideInfluence))
@@ -22969,9 +22982,14 @@ const powerRef = useRef(hud.power);
           const remoteSpinMagnitude = Math.hypot(remoteSpin.x ?? 0, remoteSpin.y ?? 0);
           const remoteSwerveActive = remoteSpinMagnitude >= SWERVE_THRESHOLD;
           const remotePhysicsSpin = mapSpinForPhysics(remoteSpin);
+          const remoteSpinScale = resolvePowerSpinScale(powerStrength);
+          const scaledRemoteSpin = {
+            x: remotePhysicsSpin.x * remoteSpinScale,
+            y: remotePhysicsSpin.y * remoteSpinScale
+          };
           const guideAimDir2D = resolveSwerveAimDir(
             remoteAimDir,
-            remotePhysicsSpin,
+            scaledRemoteSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -22992,7 +23010,7 @@ const powerRef = useRef(hud.power);
             end,
             baseDir,
             perp,
-            remotePhysicsSpin,
+            scaledRemoteSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -23336,7 +23354,7 @@ const powerRef = useRef(hud.power);
             const liftAmount = b.lift ?? 0;
             b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
             if (scaledSpeed > 0) {
-              const axis = new THREE.Vector3(-b.vel.y, 0, b.vel.x).normalize();
+              const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
               const angle = scaledSpeed / BALL_R;
               b.mesh.rotateOnWorldAxis(axis, angle);
             }
@@ -24355,6 +24373,7 @@ const powerRef = useRef(hud.power);
 
     box.style.transition = 'transform 0.18s ease';
     box.style.transformOrigin = '50% 50%';
+    box.style.transform = 'scale(1)';
     box.style.touchAction = 'none';
 
     let revertTimer = null;
@@ -24410,10 +24429,7 @@ const powerRef = useRef(hud.power);
       setSpin(nx, ny);
     };
 
-    const scaleBox = (value) => {
-      box.style.transform = `scale(${value})`;
-    };
-    scaleBox(1);
+    const scaleBox = () => {};
 
     const clearTimer = () => {
       if (revertTimer) {


### PR DESCRIPTION
### Motivation

- Improve realism by making cue-ball spin influence depend on shot power so previews and physics match expected behavior.
- Restore stable touch input for the spin control so dragging does not rescale the control unexpectedly during interaction.
- Fix visual cue-ball rolling so the rotation direction matches travel and looks physically correct.

### Description

- Add `resolvePowerSpinScale` and apply power-scaled spin everywhere the system uses spin for physics, aim previews and remote aims (changed handling in `apply`/preview/aim code paths), primarily inside `webapp/src/pages/Games/PoolRoyale.jsx`.
- Replace on-shot spin application with a `scaledSpin` computed from `mapSpinForPhysics(appliedSpin)` and `resolvePowerSpinScale(clampedPower)` so `swerve` and spin impulses respect shot power when setting `cue.spin` and when resolving swerve (`resolveSwerveSettings`).
- Use power-scaled spin for swerve aim preview and aim-line building (local and remote aims) so visual curves now match physics-scaled spin.
- Stabilize the spin controller by removing the runtime scaling transform during pointer drag (make `scaleBox` a no-op and set the box transform once) to avoid input scaling changes while dragging.
- Correct the cue-ball visual rotation axis in the physics loop so the ball rotates in the correct direction relative to its velocity (flip axis vector used by `rotateOnWorldAxis`).

### Testing

- No automated tests were executed as part of this change.
- Change set limited to `webapp/src/pages/Games/PoolRoyale.jsx` and contains only client-side logic updates for spin, input, and visual roll.
- Recommend running the existing gameplay unit/integration tests and a manual playtest on mobile portrait to verify cue-ball roll direction, spin vs power alignment, and spin controller touch behavior.
- If CI is available, run the web build and unit tests to confirm no regressions (`npm test` / `yarn test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a2dd4cc483299558f08ba6a432bf)