### PR TITLE
Adjust Pool Royale top-down camera framing and view buttons

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.042, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.038 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: -PLAY_W * 0.06, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: -PLAY_H * 0.055 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -10885,7 +10885,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const viewButtonsOffsetPx = 12;
+  const viewButtonsOffsetPx = 24;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );


### PR DESCRIPTION
### Motivation
- Improve portrait (phone) framing so the table appears slightly more to the left and higher on screen for the 2D/top-down view.
- Improve ergonomics by moving the 2D/look/view button stack downward so it sits lower on portrait screens.

### Description
- Increased the top-down X offset by changing `TOP_VIEW_SCREEN_OFFSET.x` from `-PLAY_W * 0.042` to `-PLAY_W * 0.06` to raise the table on-screen.
- Increased the top-down Z offset by changing `TOP_VIEW_SCREEN_OFFSET.z` from `-PLAY_H * 0.038` to `-PLAY_H * 0.055` to shift the table further left on-screen.
- Lowered the view button stack by increasing `viewButtonsOffsetPx` from `12` to `24` so the buttons render further down the UI.
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite served the app successfully (local/network URLs reported).
- Attempted an automated visual check using Playwright to capture a `430x932` portrait screenshot, but the screenshot run timed out and did not complete.
- No unit or linting tasks were executed as part of this change.
- Manual QA is recommended on portrait devices to confirm the new framing and button placement visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663c44fad08329ac9b08a7509ea399)