### PR TITLE
Centralize and fix Pool Royale spin controller mapping

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -1,0 +1,38 @@
+import { mapSpinForPhysics } from '../webapp/src/pages/Games/poolRoyaleSpinUtils.js';
+
+const getSigns = (vec) => ({
+  x: Math.sign(vec.x),
+  y: Math.sign(vec.y)
+});
+
+describe('Pool Royale spin controller mapping', () => {
+  it('maps the center to no spin', () => {
+    const center = mapSpinForPhysics({ x: 0, y: 0 });
+    expect(Math.abs(center.x)).toBe(0);
+    expect(Math.abs(center.y)).toBe(0);
+  });
+
+  it('keeps left/right spin directions aligned with the controller', () => {
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(-1);
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(1);
+  });
+
+  it('maps up to topspin and down to backspin', () => {
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: -1 })).y).toBe(1);
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: 1 })).y).toBe(-1);
+  });
+
+  it('preserves diagonal quadrants without mirroring', () => {
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: -1 });
+  });
+
+  it('scales spin strength with distance from center', () => {
+    const inner = Math.abs(mapSpinForPhysics({ x: 0, y: -0.4 }).y);
+    const outer = Math.abs(mapSpinForPhysics({ x: 0, y: -0.9 }).y);
+    expect(inner).toBeGreaterThan(0);
+    expect(outer).toBeGreaterThan(inner);
+  });
+});

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,0 +1,50 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const SPIN_INPUT_DEAD_ZONE = 0.02;
+export const SPIN_RESPONSE_EXPONENT = 1.65;
+
+export const clampToUnitCircle = (x, y) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= 1) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? 1 / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+export const normalizeSpinInput = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const magnitude = Math.hypot(x, y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  return clampToUnitCircle(x, y);
+};
+
+export const applySpinResponseCurve = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const magnitude = Math.hypot(x, y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  const clamped = clampToUnitCircle(x, y);
+  const clampedMag = Math.hypot(clamped.x, clamped.y);
+  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
+  return { x: clamped.x * scale, y: clamped.y * scale };
+};
+
+export const mapSpinForPhysics = (spin) => {
+  const adjusted = {
+    x: clamp(spin?.x ?? 0, -1, 1),
+    y: clamp(spin?.y ?? 0, -1, 1)
+  };
+  const curved = applySpinResponseCurve(adjusted);
+  return {
+    x: curved.x,
+    // UI has +Y downward; physics expects +Y for topspin.
+    y: -curved.y
+  };
+};


### PR DESCRIPTION
### Motivation
- The spin controller behavior was inconsistent with the visual controller and mirrored/inverted vertical input in places, causing confusing top/backspin directions. 
- Spin normalization, response curve and mapping logic were duplicated inside `PoolRoyale.jsx` which made maintenance and correctness harder. 
- The goal is to ensure controller input matches the screenshot orientation and to expose a single mapping used by the game and tests. 

### Description
- Extracted spin utilities into a new module `webapp/src/pages/Games/poolRoyaleSpinUtils.js` containing `normalizeSpinInput`, `applySpinResponseCurve`, `mapSpinForPhysics`, and constants like `SPIN_INPUT_DEAD_ZONE`. 
- Replaced the inline spin code in `webapp/src/pages/Games/PoolRoyale.jsx` with imports from the new `poolRoyaleSpinUtils.js` and removed the duplicated implementations. 
- Implemented `mapSpinForPhysics` to apply clamping, response curve and to invert the UI Y-axis into physics-space so topspin/backspin match the visual controller. 
- Added unit tests in `test/poolRoyaleSpinController.test.js` that cover center/no-spin, left/right, up/down (top/back), diagonal quadrants, and magnitude scaling behavior. 

### Testing
- Ran the unit tests with `npm test -- poolRoyaleSpinController.test.js`. 
- Test suite `poolRoyaleSpinController.test.js` passed with 5 tests green. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965255dd3208329b4154cabd8462493)