### PR TITLE
Allow cue ball spin to enable pre-impact rolling in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23253,7 +23253,8 @@ const powerRef = useRef(hud.power);
               const swervePowerScale = swerveStrength > 0 ? 0.85 + swervePower * 0.9 : 0;
               const swerveScale =
                 swerveStrength > 0 ? (0.6 + swerveStrength * 0.9) * swervePowerScale : 0;
-              const allowRoll = !isCue || b.impacted || swerveTravel;
+              const allowRoll =
+                !isCue || b.impacted || swerveTravel || (isCue && b.spin?.lengthSq() > 1e-8);
               const preImpact = isCue && !b.impacted;
               if (allowRoll) {
                 const rollMultiplier = swerveTravel


### PR DESCRIPTION
### Motivation

- The cue ball was drifting instead of rolling before contacting other balls, causing incorrect pre-impact motion. 
- The intent is to restore the previous behavior where spin can contribute to the cue ball's velocity prior to impact. 
- Make Pool Royale physics consistent with the cue-ball spin handling used elsewhere (so spin-driven roll applies for the cue ball pre-contact).

### Description

- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to relax the `allowRoll` condition so the cue ball can roll when it has non-trivial spin. 
- The new condition adds `(isCue && b.spin?.lengthSq() > 1e-8)` to `allowRoll` so spin-driven roll is applied pre-impact. 
- This change lets the code apply the `SPIN_ROLL_STRENGTH` contribution to `b.vel` for a spinning cue ball before it has impacted another ball. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963728aa7408329b599b5bd28b4038b)