### PR TITLE
Tune Pool Royale spin response curve

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5043,7 +5043,7 @@ const applySpinResponseCurve = (spin) => {
   }
   const clamped = clampToUnitCircle(x, y);
   const clampedMag = Math.hypot(clamped.x, clamped.y);
-  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const curvedMag = 1 - Math.pow(1 - clampedMag, SPIN_RESPONSE_EXPONENT);
   const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
   return { x: clamped.x * scale, y: clamped.y * scale };
 };


### PR DESCRIPTION
### Motivation
- The spin controller produced unintuitive scaling between controller input and applied top/back/side spin, so the mapping needed adjustment to change how small and large inputs translate to physics spin.
- The change aims to invert the non-linear response behavior without altering controller layout or legality checks.

### Description
- Replaced the spin magnitude mapping in `applySpinResponseCurve` inside `webapp/src/pages/Games/PoolRoyale.jsx` to use a complementary power curve: `const curvedMag = 1 - Math.pow(1 - clampedMag, SPIN_RESPONSE_EXPONENT)` instead of `Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT)`.
- This modifies only the non-linear mapping from normalized UI spin input to the curved magnitude fed to physics, leaving limits, clamping and downstream mapping (`mapSpinForPhysics`) unchanged.

### Testing
- No automated tests were executed for this change.
- The modification was committed to the repository (`webapp/src/pages/Games/PoolRoyale.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651d18eca48329a764a832d21f14fd)