### PR TITLE
Enforce snooker foul scoring cap, nomination rules, and respot/in-hand behavior

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -22364,6 +22364,7 @@ const powerRef = useRef(hud.power);
         }
         const shouldRespotColours =
           (currentState?.phase ?? frameState?.phase) === 'REDS_AND_COLORS' &&
+          (currentState?.redsRemaining ?? frameState?.redsRemaining ?? 0) > 0 &&
           (!isTraining || trainingRulesRef.current);
         if (shouldRespotColours && potted.length) {
           const ballsList = ballsRef.current?.length > 0 ? ballsRef.current : balls;
@@ -22460,7 +22461,7 @@ const powerRef = useRef(hud.power);
           contactMade: false,
           cushionAfterContact: false
         };
-        let nextInHand = cueBallPotted;
+        let nextInHand = cueBallPotted || Boolean(safeState.foul);
         try {
           if (shotResolved) {
             if (safeState.foul) {


### PR DESCRIPTION
### Motivation
- Ensure foul penalties follow official snooker rules by capping penalties and using the nominated/ball-on value when appropriate.
- Prevent colour respotting after reds are gone to match snooker end-of-phase behavior.
- Make fouls that give points also give the opponent cue-in-hand where applicable so UI/placement logic can react.
- Surface clear foul reasons for nomination errors so the rules engine can reject invalid declarations deterministically.

### Description
- Cap foul points to 7 by changing `calculateFoulPoints` to `return Math.min(7, Math.max(4, ...))` in `src/rules/SnookerRoyalRules.ts` and include `explicitFoul?.ball` in involved-ball calculations to ensure the highest relevant value is used when computing penalties.
- Use the declared/nominated ball as the effective `ballOn` for foul scoring when in a post-red nomination state and add explicit foul reasons `no nomination` and `invalid nomination` for deterministic validation in `SnookerRoyalRules.applyShot`.
- End the frame immediately if a foul occurs on the final black in the colors clearance phase and the scores are unequal, setting the winner accordingly in `SnookerRoyalRules`.
- Restrict colour respot logic in the client to only run when reds remain and mark the cue ball as in-hand after fouls by updating `webapp/src/pages/Games/SnookerRoyal.jsx` to check `redsRemaining > 0` and set `nextInHand = cueBallPotted || Boolean(safeState.foul)`.

### Testing
- No automated tests were run for these changes.
- No CI or unit test results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ff9723408329836497d10c1fe213)