### PR TITLE
Bring Pool Royale standing camera closer and adjust cue camera floor

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4708,7 +4708,7 @@ const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.1;
-const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.18; // keep the cue view a touch higher while staying above the cue
+const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.22; // keep the cue view a touch higher while staying above the cue
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
@@ -4719,7 +4719,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.58; // bring the standing camera nearer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.5; // bring the standing camera nearer while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads


### PR DESCRIPTION
### Motivation
- Pull the standing/broadcast camera closer to the table so the cue butt/back is less visible on portrait standing shots and impose a small change to the cue-camera tilt limits to refine how low the cue view can sweep.

### Description
- Reduced `STANDING_VIEW_DISTANCE_SCALE` from `0.58` to `0.5` in `webapp/src/pages/Games/PoolRoyale.jsx` to tighten the standing camera radius and bring the camera visually closer to the cloth.
- Adjusted `CAMERA_LOWEST_PHI` from `CUE_SHOT_PHI - 0.18` to `CUE_SHOT_PHI - 0.22` in the same file to change the cue-camera lower tilt bound.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968868ff45c83298f8b5bdfcf22997c)