### PR TITLE
Adjust Pool Royale camera framing and aim-line spin preview

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4683,7 +4683,7 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.14; // let the cue view drop to the s
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0165; // pull the player orbit nearer to the cloth while keeping the frame airy
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0155; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
@@ -4759,8 +4759,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.2; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * 0.03, // bias the top view so the table sits a touch lower on screen (portrait tuning)
-  z: PLAY_H * -0.026 // bias the top view so the table sits a touch to the right (portrait tuning)
+  x: PLAY_W * 0.045, // bias the top view so the table sits a touch lower on screen (portrait tuning)
+  z: PLAY_H * -0.038 // bias the top view so the table sits a touch to the right (portrait tuning)
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -4781,7 +4781,7 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 0.9; // pull the broadcast overhead camera c
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.0225; // tighten cue camera distance so the cue ball and object ball appear larger
+const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
@@ -5943,7 +5943,7 @@ function resolveSwerveAimDir(
     (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
   const powerScale = 4 + powerStrength * 6;
   const swerveScale = 0.6 + swerve.intensity * 0.9;
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const adjust =
     sideSpin *
     swerve.intensity *
@@ -5975,7 +5975,7 @@ function buildSwerveAimLinePoints(
     swerveActive,
     liftStrength
   );
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const travel = start.distanceTo(end);
   if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
     points.length = 2;


### PR DESCRIPTION
### Motivation
- Bring the standing and cue cameras slightly closer to the cue ball while preserving the existing angles so the cue and cue-ball read larger on screen.
- Ensure the 2D/top-down button camera frames the table a bit more to the right and lower on portrait screens for improved visual alignment.
- Fix the aiming-line preview so side-spin bends in the same direction the player applies (aim preview previously showed the opposite direction).

### Description
- Reduce `PLAYER_CAMERA_DISTANCE_FACTOR` from `0.0165` to `0.0155` to pull the player orbit nearer the cloth and cue view.
- Shift `TOP_VIEW_SCREEN_OFFSET` to `x: PLAY_W * 0.045` and `z: PLAY_H * -0.038` so the 2D/top-down framing sits slightly more right and lower on-screen.
- Tighten cue camera framing by changing `CUE_VIEW_RADIUS_RATIO` from `0.0225` to `0.0215` to make cue/cue-ball appear larger.
- Correct swerve preview sign by replacing `-swerve.sideSpin` with `swerve.sideSpin` in both `resolveSwerveAimDir` and `buildSwerveAimLinePoints` so the aim line curves in the applied spin direction.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to `webapp/src/pages/Games/PoolRoyale.jsx` and affects camera/constants and aim-line preview calculations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668d7076a0832996611bf8f1c499dc)