### PR TITLE
Fix spin controller vertical mapping

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -330,11 +330,12 @@
       function updateSpinDots (sx, sy) {
         const max = 40; // percentage offset inside parent
         const pos = (val) => `${50 + val * max}%`;
+        const posY = (val) => `${50 - val * max}%`;
         spinControllerDot.style.left = pos(sx);
-        spinControllerDot.style.top = pos(sy);
+        spinControllerDot.style.top = posY(sy);
         cueSpinDot.style.left = pos(sx);
         // move the cue ball's spin indicator to mirror controller input
-        cueSpinDot.style.top = pos(sy);
+        cueSpinDot.style.top = posY(sy);
       }
 
       // update spin both on click and while dragging for better precision


### PR DESCRIPTION
### Motivation
- The spin control's vertical indicator was inverted so `top` spin appeared at the bottom of the UI and cue-ball marker, which is visually confusing. 
- Align the visual mapping so positive/top spin appears higher on the screen in portrait orientation.

### Description
- Updated `examples/pool-royale/index.html` to add a `posY` helper and use `50 - val * max` to flip the vertical mapping inside `updateSpinDots`.
- Applied the corrected vertical mapping to both `spinControllerDot` and `cueSpinDot` so the controller and cue-ball indicator mirror each other.
- Left the input processing in `setSpin` unchanged (it still computes `rawSpin` with `y: -ny`) and uses the corrected display mapping when rendering.

### Testing
- Launched a local server with `python -m http.server` and loaded the demo page in a headless Chromium via Playwright to capture a screenshot. 
- The Playwright visual check (`artifacts/pool-royale-spin-controller.png`) completed successfully showing the corrected top/back spin placement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a4450dc8329b237650323a3c87a)