### PR TITLE
Pool Royale: adjust 2D camera framing, aiming visuals, HUD sizing, and spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4759,8 +4759,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * 0.016, // bias the top view so the table sits a touch lower on screen (portrait tuning)
-  z: PLAY_H * -0.012 // bias the top view so the table sits a touch to the right (portrait tuning)
+  x: PLAY_W * 0.022, // bias the top view so the table sits a touch lower on screen (portrait tuning)
+  z: PLAY_H * -0.018 // bias the top view so the table sits a touch to the right (portrait tuning)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -18542,7 +18542,9 @@ const powerRef = useRef(hud.power);
         color: 0x7ce7ff,
         linewidth: AIM_LINE_WIDTH,
         transparent: true,
-        opacity: 0.9
+        opacity: 0.9,
+        depthTest: false,
+        depthWrite: false
       });
       const aimGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -18563,7 +18565,9 @@ const powerRef = useRef(hud.power);
           dashSize: AIM_DASH_SIZE * 0.9,
           gapSize: AIM_GAP_SIZE,
           transparent: true,
-          opacity: 0.45
+          opacity: 0.45,
+          depthTest: false,
+          depthWrite: false
         })
       );
       cueAfter.visible = false;
@@ -18574,7 +18578,11 @@ const powerRef = useRef(hud.power);
       ]);
       const tick = new THREE.Line(
         tickGeom,
-        new THREE.LineBasicMaterial({ color: 0xffffff })
+        new THREE.LineBasicMaterial({
+          color: 0xffffff,
+          depthTest: false,
+          depthWrite: false
+        })
       );
       tick.visible = false;
       table.add(tick);
@@ -18591,7 +18599,9 @@ const powerRef = useRef(hud.power);
           dashSize: AIM_DASH_SIZE,
           gapSize: AIM_GAP_SIZE,
           transparent: true,
-          opacity: 0.65
+          opacity: 0.65,
+          depthTest: false,
+          depthWrite: false
         })
       );
       target.visible = false;
@@ -24768,7 +24778,7 @@ const powerRef = useRef(hud.power);
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive;
   const bottomHudScale = isPortrait ? uiScale * 1.08 : uiScale * 1.12;
   const avatarSizeClass = isPortrait ? 'h-[2.6rem] w-[2.6rem]' : 'h-[3.5rem] w-[3.5rem]';
-  const nameWidthClass = isPortrait ? 'max-w-[8rem]' : 'max-w-[10rem]';
+  const nameWidthClass = isPortrait ? 'max-w-[9rem]' : 'max-w-[12rem]';
   const nameTextClass = isPortrait ? 'text-sm' : 'text-base';
   const hudGapClass = isPortrait ? 'gap-4' : 'gap-6';
   const bottomHudLayoutClass = isPortrait ? 'justify-center px-4 w-full' : 'justify-center';
@@ -25658,11 +25668,11 @@ const powerRef = useRef(hud.power);
           }}
         >
             <div
-              className={`pointer-events-auto flex min-h-[3rem] max-w-full items-center justify-center ${hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'pl-5 pr-7 py-2' : 'pl-6 pr-8 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
+              className={`pointer-events-auto flex min-h-[3rem] max-w-full items-center justify-center ${hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'pl-6 pr-8 py-2' : 'pl-7 pr-9 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
               style={{
                 transform: `scale(${bottomHudScale})`,
                 transformOrigin: 'bottom center',
-                maxWidth: isPortrait ? 'min(31rem, 100%)' : 'min(36rem, 100%)'
+                maxWidth: isPortrait ? 'min(34rem, 100%)' : 'min(40rem, 100%)'
               }}
             >
             <div

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -44,7 +44,7 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI has +X to the right; physics should match left/right as shown.
-    x: curved.x,
+    x: -curved.x,
     // UI uses +Y for topspin; physics uses the opposite sign.
     y: -curved.y
   };


### PR DESCRIPTION
### Motivation
- Shift the 2D/top-down camera framing so the table sits slightly more to the right and lower on portrait screens for better on-screen composition.
- Make aiming and target guide visuals reliably visible above the table surface to avoid occlusion in edge cases (short-rail / side-of-rack aims).
- Expand the player/avatar HUD frame slightly so avatars, names and potted-ball tokens have more room and don't truncate.
- Correct the spin controller mapping so left/right in the UI correspond to the same left/right in physics, enabling consistent intermediate spin orientations.

### Description
- Tweaked `TOP_VIEW_SCREEN_OFFSET` (x and z) in `webapp/src/pages/Games/PoolRoyale.jsx` to bias the 2D/top view down/right on portrait layouts.
- Forced aiming/guide line materials to render above the table by disabling depth testing/writing on the aim, cue-follow, tick and target materials in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Widened the bottom HUD pill, increased name max widths and adjusted padding in `webapp/src/pages/Games/PoolRoyale.jsx` so the avatar/points frame expands on both sides.
- Flipped the lateral spin sign in `mapSpinForPhysics` inside `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so physics matches the UI left/right direction.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready and serving the app (success).
- Attempted a Playwright screenshot to validate the UI at a 430×932 portrait viewport, but the Chromium process crashed (SIGSEGV) in this environment so no screenshot is available.
- No unit or integration test suites were executed as part of this change.
- The changes were committed to the working branch (`Adjust Pool Royale camera, HUD, and spin controls`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966795d95a08329a73a97cc53f782b4)