### PR TITLE
Tweak Pool Royale HUD/controls layout and fix spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5033,10 +5033,21 @@ const normalizeSpinInput = (spin) => {
   }
   return clampToUnitCircle(x, y);
 };
-const mapSpinForPhysics = (spin) => ({
-  x: spin?.x ?? 0,
-  y: spin?.y ?? 0
-});
+const mapSpinForPhysics = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const clamped = clampToUnitCircle(x, y);
+  const magnitude = Math.hypot(clamped.x, clamped.y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  const easedMagnitude = Math.pow(magnitude, 1.35);
+  const scale = magnitude > 1e-6 ? easedMagnitude / magnitude : 0;
+  return {
+    x: clamped.x * scale,
+    y: -clamped.y * scale
+  };
+};
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
   return THREE.MathUtils.clamp(liftAngle / CUE_LIFT_MAX_TILT, 0, 1);
@@ -24739,8 +24750,8 @@ const powerRef = useRef(hud.power);
   const playerPotted = pottedBySeat[playerSeatId] || [];
   const opponentPotted = pottedBySeat[opponentSeatId] || [];
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive;
-  const bottomHudScale = isPortrait ? uiScale * 0.95 : uiScale * 1.02;
-  const avatarSizeClass = isPortrait ? 'h-8 w-8' : 'h-12 w-12';
+  const bottomHudScale = isPortrait ? uiScale * 1 : uiScale * 1.05;
+  const avatarSizeClass = isPortrait ? 'h-9 w-9' : 'h-[3.25rem] w-[3.25rem]';
   const nameWidthClass = isPortrait ? 'max-w-[6.5rem]' : 'max-w-[8.75rem]';
   const nameTextClass = isPortrait ? 'text-xs' : 'text-sm';
   const hudGapClass = isPortrait ? 'gap-3' : 'gap-5';
@@ -25582,10 +25593,10 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute left-4 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute left-2 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
           bottom: `${16 + chromeUiLiftPx}px`,
-          transform: `scale(${uiScale})`,
+          transform: `scale(${uiScale * 1.06})`,
           transformOrigin: 'bottom left'
         }}
       >
@@ -25767,9 +25778,9 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-3 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute right-2 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${20 + chromeUiLiftPx}px`,
+            bottom: `${26 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale})`,
             transformOrigin: 'bottom right'
           }}


### PR DESCRIPTION
### Motivation
- Improve portrait HUD layout so the view, 2D buttons and player panels are slightly larger and sit a bit more to the left for better reachability on phones.
- Nudge the spin controller visually upward and a touch more to the right so it matches the requested on-screen placement in portrait.
- Make the spin input behave more intuitively by easing small inputs and correcting the backspin direction applied to physics.
- Keep changes small and focused to preserve existing feel while making center adjustments easier to use.

### Description
- Adjusted HUD scaling and avatar sizes by modifying `bottomHudScale` and `avatarSizeClass` in `webapp/src/pages/Games/PoolRoyale.jsx` to slightly increase visual size in portrait.
- Moved left-side controls closer to the left edge and increased their UI scale by changing the left container `className`/`style` (`left-4`→`left-2`, `scale(${uiScale})`→`scale(${uiScale*1.06})`).
- Nudged the spin controller position and elevation by changing its wrapper (`right-3`→`right-2`, `bottom: 20`→`bottom: 26`) so the control appears a bit higher and more right on-screen.
- Reworked `mapSpinForPhysics` to clamp to the unit circle, apply a mild easing curve to magnitude (`Math.pow(magnitude, 1.35)`), and invert the vertical component so backspin direction matches expected physics behavior.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (local server reachable), indicating the app builds and serves successfully.
- Attempted an automated visual check using Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot run timed out and failed to complete.
- No unit or integration test suites were executed as part of this change.
- Changes were committed locally after verification by running the development server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964cbbccc30832987f1e1e870a517c2)