### PR TITLE
Update Pool Royale spin controller visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1444,8 +1444,21 @@ const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 1.85 * 1.35 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
-const SPIN_CONTROL_DIAMETER_PX = 96;
-const SPIN_DOT_DIAMETER_PX = 10;
+const SPIN_CONTROL_DIAMETER_PX = 132;
+const SPIN_DOT_DIAMETER_PX = 14;
+const SPIN_RING_THICKNESS_PX = 14;
+const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
+const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
+const SPIN_LABELS = [
+  { text: 'HIGH', left: '50%', top: '6%' },
+  { text: 'LOW', left: '50%', top: '94%' },
+  { text: 'LEFT', left: '6%', top: '50%' },
+  { text: 'RIGHT', left: '94%', top: '50%' },
+  { text: 'HIGH LEFT', left: '18%', top: '18%' },
+  { text: 'HIGH RIGHT', left: '82%', top: '18%' },
+  { text: 'LOW LEFT', left: '18%', top: '82%' },
+  { text: 'LOW RIGHT', left: '82%', top: '82%' }
+];
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // middle pocket cushion cuts are sharpened to a 29° cut to align the side-rail cushions with the updated spec
@@ -24411,6 +24424,19 @@ const powerRef = useRef(hud.power);
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
   const showSpinController =
     !hud.over && !replayActive && (isPlayerTurn || aiTakingShot);
+  const spinDecorationPoints = useMemo(
+    () =>
+      SPIN_DECORATION_ANGLES.flatMap((angle) => {
+        const radians = (angle * Math.PI) / 180;
+        const x = Math.cos(radians);
+        const y = Math.sin(radians);
+        return SPIN_DECORATION_RADII.map((radius) => ({
+          x: x * radius,
+          y: y * radius
+        }));
+      }),
+    []
+  );
 
   // Spin controller interactions
   useEffect(() => {
@@ -25758,12 +25784,78 @@ const powerRef = useRef(hud.power);
             style={{
               width: `${SPIN_CONTROL_DIAMETER_PX}px`,
               height: `${SPIN_CONTROL_DIAMETER_PX}px`,
-              background: '#f9fafb'
+              background: `radial-gradient(circle at center, #fef6df 0 62%, #c81d25 62% 100%)`
             }}
           >
             <div
+              className="absolute inset-0 rounded-full"
+              style={{
+                boxShadow:
+                  'inset 0 0 0 2px rgba(255,255,255,0.7), inset 0 6px 12px rgba(255,255,255,0.25)',
+                pointerEvents: 'none'
+              }}
+            />
+            <div
+              className="absolute rounded-full"
+              style={{
+                inset: `${SPIN_RING_THICKNESS_PX}px`,
+                background: '#fef6df',
+                boxShadow: 'inset 0 0 0 2px rgba(255,255,255,0.6)',
+                pointerEvents: 'none'
+              }}
+            />
+            <div
+              className="absolute left-1/2 top-0 h-full w-[2px] bg-red-500/60"
+              style={{ transform: 'translateX(-50%)', pointerEvents: 'none' }}
+            />
+            <div
+              className="absolute top-1/2 left-0 h-[2px] w-full bg-red-500/60"
+              style={{ transform: 'translateY(-50%)', pointerEvents: 'none' }}
+            />
+            <div
+              className="absolute rounded-full border-2 border-red-500/70"
+              style={{
+                width: `${SPIN_DOT_DIAMETER_PX * 1.65}px`,
+                height: `${SPIN_DOT_DIAMETER_PX * 1.65}px`,
+                left: '50%',
+                top: '50%',
+                transform: 'translate(-50%, -50%)',
+                pointerEvents: 'none'
+              }}
+            />
+            {spinDecorationPoints.map((point, index) => (
+              <span
+                key={`spin-deco-${index}`}
+                className="absolute rounded-full border-2 border-black/75"
+                style={{
+                  width: '12px',
+                  height: '12px',
+                  left: `${50 + point.x * 48}%`,
+                  top: `${50 + point.y * 48}%`,
+                  transform: 'translate(-50%, -50%)',
+                  background: 'rgba(255,255,255,0.4)',
+                  pointerEvents: 'none'
+                }}
+              />
+            ))}
+            {SPIN_LABELS.map((label) => (
+              <span
+                key={label.text}
+                className="absolute text-[9px] font-semibold uppercase tracking-[0.2em] text-[#3a0d0d]"
+                style={{
+                  left: label.left,
+                  top: label.top,
+                  transform: 'translate(-50%, -50%)',
+                  textShadow: '0 1px 2px rgba(255,255,255,0.35)',
+                  pointerEvents: 'none'
+                }}
+              >
+                {label.text}
+              </span>
+            ))}
+            <div
               id="spinDot"
-              className="absolute rounded-full bg-red-600 -translate-x-1/2 -translate-y-1/2"
+              className="absolute rounded-full bg-red-600 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
               style={{
                 width: `${SPIN_DOT_DIAMETER_PX}px`,
                 height: `${SPIN_DOT_DIAMETER_PX}px`,


### PR DESCRIPTION
### Motivation

- Restyle the Pool Royale spin controller so it matches the reference dial (red ring, crosshair, markers and labels) and improves visual clarity. 
- Increase touch target and visual weight so the control reads better on portrait/mobile screens. 
- Render directional labels and decorative markers to make spin intent more apparent. 
- Keep interaction logic unchanged while improving only presentation and layout constants.

### Description

- Increased the control size and marker sizes by updating `SPIN_CONTROL_DIAMETER_PX` and `SPIN_DOT_DIAMETER_PX`, and added `SPIN_RING_THICKNESS_PX`. 
- Added configuration arrays `SPIN_DECORATION_RADII`, `SPIN_DECORATION_ANGLES`, and `SPIN_LABELS` and compute `spinDecorationPoints` with `useMemo` to position decorative markers. 
- Reworked the `spinBox` markup to use a radial gradient background, inner ring, crosshair lines, central marker ring and decorative dots, and render directional labels; all new visuals use `pointer-events: none` so existing pointer handling is unchanged. 
- Minor styling tweaks (text color, shadows) to match the target dial while leaving spin logic and limits intact.

### Testing

- Started the web dev server with `npm --prefix webapp run dev` (Vite started successfully). 
- Attempted automated visual capture with Playwright to verify the spin controller render, but the Playwright runs timed out before the control rendered. 
- No unit tests or CI test suites were executed for this change. 
- Manual runtime interaction behavior was not modified; existing pointer handlers remain active and unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b55a0fe8832989b85ffefa6300dd)