### PR TITLE
Fix PWA offline cache auto-warm behavior

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -52,10 +52,14 @@ export default function Home() {
   const walletAddress = useTonAddress();
   const [tonConnectUI] = useTonConnectUI();
 
-  const handlePwaDownload = useCallback(async (autoTriggered = false) => {
+  const handlePwaDownload = useCallback(async ({ autoTriggered = false, isUpdate = false } = {}) => {
     setPwaDownloadStatus({
       state: 'working',
-      message: autoTriggered ? 'Preparing Telegram offline package…' : 'Preparing offline download…'
+      message: autoTriggered
+        ? isUpdate
+          ? 'Updating cached assets…'
+          : 'Preparing Telegram offline package…'
+        : 'Preparing offline download…'
     });
 
     try {
@@ -85,8 +89,11 @@ export default function Home() {
 
 
   useEffect(() => {
-    if (isTelegramEnvironment() && shouldAutoWarmOfflineCache()) {
-      handlePwaDownload(true);
+    if (isTelegramEnvironment()) {
+      const { shouldWarm, isUpdate } = shouldAutoWarmOfflineCache();
+      if (shouldWarm) {
+        handlePwaDownload({ autoTriggered: true, isUpdate });
+      }
     }
   }, [handlePwaDownload]);
 
@@ -283,7 +290,7 @@ export default function Home() {
         <div className="space-y-3">
           <button
             type="button"
-            onClick={handlePwaDownload}
+            onClick={() => handlePwaDownload()}
             className="w-full inline-flex items-center justify-center px-3 py-2 text-sm font-semibold bg-primary text-surface rounded-full shadow-primary/40 hover:shadow-primary/60 shadow disabled:opacity-60 disabled:cursor-not-allowed"
             disabled={pwaDownloadStatus.state === 'working'}
           >

--- a/webapp/src/pwa/offlineCache.js
+++ b/webapp/src/pwa/offlineCache.js
@@ -2,6 +2,7 @@ import { RUNTIME_CACHE_NAME } from './preloadGames.js';
 
 const OFFLINE_MANIFEST_PATH = 'pwa/offline-assets.json';
 const OFFLINE_CACHE_VERSION_KEY = 'tonplaygram-offline-cache-version';
+const OFFLINE_CACHE_ENABLED_KEY = 'tonplaygram-offline-cache-enabled';
 
 const normalizeBaseUrl = base => {
   if (!base) return '/';
@@ -11,8 +12,19 @@ const normalizeBaseUrl = base => {
 export const isTelegramEnvironment = () => Boolean(window.Telegram?.WebApp);
 
 export const shouldAutoWarmOfflineCache = () => {
-  const stored = localStorage.getItem(OFFLINE_CACHE_VERSION_KEY);
-  return stored !== RUNTIME_CACHE_NAME;
+  const storedVersion = localStorage.getItem(OFFLINE_CACHE_VERSION_KEY);
+  const enabled = localStorage.getItem(OFFLINE_CACHE_ENABLED_KEY) === '1';
+
+  if (!enabled && !storedVersion) {
+    return { shouldWarm: true, isUpdate: false };
+  }
+
+  if (!enabled) {
+    return { shouldWarm: false, isUpdate: false };
+  }
+
+  const isUpdate = storedVersion !== RUNTIME_CACHE_NAME;
+  return { shouldWarm: isUpdate, isUpdate };
 };
 
 export async function cacheOfflineAssets({ baseUrl = '/', onUpdate } = {}) {
@@ -68,6 +80,7 @@ export async function cacheOfflineAssets({ baseUrl = '/', onUpdate } = {}) {
   }
 
   localStorage.setItem(OFFLINE_CACHE_VERSION_KEY, RUNTIME_CACHE_NAME);
+  localStorage.setItem(OFFLINE_CACHE_ENABLED_KEY, '1');
 
   return { successes, total: assets.length, failures };
 }


### PR DESCRIPTION
### Motivation
- Prevent the Telegram PWA from re-downloading the full offline asset pack on every visit by tracking whether offline caching was previously enabled.  
- Ensure the app auto-applies cache updates only when the packaged build changes (so users get updates when they revisit).  
- Improve user messaging for automatic runs vs manual downloads and avoid accidentally passing DOM click events into the downloader.

### Description
- Add `OFFLINE_CACHE_ENABLED_KEY` and persist it after a successful run in `webapp/src/pwa/offlineCache.js` by setting the flag when `cacheOfflineAssets` completes.  
- Change `shouldAutoWarmOfflineCache` to return an object `{ shouldWarm, isUpdate }` and implement logic to: auto-warm on first visit, skip warm when disabled, and detect build updates by comparing stored vs current `RUNTIME_CACHE_NAME`.  
- Update the Home page download flow in `webapp/src/pages/Home.jsx` to accept `handlePwaDownload({ autoTriggered, isUpdate })`, surface an update-specific message (`Updating cached assets…`) and only auto-run when `shouldWarm` is true.  
- Avoid passing the raw click event into the downloader by calling the button handler as `onClick={() => handlePwaDownload()}` instead of `onClick={handlePwaDownload}`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663039eb8c8329acb56c75835d0040)