### PR TITLE
Adjust Pool Royale 2D camera framing and lower view controls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.052, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.048 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.062, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.06 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -25577,7 +25577,7 @@ const powerRef = useRef(hud.power);
         ref={leftControlsRef}
         className={`pointer-events-none absolute right-1 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx}px`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX - 12 + 8 + chromeUiLiftPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}


### PR DESCRIPTION
### Motivation
- Align the 2D top-down framing so the table appears slightly higher and more to the left on portrait screens per UX request. 
- Make the `2D` / `view` control buttons sit lower on the screen so they do not overlap or feel too high on mobile portrait. 

### Description
- Updated `TOP_VIEW_SCREEN_OFFSET` in `webapp/src/pages/Games/PoolRoyale.jsx` to `x: -PLAY_W * 0.062` and `z: -PLAY_H * 0.06` to shift the 2D camera framing. 
- Adjusted the left controls container `style.bottom` calculation to use `SPIN_CONTROL_DIAMETER_PX - 12 + 8 + chromeUiLiftPx` to move the look/top-down buttons down. 
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect top-down camera bias and HUD control placement. 

### Testing
- No automated tests were executed for this change. 
- Verified the code compiles in the repo context (file updated and committed) but the app was not run for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662b588f9c832996bcecbe36f4e2d9)