### PR TITLE
Fix Pool Royale spin controller directions and restore straight 2D top-down camera

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -17,21 +17,21 @@ describe('Pool Royale spin controller mapping', () => {
     expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(1);
   });
 
-  it('maps up to topspin and down to backspin', () => {
-    expect(getSigns(mapSpinForPhysics({ x: 0, y: -1 })).y).toBe(1);
-    expect(getSigns(mapSpinForPhysics({ x: 0, y: 1 })).y).toBe(-1);
+  it('treats positive y as topspin and negative y as backspin', () => {
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: 1 })).y).toBe(1);
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: -1 })).y).toBe(-1);
   });
 
   it('preserves diagonal quadrants without mirroring', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: 1 });
   });
 
   it('scales spin strength with distance from center', () => {
-    const inner = Math.abs(mapSpinForPhysics({ x: 0, y: -0.4 }).y);
-    const outer = Math.abs(mapSpinForPhysics({ x: 0, y: -0.9 }).y);
+    const inner = Math.abs(mapSpinForPhysics({ x: 0, y: 0.4 }).y);
+    const outer = Math.abs(mapSpinForPhysics({ x: 0, y: 0.9 }).y);
     expect(inner).toBeGreaterThan(0);
     expect(outer).toBeGreaterThan(inner);
   });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11982,7 +11982,7 @@ const powerRef = useRef(hud.power);
   const fitRef = useRef(() => {});
   const topViewRef = useRef(false);
   const topViewLockedRef = useRef(false);
-  const overheadBroadcastVariantRef = useRef('replay');
+  const overheadBroadcastVariantRef = useRef('top');
   const preShotTopViewRef = useRef(false);
   const preShotTopViewLockRef = useRef(false);
   const sidePocketAimRef = useRef(false);
@@ -12076,12 +12076,13 @@ const powerRef = useRef(hud.power);
     if (!dot) return;
     const x = clamp(value.x ?? 0, -1, 1);
     const y = clamp(value.y ?? 0, -1, 1);
+    const displayY = -y;
     const ranges = spinRangeRef.current || {};
     const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 1e-6);
     const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 1e-6);
     const largest = Math.max(maxSide, maxVertical);
     const scaledX = (x * maxSide) / largest;
-    const scaledY = (y * maxVertical) / largest;
+    const scaledY = (displayY * maxVertical) / largest;
     dot.style.left = `${50 + scaledX * 50}%`;
     dot.style.top = `${50 + scaledY * 50}%`;
     const magnitude = Math.hypot(x, y);
@@ -17372,7 +17373,7 @@ const powerRef = useRef(hud.power);
         const enterTopView = (immediate = false) => {
           topViewRef.current = true;
           topViewLockedRef.current = true;
-          overheadBroadcastVariantRef.current = 'replay';
+          overheadBroadcastVariantRef.current = 'top';
           const margin = TOP_VIEW_MARGIN;
           fit(margin);
           const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
@@ -24485,7 +24486,7 @@ const powerRef = useRef(hud.power);
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
       let ny = ((cy - rect.top) / rect.height) * 2 - 1;
-      setSpin(nx, ny);
+      setSpin(nx, -ny);
     };
 
     const scaleBox = (value) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -45,7 +45,7 @@ export const mapSpinForPhysics = (spin) => {
   return {
     // UI has +X to the right; physics should match left/right as shown.
     x: curved.x,
-    // UI has +Y downward; physics expects +Y for topspin.
-    y: -curved.y
+    // UI uses +Y for topspin; physics expects +Y for topspin.
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Restore the spin-controller direction convention so dragging toward the top of the control produces topspin as before.
- Keep the existing spin response/strength logic but fix the direction mapping between UI and physics.
- Return the 2D/top-down camera to a straight overhead variant to match the previous visual framing.
- Keep controller dot placement consistent with the corrected spin sign so the UI matches physics.

### Description
- Updated `mapSpinForPhysics` in `poolRoyaleSpinUtils.js` to stop negating the Y component so positive Y now means topspin (`y` preserved instead of `-y`).
- Adjusted the spin controller UI logic in `PoolRoyale.jsx` so the displayed dot and input mapping invert the screen Y appropriately (`displayY = -y` and `setSpin(nx, -ny)`).
- Force the top-down camera broadcast variant to use the straight overhead mode by changing `overheadBroadcastVariantRef` default to `'top'` and setting it to `'top'` in `enterTopView` in `PoolRoyale.jsx`.
- Updated the unit test expectations in `test/poolRoyaleSpinController.test.js` to reflect the revised direction convention (positive Y = topspin) and adjusted diagonal/quadrant assertions.

### Testing
- The spin controller unit test file `test/poolRoyaleSpinController.test.js` was updated to match the new convention but no test runner was executed in this rollout.
- No automated CI or `npm test` run was performed during this change set.
- Manual runtime verification was not performed in this environment (changes are limited to input mapping and camera variant selection).
- Developers should run the existing Jest suite (`npm test`) and exercise the in-game spin controller and top-down view to confirm behavior on device.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d802ee5883299acba7a9a5d5ffb1)