### PR TITLE
Pool Royale: fix spin mapping & backspin, tweak chrome pocket cuts, polyhaven cloth and 2D button position

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -598,8 +598,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.12; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.032; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
+const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.04; // open the rounded chrome cut slightly wider on the middle pockets only
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -1333,7 +1333,7 @@ const POCKET_VIEW_MAX_HOLD_MS = 3200;
 const SPIN_STRENGTH = BALL_R * 0.034;
 const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021;
-const BACKSPIN_ROLL_BOOST = 1.6;
+const BACKSPIN_ROLL_BOOST = 2.05;
 const SPIN_ROLL_DECAY = 0.983;
 const SPIN_AIR_DECAY = 0.995; // hold spin energy while the cue ball travels straight pre-impact
 const LIFT_SPIN_AIR_DRIFT = SPIN_ROLL_STRENGTH * 1.45; // inject extra sideways carry while the cue ball is airborne
@@ -2825,12 +2825,12 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8; // enlarge Poly Haven cloth patterns ~20% more
-const POLYHAVEN_ANISOTROPY_BOOST = 5;
+const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8 * 0.83; // enlarge Poly Haven cloth patterns ~20% more
+const POLYHAVEN_ANISOTROPY_BOOST = 6;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.25, 1.25);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.45, 1.45);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -10943,6 +10943,7 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const viewButtonsOffsetPx = 32;
+  const viewToggleNudge = { x: 6, y: 6 };
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );
@@ -25821,6 +25822,7 @@ const powerRef = useRef(hud.power);
               : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
           }`}
           aria-label={isTopDownView ? 'Switch to 3D view' : 'Switch to 2D view'}
+          style={{ transform: `translate(${viewToggleNudge.x}px, ${viewToggleNudge.y}px)` }}
         >
           <span aria-hidden="true">{isTopDownView ? '3D' : '2D'}</span>
         </button>

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -44,8 +44,8 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    // Swap left/right so the spin control matches the in-game response.
-    x: -curved.x,
+    // Keep axes aligned so low-right/low-left add the correct side spin.
+    x: curved.x,
     y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Make the spin control map directly to physics so low-left/low-right + low (backspin) behave intuitively on the cue ball. 
- Increase backspin roll response so draw/backspin shots visibly pull the cue ball backwards. 
- Slightly enlarge and pull-in the rounded chrome cuts on middle pockets so the chrome reading matches the desired look. 
- Make Poly Haven cloth patterns appear stronger and sharper and nudge the 2D view toggle for improved portrait placement.

### Description
- Keep the spin X axis aligned in `mapSpinForPhysics` by removing the sign flip so UI low-right/low-left produce the expected side spin (`webapp/src/pages/Games/poolRoyaleSpinUtils.js`).
- Increase backspin roll boost by updating `BACKSPIN_ROLL_BOOST` from `1.6` to `2.05` to strengthen backward velocity on draw shots (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Widen and pull the middle chrome pocket cutouts by changing `CHROME_SIDE_POCKET_CUT_SCALE` and `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE` (tuned to `1.04` and `0.04` respectively) (`PoolRoyale.jsx`).
- Tweak Poly Haven cloth parameters by adjusting `POLYHAVEN_PATTERN_REPEAT_SCALE`, raising `POLYHAVEN_ANISOTROPY_BOOST`, and increasing `POLYHAVEN_NORMAL_SCALE` for crisper, more visible gltf/PolyHaven cloth detail (`PoolRoyale.jsx`).
- Nudge the 2D/top-down toggle visually by adding a small translate `viewToggleNudge` and applying it to the button style so it appears slightly right and down in portrait (`PoolRoyale.jsx`).

### Testing
- Started the local dev server with `npm --prefix webapp run dev` and Vite reported the app served at `http://localhost:4173/` (success).
- Attempted a Playwright screenshot of the running page to validate UI placement but the screenshot step timed out (failed to capture).
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b1d4de20832999ac55cff6349bc4)