### PR TITLE
Adjust Pool Royale backspin response curve

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -2,6 +2,7 @@ const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const SPIN_INPUT_DEAD_ZONE = 0.015;
 export const SPIN_RESPONSE_EXPONENT = 1.9;
+export const SPIN_RESPONSE_EXPONENT_BACKSPIN = 1.65;
 
 export const clampToUnitCircle = (x, y) => {
   const length = Math.hypot(x, y);
@@ -31,7 +32,8 @@ export const applySpinResponseCurve = (spin) => {
   }
   const clamped = clampToUnitCircle(x, y);
   const clampedMag = Math.hypot(clamped.x, clamped.y);
-  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const exponent = clamped.y < 0 ? SPIN_RESPONSE_EXPONENT_BACKSPIN : SPIN_RESPONSE_EXPONENT;
+  const curvedMag = Math.pow(clampedMag, exponent);
   const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
   return { x: clamped.x * scale, y: clamped.y * scale };
 };


### PR DESCRIPTION
### Motivation
- Restore the prior low/backspin feel by applying a dedicated response exponent for backspin so the low backspin matches the previously approved "perfect" feel without changing topspin behavior.

### Description
- Add `SPIN_RESPONSE_EXPONENT_BACKSPIN = 1.65` and select it inside `applySpinResponseCurve` when `clamped.y < 0`, updating `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to use the backspin exponent.

### Testing
- No automated tests were run; the repository contains spin-mapping unit tests such as `test/poolRoyaleSpinController.test.js` but they were not executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696928fcd7208329ae159154dbf2a82d)