### PR TITLE
Allow scrolling in Snake & Ladder settings menu

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2939,7 +2939,7 @@ export default function SnakeAndLadder() {
             ⚙️
           </button>
           {showConfig && (
-            <div className="absolute right-0 mt-2 w-[min(22rem,80vw)] rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">
+            <div className="absolute right-0 mt-2 w-[min(22rem,80vw)] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">
               <div className="flex items-center justify-between">
                 <span className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-sky-200/80">
                   Table Setup
@@ -2953,7 +2953,7 @@ export default function SnakeAndLadder() {
                   ✕
                 </button>
               </div>
-              <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div className="mt-4 space-y-4 pr-1">
                 {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder configuration panel usable on small/portrait screens by enabling the panel itself to scroll and avoiding nested scroll regions that hide items.

### Description
- Add `max-h-[80vh]` and `overflow-y-auto` to the outer settings panel container so the whole menu can scroll when it exceeds the viewport.
- Remove the inner `max-h-72 overflow-y-auto` from the customization list to prevent double scrollbars and ensure a single, consistent scroll surface.

### Testing
- Launched the dev server with `npm run dev` and attempted an automated Playwright capture; Vite reported ready but the Playwright navigation failed with `net::ERR_EMPTY_RESPONSE`, so no end-to-end screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cc2d14dc8329b9cb60d79fdff7c4)