### PR TITLE
Pool Royale: add spin controller labels and fix vertical spin sign

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19712,7 +19712,7 @@ const powerRef = useRef(hud.power);
         const hasSpin = magnitude > 1e-4;
         const sideInput = spin?.x ?? 0;
         let side = hasSpin ? sideInput * offsetSide : 0;
-        let vert = hasSpin ? -spin.y * offsetVertical : 0;
+        let vert = hasSpin ? spin.y * offsetVertical : 0;
         if (hasSpin) {
           vert = THREE.MathUtils.clamp(vert, -MAX_SPIN_VISUAL_LIFT, MAX_SPIN_VISUAL_LIFT);
         }
@@ -24427,6 +24427,19 @@ const powerRef = useRef(hud.power);
       }),
     []
   );
+  const spinLabelPoints = useMemo(
+    () => [
+      { label: 'HIGH', x: 0, y: -0.78, rotate: 0 },
+      { label: 'HIGH RIGHT', x: 0.56, y: -0.56, rotate: 35 },
+      { label: 'RIGHT', x: 0.78, y: 0, rotate: 90 },
+      { label: 'LOW RIGHT', x: 0.56, y: 0.56, rotate: 145 },
+      { label: 'LOW', x: 0, y: 0.78, rotate: 180 },
+      { label: 'LOW LEFT', x: -0.56, y: 0.56, rotate: -145 },
+      { label: 'LEFT', x: -0.78, y: 0, rotate: -90 },
+      { label: 'HIGH LEFT', x: -0.56, y: -0.56, rotate: -35 }
+    ],
+    []
+  );
 
   // Spin controller interactions
   useEffect(() => {
@@ -25813,6 +25826,22 @@ const powerRef = useRef(hud.power);
                 pointerEvents: 'none'
               }}
             />
+            {spinLabelPoints.map((point) => (
+              <span
+                key={point.label}
+                className="absolute text-[9px] font-bold uppercase tracking-[0.18em] text-[#5b1515]"
+                style={{
+                  left: `${50 + point.x * 42}%`,
+                  top: `${50 + point.y * 42}%`,
+                  transform: `translate(-50%, -50%) rotate(${point.rotate}deg)`,
+                  textShadow: '0 1px 2px rgba(255,255,255,0.5)',
+                  pointerEvents: 'none',
+                  whiteSpace: 'nowrap'
+                }}
+              >
+                {point.label}
+              </span>
+            ))}
             {spinDecorationPoints.map((point, index) => (
               <span
                 key={`spin-deco-${index}`}


### PR DESCRIPTION
### Motivation
- Make the on-screen spin controller visually match the reference art by adding directional labels around the ring. 
- Ensure the cue tip orientation visually matches the red spin dot by aligning the vertical spin sign used for cue-tip offsets. 
- Improve UX clarity for spin targeting while keeping the controller compact for portrait/mobile screens.

### Description
- Flip vertical spin mapping in `computeSpinOffsets` by changing `vert` from `-spin.y * offsetVertical` to `spin.y * offsetVertical` to align cue-tip vertical offset with the spin dot direction in the UI (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add a `spinLabelPoints` `useMemo` array with eight ring label positions and angles (e.g. `HIGH`, `HIGH RIGHT`, `RIGHT`, ...). 
- Render small, high-contrast labels around the spin controller inside the `#spinBox` element using an absolute `<span>` per label and tuned CSS (`text-[9px] font-bold uppercase tracking-[0.18em]`) so labels are readable on mobile. 
- Keep existing decorative dots and the spin dot behavior intact; labels are pointer-events-none so they do not affect input.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready (local/network URLs). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to verify visual placement, but the Playwright run timed out and no screenshot was captured. 
- No automated unit tests were executed for this visual change; changes were committed (`git commit`) after local validation in the dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664564552c8329a09c28a83dbfcc18)