### PR TITLE
Restore Pool Royale spin drift and roll

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23230,17 +23230,17 @@ const powerRef = useRef(hud.power);
                 b.liftVel = 0;
               }
             if (hasSpin && (b.lift ?? 0) > 0) {
-              const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_LIMIT);
-              const spinMag = worldSpin?.length() ?? 0;
-              if (worldSpin && spinMag > 1e-6) {
+              const airborneSpin = TMP_VEC2_LIMIT.copy(b.spin ?? TMP_VEC2_LIMIT.set(0, 0));
+              const spinMag = airborneSpin.length();
+              if (spinMag > 1e-6) {
                 const liftRatio = THREE.MathUtils.clamp(
                   (b.lift ?? 0) / MAX_POWER_LIFT_HEIGHT,
                   0,
                   1.2
                 );
                 const driftScale = LIFT_SPIN_AIR_DRIFT * liftRatio * stepScale;
-                TMP_VEC2_AXIS.copy(worldSpin).normalize().multiplyScalar(driftScale);
-                b.vel.add(TMP_VEC2_AXIS);
+                airborneSpin.normalize().multiplyScalar(driftScale);
+                b.vel.add(airborneSpin);
               }
             }
             }
@@ -23259,14 +23259,9 @@ const powerRef = useRef(hud.power);
                 const rollMultiplier = swerveTravel
                   ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
                   : 1;
-                const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
-                if (!worldSpin) {
-                  TMP_VEC2_SPIN.set(0, 0);
-                } else {
-                  worldSpin.multiplyScalar(
-                    SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-                  );
-                }
+                TMP_VEC2_SPIN.copy(b.spin).multiplyScalar(
+                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
+                );
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);


### PR DESCRIPTION
### Motivation
- Bring the Pool Royale spin controller and physics back to the previous behaviour so cue-spin drift and roll match the established feel.
- Remove an earlier world-space conversion that changed how cue spin affected airborne drift and pre-impact roll.
- Ensure airborne drift and pre-impact roll use the ball's raw spin vector so swerve and spin interactions remain consistent.

### Description
- Reverted usage of `resolveSpinWorldVector` in airborne drift and roll calculations inside `webapp/src/pages/Games/PoolRoyale.jsx` and replaced it with direct copies of `b.spin` via `TMP_VEC2_*` temporaries.
- Airborne drift now uses `TMP_VEC2_LIMIT.copy(b.spin)` and applies a normalized drift scaled by `LIFT_SPIN_AIR_DRIFT`, `liftRatio`, and `stepScale` instead of a world-space spin vector.
- Roll/roll-strength application now copies `b.spin` into `TMP_VEC2_SPIN` and multiplies by `SPIN_ROLL_STRENGTH * rollMultiplier * stepScale` instead of calling `resolveSpinWorldVector`.

### Testing
- No automated unit or integration tests were run for this change.
- No CI or build jobs were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696350fdafec8329b3886d0d635b2167)