### PR TITLE
Frame-rate-based HDRI resolution selection for MurlanRoyaleArena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1176,6 +1176,32 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
+const HDRI_RESOLUTION_PROFILE = Object.freeze({
+  hd50: {
+    preferred: ['1k'],
+    fallback: '1k'
+  },
+  fhd60: {
+    preferred: ['2k', '1k'],
+    fallback: '2k'
+  },
+  qhd90: {
+    preferred: ['4k', '2k'],
+    fallback: '4k'
+  },
+  uhd120: {
+    preferred: ['6k', '4k', '2k'],
+    fallback: '6k'
+  }
+});
+
+const resolveHdriResolutionProfile = (frameRateId) => {
+  if (frameRateId && HDRI_RESOLUTION_PROFILE[frameRateId]) {
+    return HDRI_RESOLUTION_PROFILE[frameRateId];
+  }
+  return HDRI_RESOLUTION_PROFILE[DEFAULT_FRAME_RATE_ID] ?? HDRI_RESOLUTION_PROFILE.fhd60;
+};
+
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };
 
@@ -1242,6 +1268,10 @@ export default function MurlanRoyaleArena({ search }) {
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
+  );
+  const hdriResolutionProfile = useMemo(
+    () => resolveHdriResolutionProfile(activeFrameRateOption?.id),
+    [activeFrameRateOption]
   );
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
@@ -1806,7 +1836,12 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
-      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, activeVariant);
+      const resolutionProfile = hdriResolutionProfile ?? resolveHdriResolutionProfile(activeFrameRateOption?.id);
+      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
+        ...activeVariant,
+        preferredResolutions: resolutionProfile?.preferred ?? DEFAULT_HDRI_RESOLUTIONS,
+        fallbackResolution: resolutionProfile?.fallback ?? DEFAULT_HDRI_RESOLUTIONS[0]
+      });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
       const prevTexture = envTextureRef.current;
@@ -1835,8 +1870,13 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    []
+    [activeFrameRateOption, hdriResolutionProfile]
   );
+
+  useEffect(() => {
+    if (!threeReady) return;
+    void applyHdriEnvironment(hdriVariantRef.current);
+  }, [applyHdriEnvironment, hdriResolutionProfile, threeReady]);
 
   const updateSceneAppearance = useCallback(
     (nextAppearance, { refreshCards = false } = {}) => {


### PR DESCRIPTION
### Motivation

- Ensure HDRI downloads and environment selection match the selected rendering / refresh-rate profile (50/60/90/120 Hz) so higher-refresh devices get higher-resolution HDRIs and lower-refresh devices use smaller HDRIs.
- Reduce wasted bandwidth and memory on lower-end or lower-refresh-rate devices by preferring smaller HDRI sizes when appropriate.
- Tie HDRI preference into the existing frame-rate / quality system so the HDRI choice follows user or detected frame-rate selection.

### Description

- Added a `HDRI_RESOLUTION_PROFILE` mapping and `resolveHdriResolutionProfile` helper to express preferred and fallback HDRI sizes per frame-rate id (e.g. `hd50`, `fhd60`, `qhd90`, `uhd120`).
- Added a `hdriResolutionProfile` `useMemo` and wired it into `applyHdriEnvironment` so HDRI loads call `loadPolyHavenHdriEnvironment` with `preferredResolutions` and `fallbackResolution` derived from the active frame-rate profile.
- Updated the `applyHdriEnvironment` hook dependencies and added a `useEffect` to reload the active HDRI when the resolution profile or renderer readiness changes.
- All changes are in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and keep existing loading fallback behavior via `loadPolyHavenHdriEnvironment`.

### Testing

- No automated tests were run for this change.
- The modified file was committed (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696389cb4b948329a04a626ab6dc262d)