### PR TITLE
Fix Pool Royale spin controller mapping

### DIFF
--- a/test/poolSpinMapping.test.js
+++ b/test/poolSpinMapping.test.js
@@ -1,0 +1,54 @@
+import { mapSpinForPhysics } from '../webapp/src/utils/spinMapping.js';
+
+const expectVector = (vec) => ({
+  x: vec.x ?? 0,
+  y: vec.y ?? 0
+});
+
+describe('pool spin mapping', () => {
+  test('keeps center as no spin', () => {
+    const center = mapSpinForPhysics({ x: 0, y: 0 });
+    expect(Math.abs(center.x)).toBeCloseTo(0, 8);
+    expect(Math.abs(center.y)).toBeCloseTo(0, 8);
+  });
+
+  test('maps top/bottom/left/right to expected directions', () => {
+    const top = mapSpinForPhysics({ x: 0, y: -1 });
+    const bottom = mapSpinForPhysics({ x: 0, y: 1 });
+    const left = mapSpinForPhysics({ x: -1, y: 0 });
+    const right = mapSpinForPhysics({ x: 1, y: 0 });
+
+    expect(top.y).toBeGreaterThan(0);
+    expect(bottom.y).toBeLessThan(0);
+    expect(left.x).toBeLessThan(0);
+    expect(right.x).toBeGreaterThan(0);
+  });
+
+  test('preserves corner directions', () => {
+    const topLeft = mapSpinForPhysics({ x: -1, y: -1 });
+    const topRight = mapSpinForPhysics({ x: 1, y: -1 });
+    const bottomLeft = mapSpinForPhysics({ x: -1, y: 1 });
+    const bottomRight = mapSpinForPhysics({ x: 1, y: 1 });
+
+    expect(topLeft.x).toBeLessThan(0);
+    expect(topLeft.y).toBeGreaterThan(0);
+    expect(topRight.x).toBeGreaterThan(0);
+    expect(topRight.y).toBeGreaterThan(0);
+    expect(bottomLeft.x).toBeLessThan(0);
+    expect(bottomLeft.y).toBeLessThan(0);
+    expect(bottomRight.x).toBeGreaterThan(0);
+    expect(bottomRight.y).toBeLessThan(0);
+  });
+
+  test('spin magnitude grows with distance from center', () => {
+    const near = mapSpinForPhysics({ x: 0, y: -0.2 });
+    const far = mapSpinForPhysics({ x: 0, y: -0.8 });
+    expect(Math.abs(near.y)).toBeLessThan(Math.abs(far.y));
+  });
+
+  test('small inputs fall back to no spin', () => {
+    const tiny = mapSpinForPhysics({ x: 0.01, y: 0.01 });
+    expect(Math.abs(tiny.x)).toBeCloseTo(0, 8);
+    expect(Math.abs(tiny.y)).toBeCloseTo(0, 8);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -74,6 +74,11 @@ import {
   resolvePlayableTrainingLevel
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import {
+  mapSpinForPhysics,
+  normalizeSpinInput,
+  SPIN_INPUT_DEAD_ZONE
+} from '../../utils/spinMapping.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
@@ -5013,58 +5018,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
-const SPIN_INPUT_DEAD_ZONE = 0.02;
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_RESPONSE_EXPONENT = 1.65;
-
-const clampToUnitCircle = (x, y) => {
-  const L = Math.hypot(x, y);
-  if (!Number.isFinite(L) || L <= 1) {
-    return { x, y };
-  }
-  const scale = L > 1e-6 ? 1 / L : 0;
-  return { x: x * scale, y: y * scale };
-};
-const normalizeSpinInput = (spin) => {
-  const x = spin?.x ?? 0;
-  const y = spin?.y ?? 0;
-  const magnitude = Math.hypot(x, y);
-  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
-    return { x: 0, y: 0 };
-  }
-  return clampToUnitCircle(x, y);
-};
-const applySpinResponseCurve = (spin) => {
-  const x = spin?.x ?? 0;
-  const y = spin?.y ?? 0;
-  const magnitude = Math.hypot(x, y);
-  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
-    return { x: 0, y: 0 };
-  }
-  const clamped = clampToUnitCircle(x, y);
-  const clampedMag = Math.hypot(clamped.x, clamped.y);
-  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
-  const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
-  return { x: clamped.x * scale, y: clamped.y * scale };
-};
-const invertSpinMagnitude = (value) => {
-  const clamped = clamp(value ?? 0, -1, 1);
-  const magnitude = Math.abs(clamped);
-  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) return 0;
-  return Math.sign(clamped) * (1 - magnitude);
-};
-const mapSpinForPhysics = (spin) => {
-  const adjusted = {
-    x: spin?.x ?? 0,
-    y: invertSpinMagnitude(spin?.y ?? 0)
-  };
-  const curved = applySpinResponseCurve(adjusted);
-  return {
-    x: curved.x,
-    // UI has +Y downward; physics expects +Y for topspin.
-    y: -curved.y
-  };
-};
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
   return THREE.MathUtils.clamp(liftAngle / CUE_LIFT_MAX_TILT, 0, 1);

--- a/webapp/src/utils/spinMapping.js
+++ b/webapp/src/utils/spinMapping.js
@@ -1,0 +1,51 @@
+const SPIN_INPUT_DEAD_ZONE = 0.02;
+const SPIN_RESPONSE_EXPONENT = 1.65;
+
+const clampToUnitCircle = (x, y) => {
+  const L = Math.hypot(x, y);
+  if (!Number.isFinite(L) || L <= 1) {
+    return { x, y };
+  }
+  const scale = L > 1e-6 ? 1 / L : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+const normalizeSpinInput = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const magnitude = Math.hypot(x, y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  return clampToUnitCircle(x, y);
+};
+
+const applySpinResponseCurve = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const magnitude = Math.hypot(x, y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  const clamped = clampToUnitCircle(x, y);
+  const clampedMag = Math.hypot(clamped.x, clamped.y);
+  if (clampedMag < 1e-6) return { x: 0, y: 0 };
+  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const scale = curvedMag / clampedMag;
+  return { x: clamped.x * scale, y: clamped.y * scale };
+};
+
+const mapSpinForPhysics = (spin, { invertY = true } = {}) => {
+  const curved = applySpinResponseCurve(spin);
+  return {
+    x: curved?.x ?? 0,
+    y: invertY ? -(curved?.y ?? 0) : (curved?.y ?? 0)
+  };
+};
+
+export {
+  SPIN_INPUT_DEAD_ZONE,
+  applySpinResponseCurve,
+  mapSpinForPhysics,
+  normalizeSpinInput
+};


### PR DESCRIPTION
### Motivation
- The spin controller input was producing inverted/incorrect spin directions and inconsistent magnitudes relative to the UI, causing the controller to behave out of order.
- Centralize spin input normalization and mapping so the same logic is reused across Pool/Snooker, avoiding duplicated and divergent implementations.

### Description
- Add a shared helper `webapp/src/utils/spinMapping.js` that provides `normalizeSpinInput`, `applySpinResponseCurve`, and `mapSpinForPhysics` (with a configurable `invertY` option).
- Replace the in-file spin normalization in `webapp/src/pages/Games/PoolRoyale.jsx` with imports from the new `spinMapping` utilities and remove the duplicated code.
- Add unit tests `test/poolSpinMapping.test.js` covering center/no-spin, cardinal directions, corner directions, magnitude scaling, and dead-zone behavior.

### Testing
- Ran the focused test suite with `npm test -- poolSpinMapping.test.js`, and all tests passed (5 passed).
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965255dd3208329b4154cabd8462493)