### PR TITLE
Adjust Pool Royale 2D camera and HUD controls positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.04, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.035 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.052, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.048 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -25575,9 +25575,9 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute right-2 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute right-1 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 16 + chromeUiLiftPx}px`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}
@@ -25622,7 +25622,7 @@ const powerRef = useRef(hud.power);
           }}
         >
           <div
-            className={`pointer-events-auto flex min-h-[3rem] max-w-full items-center justify-center ${hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'px-5 py-2' : 'px-6 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
+            className={`pointer-events-auto flex min-h-[3rem] max-w-full items-center justify-center ${hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'pl-5 pr-7 py-2' : 'pl-6 pr-8 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
             style={{
               transform: `scale(${bottomHudScale})`,
               transformOrigin: 'bottom center',
@@ -25762,7 +25762,7 @@ const powerRef = useRef(hud.power);
           ref={spinBoxRef}
           className={`absolute right-2 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${12 + chromeUiLiftPx}px`,
+            bottom: `${6 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,
             transformOrigin: 'bottom right'
           }}


### PR DESCRIPTION
### Motivation
- Make the 2D/top-down table framing sit slightly higher and a bit more left on portrait screens so the playfield reads better. 
- Move the 2D/`3D` view buttons slightly toward the right edge and down so they line up better with the control cluster. 
- Lower the spin controller a bit to improve reach and visual alignment with the HUD. 
- Shift the HUD frame padding to visually expand the right-side player/opponent frames toward the spin controller without changing their contents.

### Description
- Updated the top-view screen bias in `PoolRoyale.jsx` by changing `TOP_VIEW_SCREEN_OFFSET` (`x` and `z`) so the table appears more up and left in the 2D view. 
- Nudged the view buttons container by changing the wrapper from `right-2` to `right-1` and reduced its bottom offset (controlled via `SPIN_CONTROL_DIAMETER_PX + ...`). 
- Lowered the spin controller by reducing its `bottom` style value from `12 + chromeUiLiftPx` to `6 + chromeUiLiftPx` in the `spinBox` wrapper. 
- Widened the HUD right padding by changing the bottom HUD container classes (replacing symmetric `px-*` with `pl-* pr-*`) to push the avatar/name frames more to the right toward the spin controller; all edits are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready at `http://localhost:4173/`. 
- Attempted automated UI snapshot using Playwright but the screenshot step timed out, so no visual snapshot was captured. 
- No unit or Jest tests were run for this layout-only change. 
- Changes were committed to the repository and are ready for review and manual QA on a portrait mobile viewport (recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966197ff06c8329944e87a5da114011)