### PR TITLE
Restore Pool Royale 2D top view angle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4754,9 +4754,9 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
+const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
-const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
+const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
   z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left


### PR DESCRIPTION
### Motivation
- The 2D camera for Pool Royale should match the previous straight-overhead framing that players expect from the 2D view toggle.
- Recent adjustments made the top-down view tilt slightly for depth, but the 2D button must restore the original flat overhead for clearer 2D play.

### Description
- Reset the 2D/top-down view angle by setting `TOP_VIEW_PHI = 0` so the 2D camera is locked to a straight overhead.
- Make `TOP_VIEW_RESOLVED_PHI` equal to `TOP_VIEW_PHI` to ensure downstream code uses the locked overhead value.
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing margin/scale constants used for portrait framing.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev`, and Vite reported as ready (local server available), which succeeded. 
- Attempted an automated Playwright screenshot of the Pool Royale 2D page, but the run timed out and the screenshot step failed. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965cdea28e483298f57d3517059c77a)