### PR TITLE
Air Hockey: add Murlan Royale HDRIs, table finishes & bases and switch to HDRI lighting

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -1,3 +1,382 @@
+const AIR_HOCKEY_HDRI_PLACEMENTS = Object.freeze({
+  neonPhotostudio: {
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120,
+    arenaScale: 1.1
+  },
+  colorfulStudio: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4,
+    groundResolution: 120,
+    arenaScale: 1.15,
+    rotationY: Math.PI / 2
+  },
+  dancingHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.3
+  },
+  abandonedHall: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.25
+  },
+  mirroredHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.25
+  },
+  musicHall02: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.3
+  },
+  oldHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.22
+  },
+  blockyPhotoStudio: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120,
+    arenaScale: 1.14,
+    rotationY: -Math.PI / 2
+  },
+  cycloramaHardLight: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120,
+    arenaScale: 1.15
+  },
+  abandonedGarage: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
+  },
+  vestibule: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.7,
+    groundResolution: 112,
+    arenaScale: 1.2,
+    rotationY: 0
+  },
+  countryClub: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    arenaScale: 1.24,
+    rotationY: Math.PI
+  },
+  sepulchralChapelRotunda: {
+    cameraHeightM: 1.62,
+    groundRadiusMultiplier: 5.6,
+    groundResolution: 112,
+    arenaScale: 1.32
+  },
+  squashCourt: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4.1,
+    groundResolution: 120,
+    arenaScale: 1.18,
+    rotationY: Math.PI / 2
+  }
+});
+
+const RAW_AIR_HOCKEY_HDRI_VARIANTS = [
+  {
+    id: 'neonPhotostudio',
+    name: 'Neon Photo Studio',
+    assetId: 'neon_photostudio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1420,
+    exposure: 1.18,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#0ea5e9', '#8b5cf6'],
+    description: 'Vibrant cyber studio wrap with strong rim accents.'
+  },
+  {
+    id: 'colorfulStudio',
+    name: 'Colorful Studio',
+    assetId: 'colorful_studio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 0,
+    exposure: 1.02,
+    environmentIntensity: 0.92,
+    backgroundIntensity: 0.92,
+    swatches: ['#ec4899', '#a855f7'],
+    description: 'Playful multi-hue studio for glossy highlight variety.'
+  },
+  {
+    id: 'dancingHall',
+    name: 'Dancing Hall',
+    assetId: 'dancing_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1840,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#22c55e', '#f97316'],
+    description: 'Spacious dance hall bounce light for soft, even sheen.'
+  },
+  {
+    id: 'abandonedHall',
+    name: 'Abandoned Hall',
+    assetId: 'abandoned_hall_01',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1860,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 0.98,
+    swatches: ['#64748b', '#0f172a'],
+    description: 'Moody derelict hall with soft overhead spill and cool shadows.'
+  },
+  {
+    id: 'mirroredHall',
+    name: 'Mirrored Hall',
+    assetId: 'mirrored_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2020,
+    exposure: 1.15,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#22c55e', '#10b981'],
+    description: 'Reflective hall with bright symmetrical highlights for chrome polish.'
+  },
+  {
+    id: 'musicHall02',
+    name: 'Music Hall 02',
+    assetId: 'music_hall_02',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2060,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#a855f7', '#2563eb'],
+    description: 'Alternate music hall mood with richer purple-blue spill and soft roof glow.'
+  },
+  {
+    id: 'oldHall',
+    name: 'Old Hall',
+    assetId: 'old_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2080,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 0.99,
+    swatches: ['#78350f', '#fbbf24'],
+    description: 'Vintage hall ambience with warm wood bounce and subtle window fill.'
+  },
+  {
+    id: 'blockyPhotoStudio',
+    name: 'Blocky Photo Studio',
+    assetId: 'blocky_photo_studio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2200,
+    exposure: 1.12,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.05,
+    swatches: ['#60a5fa', '#a855f7'],
+    description: 'Graphic studio blocks with crisp edges and balanced bounce.'
+  },
+  {
+    id: 'cycloramaHardLight',
+    name: 'Cyclorama Hard Light',
+    assetId: 'cyclorama_hard_light',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2260,
+    exposure: 1.16,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.08,
+    swatches: ['#f8fafc', '#94a3b8'],
+    description: 'Studio cyc with punchy hard light and sharp specular falloff.'
+  },
+  {
+    id: 'abandonedGarage',
+    name: 'Abandoned Garage',
+    assetId: 'abandoned_garage',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2340,
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.98,
+    swatches: ['#334155', '#94a3b8'],
+    description: 'Gritty garage mood with diffused skylight and cool steel reflections.'
+  },
+  {
+    id: 'vestibule',
+    name: 'Vestibule',
+    assetId: 'vestibule',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2360,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#e2e8f0', '#64748b'],
+    description: 'Elegant entry lighting with neutral stone bounce and soft fill.'
+  },
+  {
+    id: 'countryClub',
+    name: 'Country Club',
+    assetId: 'country_club',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2380,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.03,
+    swatches: ['#f8fafc', '#22c55e'],
+    description: 'Upscale lounge ambience with bright daylight and warm interiors.'
+  },
+  {
+    id: 'sepulchralChapelRotunda',
+    name: 'Sepulchral Chapel Rotunda',
+    assetId: 'sepulchral_chapel_rotunda',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2480,
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98,
+    swatches: ['#1f2937', '#6b7280'],
+    description: 'Stone rotunda with dramatic overhead light and deep shadows.'
+  },
+  {
+    id: 'squashCourt',
+    name: 'Squash Court',
+    assetId: 'squash_court',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2440,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#f8fafc', '#f97316'],
+    description: 'Bright court lighting with clean white walls and strong bounce.'
+  }
+];
+
+const HDRI_RESOLUTION_STACK = Object.freeze(['4k']);
+
+const AIR_HOCKEY_HDRI_VARIANTS = Object.freeze(
+  RAW_AIR_HOCKEY_HDRI_VARIANTS.map((variant) => ({
+    ...variant,
+    preferredResolutions: HDRI_RESOLUTION_STACK,
+    ...(AIR_HOCKEY_HDRI_PLACEMENTS[variant.id] || {})
+  }))
+);
+
+const AIR_HOCKEY_TABLE_FINISHES = Object.freeze([
+  Object.freeze({
+    id: 'peelingPaintWeathered',
+    name: 'Wood Peeling Paint Weathered',
+    wood: '#a89f95',
+    trim: '#b8b3aa',
+    swatches: ['#a89f95', '#b8b3aa'],
+    price: 980,
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+  }),
+  Object.freeze({
+    id: 'oakVeneer01',
+    name: 'Oak Veneer 01',
+    wood: '#b9854e',
+    trim: '#c89a64',
+    swatches: ['#b9854e', '#c89a64'],
+    price: 990,
+    description: 'Warm oak veneer rails with smooth satin polish.'
+  }),
+  Object.freeze({
+    id: 'woodTable001',
+    name: 'Wood Table 001',
+    wood: '#8f6243',
+    trim: '#a4724f',
+    swatches: ['#8f6243', '#a4724f'],
+    price: 1000,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+  }),
+  Object.freeze({
+    id: 'darkWood',
+    name: 'Dark Wood',
+    wood: '#2f241f',
+    trim: '#3d2f2a',
+    swatches: ['#2f241f', '#3d2f2a'],
+    price: 1010,
+    description: 'Deep espresso rails with strong grain contrast.'
+  }),
+  Object.freeze({
+    id: 'rosewoodVeneer01',
+    name: 'Rosewood Veneer 01',
+    wood: '#5b2f26',
+    trim: '#6f3a2f',
+    swatches: ['#5b2f26', '#6f3a2f'],
+    price: 1020,
+    description: 'Rosewood veneer rails with rich, reddish undertones.'
+  })
+]);
+
+const AIR_HOCKEY_TABLE_BASES = Object.freeze([
+  Object.freeze({
+    id: 'classicCylinders',
+    name: 'Classic Cylinders',
+    description: 'Rounded skirt with six cylinder legs and subtle foot pads.',
+    base: '#8f6243',
+    accent: '#6f3a2f',
+    swatches: ['#8f6243', '#6f3a2f']
+  }),
+  Object.freeze({
+    id: 'openPortal',
+    name: 'Open Portal',
+    description: 'Twin portal legs with angled sides and negative space.',
+    base: '#f8fafc',
+    accent: '#e5e7eb',
+    swatches: ['#f8fafc', '#e5e7eb']
+  }),
+  Object.freeze({
+    id: 'coffeeTableRound01',
+    name: 'Coffee Table Round 01 Base',
+    description: 'Rounded Poly Haven coffee table legs tucked beneath the pool table.',
+    base: '#c5a47e',
+    accent: '#7a5534',
+    swatches: ['#c5a47e', '#7a5534']
+  }),
+  Object.freeze({
+    id: 'gothicCoffeeTable',
+    name: 'Gothic Coffee Table Base',
+    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
+    base: '#8f4a2b',
+    accent: '#3b2a1f',
+    swatches: ['#8f4a2b', '#3b2a1f']
+  }),
+  Object.freeze({
+    id: 'woodenTable02Alt',
+    name: 'Wooden Table 02 Alt Base',
+    description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
+    base: '#6f5140',
+    accent: '#caa07a',
+    swatches: ['#6f5140', '#caa07a']
+  })
+]);
+
 export const AIR_HOCKEY_CUSTOMIZATION = Object.freeze({
   field: Object.freeze([
     Object.freeze({
@@ -36,13 +415,9 @@ export const AIR_HOCKEY_CUSTOMIZATION = Object.freeze({
       rings: '#34d399'
     })
   ]),
-  table: Object.freeze([
-    Object.freeze({ id: 'walnut', name: 'Walnut', wood: '#5d3725', trim: '#2c1a11' }),
-    Object.freeze({ id: 'ashGrey', name: 'Ash Grey', wood: '#6b7280', trim: '#111827' }),
-    Object.freeze({ id: 'ivoryEdge', name: 'Ivory Edge', wood: '#f8fafc', trim: '#cbd5e1' }),
-    Object.freeze({ id: 'obsidian', name: 'Obsidian', wood: '#0b0f1a', trim: '#1f2937' }),
-    Object.freeze({ id: 'sapphire', name: 'Sapphire', wood: '#1d4ed8', trim: '#0f172a' })
-  ]),
+  table: AIR_HOCKEY_TABLE_FINISHES,
+  tableBase: AIR_HOCKEY_TABLE_BASES,
+  environmentHdri: AIR_HOCKEY_HDRI_VARIANTS,
   puck: Object.freeze([
     Object.freeze({ id: 'carbon', name: 'Carbon', color: '#111111', emissive: '#1f2937' }),
     Object.freeze({ id: 'volt', name: 'Volt', color: '#eab308', emissive: '#854d0e' }),
@@ -101,10 +476,14 @@ export const AIR_HOCKEY_STORE_ITEMS = [
   { id: 'field-sunsetClash', type: 'field', optionId: 'sunsetClash', name: 'Sunset Clash Rink', price: 520, description: 'Warm sunset cloth with soft ivory lines.' },
   { id: 'field-midnightSteel', type: 'field', optionId: 'midnightSteel', name: 'Midnight Steel Rink', price: 560, description: 'Slate midnight tones with metallic accents.' },
   { id: 'field-mintRush', type: 'field', optionId: 'mintRush', name: 'Mint Rush Rink', price: 600, description: 'Mint-emerald surface with bright rings.' },
-  { id: 'table-ashGrey', type: 'table', optionId: 'ashGrey', name: 'Ash Grey Table', price: 360, description: 'Cool grey rails with dark charcoal trim.' },
-  { id: 'table-ivoryEdge', type: 'table', optionId: 'ivoryEdge', name: 'Ivory Edge Table', price: 390, description: 'Ivory rails with soft silver edging.' },
-  { id: 'table-obsidian', type: 'table', optionId: 'obsidian', name: 'Obsidian Table', price: 430, description: 'Deep obsidian rails with graphite trim.' },
-  { id: 'table-sapphire', type: 'table', optionId: 'sapphire', name: 'Sapphire Table', price: 470, description: 'Royal blue rails with midnight trim.' },
+  ...AIR_HOCKEY_TABLE_FINISHES.map((finish) => ({
+    id: `finish-${finish.id}`,
+    type: 'table',
+    optionId: finish.id,
+    name: `${finish.name} Finish`,
+    price: finish.price,
+    description: finish.description
+  })),
   { id: 'puck-volt', type: 'puck', optionId: 'volt', name: 'Volt Puck', price: 220, description: 'High-voltage yellow puck glow.' },
   { id: 'puck-magenta', type: 'puck', optionId: 'magenta', name: 'Magenta Puck', price: 240, description: 'Magenta puck with vivid emissive edge.' },
   { id: 'puck-frost', type: 'puck', optionId: 'frost', name: 'Frost Puck', price: 260, description: 'Frost-white puck with cyan glow.' },
@@ -120,12 +499,30 @@ export const AIR_HOCKEY_STORE_ITEMS = [
   { id: 'goal-crimson', type: 'goals', optionId: 'crimsonNet', name: 'Crimson Net Goals', price: 330, description: 'Crimson goal nets with deep ember glow.' },
   { id: 'goal-cobalt', type: 'goals', optionId: 'cobaltNet', name: 'Cobalt Net Goals', price: 360, description: 'Cobalt nets with electric blue emissive.' },
   { id: 'goal-amber', type: 'goals', optionId: 'amberNet', name: 'Amber Net Goals', price: 390, description: 'Amber nets with warm metallic shine.' },
-  { id: 'goal-ghost', type: 'goals', optionId: 'ghostNet', name: 'Ghost Net Goals', price: 420, description: 'Ghostly pale nets with steel glow.' }
+  { id: 'goal-ghost', type: 'goals', optionId: 'ghostNet', name: 'Ghost Net Goals', price: 420, description: 'Ghostly pale nets with steel glow.' },
+  ...AIR_HOCKEY_TABLE_BASES.map((variant) => ({
+    id: `base-${variant.id}`,
+    type: 'tableBase',
+    optionId: variant.id,
+    name: `${variant.name} Base`,
+    price: 0,
+    description: variant.description
+  })),
+  ...AIR_HOCKEY_HDRI_VARIANTS.map((variant) => ({
+    id: `hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price,
+    description: variant.description
+  }))
 ];
 
 export const AIR_HOCKEY_DEFAULT_LOADOUT = [
   { type: 'field', optionId: AIR_HOCKEY_CUSTOMIZATION.field[0].id, label: AIR_HOCKEY_CUSTOMIZATION.field[0].name },
   { type: 'table', optionId: AIR_HOCKEY_CUSTOMIZATION.table[0].id, label: AIR_HOCKEY_CUSTOMIZATION.table[0].name },
+  { type: 'tableBase', optionId: AIR_HOCKEY_CUSTOMIZATION.tableBase[0].id, label: AIR_HOCKEY_CUSTOMIZATION.tableBase[0].name },
+  { type: 'environmentHdri', optionId: AIR_HOCKEY_CUSTOMIZATION.environmentHdri[0].id, label: AIR_HOCKEY_CUSTOMIZATION.environmentHdri[0].name },
   { type: 'puck', optionId: AIR_HOCKEY_CUSTOMIZATION.puck[0].id, label: AIR_HOCKEY_CUSTOMIZATION.puck[0].name },
   { type: 'mallet', optionId: AIR_HOCKEY_CUSTOMIZATION.mallet[0].id, label: AIR_HOCKEY_CUSTOMIZATION.mallet[0].name },
   { type: 'rails', optionId: AIR_HOCKEY_CUSTOMIZATION.rails[0].id, label: AIR_HOCKEY_CUSTOMIZATION.rails[0].name },

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -136,7 +136,9 @@ const SNOOKER_TYPE_LABELS = {
 
 const AIR_HOCKEY_TYPE_LABELS = {
   field: 'Rink Surface',
-  table: 'Table Frame',
+  table: 'Table Finish',
+  tableBase: 'Table Bases',
+  environmentHdri: 'HDR Environments',
   puck: 'Puck Finish',
   mallet: 'Mallets',
   rails: 'Rails',


### PR DESCRIPTION
### Motivation
- Bring Air Hockey visuals and store options in line with the Pool/Murlan Royale asset set by exposing the same HDRI environments, table finishes and table bases for users to buy and apply.
- Replace the baked arena (walls, carpet, directional lights) with HDRI-driven lighting to reuse higher-quality environment lighting from the Murlan/Pool library and make table visuals consistent across games.
- Allow Air Hockey to have its own inventory entries and defaults for `tableBase` and `environmentHdri` while keeping game-specific code and assets isolated.
- Surface the new customization options in the in-game customizer and the Store UI so players can buy and equip them.

### Description
- Added Murlan/Pool HDRI variants, table finishes and table base definitions and mapped them into Air Hockey inventory and store items in `webapp/src/config/airHockeyInventoryConfig.js` and updated the `AIR_HOCKEY_DEFAULT_LOADOUT`.
- Switched the Air Hockey renderer to support HDRI environments by adding `EXRLoader`/`RGBELoader` imports and implementing `resolvePolyHavenHdriUrl` and `loadPolyHavenHdriEnvironment` in `webapp/src/components/AirHockey3D.jsx` and using the loaded PMREM environment as `scene.environment`/`scene.background`.
- Removed arena geometry/lighting (walls, carpet, directional lights) and introduced new table base/material slots plus `tableBase` and `environmentHdri` selection handling and material application logic in `AirHockey3D.jsx`.
- Exposed the new customization rows (`Table Finish`, `Table Base`, `HDRI Environment`) in the in-game customizer and added `tableBase`/`environmentHdri` labels in the Store mapping at `webapp/src/pages/Store.jsx`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev`, and Vite reported the server ready, which succeeded.  
- Ran a headless Playwright script that opened `/games/airhockey` and produced a screenshot (`artifacts/air-hockey-hdri.png`), confirming the HDRI-driven scene rendered, which succeeded.  
- No unit or integration test suites were executed as part of this change.  
- Changes were linted/compiled by the dev server run but no formal CI test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963be6514d88329a5d2cf1843ca6cdd)