### PR TITLE
Fix Pool Royale spin Y mapping (top/back inversion)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5018,7 +5018,7 @@ const normalizeSpinInput = (spin) => {
 };
 const mapSpinForPhysics = (spin) => ({
   x: spin?.x ?? 0,
-  y: spin?.y ?? 0
+  y: -(spin?.y ?? 0)
 });
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;


### PR DESCRIPTION
### Motivation
- Players reported top-spin and back-spin were inverted when using the spin controller, causing inputs to produce the opposite effect. 
- The physics layer expected the Y spin axis with the opposite sign to the UI input, so the mapping needed correction. 
- This change aligns the spin input sign with physics so top/back spin behave as the controller indicates. 

### Description
- Inverted the Y component in `mapSpinForPhysics` by changing `y: spin?.y ?? 0` to `y: -(spin?.y ?? 0)` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Kept all existing normalization, limits and swerve/physics logic unchanged so only the sign mapping was adjusted.
- Change is a single-line mapping fix that preserves X (side spin) handling.

### Testing
- No automated tests were executed as part of this change.
- Change was committed to the repository (`webapp/src/pages/Games/PoolRoyale.jsx`) and is ready for verification in the running app or CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963420ae89c832985e1cf5c27b14977)