### PR TITLE
Keep spin directions in screen-space (fix inversion)

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,9 +43,8 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI has +X to the right; physics should match left/right as shown.
-    x: -curved.x,
-    // UI uses +Y for topspin; physics uses the opposite sign.
-    y: -curved.y
+    // Keep screen-space directions: +X = right english, +Y = topspin.
+    x: curved.x,
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Ensure the spin input from the on-screen controller maps 1:1 to physics in screen/camera space so RIGHT/LEFT and HIGH/LOW behave exactly as shown in the hit-map UI and avoid handedness/cross-product sign inversion.

### Description
- Remove the sign flips in `mapSpinForPhysics` so the post-response `x`/`y` values are passed through unchanged (preserving `+X = right english`, `+Y = topspin`) by updating `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- No automated tests were run for this small logic-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f75c69a08329a0a18087f6006341)