### PR TITLE
Adjust top-view framing, invert cue backspin mapping, and refine chrome & PolyHaven cloth visuals

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -648,8 +648,8 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.032; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
+const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.03; // open the rounded chrome cut slightly wider on the middle pockets only
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -2887,11 +2887,11 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.76; // tighten the pattern footprint so the scan resolves more clearly
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = 1 / 3;
-const POLYHAVEN_ANISOTROPY_BOOST = 3.6;
+const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 3) / 1.2;
+const POLYHAVEN_ANISOTROPY_BOOST = 4.4;
 const POLYHAVEN_TEXTURE_RESOLUTION = '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(2.6, 1.4);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(3.05, 1.7);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -4831,8 +4831,8 @@ const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); 
 const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: -PLAY_W * 0.015, // bias the top view so the table sits a touch higher on screen
-  z: -PLAY_H * 0.012 // bias the top view so the table sits slightly more to the left
+  x: PLAY_W * 0.006, // bias the top view so the table sits slightly lower on screen
+  z: PLAY_H * 0.006 // bias the top view so the table sits slightly more to the right
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -5128,7 +5128,7 @@ const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(spin);
   return {
     x: curved?.x ?? 0,
-    y: curved?.y ?? 0
+    y: -(curved?.y ?? 0)
   };
 };
 const normalizeCueLift = (liftAngle = 0) => {
@@ -6680,7 +6680,7 @@ function Table3D(
   const baseBumpScale =
     (0.64 * 1.52 * 1.34 * 1.26 * 1.18 * 1.12) *
     CLOTH_QUALITY.bumpScaleMultiplier *
-    (isPolyHavenCloth ? 1.2 : 1);
+    (isPolyHavenCloth ? 1.35 : 1);
   const flattenedBumpScale = baseBumpScale * 0.48;
   if (clothMap) {
     clothMat.map = clothMap;


### PR DESCRIPTION
### Motivation
- Reframe the 2D/top-view camera so the Pool Royale table appears slightly lower and to the right on portrait screens for the 2D button view.
- Ensure the spin controller applies backspin when the user sets the control to the low (bottom) position and correctly combines backspin with left/right side-spin.
- Tweak the middle-pocket chrome cut geometry so the rounded cut is a bit larger and sits slightly closer to the pocket centre.
- Make PolyHaven GLTF cloth textures look larger/sharper and increase normal/bump detail so scanned cloth patterns read more clearly.

### Description
- Moved the top/2D view bias by changing `TOP_VIEW_SCREEN_OFFSET` so the table frames slightly lower and to the right on screen (`x` and `z` updated). (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Inverted the vertical spin mapping in `mapSpinForPhysics` so the physics `y` spin is negated, causing downward/low inputs to produce backspin as expected. (`mapSpinForPhysics`)
- Adjusted chrome/middle-pocket parameters: increased `CHROME_SIDE_POCKET_CUT_SCALE` and raised `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE` so the rounded chrome cut on middle pockets is marginally larger and pulled a bit inward. (`CHROME_SIDE_POCKET_CUT_SCALE`, `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE`)
- Tuned PolyHaven cloth appearance by changing `POLYHAVEN_PATTERN_REPEAT_SCALE`, increasing `POLYHAVEN_ANISOTROPY_BOOST`, enlarging `POLYHAVEN_NORMAL_SCALE`, and raising the polyhaven bump multiplier (`isPolyHavenCloth ? 1.35 : 1`) to make patterns sharper and more visible. (clothing texture creation and material setup)

### Testing
- No automated tests were executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b1d4de20832999ac55cff6349bc4)