### PR TITLE
Guard snooker club inventory storage access

### DIFF
--- a/webapp/src/utils/snookerClubInventory.js
+++ b/webapp/src/utils/snookerClubInventory.js
@@ -15,8 +15,12 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    const stored = window.localStorage.getItem('accountId');
-    if (stored) return stored;
+    try {
+      const stored = window.localStorage.getItem('accountId');
+      if (stored) return stored;
+    } catch (err) {
+      console.warn('Failed to read accountId from storage, falling back to guest', err);
+    }
   }
   return 'guest';
 };
@@ -34,7 +38,11 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.warn('Failed to persist snooker inventory, skipping write', err);
+  }
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `localStorage` is unavailable (e.g., private browsing or restricted environments) that can break the Snooker Club page load.
- Avoid the black-screen / crash scenario caused by unguarded reads of `accountId` or writes of inventory data.
- Keep the Snooker Club inventory handling resilient across environments where storage operations may throw.

### Description
- Added a `try/catch` around the `localStorage` read in `resolveAccountId` to fall back to `'guest'` and log a warning when access fails.
- Wrapped `writeAllInventories` `localStorage.setItem` call in a `try/catch` and log a warning when persistence fails instead of throwing.
- Updated `webapp/src/utils/snookerClubInventory.js` to include the new guards and messages.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634ee042888329b2e82c86acee7fcc)