### PR TITLE
Pool Royale: tune cue impact, cameras, cloth and pocket visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -595,7 +595,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.18; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.22; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -1211,7 +1211,7 @@ const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall sligh
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
 const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
-const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.22; // raise the net so the weave meets the pocket mouth
+const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.26; // raise the net so the weave meets the pocket mouth
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
@@ -1222,11 +1222,11 @@ const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails jus
 const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
 const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.03; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.01; // lift the chrome holder rails so the short L segments meet the ring
 const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
-const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.45; // let potted balls roll a touch farther before stopping
+const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.0; // tighter spacing so potted balls touch on the holder rails
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.7; // let potted balls roll a touch farther before stopping
 const POCKET_HOLDER_REST_DROP = BALL_R * 2.02; // lift the resting spot so balls ride higher on the chrome holder
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
@@ -1241,13 +1241,13 @@ const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // rais
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_BASE_MIN_OUTSIDE =
-  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.18 +
-  POCKET_VIS_R * 2.25 +
-  BALL_R * 1.6;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.08 +
+  POCKET_VIS_R * 2.1 +
+  BALL_R * 1.45;
 const POCKET_CAM_BASE_OUTWARD_OFFSET =
-  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.34 +
-  POCKET_VIS_R * 2.28 +
-  BALL_R * 1.54;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.22 +
+  POCKET_VIS_R * 2.12 +
+  BALL_R * 1.4;
 const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 12,
   dotThreshold: 0.22,
@@ -1334,7 +1334,7 @@ const SPIN_STRENGTH = BALL_R * 0.034;
 const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021;
 const BACKSPIN_ROLL_BOOST = 1.6;
-const CUE_BACKSPIN_ROLL_BOOST = 2.2;
+const CUE_BACKSPIN_ROLL_BOOST = 2.8;
 const SPIN_ROLL_DECAY = 0.983;
 const SPIN_AIR_DECAY = 0.995; // hold spin energy while the cue ball travels straight pre-impact
 const LIFT_SPIN_AIR_DRIFT = SPIN_ROLL_STRENGTH * 1.45; // inject extra sideways carry while the cue ball is airborne
@@ -1412,7 +1412,7 @@ const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.22; // widen the visible air gap so the blue tip never kisses the cue ball
+const CUE_TIP_CLEARANCE = BALL_R * 0.1; // tighten the visible air gap so the blue tip visually kisses the cue ball
 const CUE_TIP_GAP = BALL_R * 1.08 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
@@ -1426,8 +1426,8 @@ const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_STROKE_MIN_MS = 125;
 const CUE_STROKE_MAX_MS = 520;
-const CUE_STROKE_SPEED_MIN = BALL_R * 15;
-const CUE_STROKE_SPEED_MAX = BALL_R * 28;
+const CUE_STROKE_SPEED_MIN = BALL_R * 13.2;
+const CUE_STROKE_SPEED_MAX = BALL_R * 24.5;
 const CUE_FOLLOW_MIN_MS = 220;
 const CUE_FOLLOW_MAX_MS = 520;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 10;
@@ -2826,12 +2826,13 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 1.4) * 0.72; // enlarge Poly Haven cloth patterns ~28% more
+const POLYHAVEN_PATTERN_REPEAT_SCALE = 0.58; // enlarge Poly Haven cloth patterns slightly more for clearer weave
 const POLYHAVEN_ANISOTROPY_BOOST = 7;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
-const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.45, 1.45);
+const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(2.15, 2.15);
+const POLYHAVEN_ROUGHNESS_ADJUST = -0.05; // deepen Poly Haven texture contrast without shifting color tone
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
@@ -3486,14 +3487,23 @@ function updateClothTexturesForFinish (
   registerClothTextureConsumer(textureKey, finishInfo);
   const textures = createClothTextures(textureKey, textureSource);
   const textureScale = textures.mapSource === 'polyhaven' ? POLYHAVEN_PATTERN_REPEAT_SCALE : 1;
-  const targetNormalScale =
-    finishInfo.clothBase?.isPolyHavenCloth && textures.normal
-      ? POLYHAVEN_NORMAL_SCALE
-      : CLOTH_NORMAL_SCALE;
+  const isPolyHaven = Boolean(finishInfo.clothBase?.isPolyHavenCloth && textures.normal);
+  const targetNormalScale = isPolyHaven ? POLYHAVEN_NORMAL_SCALE : CLOTH_NORMAL_SCALE;
   const roughnessBase =
     finishInfo.clothBase?.roughness ?? finishInfo.clothMat.roughness ?? CLOTH_ROUGHNESS_BASE;
   const roughnessTarget =
     finishInfo.clothBase?.roughnessTarget ?? CLOTH_ROUGHNESS_TARGET;
+  const roughnessShift = isPolyHaven ? POLYHAVEN_ROUGHNESS_ADJUST : 0;
+  const adjustedRoughnessBase = THREE.MathUtils.clamp(
+    roughnessBase + roughnessShift,
+    0.5,
+    0.95
+  );
+  const adjustedRoughnessTarget = THREE.MathUtils.clamp(
+    roughnessTarget + roughnessShift,
+    0.5,
+    0.95
+  );
   const baseRepeatRaw =
     finishInfo.clothMat.userData?.baseRepeatRaw ??
     finishInfo.clothBase?.baseRepeatRaw ??
@@ -3534,9 +3544,9 @@ function updateClothTexturesForFinish (
     );
   }
   if (textures.roughness) {
-    finishInfo.clothMat.roughness = roughnessTarget;
+    finishInfo.clothMat.roughness = adjustedRoughnessTarget;
   } else {
-    finishInfo.clothMat.roughness = roughnessBase;
+    finishInfo.clothMat.roughness = adjustedRoughnessBase;
   }
   if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
     finishInfo.clothMat.bumpScale = finishInfo.clothBase.baseBumpScale;
@@ -4791,7 +4801,7 @@ const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.02, // shift the top view slightly left away from the power slider
+  x: PLAY_W * -0.03, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
 });
 const REPLAY_TOP_VIEW_MARGIN = 1.15;
@@ -4915,8 +4925,8 @@ const AI_CUE_PULL_VISIBILITY_BOOST = 1.34;
 const AI_WARMUP_PULL_RATIO = 0.55;
 const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.62;
-const PLAYER_STROKE_TIME_SCALE = 1.45;
-const PLAYER_FORWARD_SLOWDOWN = 1.2;
+const PLAYER_STROKE_TIME_SCALE = 1.65;
+const PLAYER_FORWARD_SLOWDOWN = 1.35;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.2;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
@@ -6507,8 +6517,17 @@ function Table3D(
   const clothSheenRoughness = CLOTH_REFLECTIONS_DISABLED
     ? 1
     : Math.min(1, CLOTH_QUALITY.sheenRoughness * 1.12);
-  const clothRoughnessBase = CLOTH_ROUGHNESS_BASE + 0.06;
-  const clothRoughnessTarget = CLOTH_ROUGHNESS_TARGET + 0.06;
+  const polyhavenRoughnessShift = isPolyHavenCloth ? POLYHAVEN_ROUGHNESS_ADJUST : 0;
+  const clothRoughnessBase = THREE.MathUtils.clamp(
+    CLOTH_ROUGHNESS_BASE + 0.06 + polyhavenRoughnessShift,
+    0.5,
+    0.95
+  );
+  const clothRoughnessTarget = THREE.MathUtils.clamp(
+    CLOTH_ROUGHNESS_TARGET + 0.06 + polyhavenRoughnessShift,
+    0.5,
+    0.95
+  );
   const clothEmissiveIntensity = 0.18;
   const clothNormalScale = isPolyHavenCloth ? POLYHAVEN_NORMAL_SCALE : CLOTH_NORMAL_SCALE;
   const clothMat = new THREE.MeshPhysicalMaterial({
@@ -17024,6 +17043,31 @@ const powerRef = useRef(hud.power);
               return snapshot;
             }
           }
+          const broadcastRig = broadcastCamerasRef.current;
+          if (broadcastRig?.cameras) {
+            const activeRail =
+              broadcastRig.activeRail === 'front'
+                ? broadcastRig.cameras.front
+                : broadcastRig.activeRail === 'back'
+                  ? broadcastRig.cameras.back
+                  : broadcastRig.cameras.back ?? broadcastRig.cameras.front;
+            const head = activeRail?.head ?? null;
+            if (head) {
+              const position = head.getWorldPosition(new THREE.Vector3());
+              const focusTarget =
+                broadcastRig.userData?.focus?.clone?.() ??
+                broadcastRig.defaultFocusWorld?.clone?.() ??
+                broadcastRig.defaultFocus?.clone?.() ??
+                new THREE.Vector3(playerOffsetRef.current, ORBIT_FOCUS_BASE_Y, 0).multiplyScalar(scale);
+              focusTarget.y = Math.max(focusTarget.y ?? 0, minTargetY);
+              return {
+                position,
+                target: focusTarget,
+                fov: fovSnapshot,
+                minTargetY
+              };
+            }
+          }
           const tableFocus = new THREE.Vector3(
             playerOffsetRef.current,
             ORBIT_FOCUS_BASE_Y,
@@ -23777,7 +23821,7 @@ const powerRef = useRef(hud.power);
                 }
                 if (cueBall && cueBall.spin?.lengthSq() > 0) {
                   cueBall.impacted = true;
-                  const backspinBoost = cueBall.spin.y < -1e-4 ? 2.1 : 1.1;
+                  const backspinBoost = cueBall.spin.y < -1e-4 ? 2.6 : 1.15;
                   applySpinImpulse(cueBall, backspinBoost);
                 }
               }


### PR DESCRIPTION
### Motivation
- Improve visual fidelity and gameplay feedback so the cue ball and aiming overlay match what the player sees (stronger backspin response and visible cue-tip contact). 
- Move the 2D/top view framing slightly left on portrait screens to better clear the power slider and bias replays toward the rail-overhead broadcast cameras for the classic TV-style playback. 
- Make PolyHaven cloth patterns and normal detail more visible and slightly increase cloth contrast so material weave reads better. 
- Adjust pocket/chrome/holder geometry and pocket cameras so chrome plates sit a touch farther out, nets/holders align with pockets, and potted balls rest/touch naturally without overlaps.

### Description
- Tuned cue/collision & stroke timing in `PoolRoyale.jsx`: tightened `CUE_TIP_CLEARANCE`, lowered `CUE_STROKE_SPEED_*`, increased `PLAYER_STROKE_TIME_SCALE`/`PLAYER_FORWARD_SLOWDOWN`, and increased cue backspin response via `CUE_BACKSPIN_ROLL_BOOST` and the backspin `applySpinImpulse` multiplier so the cue ball more directly follows the aiming line after impact. (See constants and collision handling sections.)
- Replay / camera behavior: shifted the 2D top-view screen offset left (`TOP_VIEW_SCREEN_OFFSET.x`) and reused the broadcast rail/head world transform when storing replay camera snapshots so rail-overhead broadcast heads are used more often for replays (adds preference for `broadcastCamerasRef.current` head positions in the replay snapshot code).
- Cloth/texture improvements: increased `POLYHAVEN_PATTERN_REPEAT_SCALE`, boosted `POLYHAVEN_NORMAL_SCALE`, and apply a small `POLYHAVEN_ROUGHNESS_ADJUST` when PolyHaven textures are used; adjusted the cloth roughness clamps and per-finish roughness handling to make polyhaven cloth patterns sharper and more visible (updates in `createClothTextures`/`updateClothTexturesForFinish` and material creation).
- Pocket & chrome adjustments: nudged `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` outward, raised `POCKET_NET_VERTICAL_LIFT`, reduced `POCKET_GUIDE_VERTICAL_DROP`, tightened `POCKET_HOLDER_REST_SPACING` and slightly increased `POCKET_HOLDER_REST_PULLBACK` so potted balls roll a tiny bit farther and rest touching without overlap; nudged pocket camera outward/closer parameters (`POCKET_CAM_BASE_MIN_OUTSIDE`, `POCKET_CAM_BASE_OUTWARD_OFFSET`) to place pocket cameras nearer the table edge.
- Misc: small improvements to cue animation visibility and replay cue-stroke capture (cue stroke recording unchanged in shape but timing/visibility improved by the stroke speed/timing changes).
- Files modified: `webapp/src/pages/Games/PoolRoyale.jsx` (centralized changes to constants, cloth texture handling, pocket geometry, replay camera snapshot, and cue/collision handling).

### Testing
- Automated tests: no automated tests were executed for this change (no CI/test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f8e85aac8329826aa0f0c100d9d6)