### PR TITLE
Fix Pool Royale topspin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5051,7 +5051,8 @@ const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(spin);
   return {
     x: curved.x,
-    y: curved.y
+    // UI has +Y downward; physics expects +Y for topspin.
+    y: -curved.y
   };
 };
 const normalizeCueLift = (liftAngle = 0) => {


### PR DESCRIPTION
### Motivation
- The on-screen spin controller showed topspin when the user dragged the red dot upward, but the physics applied the opposite (backspin), causing inconsistent gameplay feedback.
- The change aligns visual input direction with the physics engine so the controller UX matches the cue ball behaviour.
- Keep the spin conversion explicit and documented so future maintainers understand the UI-to-physics Y-axis mapping.

### Description
- Inverted the vertical spin mapping inside `mapSpinForPhysics` so UI Y (controller) is converted to physics Y with the sign flipped by returning `y: -curved.y`.
- Added an inline comment explaining that the UI has +Y downward while physics expects +Y for topspin.
- The modification is contained to `webapp/src/pages/Games/PoolRoyale.jsx` and preserves existing response-curve logic (`applySpinResponseCurve`).

### Testing
- No automated tests were executed for this change.
- Local runtime validation was not recorded in CI; recommend running the game and verifying that moving the spin dot upward now applies topspin to the cue ball.
- Suggest adding a unit test for `mapSpinForPhysics` and a visual smoke test for the spin controller in a follow-up PR.
- CI should run existing test suites after this change is merged to ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696500c17d2483298cce284e52c0128d)