### PR TITLE
Fix Pool Royale loading overlay state

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10257,6 +10257,20 @@ function PoolRoyaleGame({
       const ratio = Number.isFinite(loaded) ? loaded / safeTotal : 0;
       setLoadingProgress(Math.max(0, Math.min(1, ratio)));
     };
+    const syncManagerState = () => {
+      const loaded = Number(manager.itemsLoaded || 0);
+      const total = Number(manager.itemsTotal || 0);
+      if (total > 0) {
+        updateProgress(loaded, total);
+        if (loaded >= total) {
+          setLoadingProgress(1);
+          setLoadingActive(false);
+        }
+      } else {
+        setLoadingProgress(0);
+        setLoadingActive(false);
+      }
+    };
     manager.onStart = (url, loaded, total) => {
       prev.onStart?.(url, loaded, total);
       if (cancelled) return;
@@ -10281,6 +10295,7 @@ function PoolRoyaleGame({
       if (cancelled) return;
       setLoadingProgress((prevValue) => Math.max(prevValue, 0.9));
     };
+    syncManagerState();
     return () => {
       cancelled = true;
       manager.onStart = prev.onStart;


### PR DESCRIPTION
### Motivation
- The Pool Royale loading overlay could remain visible when assets were already cached or the Three.js loading manager had completed before the component mounted. 
- The UI should reflect the actual `THREE.DefaultLoadingManager` progress so the overlay hides as soon as loading is already finished.

### Description
- Added a `syncManagerState` helper that reads `THREE.DefaultLoadingManager.itemsLoaded` and `itemsTotal` and updates `loadingProgress` and `loadingActive` accordingly.
- Call `syncManagerState()` on mount so cached/complete loads clear the overlay immediately without waiting for new manager events.
- Kept existing `manager.onStart/onProgress/onLoad/onError` handlers and preserved previous handlers during cleanup.
- Ensures the overlay is disabled when `itemsTotal` is zero or when `itemsLoaded >= itemsTotal` by calling `setLoadingActive(false)` and setting progress to `1` when appropriate.

### Testing
- No automated tests were run for this change.
- The change is limited to `webapp/src/pages/Games/PoolRoyale.jsx` and updates only loading state synchronization with Three.js.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f24589e083298e096ed28cf66dc2)