### PR TITLE
Fix Snooker Royal route aliases and navigation

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -127,6 +127,14 @@ export default function App() {
             />
             <Route path="/games/snookerroyal" element={<SnookerRoyal />} />
             <Route
+              path="/games/snookerroyale/lobby"
+              element={<Navigate to="/games/snookerroyal/lobby" replace />}
+            />
+            <Route
+              path="/games/snookerroyale"
+              element={<Navigate to="/games/snookerroyal" replace />}
+            />
+            <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}
             />

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10717,7 +10717,7 @@ function SnookerRoyalGame({
       }
       const telegramId = tgIdRef.current || getTelegramId();
       await addTransaction(telegramId, -50, 'cue_fee', {
-        game: 'snookerroyale',
+        game: 'snookerroyal',
         reason: 'cue_switch',
         accountId: id
       });
@@ -11992,8 +11992,8 @@ const powerRef = useRef(hud.power);
       return;
     }
     const lobbyUrl = winnerParam
-      ? `/games/snookerroyale/lobby?winner=${winnerParam}`
-      : '/games/snookerroyale/lobby';
+      ? `/games/snookerroyal/lobby?winner=${winnerParam}`
+      : '/games/snookerroyal/lobby';
     window.location.assign(lobbyUrl);
   }, [frameState.winner, location.search, tournamentMode]);
   const simulateRoundAI = useCallback((st, round) => {
@@ -25725,7 +25725,7 @@ export default function SnookerRoyal() {
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {
       if (confirmed) {
-        navigate('/games/snookerroyale/lobby');
+        navigate('/games/snookerroyal/lobby');
       }
     });
   });
@@ -25740,7 +25740,7 @@ export default function SnookerRoyal() {
         if (!confirmed) {
           window.history.pushState(null, '', window.location.href);
         } else {
-          navigate('/games/snookerroyale/lobby');
+          navigate('/games/snookerroyal/lobby');
         }
       });
     };


### PR DESCRIPTION
### Motivation
- The Snooker Royal page could render a blank/black screen due to inconsistent route and identifier usage between `/games/snookerroyale` (legacy) and the canonical `/games/snookerroyal` paths. 
- Navigation and server transaction calls used mismatched identifiers which can cause incorrect redirects or API metadata for cue purchases. 
- Aligning route aliases to a single canonical path prevents users landing on non-working legacy URLs. 
- Provide a small compatibility shim so older links continue to work without changing the canonical codepaths.

### Description
- Standardized in-game navigation and transaction payloads by changing the cue-fee transaction `game` field to `snookerroyal` in `SnookerRoyal.jsx` using `addTransaction` with `game: 'snookerroyal'`.
- Replaced all exit/lobby navigation usages to point at the canonical route `'/games/snookerroyal/lobby'` in `SnookerRoyal.jsx` so redirects and popstate handling use the correct path.
- Added redirect route aliases in `App.jsx` so legacy paths `'/games/snookerroyale'` and `'/games/snookerroyale/lobby'` are `Navigate`-redirected to their canonical counterparts and avoid blank screens.
- Kept changes minimal and focused on route/identifier alignment without modifying gameplay logic or assets.

### Testing
- No automated tests were executed for this change.
- Manual smoke checks are recommended: open `/games/snookerroyale` and `/games/snookerroyale/lobby` and confirm they redirect to `'/games/snookerroyal'` and `'/games/snookerroyal/lobby'` respectively.
- Verify navigating back/exit flows from the Snooker Royal game return to `'/games/snookerroyal/lobby'` and that cue-change transactions carry `game: 'snookerroyal'` in the API call.
- If available, run the webapp's existing frontend test suite and a local dev server smoke-run to confirm no regressions in other game routes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963db407128832988c5f0cae8b23654)