### PR TITLE
Shrink Snake & Ladder customization thumbnails and compact settings grid

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2688,7 +2688,7 @@ export default function SnakeAndLadder() {
         const carpetPrimary = option.carpet?.primary ?? '#0f172a';
         const carpetAccent = option.carpet?.accent ?? carpetPrimary;
         return (
-          <div className="w-full h-16 rounded-xl overflow-hidden border border-white/10 shadow-inner flex">
+          <div className="w-full h-12 rounded-xl overflow-hidden border border-white/10 shadow-inner flex">
             <div
               className="w-1/2 h-full"
               style={{
@@ -2707,12 +2707,12 @@ export default function SnakeAndLadder() {
         const dark = option.dark ?? '#9c7b5a';
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               backgroundColor: dark,
               backgroundImage: `linear-gradient(45deg, ${light} 25%, transparent 25%), linear-gradient(-45deg, ${light} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${light} 75%), linear-gradient(-45deg, transparent 75%, ${light} 75%)`,
-              backgroundSize: '20px 20px',
-              backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0'
+              backgroundSize: '16px 16px',
+              backgroundPosition: '0 0, 0 8px, 8px -8px, -8px 0'
             }}
           />
         );
@@ -2723,11 +2723,11 @@ export default function SnakeAndLadder() {
         const stroke = option.stroke ?? 'rgba(255,255,255,0.08)';
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               backgroundColor: base,
               backgroundImage: `radial-gradient(circle at 25% 25%, ${diamond} 30%, transparent 31%), radial-gradient(circle at 75% 75%, ${diamond} 30%, transparent 31%), linear-gradient(${stroke}, ${stroke})`,
-              backgroundSize: '24px 24px'
+              backgroundSize: '18px 18px'
             }}
           />
         );
@@ -2737,17 +2737,17 @@ export default function SnakeAndLadder() {
         const pip = option.pip ?? '#111827';
         const rim = option.rim ?? '#fbbf24';
         return (
-          <div className="w-full h-16 flex items-center justify-center">
+          <div className="w-full h-12 flex items-center justify-center">
             <div
-              className="relative w-12 h-12 rounded-2xl shadow-[0_8px_20px_rgba(15,23,42,0.55)]"
+              className="relative w-9 h-9 rounded-xl shadow-[0_6px_16px_rgba(15,23,42,0.55)]"
               style={{ background: body, boxShadow: `0 6px 16px ${rim}44` }}
             >
               <span
-                className="absolute left-2 top-2 block h-2.5 w-2.5 rounded-full"
+                className="absolute left-1.5 top-1.5 block h-2 w-2 rounded-full"
                 style={{ background: pip, boxShadow: `0 0 0 2px ${rim}` }}
               />
               <span
-                className="absolute right-2 bottom-2 block h-2.5 w-2.5 rounded-full"
+                className="absolute right-1.5 bottom-1.5 block h-2 w-2 rounded-full"
                 style={{ background: pip, boxShadow: `0 0 0 2px ${rim}` }}
               />
             </div>
@@ -2759,7 +2759,7 @@ export default function SnakeAndLadder() {
         const woodLight = option.woodLight ?? '#d6b68c';
         const woodDark = option.woodDark ?? '#8b5e34';
         return (
-          <div className="w-full h-16 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
+          <div className="w-full h-12 rounded-xl border border-white/10 flex flex-col justify-center gap-1.5 px-2">
             <div
               className="h-2 rounded-full"
               style={{ background: `linear-gradient(90deg, ${metal}, ${lightenHex(metal, 0.2)})` }}
@@ -2778,9 +2778,9 @@ export default function SnakeAndLadder() {
       case 'tokenFinish': {
         const accent = option.accentTarget ?? '#f8fafc';
         return (
-          <div className="w-full h-16 flex items-center justify-center">
+          <div className="w-full h-12 flex items-center justify-center">
             <div
-              className="relative h-14 w-14 rounded-full"
+              className="relative h-10 w-10 rounded-full"
               style={{
                 background: `radial-gradient(circle at 30% 30%, ${accent}, ${darkenHex(accent, 0.65)})`,
                 boxShadow: `0 10px 25px ${accent}33`
@@ -2796,7 +2796,7 @@ export default function SnakeAndLadder() {
       }
       case 'tokenShape': {
         return (
-          <div className="flex h-16 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-lg text-white/80">
+          <div className="flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-base text-white/80">
             ♟️
           </div>
         );
@@ -2805,7 +2805,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#cbd5f5', '#475569'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})`
             }}
@@ -2816,7 +2816,7 @@ export default function SnakeAndLadder() {
         const thumb = option.thumbnail;
         const accent = option.accentColor || '#94a3b8';
         return (
-          <div className="relative w-full h-20 overflow-hidden rounded-xl border border-white/10 bg-slate-800/50">
+          <div className="relative w-full h-14 overflow-hidden rounded-xl border border-white/10 bg-slate-800/50">
             {thumb ? (
               <img src={thumb} alt={option.label} className="absolute inset-0 h-full w-full object-cover" />
             ) : (
@@ -2828,7 +2828,7 @@ export default function SnakeAndLadder() {
               />
             )}
             <div className="absolute inset-0 bg-gradient-to-tr from-black/50 via-transparent to-transparent" />
-            <div className="absolute bottom-2 right-2 rounded-full bg-black/60 px-2 py-1 text-[0.6rem] font-semibold text-white/80">
+            <div className="absolute bottom-1.5 right-1.5 rounded-full bg-black/60 px-2 py-0.5 text-[0.55rem] font-semibold text-white/80">
               Poly Haven
             </div>
           </div>
@@ -2838,14 +2838,14 @@ export default function SnakeAndLadder() {
         const seat = option.seatColor || option.primary || '#7c3aed';
         const legs = option.legColor || '#111827';
         return (
-          <div className="w-full h-16 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-3">
-            <div className="flex h-full items-end gap-3">
+          <div className="w-full h-12 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-2">
+            <div className="flex h-full items-end gap-2">
               <div
-                className="h-3 w-full rounded-full"
+                className="h-2 w-full rounded-full"
                 style={{ background: `linear-gradient(90deg, ${legs}, ${lightenHex(legs, 0.2)})` }}
               />
               <div
-                className="h-8 w-10 rounded-lg border border-white/10 shadow-lg"
+                className="h-6 w-8 rounded-lg border border-white/10 shadow-lg"
                 style={{
                   background: `linear-gradient(180deg, ${seat}, ${darkenHex(seat, 0.25)})`,
                   boxShadow: `0 10px 20px ${seat}33`
@@ -2860,7 +2860,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#94a3b8', '#1f2937'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(120deg, ${swatches[0]}, ${swatches[1]})`,
               boxShadow: `0 8px 18px ${swatches[1]}44`
@@ -2874,13 +2874,13 @@ export default function SnakeAndLadder() {
           : ['#0ea5e9', '#312e81'];
         return (
           <div
-            className="w-full h-16 rounded-xl border border-white/10"
+            className="w-full h-12 rounded-xl border border-white/10"
             style={{
               background: `linear-gradient(120deg, ${swatches[0]}, ${swatches[1]})`,
               boxShadow: `0 10px 25px ${swatches[0]}44`
             }}
           >
-            <div className="flex h-full items-center justify-center gap-2 text-[0.65rem] font-semibold text-white/80">
+            <div className="flex h-full items-center justify-center gap-2 text-[0.55rem] font-semibold text-white/80">
               <span role="img" aria-label="sunset">🌇</span>
               <span>HDR Lighting</span>
             </div>
@@ -2957,7 +2957,7 @@ export default function SnakeAndLadder() {
                 {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
                   <div key={key} className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-1 gap-2">
+                    <div className="grid grid-cols-2 gap-2">
                       {options.map((option, idx) => {
                         const unlocked = isSnakeOptionUnlocked(key, option.id, snakeInventory);
                         if (!unlocked) return null;
@@ -2970,14 +2970,14 @@ export default function SnakeAndLadder() {
                               setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
                             }
                             aria-pressed={selected}
-                            className={`flex flex-col items-center gap-2 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            className={`flex flex-col items-center gap-1.5 rounded-2xl border px-2 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                               selected
                                 ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
                                 : 'border-white/10 bg-white/5 hover:border-white/20'
                             }`}
                           >
                             {renderPreview(key, option)}
-                            <span className="block w-full text-center text-[0.65rem] font-semibold text-gray-200">
+                            <span className="block w-full text-center text-[0.6rem] font-semibold text-gray-200">
                               {option.label}
                             </span>
                           </button>


### PR DESCRIPTION
### Motivation
- Improve menu navigation performance and match the compact thumbnail style used by Murlan Royale by reducing preview sizes and tightening the customization UI.

### Description
- Reduced preview tile heights and inner element sizes across Snake & Ladder customization previews in `webapp/src/pages/Games/SnakeAndLadder.jsx` (many `h-16` -> `h-12`, smaller icon/container sizes, tightened background tile spacing).
- Tightened paddings, background pattern scales (e.g. `backgroundSize` adjustments) and lowered font/label sizing to keep previews legible while using less vertical space.
- Changed the customization options layout from a single-column list to a two-column grid and reduced gaps so the settings panel scrolls faster and shows more thumbnails at once.

### Testing
- Started the development server with `npm --prefix webapp run dev` which launched Vite successfully (server ready). (succeeded)
- Ran an automated Playwright attempt to open the Snake page and capture the config menu but the navigation / page interaction timed out when loading `/games/snake`; the Playwright capture for the home page succeeded while the Snake page attempt failed due to timeout. (partial: home screenshot succeeded, Snake UI capture timed out)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d1c5b1608329836c938c41f79aa6)