### PR TITLE
Use PolyHaven 8K cloth patterns, enlarge balls by 4%, and retune standing/cue cameras

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -70,7 +70,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleece',
     label: 'Polar Fleece',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 640,
     priceStep: 10,
     bluePremium: 20,
@@ -89,7 +89,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleecePlush',
     label: 'Polar Fleece Plush',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 700,
     priceStep: 10,
     bluePremium: 20,
@@ -108,7 +108,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleeceNatureOcean',
     label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 660,
     priceStep: 10,
     bluePremium: 20,


### PR DESCRIPTION
### Motivation
- Ensure cloth patterns come from PolyHaven originals at the highest available resolution for authentic, ultra‑HD pattern detail. 
- Make the balls slightly larger to match the requested 4% increase in visual scale. 
- Pull the standing/broadcast framing closer to the table so the table feels less distant, and prevent the cue camera from lowering too far below the cue tip. 

### Description
- Map Polar Fleece variants to the correct PolyHaven source IDs by updating `POOL_ROYALE_CLOTH_VARIANTS` sourceId entries in `webapp/src/config/poolRoyaleClothPresets.js` (use `polar_fleece`).
- Force PolyHaven cloth textures to use 8K patterns by setting `POLYHAVEN_TEXTURE_RESOLUTION = '8k'`, preferring 8K candidates, adding an `upgradePolyHavenTextureUrlTo8k` helper, and removing the procedural source option in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Prefer and score `8k` texture URLs higher when picking PolyHaven assets and add 8K fallback/legacy URL candidates when loading textures in `createClothTextures`.
- Increase ball visual size by setting `BALL_SIZE_SCALE = 1.04` (4% larger) and update related radius/scale calculations referenced across the file `webapp/src/pages/Games/PoolRoyale.jsx`.
- Tighten standing view framing margins and raise the lowest allowed cue camera tilt by adjusting `STANDING_VIEW_MARGIN_LANDSCAPE`, `STANDING_VIEW_MARGIN_PORTRAIT`, `CAMERA_LOWEST_PHI` and `CAMERA_ZOOM_PROFILES` to pull the standing camera closer while keeping angles/logic unchanged.

### Testing
- Launched the webapp dev server (`npm --prefix webapp run dev`) and confirmed Vite served the app successfully (local host available). — succeeded.
- Captured a portrait screenshot of the Pool Royale standing view using Playwright to validate the framing change (`artifacts/pool-royale-standing-camera.png`). — succeeded.
- No unit or CI tests were run for these visual/asset changes during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d2d7c2988329ac5e6dfcc548341f)