### PR TITLE
Snooker Royal: Fix WebGL renderer sizing fallback to avoid black canvas

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -12158,6 +12158,12 @@ const powerRef = useRef(hud.power);
     const renderer = rendererRef.current;
     const host = mountRef.current;
     if (!renderer || !host) return;
+    const fallbackWidth =
+      typeof window !== 'undefined' ? window.innerWidth || document.documentElement?.clientWidth || 0 : 0;
+    const fallbackHeight =
+      typeof window !== 'undefined' ? window.innerHeight || document.documentElement?.clientHeight || 0 : 0;
+    const hostWidth = host.clientWidth || fallbackWidth;
+    const hostHeight = host.clientHeight || fallbackHeight;
     const quality = frameQualityRef.current;
     const timing = frameTimingRef.current;
     const targetMs =
@@ -12186,7 +12192,7 @@ const powerRef = useRef(hud.power);
       highFpsBias < 1 ? cappedDpr * (0.92 + highFpsBias * 0.08) : cappedDpr;
     const resolvedPixelRatio = Math.max(1, performanceDpr);
     renderer.setPixelRatio(resolvedPixelRatio);
-    renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);
+    renderer.setSize(hostWidth * renderScale, hostHeight * renderScale, false);
     renderer.domElement.style.width = '100%';
     renderer.domElement.style.height = '100%';
   }, []);
@@ -24291,7 +24297,13 @@ const powerRef = useRef(hud.power);
       // Resize
       const onResize = () => {
         if (disposed || !host) return;
-        renderer.setSize(host.clientWidth, host.clientHeight);
+        const fallbackWidth =
+          typeof window !== 'undefined' ? window.innerWidth || document.documentElement?.clientWidth || 0 : 0;
+        const fallbackHeight =
+          typeof window !== 'undefined' ? window.innerHeight || document.documentElement?.clientHeight || 0 : 0;
+        const hostWidth = host.clientWidth || fallbackWidth;
+        const hostHeight = host.clientHeight || fallbackHeight;
+        renderer.setSize(hostWidth, hostHeight);
         // Update canvas dimensions when the window size changes so the table
         // remains fully visible.
         const scaleChanged = applyWorldScaleRef.current?.() ?? false;


### PR DESCRIPTION
### Motivation
- Prevent a black/empty canvas when Snooker Royal initializes or resizes the WebGL renderer on hosts where `host.clientWidth`/`host.clientHeight` are zero or not yet available.
- Ensure the renderer always gets sensible size values so the scene can render even if the DOM host size is temporarily unavailable.

### Description
- Use viewport fallbacks (`window.innerWidth` / `window.innerHeight`) and compute `hostWidth` / `hostHeight` to avoid zero-size measurements before calling `renderer.setSize` in `applyRendererQuality`.
- Apply the same fallback logic in the resize handler so `onResize` uses `hostWidth` / `hostHeight` instead of raw `host.clientWidth`/`host.clientHeight`.
- Changes made in `webapp/src/pages/Games/SnookerRoyal.jsx` to compute and use `hostWidth`/`hostHeight` when setting renderer size.

### Testing
- Automated tests: none were run for this change.
- (No automated test failures to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964991e8860832995f81f550a26a368)