### PR TITLE
Swap Pool Royale spin controller directions (left/right and high/low)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24707,14 +24707,14 @@ const powerRef = useRef(hud.power);
     () => {
       const radius = 72;
       const labels = [
-        { text: 'HIGH', angle: -90 },
-        { text: 'HIGH RIGHT', angle: -45 },
-        { text: 'RIGHT', angle: 0 },
-        { text: 'LOW RIGHT', angle: 45 },
-        { text: 'LOW', angle: 90 },
-        { text: 'LOW LEFT', angle: 135 },
-        { text: 'LEFT', angle: 180 },
-        { text: 'HIGH LEFT', angle: 225 }
+        { text: 'LOW', angle: -90 },
+        { text: 'LOW LEFT', angle: -45 },
+        { text: 'LEFT', angle: 0 },
+        { text: 'HIGH LEFT', angle: 45 },
+        { text: 'HIGH', angle: 90 },
+        { text: 'HIGH RIGHT', angle: 135 },
+        { text: 'RIGHT', angle: 180 },
+        { text: 'LOW RIGHT', angle: 225 }
       ];
       return labels.map((label) => {
         const radians = (label.angle * Math.PI) / 180;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -46,7 +46,8 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    x: curved.x,
-    y: curved.y
+    // Pool Royale spin physics expects the opposite orientation.
+    x: -curved.x,
+    y: -curved.y
   };
 };


### PR DESCRIPTION
### Motivation

- The spin controller should match the requested orientation where left/right and high/low are swapped so the visual control maps correctly to physics and user expectations.

### Description

- Inverted the spin-to-physics mapping by negating both axes in `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so UI screen-space input is remapped to the physics orientation the Pool Royale simulation expects.
- Reordered the `spinRingLabels` in `webapp/src/pages/Games/PoolRoyale.jsx` so the on-screen labels (`HIGH`/`LOW` and `LEFT`/`RIGHT`) match the updated controller orientation.
- Changes are restricted to the Pool Royale spin UI and spin mapping and do not alter unrelated gameplay code.

### Testing

- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported ready (server launch succeeded).
- Attempted an automated visual verification via Playwright to capture a screenshot of the Pool Royale page, but the Playwright screenshot run timed out and did not complete.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696931ba1fa88329bcd3ff257ad300c1)