### PR TITLE
Align Snooker Royal table specs with Pool Royale geometry

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,21 +1017,23 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Snooker Club 12ft reference so table proportions, pockets, and chrome align with the legacy layout.
-  const WIDTH_REF = 3556;
-  const HEIGHT_REF = 1778;
-  const BALL_D_REF = 52.5;
+  // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
+  // (WPA 9ft reference: 100" × 50", 2.25" balls)
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
+  const BALL_D_REF = 57.15;
   const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 86; // Official snooker corner pocket mouth (mm)
-  const SIDE_MOUTH_REF = 92; // Official snooker side pocket mouth (mm)
+  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
+  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
+  // and preserving pocket proportions from the previous build.
+  const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1047,7 +1049,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1; // use official snooker ball diameter without extra scaling
+const BALL_SIZE_SCALE = 0.94248; // 5% larger than the last Pool Royale build (15.8% over the original baseline)
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Make Snooker Royal pockets, cushions, jaws, chrome plates and wooden rail cuts match the size and layout used by the Pool Royale table so visuals and geometry align.
- Reuse the Pool Royale playfield and pocket metrics to ensure pocket/cushion interactions and ball capture radii are consistent across both modes.
- Relax the snooker aspect ratio so the table reads wider on modern screens while preserving playfield height and pocket proportions.
- Keep ball sizing consistent with Pool Royale to avoid mismatches in collisions and visual scale.

### Description
- Replace Snooker reference dimensions with Pool Royale metrics by updating `WIDTH_REF`, `HEIGHT_REF`, and `BALL_D_REF` in `SnookerRoyal.jsx`.
- Increase corner and side pocket mouth sizes by updating `CORNER_MOUTH_REF` and `SIDE_MOUTH_REF` to Pool Royale values so chrome/wood pocket cuts match.
- Change table aspect ratio to `TARGET_RATIO = 1.83` and set `BALL_SIZE_SCALE = 0.94248` to match Pool Royale ball sizing and screen presentation.
- Updated inline comments to reflect reuse of Pool Royale playfield/pocket metrics and preserve pocket/cushion alignment logic.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, serving the app locally at the expected port.
- Attempted an automated visual render using Playwright to visit `/games/snookerroyale` and capture a screenshot, but the screenshot step timed out.
- No unit or integration tests were run as part of this change.
- The modified file was smoke-tested by launching the app locally (render verification timed out as noted above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c5aea13c8329b6f690c674d2cd61)