### PR TITLE
Fix Snooker Royal WebGL context detection

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -194,14 +194,29 @@ const wait = (ms = 0) =>
     window.setTimeout(resolve, ms);
   });
 
+const WEBGL_CONTEXT_IDS = ['webgl2', 'webgl', 'experimental-webgl'];
+
+const tryGetWebGLContext = (canvas, contextId) => {
+  try {
+    return canvas.getContext(contextId);
+  } catch (err) {
+    return null;
+  }
+};
+
+const resolveWebGLContext = (canvas) => {
+  for (const contextId of WEBGL_CONTEXT_IDS) {
+    const gl = tryGetWebGLContext(canvas, contextId);
+    if (gl) return gl;
+  }
+  return null;
+};
+
 function isWebGLAvailable() {
   if (typeof document === 'undefined') return false;
   try {
     const canvas = document.createElement('canvas');
-    const gl =
-      canvas.getContext('webgl2') ||
-      canvas.getContext('webgl') ||
-      canvas.getContext('experimental-webgl');
+    const gl = resolveWebGLContext(canvas);
     return Boolean(gl);
   } catch (err) {
     console.warn('WebGL availability check failed', err);
@@ -286,10 +301,7 @@ function readGraphicsRendererString() {
   }
   try {
     const canvas = document.createElement('canvas');
-    const gl =
-      canvas.getContext('webgl') ||
-      canvas.getContext('experimental-webgl') ||
-      canvas.getContext('webgl2');
+    const gl = resolveWebGLContext(canvas);
     if (!gl) {
       return null;
     }


### PR DESCRIPTION
### Motivation
- WebGL availability checks were producing false negatives or throwing when `canvas.getContext` for certain context IDs failed on some devices.
- The Snooker Royal renderer initialization depends on reliable detection of a usable WebGL context to avoid showing an error to users.
- Reusing a single safe resolver reduces duplicated logic and prevents missed context IDs.

### Description
- Added `WEBGL_CONTEXT_IDS`, `tryGetWebGLContext`, and `resolveWebGLContext` helpers to safely probe context types without throwing. 
- Replaced direct `canvas.getContext(...)` calls with `resolveWebGLContext` in `isWebGLAvailable` and `readGraphicsRendererString` to centralize and harden detection.  
- Changed code in `webapp/src/pages/Games/SnookerRoyal.jsx` to use the new helpers and avoid context lookup exceptions. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647d630dfc8329b833376975b6e3c2)