### PR TITLE
Adjust Pool Royale top-down camera framing and view button offset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.042, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.038 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.056, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.052 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -10885,7 +10885,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const viewButtonsOffsetPx = 12;
+  const viewButtonsOffsetPx = 22;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );


### PR DESCRIPTION
### Motivation

- Align the 2D top-down framing so the table appears slightly higher and more left on portrait screens to match design intent.  
- Move the 2D/look/view control stack lower so buttons sit more comfortably near the bottom of portrait screens.  
- Keep changes minimal and local to the Pool Royale page configuration to avoid unintended side effects.  

### Description

- Updated `TOP_VIEW_SCREEN_OFFSET` in `webapp/src/pages/Games/PoolRoyale.jsx` by changing the `x` and `z` bias multipliers to `-PLAY_W * 0.056` and `-PLAY_H * 0.052` respectively to shift the 2D camera framing.  
- Increased the view button vertical offset by changing `viewButtonsOffsetPx` from `12` to `22` in the same file so the 2D/view buttons render lower on the screen.  
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and target portrait/top-down view behavior.  

### Testing

- Started the dev server with `npm run dev` and confirmed Vite reported as ready, indicating the app builds and serves successfully.  
- Attempted an automated visual check using Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot step timed out and did not complete.  
- No unit or snapshot tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663c44fad08329ac9b08a7509ea399)