### PR TITLE
Pool Royale: enlarge PolyHaven cloth patterns, remove floor shadow, and refine replay & pocket cameras

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -59,10 +59,11 @@ const MATERIAL_SERIES = [
     stray: 1.06,
     detail: {
       bumpMultiplier: 1.22,
-      sheen: 0.58,
-      sheenRoughness: 0.46,
+      sheen: 0,
+      sheenRoughness: 1,
+      clearcoat: 0,
       emissiveIntensity: 0.24,
-      envMapIntensity: 0.18
+      envMapIntensity: 0
     },
     greens: CABAN_GREEN_SWATCHES,
     blues: CABAN_OCEAN_BLUE_SWATCHES
@@ -70,7 +71,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleece',
     label: 'Polar Fleece',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 640,
     priceStep: 10,
     bluePremium: 20,
@@ -78,10 +79,11 @@ const MATERIAL_SERIES = [
     stray: 1.1,
     detail: {
       bumpMultiplier: 1.12,
-      sheen: 0.7,
-      sheenRoughness: 0.52,
+      sheen: 0,
+      sheenRoughness: 1,
+      clearcoat: 0,
       emissiveIntensity: 0.34,
-      envMapIntensity: 0.14
+      envMapIntensity: 0
     },
     greens: CABAN_GREEN_SWATCHES,
     blues: CABAN_OCEAN_BLUE_SWATCHES
@@ -89,7 +91,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleecePlush',
     label: 'Polar Fleece Plush',
-    sourceId: 'caban',
+    sourceId: 'knitted_fleece',
     basePrice: 700,
     priceStep: 10,
     bluePremium: 20,
@@ -97,10 +99,11 @@ const MATERIAL_SERIES = [
     stray: 1.12,
     detail: {
       bumpMultiplier: 1.14,
-      sheen: 0.72,
-      sheenRoughness: 0.5,
+      sheen: 0,
+      sheenRoughness: 1,
+      clearcoat: 0,
       emissiveIntensity: 0.36,
-      envMapIntensity: 0.16
+      envMapIntensity: 0
     },
     greens: CABAN_GREEN_SWATCHES,
     blues: CABAN_OCEAN_BLUE_SWATCHES
@@ -108,7 +111,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleeceNatureOcean',
     label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 660,
     priceStep: 10,
     bluePremium: 20,
@@ -116,10 +119,11 @@ const MATERIAL_SERIES = [
     stray: 1.08,
     detail: {
       bumpMultiplier: 1.16,
-      sheen: 0.68,
-      sheenRoughness: 0.5,
+      sheen: 0,
+      sheenRoughness: 1,
+      clearcoat: 0,
       emissiveIntensity: 0.34,
-      envMapIntensity: 0.15
+      envMapIntensity: 0
     },
     greens: CABAN_GREEN_SWATCHES,
     blues: CABAN_OCEAN_BLUE_SWATCHES,
@@ -137,10 +141,11 @@ const MATERIAL_SERIES = [
     stray: 1.08,
     detail: {
       bumpMultiplier: 1.24,
-      sheen: 0.54,
-      sheenRoughness: 0.58,
+      sheen: 0,
+      sheenRoughness: 1,
+      clearcoat: 0,
       emissiveIntensity: 0.26,
-      envMapIntensity: 0.17
+      envMapIntensity: 0
     },
     greens: CABAN_GREEN_SWATCHES,
     blues: CABAN_OCEAN_BLUE_SWATCHES


### PR DESCRIPTION
### Motivation
- Make Poly Haven cloth patterns larger (≈40%) and use the original source textures for each cloth variant so inventory matches source assets. 
- Prevent cloth surfaces from producing specular reflections so felt appears non-reflective in-game. 
- Ensure replays frame both the target and cue ball and provide pocket cameras that sit outside the rails and look toward incoming balls rather than tracking them. 
- Remove the table floor shadow to match the requested visual style.

### Description
- Increased PolyHaven pattern footprint by changing `POLYHAVEN_PATTERN_REPEAT_SCALE` to `1 / 1.4` so polyhaven-sourced maps render ~40% larger. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Updated cloth presets to reference appropriate source IDs and reduced reflective properties by setting `sheen`, `clearcoat`, and `envMapIntensity` to zero (and raising `sheenRoughness`) so cloth does not reflect light. (`webapp/src/config/poolRoyaleClothPresets.js`)
- Disabled table floor shadow by setting `ENABLE_TABLE_FLOOR_SHADOW = false` and keeping the floor-shadow mesh creation gated by that flag. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Replay camera: `captureReplayCameraSnapshot` now prefers a midpoint between the cue and predicted target ball (when both are active) so both balls are kept in frame, and `shotRecording` stores `targetBallId` to drive the replay framing. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Pocket camera behavior: tuned `POCKET_CAM` (lowered `heightOffset`, disabled `focusBlend`/`lateralFocusShift`/`railFocus*`, added `incomingFocusOffset`) and made pocket views non-following by default (`followBall: false`) while keeping the camera positioned just outside the rails and oriented toward the incoming pocket approach. Logic was added so pocket views only follow the ball when explicitly allowed. (`webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- No automated tests were executed against these changes during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b88ca9388329b4cc0e518d1a8759)