### PR TITLE
Align Snooker Royal table geometry with Pool Royale layout

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,37 +1,39 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '12ft': {
-    id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+  '9ft': {
+    id: '9ft',
+    label: '9 ft (Tournament)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+  '8ft': {
+    id: '8ft',
+    label: '8 ft',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 171.45,
+      side: 152.4
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 
@@ -70,7 +72,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '12ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,37 +1,39 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '12ft': {
-    id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+  '9ft': {
+    id: '9ft',
+    label: '9 ft (Tournament)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+  '8ft': {
+    id: '8ft',
+    label: '8 ft',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 171.45,
+      side: 152.4
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 
@@ -70,7 +72,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '12ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,21 +1017,21 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Snooker Club 12ft reference so table proportions, pockets, and chrome align with the legacy layout.
-  const WIDTH_REF = 3556;
-  const HEIGHT_REF = 1778;
-  const BALL_D_REF = 52.5;
+  // Match the Pool Royale reference so pocket sizing and chrome layout align to that table.
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
+  const BALL_D_REF = 57.15;
   const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 86; // Official snooker corner pocket mouth (mm)
-  const SIDE_MOUTH_REF = 92; // Official snooker side pocket mouth (mm)
+  const CORNER_MOUTH_REF = 114.3; // Pool Royale corner pocket mouth (mm)
+  const SIDE_MOUTH_REF = 127; // Pool Royale side pocket mouth (mm)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  // Match the Pool Royale playfield ratio so the layout reads the same size.
+  const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1047,7 +1047,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1; // use official snooker ball diameter without extra scaling
+const BALL_SIZE_SCALE = 0.94248; // match Pool Royale ball scale for pocket/jaw alignment
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation

- Make Snooker Royal pockets, cushions, pocket jaws, chrome plates and rail geometry visually and dimensionally match the Pool Royale table so visuals and play feel align across modes.
- Unify table scales and playfield references so pocket/jaw/chrome cut math reuses Pool Royale reference metrics for consistent sizing.
- Reduce mismatch between Snooker and Pool layouts to avoid rework in chrome/rail/pocket rendering and collision math.

### Description

- Updated table presets in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js` to use a Pool Royale (9ft) base: `playfield` set to `2540×1270`, `ballDiameterMm` to `57.15`, `pocketMouthMm` to `corner:114.3, side:127`, and cushion angle/scale overrides adjusted accordingly, plus `DEFAULT_TABLE_SIZE_ID` set to `9ft`.
- Adjusted Snooker Royal runtime constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to reference Pool Royale metrics by changing `WIDTH_REF`, `HEIGHT_REF`, `BALL_D_REF`, `CORNER_MOUTH_REF`, `SIDE_MOUTH_REF`, `TARGET_RATIO`, and `BALL_SIZE_SCALE` so chrome plate, rounded cuts and pocket/jaw math align with Pool Royale.
- Normalized base scale constants (`BASE_TABLE_*_SCALE`) to better match Pool Royale sizing and updated mobile/compact scale overrides for consistent rendering on different device classes.

### Testing

- Ran `npm run dev` and verified the Vite development server started and served the app (local server ready). 
- Attempted an automated Playwright screenshot to validate the Snooker Royal view, but the Playwright capture timed out and did not complete. 
- No unit or integration test suites were executed as part of this change. 
- The changes were committed after local verification of the modified files compiling under the dev server run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c5aea13c8329b6f690c674d2cd61)