### PR TITLE
Fix spin mapping and aim preview in Pool Royale

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -12,21 +12,21 @@ describe('Pool Royale spin controller mapping', () => {
     expect(Math.abs(center.y)).toBe(0);
   });
 
-  it('keeps left/right spin directions aligned with the controller', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(-1);
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(1);
+  it('keeps left/right spin directions aligned with the table axes', () => {
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(1);
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(-1);
   });
 
-  it('flips vertical spin so topspin maps to the physics forward axis', () => {
-    expect(getSigns(mapSpinForPhysics({ x: 0, y: 1 })).y).toBe(-1);
-    expect(getSigns(mapSpinForPhysics({ x: 0, y: -1 })).y).toBe(1);
+  it('keeps vertical spin aligned so topspin drives forward motion', () => {
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: 1 })).y).toBe(1);
+    expect(getSigns(mapSpinForPhysics({ x: 0, y: -1 })).y).toBe(-1);
   });
 
-  it('preserves diagonal quadrants while flipping vertical spin', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: -1 });
+  it('preserves diagonal quadrants while keeping vertical spin aligned', () => {
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: 1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: -1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: 1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: -1, y: 1 });
   });
 
   it('scales spin strength with distance from center', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6009,7 +6009,7 @@ function resolveSwerveAimDir(
     (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
   const powerScale = 4 + powerStrength * 6;
   const swerveScale = 0.6 + swerve.intensity * 0.9;
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const adjust =
     sideSpin *
     swerve.intensity *
@@ -6041,7 +6041,7 @@ function buildSwerveAimLinePoints(
     swerveActive,
     liftStrength
   );
-  const sideSpin = -swerve.sideSpin;
+  const sideSpin = swerve.sideSpin;
   const travel = start.distanceTo(end);
   if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
     points.length = 2;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -46,8 +46,8 @@ export const mapSpinForPhysics = (spin) => {
   const curved = applySpinResponseCurve(adjusted);
   return {
     // UI uses screen-space: +X is right, +Y is up (topspin).
-    // Pool Royale spin physics expects the opposite orientation.
+    // Pool Royale spin physics expects opposite orientation for side spin only.
     x: -curved.x,
-    y: -curved.y
+    y: curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- The aiming preview and cue-follow visuals were showing the wrong direction for controller spin input, so the aim guide must reflect the true ball behaviour without changing the controller input semantics.
- Top/back spin (high/low) mapping should drive forward/backward motion consistently with the controller UI while side-spin must remain mapped to table axes for physics.

### Description
- Change `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to only invert the side axis and keep the vertical/topspin axis aligned with controller input (`x: -curved.x`, `y: curved.y`).
- Align swerve/preview code in `webapp/src/pages/Games/PoolRoyale.jsx` by removing an extra sign flip for `swerve.sideSpin` so the aim curve mirrors side spin direction correctly.
- Update unit expectations in `test/poolRoyaleSpinController.test.js` to reflect the corrected orientation rules for horizontal and vertical spin.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready on the configured host and port.
- Attempted an automated UI verification with Playwright to capture a screenshot of the Pool Royale page, but the Playwright run timed out while loading the page.
- No Jest unit tests were executed in this rollout, although the spin controller test file `test/poolRoyaleSpinController.test.js` was updated to match the new mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969bf88805883299eb8b8884b10c6b7)