### PR TITLE
Fix Pool Royale spin control mapping

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -44,8 +44,7 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    // Swap left/right so the spin control matches the in-game response.
-    x: -curved.x,
+    x: curved.x,
     y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- The spin controller produced inverted left/right input so left backspin required placing the dot top-right, and topspin/backspin semantics were inconsistent with the UI, so the physics mapping needed to match screen-space directions.

### Description
- Stop negating the X component in `mapSpinForPhysics` by updating `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so the UI's +X (right) maps directly to the physics +X and +Y remains topspin.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969154b445c8329a4da930e0ac27a6d)