### PR TITLE
Snooker: align spin physics, enlarge spin controller, and add color respot logic

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -26,6 +26,19 @@ const COLOR_VALUES: Record<BallColor, number> = {
 
 const COLOR_ORDER: BallColor[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'];
 
+function buildSnookerBalls(phase: FrameState['phase'], colorsRemaining: BallColor[]) {
+  const onTableColors =
+    phase === 'COLORS_ORDER'
+      ? new Set(colorsRemaining)
+      : new Set(COLOR_ORDER);
+  return COLOR_ORDER.map((color) => ({
+    id: color.toLowerCase(),
+    color,
+    onTable: onTableColors.has(color),
+    potted: !onTableColors.has(color)
+  }));
+}
+
 function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
   return {
     A: { id: 'A', name: playerA, score: 0 },
@@ -88,7 +101,7 @@ export class SnookerRoyalRules {
 
   getInitialFrame(playerA: string, playerB: string): FrameState {
     const base: FrameState = {
-      balls: [],
+      balls: buildSnookerBalls('REDS_AND_COLORS', COLOR_ORDER),
       activePlayer: 'A',
       players: basePlayers(playerA, playerB),
       currentBreak: 0,
@@ -212,6 +225,9 @@ export class SnookerRoyalRules {
       nextActivePlayer = opponent;
       nextBreak = 0;
       nextFreeBall = Boolean(context.snookered);
+      if (pottedReds.length) {
+        redsRemaining = Math.max(0, redsRemaining - pottedReds.length);
+      }
     } else if (pottedNonCue.length === 0) {
       nextActivePlayer = state.activePlayer === 'A' ? 'B' : 'A';
       nextBreak = 0;
@@ -261,6 +277,7 @@ export class SnookerRoyalRules {
     const nextState: FrameState = {
       ...state,
       activePlayer: nextActivePlayer,
+      balls: buildSnookerBalls(nextPhase, colorsRemaining),
       players: {
         A: { ...state.players.A, score: scores.A },
         B: { ...state.players.B, score: scores.B }


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal experience match the Pool Royale controls and physics for spin so players get consistent behavior across modes.
- Enforce correct snooker rules for colours by tracking color-ball on-table state and respotting potted colours per official behaviour.
- Ensure the 2D/3D view/button layout matches the Pool Royale placement for consistent UI on portrait screens.
- Keep gameplay modular and clear by moving visual/physics tuning into the snooker page and rules module.

### Description
- Added `buildSnookerBalls` and updated `SnookerRoyalRules` to populate and maintain `frameState.balls`, update `redsRemaining` on fouls/pots, and include color-ball table state in the returned `FrameState` (file: `src/rules/SnookerRoyalRules.ts`).
- Implemented respot placement search `resolveSnookerRespotPosition` and applied it when reactivating colour balls so they are placed back to their spot or nearest valid nearby position without overlapping other balls (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Aligned spin controller tuning and physics to Pool Royale by adjusting constants (`SPIN_STRENGTH`, `SPIN_ROLL_STRENGTH`, `SPIN_ROLL_DECAY`, `SPIN_AIR_DECAY`, `RAIL_SPIN_THROW_SCALE`, `BACKSPIN_ROLL_BOOST`), using `resolveSpinWorldVector` for world-space spin handling and applying backspin boost logic, and enlarging the spin UI control (`SPIN_CONTROL_DIAMETER_PX`).
- Small UI placement tweak to the left control buttons (bottom offset) to match the Pool Royale layout on portrait phones.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported the dev server ready (succeeded).
- Attempted a UI smoke capture with Playwright to validate the in-browser behavior, but Chromium crashed when launching in the environment (Playwright screenshot failed with a SIGSEGV).
- No unit tests were run as part of this change; no automated rule/unit test suite failures reported during the local dev start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e62e90a883298affd5716eb2d9e5)