### PR TITLE
Tune cue ball backspin, 2D top camera, and PolyHaven cloth visuals for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1333,7 +1333,7 @@ const POCKET_VIEW_MAX_HOLD_MS = 3200;
 const SPIN_STRENGTH = BALL_R * 0.034;
 const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021;
-const BACKSPIN_ROLL_BOOST = 1.6;
+const BACKSPIN_ROLL_BOOST = 2.05;
 const SPIN_ROLL_DECAY = 0.983;
 const SPIN_AIR_DECAY = 0.995; // hold spin energy while the cue ball travels straight pre-impact
 const LIFT_SPIN_AIR_DRIFT = SPIN_ROLL_STRENGTH * 1.45; // inject extra sideways carry while the cue ball is airborne
@@ -2825,12 +2825,12 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.8; // enlarge Poly Haven cloth patterns ~20% more
+const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.55) * 0.8; // enlarge Poly Haven cloth patterns to read more clearly
 const POLYHAVEN_ANISOTROPY_BOOST = 5;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.25, 1.25);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.45, 1.45);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -4791,7 +4791,22 @@ const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep fr
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.012, // bias the top view slightly higher on portrait displays
-  z: PLAY_H * -0.078 // bias the top view further right on portrait displays
+  z: PLAY_H * -0.088 // bias the top view further right on portrait displays
+});
+const REPLAY_TOP_VIEW_PHI = Math.max(
+  CAMERA_ABS_MIN_PHI * 0.45,
+  CAMERA.minPhi * 0.22
+);
+const REPLAY_TOP_VIEW_MARGIN = 1.15;
+const REPLAY_TOP_VIEW_RADIUS_SCALE = 1.26;
+const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = 1.08;
+const REPLAY_TOP_VIEW_RESOLVED_PHI = Math.max(
+  REPLAY_TOP_VIEW_PHI,
+  CAMERA_ABS_MIN_PHI * 0.5
+);
+const REPLAY_TOP_VIEW_SCREEN_OFFSET = Object.freeze({
+  x: PLAY_W * 0.006,
+  z: PLAY_H * 0.006
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
@@ -5835,7 +5850,7 @@ function applySpinImpulse(ball, scale = 1) {
   const { forward, lateral, speed } = resolveSpinFrame(ball);
   const sideSpin = ball.spin.x || 0;
   const forwardSpin = ball.spin.y || 0;
-  const backspinBoost = forwardSpin < -1e-4 ? 1.75 : 1;
+  const backspinBoost = forwardSpin < -1e-4 ? 2.25 : 1;
   const swerveScale = 0.8 + Math.min(speed, 8) * 0.15;
   const liftScale = 0.35 + Math.min(speed, 6) * 0.08;
   const lateralKick = sideSpin * SPIN_STRENGTH * swerveScale * scale;
@@ -5880,7 +5895,7 @@ function applyRailSpinResponse(ball, impact) {
     ball.vel.addScaledVector(tangent, throwStrength);
   }
   ball.spin.copy(preImpactSpin);
-  const backspinBoost = ball.spin.y < -1e-4 ? 0.95 : 0.6;
+  const backspinBoost = ball.spin.y < -1e-4 ? 1.35 : 0.6;
   applySpinImpulse(ball, backspinBoost);
 }
 
@@ -16988,17 +17003,22 @@ const powerRef = useRef(hud.power);
             }
           }
           const tableFocus = new THREE.Vector3(
-            playerOffsetRef.current,
+            playerOffsetRef.current + REPLAY_TOP_VIEW_SCREEN_OFFSET.x,
             ORBIT_FOCUS_BASE_Y,
-            0
+            REPLAY_TOP_VIEW_SCREEN_OFFSET.z
           ).multiplyScalar(scale);
           tableFocus.y = Math.max(tableFocus.y ?? 0, minTargetY);
           const topRadiusBase =
-            fitRadius(fallbackCamera ?? camera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE;
+            fitRadius(fallbackCamera ?? camera, REPLAY_TOP_VIEW_MARGIN) *
+            REPLAY_TOP_VIEW_RADIUS_SCALE;
           const topRadius = clampOrbitRadius(
-            Math.max(topRadiusBase, CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE)
+            Math.max(topRadiusBase, CAMERA.minR * REPLAY_TOP_VIEW_MIN_RADIUS_SCALE)
           );
-          const position = tableFocus.clone().add(new THREE.Vector3(0, topRadius, 0));
+          const position = new THREE.Vector3()
+            .setFromSpherical(
+              new THREE.Spherical(topRadius, REPLAY_TOP_VIEW_RESOLVED_PHI, Math.PI)
+            )
+            .add(tableFocus);
           return {
             position,
             target: tableFocus,
@@ -23737,7 +23757,7 @@ const powerRef = useRef(hud.power);
                 }
                 if (cueBall && cueBall.spin?.lengthSq() > 0) {
                   cueBall.impacted = true;
-                  const backspinBoost = cueBall.spin.y < -1e-4 ? 1.55 : 1.1;
+                  const backspinBoost = cueBall.spin.y < -1e-4 ? 2.15 : 1.1;
                   applySpinImpulse(cueBall, backspinBoost);
                 }
               }


### PR DESCRIPTION
### Motivation
- Make cue ball backspin behave more realistically so hits that impart back/top spin cause the cue ball to roll backward after contact or cushion hits.
- Shift the 2D top-down camera framing slightly to the right so the table lines up better with the 2D button view and improve replay framing to match the Snooker Royale 2D camera angle/distance.
- Improve visibility of Poly Haven cloth patterns so the weave/detail reads sharper and the tone is preserved.

### Description
- Increased backspin response tuning by adjusting `BACKSPIN_ROLL_BOOST` and the backspin multipliers used by `applySpinImpulse` and rail/collision responses (tuning values around `backspinBoost` in `applySpinImpulse`, `applyRailSpinResponse`, and the cue-collision path). (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Nudged the 2D/top view framing by changing `TOP_VIEW_SCREEN_OFFSET.z` (small rightward shift) and added a set of replay-specific top-view constants (`REPLAY_TOP_VIEW_*`) so replay capture uses the Snooker-style top camera angle/distance and an adjusted offset.
- Increased PolyHaven cloth pattern visibility by updating `POLYHAVEN_PATTERN_REPEAT_SCALE` and `POLYHAVEN_NORMAL_SCALE` to enlarge pattern repeat and strengthen normal-map scale for clearer weave detail.
- All changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and are tuning/parameter adjustments (no new systems introduced).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968da7fcfd4832993130eac6d3a2fb6)