### PR TITLE
Restore Pool Royale 2D camera angle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4754,9 +4754,9 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
-const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
   z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale 2D/top-down camera framing to the previous overhead view so the 2D button shows the same camera as before.
- The prior change locked the top view to a flat overhead (`0`), which changed the visual framing on portrait phones and broke the expected 2D view.

### Description
- Replaced the hard `0` top-view angle with a computed angle using `Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22)` and updated `TOP_VIEW_RESOLVED_PHI` to `Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5)`.
- The single modified file is `webapp/src/pages/Games/PoolRoyale.jsx`, restoring the 2D/top-view camera constants to the previous behavior.

### Testing
- No automated tests were executed for this change.
- Manual visual verification was not performed in CI as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c89df64883299ce992cf2b0d5073)