### PR TITLE
Lock Murlan Royale HDRI resolution to 4k

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1176,31 +1176,10 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
-const HDRI_RESOLUTION_PROFILE = Object.freeze({
-  hd50: {
-    preferred: ['2k'],
-    fallback: '2k'
-  },
-  fhd60: {
-    preferred: ['2k'],
-    fallback: '2k'
-  },
-  qhd90: {
-    preferred: ['4k'],
-    fallback: '4k'
-  },
-  uhd120: {
-    preferred: ['6k'],
-    fallback: '6k'
-  }
+const MURLAN_HDRI_RESOLUTION_LOCK = Object.freeze({
+  preferred: ['4k'],
+  fallback: '4k'
 });
-
-const resolveHdriResolutionProfile = (frameRateId) => {
-  if (frameRateId && HDRI_RESOLUTION_PROFILE[frameRateId]) {
-    return HDRI_RESOLUTION_PROFILE[frameRateId];
-  }
-  return HDRI_RESOLUTION_PROFILE[DEFAULT_FRAME_RATE_ID] ?? HDRI_RESOLUTION_PROFILE.fhd60;
-};
 
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };
@@ -1268,10 +1247,6 @@ export default function MurlanRoyaleArena({ search }) {
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
-  );
-  const hdriResolutionProfile = useMemo(
-    () => resolveHdriResolutionProfile(activeFrameRateOption?.id),
-    [activeFrameRateOption]
   );
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
@@ -1836,11 +1811,10 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
-      const resolutionProfile = hdriResolutionProfile ?? resolveHdriResolutionProfile(activeFrameRateOption?.id);
       const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
         ...activeVariant,
-        preferredResolutions: resolutionProfile?.preferred ?? DEFAULT_HDRI_RESOLUTIONS,
-        fallbackResolution: resolutionProfile?.fallback ?? DEFAULT_HDRI_RESOLUTIONS[0]
+        preferredResolutions: MURLAN_HDRI_RESOLUTION_LOCK.preferred ?? DEFAULT_HDRI_RESOLUTIONS,
+        fallbackResolution: MURLAN_HDRI_RESOLUTION_LOCK.fallback ?? DEFAULT_HDRI_RESOLUTIONS[0]
       });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
@@ -1870,13 +1844,13 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    [activeFrameRateOption, hdriResolutionProfile]
+    []
   );
 
   useEffect(() => {
     if (!threeReady) return;
     void applyHdriEnvironment(hdriVariantRef.current);
-  }, [applyHdriEnvironment, hdriResolutionProfile, threeReady]);
+  }, [applyHdriEnvironment, threeReady]);
 
   const updateSceneAppearance = useCallback(
     (nextAppearance, { refreshCards = false } = {}) => {


### PR DESCRIPTION
### Motivation
- The Murlan Royale arena must always use 4k HDRI textures and not change resolution when global graphics or Pool Royale settings change.
- Frame-rate or global HDRI resolution profiles previously influenced the Murlan HDRI selection, causing inconsistent visuals for the Murlan game.
- Locking HDRI resolution ensures consistent lighting/reflections and avoids regressions when other game pages adjust HDRI resolution.

### Description
- Added a `MURLAN_HDRI_RESOLUTION_LOCK` constant that forces `preferred: ['4k']` and `fallback: '4k'` for Murlan HDRIs. 
- Removed the frame-rate driven `HDRI_RESOLUTION_PROFILE` / `resolveHdriResolutionProfile` usage in this page and no longer compute a resolution profile from the active frame-rate option.
- Updated `applyHdriEnvironment` to pass the locked 4k `preferredResolutions` and `fallbackResolution` into `loadPolyHavenHdriEnvironment` instead of using a dynamic profile. 
- Changes applied to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and related `useEffect` dependencies were adjusted to remove the removed profile dependency.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696396d60e7883299da6088c9f8363d8)