### PR TITLE
Restore Snooker Club arena by removing HDRI environment support

### DIFF
--- a/webapp/src/config/snookerClubInventoryConfig.js
+++ b/webapp/src/config/snookerClubInventoryConfig.js
@@ -1,8 +1,4 @@
 import { CUE_STYLE_PRESETS } from './cueStyles.js';
-import {
-  POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
-} from './poolRoyaleInventoryConfig.js';
 
 export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['rusticSplit'],
@@ -10,17 +6,10 @@ export const SNOOKER_CLUB_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['chrome'],
   clothColor: ['freshGreen'],
   cueStyle: [CUE_STYLE_PRESETS[0]?.id],
-  pocketLiner: ['fabric_leather_02'],
-  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
+  pocketLiner: ['fabric_leather_02']
 });
 
 export const SNOOKER_CLUB_OPTION_LABELS = Object.freeze({
-  environmentHdri: Object.freeze(
-    POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
-      acc[variant.id] = `${variant.name} HDRI`;
-      return acc;
-    }, {})
-  ),
   tableFinish: Object.freeze({
     rusticSplit: 'Pearl Cream',
     charredTimber: 'Charred Timber',
@@ -186,14 +175,6 @@ export const SNOOKER_CLUB_STORE_ITEMS = [
     name: `${preset.label} Cue`,
     price: 320 + idx * 25,
     description: 'Unlock an alternate cue butt finish for Snooker Club.'
-  })),
-  ...POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-    id: `snooker-hdri-${variant.id}`,
-    type: 'environmentHdri',
-    optionId: variant.id,
-    name: `${variant.name} HDRI`,
-    price: variant.price,
-    description: variant.description
   }))
 ];
 
@@ -207,12 +188,5 @@ export const SNOOKER_CLUB_DEFAULT_LOADOUT = [
     type: 'pocketLiner',
     optionId: 'fabric_leather_02',
     label: 'Fabric Leather 02 Pocket Jaws'
-  },
-  {
-    type: 'environmentHdri',
-    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
-    label:
-      SNOOKER_CLUB_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID] ||
-      'HDR Environment'
   }
 ];

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -131,8 +131,7 @@ const SNOOKER_TYPE_LABELS = {
   chromeColor: 'Chrome Fascias',
   railMarkerColor: 'Rail Markers',
   clothColor: 'Cloth Colors',
-  cueStyle: 'Cue Styles',
-  environmentHdri: 'HDR Environments'
+  cueStyle: 'Cue Styles'
 };
 
 const AIR_HOCKEY_TYPE_LABELS = {


### PR DESCRIPTION
### Motivation
- Restore the Snooker Club arena to its previous appearance by removing HDRI environment selection and loading so the arena matches the pre-HDRI build.
- Keep all non-SnookerClub systems untouched and limit the change to the Snooker Club game UI/config and related assets.

### Description
- Removed HDRI-related imports, loaders, URL resolution, PMREM setup, and environment application code from `webapp/src/pages/Games/SnookerClubGame.jsx` so the game no longer loads or applies HDRI skyboxes.
- Eliminated HDRI state, refs, disposal logic, and the HDRI selector UI from the Snooker Club configuration panel in `webapp/src/pages/Games/SnookerClubGame.jsx`.
- Removed HDRI inventory options and default HDRI loadout entries from `webapp/src/config/snookerClubInventoryConfig.js` and adjusted store labels by removing the Snooker HDRI type from `webapp/src/pages/Store.jsx`.
- Cleaned up related references and disposal calls so the Snooker Club build uses only table finishes, chrome, cloth, rail markers, pocket liners, and cues.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready (local server started successfully).
- Attempted an automated visual check using Playwright to capture `/games/snookerclub`, but the screenshot timed out and failed.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b9879e9483299a1442188a4127e3)