### PR TITLE
Match Snooker Royal HDRI resolution options to Pool

### DIFF
--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -278,7 +278,7 @@ const RAW_SNOOKER_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['4k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['4k', '2k']);
 
 export const SNOOKER_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_SNOOKER_ROYALE_HDRI_VARIANTS.map((variant) => ({

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -4101,8 +4101,21 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 
 const HDRI_STORAGE_KEY = 'snookerHdriEnvironment';
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const HDRI_RESOLUTION_STORAGE_KEY = 'snookerHdriResolution';
 const DEFAULT_HDRI_RESOLUTION_MODE = '4k';
-const HDRI_RESOLUTION_OPTION = Object.freeze({ id: '4k', label: '4K (Locked)' });
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: 'auto', label: 'Match Table' },
+  { id: '8k', label: '8K' },
+  { id: '6k', label: '6K' },
+  { id: '4k', label: '4K' },
+  { id: '2k', label: '2K' }
+]);
+const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
+  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
@@ -4111,6 +4124,14 @@ const HDRI_GROUNDED_RESOLUTION = 256;
 const HDRI_CAMERA_SCALE_MIN = 0.78;
 const HDRI_CAMERA_SCALE_MAX = 1.32;
 const HDRI_CAMERA_SCALE_LERP = 0.18;
+
+function resolveHdriResolutionForTable(tableSizeMeta) {
+  const widthMm = tableSizeMeta?.playfield?.widthMm;
+  if (Number.isFinite(widthMm) && widthMm >= 2540) {
+    return '8k';
+  }
+  return '4k';
+}
 
 function pickPolyHavenHdriUrl(apiJson, preferredResolutions = []) {
   const urls = [];
@@ -10618,6 +10639,15 @@ function SnookerRoyalGame({
       SNOOKER_ROYALE_DEFAULT_HDRI_ID
     );
   });
+  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = safeLocalStorageGet(HDRI_RESOLUTION_STORAGE_KEY);
+      if (stored && HDRI_RESOLUTION_OPTION_MAP[stored]) {
+        return stored;
+      }
+    }
+    return DEFAULT_HDRI_RESOLUTION_MODE;
+  });
   const [lightingId, setLightingId] = useState(() => DEFAULT_LIGHTING_ID);
   const [chromeColorId, setChromeColorId] = useState(() => {
     return resolveStoredSelection(
@@ -10652,7 +10682,8 @@ function SnookerRoyalGame({
       FRAME_RATE_OPTIONS[0],
     [frameRateId]
   );
-  const activeHdriResolutionOption = HDRI_RESOLUTION_OPTION;
+  const activeHdriResolutionOption =
+    HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] ?? HDRI_RESOLUTION_OPTIONS[0];
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
     const fallback = FRAME_RATE_OPTIONS[0];
@@ -10761,7 +10792,10 @@ function SnookerRoyalGame({
       SNOOKER_ROYALE_BASE_VARIANTS[0],
     [availableTableBases, tableBaseId]
   );
-  const resolvedHdriResolution = DEFAULT_HDRI_RESOLUTION_MODE;
+  const resolvedHdriResolution =
+    activeHdriResolutionOption.id === 'auto'
+      ? resolveHdriResolutionForTable(responsiveTableSize)
+      : activeHdriResolutionOption.id;
   const activeEnvironmentHdri = useMemo(
     () => {
       const variant =
@@ -11456,6 +11490,12 @@ function SnookerRoyalGame({
     if (typeof window === 'undefined') return;
     safeLocalStorageSet(HDRI_STORAGE_KEY, environmentHdriId);
   }, [environmentHdriId]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) {
+      safeLocalStorageSet(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
+    }
+  }, [hdriResolutionId]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     safeLocalStorageSet(LIGHTING_STORAGE_KEY, lightingId);
@@ -25437,8 +25477,25 @@ const powerRef = useRef(hud.power);
                   <p className="mt-1 text-[0.7rem] text-white/60">
                     Active: {resolvedHdriResolution?.toUpperCase() || activeHdriResolutionOption.label}
                   </p>
-                  <div className="mt-2 rounded-2xl border border-white/15 bg-white/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-white/70">
-                    {activeHdriResolutionOption.label}
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {HDRI_RESOLUTION_OPTIONS.map((option) => {
+                      const active = option.id === hdriResolutionId;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setHdriResolutionId(option.id)}
+                          aria-pressed={active}
+                          className={`flex-1 min-w-[7.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
                 <div className="mt-2 grid gap-2">


### PR DESCRIPTION
### Motivation

- Align Snooker Royal HDRI resolution selection and behavior with Pool so players can pick or auto-resolve HDRI quality consistently.
- Provide an `auto` mode that selects an appropriate HDRI resolution based on table size for better defaults on different devices.
- Persist the HDRI resolution choice to improve UX across sessions.
- Allow HDRI variants to prefer `2k` fallbacks to reduce load for lighter environments.

### Description

- Added selectable HDRI resolution options and an option map via `HDRI_RESOLUTION_OPTIONS` and `HDRI_RESOLUTION_OPTION_MAP` in `webapp/src/pages/Games/SnookerRoyal.jsx` and introduced the storage key `HDRI_RESOLUTION_STORAGE_KEY`.
- Implemented `resolveHdriResolutionForTable(tableSizeMeta)` and `hdriResolutionId` state with persistence using `safeLocalStorageSet`/`safeLocalStorageGet`, and wired the resolved resolution into the environment selection logic (auto vs explicit selection).
- Replaced the single locked 4K label UI with a set of selectable buttons in the Snooker Royal graphics settings that mirror Pool Royale's controls and behavior.
- Updated `webapp/src/config/snookerRoyalInventoryConfig.js` to change `HDRI_RESOLUTION_STACK` from `['4k']` to `['4k','2k']` so HDRI variants can prefer 2K fallbacks.

### Testing

- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the dev server started successfully (Vite ready).
- Attempted an automated Playwright screenshot of `/games/snookerroyale`, but the Playwright run timed out after 30s and did not complete.
- No unit tests (`jest`) or other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648d5eae5883298446d5f89d1a0b10)