### PR TITLE
Align Snooker Royal ball materials, table sizing and remove lobby ball-set option

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -30,8 +30,7 @@ import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { SnookerRoyalRules } from '../../../../src/rules/SnookerRoyalRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
-import { resolveTableSize } from '../../config/snookerRoyalTables.js';
-import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
+import { resolveTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import {
   createBallPreviewDataUrl,
@@ -1523,6 +1522,7 @@ const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
 const DEFAULT_POOL_VARIANT = 'snooker';
+const SNOOKER_BALL_MATERIAL_VARIANT = 'pool';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
@@ -6209,7 +6209,7 @@ function Guret(parent, id, color, x, y, options = {}) {
     color,
     pattern,
     number,
-    variantKey: 'snooker'
+    variantKey: SNOOKER_BALL_MATERIAL_VARIANT
   });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
@@ -18095,7 +18095,7 @@ const powerRef = useRef(hud.power);
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
       const resolveSnookerScale = () => {
         const poolWidth = tableSizeMeta?.playfield?.widthMm ?? 2540;
-        const snookerWidth = resolveSnookerTableSize()?.playfield?.widthMm ?? 3556;
+        const snookerWidth = resolveTableSize()?.playfield?.widthMm ?? 3556;
         if (!poolWidth || poolWidth <= 0) return 1.2;
         return Math.max(1.15, snookerWidth / poolWidth);
       };
@@ -18122,7 +18122,7 @@ const powerRef = useRef(hud.power);
             disposables.push(item);
           }
         };
-        const addDecorBall = (color, number, pattern, pos, variantKey = variant === 'snooker' ? 'snooker' : 'pool') => {
+        const addDecorBall = (color, number, pattern, pos, variantKey = variant === 'snooker' ? SNOOKER_BALL_MATERIAL_VARIANT : 'pool') => {
           const material = getBilliardBallMaterial({
             color,
             pattern,
@@ -18181,7 +18181,7 @@ const powerRef = useRef(hud.power);
           };
           rackPositions.forEach((pos, index) => {
             const placement = pos || rackPositions[rackPositions.length - 1] || { x: 0, z: rackStartZ + index * BALL_R * 1.6 };
-            addDecorBall(snookerPalette.red, null, 'solid', placement, 'snooker');
+            addDecorBall(snookerPalette.red, null, 'solid', placement, SNOOKER_BALL_MATERIAL_VARIANT);
           });
           [
             { color: snookerPalette.yellow, spot: SPOTS.yellow },
@@ -18191,9 +18191,9 @@ const powerRef = useRef(hud.power);
             { color: snookerPalette.pink, spot: SPOTS.pink },
             { color: snookerPalette.black, spot: SPOTS.black }
           ].forEach(({ color, spot }) => {
-            addDecorBall(color, null, 'solid', { x: spot[0], z: spot[1] }, 'snooker');
+            addDecorBall(color, null, 'solid', { x: spot[0], z: spot[1] }, SNOOKER_BALL_MATERIAL_VARIANT);
           });
-          addDecorBall(snookerPalette.cue, null, 'solid', { x: -BALL_R * 3, z: baulkZ - BALL_R * 5 }, 'snooker');
+          addDecorBall(snookerPalette.cue, null, 'solid', { x: -BALL_R * 3, z: baulkZ - BALL_R * 5 }, SNOOKER_BALL_MATERIAL_VARIANT);
           addCueStick(-PLAY_W * 0.2, rackStartZ + BALL_R * 4.2, -Math.PI * 0.04);
           addCueStick(PLAY_W * 0.22, baulkZ - BALL_R * 1.2, Math.PI * 0.06);
         } else {
@@ -24765,7 +24765,7 @@ const powerRef = useRef(hud.power);
         color: colorHex,
         pattern,
         number,
-        variantKey: 'snooker',
+        variantKey: SNOOKER_BALL_MATERIAL_VARIANT,
         size: 128
       });
       cache.set(cacheKey, preview || null);

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -6,7 +6,7 @@ import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
-import { resolveTableSize } from '../../config/snookerRoyalTables.js';
+import { resolveTableSize } from '../../config/snookerClubTables.js';
 import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
@@ -34,7 +34,6 @@ export default function SnookerRoyalLobby() {
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
   const [variant, setVariant] = useState('uk');
-  const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -86,11 +85,6 @@ export default function SnookerRoyalLobby() {
     matchPlayersRef.current = matchPlayers;
   }, [matchPlayers]);
 
-  useEffect(() => {
-    if (variant !== 'uk') {
-      setUkBallSet('uk');
-    }
-  }, [variant]);
 
   const navigateToSnookerRoyal = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
     const selfId = accountId || accountIdRef.current;
@@ -386,27 +380,6 @@ export default function SnookerRoyalLobby() {
           ))}
         </div>
       </div>
-      {variant === 'uk' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Ball Set</h3>
-          <p className="text-xs text-subtext">
-            Switch the snooker ball visuals for practice sessions while keeping official rules intact.
-          </p>
-          <div className="flex gap-2">
-            {[{ id: 'uk', label: 'Tournament Palette' }, { id: 'american', label: 'High Contrast' }].map(
-              ({ id, label }) => (
-                <button
-                  key={id}
-                  onClick={() => setUkBallSet(id)}
-                  className={`lobby-tile ${ukBallSet === id ? 'lobby-selected' : ''}`}
-                >
-                  {label}
-                </button>
-              )
-            )}
-          </div>
-        </div>
-      )}
       {playType === 'tournament' && (
         <div className="space-y-2">
           <h3 className="font-semibold">Players</h3>


### PR DESCRIPTION
### Motivation
- Make Snooker Royal use the same glossy/preview material technique as Pool Royale so yellow/red balls match the pool visuals while preserving the official snooker colours and appearance.
- Ensure Snooker table sizing resolves from the shared snooker table configuration used elsewhere so decorations and spacing match the existing HDRI "old hall" layout.
- Remove the per-lobby ball-set chooser so snooker visuals are fixed to the default material set and not configurable from the lobby.

### Description
- Swap the snooker table size resolver to use the shared config by importing `resolveTableSize` from `snookerClubTables.js` instead of the local snookerRoyal tables file.
- Introduce `SNOOKER_BALL_MATERIAL_VARIANT = 'pool'` and use it for runtime ball materials and decorative ball previews by passing it to `getBilliardBallMaterial` and `createBallPreviewDataUrl` in `SnookerRoyal.jsx`.
- Update decorative ball construction (`addDecorBall`) and the `Guret` ball factory to use the new material variant so snooker rack and coloured balls reuse the pool material technique.
- Remove the `ukBallSet` state and the Ball Set selection UI from `SnookerRoyalLobby.jsx` so the ball visuals are no longer selectable from the lobby.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to validate the app boot (successful).
- Ran an automated Playwright script to open `/games/snookerroyale/lobby` and capture a screenshot to verify the lobby loads and the removed UI element is not present (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b53044348329a4f1667119015648)