### PR TITLE
Recenter Pool Royale 2D top-down view and lower view buttons

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4758,8 +4758,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.042, // bias the top view so the table sits higher on screen (match legacy portrait framing)
-  z: -PLAY_H * 0.038 // bias the top view so the table sits further to the left (match legacy portrait framing)
+  x: PLAY_W * 0.022, // bias the top view so the table sits higher on screen (match legacy portrait framing)
+  z: PLAY_H * 0.02 // bias the top view so the table sits further to the left (match legacy portrait framing)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -10885,7 +10885,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const viewButtonsOffsetPx = 12;
+  const viewButtonsOffsetPx = 24;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );


### PR DESCRIPTION
### Motivation
- Restore the intended portrait framing so the Pool Royale table appears higher and shifted left in the 2D/top-down view without obstructing bottom UI elements.
- Improve ergonomics on portrait phones by lowering the 2D/look/view button stack so it sits further down the screen.
- Correct the previous offset direction that caused the table to appear more to the right and lower than intended.

### Description
- Updated the top-down camera bias by changing the `TOP_VIEW_SCREEN_OFFSET` values in `webapp/src/pages/Games/PoolRoyale.jsx` to `x: PLAY_W * 0.022` and `z: PLAY_H * 0.02` so the table frames higher and more left on portrait screens.
- Increased the view button stack offset by setting `viewButtonsOffsetPx` to `24` so the buttons render lower on portrait UIs.
- Changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and adjust only UI/camera constants used for portrait framing.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready with local and network URLs.
- Attempted an automated Playwright screenshot (`430x932` viewport) to validate portrait framing, but the screenshot run timed out and did not complete.
- No unit tests or linting were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663c44fad08329ac9b08a7509ea399)