### PR TITLE
Pool Royale: move config to top-right, nudge left controls, invert spin X input

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24490,7 +24490,7 @@ const powerRef = useRef(hud.power);
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
       let ny = ((cy - rect.top) / rect.height) * 2 - 1;
-      setSpin(nx, -ny);
+      setSpin(-nx, -ny);
     };
 
     const scaleBox = (value) => {
@@ -24961,7 +24961,7 @@ const powerRef = useRef(hud.power);
       )}
 
       <div
-        className={`absolute top-2 left-2 z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
+        className={`absolute top-2 right-2 z-50 flex flex-col items-end gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
       >
         <button
           ref={configButtonRef}
@@ -25569,9 +25569,9 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute left-1 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute left-0 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${10 + chromeUiLiftPx}px`,
+          bottom: `${28 + chromeUiLiftPx}px`,
           transform: `scale(${uiScale * 1.06})`,
           transformOrigin: 'bottom left'
         }}


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving the configuration button stack to the top-right so it no longer collides with other HUD elements.
- Shift the left control stack upward and slightly left to make room for the 2D tutorial overlay and better visual alignment on portrait screens.
- Fix the mismatch between the spinning controller's horizontal drag direction and the cueball spin so left/right on the control matches the expected result.

### Description
- Moved the config button container from the top-left to the top-right and updated layout classes to `items-end` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjusted the left controls container position (`left` → `left-0`) and raised it by increasing the bottom offset from `10 + chromeUiLiftPx` to `28 + chromeUiLiftPx` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Reversed the spin controller horizontal mapping by changing `setSpin(nx, -ny)` to `setSpin(-nx, -ny)` so left/right are swapped without affecting vertical behavior (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, indicating the app built and served successfully.
- Attempted an automated UI capture using Playwright to validate the visual placement, but the Playwright run timed out while loading the Pool Royale view.
- No unit test suite was executed for these changes during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f48451e483298bb81704a2838fe3)