### PR TITLE
Set Pool Royale HDRI defaults to 4k

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4020,9 +4020,9 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 }
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '6k', '4k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const HDRI_RESOLUTION_STORAGE_KEY = 'poolHdriResolution';
-const DEFAULT_HDRI_RESOLUTION_MODE = 'auto';
+const DEFAULT_HDRI_RESOLUTION_MODE = '4k';
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: 'auto', label: 'Match Table' },
   { id: '8k', label: '8K' },


### PR DESCRIPTION
### Motivation
- Make Pool Royale HDRI defaults use 4k resolution to standardize environment quality across scenes.
- Replace the previous multi-resolution preference/backstop behavior with a single, predictable default resolution.

### Description
- Updated `DEFAULT_HDRI_RESOLUTIONS` in `webapp/src/pages/Games/PoolRoyale.jsx` from `['8k','6k','4k']` to `['4k']`.
- Changed `DEFAULT_HDRI_RESOLUTION_MODE` in the same file from `'auto'` to `'4k'` so the default selection is `4k`.
- Only the `PoolRoyale.jsx` file was modified to enforce the new HDRI defaults.

### Testing
- No automated tests were run on this change (CI/tests were not executed as part of this update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696391a254148329a9fa00511aa3006f)