### PR TITLE
Align snooker table sizing with Pool Royale 9ft dimensions

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,13 +1,13 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // match pool royale 9 ft playing surface width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '12ft': {
-    id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
+  '9ft': {
+    id: '9ft',
+    label: '9 ft (Tournament)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
@@ -18,18 +18,18 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
+  '8ft': {
+    id: '8ft',
+    label: '8 ft',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
+      corner: 171.45,
+      side: 152.4
     }),
     cushionCutAngleDeg: 27,
     sideCushionCutAngleDeg: 27,
@@ -72,7 +72,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '12ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,13 +1,13 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // match pool royale 9 ft playing surface width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
-  '12ft': {
-    id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
+  '9ft': {
+    id: '9ft',
+    label: '9 ft (Tournament)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // 100" × 50"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
@@ -18,18 +18,18 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
-  '10ft': {
-    id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
+  '8ft': {
+    id: '8ft',
+    label: '8 ft',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // 88" × 44"
     ballDiameterMm: 52.5,
     pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
+      corner: 171.45,
+      side: 152.4
     }),
     cushionCutAngleDeg: 27,
     sideCushionCutAngleDeg: 27,
@@ -72,7 +72,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '12ft';
+export const DEFAULT_TABLE_SIZE_ID = '9ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';


### PR DESCRIPTION
### Motivation
- Make Snooker Royal tables match the Pool Royale table shape/size/height so the two modes render and stack rails/cushions consistently. 
- Preserve snooker-specific gameplay sizing (ball diameter) while harmonizing playfield and scale drivers with the pool reference.

### Description
- Updated `BASE_TABLE_SCALE`, `BASE_TABLE_MOBILE_SCALE`, `BASE_TABLE_COMPACT_SCALE`, and `BASE_PLAYFIELD_WIDTH_MM` to pool-aligned values in `webapp/src/config/snookerClubTables.js` and `webapp/src/config/snookerRoyalTables.js`.
- Replaced the previous 12ft/10ft specs with `9ft`/`8ft` entries using a `playfield` of `widthMm: 2540` and matching height, and applied matching `scaleOverrides` to mirror Pool Royale behavior.
- Changed the default selection `DEFAULT_TABLE_SIZE_ID` to `'9ft'` in both files and adjusted pocket mouth and mobile scale values to align with the pool-derived profile while keeping `ballDiameterMm` at 52.5.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69674f75acdc832989ef549330447305)