### PR TITLE
Pool Royale: tweak HUD layout, resize spin controller, and refine backspin behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1450,7 +1450,7 @@ const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 1.85 * 1.35 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
-const SPIN_CONTROL_DIAMETER_PX = 138;
+const SPIN_CONTROL_DIAMETER_PX = 130;
 const SPIN_DOT_DIAMETER_PX = 16;
 const SPIN_RING_THICKNESS_PX = 14;
 const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
@@ -23299,7 +23299,7 @@ const powerRef = useRef(hud.power);
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
+                  const forwardMag = Math.max(0, TMP_VEC2_SPIN.dot(launchDir));
                   TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
                   b.vel.add(TMP_VEC2_AXIS);
                   TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
@@ -24957,7 +24957,7 @@ const powerRef = useRef(hud.power);
       )}
 
       <div
-        className={`absolute top-4 left-4 z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
+        className={`absolute top-3 left-3 z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
       >
         <button
           ref={configButtonRef}
@@ -25565,7 +25565,7 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute left-3 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute left-2 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
           bottom: `${16 + chromeUiLiftPx}px`,
           transform: `scale(${uiScale * 1.06})`,
@@ -25750,9 +25750,9 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-2 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute right-1 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${28 + chromeUiLiftPx}px`,
+            bottom: `${20 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale})`,
             transformOrigin: 'bottom right'
           }}

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const SPIN_INPUT_DEAD_ZONE = 0.02;
-export const SPIN_RESPONSE_EXPONENT = 1.65;
+export const SPIN_INPUT_DEAD_ZONE = 0.015;
+export const SPIN_RESPONSE_EXPONENT = 1.75;
 
 export const clampToUnitCircle = (x, y) => {
   const length = Math.hypot(x, y);


### PR DESCRIPTION
### Motivation
- Improve Pool Royale mobile (portrait) UX by nudging the 2D/view and config buttons and better positioning the spin controller to match the requested screen layout.
- Make the spinning controller slightly smaller and adjust its position so it appears more to the right and down on portrait screens.
- Ensure applying backspin behaves like a normal-power shot while making the cue ball roll backwards on impact rather than reducing forward power pre-impact.
- Calibrate the spin input/response curve for a more professional, sensitive feel matching visual feedback.

### Description
- Reduced the spin controller visual diameter by changing `SPIN_CONTROL_DIAMETER_PX` from `138` to `130` in `PoolRoyale.jsx` and adjusted the controller container `right` and `bottom` offsets from `right-2/bottom:28px` to `right-1/bottom:20px` to move it slightly right and down.
- Nudged the configuration button and HUD: moved the config group from `top-4 left-4` to `top-3 left-3`, and shifted the left control column from `left-3` to `left-2` to move those buttons a bit left/up as requested in portrait.
- Prevented pre-impact backspin from reducing forward shot momentum by clamping the pre-impact forward spin contribution with `Math.max(0, TMP_VEC2_SPIN.dot(launchDir))` so the cue-ball keeps normal shot power while still allowing the cue ball to roll/backspin on impact (`PoolRoyale.jsx`).
- Recalibrated spin input sensitivity by lowering `SPIN_INPUT_DEAD_ZONE` from `0.02` to `0.015` and increasing `SPIN_RESPONSE_EXPONENT` from `1.65` to `1.75` in `poolRoyaleSpinUtils.js` for crisper edge response and finer control.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, indicating the app builds and serves successfully in dev mode.
- Attempted an automated Playwright screenshot of `/games/poolroyale` to verify visual placement, but the screenshot run timed out and failed.
- No unit tests were modified or executed as part of this change.
- Changes were committed locally (`Adjust Pool Royale spin controls and backspin behavior`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e0aae9d08329aef541d095a5ccfc)