### PR TITLE
Pool Royale: lock 2D top view overhead & correct spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4749,9 +4749,9 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
+const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
-const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
+const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
   z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left
@@ -5051,7 +5051,7 @@ const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(spin);
   return {
     x: curved.x,
-    y: -curved.y
+    y: curved.y
   };
 };
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- The 2D/top-down camera should match the straight-overhead view shown in the design, not a tilted/angled framing.  
- The spin controller mapping needed calibration so top/backspin on the UI map directly to the physics input (they were inverted).  

### Description
- Locked the 2D top view by setting `TOP_VIEW_PHI = 0` and `TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Removed the vertical sign flip in `mapSpinForPhysics` so the returned spin now uses `y: curved.y` instead of `y: -curved.y` to align controller input with physics.  
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and keep existing top-view radius/scale logic intact.  

### Testing
- Started the dev server with `npm --prefix webapp run dev` which launched Vite and reported the app as ready.  
- Attempted an automated browser check (Playwright) to capture a top-view screenshot, but the headless run timed out and did not complete.  
- No unit test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e8dbd068832985b7020fbca0c536)