### PR TITLE
Force Murlan HDRIs to 4k regardless of settings

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -41,8 +41,11 @@ import {
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const MURLAN_HDRI_RESOLUTION_LOCK = '4k';
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
+  preferredResolutions: [MURLAN_HDRI_RESOLUTION_LOCK],
+  fallbackResolution: MURLAN_HDRI_RESOLUTION_LOCK,
   label: `${variant.name} HDRI`
 }));
 const DEFAULT_HDRI_INDEX = Math.max(
@@ -410,10 +413,16 @@ const pickPolyHavenHdriUrl = (json, preferred = DEFAULT_HDRI_RESOLUTIONS) => {
 };
 
 async function resolvePolyHavenHdriUrl(config = {}) {
-  const preferred = Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
-    ? config.preferredResolutions
-    : DEFAULT_HDRI_RESOLUTIONS;
-  const fallbackRes = config?.fallbackResolution || preferred[0] || '8k';
+  const forcedResolution =
+    typeof config?.forceResolution === 'string' && config.forceResolution.length
+      ? config.forceResolution
+      : null;
+  const preferred = forcedResolution
+    ? [forcedResolution]
+    : Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+      ? config.preferredResolutions
+      : DEFAULT_HDRI_RESOLUTIONS;
+  const fallbackRes = forcedResolution || config?.fallbackResolution || preferred[0] || '8k';
   const fallbackUrl =
     config?.fallbackUrl ||
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;
@@ -1176,32 +1185,6 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
-const HDRI_RESOLUTION_PROFILE = Object.freeze({
-  hd50: {
-    preferred: ['2k'],
-    fallback: '2k'
-  },
-  fhd60: {
-    preferred: ['2k'],
-    fallback: '2k'
-  },
-  qhd90: {
-    preferred: ['4k'],
-    fallback: '4k'
-  },
-  uhd120: {
-    preferred: ['6k'],
-    fallback: '6k'
-  }
-});
-
-const resolveHdriResolutionProfile = (frameRateId) => {
-  if (frameRateId && HDRI_RESOLUTION_PROFILE[frameRateId]) {
-    return HDRI_RESOLUTION_PROFILE[frameRateId];
-  }
-  return HDRI_RESOLUTION_PROFILE[DEFAULT_FRAME_RATE_ID] ?? HDRI_RESOLUTION_PROFILE.fhd60;
-};
-
 const GAME_CONFIG = { ...BASE_CONFIG };
 const START_CARD = { rank: '3', suit: '♠' };
 
@@ -1268,10 +1251,6 @@ export default function MurlanRoyaleArena({ search }) {
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
-  );
-  const hdriResolutionProfile = useMemo(
-    () => resolveHdriResolutionProfile(activeFrameRateOption?.id),
-    [activeFrameRateOption]
   );
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
@@ -1836,11 +1815,11 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
-      const resolutionProfile = hdriResolutionProfile ?? resolveHdriResolutionProfile(activeFrameRateOption?.id);
       const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
         ...activeVariant,
-        preferredResolutions: resolutionProfile?.preferred ?? DEFAULT_HDRI_RESOLUTIONS,
-        fallbackResolution: resolutionProfile?.fallback ?? DEFAULT_HDRI_RESOLUTIONS[0]
+        forceResolution: MURLAN_HDRI_RESOLUTION_LOCK,
+        preferredResolutions: [MURLAN_HDRI_RESOLUTION_LOCK],
+        fallbackResolution: MURLAN_HDRI_RESOLUTION_LOCK
       });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
@@ -1870,13 +1849,13 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    [activeFrameRateOption, hdriResolutionProfile]
+    []
   );
 
   useEffect(() => {
     if (!threeReady) return;
     void applyHdriEnvironment(hdriVariantRef.current);
-  }, [applyHdriEnvironment, hdriResolutionProfile, threeReady]);
+  }, [applyHdriEnvironment, threeReady]);
 
   const updateSceneAppearance = useCallback(
     (nextAppearance, { refreshCards = false } = {}) => {


### PR DESCRIPTION
### Motivation
- Ensure the Murlan Royale arena always uses 4k HDRI assets so lighting and reflections remain consistent.
- Prevent global HDRI resolution or frame-rate-driven profiles from causing the Murlan HDRI to downgrade below 4k.
- Fix a reported issue where the Murlan HDRI was not being requested or loaded at 4k.

### Description
- Added a fixed `MURLAN_HDRI_RESOLUTION_LOCK = '4k'` and applied it to each Murlan HDRI variant via `preferredResolutions` and `fallbackResolution`.
- Extended the Poly Haven resolver (`resolvePolyHavenHdriUrl`) to accept and prioritize a `forceResolution` option so callers can request an exact resolution.
- Updated `applyHdriEnvironment` to pass `forceResolution`, `preferredResolutions`, and `fallbackResolution` set to `MURLAN_HDRI_RESOLUTION_LOCK` when loading the environment.
- Removed usage of the frame-rate-derived HDRI resolution profile and eliminated that profile from the `useEffect` dependency chain for Murlan HDRI application.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696396d60e7883299da6088c9f8363d8)