### PR TITLE
Restore Snooker Royal table footprint scale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -934,11 +934,11 @@ function addPocketCuts(
 // separate scales for table and balls
 // Dimensions tuned for an official 9ft pool table footprint while globally reduced
 // to fit comfortably inside the existing mobile arena presentation.
-const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
-const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
+const TABLE_SIZE_SHRINK = 1; // restore the original snooker club footprint without tightening the table proportions
+const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim while keeping the classic table footprint intact
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.88; // pull the entire table set ~12% closer so the arena feels more intimate without distorting proportions
+const TABLE_DISPLAY_SCALE = 1; // keep the full snooker club presentation scale so the table layout matches the prior build
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;


### PR DESCRIPTION
### Motivation
- Restore the Snooker Royal table footprint and display scale to match the previous snooker club layout so pockets, chrome plates and overall proportions align with the older build.
- Undo the deliberate visual tightening that reduced the table footprint and presentation distance, while keeping the rest of the game configuration intact.
- Ensure the in-scene playfield and pocket metrics remain consistent with the snooker variant used elsewhere in the codebase.

### Description
- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to set `TABLE_SIZE_SHRINK` to `1` so the table footprint is no longer tightened. 
- Set `TABLE_DISPLAY_SCALE` to `1` to preserve the prior snooker club presentation distance and layout. 
- Adjusted inline comments to reflect the restored sizing behavior and preserved the rest of the table configuration and derived constants.

### Testing
- No automated tests were run against this change.
- The change was committed to the working branch after applying the three-line edit to `SnookerRoyal.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964bc483eb48329be258117286e4820)