### PR TITLE
Invert vertical spin input so topspin/backspin match controller

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -24783,7 +24783,7 @@ const powerRef = useRef(hud.power);
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
       let ny = ((cy - rect.top) / rect.height) * 2 - 1;
-      setSpin(nx, ny);
+      setSpin(nx, -ny);
     };
 
     const scaleBox = (value) => {


### PR DESCRIPTION
### Motivation
- Players observed that pulling the spin controller up produced backspin while pulling down produced topspin, which is opposite the expected behavior.
- The input-to-physics mapping used the raw pointer Y coordinate directly, causing the vertical spin axis to be inverted relative to the UI.
- The change aims to align the visual spin control with the physics spin applied to the cue ball.

### Description
- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to invert the vertical pointer mapping in the spin controller by calling `setSpin(nx, -ny)` instead of `setSpin(nx, ny)` inside `updateSpin`.
- The inversion occurs before normalization, limit-clamping and legality checks so the rest of the spin pipeline receives a corrected `spinRequestRef` value.
- This is a single-line, localized change that adjusts input interpretation only and does not modify physics formulas or spin application logic.

### Testing
- No automated tests were executed for this change.
- Manual playtesting is recommended to verify that topspin/backspin now matches on-screen drag direction across devices and camera views.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696514e296688329b4a409a3ab0a7969)