### PR TITLE
Adjust Pool Royale top-down camera offset for legacy portrait framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
-  z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left
+  x: -PLAY_W * 0.022, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.018 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.


### PR DESCRIPTION
### Motivation
- Restore the 2D/top-down camera framing to match the legacy portrait reference so the table appears in the same place as the photo.
- This is a purely visual/UX change to improve portrait onboarding and consistency with last week's calibration.

### Description
- Update `TOP_VIEW_SCREEN_OFFSET` in `webapp/src/pages/Games/PoolRoyale.jsx` to new portrait offsets.
- Changed `x` from `-PLAY_W * 0.015` to `-PLAY_W * 0.022` and `z` from `-PLAY_H * 0.012` to `-PLAY_H * 0.018` to raise and shift the top-down framing.
- No other gameplay or logic changes were made.

### Testing
- Started the local dev server (`npm --prefix webapp run dev`) and Vite reported the app ready and serving on the configured port.
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the screenshot step timed out and did not complete.
- No unit tests were executed since this is a visual-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d3153df0832984d899ac602c14bb)