### PR TITLE
Align Snooker Royal table metrics with Pool Royale sizing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,21 +1017,21 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Snooker Club 12ft reference so table proportions, pockets, and chrome align with the legacy layout.
-  const WIDTH_REF = 3556;
-  const HEIGHT_REF = 1778;
-  const BALL_D_REF = 52.5;
+  // Reuse the Pool Royale playfield and pocket metrics so pockets + rails align perfectly.
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
+  const BALL_D_REF = 57.15;
   const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 86; // Official snooker corner pocket mouth (mm)
-  const SIDE_MOUTH_REF = 92; // Official snooker side pocket mouth (mm)
+  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
+  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched.
+  const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1047,7 +1047,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1; // use official snooker ball diameter without extra scaling
+const BALL_SIZE_SCALE = 0.94248; // match Pool Royale ball scaling so pockets, jaws, and rails line up
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Ensure snooker table pockets, cushions, jaws, chrome plates and rounded rail cuts match the size and layout used by the Pool Royale table so visuals and play geometry align across modes.
- Reuse existing Pool Royale reference metrics to avoid divergent constants and make the two table builds consistent.

### Description
- Updated reference metrics in `webapp/src/pages/Games/SnookerRoyal.jsx` to use Pool Royale playfield values by changing `WIDTH_REF`, `HEIGHT_REF`, and `BALL_D_REF`.
- Increased pocket mouth sizes by setting `CORNER_MOUTH_REF` and `SIDE_MOUTH_REF` to Pool Royale values and relaxed the aspect ratio via `TARGET_RATIO = 1.83`.
- Adjusted `BALL_SIZE_SCALE` to `0.94248` so ball diameter, pocket jaws and chrome plates line up with Pool Royale scaling.
- Minor comment updates to clarify the change in source of table/pocket metrics.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported `ready` indicating the dev server launched successfully.
- Attempted an automated Playwright screenshot of `/games/snookerroyale` which timed out and failed to capture the scene.
- No unit or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c5aea13c8329b6f690c674d2cd61)