### PR TITLE
Map HDRI resolutions to refresh-rate tiers in MurlanRoyaleArena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -41,6 +41,12 @@ import {
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const HDRI_RESOLUTIONS_BY_FRAME_RATE = Object.freeze({
+  hd50: ['1k'],
+  fhd60: ['2k'],
+  qhd90: ['4k'],
+  uhd120: ['6k']
+});
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -1175,6 +1181,8 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 ]);
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
+const resolveHdriResolutionsForFrameRate = (frameRateId) =>
+  HDRI_RESOLUTIONS_BY_FRAME_RATE[frameRateId] ?? DEFAULT_HDRI_RESOLUTIONS;
 
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };
@@ -1241,6 +1249,10 @@ export default function MurlanRoyaleArena({ search }) {
   });
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
+    [frameRateId]
+  );
+  const hdriResolutions = useMemo(
+    () => resolveHdriResolutionsForFrameRate(frameRateId),
     [frameRateId]
   );
   const frameQualityProfile = useMemo(() => {
@@ -1806,7 +1818,14 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
-      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, activeVariant);
+      const preferredResolutions = Array.isArray(hdriResolutions) && hdriResolutions.length
+        ? hdriResolutions
+        : DEFAULT_HDRI_RESOLUTIONS;
+      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
+        ...activeVariant,
+        preferredResolutions,
+        fallbackResolution: preferredResolutions[0] ?? activeVariant?.fallbackResolution
+      });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
       const prevTexture = envTextureRef.current;
@@ -1835,7 +1854,7 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    []
+    [hdriResolutions]
   );
 
   const updateSceneAppearance = useCallback(


### PR DESCRIPTION
### Motivation
- Align HDRI asset resolution with the chosen frame-rate profile so environment textures match target visual fidelity and performance budgets.
- Follow the requirement that 50 Hz uses Full HD, 60 Hz uses 2k, 90 Hz uses 4k, and Ultra HD uses 6k HDRIs.
- Reduce unnecessary bandwidth and loading of oversized HDRIs on lower-refresh/less-capable devices.
- Make the HDRI resolution choice deterministic and easy to extend per frame-rate tier.

### Description
- Added `HDRI_RESOLUTIONS_BY_FRAME_RATE` and `resolveHdriResolutionsForFrameRate` and wired them into `MurlanRoyaleArena.jsx` to map frame-rate ids to preferred HDRI sizes (hd50→`1k`, fhd60→`2k`, qhd90→`4k`, uhd120→`6k`).
- Exposed a `hdriResolutions` `useMemo` based on `frameRateId` and made `applyHdriEnvironment` depend on it so environment loads react to profile changes.
- When loading an environment, passed `preferredResolutions` and `fallbackResolution` into `loadPolyHavenHdriEnvironment` so the PolyHaven resolution picker prefers the mapped sizes.
- Changes are localized to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and do not alter existing loader implementations.

### Testing
- No automated tests were executed for this change.
- Manual runtime verification was not recorded by CI in this rollout.
- Recommend running the app and switching `frameRateId` profiles to validate HDRI URLs and memory usage.
- Recommend adding unit/integration tests for `resolveHdriResolutionsForFrameRate` and mocking `loadPolyHavenHdriEnvironment` in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696389cb4b948329a04a626ab6dc262d)