### PR TITLE
Adjust pool camera framing, cue camera limits, and lighting/shadows

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -29,25 +29,25 @@ public class CameraController : MonoBehaviour
     // the cue stick.
     public float minimumCueViewDistance = 1.1f;
     // How far above the rails the camera is allowed to travel.
-    public float maxHeightAboveTable = 1.95f;
+    public float maxHeightAboveTable = 2.05f;
     // Default distance of the camera from the table centre when fully raised to
     // provide a broad overview of the action.
-    public float distanceFromCenter = 2.25f;
+    public float distanceFromCenter = 2.45f;
     // Minimum distance from the table centre allowed when the camera is pulled
     // down toward the rails for a closer look.
-    public float minDistanceFromCenter = 1.35f;
+    public float minDistanceFromCenter = 1.45f;
     // Extra distance the camera is allowed to shed as it hugs the table so the
     // cue ball fills more of the view during low-angle aiming.
-    public float lowHeightDistanceReduction = 1.05f;
+    public float lowHeightDistanceReduction = 0.75f;
     // Extra pullback applied when the camera is raised to its maximum height so
     // the player gets a slightly wider view while aiming.
-    public float zoomOutWhenRaised = 0.08f;
+    public float zoomOutWhenRaised = 0.12f;
     // Buffer that keeps the camera just outside the rails even at the closest
     // zoom level.
     public float railBuffer = 0.012f;
     // Slight height offset so the camera looks just above the table centre
     // to reduce the viewing angle and give a lower perspective.
-    public float lookAtHeightOffset = 0.11f;
+    public float lookAtHeightOffset = 0.13f;
     // Extra upward offset applied to the camera's look target when the camera is
     // pulled down close to the cloth so the player can still see more of the
     // table surface instead of just the rails.

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -29,10 +29,10 @@ public class CueCamera : MonoBehaviour
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.04f;
+    public float cueLoweredDistanceFromBall = 0.06f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
-    public float cueDistancePullIn = 0.55f;
+    public float cueDistancePullIn = 0.45f;
     // Minimum separation we allow once the pull-in is applied. Prevents the
     // camera from intersecting the cue or cloth when the player drops in tight.
     public float cueMinimumDistance = 0.02f;
@@ -43,7 +43,7 @@ public class CueCamera : MonoBehaviour
     // view.
     public float cueRaisedHeightPadding = 0.05f;
     // Minimum height maintained when the player drops the camera toward the cue.
-    public float cueLoweredHeight = 0.25f;
+    public float cueLoweredHeight = 0.3f;
     // Extra forward push applied as the player lowers the camera so the framing
     // stays tight on the cue ball and shaft instead of drifting backward.
     public float cueLoweredForwardPush = 0.08f;
@@ -84,7 +84,7 @@ public class CueCamera : MonoBehaviour
     // Keeps the framing just above the cue stick instead of letting the
     // view slide down into the shaft.
     [Range(0f, 1f)]
-    public float maxCueAimLowering = 0.7f;
+    public float maxCueAimLowering = 0.6f;
 
     [Header("Cue aim framing")]
     // Scale applied to the cue distance when the camera is raised. Values below
@@ -94,11 +94,11 @@ public class CueCamera : MonoBehaviour
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.38f;
+    public float cueLoweredDistanceScale = 0.42f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]
-    public float cueHeightClothScale = 0.65f;
+    public float cueHeightClothScale = 0.7f;
     // Weight controlling how much of the look target should favour the aiming
     // line (0) versus the cue butt (1). Lower values keep the focus locked on
     // the target ball.


### PR DESCRIPTION
### Motivation
- Improve portrait UI clearance so the table and 2D HUD (power slider / right-side buttons / bottom avatars) are not occluded by the camera framing.  
- Make the cue-aim camera behave like the snooker broadcast/cue framing by tightening lowering limits and distance/height scaling.  
- Reduce bright cloth/specular reflections on GLTF cloths so patterns read better and increase felt detail resolution.  
- Align cue stick shadow direction with the cue and ensure the table casts visible shadow onto the floor.

### Description
- Updated camera framing defaults in `billiards.Unity/CameraController.cs` by increasing `maxHeightAboveTable`, `distanceFromCenter`, `minDistanceFromCenter`, increasing `zoomOutWhenRaised`, reducing `lowHeightDistanceReduction`, and raising `lookAtHeightOffset` to push the table slightly farther/clearer in portrait.  
- Tweaked cue-aim behavior in `billiards.Unity/CueCamera.cs` by changing `cueLoweredDistanceFromBall`, `cueDistancePullIn`, `cueLoweredHeight`, `maxCueAimLowering`, `cueLoweredDistanceScale`, and `cueHeightClothScale` to tighten the low-angle cue framing.  
- Enhanced cloth and shadow handling in `billiards.Unity/BilliardLighting.cs` by adding `using UnityEngine.Rendering`, new public fields for cue/table shadow control (`cueStick`, `cueShadowLight`, `tableRoot`, `floorRenderer`), and new routines `ConfigureTableShadows`, `ConfigureCueShadowLight`, and `UpdateCueShadowLight` to orient a directional light to the cue and enable table parts to cast/receive shadows.  
- Reduced cloth gloss (`_Glossiness`), increased `mainTextureScale`, set cloth texture filter/aniso where available, boosted bump scale, and adjusted cue-ball and ball highlight setup to reduce over-bright reflections while keeping cloth pattern detail clearer.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967795159ec8329934c75082d66b95c)