### PR TITLE
Invert Pool Royale spin controller directions (swap left/right and high/low)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24707,14 +24707,14 @@ const powerRef = useRef(hud.power);
     () => {
       const radius = 72;
       const labels = [
-        { text: 'HIGH', angle: -90 },
-        { text: 'HIGH RIGHT', angle: -45 },
-        { text: 'RIGHT', angle: 0 },
-        { text: 'LOW RIGHT', angle: 45 },
-        { text: 'LOW', angle: 90 },
-        { text: 'LOW LEFT', angle: 135 },
-        { text: 'LEFT', angle: 180 },
-        { text: 'HIGH LEFT', angle: 225 }
+        { text: 'HIGH', angle: 90 },
+        { text: 'HIGH RIGHT', angle: 135 },
+        { text: 'RIGHT', angle: 180 },
+        { text: 'LOW RIGHT', angle: 225 },
+        { text: 'LOW', angle: 270 },
+        { text: 'LOW LEFT', angle: 315 },
+        { text: 'LEFT', angle: 360 },
+        { text: 'HIGH LEFT', angle: 405 }
       ];
       return labels.map((label) => {
         const radians = (label.angle * Math.PI) / 180;
@@ -24798,6 +24798,8 @@ const powerRef = useRef(hud.power);
       const cy = clientY ?? rect.top + rect.height / 2;
       let nx = ((cx - rect.left) / rect.width) * 2 - 1;
       let ny = -(((cy - rect.top) / rect.height) * 2 - 1);
+      nx = -nx;
+      ny = -ny;
       setSpin(nx, ny);
     };
 


### PR DESCRIPTION
### Motivation
- The spin controller mapping was reversed for player expectations, so left/right and high/low directions must be swapped to match the intended control orientation.

### Description
- Update `spinRingLabels` in `webapp/src/pages/Games/PoolRoyale.jsx` to move the label angles so the visual labels are rotated to the swapped orientation. 
- Invert the controller input mapping by negating the normalized pointer values (`nx` and `ny`) before calling `setSpin` so touch/drag produces the swapped directions.
- Changes are limited to `PoolRoyale.jsx` (spin controller labels and input handling).

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully (site served at the dev URL). 
- Attempted an automated Playwright screenshot to validate the UI, but the browser crashed during the run (Playwright `TargetClosedError` / SIGSEGV), so no screenshot was produced and no UI integration test completed.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696931ba1fa88329bcd3ff257ad300c1)