### PR TITLE
Adjust Pool Royale backspin response curve

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -2,6 +2,7 @@ const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const SPIN_INPUT_DEAD_ZONE = 0.015;
 export const SPIN_RESPONSE_EXPONENT = 1.9;
+export const SPIN_BACKSPIN_RESPONSE_EXPONENT = 1.75;
 
 export const clampToUnitCircle = (x, y) => {
   const length = Math.hypot(x, y);
@@ -22,7 +23,7 @@ export const normalizeSpinInput = (spin) => {
   return clampToUnitCircle(x, y);
 };
 
-export const applySpinResponseCurve = (spin) => {
+export const applySpinResponseCurve = (spin, exponent = SPIN_RESPONSE_EXPONENT) => {
   const x = spin?.x ?? 0;
   const y = spin?.y ?? 0;
   const magnitude = Math.hypot(x, y);
@@ -31,7 +32,7 @@ export const applySpinResponseCurve = (spin) => {
   }
   const clamped = clampToUnitCircle(x, y);
   const clampedMag = Math.hypot(clamped.x, clamped.y);
-  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const curvedMag = Math.pow(clampedMag, exponent);
   const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
   return { x: clamped.x * scale, y: clamped.y * scale };
 };
@@ -41,7 +42,9 @@ export const mapSpinForPhysics = (spin) => {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
   };
-  const curved = applySpinResponseCurve(adjusted);
+  const exponent =
+    adjusted.y < 0 ? SPIN_BACKSPIN_RESPONSE_EXPONENT : SPIN_RESPONSE_EXPONENT;
+  const curved = applySpinResponseCurve(adjusted, exponent);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
     x: curved.x,


### PR DESCRIPTION
### Motivation
- Restore the previous *backspin* feel by using a different response curve when the spin control is dragged low, while keeping topspin behavior unchanged.

### Description
- Add `SPIN_BACKSPIN_RESPONSE_EXPONENT` and allow `applySpinResponseCurve` to accept a custom exponent, then select the backspin exponent when `spin.y < 0` before mapping to physics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696928fcd7208329ae159154dbf2a82d)