### PR TITLE
Fix Pool Royale spin alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20009,9 +20009,13 @@ const powerRef = useRef(hud.power);
           } else if (physicsSpin.y < 0) {
             spinTop *= TOPSPIN_MULTIPLIER;
           }
+          const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
           cue.vel.copy(base);
           if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
+            cue.spin.set(
+              perp.x * spinSide + aimDir.x * spinTop,
+              perp.y * spinSide + aimDir.y * spinTop
+            );
           }
           if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
           cue.spinMode =


### PR DESCRIPTION
### Motivation
- Players reported inconsistent cueball behavior when applying top or slight top spin at medium power, indicating spin axes were not aligned with the shot direction. 
- The intent is to make top/back/side spin apply consistently relative to the current aim so small changes in spin produce predictable outcomes. 

### Description
- Map spin into world-aligned vectors by computing a perpendicular `perp` from the shot `aimDir` and applying `cue.spin.set(perp * spinSide + aimDir * spinTop)` instead of the previous raw `(spinSide, spinTop)` assignment. 
- This change was applied in `webapp/src/pages/Games/PoolRoyale.jsx` where the shot is fired and the cue spin is initialized. 
- The implementation still uses existing spin scaling and multipliers (`SIDE_SPIN_MULTIPLIER`, `BACKSPIN_MULTIPLIER`, `TOPSPIN_MULTIPLIER`) and integrates with `applySpinConstraints` and `mapSpinForPhysics`. 

### Testing
- No automated tests or CI were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639bbf7b308329a50021c3397829da)