### PR TITLE
Restore Snooker Club rules and table specs (revert Pool Royale pocket changes)

### DIFF
--- a/src/rules/SnookerClubRules.ts
+++ b/src/rules/SnookerClubRules.ts
@@ -1,4 +1,9 @@
 import { BallColor, FrameState, Player, ShotContext, ShotEvent } from '../types';
+import { UkPool } from '../../lib/poolUk8Ball.js';
+import { AmericanBilliards } from '../../lib/americanBilliards.js';
+import { NineBall } from '../../lib/nineBall.js';
+
+type PoolVariantId = 'american' | 'uk' | '9ball' | 'snooker';
 
 type SnookerSerializedState = {
   redsRemaining: number;
@@ -6,15 +11,87 @@ type SnookerSerializedState = {
   colorOnAfterRed: boolean;
   currentPlayer: 'A' | 'B';
   frameOver: boolean;
-  winner: 'A' | 'B' | null | 'TIE';
+  winner: 'A' | 'B' | null;
 };
 
-type SnookerMeta = {
-  variant: 'snooker';
-  state: SnookerSerializedState;
+type UkColour = 'blue' | 'red' | 'black' | 'cue';
+
+type HudInfo = {
+  next: string;
+  phase: string;
+  scores: { A: number; B: number };
 };
 
-const DEFAULT_COLORS: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+type UkSerializedState = {
+  ballsOnTable: {
+    blue: number[];
+    red: number[];
+    black8: boolean;
+    cueInPocket: boolean;
+  };
+  assignments: { A: UkColour | null; B: UkColour | null };
+  currentPlayer: 'A' | 'B';
+  shotsRemaining: number;
+  isOpenTable: boolean;
+  lastEvent: string | null;
+  frameOver: boolean;
+  winner: 'A' | 'B' | null;
+  mustPlayFromBaulk: boolean;
+};
+
+type AmericanSerializedState = {
+  ballsOnTable: number[];
+  currentPlayer: 'A' | 'B';
+  scores: { A: number; B: number };
+  ballInHand: boolean;
+  foulStreak: { A: number; B: number };
+  frameOver: boolean;
+  winner: 'A' | 'B' | 'TIE' | null;
+};
+
+type NineSerializedState = {
+  ballsOnTable: number[];
+  currentPlayer: 'A' | 'B';
+  ballInHand: boolean;
+  foulStreak: { A: number; B: number };
+  gameOver: boolean;
+  winner: 'A' | 'B' | null;
+};
+
+type PoolMeta =
+  | {
+      variant: 'uk';
+      state: UkSerializedState;
+      totals: { blue: number; red: number };
+      hud: HudInfo;
+    }
+  | {
+      variant: 'snooker';
+      state: SnookerSerializedState;
+      hud?: HudInfo;
+    }
+  | {
+      variant: 'american';
+      state: AmericanSerializedState;
+      hud: HudInfo;
+      breakInProgress?: boolean;
+    }
+  | {
+      variant: '9ball';
+      state: NineSerializedState;
+      hud: HudInfo;
+      breakInProgress?: boolean;
+    };
+
+const UK_TOTAL_PER_COLOUR = 7;
+
+function normalizeVariantId(value: string | null | undefined): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '')
+    .trim();
+}
 
 function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
   return {
@@ -23,38 +100,271 @@ function basePlayers(playerA: string, playerB: string): { A: Player; B: Player }
   };
 }
 
-export class SnookerClubRules {
+function serializeUkState(state: UkPool['state']): UkSerializedState {
+  return {
+    ballsOnTable: {
+      blue: Array.from(state.ballsOnTable.blue.values()),
+      red: Array.from(state.ballsOnTable.red.values()),
+      black8: state.ballsOnTable.black8,
+      cueInPocket: state.ballsOnTable.cueInPocket
+    },
+    assignments: { ...state.assignments },
+    currentPlayer: state.currentPlayer,
+    shotsRemaining: state.shotsRemaining,
+    isOpenTable: state.isOpenTable,
+    lastEvent: state.lastEvent,
+    frameOver: state.frameOver,
+    winner: state.winner,
+    mustPlayFromBaulk: state.mustPlayFromBaulk
+  };
+}
+
+function applyUkState(game: UkPool, snapshot: UkSerializedState) {
+  game.state = {
+    ballsOnTable: {
+      blue: new Set(snapshot.ballsOnTable.blue),
+      red: new Set(snapshot.ballsOnTable.red),
+      black8: snapshot.ballsOnTable.black8,
+      cueInPocket: snapshot.ballsOnTable.cueInPocket
+    },
+    assignments: { ...snapshot.assignments },
+    currentPlayer: snapshot.currentPlayer,
+    shotsRemaining: snapshot.shotsRemaining,
+    isOpenTable: snapshot.isOpenTable,
+    lastEvent: snapshot.lastEvent,
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner,
+    mustPlayFromBaulk: snapshot.mustPlayFromBaulk
+  };
+}
+
+function serializeAmericanState(state: AmericanBilliards['state']): AmericanSerializedState {
+  return {
+    ballsOnTable: Array.from(state.ballsOnTable.values()),
+    currentPlayer: state.currentPlayer,
+    scores: { ...state.scores },
+    ballInHand: state.ballInHand,
+    foulStreak: { ...state.foulStreak },
+    frameOver: state.frameOver,
+    winner: state.winner
+  };
+}
+
+function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerializedState) {
+  game.state = {
+    ballsOnTable: new Set(snapshot.ballsOnTable),
+    currentPlayer: snapshot.currentPlayer,
+    scores: { ...snapshot.scores },
+    ballInHand: snapshot.ballInHand,
+    foulStreak: { ...snapshot.foulStreak },
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner
+  };
+}
+
+function serializeNineState(state: NineBall['state']): NineSerializedState {
+  return {
+    ballsOnTable: Array.from(state.ballsOnTable.values()),
+    currentPlayer: state.currentPlayer,
+    ballInHand: state.ballInHand,
+    foulStreak: { ...state.foulStreak },
+    gameOver: state.gameOver,
+    winner: state.winner
+  };
+}
+
+function applyNineState(game: NineBall, snapshot: NineSerializedState) {
+  game.state = {
+    ballsOnTable: new Set(snapshot.ballsOnTable),
+    currentPlayer: snapshot.currentPlayer,
+    ballInHand: snapshot.ballInHand,
+    foulStreak: { ...snapshot.foulStreak },
+    gameOver: snapshot.gameOver,
+    winner: snapshot.winner
+  };
+}
+
+function parseUkColour(value: unknown): UkColour | null {
+  if (typeof value !== 'string') return null;
+  const lower = value.toLowerCase();
+  if (lower.startsWith('yellow')) return 'blue';
+  if (lower.startsWith('blue')) return 'blue';
+  if (lower.startsWith('red')) return 'red';
+  if (lower.startsWith('black')) return 'black';
+  if (lower === 'cue') return 'cue';
+  return null;
+}
+
+function isCueBallId(value: unknown): boolean {
+  if (value === 0) return true;
+  if (typeof value !== 'string') return false;
+  return value.toLowerCase() === 'cue' || value.toLowerCase() === 'cue_ball';
+}
+
+function parseNumericId(value: unknown): number | null {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const match = value.match(/(\d+)/);
+    if (match) return Number.parseInt(match[1], 10);
+  }
+  return null;
+}
+
+function lowestBall(balls: Iterable<number>): number | null {
+  let lowest: number | null = null;
+  for (const value of balls) {
+    if (lowest == null || value < lowest) {
+      lowest = value;
+    }
+  }
+  return lowest;
+}
+
+export class PoolRoyaleRules {
+  private readonly variant: PoolVariantId;
+
+  constructor(variantKey: string | null | undefined) {
+    const normalized = normalizeVariantId(variantKey);
+    if (
+      normalized === 'uk' ||
+      normalized === '8balluk' ||
+      normalized === 'eightballuk' ||
+      normalized === 'uk8' ||
+      normalized === 'snooker'
+    ) {
+      this.variant = normalized === 'snooker' ? 'snooker' : 'uk';
+    } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
+      this.variant = '9ball';
+    } else {
+      this.variant = 'american';
+    }
+  }
+
   getInitialFrame(playerA: string, playerB: string): FrameState {
-    const base: FrameState = {
-      balls: [],
-      activePlayer: 'A',
-      players: basePlayers(playerA, playerB),
-      currentBreak: 0,
-      phase: 'REDS_AND_COLORS',
-      redsRemaining: 15,
-      colorOnAfterRed: false,
-      ballOn: ['RED'],
-      frameOver: false
-    };
-
-    const meta: SnookerMeta = {
-      variant: 'snooker',
-      state: {
-        redsRemaining: 15,
-        colorsOnTable: [...DEFAULT_COLORS],
-        colorOnAfterRed: false,
-        currentPlayer: 'A',
-        frameOver: false,
-        winner: null
+    switch (this.variant) {
+      case 'snooker': {
+        const colorsOnTable: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: 15,
+          colorOnAfterRed: false,
+          ballOn: ['RED'],
+          frameOver: false
+        };
+        base.meta = {
+          variant: 'snooker',
+          state: {
+            redsRemaining: 15,
+            colorsOnTable,
+            colorOnAfterRed: false,
+            currentPlayer: 'A',
+            frameOver: false,
+            winner: null
+          }
+        } satisfies PoolMeta;
+        return base;
       }
-    };
-
-    base.meta = meta;
-    return base;
+      case 'uk': {
+        const game = new UkPool();
+        game.startBreak();
+        const snapshot = serializeUkState(game.state);
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: UK_TOTAL_PER_COLOUR * 2,
+          ballOn: ['RED', 'YELLOW'],
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: 'open table',
+          phase: 'open',
+          scores: { A: 0, B: 0 }
+        };
+        base.meta = {
+          variant: 'uk',
+          state: snapshot,
+          totals: { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR },
+          hud
+        } satisfies PoolMeta;
+        return base;
+      }
+      case '9ball': {
+        const game = new NineBall();
+        game.state.ballInHand = true;
+        const snapshot = serializeNineState(game.state);
+        const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: 9,
+          ballOn: [`BALL_${lowest}`],
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: `ball ${lowest}`,
+          phase: 'rack',
+          scores: { A: 0, B: 0 }
+        };
+        base.meta = {
+          variant: '9ball',
+          state: snapshot,
+          hud,
+          breakInProgress: true
+        } satisfies PoolMeta;
+        return base;
+      }
+      default: {
+        const game = new AmericanBilliards();
+        game.state.ballInHand = true;
+        const snapshot = serializeAmericanState(game.state);
+        const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: snapshot.ballsOnTable.length,
+          ballOn: [`BALL_${lowest}`],
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: `ball ${lowest}`,
+          phase: 'rotation',
+          scores: { A: 0, B: 0 }
+        };
+        base.meta = {
+          variant: 'american',
+          state: snapshot,
+          hud,
+          breakInProgress: true
+        } satisfies PoolMeta;
+        return base;
+      }
+    }
   }
 
   applyShot(state: FrameState, events: ShotEvent[], context: ShotContext = {}): FrameState {
-    return this.applySnookerShot(state, events, context);
+    switch (this.variant) {
+      case 'snooker':
+        return this.applySnookerShot(state, events, context);
+      case 'uk':
+        return this.applyUkShot(state, events, context);
+      case '9ball':
+        return this.applyNineBallShot(state, events, context);
+      default:
+        return this.applyAmericanShot(state, events, context);
+    }
   }
 
   private resolveBallColor(value: unknown): BallColor | null {
@@ -99,27 +409,30 @@ export class SnookerClubRules {
     colorOnAfterRed: boolean,
     colorsOnTable: Set<BallColor>
   ): string[] {
+    const orderedColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
     if (phase === 'COLORS_ORDER') {
-      const next = DEFAULT_COLORS.find((c) => colorsOnTable.has(c));
+      const next = orderedColors.find((c) => colorsOnTable.has(c));
       return next ? [next] : [];
     }
     if (colorOnAfterRed) {
-      const remaining = DEFAULT_COLORS.filter((c) => colorsOnTable.has(c));
-      return remaining.length > 0 ? remaining : DEFAULT_COLORS;
+      const remaining = orderedColors.filter((c) => colorsOnTable.has(c));
+      return remaining.length > 0 ? remaining : orderedColors;
     }
     if (redsRemaining > 0) return ['RED'];
-    const next = DEFAULT_COLORS.find((c) => colorsOnTable.has(c));
+    const next = orderedColors.find((c) => colorsOnTable.has(c));
     return next ? [next] : [];
   }
 
   private applySnookerShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const meta = (state.meta ?? {}) as SnookerMeta | Record<string, unknown>;
-    const previous = meta.variant === 'snooker' ? meta.state : null;
+    const defaultColors: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
+    const meta = (state.meta ?? {}) as PoolMeta;
+    const previous: SnookerSerializedState | null =
+      meta.variant === 'snooker' && meta.state ? (meta.state as SnookerSerializedState) : null;
 
     let redsRemaining = Number.isFinite(state.redsRemaining) ? state.redsRemaining : 15;
     let colorOnAfterRed = Boolean(state.colorOnAfterRed);
     let phase: FrameState['phase'] = state.phase === 'COLORS_ORDER' ? 'COLORS_ORDER' : 'REDS_AND_COLORS';
-    const colorsOnTable = new Set<BallColor>(previous?.colorsOnTable ?? DEFAULT_COLORS);
+    const colorsOnTable = new Set<BallColor>(previous?.colorsOnTable ?? defaultColors);
     let activePlayer: 'A' | 'B' = state.activePlayer ?? 'A';
     const opponent: 'A' | 'B' = activePlayer === 'A' ? 'B' : 'A';
     const players: { A: Player; B: Player } = {
@@ -190,7 +503,12 @@ export class SnookerClubRules {
       if (redsRemaining === 0 && phase === 'REDS_AND_COLORS' && !colorOnAfterRed) {
         phase = 'COLORS_ORDER';
       }
-      const ballOnNext = this.computeSnookerBallOn(phase, redsRemaining, colorOnAfterRed, colorsOnTable);
+      const ballOnNext = this.computeSnookerBallOn(
+        phase,
+        redsRemaining,
+        colorOnAfterRed,
+        colorsOnTable
+      );
       const frameOver = ballOnNext.length === 0 && phase === 'COLORS_ORDER';
       const winner = frameOver
         ? players.A.score === players.B.score
@@ -222,9 +540,9 @@ export class SnookerClubRules {
             colorOnAfterRed,
             currentPlayer: activePlayer,
             frameOver,
-            winner: (winner ?? null) as SnookerSerializedState['winner']
+            winner: winner ?? null
           }
-        }
+        } satisfies PoolMeta
       };
     }
 
@@ -293,11 +611,263 @@ export class SnookerClubRules {
           colorOnAfterRed,
           currentPlayer: activePlayer,
           frameOver,
-          winner: (winner ?? null) as SnookerSerializedState['winner']
+          winner: winner ?? null
+        }
+      } satisfies PoolMeta
+    };
+  }
+
+  private applyUkShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === 'uk' && meta.state ? meta : null;
+    const game = new UkPool();
+    if (previous) {
+      applyUkState(game, previous.state);
+    } else {
+      game.startBreak();
+    }
+    const contactOrder: UkColour[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const colour = parseUkColour(ev.ballId ?? ev.firstContact);
+      if (colour && colour !== 'cue') {
+        contactOrder.push(colour);
+      }
+    }
+    const potted: UkColour[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push('cue');
+      } else {
+        const colour = parseUkColour(ev.ballId ?? ev.ball);
+        if (colour && colour !== 'cue') {
+          potted.push(colour);
         }
       }
+    }
+    const shotResult = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact),
+      placedFromHand: Boolean(context.placedFromHand)
+    });
+    const snapshot = serializeUkState(game.state);
+    const totals = previous ? previous.totals : { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR };
+    const playerScores = this.computeUkScores(snapshot, totals);
+    const ballOn = this.computeUkBallOn(snapshot);
+    const hud: HudInfo = {
+      next: ballOn.length === 0 ? 'black' : ballOn.map((entry) => entry.toLowerCase()).join(' / '),
+      phase: snapshot.isOpenTable ? 'open' : 'groups',
+      scores: playerScores
     };
+    const nextState: FrameState = {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: playerScores.A },
+        B: { ...state.players.B, score: playerScores.B }
+      },
+      ballOn,
+      frameOver: game.state.frameOver,
+      winner: game.state.winner ?? undefined,
+      foul: shotResult.foul
+        ? {
+            points: 0,
+            reason: shotResult.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: 'uk',
+        state: snapshot,
+        totals,
+        hud
+      } satisfies PoolMeta
+    };
+    return nextState;
+  }
+
+  private computeUkScores(state: UkSerializedState, totals: { blue: number; red: number }): { A: number; B: number } {
+    const remainingBlue = state.ballsOnTable.blue.length;
+    const remainingRed = state.ballsOnTable.red.length;
+    const pottedBlue = totals.blue - remainingBlue;
+    const pottedRed = totals.red - remainingRed;
+    const assignA = state.assignments.A;
+    const assignB = state.assignments.B;
+    return {
+      A: assignA === 'blue' ? pottedBlue : assignA === 'red' ? pottedRed : 0,
+      B: assignB === 'blue' ? pottedBlue : assignB === 'red' ? pottedRed : 0
+    };
+  }
+
+  private computeUkBallOn(state: UkSerializedState): string[] {
+    if (state.frameOver) return [];
+    const current = state.currentPlayer;
+    const assignment = state.assignments[current];
+    const available: string[] = [];
+    if (state.isOpenTable || !assignment) {
+      if (state.ballsOnTable.red.length > 0) available.push('RED');
+      if (state.ballsOnTable.blue.length > 0) available.push('YELLOW');
+      if (available.length === 0 && state.ballsOnTable.black8) available.push('BLACK');
+      return available;
+    }
+    if (assignment === 'red') {
+      if (state.ballsOnTable.red.length > 0) return ['RED'];
+    } else if (assignment === 'blue') {
+      if (state.ballsOnTable.blue.length > 0) return ['YELLOW'];
+    }
+    if (state.ballsOnTable.black8) return ['BLACK'];
+    return [];
+  }
+
+  private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
+    const game = new AmericanBilliards();
+    if (previous) {
+      applyAmericanState(game, previous.state);
+    } else {
+      game.state.ballInHand = true;
+    }
+    const contactOrder: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const id = parseNumericId(ev.ballId ?? ev.firstContact);
+      if (id != null) contactOrder.push(id);
+    }
+    const potted: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push(0);
+      } else {
+        const id = parseNumericId(ev.ballId ?? ev.ball);
+        if (id != null) potted.push(id);
+      }
+    }
+    const result = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      placedFromHand: Boolean(context.placedFromHand),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+    });
+    const snapshot = serializeAmericanState(game.state);
+    const lowest = lowestBall(snapshot.ballsOnTable);
+    const tableClear = snapshot.ballsOnTable.length === 0;
+    const frameOver = snapshot.frameOver || tableClear;
+    const hud: HudInfo = {
+      next:
+        frameOver && snapshot.winner
+          ? 'frame over'
+          : lowest != null
+            ? `ball ${lowest}`
+            : tableClear
+              ? 'frame over'
+              : 'rack clear',
+      phase: frameOver ? 'complete' : 'rotation',
+      scores: { ...snapshot.scores }
+    };
+    let winner: FrameState['winner'];
+    if (frameOver) {
+      if (snapshot.winner === 'A' || snapshot.winner === 'B' || snapshot.winner === 'TIE') {
+        winner = snapshot.winner;
+      } else if (snapshot.scores.A > snapshot.scores.B) winner = 'A';
+      else if (snapshot.scores.B > snapshot.scores.A) winner = 'B';
+      else winner = 'TIE';
+    }
+    const nextState: FrameState = {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: snapshot.scores.A },
+        B: { ...state.players.B, score: snapshot.scores.B }
+      },
+      ballOn: lowest != null && !frameOver ? [`BALL_${lowest}`] : [],
+      frameOver,
+      winner,
+      foul: result.foul
+        ? {
+            points: 0,
+            reason: result.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: 'american',
+        state: snapshot,
+        hud,
+        breakInProgress: false
+      } satisfies PoolMeta
+    };
+    return nextState;
+  }
+
+  private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === '9ball' && meta.state ? meta : null;
+    const game = new NineBall();
+    if (previous) {
+      applyNineState(game, previous.state);
+    } else {
+      game.state.ballInHand = true;
+    }
+    const contactOrder: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const id = parseNumericId(ev.ballId ?? ev.firstContact);
+      if (id != null) contactOrder.push(id);
+    }
+    const potted: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push(0);
+      } else {
+        const id = parseNumericId(ev.ballId ?? ev.ball);
+        if (id != null) potted.push(id);
+      }
+    }
+    const result = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      placedFromHand: Boolean(context.placedFromHand),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+    });
+    const snapshot = serializeNineState(game.state);
+    const lowest = lowestBall(snapshot.ballsOnTable);
+    const hud: HudInfo = {
+      next: snapshot.gameOver ? 'frame over' : lowest != null ? `ball ${lowest}` : 'nine',
+      phase: snapshot.gameOver ? 'complete' : 'run',
+      scores: { A: 0, B: 0 }
+    };
+    const nextState: FrameState = {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: 0 },
+        B: { ...state.players.B, score: 0 }
+      },
+      ballOn: lowest != null && !snapshot.gameOver ? [`BALL_${lowest}`] : [],
+      frameOver: game.state.gameOver,
+      winner: game.state.winner ?? undefined,
+      foul: result.foul
+        ? {
+            points: 0,
+            reason: result.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: '9ball',
+        state: snapshot,
+        hud,
+        breakInProgress: false
+      } satisfies PoolMeta
+    };
+    return nextState;
   }
 }
 
-export default SnookerClubRules;
+export default PoolRoyaleRules;
+export { PoolRoyaleRules as SnookerClubRules };

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,39 +1,37 @@
-const BASE_TABLE_SCALE = 1.44;
-const BASE_TABLE_MOBILE_SCALE = 1.44;
-const BASE_TABLE_COMPACT_SCALE = 1.44;
-const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
+const BASE_TABLE_SCALE = 1.46;
+const BASE_TABLE_MOBILE_SCALE = 1.52;
+const BASE_TABLE_COMPACT_SCALE = 1.36;
+const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '9ft': {
-    id: '9ft',
-    label: '9 ft (Pool Royale)',
-    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+  '12ft': {
+    id: '12ft',
+    label: '12 ft (Championship)',
+    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
+      corner: 86,
+      side: 92
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.72,
+      mobileScale: 1.68,
       compactScale: 1.48
     })
   },
-  '8ft': {
-    id: '8ft',
-    label: '8 ft (Pool Royale)',
-    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
+  '10ft': {
+    id: '10ft',
+    label: '10 ft (Club)',
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 171.45,
-      side: 152.4
+      corner: 86,
+      side: 92
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+    cushionCutAngleDeg: 35,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
   }
 });
 
@@ -72,7 +70,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '9ft';
+export const DEFAULT_TABLE_SIZE_ID = '12ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/SnookerClubGame.jsx
+++ b/webapp/src/pages/Games/SnookerClubGame.jsx
@@ -21,7 +21,7 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { SnookerClubRules } from '../../../../src/rules/SnookerClubRules.ts';
+import { SnookerClubRules as PoolRoyaleRules } from '../../../../src/rules/SnookerClubRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/snookerClubTables.js';
 import {
@@ -8295,7 +8295,7 @@ export function PoolRoyaleGame({
   const rafRef = useRef(null);
   const worldRef = useRef(null);
   const sceneRef = useRef(null);
-  const rules = useMemo(() => new SnookerClubRules(), []);
+  const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
   const activeVariant = useMemo(
     () => resolvePoolVariant(variantKey),
     [variantKey]


### PR DESCRIPTION
### Motivation
- Revert recent pocket / Pool Royale-driven changes and restore the Snooker Club game to the snooker-specific baseline (table sizing, pockets and rules). 
- Ensure the snooker ruleset (and related pool variants used for serialization) are fully reinstated so in-game state, scoring and respot logic behave as expected. 
- Keep table geometry and play feel faithful to full-size snooker (12ft/10ft) rather than the Pool Royale pocket sizing that was previously applied. 
- Align the game code to consume the restored rules implementation with a variant-aware constructor. 

### Description
- Reintroduced full rules and per-variant serialization/restore helpers in `src/rules/SnookerClubRules.ts` (adds UK/american/9ball helpers, state serializers, and variant-aware rule dispatch). 
- Restored snooker table physical specs and pocket mouth sizes in `webapp/src/config/snookerClubTables.js` (switch to 12ft/10ft reference sizes, smaller pocket mouths, updated cushion angles and default table id). 
- Updated game code in `webapp/src/pages/Games/SnookerClubGame.jsx` to use the restored rules API by instantiating the variant-aware rules class (`SnookerClubRules as PoolRoyaleRules`) with `variantKey`. 
- Kept exports compatible by exporting the restored rules class and aliasing it back to `SnookerClubRules` so callers keep working. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (dev server ready). 
- Captured an automated lobby screenshot using a Playwright script which succeeded and produced an artifact (`snookerclub-lobby.png`). 
- Attempted an automated in-game page capture with Playwright but the Chromium run failed with a `TargetClosedError` / SIGSEGV during browser launch, so the in-game screenshot attempt did not complete. 
- No unit tests were run as part of this rollout; manual/dev server smoke checks above are the performed automated validations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963974b66248329befd791228fe9170)