### PR TITLE
Adjust Snooker Royal render defaults to 60fps and add 2k HDRI fallback

### DIFF
--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -278,7 +278,7 @@ const RAW_SNOOKER_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['4k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['4k', '2k']);
 
 export const SNOOKER_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_SNOOKER_ROYALE_HDRI_VARIANTS.map((variant) => ({

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2642,6 +2642,15 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Low-power 50 Hz profile for battery saver and thermal relief.'
   },
   {
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
+    fps: 60,
+    renderScale: 1.06,
+    pixelRatioCap: 1.45,
+    resolution: 'Full HD render • DPR 1.45 cap',
+    description: 'Balanced 60 Hz profile for smooth play with steady thermals.'
+  },
+  {
     id: 'fhd90',
     label: 'Full HD (90 Hz)',
     fps: 90,
@@ -2669,7 +2678,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: '4K-oriented profile tuned for smooth play up to 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd90';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const BROADCAST_SYSTEM_STORAGE_KEY = 'snookerBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([


### PR DESCRIPTION
### Motivation
- Align Snooker Royal rendering defaults with Pool Royale by using a balanced 60 FPS profile and ensuring HDRI availability.
- Prevent situations where high-resolution HDRI resolution choices can cause loading fallbacks by allowing a 2k fallback while keeping 4k preferred.
- Reduce user-facing rendering surprises (black/blank screens) by choosing a conservative default frame-rate and explicit HDRI resolution stack.
- Make the Snooker build use the same rendering configuration approach as other table modes.

### Description
- Added a new frame rate option `fhd60` and set `DEFAULT_FRAME_RATE_ID` to `fhd60` in `webapp/src/pages/Games/SnookerRoyal.jsx` to make 60 FPS the default.
- Inserted the `fhd60` profile into `FRAME_RATE_OPTIONS` with tuned `renderScale` and `pixelRatioCap` values for balanced quality and performance in `SnookerRoyal.jsx`.
- Expanded `HDRI_RESOLUTION_STACK` to `['4k','2k']` in `webapp/src/config/snookerRoyalInventoryConfig.js` so HDRI variants can fall back to 2k while keeping 4k preferred.
- Kept HDRI loading logic and other renderer configuration untouched; changes only adjust defaults and preference stacks.

### Testing
- Started the local dev server with `npm run dev` and Vite reported ready and serving the site (local/network URLs printed), which succeeded.
- Attempted an automated headless browser check (Playwright) to load `/games/snookerroyale` and capture a screenshot, but the Playwright run timed out and the screenshot step failed.
- No unit or CI test suite was executed as part of this change.
- Manual UI verification was not completed due to the headless screenshot timing out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f2fdd3648329a54ce3c8fb795b65)