### PR TITLE
Harden Snooker Royal WebGL detection; sync loading overlay, HDRI fallback, default 60 FPS

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -194,18 +194,25 @@ const wait = (ms = 0) =>
     window.setTimeout(resolve, ms);
   });
 
-function isWebGLAvailable() {
+function isWebGLAvailable(host = null) {
   if (typeof document === 'undefined') return false;
+  const canvas = document.createElement('canvas');
   try {
-    const canvas = document.createElement('canvas');
+    if (host?.appendChild) {
+      host.appendChild(canvas);
+    }
     const gl =
-      canvas.getContext('webgl2') ||
-      canvas.getContext('webgl') ||
+      canvas.getContext('webgl2', { powerPreference: 'high-performance' }) ||
+      canvas.getContext('webgl', { powerPreference: 'high-performance' }) ||
       canvas.getContext('experimental-webgl');
     return Boolean(gl);
   } catch (err) {
     console.warn('WebGL availability check failed', err);
     return false;
+  } finally {
+    if (canvas.parentNode) {
+      canvas.parentNode.removeChild(canvas);
+    }
   }
 }
 
@@ -2642,6 +2649,15 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: 'Low-power 50 Hz profile for battery saver and thermal relief.'
   },
   {
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
+    fps: 60,
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
+  },
+  {
     id: 'fhd90',
     label: 'Full HD (90 Hz)',
     fps: 90,
@@ -2669,7 +2685,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: '4K-oriented profile tuned for smooth play up to 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd90';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const BROADCAST_SYSTEM_STORAGE_KEY = 'snookerBroadcastSystem';
 const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
@@ -10250,6 +10266,20 @@ function SnookerRoyalGame({
       const ratio = Number.isFinite(loaded) ? loaded / safeTotal : 0;
       setLoadingProgress(Math.max(0, Math.min(1, ratio)));
     };
+    const syncManagerState = () => {
+      const loaded = Number(manager.itemsLoaded || 0);
+      const total = Number(manager.itemsTotal || 0);
+      if (total > 0) {
+        updateProgress(loaded, total);
+        if (loaded >= total) {
+          setLoadingProgress(1);
+          setLoadingActive(false);
+        }
+      } else {
+        setLoadingProgress(0);
+        setLoadingActive(false);
+      }
+    };
     manager.onStart = (url, loaded, total) => {
       prev.onStart?.(url, loaded, total);
       if (cancelled) return;
@@ -10274,6 +10304,7 @@ function SnookerRoyalGame({
       if (cancelled) return;
       setLoadingProgress((prevValue) => Math.max(prevValue, 0.9));
     };
+    syncManagerState();
     return () => {
       cancelled = true;
       manager.onStart = prev.onStart;
@@ -13118,7 +13149,7 @@ const powerRef = useRef(hud.power);
     const host = mountRef.current;
     if (!host) return;
     setErr(null);
-    if (!isWebGLAvailable()) {
+    if (!isWebGLAvailable(host)) {
       setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
       return;
     }
@@ -13174,19 +13205,9 @@ const powerRef = useRef(hud.power);
       const world = new THREE.Group();
       scene.add(world);
       worldRef.current = world;
-      const applyHdriEnvironment = async (variantConfig = activeEnvironmentVariantRef.current) => {
+      const applyEnvironmentMaps = (envMap, skyboxMap, activeVariant) => {
         const sceneInstance = sceneRef.current;
-        if (!renderer || !sceneInstance) return;
-        const activeVariant = variantConfig || activeEnvironmentVariantRef.current;
-        const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
-        if (!envResult) return;
-        const { envMap, skyboxMap } = envResult;
-        if (!envMap) return;
-        if (disposed) {
-          envMap.dispose?.();
-          skyboxMap?.dispose?.();
-          return;
-        }
+        if (!envMap || !sceneInstance) return;
         const prevDispose = disposeEnvironmentRef.current;
         const prevTexture = envTextureRef.current;
         const worldOffsetY = worldRef.current?.position?.y ?? 0;
@@ -13293,6 +13314,27 @@ const powerRef = useRef(hud.power);
         if (prevDispose && prevTexture !== envMap) {
           prevDispose();
         }
+      };
+      const applyHdriEnvironment = async (variantConfig = activeEnvironmentVariantRef.current) => {
+        const sceneInstance = sceneRef.current;
+        if (!renderer || !sceneInstance) return;
+        const activeVariant = variantConfig || activeEnvironmentVariantRef.current;
+        if (!envTextureRef.current && !disposed) {
+          const fallbackEnv = await createFallbackHdriEnvironment(renderer);
+          if (fallbackEnv?.envMap && !disposed) {
+            applyEnvironmentMaps(fallbackEnv.envMap, fallbackEnv.skyboxMap, activeVariant);
+          }
+        }
+        const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
+        if (!envResult) return;
+        const { envMap, skyboxMap } = envResult;
+        if (!envMap) return;
+        if (disposed) {
+          envMap.dispose?.();
+          skyboxMap?.dispose?.();
+          return;
+        }
+        applyEnvironmentMaps(envMap, skyboxMap, activeVariant);
       };
       updateEnvironmentRef.current = applyHdriEnvironment;
       void applyHdriEnvironment(activeEnvironmentVariantRef.current);


### PR DESCRIPTION
### Motivation
- Reduce false-negative WebGL availability checks on devices by probing a canvas attached to the actual mount host and requesting a high-performance context.  
- Prevent persistent black loading frames and incorrect loading UI when the Three.js loading manager reports zero items or remote HDRIs are in flight.  
- Apply a quick visible environment while remote HDRIs load to avoid visual gaps and avoid leaking previous textures.  
- Align Snooker Royal default pacing with other table games by switching to a 60 FPS baseline profile.

### Description
- Hardened the WebGL probe by changing `isWebGLAvailable()` to accept an optional `host` DOM node, append a temporary canvas to it, request contexts with `{ powerPreference: 'high-performance' }`, and always clean up the probe canvas.  
- Use the host-aware probe when initializing the renderer to avoid false hardware-acceleration error banners.  
- Added `syncManagerState` wiring to the `THREE.DefaultLoadingManager` handler so `loadingProgress`/`loadingActive` reflect `itemsLoaded`/`itemsTotal` and added an immediate sync call.  
- Refactored HDRI setup by adding `applyEnvironmentMaps` and layering a fallback environment from `createFallbackHdriEnvironment` before calling `loadPolyHavenHdriEnvironment`, and ensured prior textures/skyboxes are disposed when replaced; also added `fhd60` to `FRAME_RATE_OPTIONS` and set `DEFAULT_FRAME_RATE_ID` to `fhd60`.

### Testing
- Ran the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server started successfully.  
- Executed a Playwright Firefox screenshot script that opened `/games/snookerroyale` and produced `artifacts/snooker-royale.png` to verify rendering (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f9da35c883298d4725e45e76ebd8)