### PR TITLE
Adjust Pool Royale 2D top-down framing and lower view buttons

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.052, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.048 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.065, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.062 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -10885,6 +10885,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
+  const viewButtonsOffsetPx = 12;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );
@@ -25577,7 +25578,7 @@ const powerRef = useRef(hud.power);
         ref={leftControlsRef}
         className={`pointer-events-none absolute right-1 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx}px`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx - viewButtonsOffsetPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}


### PR DESCRIPTION
### Motivation
- The 2D top-down camera framing should show the table shifted slightly left and higher on portrait screens to match legacy portrait framing.
- The `2D` / view toggle buttons need to sit lower on screen so controls don't overlap important play area on mobile portrait.

### Description
- Tweaked `TOP_VIEW_SCREEN_OFFSET` in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing the `x` and `z` bias so the top-down table appears more left and higher on screen. 
- Added a `viewButtonsOffsetPx` constant and subtracted it from the button cluster `style.bottom` for the `leftControlsRef` so the look/2D buttons render lower on the screen. 
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect portrait/top-down UI framing and control placement.

### Testing
- Launched the dev server with `npm --prefix webapp run dev` which started Vite successfully and served the app (succeeded). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the browser process crashed with a SIGSEGV during the run (failed). 
- No unit or integration test suites were executed as part of this change (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662b588f9c832996bcecbe36f4e2d9)