### PR TITLE
Fix cue ball spin roll alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23230,17 +23230,17 @@ const powerRef = useRef(hud.power);
                 b.liftVel = 0;
               }
             if (hasSpin && (b.lift ?? 0) > 0) {
-              const airborneSpin = TMP_VEC2_LIMIT.copy(b.spin ?? TMP_VEC2_LIMIT.set(0, 0));
-              const spinMag = airborneSpin.length();
-              if (spinMag > 1e-6) {
+              const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_LIMIT);
+              const spinMag = worldSpin?.length() ?? 0;
+              if (worldSpin && spinMag > 1e-6) {
                 const liftRatio = THREE.MathUtils.clamp(
                   (b.lift ?? 0) / MAX_POWER_LIFT_HEIGHT,
                   0,
                   1.2
                 );
                 const driftScale = LIFT_SPIN_AIR_DRIFT * liftRatio * stepScale;
-                airborneSpin.normalize().multiplyScalar(driftScale);
-                b.vel.add(airborneSpin);
+                TMP_VEC2_AXIS.copy(worldSpin).normalize().multiplyScalar(driftScale);
+                b.vel.add(TMP_VEC2_AXIS);
               }
             }
             }
@@ -23259,9 +23259,14 @@ const powerRef = useRef(hud.power);
                 const rollMultiplier = swerveTravel
                   ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
                   : 1;
-                TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
-                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-                );
+                const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
+                if (!worldSpin) {
+                  TMP_VEC2_SPIN.set(0, 0);
+                } else {
+                  worldSpin.multiplyScalar(
+                    SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
+                  );
+                }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);


### PR DESCRIPTION
### Motivation
- Cue ball motion should reflect player-applied spin and power so forward/back/side spin moves the ball in the expected world directions.
- The previous implementation applied roll and airborne drift using raw local `b.spin` coordinates which produced incorrect/backspin-only behaviour.
- This change aims to map spin into the shot’s forward/lateral world frame so impulses are applied in the correct directions.
- Improve realism for follow/draw and side-spin interactions to match professional pool behavior.

### Description
- Replace direct usage of `b.spin` for airborne drift with `resolveSpinWorldVector(b, ...)` and apply the resulting world vector to velocity.
- Compute rolling impulses by mapping spin into world space via `resolveSpinWorldVector(b, TMP_VEC2_SPIN)` and then scale by `SPIN_ROLL_STRENGTH * rollMultiplier * stepScale`.
- Normalize and copy into `TMP_VEC2_AXIS` when adding drift to `b.vel`, and guard for missing `worldSpin` to fall back safely to zero.
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx` (updates to airborne spin drift and roll handling logic).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633db78f388329b3258167ddf25d49)