### PR TITLE
Select HDRI resolution by refresh rate and add 144Hz (8k) profile

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -40,7 +40,6 @@ import {
 } from '../../config/murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -64,6 +63,20 @@ const resolveTableFinish = (index) => {
 };
 
 const DEFAULT_FRAME_RATE_ID = 'uhd120';
+const HDRI_RESOLUTION_PROFILES = Object.freeze({
+  hd50: Object.freeze(['1k']),
+  fhd60: Object.freeze(['2k', '1k']),
+  qhd90: Object.freeze(['4k', '2k']),
+  uhd120: Object.freeze(['6k', '4k', '2k']),
+  uhd144: Object.freeze(['8k', '6k', '4k'])
+});
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(
+  HDRI_RESOLUTION_PROFILES[DEFAULT_FRAME_RATE_ID] ?? ['4k']
+);
+const resolveHdriResolutionStack = (frameRateId) =>
+  HDRI_RESOLUTION_PROFILES[frameRateId] ??
+  HDRI_RESOLUTION_PROFILES[DEFAULT_FRAME_RATE_ID] ??
+  DEFAULT_HDRI_RESOLUTIONS;
 
 const MODEL_SCALE = 0.75;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
@@ -137,6 +150,23 @@ function detectHighRefreshDisplay() {
     return false;
   }
   const queries = ['(min-refresh-rate: 120hz)', '(min-refresh-rate: 90hz)'];
+  for (const query of queries) {
+    try {
+      if (window.matchMedia(query).matches) {
+        return true;
+      }
+    } catch (err) {
+      // ignore unsupported query
+    }
+  }
+  return false;
+}
+
+function detectUltraRefreshDisplay() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  const queries = ['(min-refresh-rate: 144hz)', '(min-refresh-rate: 140hz)'];
   for (const query of queries) {
     try {
       if (window.matchMedia(query).matches) {
@@ -236,6 +266,7 @@ function detectPreferredFrameRateId() {
   const deviceMemory = typeof navigator.deviceMemory === 'number' ? navigator.deviceMemory : null;
   const hardwareConcurrency = navigator.hardwareConcurrency ?? 4;
   const lowRefresh = detectLowRefreshDisplay();
+  const ultraRefresh = detectUltraRefreshDisplay();
   const highRefresh = detectHighRefreshDisplay();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
@@ -246,6 +277,9 @@ function detectPreferredFrameRateId() {
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
       return 'hd50';
+    }
+    if (ultraRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
+      return 'uhd144';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
@@ -261,6 +295,9 @@ function detectPreferredFrameRateId() {
   }
 
   if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
+    if (ultraRefresh) {
+      return 'uhd144';
+    }
     return 'uhd120';
   }
 
@@ -1171,6 +1208,15 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     pixelRatioCap: 2,
     resolution: 'Ultra HD render • DPR 2.0 cap',
     description: '4K-oriented profile for 120 Hz flagships and desktops.'
+  },
+  {
+    id: 'uhd144',
+    label: 'Ultra HD+ (144 Hz)',
+    fps: 144,
+    renderScale: 1.4,
+    pixelRatioCap: 2.1,
+    resolution: 'Ultra HD+ render • DPR 2.1 cap',
+    description: '8K HDRI profile tuned for 144 Hz high-refresh displays.'
   }
 ]);
 const DEFAULT_FRAME_RATE_OPTION =
@@ -1456,6 +1502,11 @@ export default function MurlanRoyaleArena({ search }) {
   useEffect(() => {
     applyRendererQuality();
   }, [applyRendererQuality, frameQualityProfile]);
+
+  useEffect(() => {
+    if (!threeReady) return;
+    void applyHdriEnvironment(hdriVariantRef.current || DEFAULT_HDRI_VARIANT);
+  }, [applyHdriEnvironment, frameRateId, threeReady]);
 
   const updateScoreboardDisplay = useCallback((entries = []) => {
     const store = threeStateRef.current;
@@ -1806,7 +1857,12 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
-      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, activeVariant);
+      const preferredResolutions = resolveHdriResolutionStack(frameQualityRef.current?.id);
+      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
+        ...activeVariant,
+        preferredResolutions,
+        fallbackResolution: preferredResolutions[0] ?? activeVariant.fallbackResolution
+      });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
       const prevTexture = envTextureRef.current;


### PR DESCRIPTION
### Motivation
- Ensure HDRI asset resolution matches display refresh-rate profiles so higher-refresh devices receive higher-resolution HDRIs (e.g. 144 Hz → 8k, 120 Hz → 6k, 90 Hz → 4k, 60 Hz → 2k, 50 Hz → 1k). 
- Automatically pick HDRI resolution stacks based on the selected frame-rate/profile to improve visual fidelity on capable hardware. 
- Add explicit detection for ultra-refresh displays and a corresponding quality profile for 144 Hz devices. 
- Refresh the environment HDRI when the user or device changes the frame-rate/profile to apply the new resolution preferences immediately.

### Description
- Added `HDRI_RESOLUTION_PROFILES` and `resolveHdriResolutionStack` to map `frameRateId` values to HDRI resolution stacks and replaced the previous static default stack with `DEFAULT_HDRI_RESOLUTIONS` that derives from that mapping. 
- Implemented `detectUltraRefreshDisplay()` and updated `detectPreferredFrameRateId()` to return a new `uhd144` profile for detected 144 Hz (or similar) displays. 
- Added a new `FRAME_RATE_OPTIONS` entry for `uhd144` (144 FPS) and wired `applyHdriEnvironment` to pass `preferredResolutions` (resolved from the current frame-rate profile) into `loadPolyHavenHdriEnvironment`. 
- Trigger HDRI reload when the `frameRateId` changes by adding an effect that reapplies the environment via `applyHdriEnvironment` when `frameRateId` and `threeReady` change.

### Testing
- No automated tests were executed for this change.
- The change was committed to the local branch (`Adjust Murlan HDRI resolution by refresh rate`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963835384cc8329b85e53d4424f79de)