### PR TITLE
Add HDRI resolution selector (2K/4K/6K) to Murlan Royale table setup

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -40,12 +40,27 @@ import {
 } from '../../config/murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const MURLAN_HDRI_RESOLUTION_LOCK = '4k';
+const DEFAULT_HDRI_RESOLUTION_ID = '4k';
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze([DEFAULT_HDRI_RESOLUTION_ID]);
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  {
+    id: '2k',
+    label: '2K HDRI',
+    description: 'Faster loads for mobile and battery saver setups.'
+  },
+  {
+    id: '4k',
+    label: '4K HDRI',
+    description: 'Balanced clarity recommended for most devices.'
+  },
+  {
+    id: '6k',
+    label: '6K HDRI',
+    description: 'Ultra-crisp reflections for high-end GPUs.'
+  }
+]);
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
-  preferredResolutions: [MURLAN_HDRI_RESOLUTION_LOCK],
-  fallbackResolution: MURLAN_HDRI_RESOLUTION_LOCK,
   label: `${variant.name} HDRI`
 }));
 const DEFAULT_HDRI_INDEX = Math.max(
@@ -623,6 +638,7 @@ const DEFAULT_APPEARANCE = {
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
+const HDRI_RESOLUTION_STORAGE_KEY = 'murlanHdriResolution';
 const CUSTOMIZATION_SECTIONS = [
   { key: 'tables', label: 'Table Model', options: TABLE_THEMES },
   { key: 'tableFinish', label: 'Table Finish', options: MURLAN_TABLE_FINISHES },
@@ -1248,9 +1264,22 @@ export default function MurlanRoyaleArena({ search }) {
     }
     return DEFAULT_FRAME_RATE_ID || DEFAULT_FRAME_RATE_OPTION.id;
   });
+  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      if (stored && HDRI_RESOLUTION_OPTIONS.some((opt) => opt.id === stored)) {
+        return stored;
+      }
+    }
+    return DEFAULT_HDRI_RESOLUTION_ID;
+  });
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
+  );
+  const activeHdriResolution = useMemo(
+    () => HDRI_RESOLUTION_OPTIONS.find((opt) => opt.id === hdriResolutionId) ?? HDRI_RESOLUTION_OPTIONS[1],
+    [hdriResolutionId]
   );
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
@@ -1280,6 +1309,7 @@ export default function MurlanRoyaleArena({ search }) {
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
   }, [frameQualityProfile]);
+  const resolvedHdriResolution = activeHdriResolution?.id ?? DEFAULT_HDRI_RESOLUTION_ID;
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
@@ -1357,6 +1387,14 @@ export default function MurlanRoyaleArena({ search }) {
       console.warn('Failed to persist frame rate option', error);
     }
   }, [frameRateId]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, resolvedHdriResolution);
+    } catch (error) {
+      console.warn('Failed to persist HDRI resolution option', error);
+    }
+  }, [resolvedHdriResolution]);
 
   const gameStateRef = useRef(gameState);
   const selectedRef = useRef(selectedIds);
@@ -1815,11 +1853,12 @@ export default function MurlanRoyaleArena({ search }) {
       if (!three.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
+      const resolution = resolvedHdriResolution || DEFAULT_HDRI_RESOLUTION_ID;
       const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
         ...activeVariant,
-        forceResolution: MURLAN_HDRI_RESOLUTION_LOCK,
-        preferredResolutions: [MURLAN_HDRI_RESOLUTION_LOCK],
-        fallbackResolution: MURLAN_HDRI_RESOLUTION_LOCK
+        forceResolution: resolution,
+        preferredResolutions: [resolution],
+        fallbackResolution: resolution
       });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
@@ -1849,7 +1888,7 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    []
+    [resolvedHdriResolution]
   );
 
   useEffect(() => {
@@ -2841,6 +2880,46 @@ export default function MurlanRoyaleArena({ search }) {
                   <div className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Graphics</p>
                     <div className="grid gap-2">
+                      <div className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-[10px] font-semibold uppercase tracking-[0.26em] text-white">
+                            HDRI Resolution
+                          </span>
+                          <span className="text-[10px] font-semibold tracking-wide text-sky-100">
+                            {activeHdriResolution?.label ?? '4K HDRI'}
+                          </span>
+                        </div>
+                        <div className="mt-2 grid gap-1.5">
+                          {HDRI_RESOLUTION_OPTIONS.map((option) => {
+                            const active = option.id === resolvedHdriResolution;
+                            return (
+                              <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => setHdriResolutionId(option.id)}
+                                aria-pressed={active}
+                                className={`w-full rounded-xl border px-2.5 py-1.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                  active
+                                    ? 'border-sky-300 bg-sky-300/15 text-white shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                                    : 'border-white/10 bg-white/5 text-white/80 hover:border-white/20'
+                                }`}
+                              >
+                                <span className="flex items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.24em]">
+                                  {option.label}
+                                  <span className="text-[9px] font-semibold tracking-wide text-sky-100">
+                                    {option.id.toUpperCase()}
+                                  </span>
+                                </span>
+                                {option.description ? (
+                                  <span className="mt-1 block text-[9px] uppercase tracking-[0.2em] text-white/60">
+                                    {option.description}
+                                  </span>
+                                ) : null}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
                       {FRAME_RATE_OPTIONS.map((option) => {
                         const active = option.id === frameRateId;
                         return (


### PR DESCRIPTION
### Motivation
- Provide an in-UI option to change HDRI load resolution for the Murlan Royale table so users can choose performance vs. clarity (2k/4k/6k).
- Persist the selected HDRI resolution across sessions so the chosen quality is applied consistently.
- Ensure HDRI loading honors the selected resolution instead of being hard-locked to a single resolution.

### Description
- Added `HDRI_RESOLUTION_OPTIONS`, `HDRI_RESOLUTION_STORAGE_KEY` and related state (`hdriResolutionId`, `activeHdriResolution`, `resolvedHdriResolution`) to `MurlanRoyaleArena.jsx` and defaulted to `4k`.
- Wired a UI selector into the Table Setup -> Graphics panel that displays and lets users pick `2k`, `4k`, or `6k` HDRI resolution options.
- Persist the choice to `localStorage` and pass the selected resolution into `loadPolyHavenHdriEnvironment` via `forceResolution`, `preferredResolutions`, and `fallbackResolution` when applying HDRI environments.
- Removed the previous hard-lock use of `MURLAN_HDRI_RESOLUTION_LOCK` and added dependency on `resolvedHdriResolution` for the `applyHdriEnvironment` hook.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (server ready message shown).
- Ran a small Playwright smoke script that opened `/games/murlanroyale`, opened the Table Setup panel, and captured a screenshot which completed successfully and produced an artifact.
- No unit test changes were required and existing test suite was not modified in this change.
- Verified there were no runtime errors in the console during the local UI smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ba0d88d883298ffedd56da6a924e)