### PR TITLE
Fix spin controller orientation (topspin up, backspin down)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12081,7 +12081,7 @@ const powerRef = useRef(hud.power);
     const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 1e-6);
     const largest = Math.max(maxSide, maxVertical);
     const scaledX = (x * maxSide) / largest;
-    const scaledY = (y * maxVertical) / largest;
+    const scaledY = (-y * maxVertical) / largest;
     dot.style.left = `${50 + scaledX * 50}%`;
     dot.style.top = `${50 + scaledY * 50}%`;
     const magnitude = Math.hypot(x, y);
@@ -19707,7 +19707,7 @@ const powerRef = useRef(hud.power);
         const hasSpin = magnitude > 1e-4;
         const sideInput = spin?.x ?? 0;
         let side = hasSpin ? sideInput * offsetSide : 0;
-        let vert = hasSpin ? -spin.y * offsetVertical : 0;
+        let vert = hasSpin ? spin.y * offsetVertical : 0;
         if (hasSpin) {
           vert = THREE.MathUtils.clamp(vert, -MAX_SPIN_VISUAL_LIFT, MAX_SPIN_VISUAL_LIFT);
         }
@@ -20132,7 +20132,7 @@ const powerRef = useRef(hud.power);
             0,
             Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
           );
-          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, -(appliedSpin.y || 0)) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
           applyCueButtTilt(
@@ -22831,7 +22831,7 @@ const powerRef = useRef(hud.power);
           );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
+          const tiltAmount = hasSpin ? Math.max(0, -(appliedSpin.y || 0)) : 0;
           const liftTilt = resolveUserCueLift();
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftTilt;
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
@@ -24479,14 +24479,14 @@ const powerRef = useRef(hud.power);
     resetSpin();
     resetSpinRef.current = resetSpin;
 
-    const updateSpin = (clientX, clientY) => {
-      const rect = box.getBoundingClientRect();
-      const cx = clientX ?? rect.left + rect.width / 2;
-      const cy = clientY ?? rect.top + rect.height / 2;
-      let nx = ((cx - rect.left) / rect.width) * 2 - 1;
-      let ny = ((cy - rect.top) / rect.height) * 2 - 1;
-      setSpin(nx, ny);
-    };
+      const updateSpin = (clientX, clientY) => {
+        const rect = box.getBoundingClientRect();
+        const cx = clientX ?? rect.left + rect.width / 2;
+        const cy = clientY ?? rect.top + rect.height / 2;
+        let nx = ((cx - rect.left) / rect.width) * 2 - 1;
+        let ny = ((cy - rect.top) / rect.height) * 2 - 1;
+        setSpin(nx, -ny);
+      };
 
     const scaleBox = (value) => {
       box.style.transform = `scale(${value})`;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -45,7 +45,7 @@ export const mapSpinForPhysics = (spin) => {
   return {
     // UI has +X to the right, physics expects +X for left english.
     x: -curved.x,
-    // UI has +Y downward; physics expects +Y for topspin.
-    y: -curved.y
+    // UI has +Y upward; physics expects +Y for topspin.
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- The spin UI and physics mapping used an inconsistent vertical convention so upward UI input did not produce topspin in simulation.
- The visual spin dot and cue-tip offsets therefore needed to match the intended top/back/left/right labeling on the controller.
- Aligning UI, input and physics prevents confusing reversed behaviour for players when applying top/back spin.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the spin dot positioning was inverted by negating the Y when computing `scaledY` and the pointer-to-spin mapping was adjusted in `updateSpin` to use `setSpin(nx, -ny)` so UI input maps visually as expected.
- The cue-tip vertical offset calculation in `computeSpinOffsets` now uses `spin.y` (not `-spin.y`) and backspin/cue tilt computations now negate `appliedSpin.y` where appropriate so the cue animation matches the new vertical convention.
- In `webapp/src/pages/Games/poolRoyaleSpinUtils.js` the spin->physics mapping (`mapSpinForPhysics`) was updated so the UI Y (now interpreted as upward for topspin) maps correctly into physics by returning `y: curved.y` and updated comments.
- Changes are limited to `PoolRoyale.jsx` and `poolRoyaleSpinUtils.js` to keep the UI, input and physics spin direction consistent.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the Vite server reported ready (server start succeeded).
- Attempted automated browser screenshot via Playwright to visually verify the controller but the screenshot attempts timed out (Playwright failed due to timeouts).
- No automated unit tests (`npm test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a4450dc8329b237650323a3c87a)