### PR TITLE
Adjust Pool Royale camera framing, spin logic, chrome pocket cuts, and PolyHaven cloth tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -598,8 +598,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.12; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.032; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
+const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.03; // open the rounded chrome cut slightly wider on the middle pockets only
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.038; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -2825,12 +2825,12 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8; // enlarge Poly Haven cloth patterns ~20% more
+const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.64; // enlarge Poly Haven cloth patterns ~20% more
 const POLYHAVEN_ANISOTROPY_BOOST = 5;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.25, 1.25);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.55, 1.55);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -4790,8 +4790,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.012, // bias the top view slightly higher on portrait displays
-  z: PLAY_H * -0.078 // bias the top view further right on portrait displays
+  x: PLAY_W * -0.006, // bias the top view slightly lower on portrait displays
+  z: PLAY_H * -0.086 // bias the top view further right on portrait displays
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -17606,7 +17606,10 @@ const powerRef = useRef(hud.power);
           }
           const result = legality.blocked ? { x: 0, y: 0 } : normalized;
           const magnitude = Math.hypot(result.x ?? 0, result.y ?? 0);
-          const mode = magnitude >= SWERVE_THRESHOLD ? 'swerve' : 'standard';
+          const sideDominant =
+            Math.abs(result.x ?? 0) >= Math.abs(result.y ?? 0) * 0.85;
+          const mode =
+            magnitude >= SWERVE_THRESHOLD && sideDominant ? 'swerve' : 'standard';
           spinAppliedRef.current = { ...result, magnitude, mode };
           return result;
         };


### PR DESCRIPTION
### Motivation
- Improve portrait camera framing so the 2D/top view sits slightly more to the right and lower on mobile screens for better visual balance.
- Make the spin controller behave more predictably for low/backspin + combined left/right inputs so backspin produces draw/backwards roll while low-left/right produces backspin+side roll as expected.
- Slightly enlarge and recenter the rounded chrome cutouts at the middle pockets to better match art direction for those plates.
- Make PolyHaven (GLTF) cloth textures appear larger and sharper so patterns are more visible and defined compared to the procedural cloth.

### Description
- Updated the top-down camera screen offset (`TOP_VIEW_SCREEN_OFFSET`) to bias the top view a bit lower and further right on portrait displays in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Refined spin-mode selection so swerve now requires side-dominant input (`sideDominant` check) before enabling `swerve`; this keeps backspin inputs (low) resulting in backward roll while low+left/right combines backspin with lateral roll.
- Increased middle chrome pocket cut scaling and center pull constants (`CHROME_SIDE_POCKET_CUT_SCALE` and `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE`) so the rounded chrome cut is slightly larger and pulled a touch closer to center.
- Tuned PolyHaven cloth parameters by adjusting `POLYHAVEN_PATTERN_REPEAT_SCALE` and increasing `POLYHAVEN_NORMAL_SCALE` to make PolyHaven cloth patterns appear larger and normals stronger for a sharper look.
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx` (camera, spin, chrome, and cloth constants + the small spin-mode logic change).

### Testing
- No automated tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b1d4de20832999ac55cff6349bc4)