### PR TITLE
Fix pool spin orientation to match screen-space

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,9 +43,9 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI has +X to the right; physics should match left/right as shown.
-    x: -curved.x,
-    // UI uses +Y for topspin; physics uses the opposite sign.
-    y: -curved.y
+    // UI uses screen-space: +X is right, +Y is up (topspin).
+    // Physics expects the same orientation so the diagram matches 1:1.
+    x: curved.x,
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- The spin UI was being inverted before physics (left/right and top/bottom signs flipped), causing hits to behave opposite to the on-screen hit-map; the change makes spin input interpret directions in screen-space so the mapping is 1:1 with the diagram.

### Description
- Replace the sign-inversion in `mapSpinForPhysics` so the function now returns `x: curved.x` and `y: curved.y` and update the comment to state the UI uses screen-space (file: `webapp/src/pages/Games/poolRoyaleSpinUtils.js`).

### Testing
- No automated tests were run for this small mapping change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f75c69a08329a0a18087f6006341)