### PR TITLE
Pool Royale: camera, spin, chrome plate and PolyHaven cloth tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -598,8 +598,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.12; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.032; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
+const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.03; // open the rounded chrome cut slightly wider on the middle pockets only
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -2825,12 +2825,12 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8; // enlarge Poly Haven cloth patterns ~20% more
+const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8 * (1 / 1.2); // enlarge Poly Haven cloth patterns ~20% more
 const POLYHAVEN_ANISOTROPY_BOOST = 5;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.25, 1.25);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.45, 1.45);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -4790,8 +4790,8 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.012, // bias the top view slightly higher on portrait displays
-  z: PLAY_H * -0.078 // bias the top view further right on portrait displays
+  x: PLAY_W * -0.004, // bias the top view slightly lower on portrait displays
+  z: PLAY_H * -0.088 // bias the top view further right on portrait displays
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -6543,7 +6543,7 @@ function Table3D(
   const baseBumpScale =
     (0.64 * 1.52 * 1.34 * 1.26 * 1.18 * 1.12) *
     CLOTH_QUALITY.bumpScaleMultiplier *
-    (isPolyHavenCloth ? 1.2 : 1);
+    (isPolyHavenCloth ? 1.35 : 1);
   const flattenedBumpScale = baseBumpScale * 0.48;
   if (clothMap) {
     clothMat.map = clothMap;
@@ -17606,7 +17606,10 @@ const powerRef = useRef(hud.power);
           }
           const result = legality.blocked ? { x: 0, y: 0 } : normalized;
           const magnitude = Math.hypot(result.x ?? 0, result.y ?? 0);
-          const mode = magnitude >= SWERVE_THRESHOLD ? 'swerve' : 'standard';
+          const mode =
+            magnitude >= SWERVE_THRESHOLD && (result.y ?? 0) >= 0
+              ? 'swerve'
+              : 'standard';
           spinAppliedRef.current = { ...result, magnitude, mode };
           return result;
         };
@@ -23481,7 +23484,7 @@ const powerRef = useRef(hud.power);
                 TMP_VEC2_SPIN.multiplyScalar(
                   SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
                 );
-                if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
+                if ((b.spin?.y ?? 0) < -1e-4 || (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0)) {
                   TMP_VEC2_SPIN.multiplyScalar(BACKSPIN_ROLL_BOOST);
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {


### PR DESCRIPTION
### Motivation

- Improve 2D/portrait framing so the top-down camera reads slightly lower and a touch to the right on mobile screens.
- Fix backspin behavior so low/back inputs reliably produce backward motion (including diagonal low-left/low-right) while avoiding false swerve activation for downward spin.
- Make the chrome plate rounded cuts at the middle pockets slightly larger and move them a little closer to center so the chrome read better with existing geometry.
- Make GLTF (PolyHaven) cloth patterns clearer and sharper compared to the procedural cloth.

### Description

- Nudged the 2D top-down framing by changing `TOP_VIEW_SCREEN_OFFSET` to shift the view slightly down and right on portrait screens (`x` from `PLAY_W * -0.012` to `PLAY_W * -0.004`, `z` from `PLAY_H * -0.078` to `PLAY_H * -0.088`).
- Prevented low/backspin from being treated as `swerve` by only selecting `swerve` mode when magnitude >= `SWERVE_THRESHOLD` and the applied spin `y` is non-negative, keeping backspin inputs in `standard` mode for correct backward behavior (`mode` decision in spin handling).
- Increased backspin roll responsiveness by applying the `BACKSPIN_ROLL_BOOST` when the spin `y` component is negative (backspin) or when the velocity direction implies reversal, so low/low-right/low-left inputs produce backward + side roll as intended (adjusted the roll multiplier check in the roll application).
- Enlarged and shifted the chrome middle-pocket cut parameters by increasing `CHROME_SIDE_POCKET_CUT_SCALE` and `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE` so the rounded chrome cutouts read a bit larger and move slightly toward the center.
- Tuned PolyHaven cloth texture handling to make GLTF-sourced cloth more visible by adjusting `POLYHAVEN_PATTERN_REPEAT_SCALE`, raising `POLYHAVEN_NORMAL_SCALE`, and increasing the polyhaven bump/normal scaling applied for GLTF cloths (`baseBumpScale` multiplier bumped for polyhaven materials), producing larger and crisper pattern and normal detail for PolyHaven cloth textures.

### Testing

- Started the dev server with `npm run dev` in the `webapp` folder and Vite reported ready at `http://localhost:4173/`, indicating the build runs locally (succeeded).
- Attempted an automated visual smoke test using Playwright to capture a screenshot of `/games/poolroyale`, but the Chromium process in the container crashed and the Playwright run failed (failed).
- Changes were staged and committed locally with a descriptive commit message (`Adjust Pool Royale camera, spin, and cloth tuning`) after edits to `webapp/src/pages/Games/PoolRoyale.jsx` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b1d4de20832999ac55cff6349bc4)