### PR TITLE
Pool Royale: lock cloth tone, enlarge PolyHaven patterns, disable floor shadow, and refine pocket/replay cameras

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -70,7 +70,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleece',
     label: 'Polar Fleece',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 640,
     priceStep: 10,
     bluePremium: 20,
@@ -89,7 +89,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleecePlush',
     label: 'Polar Fleece Plush',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 700,
     priceStep: 10,
     bluePremium: 20,
@@ -108,7 +108,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleeceNatureOcean',
     label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 660,
     priceStep: 10,
     bluePremium: 20,


### PR DESCRIPTION
### Motivation
- Increase visible weave on PolyHaven cloth textures (~+40% pattern footprint) and ensure each inventory cloth uses its original PolyHaven source where configured. 
- Prevent HDRI/lighting from shifting cloth color/brightness so felt keeps a constant tone from every view. 
- Improve replay framing so both cue and target are kept in-frame and add pocket camera views that sit above the chrome plates and only follow when a ball is dropping. 
- Remove the table floor shadow that was casting beneath the table for a cleaner arena floor.

### Description
- Cloth presets: switched polar fleece variants to use the correct PolyHaven `sourceId` (`polar_fleece`) in `webapp/src/config/poolRoyaleClothPresets.js`. 
- PolyHaven pattern and tone handling: added `POLYHAVEN_PATTERN_REPEAT_SCALE = 1/1.4` to enlarge PolyHaven patterns by ~40%, introduced `CLOTH_TONE_LOCKED` mode and `neutralizeClothColorMap` to desaturate/neutralize color maps and use cloth textures as `emissiveMap` so felt keeps a locked tone; updated material setup and texture replacement code to use emissive maps and to preserve repeat/scaling logic in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Pocket / replay camera changes: lowered and simplified pocket camera offsets and disabled lateral focus/rail focus to make pocket cams sit just outside the chrome, added `POCKET_CAM_FOCUS_LEAD` and logic to anchor pocket focus above chrome plates, and adjusted pocket camera smoothing; captured additional metadata for replay camera snapshots (`mode`) and added `shotRecording.targetId` plus `resolveReplayBallFocus` to choose cue+target and ensure replay framing centers both balls when not in pocket mode. Also updated camera-switch logic to consider camera `mode` when deciding replay camera swaps. 
- Misc: disabled the table floor shadow by setting `ENABLE_TABLE_FLOOR_SHADOW = false` so the table no longer casts a ground-plane shadow.

### Testing
- No automated tests were executed against these changes in this rollout; only local edits and a commit were produced.  Manual verification steps (recommended): run the Pool Royale scene, verify PolyHaven cloth variants use the external textures, confirm pattern appears ~40% larger, check felt tone remains visually constant under different HDRIs, confirm table floor shadow is gone, and validate replay and pocket camera behavior (cue+target framing and pocket cam hold behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967abad9a6c832992b8e163d3f434ad)