### PR TITLE
Match Snooker Royal table proportions to legacy 12ft Snooker Club layout

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,10 +1017,9 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Reuse the Snooker Royal playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
+  // Match the Snooker Club 12ft reference so table proportions, pockets, and chrome align with the legacy layout.
+  const WIDTH_REF = 3556;
+  const HEIGHT_REF = 1778;
   const BALL_D_REF = 52.5;
   const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
@@ -1031,9 +1030,8 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
-  // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
+  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
+  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);


### PR DESCRIPTION
### Motivation

- Restore the Snooker Royal table geometry to match the legacy 12ft Snooker Club layout so pockets, chrome plates, and overall playfield proportions align with the removed snooker club configuration.
- Prevent visual/physics drift between Snooker Royal and the previous snooker club build by using the original reference dimensions and aspect ratio.

### Description

- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to use the 12ft snooker reference by changing `WIDTH_REF` to `3556` and `HEIGHT_REF` to `1778`.
- Replaced the fixed wider aspect ratio constant with a table-driven value by setting `TARGET_RATIO = WIDTH_REF / HEIGHT_REF` so the playfield aspect preserves the 12ft proportions.
- Adjusted downstream geometry scaling which now derives `MM_TO_UNITS` and ball/pocket sizing from the new `WIDTH_REF`.

### Testing

- Started the dev server with `npm --prefix webapp run dev` which launched Vite successfully (server reported ready). 
- Attempted an automated Playwright screenshot of `/games/snookerroyale`, but the capture timed out (screenshot failed).
- No unit or integration test suites were executed against the change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964bc483eb48329be258117286e4820)