### PR TITLE
Fix snooker phase transition after final red

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -254,6 +254,14 @@ export class SnookerRoyalRules {
     } else if (pottedNonCue.length === 0) {
       nextActivePlayer = state.activePlayer === 'A' ? 'B' : 'A';
       nextBreak = 0;
+      if (state.phase === 'REDS_AND_COLORS') {
+        if (redsRemaining === 0) {
+          nextPhase = 'COLORS_ORDER';
+          colorOnAfterRed = false;
+        } else {
+          colorOnAfterRed = false;
+        }
+      }
     } else {
       if (state.phase === 'REDS_AND_COLORS' && !state.colorOnAfterRed) {
         const freeBallScore = freeBallPotted ? COLOR_VALUES.RED : 0;
@@ -262,7 +270,12 @@ export class SnookerRoyalRules {
         scores[state.activePlayer] += scored;
         nextBreak = (state.currentBreak ?? 0) + scored;
         if (pottedReds.length > 0 || freeBallPotted) {
-          colorOnAfterRed = true;
+          if (redsRemaining === 0) {
+            nextPhase = 'COLORS_ORDER';
+            colorOnAfterRed = false;
+          } else {
+            colorOnAfterRed = true;
+          }
         }
       } else if (state.phase === 'REDS_AND_COLORS' && state.colorOnAfterRed) {
         const color = declaredBall ?? pottedColors[0] ?? nominatedFreeBall;


### PR DESCRIPTION
### Motivation
- Ensure the rules engine follows snooker rule that the frame moves into `COLORS_ORDER` immediately when the last red (or a free ball treated as a red) is removed from play.
- Prevent lingering `colorOnAfterRed` state after the final red is gone which could cause incorrect ball nominations or illegal-first-contact detection.
- Make no-pot (miss) visits behave deterministically when there are no reds left by advancing the phase rather than leaving ambiguous state.
- Keep ball-on resolution consistent with the absolute game state rules for end-of-reds transitions.

### Description
- Updated `applyShot` logic in `SnookerRoyalRules` so an empty visit (`pottedNonCue.length === 0`) will set `nextPhase = 'COLORS_ORDER'` and clear `colorOnAfterRed` when `redsRemaining === 0`.
- When a red (or free ball counted as red) is potted and `redsRemaining` becomes 0 the code now immediately sets `nextPhase = 'COLORS_ORDER'` and clears `colorOnAfterRed` instead of leaving it true.
- Preserved existing foul and scoring logic while ensuring `ballOn` is resolved against the updated `phase` and `colorOnAfterRed` values.
- Changes are localized to `src/rules/SnookerRoyalRules.ts` within the `applyShot` flow for the `REDS_AND_COLORS` / `COLORS_ORDER` transitions.

### Testing
- No automated tests were run as part of this change.
- Recommend running the unit test suite (e.g. `npm test` / `jest`) and the snooker rule-specific tests to validate edge cases around the last-red and free-ball-as-red scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ed2423048329a5989d39200dda5e)