### PR TITLE
Align Snooker Royal pocket specs with Pool Royale layout

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -10,11 +10,12 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
       mobileScale: 1.68,
@@ -27,11 +28,12 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -10,11 +10,12 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 }),
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
       mobileScale: 1.68,
@@ -27,11 +28,12 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 86,
-      side: 92
+      corner: 114.3,
+      side: 127
     }),
-    cushionCutAngleDeg: 35,
-    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 105 })
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
 

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,7 +1017,7 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Snooker Club 12ft reference so table proportions, pockets, and chrome align with the legacy layout.
+  // Match the Pool Royale pocket layout while keeping the current table footprint.
   const WIDTH_REF = 3556;
   const HEIGHT_REF = 1778;
   const BALL_D_REF = 52.5;
@@ -1025,8 +1025,8 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 86; // Official snooker corner pocket mouth (mm)
-  const SIDE_MOUTH_REF = 92; // Official snooker side pocket mouth (mm)
+  const CORNER_MOUTH_REF = 114.3; // Pool Royale corner pocket mouth (mm)
+  const SIDE_MOUTH_REF = 127; // Pool Royale side pocket mouth (mm)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;


### PR DESCRIPTION
### Motivation
- The Snooker Royal table needs its pocket, cushion and jaw geometry to match the Pool Royale pocket layout while preserving the existing table footprint and overall size.
- Keep visual elements like chrome fascias and cushion mouth positions consistent with the Pool Royale reference so pocket behavior and appearance match the requested layout.

### Description
- Updated pocket mouth dimensions and cushion metrics in `webapp/src/config/snookerClubTables.js` to use Pool Royale values (`corner: 114.3`, `side: 127`, and `cushionCutAngleDeg: 27` / `sideCushionCutAngleDeg: 27`).
- Mirrored the same pocket and cushion changes in `webapp/src/config/snookerRoyalTables.js` for the royal table variants.
- Adjusted the pocket mouth reference constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to use Pool Royale mouth sizes and annotated the change with an explanatory comment.
- Committed the three updated files so the Snooker Royal runtime uses the Pool Royale pocket geometry while keeping table dimensions unchanged.

### Testing
- Started the webapp development server with `npm --prefix webapp run dev` and Vite reported the site ready on `http://localhost:4173/`, which succeeded.
- Attempted an automated visual smoke test using Playwright to capture `/games/snookerroyale`, but the screenshot run timed out and failed.
- No unit tests (`jest`) or lint runs were executed as part of this rollout.
- Files changed and committed: `webapp/src/config/snookerClubTables.js`, `webapp/src/config/snookerRoyalTables.js`, and `webapp/src/pages/Games/SnookerRoyal.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964cea31dc48329a39b6740c918fb95)