### PR TITLE
Tighten Pool Royale camera distances (closer standing view, cap cue lowering)

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -32,7 +32,7 @@ public class CameraController : MonoBehaviour
     public float maxHeightAboveTable = 1.95f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 2.45f;
+    public float distanceFromCenter = 2.25f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
     public float minDistanceFromCenter = 1.35f;
@@ -41,7 +41,7 @@ public class CameraController : MonoBehaviour
     public float lowHeightDistanceReduction = 1.05f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
-    public float zoomOutWhenRaised = 0.12f;
+    public float zoomOutWhenRaised = 0.08f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
     public float railBuffer = 0.012f;

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -84,7 +84,7 @@ public class CueCamera : MonoBehaviour
     // Keeps the framing just above the cue stick instead of letting the
     // view slide down into the shaft.
     [Range(0f, 1f)]
-    public float maxCueAimLowering = 0.82f;
+    public float maxCueAimLowering = 0.7f;
 
     [Header("Cue aim framing")]
     // Scale applied to the cue distance when the camera is raised. Values below


### PR DESCRIPTION
### Motivation
- Bring the standing (overview) camera visually closer to the table and prevent the cue camera from lowering as far as before while keeping existing angles and framing logic.

### Description
- Reduce `distanceFromCenter` from `2.45` to `2.25` and `zoomOutWhenRaised` from `0.12` to `0.08` in `billiards.Unity/CameraController.cs` to tighten the standing camera distance.
- Lower the hard cap `maxCueAimLowering` from `0.82` to `0.7` in `billiards.Unity/CueCamera.cs` to stop the cue camera from reaching the previous deepest lowering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69672812286c8329971237b02cf5f7aa)