### PR TITLE
Restore Pool Royale 2D camera tilt

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4754,9 +4754,9 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
-const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
   z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left


### PR DESCRIPTION
### Motivation
- Restore the 2D top-view camera framing for Pool Royale so the `2D` button returns the same overhead tilt and framing used previously.
- The prior change locked the top view to a perfectly overhead camera which altered the portrait framing and broadcast alignment.

### Description
- Reverted the `TOP_VIEW_PHI` constant in `webapp/src/pages/Games/PoolRoyale.jsx` to compute an angled top-view using `Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22)` instead of `0`.
- Restored `TOP_VIEW_RESOLVED_PHI` to `Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5)` so overhead/broadcast cameras keep the intended small tilt.
- Changes preserve the existing `TOP_VIEW_RADIUS_SCALE` and broadcast distance math so portrait framing and rail coverage remain consistent.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the app served successfully at the configured host/port. 
- Attempted an automated screenshot of `/games/poolroyale` with Playwright but the capture timed out (failed).
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c89df64883299ce992cf2b0d5073)