### PR TITLE
Match HDRI fallback resolution to 4k across games

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1434,7 +1434,7 @@ async function resolvePolyHavenHdriUrl(config = {}) {
   const preferred = Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
     ? config.preferredResolutions
     : DEFAULT_HDRI_RESOLUTIONS;
-  const fallbackRes = config?.fallbackResolution || preferred[0] || '8k';
+  const fallbackRes = config?.fallbackResolution || preferred[0] || '4k';
   const fallbackUrl =
     config?.fallbackUrl ||
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -422,7 +422,7 @@ async function resolvePolyHavenHdriUrl(config = {}) {
     : Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
       ? config.preferredResolutions
       : DEFAULT_HDRI_RESOLUTIONS;
-  const fallbackRes = forcedResolution || config?.fallbackResolution || preferred[0] || '8k';
+  const fallbackRes = forcedResolution || config?.fallbackResolution || preferred[0] || '4k';
   const fallbackUrl =
     config?.fallbackUrl ||
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1059,7 +1059,7 @@ async function resolvePolyHavenHdriUrl(config = {}, preferred = PREFERRED_HDRI_R
       ? config.preferredResolutions
       : preferred;
   const fallbackResolution =
-    config?.fallbackResolution || preferredResolutions?.[0] || PREFERRED_HDRI_RESOLUTIONS[0] || '2k';
+    config?.fallbackResolution || preferredResolutions?.[0] || PREFERRED_HDRI_RESOLUTIONS[0] || '4k';
   const assetId = config?.assetId || 'neon_photostudio';
   const fallbackUrl =
     config?.fallbackUrl ||


### PR DESCRIPTION
### Motivation
- Ensure all games that use Poly Haven HDRIs default to the same resolution as Pool Royale (`4k`).
- Prevent lower-resolution fallbacks (previously `2k`/`8k` defaults) from reducing visual quality in other games.
- Keep HDRI URL resolution behavior consistent when `preferredResolutions` or `fallbackResolution` are not provided.

### Description
- Updated the `resolvePolyHavenHdriUrl` fallback resolution default in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to `'4k'` from `'8k'`.
- Updated the `resolvePolyHavenHdriUrl` fallback resolution default in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to `'4k'` from `'8k'`.
- Updated the `resolvePolyHavenHdriUrl` fallback resolution default in `webapp/src/pages/Games/TexasHoldemArena.jsx` to `'4k'` from `'2k'`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b14ee6bc8329b3346f7801b5a5d1)