### PR TITLE
Increase Pool Royale shot power by 25%

### DIFF
--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -1115,11 +1115,22 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable, then lift Snooker Club power by 25%.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
+// Pool Royale power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.85;
 const SHOT_POWER_BOOST = 1.25;
 const SHOT_POWER_MULTIPLIER = 1.3 * 1.15; // raise overall cue strike strength by 30% and add a further 15% punch for max-power jumps
+const SHOT_POWER_POOL_ROYALE_BOOST = 1.25;
 const SHOT_FORCE_BOOST =
-  1.5 * 0.75 * 0.85 * 0.8 * 1.3 * 0.85 * SHOT_POWER_REDUCTION * SHOT_POWER_BOOST * SHOT_POWER_MULTIPLIER;
+  1.5 *
+  0.75 *
+  0.85 *
+  0.8 *
+  1.3 *
+  0.85 *
+  SHOT_POWER_REDUCTION *
+  SHOT_POWER_BOOST *
+  SHOT_POWER_MULTIPLIER *
+  SHOT_POWER_POOL_ROYALE_BOOST;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;


### PR DESCRIPTION
### Motivation
- Increase the Pool Royale shot strength by 25% to match design feedback for stronger standard shots and more powerful breaks.
- Apply the change through an additive game tuning multiplier so existing balancing remains intact.
- Keep mobile-friendly reductions and other tuning factors while lifting overall strike strength for Pool Royale gameplay.

### Description
- Add a new constant `SHOT_POWER_POOL_ROYALE_BOOST = 1.25` in `webapp/src/pages/Games/SnookerClubGame.jsx` and document the change inline. 
- Multiply `SHOT_FORCE_BOOST` by `SHOT_POWER_POOL_ROYALE_BOOST` so `SHOT_BASE_SPEED` and related derived values increase accordingly. 
- Reformat the `SHOT_FORCE_BOOST` expression across multiple lines for readability while preserving the existing factors and ordering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637b866d1c83299a17c791d98e59a5)