### PR TITLE
Adjust Pool Royale HUD sizing and 2D view framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.03, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.026 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.04, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.035 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -4878,7 +4878,7 @@ const PLAYER_STROKE_PULLBACK_FACTOR = 0.68;
 const PLAYER_PULLBACK_MIN_SCALE = 1.1;
 const MIN_PULLBACK_GAP = BALL_R * 0.5;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
-const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 100;
+const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 60;
 const REPLAY_CAMERA_SWITCH_THRESHOLD = BALL_R * 0.35;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
@@ -24629,8 +24629,8 @@ const powerRef = useRef(hud.power);
     },
     [ballPreviewCache]
   );
-  const pottedTokenSize = isPortrait ? 20 : 22;
-  const pottedGap = isPortrait ? 7 : 9;
+  const pottedTokenSize = isPortrait ? 24 : 26;
+  const pottedGap = isPortrait ? 8 : 10;
   const renderPottedRow = useCallback(
     (entries = []) => {
       if (!entries.length) {
@@ -24732,11 +24732,11 @@ const powerRef = useRef(hud.power);
   const playerPotted = pottedBySeat[playerSeatId] || [];
   const opponentPotted = pottedBySeat[opponentSeatId] || [];
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive;
-  const bottomHudScale = isPortrait ? uiScale * 0.99 : uiScale * 1.06;
-  const avatarSizeClass = isPortrait ? 'h-[2.25rem] w-[2.25rem]' : 'h-[3.25rem] w-[3.25rem]';
-  const nameWidthClass = isPortrait ? 'max-w-[7rem]' : 'max-w-[9.25rem]';
-  const nameTextClass = isPortrait ? 'text-xs' : 'text-sm';
-  const hudGapClass = isPortrait ? 'gap-3' : 'gap-5';
+  const bottomHudScale = isPortrait ? uiScale * 1.08 : uiScale * 1.12;
+  const avatarSizeClass = isPortrait ? 'h-[2.6rem] w-[2.6rem]' : 'h-[3.5rem] w-[3.5rem]';
+  const nameWidthClass = isPortrait ? 'max-w-[8rem]' : 'max-w-[10rem]';
+  const nameTextClass = isPortrait ? 'text-sm' : 'text-base';
+  const hudGapClass = isPortrait ? 'gap-4' : 'gap-6';
   const bottomHudLayoutClass = isPortrait ? 'justify-center px-4 w-full' : 'justify-center';
   const playerPanelClass = isPortrait
     ? `flex min-w-0 items-center gap-2.5 rounded-full ${isPlayerTurn ? 'text-white' : 'text-white/80'}`
@@ -25575,10 +25575,10 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute right-3 z-50 flex flex-col gap-2 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute right-2 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 36 + chromeUiLiftPx}px`,
-          transform: `scale(${uiScale * 1.02})`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX + 16 + chromeUiLiftPx}px`,
+          transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}
       >
@@ -25586,7 +25586,7 @@ const powerRef = useRef(hud.power);
           type="button"
           aria-pressed={isLookMode}
           onClick={() => setIsLookMode((prev) => !prev)}
-          className={`pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border text-lg font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+          className={`pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full border text-xl font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
             isLookMode
               ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
               : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
@@ -25599,7 +25599,7 @@ const powerRef = useRef(hud.power);
           type="button"
           aria-pressed={isTopDownView}
           onClick={() => setIsTopDownView((prev) => !prev)}
-          className={`pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border text-[11px] font-semibold uppercase tracking-[0.28em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+          className={`pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full border text-[12px] font-semibold uppercase tracking-[0.28em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
             isTopDownView
               ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
               : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
@@ -25760,7 +25760,7 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-0 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute right-2 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
             bottom: `${12 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,


### PR DESCRIPTION
### Motivation

- Improve portrait UI ergonomics so the 2D/View controls, bottom HUD and spin controller sit better around the spinner on phone screens. 
- Make the player avatars, names and potted balls more legible by increasing size and spacing in the bottom HUD.
- Nudge the top-down (2D) camera framing so the table appears slightly higher and more left on portrait screens to match requested visual balance.

### Description

- Updated layout and camera constants in `webapp/src/pages/Games/PoolRoyale.jsx` including `TOP_VIEW_SCREEN_OFFSET.x` and `.z` to bias the 2D view upward/left and reduced `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` from `100` to `60` to shift centering toward the spin controller. 
- Enlarged bottom HUD elements by increasing potted token size (`pottedTokenSize` to `24/26`), `pottedGap`, `bottomHudScale`, avatar size classes, name width/text classes, and HUD gaps to make avatars, usernames and potted balls larger. 
- Increased look/2D control button sizes and spacing and pulled them slightly downward and closer to the spin control by adjusting the left controls container (scale, bottom offset, button `h/w` and `right` offsets). 
- Nudged the spin controller horizontally (`right` changed from `0` to `2`) to place the spinner a bit left relative to the control cluster.

### Testing

- Started the development server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported the site as ready (served at the listed addresses), which indicates the application mounts with the changes. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` on a 430x932 viewport, but the script timed out before the capture completed. 
- No unit tests were executed as part of this change. 
- Manual visual QA is recommended on a portrait phone viewport to confirm spacing/placement and to iterate if small pixel adjustments are needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966161585188329833072d8186f2a45)