### PR TITLE
Adjust Pool Royale spin mapping (flip vertical input)

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,10 +43,15 @@ export const mapSpinForPhysics = (spin) => {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
   };
-  const curved = applySpinResponseCurve(adjusted);
+  const flipped = {
+    x: adjusted.x,
+    y: -adjusted.y
+  };
+  const curved = applySpinResponseCurve(flipped);
   return {
-    // UI uses screen-space: +X is right, +Y is up (topspin).
-    // Pool Royale spin physics expects opposite orientation for side spin only.
+    // UI uses screen-space: +X is right, +Y is up. The Pool Royale controller
+    // labels place HIGH at the bottom, so flip Y to map controller positions
+    // to forward/backspin. Side spin still needs the opposite orientation.
     x: -curved.x,
     y: curved.y
   };


### PR DESCRIPTION
### Motivation
- Ensure the Pool Royale spin controller’s `HIGH`/`LOW` UI positions produce intuitive forward/backspin while preserving existing left/right side-spin behavior.

### Description
- In `webapp/src/pages/Games/poolRoyaleSpinUtils.js` invert the vertical input (`y`) before calling `applySpinResponseCurve` inside `mapSpinForPhysics`, and update the inline comment to document the mapping so controller positions map to forward/backspin while side spin orientation remains negated (`x: -curved.x`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cacbc3d88329bc95f377eff0aae2)