### PR TITLE
Pool Royale: move config to top-right, nudge left controls, and invert side-spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24961,7 +24961,7 @@ const powerRef = useRef(hud.power);
       )}
 
       <div
-        className={`absolute top-2 left-2 z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
+        className={`absolute top-2 right-2 z-50 flex flex-col items-end gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
       >
         <button
           ref={configButtonRef}
@@ -24999,7 +24999,7 @@ const powerRef = useRef(hud.power);
           <div
             id="snooker-config-panel"
             ref={configPanelRef}
-            className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur"
+            className="pointer-events-auto mt-2 w-72 max-w-[80vw] self-end rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur"
           >
             <div className="flex items-center justify-between gap-4">
               <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">
@@ -25569,9 +25569,9 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute left-1 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute left-0 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${10 + chromeUiLiftPx}px`,
+          bottom: `${28 + chromeUiLiftPx}px`,
           transform: `scale(${uiScale * 1.06})`,
           transformOrigin: 'bottom left'
         }}

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,8 +43,8 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI has +X to the right; physics should match left/right as shown.
-    x: curved.x,
+    // UI has +X to the right; physics uses the opposite sign for side spin.
+    x: -curved.x,
     // UI uses +Y for topspin; physics expects +Y for topspin.
     y: curved.y
   };


### PR DESCRIPTION
### Motivation
- Improve portrait HUD layout by moving the table configuration control out of the left/top area so tutorial elements and the spin controller no longer overlap. 
- Shift the left control cluster upward to create visual space for 2D tutorial content on portrait screens. 
- Make side-spin directions intuitive by ensuring the UI left/right input matches the physics side-spin direction. 

### Description
- Moved the config/settings button from top-left to top-right and right-aligned its panel by updating `webapp/src/pages/Games/PoolRoyale.jsx` (`configButtonRef` and panel `self-end`).
- Adjusted the left control cluster positioning by changing the container to `left-0` and increasing the bottom offset to `28 + chromeUiLiftPx` in `PoolRoyale.jsx` so tutorial placement is less obstructed.
- Inverted the side-spin sign by negating the x component returned from `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so `left`/`right` on the controller match physics as shown.

### Testing
- Started the dev server with `npm --prefix webapp run dev` (Vite) which reported ready and served the app (succeeded).
- Attempted an automated Playwright screenshot to validate UI placement but the headless browser crashed (Playwright `TargetClosedError` / SIGSEGV), so the visual check failed.
- No unit/test-suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f48451e483298bb81704a2838fe3)