### PR TITLE
Match Snooker Royale table footprint to Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1017,9 +1017,10 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Pool Royale pocket layout while keeping the current table footprint.
-  const WIDTH_REF = 3556;
-  const HEIGHT_REF = 1778;
+  // Match the Pool Royale table footprint so snooker tables share the same shape and height.
+  // (WPA 9ft reference: 100" × 50")
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
   const BALL_D_REF = 52.5;
   const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
   const D_RADIUS_REF = 292;
@@ -1030,8 +1031,8 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  // Reuse the Pool Royale playfield aspect ratio so the table footprint matches exactly.
+  const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);


### PR DESCRIPTION
### Motivation
- Make Snooker Royale use the same table footprint, shape and perceived height as Pool Royale so both modes align visually and playfield geometry matches across modes.

### Description
- Updated Snooker Royale playfield reference dimensions from `3556×1778` to `2540×1270`, set the `TARGET_RATIO` to `1.83`, and adjusted accompanying comments in `webapp/src/pages/Games/SnookerRoyal.jsx` so the snooker table reuses Pool Royale’s footprint and aspect ratio.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` (Vite reported ready), attempted an automated Playwright screenshot which timed out, and no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69674f75acdc832989ef549330447305)