### PR TITLE
Restore Pool Royale pre-impact swerve logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23230,22 +23230,22 @@ const powerRef = useRef(hud.power);
                 b.liftVel = 0;
               }
             if (hasSpin && (b.lift ?? 0) > 0) {
-                const airborneSpin = resolveSpinWorldVector(b, TMP_VEC2_LIMIT);
-                const spinMag = airborneSpin?.length() ?? 0;
-                if (spinMag > 1e-6 && airborneSpin) {
-                  const liftRatio = THREE.MathUtils.clamp(
-                    (b.lift ?? 0) / MAX_POWER_LIFT_HEIGHT,
-                    0,
-                    1.2
-                  );
-                  const driftScale = LIFT_SPIN_AIR_DRIFT * liftRatio * stepScale;
-                  airborneSpin.normalize().multiplyScalar(driftScale);
-                  b.vel.add(airborneSpin);
-                }
+              const airborneSpin = TMP_VEC2_LIMIT.copy(b.spin ?? TMP_VEC2_LIMIT.set(0, 0));
+              const spinMag = airborneSpin.length();
+              if (spinMag > 1e-6) {
+                const liftRatio = THREE.MathUtils.clamp(
+                  (b.lift ?? 0) / MAX_POWER_LIFT_HEIGHT,
+                  0,
+                  1.2
+                );
+                const driftScale = LIFT_SPIN_AIR_DRIFT * liftRatio * stepScale;
+                airborneSpin.normalize().multiplyScalar(driftScale);
+                b.vel.add(airborneSpin);
               }
             }
+            }
             if (hasSpin) {
-              const swerveTravel = isCue && b.spinMode === 'swerve';
+              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
               const swerveStrength = swerveTravel ? Math.max(0, b.swerveStrength ?? 0) : 0;
               const swervePower = swerveTravel
                 ? Math.max(0, b.swervePowerStrength ?? 0)
@@ -23253,36 +23253,67 @@ const powerRef = useRef(hud.power);
               const swervePowerScale = swerveStrength > 0 ? 0.85 + swervePower * 0.9 : 0;
               const swerveScale =
                 swerveStrength > 0 ? (0.6 + swerveStrength * 0.9) * swervePowerScale : 0;
-              const rollMultiplier = swerveTravel
-                ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
-                : 1;
-              const spinWorld = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
-              if (spinWorld) {
-                spinWorld.multiplyScalar(
+              const allowRoll = !isCue || b.impacted || swerveTravel;
+              const preImpact = isCue && !b.impacted;
+              if (allowRoll) {
+                const rollMultiplier = swerveTravel
+                  ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
+                  : 1;
+                TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
                   SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
                 );
-                b.vel.add(spinWorld);
-              }
-              if (
-                isCue &&
-                b.spinMode === 'swerve' &&
-                b.pendingSpin &&
-                b.pendingSpin.lengthSq() > 0
-              ) {
-                const driftScale = swerveScale > 0 ? swerveScale : 1;
-                b.vel.addScaledVector(
-                  b.pendingSpin,
-                  PRE_IMPACT_SPIN_DRIFT * driftScale
-                );
-                b.pendingSpin.multiplyScalar(0);
-              }
-              const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
-              b.spin.multiplyScalar(rollDecay);
-              if (isCue && b.swerveStrength > 0) {
-                b.swerveStrength *= rollDecay;
-                if (b.swerveStrength < 1e-3) {
-                  b.swerveStrength = 0;
-                  b.swervePowerStrength = 0;
+                if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
+                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
+                  const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  b.vel.add(TMP_VEC2_AXIS);
+                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
+                  if (b.spinMode === 'swerve' && b.pendingSpin && swerveScale > 0) {
+                    b.pendingSpin.addScaledVector(TMP_VEC2_LATERAL, swerveScale);
+                  }
+                  const alignedSpeed = b.vel.dot(launchDir);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
+                  b.vel.copy(TMP_VEC2_AXIS);
+                  if (b.spinMode === 'swerve' && swerveScale > 0) {
+                    b.vel.addScaledVector(
+                      TMP_VEC2_LATERAL,
+                      SWERVE_PRE_IMPACT_DRIFT * swerveScale
+                    );
+                  }
+                } else {
+                  b.vel.add(TMP_VEC2_SPIN);
+                  if (
+                    isCue &&
+                    b.spinMode === 'swerve' &&
+                    b.pendingSpin &&
+                    b.pendingSpin.lengthSq() > 0
+                  ) {
+                    const driftScale = swerveScale > 0 ? swerveScale : 1;
+                    b.vel.addScaledVector(
+                      b.pendingSpin,
+                      PRE_IMPACT_SPIN_DRIFT * driftScale
+                    );
+                    b.pendingSpin.multiplyScalar(0);
+                  }
+                }
+                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
+                b.spin.multiplyScalar(rollDecay);
+                if (isCue && b.swerveStrength > 0) {
+                  b.swerveStrength *= rollDecay;
+                  if (b.swerveStrength < 1e-3) {
+                    b.swerveStrength = 0;
+                    b.swervePowerStrength = 0;
+                  }
+                }
+              } else {
+                const airDecay = Math.pow(SPIN_AIR_DECAY, stepScale);
+                b.spin.multiplyScalar(airDecay);
+                if (isCue && b.swerveStrength > 0) {
+                  b.swerveStrength *= airDecay;
+                  if (b.swerveStrength < 1e-3) {
+                    b.swerveStrength = 0;
+                    b.swervePowerStrength = 0;
+                  }
                 }
               }
               if (b.spin.lengthSq() < 1e-6) {


### PR DESCRIPTION
### Motivation

- Restore the Pool Royale cue-ball spin behavior that was present before the earlier change which removed pre-impact swerve, so the cue ball does not apply swerve drift until it first contacts another ball or a cushion. 
- Reintroduce airborne spin drift that influences lifted balls and the pre-impact pending-spin drift used to produce visible curve before first contact. 
- Keep spin decay and roll behavior consistent with prior gameplay tuning for feel and predictability. 

### Description

- Reworked spin handling in `webapp/src/pages/Games/PoolRoyale.jsx` to copy airborne spin with `TMP_VEC2_LIMIT.copy(b.spin)` and apply an airborne drift while the ball is lifted. 
- Re-enabled gating of swerve travel by checking `!b.impacted` and introduced `allowRoll`/`preImpact` branches so pre-impact roll and pending-spin accumulation happen only before the first impact. 
- Restored pre-impact pending-spin accumulation and application using `b.pendingSpin` and `PRE_IMPACT_SPIN_DRIFT`/`SWERVE_PRE_IMPACT_DRIFT` so curves and lateral throws match previous physics. 
- Restored roll/air decay branches and roll multiplier logic using `TMP_VEC2_SPIN`/`TMP_VEC2_LATERAL` so spin-to-velocity conversion and spin decay behave like the prior implementation. 

### Testing

- No automated tests were executed for this change. 
- Changes were limited to `webapp/src/pages/Games/PoolRoyale.jsx` and committed for manual validation in the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696339bcd32c8329968274a67947ad29)