### PR TITLE
Fix Pool Royale topspin direction mapping

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -43,15 +43,11 @@ export const mapSpinForPhysics = (spin) => {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
   };
-  const flipped = {
-    x: adjusted.x,
-    y: -adjusted.y
-  };
-  const curved = applySpinResponseCurve(flipped);
+  const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI uses screen-space: +X is right, +Y is up. The Pool Royale controller
-    // labels place HIGH at the bottom, so flip Y to map controller positions
-    // to forward/backspin. Side spin still needs the opposite orientation.
+    // UI uses screen-space: +X is right, +Y is up. Keep Y aligned so topspin
+    // drives the cue ball forward; invert X to keep left/right aligned to the
+    // table axes for side spin.
     x: -curved.x,
     y: curved.y
   };


### PR DESCRIPTION
### Motivation
- Ensure the spin controller maps UI inputs so positive Y produces forward topspin while preserving left/right side-spin orientation, fixing topspin/diagonal spin behavior so the cue ball rolls forward (and forward+sideways for diagonal inputs).

### Description
- Stop flipping Y before applying the response curve and instead apply `applySpinResponseCurve` to the clamped input, then invert X only in `mapSpinForPhysics`; this updates `webapp/src/pages/Games/poolRoyaleSpinUtils.js` and refreshes the inline mapping comment to match the corrected behavior.

### Testing
- No automated tests were run for this change; the repository contains `test/poolRoyaleSpinController.test.js` which validates `mapSpinForPhysics` but it was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cfbcaed083298366570d824ead0a)