### PR TITLE
Fix Pool Royale spin preview direction and topspin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6009,7 +6009,7 @@ function resolveSwerveAimDir(
     (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
   const powerScale = 4 + powerStrength * 6;
   const swerveScale = 0.6 + swerve.intensity * 0.9;
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const adjust =
     sideSpin *
     swerve.intensity *
@@ -6041,7 +6041,7 @@ function buildSwerveAimLinePoints(
     swerveActive,
     liftStrength
   );
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const travel = start.distanceTo(end);
   if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
     points.length = 2;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -46,8 +46,8 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    // Pool Royale spin physics expects the opposite orientation.
+    // Pool Royale side spin expects the opposite X orientation.
     x: -curved.x,
-    y: -curved.y
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Players saw the aim preview curve mirror side-spin (left/right) and the topspin/backspin mapping inverted relative to the spin controller; the visual aim needed to reflect true cue-ball behavior without changing the input semantics.

### Description
- Adjusted physics mapping in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so the UI spin Y (vertical/top-back) is not inverted for physics while keeping side-spin X inverted, by returning `x: -curved.x, y: curved.y` from `mapSpinForPhysics`.
- Aligned the swerve/preview math in `webapp/src/pages/Games/PoolRoyale.jsx` so the aim preview uses the same sign for side spin as the physics engine by removing the previous negation of `swerve.sideSpin` in `resolveSwerveAimDir` and `buildSwerveAimLinePoints`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969bf88805883299eb8b8884b10c6b7)