### PR TITLE
Pool Royale: taller table, extended legs, tighter finish patterns, and view button offset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1368,7 +1368,7 @@ const LEG_HEIGHT_MULTIPLIER = 4.5;
 const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 1;
-const TABLE_HEIGHT_SCALE = 1.56;
+const TABLE_HEIGHT_SCALE = 1.56 * 1.3;
 const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE;
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
@@ -1398,7 +1398,8 @@ const BASE_HEIGHT_FILL = 0.94; // grow bases upward so the stance stays consiste
 // adjust overall table position so the shorter legs bring the playfield closer to floor level
 const BASE_TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H + TABLE_LIFT - TABLE_DROP;
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA;
-const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT + 0.3;
+const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
+const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.22; // widen the visible air gap so the blue tip never kisses the cue ball
@@ -1471,7 +1472,7 @@ const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playabl
 const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Match cue grain scale to the table finish
 const CUE_WOOD_REPEAT_SCALE = 1 / 9; // enlarge cue wood grain 3× so the pattern reads more clearly at table scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
-const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // enlarge grain 3× so rails, skirts, and legs read at table scale; push pattern larger for the new finish pass
+const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7 * 2, 0.44 / 3 * 0.7 * 2); // shrink finish grain 50% so the pattern reads tighter on the table surface
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
@@ -10885,7 +10886,7 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const viewButtonsOffsetPx = 24;
+  const viewButtonsOffsetPx = 32;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );


### PR DESCRIPTION
### Motivation
- Implement the requested visual changes to the Pool Royale table so the finish pattern is smaller, the table and legs extend downward, and the view controls are nudged lower for portrait screens. 
- Ensure camera and orbit-derived values respond to the taller table stance by relying on the existing derived constants so HDRI/environment placement and aiming vectors adapt automatically. 

### Description
- Increased `TABLE_HEIGHT_SCALE` (multiplied by `1.3`) in `webapp/src/pages/Games/PoolRoyale.jsx` to make the table ~30% taller via the existing table height math. 
- Added `LEG_BASE_DROP` and adjusted `FLOOR_Y` so the leg/base drops further (leg room extended by ~30%) to visually extend the legs downward. 
- Tightened the table finish pattern by adjusting `TABLE_WOOD_REPEAT` (scaled) so the visible wood grain/pattern reads ~50% smaller on table surfaces. 
- Nudged the view/2D UI buttons lower by increasing `viewButtonsOffsetPx` from `24` to `32` so the buttons sit a bit more down on portrait screens. 

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the Vite server reported ready (local network URL returned). 
- Attempted a Playwright screenshot to validate the visual change, but the headless browser crashed (Playwright `TargetClosedError`/SIGSEGV) and the capture failed. 
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664fcc659c832999693edac4c12bac)