### PR TITLE
Increase Pool Royale shot power by 25%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1332,9 +1332,18 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
+// Pool Royale power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.85;
+const SHOT_POWER_MULTIPLIER = 1.25;
 const SHOT_FORCE_BOOST =
-  1.5 * 0.75 * 0.85 * 0.8 * 1.3 * 0.85 * SHOT_POWER_REDUCTION;
+  1.5 *
+  0.75 *
+  0.85 *
+  0.8 *
+  1.3 *
+  0.85 *
+  SHOT_POWER_REDUCTION *
+  SHOT_POWER_MULTIPLIER;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;


### PR DESCRIPTION
### Motivation
- Raise the cue strike strength for the Pool Royale game to meet the requested 25% power increase and make breaks feel stronger.

### Description
- Add a new constant `SHOT_POWER_MULTIPLIER = 1.25` and apply it to the `SHOT_FORCE_BOOST` computation in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Update the surrounding inline comment to document the new Pool Royale power pass alongside existing tuning notes.
- The change only adjusts the shot force calculation and does not modify other gameplay systems.

### Testing
- No automated tests were executed after this change.
- Existing automated suites such as `test/poolAi.test.js` are present in the repository but were not run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637f271de483298c984640f0d6bb0d)