### PR TITLE
Nudge Pool Royale top-down framing and shift view buttons

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.052, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.048 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.042, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.038 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -10885,6 +10885,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
+  const viewButtonsOffsetPx = 12;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );
@@ -25577,7 +25578,7 @@ const powerRef = useRef(hud.power);
         ref={leftControlsRef}
         className={`pointer-events-none absolute right-1 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx}px`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx - viewButtonsOffsetPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}


### PR DESCRIPTION
### Motivation
- Align the 2D top-down portrait framing so the table appears slightly higher and more left on phone portrait screens.
- Keep control placement visually consistent by shifting the view buttons to match the framing nudge.
- Limit the change to rendering/framing and UI positioning without touching gameplay logic.
- Fulfill the request to move elements a bit more in the same visual direction as the prior adjustment.

### Description
- Updated `TOP_VIEW_SCREEN_OFFSET` in `webapp/src/pages/Games/PoolRoyale.jsx` to `x: -PLAY_W * 0.042` and `z: -PLAY_H * 0.038` to nudge the top-down camera framing higher/left on portrait screens.
- Added `viewButtonsOffsetPx = 12` and adjusted the left-controls `bottom` style to subtract `viewButtonsOffsetPx` so the view buttons shift slightly with the new framing.
- Changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect camera offset and control positioning.
- No gameplay logic or other UI clusters were modified by this change.

### Testing
- Ran `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the Vite dev server started successfully.
- Attempted a Playwright screenshot of `/games/poolroyale` at a 430x932 viewport, but Chromium crashed (SIGSEGV) so the capture failed.
- No unit or integration test suites were executed for this change.
- The modified file was staged and committed locally as part of the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662b588f9c832996bcecbe36f4e2d9)