### PR TITLE
Fix cue ball roll direction in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23368,7 +23368,7 @@ const powerRef = useRef(hud.power);
             const liftAmount = b.lift ?? 0;
             b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
             if (scaledSpeed > 0) {
-              const axis = new THREE.Vector3(-b.vel.y, 0, b.vel.x).normalize();
+              const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
               const angle = scaledSpeed / BALL_R;
               b.mesh.rotateOnWorldAxis(axis, angle);
             }


### PR DESCRIPTION
### Motivation

- Players observed the cue ball visually rolling opposite to its travel direction in Pool Royale, which breaks immersion and can confuse shots.
- The rotation axis calculation used for ball mesh rotation was incorrect and needed to match the physics velocity direction.
- Align behavior with the other table implementation that uses the corrected rotation axis for accurate visual roll.

### Description

- Corrected the rotation axis calculation in `webapp/src/pages/Games/PoolRoyale.jsx` from `new THREE.Vector3(-b.vel.y, 0, b.vel.x)` to `new THREE.Vector3(b.vel.y, 0, -b.vel.x)` so the mesh roll matches travel direction.
- This is a single-line visual fix that keeps the existing `b.mesh.rotateOnWorldAxis(axis, angle)` logic intact.
- Change affects the per-step physics/render loop where ball mesh rotation is applied.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696375950a3c8329be95be1bcea679e4)