### PR TITLE
Fix Snooker Royal HUD typing to unblock builds

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -60,7 +60,11 @@ function resolveBallOn(state: FrameState, colorsRemaining: BallColor[]): BallCol
   return ['RED'];
 }
 
-function buildHud(state: FrameState, scores: { A: number; B: number }, ballOn: BallColor[]): HudInfo {
+function buildHud(
+  state: FrameState,
+  scores: { A: number; B: number },
+  ballOn: Array<BallColor | string>
+): HudInfo {
   return {
     next: ballOn.length ? ballOn.map((entry) => entry.toLowerCase()).join(' / ') : 'frame over',
     phase: state.phase === 'COLORS_ORDER' ? 'colors' : 'reds',


### PR DESCRIPTION
### Motivation
- The TypeScript build failed due to a type mismatch when constructing the Snooker HUD string from `ballOn` values that can contain both `BallColor` and string identifiers.
- The intent is to allow the HUD formatting to accept mixed ball identifiers without changing runtime logic.
- Keep the HUD formatting behavior unchanged while removing the compile-time error.

### Description
- Relaxed the `buildHud` parameter typing from `BallColor[]` to `Array<BallColor | string>` in `src/rules/SnookerRoyalRules.ts` so mixed identifiers are accepted.
- Kept the HUD string construction logic intact (`.map(...).join(' / ')`).
- No runtime logic or UI changes were made, only the TypeScript signature was adjusted.

### Testing
- Ran the TypeScript build with `npm run build` and the build completed successfully.
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a444bb8c8329b7baa19ec3016482)