### PR TITLE
Add Pool Royale physics demo with spin controller and physics core

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
     "@capacitor/push-notifications": "6.0.5",
     "@aparajita/capacitor-biometric-auth": "^6.0.0",
     "@github/webauthn-json": "^2.0.2",
+    "@react-three/fiber": "^8.17.10",
     "@tonconnect/sdk": "^3.2.0",
     "@tonconnect/ui-react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -36,6 +36,7 @@ import TexasHoldem from './pages/Games/TexasHoldem.jsx';
 import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import DominoRoyal from './pages/Games/DominoRoyal.jsx';
 import DominoRoyalLobby from './pages/Games/DominoRoyalLobby.jsx';
+import PoolRoyalePhysicsDemo from './pages/Games/PoolRoyalePhysicsDemo.tsx';
 
 const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal.jsx'));
 const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
@@ -121,6 +122,10 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/poolroyale-physics"
+              element={<PoolRoyalePhysicsDemo />}
+            />
             <Route
               path="/games/snookerroyale/lobby"
               element={<SnookerRoyalLobby />}

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo.tsx
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import PhysicsDemoApp from './PoolRoyalePhysicsDemo/App';
+
+export default function PoolRoyalePhysicsDemo() {
+  return <PhysicsDemoApp />;
+}

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo/App.tsx
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo/App.tsx
@@ -1,0 +1,352 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import {
+  DEFAULT_PARAMS,
+  DEFAULT_TABLE,
+  PhysicsState,
+  SpinOffset,
+  createInitialState,
+  resetState,
+  stepPhysics,
+  strikeCueBall
+} from './physics';
+
+const TABLE_COLOR = '#1f5f3b';
+const RAIL_COLOR = '#4b2e1f';
+
+const usePhysicsState = () => {
+  const stateRef = useRef<PhysicsState>(createInitialState(DEFAULT_PARAMS));
+  const [revision, setRevision] = useState(0);
+
+  const reset = () => {
+    resetState(stateRef.current);
+    setRevision((prev) => prev + 1);
+  };
+
+  return { stateRef, revision, reset };
+};
+
+const BallMeshes = ({ stateRef }: { stateRef: React.MutableRefObject<PhysicsState> }) => {
+  const meshes = useRef<Record<string, THREE.Mesh>>({});
+
+  useFrame((_, delta) => {
+    stepPhysics(stateRef.current, Math.min(delta, 0.016), DEFAULT_TABLE);
+    for (const ball of stateRef.current.balls) {
+      const mesh = meshes.current[ball.id];
+      if (!mesh) continue;
+      mesh.position.set(ball.position.x, ball.radius, ball.position.y);
+      const axis = ball.omega.clone();
+      const angle = axis.length() * delta;
+      if (angle > 0.0001) {
+        axis.normalize();
+        mesh.rotateOnAxis(axis, angle);
+      }
+    }
+  });
+
+  return (
+    <group>
+      {stateRef.current.balls.map((ball) => (
+        <mesh
+          key={ball.id}
+          ref={(node) => {
+            if (node) meshes.current[ball.id] = node;
+          }}
+          position={[ball.position.x, ball.radius, ball.position.y]}
+          castShadow
+          receiveShadow
+        >
+          <sphereGeometry args={[ball.radius, 32, 32]} />
+          <meshStandardMaterial color={ball.color} />
+        </mesh>
+      ))}
+    </group>
+  );
+};
+
+const Table = () => {
+  const width = DEFAULT_TABLE.maxX - DEFAULT_TABLE.minX;
+  const depth = DEFAULT_TABLE.maxZ - DEFAULT_TABLE.minZ;
+  const railHeight = 0.06;
+  const railThickness = 0.08;
+
+  return (
+    <group>
+      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[width, depth]} />
+        <meshStandardMaterial color={TABLE_COLOR} />
+      </mesh>
+      <mesh
+        position={[0, railHeight / 2, DEFAULT_TABLE.minZ - railThickness / 2]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[width + railThickness * 2, railHeight, railThickness]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[0, railHeight / 2, DEFAULT_TABLE.maxZ + railThickness / 2]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[width + railThickness * 2, railHeight, railThickness]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[DEFAULT_TABLE.minX - railThickness / 2, railHeight / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[railThickness, railHeight, depth]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[DEFAULT_TABLE.maxX + railThickness / 2, railHeight / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[railThickness, railHeight, depth]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+    </group>
+  );
+};
+
+const ShotTests = [
+  {
+    label: 'Stun (stop cue ball)',
+    spinOffset: { x: 0, y: 0 },
+    power: 0.5,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Draw (backspin)',
+    spinOffset: { x: 0, y: -0.6 },
+    power: 0.55,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Follow (topspin)',
+    spinOffset: { x: 0, y: 0.6 },
+    power: 0.55,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Rail english',
+    spinOffset: { x: 0.7, y: 0.1 },
+    power: 0.5,
+    angle: -Math.PI / 3
+  },
+  {
+    label: 'Cut throw',
+    spinOffset: { x: -0.4, y: 0.1 },
+    power: 0.45,
+    angle: -Math.PI / 2.4
+  },
+  {
+    label: 'Break stability',
+    spinOffset: { x: 0, y: 0 },
+    power: 1,
+    angle: -Math.PI / 2
+  }
+];
+
+const SpinController = ({
+  spinOffset,
+  onChange
+}: {
+  spinOffset: SpinOffset;
+  onChange: (next: SpinOffset) => void;
+}) => {
+  const radius = 60;
+  const maxOffset = DEFAULT_PARAMS.maxSpinOffset;
+
+  const handlePointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const rawX = (event.clientX - centerX) / radius;
+    const rawY = (centerY - event.clientY) / radius;
+    const length = Math.hypot(rawX, rawY);
+    const clamped = length > 1 ? 1 / length : 1;
+    const nextX = rawX * clamped;
+    const nextY = rawY * clamped;
+    const limitedX = THREE.MathUtils.clamp(nextX, -maxOffset, maxOffset);
+    const limitedY = THREE.MathUtils.clamp(nextY, -maxOffset, maxOffset);
+    onChange({ x: limitedX, y: limitedY });
+  };
+
+  const dotStyle = {
+    transform: `translate(${spinOffset.x * radius}px, ${-spinOffset.y * radius}px)`
+  } as React.CSSProperties;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="relative h-32 w-32 rounded-full border border-white/50 bg-white/10"
+        onPointerDown={handlePointer}
+        onPointerMove={(event) => {
+          if (event.buttons !== 1) return;
+          handlePointer(event);
+        }}
+      >
+        <div
+          className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+          style={dotStyle}
+        />
+      </div>
+      <div className="text-xs text-white/70">Spin offset: {spinOffset.x.toFixed(2)}, {spinOffset.y.toFixed(2)}</div>
+    </div>
+  );
+};
+
+const ShotPanel = ({
+  spinOffset,
+  setSpinOffset,
+  power,
+  setPower,
+  angle,
+  setAngle,
+  onShoot,
+  onReset
+}: {
+  spinOffset: SpinOffset;
+  setSpinOffset: (next: SpinOffset) => void;
+  power: number;
+  setPower: (next: number) => void;
+  angle: number;
+  setAngle: (next: number) => void;
+  onShoot: () => void;
+  onReset: () => void;
+}) => (
+  <div className="flex w-full flex-col gap-4 rounded-2xl bg-slate-900/80 p-4 text-white shadow-xl">
+    <div className="flex items-center justify-between">
+      <div>
+        <h2 className="text-lg font-semibold">Pool Royale Physics Demo</h2>
+        <p className="text-xs text-white/70">Spin controller + realistic slip-to-roll response.</p>
+      </div>
+      <button
+        className="rounded-full border border-white/20 px-3 py-1 text-xs hover:bg-white/10"
+        onClick={onReset}
+        type="button"
+      >
+        Reset rack
+      </button>
+    </div>
+
+    <SpinController spinOffset={spinOffset} onChange={setSpinOffset} />
+
+    <label className="flex flex-col gap-2 text-sm">
+      <span>Power: {power.toFixed(2)}</span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={power}
+        onChange={(event) => setPower(Number(event.target.value))}
+      />
+    </label>
+
+    <label className="flex flex-col gap-2 text-sm">
+      <span>Aim angle: {(THREE.MathUtils.radToDeg(angle) + 90).toFixed(0)}°</span>
+      <input
+        type="range"
+        min={-Math.PI}
+        max={0}
+        step={0.01}
+        value={angle}
+        onChange={(event) => setAngle(Number(event.target.value))}
+      />
+    </label>
+
+    <button
+      className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900"
+      onClick={onShoot}
+      type="button"
+    >
+      Shoot
+    </button>
+
+    <div className="space-y-2 text-xs text-white/70">
+      <div className="font-semibold text-white">Shot tests</div>
+      <div className="grid gap-2">
+        {ShotTests.map((shot) => (
+          <button
+            key={shot.label}
+            className="rounded-lg border border-white/10 px-2 py-1 text-left hover:bg-white/10"
+            onClick={() => {
+              setSpinOffset(shot.spinOffset);
+              setPower(shot.power);
+              setAngle(shot.angle);
+              onShoot();
+            }}
+            type="button"
+          >
+            {shot.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const CameraRig = () => {
+  const cameraRef = useRef<THREE.PerspectiveCamera>(null);
+  useFrame(() => {
+    if (!cameraRef.current) return;
+    cameraRef.current.lookAt(0, 0, 0);
+  });
+  return (
+    <perspectiveCamera
+      ref={cameraRef}
+      position={[0, 2.6, 3.6]}
+      fov={45}
+      near={0.1}
+      far={50}
+    />
+  );
+};
+
+export default function App() {
+  const { stateRef, reset } = usePhysicsState();
+  const [spinOffset, setSpinOffset] = useState<SpinOffset>({ x: 0, y: 0 });
+  const [power, setPower] = useState(0.55);
+  const [angle, setAngle] = useState(-Math.PI / 2);
+
+  const direction = useMemo(() => {
+    const dir = new THREE.Vector2(Math.cos(angle), Math.sin(angle));
+    return dir;
+  }, [angle]);
+
+  const shoot = () => {
+    strikeCueBall(stateRef.current, direction, power, spinOffset);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-slate-950 text-white">
+      <div className="absolute inset-0">
+        <Canvas shadows camera={{ position: [0, 2.6, 3.6], fov: 45 }}>
+          <CameraRig />
+          <ambientLight intensity={0.7} />
+          <directionalLight position={[2, 4, 3]} intensity={1.2} castShadow />
+          <Table />
+          <BallMeshes stateRef={stateRef} />
+        </Canvas>
+      </div>
+      <div className="relative z-10 flex min-h-screen flex-col justify-end p-4">
+        <ShotPanel
+          spinOffset={spinOffset}
+          setSpinOffset={setSpinOffset}
+          power={power}
+          setPower={setPower}
+          angle={angle}
+          setAngle={setAngle}
+          onShoot={shoot}
+          onReset={reset}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo/physics.ts
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo/physics.ts
@@ -1,0 +1,297 @@
+import * as THREE from 'three';
+
+export type SpinOffset = { x: number; y: number };
+
+export type PhysicsParams = {
+  muK: number;
+  muRoll: number;
+  muBall: number;
+  muRail: number;
+  restitution: number;
+  eps: number;
+  g: number;
+  maxSpinOffset: number;
+  maxCueImpulse: number;
+};
+
+export type BallState = {
+  id: string;
+  position: THREE.Vector2;
+  velocity: THREE.Vector2;
+  omega: THREE.Vector3;
+  radius: number;
+  mass: number;
+  inertia: number;
+  color: string;
+};
+
+export type TableBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export type PhysicsState = {
+  balls: BallState[];
+  params: PhysicsParams;
+};
+
+export const DEFAULT_PARAMS: PhysicsParams = {
+  muK: 0.2,
+  muRoll: 0.015,
+  muBall: 0.2,
+  muRail: 0.25,
+  restitution: 0.92,
+  eps: 0.02,
+  g: 9.81,
+  maxSpinOffset: 0.7,
+  maxCueImpulse: 2.8
+};
+
+export const DEFAULT_TABLE: TableBounds = {
+  minX: -1.2,
+  maxX: 1.2,
+  minZ: -2.2,
+  maxZ: 2.2
+};
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+const toVec3 = (v: THREE.Vector2) => new THREE.Vector3(v.x, 0, v.y);
+
+const applyLinearImpulse = (ball: BallState, impulse: THREE.Vector3) => {
+  ball.velocity.x += impulse.x / ball.mass;
+  ball.velocity.y += impulse.z / ball.mass;
+};
+
+const applyAngularImpulse = (ball: BallState, impulse: THREE.Vector3) => {
+  ball.omega.addScaledVector(impulse, 1 / ball.inertia);
+};
+
+export const createCueBall = (): BallState => {
+  const radius = 0.05715 / 2;
+  const mass = 0.17;
+  return {
+    id: 'cue',
+    position: new THREE.Vector2(0, 1.4),
+    velocity: new THREE.Vector2(0, 0),
+    omega: new THREE.Vector3(0, 0, 0),
+    radius,
+    mass,
+    inertia: 0.4 * mass * radius * radius,
+    color: '#f8f8f8'
+  };
+};
+
+export const createRack = (): BallState[] => {
+  const radius = 0.05715 / 2;
+  const mass = 0.17;
+  const spacing = radius * 2.05;
+  const baseZ = -1.3;
+  const balls: BallState[] = [];
+  const colors = ['#fbd34d', '#f43f5e', '#60a5fa', '#22c55e', '#fb7185'];
+
+  for (let row = 0; row < 3; row += 1) {
+    for (let i = 0; i <= row; i += 1) {
+      balls.push({
+        id: `rack-${row}-${i}`,
+        position: new THREE.Vector2((i - row / 2) * spacing, baseZ - row * spacing),
+        velocity: new THREE.Vector2(0, 0),
+        omega: new THREE.Vector3(0, 0, 0),
+        radius,
+        mass,
+        inertia: 0.4 * mass * radius * radius,
+        color: colors[(row + i) % colors.length]
+      });
+    }
+  }
+
+  return balls;
+};
+
+export const createInitialState = (params: PhysicsParams = DEFAULT_PARAMS): PhysicsState => ({
+  params,
+  balls: [createCueBall(), ...createRack()]
+});
+
+export const strikeCueBall = (
+  state: PhysicsState,
+  direction: THREE.Vector2,
+  power: number,
+  spinOffset: SpinOffset
+) => {
+  const cueBall = state.balls.find((ball) => ball.id === 'cue');
+  if (!cueBall) return;
+
+  const dir3 = toVec3(direction).normalize();
+  if (!Number.isFinite(dir3.lengthSq()) || dir3.lengthSq() < 1e-6) return;
+
+  const clampedPower = Math.min(Math.max(power, 0), 1);
+  const impulse = dir3.multiplyScalar(state.params.maxCueImpulse * clampedPower);
+  applyLinearImpulse(cueBall, impulse);
+
+  const right = new THREE.Vector3(-dir3.z, 0, dir3.x).normalize();
+  const maxOffset = state.params.maxSpinOffset * cueBall.radius;
+  const offsetX = THREE.MathUtils.clamp(spinOffset.x, -1, 1) * maxOffset;
+  const offsetY = THREE.MathUtils.clamp(spinOffset.y, -1, 1) * maxOffset;
+  const rOffset = new THREE.Vector3()
+    .addScaledVector(right, offsetX)
+    .addScaledVector(UP, offsetY);
+
+  const torqueImpulse = new THREE.Vector3().crossVectors(rOffset, impulse);
+  applyAngularImpulse(cueBall, torqueImpulse);
+};
+
+const applyFriction = (ball: BallState, params: PhysicsParams, dt: number) => {
+  const rContact = new THREE.Vector3(0, -ball.radius, 0);
+  const vContact = toVec3(ball.velocity).add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+  const vRel = new THREE.Vector3(vContact.x, 0, vContact.z);
+  const relSpeed = vRel.length();
+
+  if (relSpeed > params.eps) {
+    const frictionDir = vRel.normalize().multiplyScalar(-1);
+    const frictionForce = frictionDir.multiplyScalar(params.muK * ball.mass * params.g);
+    const linearImpulse = frictionForce.clone().multiplyScalar(dt);
+    applyLinearImpulse(ball, linearImpulse);
+
+    const torqueImpulse = new THREE.Vector3().crossVectors(rContact, linearImpulse);
+    applyAngularImpulse(ball, torqueImpulse);
+  } else {
+    const speed = ball.velocity.length();
+    if (speed > 0) {
+      const rollingForce = ball.velocity.clone().normalize().multiplyScalar(-params.muRoll * ball.mass * params.g);
+      const rollingImpulse = rollingForce.multiplyScalar(dt);
+      applyLinearImpulse(ball, new THREE.Vector3(rollingImpulse.x, 0, rollingImpulse.y));
+    }
+  }
+
+  if (ball.velocity.length() < 0.002 && ball.omega.length() < 0.2) {
+    ball.velocity.set(0, 0);
+    ball.omega.multiplyScalar(0.5);
+    if (ball.omega.length() < 0.05) {
+      ball.omega.set(0, 0, 0);
+    }
+  }
+};
+
+const resolveBallBallCollision = (a: BallState, b: BallState, params: PhysicsParams) => {
+  const delta = new THREE.Vector2().subVectors(b.position, a.position);
+  const dist = delta.length();
+  const minDist = a.radius + b.radius;
+  if (dist >= minDist || dist <= 0) return;
+
+  const normal = delta.clone().multiplyScalar(1 / dist);
+  const penetration = minDist - dist;
+  a.position.addScaledVector(normal, -penetration / 2);
+  b.position.addScaledVector(normal, penetration / 2);
+
+  const n3 = new THREE.Vector3(normal.x, 0, normal.y);
+  const rA = n3.clone().multiplyScalar(a.radius);
+  const rB = n3.clone().multiplyScalar(-b.radius);
+
+  const vRel = toVec3(a.velocity)
+    .add(new THREE.Vector3().crossVectors(a.omega, rA))
+    .sub(toVec3(b.velocity).add(new THREE.Vector3().crossVectors(b.omega, rB)));
+
+  const vn = vRel.dot(n3);
+  if (vn >= 0) return;
+
+  const invMassSum = 1 / a.mass + 1 / b.mass;
+  const jn = (-(1 + params.restitution) * vn) / invMassSum;
+  const impulseN = n3.clone().multiplyScalar(jn);
+
+  applyLinearImpulse(a, impulseN.clone().multiplyScalar(-1));
+  applyLinearImpulse(b, impulseN.clone().multiplyScalar(1));
+
+  const vt = vRel.clone().sub(n3.clone().multiplyScalar(vn));
+  const vtMag = vt.length();
+  if (vtMag < 1e-6) return;
+
+  const tDir = vt.multiplyScalar(1 / vtMag);
+  let jt = -vtMag / invMassSum;
+  const maxJt = params.muBall * jn;
+  jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+  const impulseT = tDir.clone().multiplyScalar(jt);
+
+  applyLinearImpulse(a, impulseT.clone().multiplyScalar(-1));
+  applyLinearImpulse(b, impulseT.clone().multiplyScalar(1));
+
+  applyAngularImpulse(a, new THREE.Vector3().crossVectors(rA, impulseT).multiplyScalar(-1));
+  applyAngularImpulse(b, new THREE.Vector3().crossVectors(rB, impulseT));
+};
+
+const resolveRailCollision = (ball: BallState, table: TableBounds, params: PhysicsParams) => {
+  const { radius } = ball;
+  const minX = table.minX + radius;
+  const maxX = table.maxX - radius;
+  const minZ = table.minZ + radius;
+  const maxZ = table.maxZ - radius;
+
+  const v3 = toVec3(ball.velocity);
+
+  const collisions: Array<{ normal: THREE.Vector3; position: THREE.Vector2 }> = [];
+
+  if (ball.position.x < minX) {
+    ball.position.x = minX;
+    collisions.push({ normal: new THREE.Vector3(1, 0, 0), position: ball.position });
+  } else if (ball.position.x > maxX) {
+    ball.position.x = maxX;
+    collisions.push({ normal: new THREE.Vector3(-1, 0, 0), position: ball.position });
+  }
+
+  if (ball.position.y < minZ) {
+    ball.position.y = minZ;
+    collisions.push({ normal: new THREE.Vector3(0, 0, 1), position: ball.position });
+  } else if (ball.position.y > maxZ) {
+    ball.position.y = maxZ;
+    collisions.push({ normal: new THREE.Vector3(0, 0, -1), position: ball.position });
+  }
+
+  for (const { normal } of collisions) {
+    const rContact = normal.clone().multiplyScalar(radius);
+    const vContact = v3.clone().add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+    const vn = vContact.dot(normal);
+    if (vn >= 0) continue;
+
+    const jn = -(1 + params.restitution) * vn * ball.mass;
+    const impulseN = normal.clone().multiplyScalar(jn);
+    applyLinearImpulse(ball, impulseN);
+
+    const vt = vContact.clone().sub(normal.clone().multiplyScalar(vn));
+    const vtMag = vt.length();
+    if (vtMag > 1e-6) {
+      const tDir = vt.multiplyScalar(1 / vtMag);
+      let jt = -vtMag * ball.mass;
+      const maxJt = params.muRail * jn;
+      jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+      const impulseT = tDir.multiplyScalar(jt);
+      applyLinearImpulse(ball, impulseT);
+      applyAngularImpulse(ball, new THREE.Vector3().crossVectors(rContact, impulseT));
+    }
+  }
+};
+
+export const stepPhysics = (
+  state: PhysicsState,
+  dt: number,
+  table: TableBounds = DEFAULT_TABLE
+) => {
+  state.balls.forEach((ball) => applyFriction(ball, state.params, dt));
+
+  state.balls.forEach((ball) => {
+    ball.position.addScaledVector(ball.velocity, dt);
+    resolveRailCollision(ball, table, state.params);
+  });
+
+  for (let i = 0; i < state.balls.length; i += 1) {
+    for (let j = i + 1; j < state.balls.length; j += 1) {
+      resolveBallBallCollision(state.balls[i], state.balls[j], state.params);
+    }
+  }
+};
+
+export const resetState = (state: PhysicsState) => {
+  const fresh = createInitialState(state.params);
+  state.balls = fresh.balls;
+};


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained Web demo that demonstrates realistic pool cue-ball behaviour (stun/draw/follow/english/throw) for the PoolRoyale game using React + Three.js (preferably R3F). 
- Reuse ideas from the open-source `justphil/threejs-billiard` implementation for code structure and core physics, and use `pooltool` as a reference for slip→roll, spin transfer and tangential impulse concepts. 
- Ship a compact UI + scene to experiment with tuning parameters and quick “shot tests” for iteration and onboarding.

### Description
- Added a new demo route at `/games/poolroyale-physics` and registered it in `webapp/src/App.jsx` (import `PoolRoyalePhysicsDemo`).
- Added a new demo folder `webapp/src/pages/Games/PoolRoyalePhysicsDemo/` containing a full minimal example: `App.tsx` (R3F scene, `SpinController` UI, power slider, shot test buttons) and `physics.ts` (physics core and state). The demo is exposed through `webapp/src/pages/Games/PoolRoyalePhysicsDemo.tsx`.
- Implemented the physics core in `physics.ts` with: `strikeCueBall(state, direction, power, spinOffset)` applying both linear impulse and torque impulse from the cue offset, contact point slip→roll (`v_contact = v + ω × r_c`) with kinetic friction → rolling transition and small rolling resistance, ball–ball collisions with normal and tangential (Coulomb-limited) impulses transferring spin/throw, and rail collision handling where sidespin affects tangential response.
- Added tuning parameters and defaults in `physics.ts` (`muK`, `muRoll`, `muBall`, `muRail`, `restitution`, `eps`, `maxSpinOffset`, `maxCueImpulse`) and included 6 quick `ShotTests` (stun, draw, follow, rail english, cut throw, break stability) in `App.tsx`.
- Added `@react-three/fiber` to `webapp/package.json` and wired `Canvas` + `useFrame` to step the physics and render ball rotations; also corrected impulse direction signs in the collision handling for consistent momentum transfer.

### Testing
- Installed dependencies with `npm install` in `webapp` (postinstall hooks ran) and then started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which reported Vite ready and served the app (success).
- Loaded the demo page at `http://127.0.0.1:4173/games/poolroyale-physics` and captured a runtime screenshot via an automated Playwright script to confirm the scene and UI render (succeeded).
- No unit test suite was modified; there were no automated test failures during the dev server run (no failing build/runtime errors after adding the demo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e612a7388329a0433c06f49beda5)