### PR TITLE
Compact Snake & Ladder customization thumbnails and two-column grid

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2688,7 +2688,7 @@ export default function SnakeAndLadder() {
         const carpetPrimary = option.carpet?.primary ?? '#0f172a';
         const carpetAccent = option.carpet?.accent ?? carpetPrimary;
         return (
-          <div className="w-full h-16 rounded-xl overflow-hidden border border-white/10 shadow-inner flex">
+          <div className="w-full h-12 rounded-xl overflow-hidden border border-white/10 shadow-inner flex">
             <div
               className="w-1/2 h-full"
               style={{
@@ -2707,7 +2707,7 @@ export default function SnakeAndLadder() {
         const dark = option.dark ?? '#9c7b5a';
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               backgroundColor: dark,
               backgroundImage: `linear-gradient(45deg, ${light} 25%, transparent 25%), linear-gradient(-45deg, ${light} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${light} 75%), linear-gradient(-45deg, transparent 75%, ${light} 75%)`,
@@ -2723,7 +2723,7 @@ export default function SnakeAndLadder() {
         const stroke = option.stroke ?? 'rgba(255,255,255,0.08)';
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               backgroundColor: base,
               backgroundImage: `radial-gradient(circle at 25% 25%, ${diamond} 30%, transparent 31%), radial-gradient(circle at 75% 75%, ${diamond} 30%, transparent 31%), linear-gradient(${stroke}, ${stroke})`,
@@ -2737,17 +2737,17 @@ export default function SnakeAndLadder() {
         const pip = option.pip ?? '#111827';
         const rim = option.rim ?? '#fbbf24';
         return (
-          <div className="w-full h-16 flex items-center justify-center">
+          <div className="w-full h-12 flex items-center justify-center">
             <div
-              className="relative w-12 h-12 rounded-2xl shadow-[0_8px_20px_rgba(15,23,42,0.55)]"
+              className="relative w-9 h-9 rounded-xl shadow-[0_8px_20px_rgba(15,23,42,0.55)]"
               style={{ background: body, boxShadow: `0 6px 16px ${rim}44` }}
             >
               <span
-                className="absolute left-2 top-2 block h-2.5 w-2.5 rounded-full"
+                className="absolute left-1 top-1 block h-2 w-2 rounded-full"
                 style={{ background: pip, boxShadow: `0 0 0 2px ${rim}` }}
               />
               <span
-                className="absolute right-2 bottom-2 block h-2.5 w-2.5 rounded-full"
+                className="absolute right-1 bottom-1 block h-2 w-2 rounded-full"
                 style={{ background: pip, boxShadow: `0 0 0 2px ${rim}` }}
               />
             </div>
@@ -2759,7 +2759,7 @@ export default function SnakeAndLadder() {
         const woodLight = option.woodLight ?? '#d6b68c';
         const woodDark = option.woodDark ?? '#8b5e34';
         return (
-          <div className="w-full h-16 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
+          <div className="w-full h-12 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
             <div
               className="h-2 rounded-full"
               style={{ background: `linear-gradient(90deg, ${metal}, ${lightenHex(metal, 0.2)})` }}
@@ -2778,16 +2778,16 @@ export default function SnakeAndLadder() {
       case 'tokenFinish': {
         const accent = option.accentTarget ?? '#f8fafc';
         return (
-          <div className="w-full h-16 flex items-center justify-center">
+          <div className="w-full h-12 flex items-center justify-center">
             <div
-              className="relative h-14 w-14 rounded-full"
+              className="relative h-10 w-10 rounded-full"
               style={{
                 background: `radial-gradient(circle at 30% 30%, ${accent}, ${darkenHex(accent, 0.65)})`,
                 boxShadow: `0 10px 25px ${accent}33`
               }}
             >
               <div
-                className="absolute inset-2 rounded-full border border-white/20"
+                className="absolute inset-1.5 rounded-full border border-white/20"
                 style={{ boxShadow: `inset 0 0 12px ${lightenHex(accent, 0.3)}55` }}
               />
             </div>
@@ -2796,7 +2796,7 @@ export default function SnakeAndLadder() {
       }
       case 'tokenShape': {
         return (
-          <div className="flex h-16 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-lg text-white/80">
+          <div className="flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-base text-white/80">
             ♟️
           </div>
         );
@@ -2805,7 +2805,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#cbd5f5', '#475569'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})`
             }}
@@ -2816,7 +2816,7 @@ export default function SnakeAndLadder() {
         const thumb = option.thumbnail;
         const accent = option.accentColor || '#94a3b8';
         return (
-          <div className="relative w-full h-20 overflow-hidden rounded-xl border border-white/10 bg-slate-800/50">
+          <div className="relative w-full h-14 overflow-hidden rounded-xl border border-white/10 bg-slate-800/50">
             {thumb ? (
               <img src={thumb} alt={option.label} className="absolute inset-0 h-full w-full object-cover" />
             ) : (
@@ -2828,7 +2828,7 @@ export default function SnakeAndLadder() {
               />
             )}
             <div className="absolute inset-0 bg-gradient-to-tr from-black/50 via-transparent to-transparent" />
-            <div className="absolute bottom-2 right-2 rounded-full bg-black/60 px-2 py-1 text-[0.6rem] font-semibold text-white/80">
+            <div className="absolute bottom-1.5 right-1.5 rounded-full bg-black/60 px-1.5 py-0.5 text-[0.55rem] font-semibold text-white/80">
               Poly Haven
             </div>
           </div>
@@ -2838,14 +2838,14 @@ export default function SnakeAndLadder() {
         const seat = option.seatColor || option.primary || '#7c3aed';
         const legs = option.legColor || '#111827';
         return (
-          <div className="w-full h-16 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-3">
+          <div className="w-full h-12 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-2">
             <div className="flex h-full items-end gap-3">
               <div
                 className="h-3 w-full rounded-full"
                 style={{ background: `linear-gradient(90deg, ${legs}, ${lightenHex(legs, 0.2)})` }}
               />
               <div
-                className="h-8 w-10 rounded-lg border border-white/10 shadow-lg"
+                className="h-6 w-8 rounded-lg border border-white/10 shadow-lg"
                 style={{
                   background: `linear-gradient(180deg, ${seat}, ${darkenHex(seat, 0.25)})`,
                   boxShadow: `0 10px 20px ${seat}33`
@@ -2860,7 +2860,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#94a3b8', '#1f2937'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(120deg, ${swatches[0]}, ${swatches[1]})`,
               boxShadow: `0 8px 18px ${swatches[1]}44`
@@ -2874,13 +2874,13 @@ export default function SnakeAndLadder() {
           : ['#0ea5e9', '#312e81'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(120deg, ${swatches[0]}, ${swatches[1]})`,
               boxShadow: `0 10px 25px ${swatches[0]}44`
             }}
           >
-            <div className="flex h-full items-center justify-center gap-2 text-[0.65rem] font-semibold text-white/80">
+            <div className="flex h-full items-center justify-center gap-2 text-[0.6rem] font-semibold text-white/80">
               <span role="img" aria-label="sunset">🌇</span>
               <span>HDR Lighting</span>
             </div>
@@ -2957,7 +2957,7 @@ export default function SnakeAndLadder() {
                 {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-1 gap-2">
+                    <div className="grid grid-cols-2 gap-2">
                       {options.map((option, idx) => {
                         const unlocked = isSnakeOptionUnlocked(key, option.id, snakeInventory);
                         if (!unlocked) return null;
@@ -2970,14 +2970,14 @@ export default function SnakeAndLadder() {
                               setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
                             }
                             aria-pressed={selected}
-                            className={`flex flex-col items-center gap-2 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            className={`flex flex-col items-center gap-1.5 rounded-xl border px-2 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                               selected
                                 ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
                                 : 'border-white/10 bg-white/5 hover:border-white/20'
                             }`}
                           >
                             {renderPreview(key, option)}
-                            <span className="block w-full text-center text-[0.65rem] font-semibold text-gray-200">
+                            <span className="block w-full text-center text-[0.6rem] font-semibold text-gray-200">
                               {option.label}
                             </span>
                           </button>


### PR DESCRIPTION
### Motivation
- The Snake & Ladder customization panel used large preview tiles and single-column layout which made the settings menu slow and tedious to scroll on mobile portrait screens.
- Make the appearance options denser and faster to scan while preserving visual previews similar to the more compact menus used elsewhere (e.g. Murlan Royale).

### Description
- Reduced preview tile heights and inner element sizes across multiple preview types in `webapp/src/pages/Games/SnakeAndLadder.jsx` (many `h-16` -> `h-12`, smaller icon/inner sizes and adjusted inset/padding values). 
- Switched the customization option list from a single-column grid to a two-column grid by changing `grid-cols-1` -> `grid-cols-2` and tightened each option button spacing and padding (`gap-2` -> `gap-1.5`, slightly smaller `px/py`).
- Updated label text sizes and some rounded classes to keep visual balance at the reduced tile sizes.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the app ready on `http://localhost:4173/`.
- Attempted an automated visual smoke test using Playwright to open `/games/snake` and capture the settings panel, but the Playwright runs timed out and image capture did not complete.
- No unit or integration tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d1c5b1608329836c938c41f79aa6)