### PR TITLE
Adjust Murlan Royale HDRI resolution mapping by graphics profile

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1178,19 +1178,19 @@ const DEFAULT_FRAME_RATE_OPTION =
 
 const HDRI_RESOLUTION_PROFILE = Object.freeze({
   hd50: {
-    preferred: ['1k'],
-    fallback: '1k'
+    preferred: ['2k'],
+    fallback: '2k'
   },
   fhd60: {
-    preferred: ['2k', '1k'],
+    preferred: ['2k'],
     fallback: '2k'
   },
   qhd90: {
-    preferred: ['4k', '2k'],
+    preferred: ['4k'],
     fallback: '4k'
   },
   uhd120: {
-    preferred: ['6k', '4k', '2k'],
+    preferred: ['6k'],
     fallback: '6k'
   }
 });


### PR DESCRIPTION
### Motivation
- Align HDRI selection with the graphics quality/frame-rate presets so HDRI texture resolution scales with the chosen profile.
- Ensure higher-end profiles receive higher-resolution HDRIs (Ultra → 6k, QHD 90Hz → 4k, FHD 60Hz → 2k, lower perf → lower-res).

### Description
- Updated the `HDRI_RESOLUTION_PROFILE` constant in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to use single preferred resolutions per frame-rate id.
- New mapping sets `hd50` -> `2k`, `fhd60` -> `2k`, `qhd90` -> `4k`, and `uhd120` -> `6k` with matching fallbacks.
- Left the `resolveHdriResolutionProfile` resolver unchanged so callers continue to receive the updated profiles.

### Testing
- No automated tests were executed for this change.
- Changes were committed to the branch and the modified file is `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638f2f45a08329bb5329493322edb7)