### PR TITLE
Fix Pool Royale side spin direction

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,7 +43,8 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    x: curved.x,
+    // UI has +X to the right, physics expects +X for left english.
+    x: -curved.x,
     // UI has +Y downward; physics expects +Y for topspin.
     y: -curved.y
   };


### PR DESCRIPTION
### Motivation
- Players reported side-spin (english) behaving reversed when aiming toward cushions, causing left input to produce right spin and vice versa.
- The UI spin control uses a screen-space X/Y where `+X` is right, but the physics mapping expected the opposite sign for side spin.
- This mismatch breaks feel and predictability of spin-dependent behaviour (cushion throw, swerve, etc.).
- Fixing the input-to-physics mapping restores intuitive control and consistent shot outcomes.

### Description
- In `webapp/src/pages/Games/poolRoyaleSpinUtils.js` the `mapSpinForPhysics` function now negates the computed side component so UI left/right maps correctly to physics side spin (`x: -curved.x`).
- Added an inline comment documenting that the UI uses `+X` to the right while physics expects `+X` for left english to clarify the coordinate transform.
- Change is limited to the spin input mapping and does not modify downstream spin application logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696540980b308329b4b9a79e4ba870a6)