### PR TITLE
Invert Pool Royale spin controller axes

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -46,7 +46,8 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    x: curved.x,
-    y: curved.y
+    // Pool Royale expects the spin controller to be inverted: left/right and high/low swapped.
+    x: -curved.x,
+    y: -curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Ensure the spin control mapping used by Pool Royale matches the expected on-screen directions by swapping left/right and high/low inputs.

### Description
- Negate the mapped spin axes in `mapSpinForPhysics` so the returned values are `x: -curved.x` and `y: -curved.y`, and add a comment explaining the inversion.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696931ba1fa88329bcd3ff257ad300c1)