### PR TITLE
Pool Royale: Camera framing, spin controller mapping, and chrome plate tweaks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -587,14 +587,14 @@ const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0; // keep fascia placement identical t
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2; // push the side fascia farther along the arch so it blankets the larger chrome reveal
-const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.24; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
+const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.32; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.75; // trim fascia span further so the middle plates finish before intruding into the pocket zone while keeping the rounded edge intact
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.68; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.52; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.12; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -4703,7 +4703,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.9; // tilt the standing orbit a touch more toward the table without changing height
+const STANDING_VIEW_PHI = 0.93; // tilt the standing orbit a touch more toward the table without changing height
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -4783,14 +4783,14 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.16; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.1; // raise the camera a touch to ensure full end-rail coverage
+const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.12; // lower the 2D top view slightly to keep framing consistent after the table shrink
+const TOP_VIEW_RADIUS_SCALE = 1.08; // lower the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * 0.028, // bias the top view slightly lower on portrait displays
-  z: PLAY_H * -0.028 // bias the top view a touch further right on portrait displays
+  x: PLAY_W * 0.04, // bias the top view slightly lower on portrait displays
+  z: PLAY_H * -0.04 // bias the top view a touch further right on portrait displays
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -12151,7 +12151,7 @@ const powerRef = useRef(hud.power);
     if (!dot) return;
     const x = clamp(value.x ?? 0, -1, 1);
     const y = clamp(value.y ?? 0, -1, 1);
-    const displayY = y;
+    const displayY = -y;
     const ranges = spinRangeRef.current || {};
     const maxSide = Math.max(ranges.offsetSide ?? MAX_SPIN_CONTACT_OFFSET, 1e-6);
     const maxVertical = Math.max(ranges.offsetVertical ?? MAX_SPIN_VERTICAL, 1e-6);
@@ -24755,7 +24755,7 @@ const powerRef = useRef(hud.power);
       const cx = clientX ?? rect.left + rect.width / 2;
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
-      let ny = ((cy - rect.top) / rect.height) * 2 - 1;
+      let ny = -(((cy - rect.top) / rect.height) * 2 - 1);
       setSpin(nx, ny);
     };
 

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const SPIN_INPUT_DEAD_ZONE = 0.015;
-export const SPIN_RESPONSE_EXPONENT = 1.75;
+export const SPIN_RESPONSE_EXPONENT = 1.9;
 
 export const clampToUnitCircle = (x, y) => {
   const length = Math.hypot(x, y);


### PR DESCRIPTION
### Motivation
- Make the on-screen Pool Royale table feel visually closer and slightly right-biased on portrait screens by nudging the standing/top view camera framing and offsets. 
- Fix the spin controller so top/back spin and left/right map to screen-space directions and produce a more realistic intensity curve from center → edge. 
- Broaden the middle-pocket chrome fascia slightly toward the corner pockets for a better visual match to reference styling.

### Description
- Adjusted standing/top camera constants in `webapp/src/pages/Games/PoolRoyale.jsx` (`STANDING_VIEW_PHI`, `TOP_VIEW_MARGIN`, `TOP_VIEW_MIN_RADIUS_SCALE`, `TOP_VIEW_RADIUS_SCALE`, and `TOP_VIEW_SCREEN_OFFSET.x/z`) to pull the view lower and bias it to the right. 
- Inverted the spin UI vertical mapping so the on-screen controller aligns with portrait screen directions by changing `updateSpinDotPosition` to use `displayY = -y` and negating the pointer-derived `ny` before applying spin. 
- Tuned chrome plate geometry parameters in `PoolRoyale.jsx` (`CHROME_SIDE_PLATE_HEIGHT_SCALE`, `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`, `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`) to expand the middle-pocket chrome toward the corners with reduced outward bias. 
- Increased the spin response exponent in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` (`SPIN_RESPONSE_EXPONENT` from `1.75` to `1.9`) to produce gentler near-center response and stronger edge swerve, keeping UI→physics orientation consistent via `mapSpinForPhysics`.

### Testing
- Launched a development server with `npm run dev` and Vite reported the app ready and serving (server startup succeeded). 
- Attempted an automated page capture using Playwright to validate the portrait view, but the Playwright run timed out (screenshot step failed). 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696897932d8083299f858e340845aee4)