### PR TITLE
Align cue spin with shot direction in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20011,7 +20011,14 @@ const powerRef = useRef(hud.power);
           }
           cue.vel.copy(base);
           if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
+            const spinAxis = new THREE.Vector2(aimDir.x, aimDir.y);
+            if (spinAxis.lengthSq() < 1e-6) spinAxis.set(0, 1);
+            else spinAxis.normalize();
+            const spinPerp = new THREE.Vector2(-spinAxis.y, spinAxis.x);
+            cue.spin.set(
+              spinPerp.x * spinSide + spinAxis.x * spinTop,
+              spinPerp.y * spinSide + spinAxis.y * spinTop
+            );
           }
           if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
           cue.spinMode =


### PR DESCRIPTION
### Motivation
- Players reported inconsistent cueball response when applying top/back spin at different power levels, indicating spin was not being mapped into world space relative to the shot direction.
- The intent is to make top/back and side spin behave predictably by applying spin vectors aligned to the shot's aim direction.

### Description
- Replace the previous local-axis assignment `cue.spin.set(spinSide, spinTop)` with a world-space mapping that computes `spinAxis` from the current `aimDir` and `spinPerp` and sets `cue.spin` to `spinPerp * spinSide + spinAxis * spinTop`.
- Change applied in `webapp/src/pages/Games/PoolRoyale.jsx` in the shot firing path where spin is applied to the cue ball.
- All existing spin limits, legality checks and swerve handling remain unchanged.

### Testing
- No automated tests were executed for this change.
- Functional verification should be done by playing shots with various combinations of side/top/back spin and power to confirm expected behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639bbf7b308329a50021c3397829da)