### PR TITLE
Adjust Pool Royale spin controller layout

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1445,11 +1445,13 @@ const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 1.85 * 1.35 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
-const SPIN_CONTROL_DIAMETER_PX = 132;
+const SPIN_CONTROL_DIAMETER_PX = 138;
 const SPIN_DOT_DIAMETER_PX = 16;
 const SPIN_RING_THICKNESS_PX = 14;
 const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
 const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
+const SPIN_DECORATION_DOT_SIZE_PX = 12;
+const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // middle pocket cushion cuts are sharpened to a 29° cut to align the side-rail cushions with the updated spec
@@ -25765,9 +25767,9 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-4 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute right-3 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${16 + chromeUiLiftPx}px`,
+            bottom: `${20 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale})`,
             transformOrigin: 'bottom right'
           }}
@@ -25822,10 +25824,10 @@ const powerRef = useRef(hud.power);
                 key={`spin-deco-${index}`}
                 className="absolute rounded-full border-2 border-black/75"
                 style={{
-                  width: '14px',
-                  height: '14px',
-                  left: `${50 + point.x * 48}%`,
-                  top: `${50 + point.y * 48}%`,
+                  width: `${SPIN_DECORATION_DOT_SIZE_PX}px`,
+                  height: `${SPIN_DECORATION_DOT_SIZE_PX}px`,
+                  left: `${50 + point.x * SPIN_DECORATION_OFFSET_PERCENT}%`,
+                  top: `${50 + point.y * SPIN_DECORATION_OFFSET_PERCENT}%`,
                   transform: 'translate(-50%, -50%)',
                   background: 'rgba(255,255,255,0.4)',
                   pointerEvents: 'none'


### PR DESCRIPTION
### Motivation

- Make the Pool Royale spin controller slightly larger so it is easier to target.  
- Ensure the decoration circles around the controller have a small gap so they do not touch.  
- Nudge the spin controller a bit upward and to the right on the portrait HUD so it aligns visually with other controls.  
- Keep the change minimal and localized to the spin controller layout/constants.

### Description

- Increase `SPIN_CONTROL_DIAMETER_PX` from `132` to `138` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Add `SPIN_DECORATION_DOT_SIZE_PX` (`12`) and `SPIN_DECORATION_OFFSET_PERCENT` (`58`) and use them for the decoration dots' size/placement.  
- Nudge the controller container by changing its class from `right-4` to `right-3` and the bottom offset from `16` to `20` so it moves slightly up and right.  
- Update decoration span styles to use the new constants so the dots have spacing and no longer touch the ring.

### Testing

- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which reported Vite ready and served the app.  
- Attempted an automated Playwright screenshot to verify the visual change, but the headless browser crashed/timeouted and the screenshot could not be captured.  
- No unit tests (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c51c63ac83299090f37bac140626)