### PR TITLE
Pool Royale: true 2D overhead view and fix spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4749,9 +4749,9 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
+const TOP_VIEW_PHI = 0; // true overhead view for the 2D toggle
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
-const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
+const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
   z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left
@@ -5051,7 +5051,7 @@ const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(spin);
   return {
     x: curved.x,
-    y: -curved.y
+    y: curved.y
   };
 };
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- Restore a true overhead 2D camera for the Pool Royale 2D toggle so the top-down view sits straight above without angular tilt.  
- Fix the spin calibration so user input for top/back spin maps to physics the same way it appears on screen (no inverted forward axis).  
- Keep gameplay visuals and physical behaviour consistent between the on-screen spin indicator and the applied spin.  
- Make the change localized to the Pool Royale page where camera and spin mapping are handled.  

### Description
- Set the top-down camera angle constants to a true overhead by changing `TOP_VIEW_PHI` to `0` and using that value for `TOP_VIEW_RESOLVED_PHI` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Align spin input to physics by removing the inverted Y mapping in `mapSpinForPhysics` so it now returns `{ x: curved.x, y: curved.y }` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and committed with the message `Adjust Pool Royale top view and spin mapping`.  

### Testing
- Started the local dev server with `npm run dev` and Vite served the app successfully (server ready at `http://localhost:4173/`).  
- Attempted an automated Playwright screenshot to verify the 2D toggle and visual alignment, but the headless Chromium process crashed (SIGSEGV) and the screenshot step failed.  
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e8dbd068832985b7020fbca0c536)