### PR TITLE
Refactor SnookerClub: standalone snooker rules and Pool Royale table sizing

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -1,9 +1,4 @@
 import { BallColor, FrameState, Player, ShotContext, ShotEvent } from '../types';
-import { UkPool } from '../../lib/poolUk8Ball.js';
-import { AmericanBilliards } from '../../lib/americanBilliards.js';
-import { NineBall } from '../../lib/nineBall.js';
-
-type PoolVariantId = 'american' | 'uk' | '9ball' | 'snooker';
 
 type SnookerSerializedState = {
   redsRemaining: number;
@@ -11,87 +6,15 @@ type SnookerSerializedState = {
   colorOnAfterRed: boolean;
   currentPlayer: 'A' | 'B';
   frameOver: boolean;
-  winner: 'A' | 'B' | null;
+  winner: 'A' | 'B' | null | 'TIE';
 };
 
-type UkColour = 'blue' | 'red' | 'black' | 'cue';
-
-type HudInfo = {
-  next: string;
-  phase: string;
-  scores: { A: number; B: number };
+type SnookerMeta = {
+  variant: 'snooker';
+  state: SnookerSerializedState;
 };
 
-type UkSerializedState = {
-  ballsOnTable: {
-    blue: number[];
-    red: number[];
-    black8: boolean;
-    cueInPocket: boolean;
-  };
-  assignments: { A: UkColour | null; B: UkColour | null };
-  currentPlayer: 'A' | 'B';
-  shotsRemaining: number;
-  isOpenTable: boolean;
-  lastEvent: string | null;
-  frameOver: boolean;
-  winner: 'A' | 'B' | null;
-  mustPlayFromBaulk: boolean;
-};
-
-type AmericanSerializedState = {
-  ballsOnTable: number[];
-  currentPlayer: 'A' | 'B';
-  scores: { A: number; B: number };
-  ballInHand: boolean;
-  foulStreak: { A: number; B: number };
-  frameOver: boolean;
-  winner: 'A' | 'B' | 'TIE' | null;
-};
-
-type NineSerializedState = {
-  ballsOnTable: number[];
-  currentPlayer: 'A' | 'B';
-  ballInHand: boolean;
-  foulStreak: { A: number; B: number };
-  gameOver: boolean;
-  winner: 'A' | 'B' | null;
-};
-
-type PoolMeta =
-  | {
-      variant: 'uk';
-      state: UkSerializedState;
-      totals: { blue: number; red: number };
-      hud: HudInfo;
-    }
-  | {
-      variant: 'snooker';
-      state: SnookerSerializedState;
-      hud?: HudInfo;
-    }
-  | {
-      variant: 'american';
-      state: AmericanSerializedState;
-      hud: HudInfo;
-      breakInProgress?: boolean;
-    }
-  | {
-      variant: '9ball';
-      state: NineSerializedState;
-      hud: HudInfo;
-      breakInProgress?: boolean;
-    };
-
-const UK_TOTAL_PER_COLOUR = 7;
-
-function normalizeVariantId(value: string | null | undefined): string {
-  if (typeof value !== 'string') return '';
-  return value
-    .toLowerCase()
-    .replace(/[_\s-]+/g, '')
-    .trim();
-}
+const DEFAULT_COLORS: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
 
 function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
   return {
@@ -100,271 +23,38 @@ function basePlayers(playerA: string, playerB: string): { A: Player; B: Player }
   };
 }
 
-function serializeUkState(state: UkPool['state']): UkSerializedState {
-  return {
-    ballsOnTable: {
-      blue: Array.from(state.ballsOnTable.blue.values()),
-      red: Array.from(state.ballsOnTable.red.values()),
-      black8: state.ballsOnTable.black8,
-      cueInPocket: state.ballsOnTable.cueInPocket
-    },
-    assignments: { ...state.assignments },
-    currentPlayer: state.currentPlayer,
-    shotsRemaining: state.shotsRemaining,
-    isOpenTable: state.isOpenTable,
-    lastEvent: state.lastEvent,
-    frameOver: state.frameOver,
-    winner: state.winner,
-    mustPlayFromBaulk: state.mustPlayFromBaulk
-  };
-}
-
-function applyUkState(game: UkPool, snapshot: UkSerializedState) {
-  game.state = {
-    ballsOnTable: {
-      blue: new Set(snapshot.ballsOnTable.blue),
-      red: new Set(snapshot.ballsOnTable.red),
-      black8: snapshot.ballsOnTable.black8,
-      cueInPocket: snapshot.ballsOnTable.cueInPocket
-    },
-    assignments: { ...snapshot.assignments },
-    currentPlayer: snapshot.currentPlayer,
-    shotsRemaining: snapshot.shotsRemaining,
-    isOpenTable: snapshot.isOpenTable,
-    lastEvent: snapshot.lastEvent,
-    frameOver: snapshot.frameOver,
-    winner: snapshot.winner,
-    mustPlayFromBaulk: snapshot.mustPlayFromBaulk
-  };
-}
-
-function serializeAmericanState(state: AmericanBilliards['state']): AmericanSerializedState {
-  return {
-    ballsOnTable: Array.from(state.ballsOnTable.values()),
-    currentPlayer: state.currentPlayer,
-    scores: { ...state.scores },
-    ballInHand: state.ballInHand,
-    foulStreak: { ...state.foulStreak },
-    frameOver: state.frameOver,
-    winner: state.winner
-  };
-}
-
-function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerializedState) {
-  game.state = {
-    ballsOnTable: new Set(snapshot.ballsOnTable),
-    currentPlayer: snapshot.currentPlayer,
-    scores: { ...snapshot.scores },
-    ballInHand: snapshot.ballInHand,
-    foulStreak: { ...snapshot.foulStreak },
-    frameOver: snapshot.frameOver,
-    winner: snapshot.winner
-  };
-}
-
-function serializeNineState(state: NineBall['state']): NineSerializedState {
-  return {
-    ballsOnTable: Array.from(state.ballsOnTable.values()),
-    currentPlayer: state.currentPlayer,
-    ballInHand: state.ballInHand,
-    foulStreak: { ...state.foulStreak },
-    gameOver: state.gameOver,
-    winner: state.winner
-  };
-}
-
-function applyNineState(game: NineBall, snapshot: NineSerializedState) {
-  game.state = {
-    ballsOnTable: new Set(snapshot.ballsOnTable),
-    currentPlayer: snapshot.currentPlayer,
-    ballInHand: snapshot.ballInHand,
-    foulStreak: { ...snapshot.foulStreak },
-    gameOver: snapshot.gameOver,
-    winner: snapshot.winner
-  };
-}
-
-function parseUkColour(value: unknown): UkColour | null {
-  if (typeof value !== 'string') return null;
-  const lower = value.toLowerCase();
-  if (lower.startsWith('yellow')) return 'blue';
-  if (lower.startsWith('blue')) return 'blue';
-  if (lower.startsWith('red')) return 'red';
-  if (lower.startsWith('black')) return 'black';
-  if (lower === 'cue') return 'cue';
-  return null;
-}
-
-function isCueBallId(value: unknown): boolean {
-  if (value === 0) return true;
-  if (typeof value !== 'string') return false;
-  return value.toLowerCase() === 'cue' || value.toLowerCase() === 'cue_ball';
-}
-
-function parseNumericId(value: unknown): number | null {
-  if (typeof value === 'number') return value;
-  if (typeof value === 'string') {
-    const match = value.match(/(\d+)/);
-    if (match) return Number.parseInt(match[1], 10);
-  }
-  return null;
-}
-
-function lowestBall(balls: Iterable<number>): number | null {
-  let lowest: number | null = null;
-  for (const value of balls) {
-    if (lowest == null || value < lowest) {
-      lowest = value;
-    }
-  }
-  return lowest;
-}
-
-export class PoolRoyaleRules {
-  private readonly variant: PoolVariantId;
-
-  constructor(variantKey: string | null | undefined) {
-    const normalized = normalizeVariantId(variantKey);
-    if (
-      normalized === 'uk' ||
-      normalized === '8balluk' ||
-      normalized === 'eightballuk' ||
-      normalized === 'uk8' ||
-      normalized === 'snooker'
-    ) {
-      this.variant = normalized === 'snooker' ? 'snooker' : 'uk';
-    } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
-      this.variant = '9ball';
-    } else {
-      this.variant = 'american';
-    }
-  }
-
+export class SnookerClubRules {
   getInitialFrame(playerA: string, playerB: string): FrameState {
-    switch (this.variant) {
-      case 'snooker': {
-        const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
-        const base: FrameState = {
-          balls: [],
-          activePlayer: 'A',
-          players: basePlayers(playerA, playerB),
-          currentBreak: 0,
-          phase: 'REDS_AND_COLORS',
-          redsRemaining: 15,
-          colorOnAfterRed: false,
-          ballOn: ['RED'],
-          frameOver: false
-        };
-        base.meta = {
-          variant: 'snooker',
-          state: {
-            redsRemaining: 15,
-            colorsOnTable,
-            colorOnAfterRed: false,
-            currentPlayer: 'A',
-            frameOver: false,
-            winner: null
-          }
-        } satisfies PoolMeta;
-        return base;
+    const base: FrameState = {
+      balls: [],
+      activePlayer: 'A',
+      players: basePlayers(playerA, playerB),
+      currentBreak: 0,
+      phase: 'REDS_AND_COLORS',
+      redsRemaining: 15,
+      colorOnAfterRed: false,
+      ballOn: ['RED'],
+      frameOver: false
+    };
+
+    const meta: SnookerMeta = {
+      variant: 'snooker',
+      state: {
+        redsRemaining: 15,
+        colorsOnTable: [...DEFAULT_COLORS],
+        colorOnAfterRed: false,
+        currentPlayer: 'A',
+        frameOver: false,
+        winner: null
       }
-      case 'uk': {
-        const game = new UkPool();
-        game.startBreak();
-        const snapshot = serializeUkState(game.state);
-        const base: FrameState = {
-          balls: [],
-          activePlayer: 'A',
-          players: basePlayers(playerA, playerB),
-          currentBreak: 0,
-          phase: 'REDS_AND_COLORS',
-          redsRemaining: UK_TOTAL_PER_COLOUR * 2,
-          ballOn: ['RED', 'YELLOW'],
-          frameOver: false
-        };
-        const hud: HudInfo = {
-          next: 'open table',
-          phase: 'open',
-          scores: { A: 0, B: 0 }
-        };
-        base.meta = {
-          variant: 'uk',
-          state: snapshot,
-          totals: { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR },
-          hud
-        } satisfies PoolMeta;
-        return base;
-      }
-      case '9ball': {
-        const game = new NineBall();
-        game.state.ballInHand = true;
-        const snapshot = serializeNineState(game.state);
-        const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
-        const base: FrameState = {
-          balls: [],
-          activePlayer: 'A',
-          players: basePlayers(playerA, playerB),
-          currentBreak: 0,
-          phase: 'REDS_AND_COLORS',
-          redsRemaining: 9,
-          ballOn: [`BALL_${lowest}`],
-          frameOver: false
-        };
-        const hud: HudInfo = {
-          next: `ball ${lowest}`,
-          phase: 'rack',
-          scores: { A: 0, B: 0 }
-        };
-        base.meta = {
-          variant: '9ball',
-          state: snapshot,
-          hud,
-          breakInProgress: true
-        } satisfies PoolMeta;
-        return base;
-      }
-      default: {
-        const game = new AmericanBilliards();
-        game.state.ballInHand = true;
-        const snapshot = serializeAmericanState(game.state);
-        const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
-        const base: FrameState = {
-          balls: [],
-          activePlayer: 'A',
-          players: basePlayers(playerA, playerB),
-          currentBreak: 0,
-          phase: 'REDS_AND_COLORS',
-          redsRemaining: snapshot.ballsOnTable.length,
-          ballOn: [`BALL_${lowest}`],
-          frameOver: false
-        };
-        const hud: HudInfo = {
-          next: `ball ${lowest}`,
-          phase: 'rotation',
-          scores: { A: 0, B: 0 }
-        };
-        base.meta = {
-          variant: 'american',
-          state: snapshot,
-          hud,
-          breakInProgress: true
-        } satisfies PoolMeta;
-        return base;
-      }
-    }
+    };
+
+    base.meta = meta;
+    return base;
   }
 
   applyShot(state: FrameState, events: ShotEvent[], context: ShotContext = {}): FrameState {
-    switch (this.variant) {
-      case 'snooker':
-        return this.applySnookerShot(state, events, context);
-      case 'uk':
-        return this.applyUkShot(state, events, context);
-      case '9ball':
-        return this.applyNineBallShot(state, events, context);
-      default:
-        return this.applyAmericanShot(state, events, context);
-    }
+    return this.applySnookerShot(state, events, context);
   }
 
   private resolveBallColor(value: unknown): BallColor | null {
@@ -409,30 +99,27 @@ export class PoolRoyaleRules {
     colorOnAfterRed: boolean,
     colorsOnTable: Set<BallColor>
   ): string[] {
-    const orderedColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
     if (phase === 'COLORS_ORDER') {
-      const next = orderedColors.find((c) => colorsOnTable.has(c));
+      const next = DEFAULT_COLORS.find((c) => colorsOnTable.has(c));
       return next ? [next] : [];
     }
     if (colorOnAfterRed) {
-      const remaining = orderedColors.filter((c) => colorsOnTable.has(c));
-      return remaining.length > 0 ? remaining : orderedColors;
+      const remaining = DEFAULT_COLORS.filter((c) => colorsOnTable.has(c));
+      return remaining.length > 0 ? remaining : DEFAULT_COLORS;
     }
     if (redsRemaining > 0) return ['RED'];
-    const next = orderedColors.find((c) => colorsOnTable.has(c));
+    const next = DEFAULT_COLORS.find((c) => colorsOnTable.has(c));
     return next ? [next] : [];
   }
 
   private applySnookerShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const defaultColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
-    const meta = (state.meta ?? {}) as PoolMeta;
-    const previous: SnookerSerializedState | null =
-      meta.variant === 'snooker' && meta.state ? (meta.state as SnookerSerializedState) : null;
+    const meta = (state.meta ?? {}) as SnookerMeta | Record<string, unknown>;
+    const previous = meta.variant === 'snooker' ? meta.state : null;
 
     let redsRemaining = Number.isFinite(state.redsRemaining) ? state.redsRemaining : 15;
     let colorOnAfterRed = Boolean(state.colorOnAfterRed);
     let phase: FrameState['phase'] = state.phase === 'COLORS_ORDER' ? 'COLORS_ORDER' : 'REDS_AND_COLORS';
-    const colorsOnTable = new Set<BallColor>(previous?.colorsOnTable ?? defaultColors);
+    const colorsOnTable = new Set<BallColor>(previous?.colorsOnTable ?? DEFAULT_COLORS);
     let activePlayer: 'A' | 'B' = state.activePlayer ?? 'A';
     const opponent: 'A' | 'B' = activePlayer === 'A' ? 'B' : 'A';
     const players: { A: Player; B: Player } = {
@@ -503,12 +190,7 @@ export class PoolRoyaleRules {
       if (redsRemaining === 0 && phase === 'REDS_AND_COLORS' && !colorOnAfterRed) {
         phase = 'COLORS_ORDER';
       }
-      const ballOnNext = this.computeSnookerBallOn(
-        phase,
-        redsRemaining,
-        colorOnAfterRed,
-        colorsOnTable
-      );
+      const ballOnNext = this.computeSnookerBallOn(phase, redsRemaining, colorOnAfterRed, colorsOnTable);
       const frameOver = ballOnNext.length === 0 && phase === 'COLORS_ORDER';
       const winner = frameOver
         ? players.A.score === players.B.score
@@ -540,9 +222,9 @@ export class PoolRoyaleRules {
             colorOnAfterRed,
             currentPlayer: activePlayer,
             frameOver,
-            winner: winner ?? null
+            winner: (winner ?? null) as SnookerSerializedState['winner']
           }
-        } satisfies PoolMeta
+        }
       };
     }
 
@@ -611,263 +293,11 @@ export class PoolRoyaleRules {
           colorOnAfterRed,
           currentPlayer: activePlayer,
           frameOver,
-          winner: winner ?? null
-        }
-      } satisfies PoolMeta
-    };
-  }
-
-  private applyUkShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'uk' && meta.state ? meta : null;
-    const game = new UkPool();
-    if (previous) {
-      applyUkState(game, previous.state);
-    } else {
-      game.startBreak();
-    }
-    const contactOrder: UkColour[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'HIT') continue;
-      const colour = parseUkColour(ev.ballId ?? ev.firstContact);
-      if (colour && colour !== 'cue') {
-        contactOrder.push(colour);
-      }
-    }
-    const potted: UkColour[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'POTTED') continue;
-      if (isCueBallId(ev.ballId ?? ev.ball)) {
-        potted.push('cue');
-      } else {
-        const colour = parseUkColour(ev.ballId ?? ev.ball);
-        if (colour && colour !== 'cue') {
-          potted.push(colour);
+          winner: (winner ?? null) as SnookerSerializedState['winner']
         }
       }
-    }
-    const shotResult = game.shotTaken({
-      contactOrder,
-      potted,
-      cueOffTable: Boolean(context.cueBallPotted),
-      noCushionAfterContact: Boolean(context.noCushionAfterContact),
-      placedFromHand: Boolean(context.placedFromHand)
-    });
-    const snapshot = serializeUkState(game.state);
-    const totals = previous ? previous.totals : { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR };
-    const playerScores = this.computeUkScores(snapshot, totals);
-    const ballOn = this.computeUkBallOn(snapshot);
-    const hud: HudInfo = {
-      next: ballOn.length === 0 ? 'black' : ballOn.map((entry) => entry.toLowerCase()).join(' / '),
-      phase: snapshot.isOpenTable ? 'open' : 'groups',
-      scores: playerScores
     };
-    const nextState: FrameState = {
-      ...state,
-      activePlayer: game.state.currentPlayer,
-      players: {
-        A: { ...state.players.A, score: playerScores.A },
-        B: { ...state.players.B, score: playerScores.B }
-      },
-      ballOn,
-      frameOver: game.state.frameOver,
-      winner: game.state.winner ?? undefined,
-      foul: shotResult.foul
-        ? {
-            points: 0,
-            reason: shotResult.reason ?? 'foul'
-          }
-        : undefined,
-      meta: {
-        variant: 'uk',
-        state: snapshot,
-        totals,
-        hud
-      } satisfies PoolMeta
-    };
-    return nextState;
-  }
-
-  private computeUkScores(state: UkSerializedState, totals: { blue: number; red: number }): { A: number; B: number } {
-    const remainingBlue = state.ballsOnTable.blue.length;
-    const remainingRed = state.ballsOnTable.red.length;
-    const pottedBlue = totals.blue - remainingBlue;
-    const pottedRed = totals.red - remainingRed;
-    const assignA = state.assignments.A;
-    const assignB = state.assignments.B;
-    return {
-      A: assignA === 'blue' ? pottedBlue : assignA === 'red' ? pottedRed : 0,
-      B: assignB === 'blue' ? pottedBlue : assignB === 'red' ? pottedRed : 0
-    };
-  }
-
-  private computeUkBallOn(state: UkSerializedState): string[] {
-    if (state.frameOver) return [];
-    const current = state.currentPlayer;
-    const assignment = state.assignments[current];
-    const available: string[] = [];
-    if (state.isOpenTable || !assignment) {
-      if (state.ballsOnTable.red.length > 0) available.push('RED');
-      if (state.ballsOnTable.blue.length > 0) available.push('YELLOW');
-      if (available.length === 0 && state.ballsOnTable.black8) available.push('BLACK');
-      return available;
-    }
-    if (assignment === 'red') {
-      if (state.ballsOnTable.red.length > 0) return ['RED'];
-    } else if (assignment === 'blue') {
-      if (state.ballsOnTable.blue.length > 0) return ['YELLOW'];
-    }
-    if (state.ballsOnTable.black8) return ['BLACK'];
-    return [];
-  }
-
-  private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
-    const game = new AmericanBilliards();
-    if (previous) {
-      applyAmericanState(game, previous.state);
-    } else {
-      game.state.ballInHand = true;
-    }
-    const contactOrder: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'HIT') continue;
-      const id = parseNumericId(ev.ballId ?? ev.firstContact);
-      if (id != null) contactOrder.push(id);
-    }
-    const potted: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'POTTED') continue;
-      if (isCueBallId(ev.ballId ?? ev.ball)) {
-        potted.push(0);
-      } else {
-        const id = parseNumericId(ev.ballId ?? ev.ball);
-        if (id != null) potted.push(id);
-      }
-    }
-    const result = game.shotTaken({
-      contactOrder,
-      potted,
-      cueOffTable: Boolean(context.cueBallPotted),
-      placedFromHand: Boolean(context.placedFromHand),
-      noCushionAfterContact: Boolean(context.noCushionAfterContact)
-    });
-    const snapshot = serializeAmericanState(game.state);
-    const lowest = lowestBall(snapshot.ballsOnTable);
-    const tableClear = snapshot.ballsOnTable.length === 0;
-    const frameOver = snapshot.frameOver || tableClear;
-    const hud: HudInfo = {
-      next:
-        frameOver && snapshot.winner
-          ? 'frame over'
-          : lowest != null
-            ? `ball ${lowest}`
-            : tableClear
-              ? 'frame over'
-              : 'rack clear',
-      phase: frameOver ? 'complete' : 'rotation',
-      scores: { ...snapshot.scores }
-    };
-    let winner: FrameState['winner'];
-    if (frameOver) {
-      if (snapshot.winner === 'A' || snapshot.winner === 'B' || snapshot.winner === 'TIE') {
-        winner = snapshot.winner;
-      } else if (snapshot.scores.A > snapshot.scores.B) winner = 'A';
-      else if (snapshot.scores.B > snapshot.scores.A) winner = 'B';
-      else winner = 'TIE';
-    }
-    const nextState: FrameState = {
-      ...state,
-      activePlayer: game.state.currentPlayer,
-      players: {
-        A: { ...state.players.A, score: snapshot.scores.A },
-        B: { ...state.players.B, score: snapshot.scores.B }
-      },
-      ballOn: lowest != null && !frameOver ? [`BALL_${lowest}`] : [],
-      frameOver,
-      winner,
-      foul: result.foul
-        ? {
-            points: 0,
-            reason: result.reason ?? 'foul'
-          }
-        : undefined,
-      meta: {
-        variant: 'american',
-        state: snapshot,
-        hud,
-        breakInProgress: false
-      } satisfies PoolMeta
-    };
-    return nextState;
-  }
-
-  private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === '9ball' && meta.state ? meta : null;
-    const game = new NineBall();
-    if (previous) {
-      applyNineState(game, previous.state);
-    } else {
-      game.state.ballInHand = true;
-    }
-    const contactOrder: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'HIT') continue;
-      const id = parseNumericId(ev.ballId ?? ev.firstContact);
-      if (id != null) contactOrder.push(id);
-    }
-    const potted: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'POTTED') continue;
-      if (isCueBallId(ev.ballId ?? ev.ball)) {
-        potted.push(0);
-      } else {
-        const id = parseNumericId(ev.ballId ?? ev.ball);
-        if (id != null) potted.push(id);
-      }
-    }
-    const result = game.shotTaken({
-      contactOrder,
-      potted,
-      cueOffTable: Boolean(context.cueBallPotted),
-      placedFromHand: Boolean(context.placedFromHand),
-      noCushionAfterContact: Boolean(context.noCushionAfterContact)
-    });
-    const snapshot = serializeNineState(game.state);
-    const lowest = lowestBall(snapshot.ballsOnTable);
-    const hud: HudInfo = {
-      next: snapshot.gameOver ? 'frame over' : lowest != null ? `ball ${lowest}` : 'nine',
-      phase: snapshot.gameOver ? 'complete' : 'run',
-      scores: { A: 0, B: 0 }
-    };
-    const nextState: FrameState = {
-      ...state,
-      activePlayer: game.state.currentPlayer,
-      players: {
-        A: { ...state.players.A, score: 0 },
-        B: { ...state.players.B, score: 0 }
-      },
-      ballOn: lowest != null && !snapshot.gameOver ? [`BALL_${lowest}`] : [],
-      frameOver: game.state.gameOver,
-      winner: game.state.winner ?? undefined,
-      foul: result.foul
-        ? {
-            points: 0,
-            reason: result.reason ?? 'foul'
-          }
-        : undefined,
-      meta: {
-        variant: '9ball',
-        state: snapshot,
-        hud,
-        breakInProgress: false
-      } satisfies PoolMeta
-    };
-    return nextState;
   }
 }
 
-export default PoolRoyaleRules;
-export { PoolRoyaleRules as SnookerClubRules };
+export default SnookerClubRules;

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,37 +1,39 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '12ft': {
-    id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
+  '9ft': {
+    id: '9ft',
+    label: '9 ft (Pool Royale)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
+  '8ft': {
+    id: '8ft',
+    label: '8 ft (Pool Royale)',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 171.45,
+      side: 152.4
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 
@@ -70,7 +72,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '12ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -21,7 +21,7 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { SnookerClubRules as PoolRoyaleRules } from '../../../../src/rules/SnookerClubRules.ts';
+import { SnookerClubRules } from '../../../../src/rules/SnookerClubRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/snookerClubTables.js';
 import {
@@ -8295,7 +8295,7 @@ export function PoolRoyaleGame({
   const rafRef = useRef(null);
   const worldRef = useRef(null);
   const sceneRef = useRef(null);
-  const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
+  const rules = useMemo(() => new SnookerClubRules(), []);
   const activeVariant = useMemo(
     () => resolvePoolVariant(variantKey),
     [variantKey]


### PR DESCRIPTION
### Motivation
- Separate Snooker logic from the mixed PoolRoyale rules so SnookerClub has its own dedicated rules engine and state model.
- Use Pool Royale table dimensions for the Snooker Club visual/physics footprint while keeping snooker ball behaviors intact.
- Remove entanglement with other pool variants and external pool libraries in the snooker rules implementation.

### Description
- Replaced the previous mixed rules implementation with a new `SnookerClubRules` class implementing snooker-only logic and state serialization in `src/rules/SnookerClubRules.ts`.
- Removed references to pool variant adapters and external pool libraries from the snooker rules file and consolidated snooker scoring, fouls, and phase flow inside the new class.
- Updated table specifications in `webapp/src/config/snookerClubTables.js` to use Pool Royale / 9ft and 8ft dimensions and set the default table size to `9ft`.
- Wired the web UI to use the new rules by importing `SnookerClubRules` and instantiating it in `webapp/src/pages/Games/SnookerClubGame.jsx`.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` which reported Vite ready and served the site (success).
- Loaded the Snooker Club page and captured a Playwright screenshot of `/games/snookerclub?variant=snooker&tableSize=9ft&mode=ai`, confirming the page renders (screenshot artifact generated, success).
- No unit test (`jest`) suite was executed as part of this change (not run).
- No automated integration tests beyond the screenshot were executed (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638d3329688329bff3e7e695626cc1)