### PR TITLE
Fix Pool Royale spin controller mapping

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,8 +43,8 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI has +X to the right, physics expects +X for left english.
-    x: -curved.x,
+    // UI has +X to the right; physics should match left/right as shown.
+    x: curved.x,
     // UI has +Y downward; physics expects +Y for topspin.
     y: -curved.y
   };


### PR DESCRIPTION
### Motivation
- The spin controller UI showed directions that did not match physics for left/right english, causing left/right inputs to be mirrored.
- The intent is to make `top` map to topspin, `back` to backspin, and left/right to the expected english directions on screen.

### Description
- Updated `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to stop negating the X component so horizontal input matches the controller (`x: curved.x`).
- Kept the Y inversion (`y: -curved.y`) so the vertical UI mapping continues to translate down=>backspin and up=>topspin.
- Change is minimal and localized to the spin mapping helper to avoid touching broader physics or UI code.

### Testing
- A unit test covering the mapping exists at `test/poolRoyaleSpinController.test.js` which asserts left/right and top/back sign behavior.
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a4450dc8329b237650323a3c87a)