### PR TITLE
Invert vertical spin mapping in Pool Royale spin controller

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5047,8 +5047,18 @@ const applySpinResponseCurve = (spin) => {
   const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
   return { x: clamped.x * scale, y: clamped.y * scale };
 };
+const invertSpinMagnitude = (value) => {
+  const clamped = clamp(value ?? 0, -1, 1);
+  const magnitude = Math.abs(clamped);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) return 0;
+  return Math.sign(clamped) * (1 - magnitude);
+};
 const mapSpinForPhysics = (spin) => {
-  const curved = applySpinResponseCurve(spin);
+  const adjusted = {
+    x: spin?.x ?? 0,
+    y: invertSpinMagnitude(spin?.y ?? 0)
+  };
+  const curved = applySpinResponseCurve(adjusted);
   return {
     x: curved.x,
     // UI has +Y downward; physics expects +Y for topspin.


### PR DESCRIPTION
### Motivation

- Players reported that applying small top/back spin produced the opposite magnitude response, so vertical spin strength needs to be remapped to match controller expectations.
- The change aims to flip how UI vertical input maps to physics so full UI top/back corresponds to expected physical top/back strength.

### Description

- Added a helper `invertSpinMagnitude` that inverts the vertical spin magnitude mapping while preserving sign and dead-zone handling.
- `mapSpinForPhysics` now constructs an `adjusted` spin with `y: invertSpinMagnitude(spin?.y)` before applying the existing `applySpinResponseCurve` to produce physics spin.
- The rest of the spin pipeline (response curve, UI-to-physics sign inversion for Y) remains unchanged, so only vertical magnitude mapping is altered.
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx` (around `applySpinResponseCurve` / `mapSpinForPhysics`).

### Testing

- No automated tests were run for this change.
- The change was committed locally and the modified file compiles in-place within the project tree (no CI run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651d18eca48329a764a832d21f14fd)