### PR TITLE
Use realistic physics core for Pool Royale (cue strike, spin, collisions)

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
     "@capacitor/push-notifications": "6.0.5",
     "@aparajita/capacitor-biometric-auth": "^6.0.0",
     "@github/webauthn-json": "^2.0.2",
+    "@react-three/fiber": "^8.17.10",
     "@tonconnect/sdk": "^3.2.0",
     "@tonconnect/ui-react": "^2.2.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -36,6 +36,7 @@ import TexasHoldem from './pages/Games/TexasHoldem.jsx';
 import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import DominoRoyal from './pages/Games/DominoRoyal.jsx';
 import DominoRoyalLobby from './pages/Games/DominoRoyalLobby.jsx';
+import PoolRoyalePhysicsDemo from './pages/Games/PoolRoyalePhysicsDemo.tsx';
 
 const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal.jsx'));
 const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
@@ -121,6 +122,10 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/poolroyale-physics"
+              element={<PoolRoyalePhysicsDemo />}
+            />
             <Route
               path="/games/snookerroyale/lobby"
               element={<SnookerRoyalLobby />}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -79,6 +79,14 @@ import {
   normalizeSpinInput,
   SPIN_INPUT_DEAD_ZONE
 } from './poolRoyaleSpinUtils.js';
+import {
+  DEFAULT_POOL_PHYSICS_PARAMS,
+  applyRailImpulse,
+  applyTableFriction,
+  ensureBallPhysics,
+  resolveBallBallCollision,
+  strikeCueBall
+} from './poolRoyalePhysicsCore';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
@@ -1004,6 +1012,7 @@ const BALL_SIZE_SCALE = 0.97; // shrink balls ~3% for a tighter match to the rea
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
+const BALL_MASS = 0.17;
 const ENABLE_BALL_FLOOR_SHADOWS = true;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
@@ -5664,7 +5673,8 @@ function makeWoodTexture({
   texture.needsUpdate = true;
   return texture;
 }
-function reflectRails(ball) {
+function reflectRails(ball, physicsParams) {
+  const params = physicsParams ?? DEFAULT_POOL_PHYSICS_PARAMS;
   const limX = RAIL_LIMIT_X;
   const limY = RAIL_LIMIT_Y;
   const cornerRad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
@@ -5686,22 +5696,8 @@ function reflectRails(ball) {
     if (distNormal < -cornerDepthLimit) continue;
     const push = BALL_R - distNormal;
     ball.pos.addScaledVector(TMP_VEC2_B, push);
-    preImpactVel = ball.vel.clone();
-    const vn = ball.vel.dot(TMP_VEC2_B);
-    if (vn < 0) {
-      const restitution = CUSHION_RESTITUTION;
-      ball.vel.addScaledVector(TMP_VEC2_B, -(1 + restitution) * vn);
-      const vt = TMP_VEC2_D.copy(ball.vel).sub(
-        TMP_VEC2_B.clone().multiplyScalar(ball.vel.dot(TMP_VEC2_B))
-      );
-      const tangentDamping = 0.96;
-      ball.vel
-        .sub(vt)
-        .add(vt.multiplyScalar(tangentDamping));
-    }
-    if (ball.spin?.lengthSq() > 0) {
-      applySpinImpulse(ball, 0.6);
-    }
+    const impact = applyRailImpulse(ball, TMP_VEC2_B, params);
+    preImpactVel = impact?.preImpactVel ?? preImpactVel;
     const stamp =
       typeof performance !== 'undefined' && performance.now
         ? performance.now()
@@ -5738,23 +5734,8 @@ function reflectRails(ball) {
     if (distNormal < -sideDepthLimit) continue;
     const push = BALL_R - distNormal;
     ball.pos.addScaledVector(normal, push);
-    preImpactVel = ball.vel.clone();
-    const vn = ball.vel.dot(normal);
-    if (vn < 0) {
-      const restitution = CUSHION_RESTITUTION;
-      ball.vel.addScaledVector(normal, -(1 + restitution) * vn);
-      TMP_VEC2_LIMIT.copy(normal).multiplyScalar(ball.vel.dot(normal));
-      const vt = TMP_VEC2_B.copy(ball.vel).sub(
-        TMP_VEC2_LIMIT
-      );
-      const tangentDamping = 0.96;
-      ball.vel
-        .sub(vt)
-        .add(vt.multiplyScalar(tangentDamping));
-    }
-    if (ball.spin?.lengthSq() > 0) {
-      applySpinImpulse(ball, 0.6);
-    }
+    const impact = applyRailImpulse(ball, normal, params);
+    preImpactVel = impact?.preImpactVel ?? preImpactVel;
     const stamp =
       typeof performance !== 'undefined' && performance.now
         ? performance.now()
@@ -5779,36 +5760,32 @@ function reflectRails(ball) {
   let collided = null;
   let collisionNormal = null;
   if (ball.pos.x < -limX && ball.vel.x < 0) {
-    preImpactVel = ball.vel.clone();
     const overshoot = -limX - ball.pos.x;
     ball.pos.x = -limX + overshoot;
-    ball.vel.x = Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
-    collided = 'rail';
     collisionNormal = new THREE.Vector2(1, 0);
+    collided = 'rail';
   }
   if (ball.pos.x > limX && ball.vel.x > 0) {
-    preImpactVel = ball.vel.clone();
     const overshoot = ball.pos.x - limX;
     ball.pos.x = limX - overshoot;
-    ball.vel.x = -Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
-    collided = 'rail';
     collisionNormal = new THREE.Vector2(-1, 0);
+    collided = 'rail';
   }
   if (ball.pos.y < -limY && ball.vel.y < 0) {
-    preImpactVel = ball.vel.clone();
     const overshoot = -limY - ball.pos.y;
     ball.pos.y = -limY + overshoot;
-    ball.vel.y = Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
-    collided = 'rail';
     collisionNormal = new THREE.Vector2(0, 1);
+    collided = 'rail';
   }
   if (ball.pos.y > limY && ball.vel.y > 0) {
-    preImpactVel = ball.vel.clone();
     const overshoot = ball.pos.y - limY;
     ball.pos.y = limY - overshoot;
-    ball.vel.y = -Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
-    collided = 'rail';
     collisionNormal = new THREE.Vector2(0, -1);
+    collided = 'rail';
+  }
+  if (collided && collisionNormal) {
+    const impact = applyRailImpulse(ball, collisionNormal, params);
+    preImpactVel = impact?.preImpactVel ?? preImpactVel;
   }
   if (collided) {
     const stamp =
@@ -6222,6 +6199,10 @@ function Guret(parent, id, color, x, y, options = {}) {
     pos: new THREE.Vector2(x, y),
     vel: new THREE.Vector2(),
     spin: new THREE.Vector2(),
+    omega: new THREE.Vector3(),
+    mass: BALL_MASS,
+    radius: BALL_R,
+    inertia: 0.4 * BALL_MASS * BALL_R * BALL_R,
     spinMode: 'standard',
     swerveStrength: 0,
     swervePowerStrength: 0,
@@ -17093,6 +17074,7 @@ const powerRef = useRef(hud.power);
             if (!state) return;
             ball.active = state.active;
             if (ball.vel) ball.vel.set(0, 0);
+            if (ball.omega) ball.omega.set(0, 0, 0);
             if (ball.spin) ball.spin.set(0, 0);
             if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
             ball.impacted = false;
@@ -17170,6 +17152,7 @@ const powerRef = useRef(hud.power);
             const posY = THREE.MathUtils.lerp(posA.y, posB.y, alpha);
             ball.pos.set(posX, posY);
             if (ball.vel) ball.vel.set(0, 0);
+            if (ball.omega) ball.omega.set(0, 0, 0);
             if (ball.spin) ball.spin.set(0, 0);
             if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
             ball.impacted = false;
@@ -19520,6 +19503,7 @@ const powerRef = useRef(hud.power);
         cue.pos.set(pos.x, pos.y);
         cue.mesh.position.set(pos.x, BALL_CENTER_Y, pos.y);
         cue.vel.set(0, 0);
+        if (cue.omega) cue.omega.set(0, 0, 0);
         cue.spin?.set(0, 0);
         cue.pendingSpin?.set(0, 0);
         cue.spinMode = 'standard';
@@ -20178,30 +20162,30 @@ const powerRef = useRef(hud.power);
           const liftStrength = normalizeCueLift(liftAngle);
           const physicsSpin = mapSpinForPhysics(appliedSpin);
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const baseSide = physicsSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
-          if (physicsSpin.y < 0) {
-            spinTop *= BACKSPIN_MULTIPLIER;
-          } else if (physicsSpin.y > 0) {
-            spinTop *= TOPSPIN_MULTIPLIER;
-          }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode =
-            spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
-          const swerveSettings = resolveSwerveSettings(
-            physicsSpin,
-            clampedPower,
-            cue.spinMode === 'swerve',
-            liftStrength
+          const spinOffset = {
+            x: THREE.MathUtils.clamp(physicsSpin.x ?? 0, -1, 1),
+            y: THREE.MathUtils.clamp(physicsSpin.y ?? 0, -1, 1)
+          };
+          cue.vel.set(0, 0);
+          if (cue.omega) cue.omega.set(0, 0, 0);
+          ensureBallPhysics(cue, BALL_R, BALL_MASS);
+          const strikeParams = {
+            ...DEFAULT_POOL_PHYSICS_PARAMS,
+            restitutionRail: CUSHION_RESTITUTION,
+            maxCueImpulse: (cue.mass ?? BALL_MASS) * speedBase
+          };
+          strikeCueBall(
+            cue,
+            aimDir.clone().normalize(),
+            powerScale,
+            spinOffset,
+            strikeParams
           );
-          cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
-          cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+          if (cue.spin) cue.spin.set(spinOffset.x, spinOffset.y);
+          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+          cue.spinMode = 'standard';
+          cue.swerveStrength = 0;
+          cue.swervePowerStrength = 0;
           resetSpinRef.current?.();
           cueLiftRef.current.lift = 0;
           cueLiftRef.current.startLift = 0;
@@ -22460,6 +22444,7 @@ const powerRef = useRef(hud.power);
                   simBall.pos.set(sx, sy);
                   simBall.mesh.position.set(sx, BALL_CENTER_Y, sy);
                   simBall.vel.set(0, 0);
+                  if (simBall.omega) simBall.omega.set(0, 0, 0);
                   simBall.spin?.set(0, 0);
                   simBall.pendingSpin?.set(0, 0);
                   simBall.spinMode = 'standard';
@@ -22503,6 +22488,7 @@ const powerRef = useRef(hud.power);
               }
               cue.active = true;
               cue.vel.set(0, 0);
+              if (cue.omega) cue.omega.set(0, 0, 0);
               cue.spin?.set(0, 0);
               cue.pendingSpin?.set(0, 0);
               cue.spinMode = 'standard';
@@ -23496,12 +23482,16 @@ const powerRef = useRef(hud.power);
             }
           }
         });
-          for (let stepIndex = 0; stepIndex < physicsSubsteps; stepIndex++) {
+        const physicsParams = {
+          ...DEFAULT_POOL_PHYSICS_PARAMS,
+          restitutionRail: CUSHION_RESTITUTION
+        };
+        for (let stepIndex = 0; stepIndex < physicsSubsteps; stepIndex++) {
           const stepScale = subStepScale;
           balls.forEach((b) => {
             if (!b.active) return;
+            ensureBallPhysics(b, BALL_R, BALL_MASS);
             const isCue = b.id === 'cue';
-            const hasSpin = b.spin?.lengthSq() > 1e-6;
             const hasLift = (b.lift ?? 0) > 1e-6 || Math.abs(b.liftVel ?? 0) > 1e-6;
             if (hasLift) {
               const dampedVel = (b.liftVel ?? 0) * Math.pow(MAX_POWER_BOUNCE_DAMPING, stepScale);
@@ -23514,146 +23504,46 @@ const powerRef = useRef(hud.power);
                 const nowLanding = performance.now();
                 if (nowLanding - lastLanding > MAX_POWER_LANDING_SOUND_COOLDOWN_MS) {
                   const landingVol = clamp(
-                  Math.abs(dampedVel) / MAX_POWER_BOUNCE_IMPULSE,
-                  0,
-                  1
-                );
+                    Math.abs(dampedVel) / MAX_POWER_BOUNCE_IMPULSE,
+                    0,
+                    1
+                  );
                   const landingHitVol = Math.max(0.45, landingVol * 0.95);
                   playBallHit(landingHitVol);
                   liftLandingTimeRef.current.set(b.id, nowLanding);
                 }
               }
-            b.lift = nextLift;
-            b.liftVel = Math.abs(nextLift) > 1e-6 ? nextVel : 0;
+              b.lift = nextLift;
+              b.liftVel = Math.abs(nextLift) > 1e-6 ? nextVel : 0;
               if (nextLift <= 1e-4 && Math.abs(nextVel) <= 1e-4) {
                 b.lift = 0;
                 b.liftVel = 0;
               }
-            if (hasSpin && (b.lift ?? 0) > 0) {
-              const airborneSpin = resolveSpinWorldVector(b, TMP_VEC2_LIMIT);
-              const spinMag = airborneSpin?.length() ?? 0;
-              if (spinMag > 1e-6) {
-                const liftRatio = THREE.MathUtils.clamp(
-                  (b.lift ?? 0) / MAX_POWER_LIFT_HEIGHT,
-                  0,
-                  1.2
-                );
-                const driftScale = LIFT_SPIN_AIR_DRIFT * liftRatio * stepScale;
-                airborneSpin.normalize().multiplyScalar(driftScale);
-                b.vel.add(airborneSpin);
-              }
             }
-            }
-            if (hasSpin) {
-              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
-              const swerveStrength = swerveTravel ? Math.max(0, b.swerveStrength ?? 0) : 0;
-              const swervePower = swerveTravel
-                ? Math.max(0, b.swervePowerStrength ?? 0)
-                : 0;
-              const swervePowerScale = swerveStrength > 0 ? 0.85 + swervePower * 0.9 : 0;
-              const swerveScale =
-                swerveStrength > 0 ? (0.6 + swerveStrength * 0.9) * swervePowerScale : 0;
-              const allowRoll =
-                !isCue || b.impacted || swerveTravel || (isCue && b.spin?.lengthSq() > 1e-8);
-              const preImpact = isCue && !b.impacted;
-              if (allowRoll) {
-                const rollMultiplier = swerveTravel
-                  ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
-                  : 1;
-                const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
-                if (!worldSpin) {
-                  TMP_VEC2_SPIN.set(0, 0);
-                } else {
-                  TMP_VEC2_SPIN.copy(worldSpin);
-                }
-                TMP_VEC2_SPIN.multiplyScalar(
-                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-                );
-                const isBackspin = (b.spin?.y ?? 0) < -1e-4;
-                if (isBackspin && isCue && b.impacted) {
-                  TMP_VEC2_SPIN.multiplyScalar(CUE_BACKSPIN_ROLL_BOOST);
-                } else if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
-                  TMP_VEC2_SPIN.multiplyScalar(BACKSPIN_ROLL_BOOST);
-                }
-                if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
-                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = Math.max(0, TMP_VEC2_SPIN.dot(launchDir));
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
-                  b.vel.add(TMP_VEC2_AXIS);
-                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
-                  if (b.spinMode === 'swerve' && b.pendingSpin && swerveScale > 0) {
-                    b.pendingSpin.addScaledVector(TMP_VEC2_LATERAL, swerveScale);
-                  }
-                  const alignedSpeed = b.vel.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
-                  b.vel.copy(TMP_VEC2_AXIS);
-                  if (b.spinMode === 'swerve' && swerveScale > 0) {
-                    b.vel.addScaledVector(
-                      TMP_VEC2_LATERAL,
-                      SWERVE_PRE_IMPACT_DRIFT * swerveScale
-                    );
-                  }
-                } else {
-                  b.vel.add(TMP_VEC2_SPIN);
-                  if (
-                    isCue &&
-                    b.spinMode === 'swerve' &&
-                    b.pendingSpin &&
-                    b.pendingSpin.lengthSq() > 0
-                  ) {
-                    const driftScale = swerveScale > 0 ? swerveScale : 1;
-                    b.vel.addScaledVector(
-                      b.pendingSpin,
-                      PRE_IMPACT_SPIN_DRIFT * driftScale
-                    );
-                    b.pendingSpin.multiplyScalar(0);
-                  }
-                }
-                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
-                b.spin.multiplyScalar(rollDecay);
-                if (isCue && b.swerveStrength > 0) {
-                  b.swerveStrength *= rollDecay;
-                  if (b.swerveStrength < 1e-3) {
-                    b.swerveStrength = 0;
-                    b.swervePowerStrength = 0;
-                  }
-                }
-              } else {
-                const airDecay = Math.pow(SPIN_AIR_DECAY, stepScale);
-                b.spin.multiplyScalar(airDecay);
-                if (isCue && b.swerveStrength > 0) {
-                  b.swerveStrength *= airDecay;
-                  if (b.swerveStrength < 1e-3) {
-                    b.swerveStrength = 0;
-                    b.swervePowerStrength = 0;
-                  }
-                }
-              }
-              if (b.spin.lengthSq() < 1e-6) {
-                b.spin.set(0, 0);
-                if (b.pendingSpin) b.pendingSpin.set(0, 0);
-                if (isCue) {
-                  b.spinMode = 'standard';
-                  b.swerveStrength = 0;
-                  b.swervePowerStrength = 0;
-                }
-              }
-            }
+
+            applyTableFriction(b, physicsParams, stepScale);
             b.pos.addScaledVector(b.vel, stepScale);
-            b.vel.multiplyScalar(Math.pow(FRICTION, stepScale));
-            let speed = b.vel.length();
-            let scaledSpeed = speed * stepScale;
-            if (scaledSpeed < STOP_EPS) {
-              b.vel.multiplyScalar(Math.pow(STOP_SOFTENING, stepScale));
-              speed = b.vel.length();
-              scaledSpeed = speed * stepScale;
+
+            const railImpact = reflectRails(b, physicsParams);
+            if (railImpact && b.id === 'cue') b.impacted = true;
+            if (railImpact && shotContextRef.current.contactMade) {
+              shotContextRef.current.cushionAfterContact = true;
             }
-            const hasSpinAfter = b.spin?.lengthSq() > 1e-6;
-            if (scaledSpeed < STOP_FINAL_EPS) {
+            if (railImpact) {
+              const nowRail = performance.now();
+              const lastPlayed = railSoundTimeRef.current.get(b.id) ?? 0;
+              if (nowRail - lastPlayed > RAIL_HIT_SOUND_COOLDOWN_MS) {
+                railSoundTimeRef.current.set(b.id, nowRail);
+              }
+            }
+
+            const speed = b.vel.length();
+            const scaledSpeed = speed * stepScale;
+            const omegaMag = b.omega?.length() ?? 0;
+            if (scaledSpeed < STOP_FINAL_EPS && omegaMag < 0.4) {
               b.vel.set(0, 0);
-              if (!hasSpinAfter && b.spin) b.spin.set(0, 0);
-              if (!hasSpinAfter && b.pendingSpin) b.pendingSpin.set(0, 0);
-              if (isCue && !hasSpinAfter) {
+              if (b.omega) b.omega.set(0, 0, 0);
+              if (isCue) {
                 b.impacted = false;
                 b.spinMode = 'standard';
                 b.swerveStrength = 0;
@@ -23661,27 +23551,12 @@ const powerRef = useRef(hud.power);
               }
               b.launchDir = null;
             }
-            const railImpact = reflectRails(b);
-            if (railImpact && b.id === 'cue') b.impacted = true;
-            if (railImpact && shotContextRef.current.contactMade) {
-              shotContextRef.current.cushionAfterContact = true;
-            }
-            if (railImpact && b.spin?.lengthSq() > 0) {
-              applyRailSpinResponse(b, railImpact);
-            }
-            if (railImpact) {
-              const nowRail = performance.now();
-              const lastPlayed = railSoundTimeRef.current.get(b.id) ?? 0;
-              if (nowRail - lastPlayed > RAIL_HIT_SOUND_COOLDOWN_MS) {
-                // Cushion contacts stay silent so only ball collisions trigger audio.
-                railSoundTimeRef.current.set(b.id, nowRail);
-              }
-            }
+
             const liftAmount = b.lift ?? 0;
             b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
-            if (scaledSpeed > 0) {
-              const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
-              const angle = scaledSpeed / BALL_R;
+            if (b.omega && b.omega.lengthSq() > 1e-6) {
+              const axis = b.omega.clone().normalize();
+              const angle = b.omega.length() * stepScale;
               b.mesh.rotateOnWorldAxis(axis, angle);
             }
             if (b.shadow) {
@@ -23708,132 +23583,91 @@ const powerRef = useRef(hud.power);
             }
           });
           // Kolizione + regjistro firstHit
-          for (let i = 0; i < balls.length; i++)
+          for (let i = 0; i < balls.length; i++) {
             for (let j = i + 1; j < balls.length; j++) {
-              const a = balls[i],
-                b = balls[j];
+              const a = balls[i];
+              const b = balls[j];
               if (!a.active || !b.active) continue;
-              const dx = b.pos.x - a.pos.x,
-                dy = b.pos.y - a.pos.y;
-              const d2 = dx * dx + dy * dy;
-              const min = (BALL_R * 2) ** 2;
-              if (d2 > 0 && d2 < min) {
-                const d = Math.sqrt(d2) || 1e-4;
-                const nx = dx / d,
-                  ny = dy / d;
-                const overlap = (BALL_R * 2 - d) / 2;
-                const pairKey =
-                  (a.id ?? i) < (b.id ?? j)
-                    ? `${a.id ?? i}:${b.id ?? j}`
-                    : `${b.id ?? j}:${a.id ?? i}`;
-                const firstPairCollision = !newCollisions.has(pairKey);
-                newCollisions.add(pairKey);
-                const wasColliding = prevCollisions.has(pairKey);
-                const isNewImpact = firstPairCollision && !wasColliding;
-                a.pos.x -= nx * overlap;
-                a.pos.y -= ny * overlap;
-                b.pos.x += nx * overlap;
-                b.pos.y += ny * overlap;
-                const avn = a.vel.x * nx + a.vel.y * ny;
-                const bvn = b.vel.x * nx + b.vel.y * ny;
-                const impulse = Math.abs(bvn - avn);
-                const at = a.vel
-                  .clone()
-                  .sub(new THREE.Vector2(nx, ny).multiplyScalar(avn));
-                const bt = b.vel
-                  .clone()
-                  .sub(new THREE.Vector2(nx, ny).multiplyScalar(bvn));
-                a.vel.copy(at.add(new THREE.Vector2(nx, ny).multiplyScalar(bvn)));
-                b.vel.copy(bt.add(new THREE.Vector2(nx, ny).multiplyScalar(avn)));
-                if (isNewImpact) {
-                  const shotScale = 0.4 + 0.6 * lastShotPower;
-                  const volume = clamp(
-                    (impulse / BALL_COLLISION_SOUND_REFERENCE_SPEED) * shotScale,
-                    0,
-                    1
-                  );
-                  if (volume > 0) playBallHit(volume);
-                }
-                const cueBall = a.id === 'cue' ? a : b.id === 'cue' ? b : null;
-                const cuePreImpactVel = cueBall?.vel?.clone?.() ?? null;
-                if (!firstHit) {
-                  if (a.id === 'cue' && b.id !== 'cue') firstHit = b.id;
-                  else if (b.id === 'cue' && a.id !== 'cue') firstHit = a.id;
-                }
-                if (
-                  !shotContextRef.current.contactMade &&
-                  (a.id === 'cue' || b.id === 'cue')
-                ) {
-                  shotContextRef.current.contactMade = true;
-                }
-                const hitBallId =
-                  a.id === 'cue' && b.id !== 'cue'
-                    ? b.id
-                    : b.id === 'cue' && a.id !== 'cue'
-                      ? a.id
-                      : null;
-                const targetImpactId = shotPrediction?.ballId ?? null;
-                const isTargetImpact =
-                  !targetImpactId || (hitBallId && String(hitBallId) === String(targetImpactId));
-                if (
-                  cueBall &&
-                  hitBallId &&
-                  isTargetImpact &&
-                  isNewImpact &&
-                  lastShotPower >= MAX_POWER_BOUNCE_THRESHOLD &&
-                  !maxPowerLiftTriggered
-                ) {
-                  const bounceStrength = THREE.MathUtils.clamp(lastShotPower, 0, 1);
-                  const liftBoost = 1.2;
-                  maxPowerLiftTriggered = true;
-                  const liftSoundVol = Math.max(0.7, bounceStrength * 0.95);
-                  playCueHit(liftSoundVol);
-                  const spinEnergy = cueBall.spin?.length() ?? 0;
-                  const spinHeightBonus = spinEnergy * MAX_POWER_SPIN_LIFT_BONUS;
-                  const liftCeiling = Math.min(
-                    MAX_POWER_LIFT_HEIGHT * liftBoost + spinHeightBonus,
-                    MAX_POWER_BOUNCE_IMPULSE * 0.9
-                  );
-                  cueBall.lift = Math.max(
-                    cueBall.lift ?? 0,
-                    liftCeiling
-                  );
-                  const launchCeiling = Math.min(
-                    MAX_POWER_BOUNCE_IMPULSE * bounceStrength * liftBoost + spinHeightBonus,
-                    MAX_POWER_BOUNCE_IMPULSE * 0.95
-                  );
-                  cueBall.liftVel = Math.max(
-                    cueBall.liftVel ?? 0,
-                    launchCeiling
-                  );
-                  if (spinEnergy > 1e-6) {
-                    const spinThrow = Math.min(
-                      spinEnergy * MAX_POWER_SPIN_LATERAL_THROW,
-                      MAX_POWER_BOUNCE_IMPULSE * 0.4
-                    );
-                    if (spinThrow > 0 && cueBall.spin) {
-                      const spinDir = resolveSpinWorldVector(cueBall, TMP_VEC2_SPIN);
-                      if (spinDir && spinDir.lengthSq() > 1e-6) {
-                        spinDir.normalize();
-                        cueBall.vel.add(spinDir.multiplyScalar(spinThrow));
-                      }
-                    }
-                  }
-                }
-                if (
-                  hitBallId &&
-                  activeShotView?.mode === 'action' &&
-                  activeShotView.targetId === hitBallId
-                ) {
-                  activeShotView.hitConfirmed = true;
-                }
-                if (cueBall && cueBall.spin?.lengthSq() > 0) {
-                  cueBall.impacted = true;
-                  const backspinBoost = cueBall.spin.y < -1e-4 ? 2.6 : 1.2;
-                  applySpinImpulse(cueBall, backspinBoost, cuePreImpactVel);
-                }
+              const pairKey =
+                (a.id ?? i) < (b.id ?? j)
+                  ? `${a.id ?? i}:${b.id ?? j}`
+                  : `${b.id ?? j}:${a.id ?? i}`;
+              const firstPairCollision = !newCollisions.has(pairKey);
+              const wasColliding = prevCollisions.has(pairKey);
+              const collision = resolveBallBallCollision(a, b, physicsParams);
+              if (!collision) continue;
+              newCollisions.add(pairKey);
+              const isNewImpact = firstPairCollision && !wasColliding;
+              if (isNewImpact) {
+                const shotScale = 0.4 + 0.6 * lastShotPower;
+                const volume = clamp(
+                  (collision.impulse / BALL_COLLISION_SOUND_REFERENCE_SPEED) * shotScale,
+                  0,
+                  1
+                );
+                if (volume > 0) playBallHit(volume);
+              }
+              const cueBall = a.id === 'cue' ? a : b.id === 'cue' ? b : null;
+              if (!firstHit) {
+                if (a.id === 'cue' && b.id !== 'cue') firstHit = b.id;
+                else if (b.id === 'cue' && a.id !== 'cue') firstHit = a.id;
+              }
+              if (
+                !shotContextRef.current.contactMade &&
+                (a.id === 'cue' || b.id === 'cue')
+              ) {
+                shotContextRef.current.contactMade = true;
+              }
+              const hitBallId =
+                a.id === 'cue' && b.id !== 'cue'
+                  ? b.id
+                  : b.id === 'cue' && a.id !== 'cue'
+                    ? a.id
+                    : null;
+              const targetImpactId = shotPrediction?.ballId ?? null;
+              const isTargetImpact =
+                !targetImpactId || (hitBallId && String(hitBallId) === String(targetImpactId));
+              if (
+                cueBall &&
+                hitBallId &&
+                isTargetImpact &&
+                isNewImpact &&
+                lastShotPower >= MAX_POWER_BOUNCE_THRESHOLD &&
+                !maxPowerLiftTriggered
+              ) {
+                const bounceStrength = THREE.MathUtils.clamp(lastShotPower, 0, 1);
+                const liftBoost = 1.2;
+                maxPowerLiftTriggered = true;
+                const liftSoundVol = Math.max(0.7, bounceStrength * 0.95);
+                playCueHit(liftSoundVol);
+                const spinEnergy = cueBall.omega?.length() ?? 0;
+                const spinHeightBonus = spinEnergy * MAX_POWER_SPIN_LIFT_BONUS;
+                const liftCeiling = Math.min(
+                  MAX_POWER_LIFT_HEIGHT * liftBoost + spinHeightBonus,
+                  MAX_POWER_BOUNCE_IMPULSE * 0.9
+                );
+                cueBall.lift = Math.max(
+                  cueBall.lift ?? 0,
+                  liftCeiling
+                );
+                const launchCeiling = Math.min(
+                  MAX_POWER_BOUNCE_IMPULSE * bounceStrength * liftBoost + spinHeightBonus,
+                  MAX_POWER_BOUNCE_IMPULSE * 0.95
+                );
+                cueBall.liftVel = Math.max(
+                  cueBall.liftVel ?? 0,
+                  launchCeiling
+                );
+              }
+              if (
+                hitBallId &&
+                activeShotView?.mode === 'action' &&
+                activeShotView.targetId === hitBallId
+              ) {
+                activeShotView.hitConfirmed = true;
               }
             }
+          }
         }
         if (
           !activeShotView &&
@@ -24096,6 +23930,7 @@ const powerRef = useRef(hud.power);
               playPocket(pocketVolume);
               b.active = false;
               b.vel.set(0, 0);
+              if (b.omega) b.omega.set(0, 0, 0);
               if (b.spin) b.spin.set(0, 0);
               if (b.pendingSpin) b.pendingSpin.set(0, 0);
               b.spinMode = 'standard';
@@ -24289,6 +24124,7 @@ const powerRef = useRef(hud.power);
               balls.forEach((ball) => {
                 if (!ball) return;
                 if (ball.vel) ball.vel.set(0, 0);
+                if (ball.omega) ball.omega.set(0, 0, 0);
                 if (ball.spin) ball.spin.set(0, 0);
                 if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
                 ball.launchDir = null;

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo.tsx
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import PhysicsDemoApp from './PoolRoyalePhysicsDemo/App';
+
+export default function PoolRoyalePhysicsDemo() {
+  return <PhysicsDemoApp />;
+}

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo/App.tsx
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo/App.tsx
@@ -1,0 +1,352 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import {
+  DEFAULT_PARAMS,
+  DEFAULT_TABLE,
+  PhysicsState,
+  SpinOffset,
+  createInitialState,
+  resetState,
+  stepPhysics,
+  strikeCueBall
+} from './physics';
+
+const TABLE_COLOR = '#1f5f3b';
+const RAIL_COLOR = '#4b2e1f';
+
+const usePhysicsState = () => {
+  const stateRef = useRef<PhysicsState>(createInitialState(DEFAULT_PARAMS));
+  const [revision, setRevision] = useState(0);
+
+  const reset = () => {
+    resetState(stateRef.current);
+    setRevision((prev) => prev + 1);
+  };
+
+  return { stateRef, revision, reset };
+};
+
+const BallMeshes = ({ stateRef }: { stateRef: React.MutableRefObject<PhysicsState> }) => {
+  const meshes = useRef<Record<string, THREE.Mesh>>({});
+
+  useFrame((_, delta) => {
+    stepPhysics(stateRef.current, Math.min(delta, 0.016), DEFAULT_TABLE);
+    for (const ball of stateRef.current.balls) {
+      const mesh = meshes.current[ball.id];
+      if (!mesh) continue;
+      mesh.position.set(ball.position.x, ball.radius, ball.position.y);
+      const axis = ball.omega.clone();
+      const angle = axis.length() * delta;
+      if (angle > 0.0001) {
+        axis.normalize();
+        mesh.rotateOnAxis(axis, angle);
+      }
+    }
+  });
+
+  return (
+    <group>
+      {stateRef.current.balls.map((ball) => (
+        <mesh
+          key={ball.id}
+          ref={(node) => {
+            if (node) meshes.current[ball.id] = node;
+          }}
+          position={[ball.position.x, ball.radius, ball.position.y]}
+          castShadow
+          receiveShadow
+        >
+          <sphereGeometry args={[ball.radius, 32, 32]} />
+          <meshStandardMaterial color={ball.color} />
+        </mesh>
+      ))}
+    </group>
+  );
+};
+
+const Table = () => {
+  const width = DEFAULT_TABLE.maxX - DEFAULT_TABLE.minX;
+  const depth = DEFAULT_TABLE.maxZ - DEFAULT_TABLE.minZ;
+  const railHeight = 0.06;
+  const railThickness = 0.08;
+
+  return (
+    <group>
+      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[width, depth]} />
+        <meshStandardMaterial color={TABLE_COLOR} />
+      </mesh>
+      <mesh
+        position={[0, railHeight / 2, DEFAULT_TABLE.minZ - railThickness / 2]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[width + railThickness * 2, railHeight, railThickness]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[0, railHeight / 2, DEFAULT_TABLE.maxZ + railThickness / 2]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[width + railThickness * 2, railHeight, railThickness]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[DEFAULT_TABLE.minX - railThickness / 2, railHeight / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[railThickness, railHeight, depth]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+      <mesh
+        position={[DEFAULT_TABLE.maxX + railThickness / 2, railHeight / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <boxGeometry args={[railThickness, railHeight, depth]} />
+        <meshStandardMaterial color={RAIL_COLOR} />
+      </mesh>
+    </group>
+  );
+};
+
+const ShotTests = [
+  {
+    label: 'Stun (stop cue ball)',
+    spinOffset: { x: 0, y: 0 },
+    power: 0.5,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Draw (backspin)',
+    spinOffset: { x: 0, y: -0.6 },
+    power: 0.55,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Follow (topspin)',
+    spinOffset: { x: 0, y: 0.6 },
+    power: 0.55,
+    angle: -Math.PI / 2
+  },
+  {
+    label: 'Rail english',
+    spinOffset: { x: 0.7, y: 0.1 },
+    power: 0.5,
+    angle: -Math.PI / 3
+  },
+  {
+    label: 'Cut throw',
+    spinOffset: { x: -0.4, y: 0.1 },
+    power: 0.45,
+    angle: -Math.PI / 2.4
+  },
+  {
+    label: 'Break stability',
+    spinOffset: { x: 0, y: 0 },
+    power: 1,
+    angle: -Math.PI / 2
+  }
+];
+
+const SpinController = ({
+  spinOffset,
+  onChange
+}: {
+  spinOffset: SpinOffset;
+  onChange: (next: SpinOffset) => void;
+}) => {
+  const radius = 60;
+  const maxOffset = DEFAULT_PARAMS.maxSpinOffset;
+
+  const handlePointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const rawX = (event.clientX - centerX) / radius;
+    const rawY = (centerY - event.clientY) / radius;
+    const length = Math.hypot(rawX, rawY);
+    const clamped = length > 1 ? 1 / length : 1;
+    const nextX = rawX * clamped;
+    const nextY = rawY * clamped;
+    const limitedX = THREE.MathUtils.clamp(nextX, -maxOffset, maxOffset);
+    const limitedY = THREE.MathUtils.clamp(nextY, -maxOffset, maxOffset);
+    onChange({ x: limitedX, y: limitedY });
+  };
+
+  const dotStyle = {
+    transform: `translate(${spinOffset.x * radius}px, ${-spinOffset.y * radius}px)`
+  } as React.CSSProperties;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="relative h-32 w-32 rounded-full border border-white/50 bg-white/10"
+        onPointerDown={handlePointer}
+        onPointerMove={(event) => {
+          if (event.buttons !== 1) return;
+          handlePointer(event);
+        }}
+      >
+        <div
+          className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+          style={dotStyle}
+        />
+      </div>
+      <div className="text-xs text-white/70">Spin offset: {spinOffset.x.toFixed(2)}, {spinOffset.y.toFixed(2)}</div>
+    </div>
+  );
+};
+
+const ShotPanel = ({
+  spinOffset,
+  setSpinOffset,
+  power,
+  setPower,
+  angle,
+  setAngle,
+  onShoot,
+  onReset
+}: {
+  spinOffset: SpinOffset;
+  setSpinOffset: (next: SpinOffset) => void;
+  power: number;
+  setPower: (next: number) => void;
+  angle: number;
+  setAngle: (next: number) => void;
+  onShoot: () => void;
+  onReset: () => void;
+}) => (
+  <div className="flex w-full flex-col gap-4 rounded-2xl bg-slate-900/80 p-4 text-white shadow-xl">
+    <div className="flex items-center justify-between">
+      <div>
+        <h2 className="text-lg font-semibold">Pool Royale Physics Demo</h2>
+        <p className="text-xs text-white/70">Spin controller + realistic slip-to-roll response.</p>
+      </div>
+      <button
+        className="rounded-full border border-white/20 px-3 py-1 text-xs hover:bg-white/10"
+        onClick={onReset}
+        type="button"
+      >
+        Reset rack
+      </button>
+    </div>
+
+    <SpinController spinOffset={spinOffset} onChange={setSpinOffset} />
+
+    <label className="flex flex-col gap-2 text-sm">
+      <span>Power: {power.toFixed(2)}</span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={power}
+        onChange={(event) => setPower(Number(event.target.value))}
+      />
+    </label>
+
+    <label className="flex flex-col gap-2 text-sm">
+      <span>Aim angle: {(THREE.MathUtils.radToDeg(angle) + 90).toFixed(0)}°</span>
+      <input
+        type="range"
+        min={-Math.PI}
+        max={0}
+        step={0.01}
+        value={angle}
+        onChange={(event) => setAngle(Number(event.target.value))}
+      />
+    </label>
+
+    <button
+      className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-900"
+      onClick={onShoot}
+      type="button"
+    >
+      Shoot
+    </button>
+
+    <div className="space-y-2 text-xs text-white/70">
+      <div className="font-semibold text-white">Shot tests</div>
+      <div className="grid gap-2">
+        {ShotTests.map((shot) => (
+          <button
+            key={shot.label}
+            className="rounded-lg border border-white/10 px-2 py-1 text-left hover:bg-white/10"
+            onClick={() => {
+              setSpinOffset(shot.spinOffset);
+              setPower(shot.power);
+              setAngle(shot.angle);
+              onShoot();
+            }}
+            type="button"
+          >
+            {shot.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const CameraRig = () => {
+  const cameraRef = useRef<THREE.PerspectiveCamera>(null);
+  useFrame(() => {
+    if (!cameraRef.current) return;
+    cameraRef.current.lookAt(0, 0, 0);
+  });
+  return (
+    <perspectiveCamera
+      ref={cameraRef}
+      position={[0, 2.6, 3.6]}
+      fov={45}
+      near={0.1}
+      far={50}
+    />
+  );
+};
+
+export default function App() {
+  const { stateRef, reset } = usePhysicsState();
+  const [spinOffset, setSpinOffset] = useState<SpinOffset>({ x: 0, y: 0 });
+  const [power, setPower] = useState(0.55);
+  const [angle, setAngle] = useState(-Math.PI / 2);
+
+  const direction = useMemo(() => {
+    const dir = new THREE.Vector2(Math.cos(angle), Math.sin(angle));
+    return dir;
+  }, [angle]);
+
+  const shoot = () => {
+    strikeCueBall(stateRef.current, direction, power, spinOffset);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-slate-950 text-white">
+      <div className="absolute inset-0">
+        <Canvas shadows camera={{ position: [0, 2.6, 3.6], fov: 45 }}>
+          <CameraRig />
+          <ambientLight intensity={0.7} />
+          <directionalLight position={[2, 4, 3]} intensity={1.2} castShadow />
+          <Table />
+          <BallMeshes stateRef={stateRef} />
+        </Canvas>
+      </div>
+      <div className="relative z-10 flex min-h-screen flex-col justify-end p-4">
+        <ShotPanel
+          spinOffset={spinOffset}
+          setSpinOffset={setSpinOffset}
+          power={power}
+          setPower={setPower}
+          angle={angle}
+          setAngle={setAngle}
+          onShoot={shoot}
+          onReset={reset}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyalePhysicsDemo/physics.ts
+++ b/webapp/src/pages/Games/PoolRoyalePhysicsDemo/physics.ts
@@ -1,0 +1,297 @@
+import * as THREE from 'three';
+
+export type SpinOffset = { x: number; y: number };
+
+export type PhysicsParams = {
+  muK: number;
+  muRoll: number;
+  muBall: number;
+  muRail: number;
+  restitution: number;
+  eps: number;
+  g: number;
+  maxSpinOffset: number;
+  maxCueImpulse: number;
+};
+
+export type BallState = {
+  id: string;
+  position: THREE.Vector2;
+  velocity: THREE.Vector2;
+  omega: THREE.Vector3;
+  radius: number;
+  mass: number;
+  inertia: number;
+  color: string;
+};
+
+export type TableBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export type PhysicsState = {
+  balls: BallState[];
+  params: PhysicsParams;
+};
+
+export const DEFAULT_PARAMS: PhysicsParams = {
+  muK: 0.2,
+  muRoll: 0.015,
+  muBall: 0.2,
+  muRail: 0.25,
+  restitution: 0.92,
+  eps: 0.02,
+  g: 9.81,
+  maxSpinOffset: 0.7,
+  maxCueImpulse: 2.8
+};
+
+export const DEFAULT_TABLE: TableBounds = {
+  minX: -1.2,
+  maxX: 1.2,
+  minZ: -2.2,
+  maxZ: 2.2
+};
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+const toVec3 = (v: THREE.Vector2) => new THREE.Vector3(v.x, 0, v.y);
+
+const applyLinearImpulse = (ball: BallState, impulse: THREE.Vector3) => {
+  ball.velocity.x += impulse.x / ball.mass;
+  ball.velocity.y += impulse.z / ball.mass;
+};
+
+const applyAngularImpulse = (ball: BallState, impulse: THREE.Vector3) => {
+  ball.omega.addScaledVector(impulse, 1 / ball.inertia);
+};
+
+export const createCueBall = (): BallState => {
+  const radius = 0.05715 / 2;
+  const mass = 0.17;
+  return {
+    id: 'cue',
+    position: new THREE.Vector2(0, 1.4),
+    velocity: new THREE.Vector2(0, 0),
+    omega: new THREE.Vector3(0, 0, 0),
+    radius,
+    mass,
+    inertia: 0.4 * mass * radius * radius,
+    color: '#f8f8f8'
+  };
+};
+
+export const createRack = (): BallState[] => {
+  const radius = 0.05715 / 2;
+  const mass = 0.17;
+  const spacing = radius * 2.05;
+  const baseZ = -1.3;
+  const balls: BallState[] = [];
+  const colors = ['#fbd34d', '#f43f5e', '#60a5fa', '#22c55e', '#fb7185'];
+
+  for (let row = 0; row < 3; row += 1) {
+    for (let i = 0; i <= row; i += 1) {
+      balls.push({
+        id: `rack-${row}-${i}`,
+        position: new THREE.Vector2((i - row / 2) * spacing, baseZ - row * spacing),
+        velocity: new THREE.Vector2(0, 0),
+        omega: new THREE.Vector3(0, 0, 0),
+        radius,
+        mass,
+        inertia: 0.4 * mass * radius * radius,
+        color: colors[(row + i) % colors.length]
+      });
+    }
+  }
+
+  return balls;
+};
+
+export const createInitialState = (params: PhysicsParams = DEFAULT_PARAMS): PhysicsState => ({
+  params,
+  balls: [createCueBall(), ...createRack()]
+});
+
+export const strikeCueBall = (
+  state: PhysicsState,
+  direction: THREE.Vector2,
+  power: number,
+  spinOffset: SpinOffset
+) => {
+  const cueBall = state.balls.find((ball) => ball.id === 'cue');
+  if (!cueBall) return;
+
+  const dir3 = toVec3(direction).normalize();
+  if (!Number.isFinite(dir3.lengthSq()) || dir3.lengthSq() < 1e-6) return;
+
+  const clampedPower = Math.min(Math.max(power, 0), 1);
+  const impulse = dir3.multiplyScalar(state.params.maxCueImpulse * clampedPower);
+  applyLinearImpulse(cueBall, impulse);
+
+  const right = new THREE.Vector3(-dir3.z, 0, dir3.x).normalize();
+  const maxOffset = state.params.maxSpinOffset * cueBall.radius;
+  const offsetX = THREE.MathUtils.clamp(spinOffset.x, -1, 1) * maxOffset;
+  const offsetY = THREE.MathUtils.clamp(spinOffset.y, -1, 1) * maxOffset;
+  const rOffset = new THREE.Vector3()
+    .addScaledVector(right, offsetX)
+    .addScaledVector(UP, offsetY);
+
+  const torqueImpulse = new THREE.Vector3().crossVectors(rOffset, impulse);
+  applyAngularImpulse(cueBall, torqueImpulse);
+};
+
+const applyFriction = (ball: BallState, params: PhysicsParams, dt: number) => {
+  const rContact = new THREE.Vector3(0, -ball.radius, 0);
+  const vContact = toVec3(ball.velocity).add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+  const vRel = new THREE.Vector3(vContact.x, 0, vContact.z);
+  const relSpeed = vRel.length();
+
+  if (relSpeed > params.eps) {
+    const frictionDir = vRel.normalize().multiplyScalar(-1);
+    const frictionForce = frictionDir.multiplyScalar(params.muK * ball.mass * params.g);
+    const linearImpulse = frictionForce.clone().multiplyScalar(dt);
+    applyLinearImpulse(ball, linearImpulse);
+
+    const torqueImpulse = new THREE.Vector3().crossVectors(rContact, linearImpulse);
+    applyAngularImpulse(ball, torqueImpulse);
+  } else {
+    const speed = ball.velocity.length();
+    if (speed > 0) {
+      const rollingForce = ball.velocity.clone().normalize().multiplyScalar(-params.muRoll * ball.mass * params.g);
+      const rollingImpulse = rollingForce.multiplyScalar(dt);
+      applyLinearImpulse(ball, new THREE.Vector3(rollingImpulse.x, 0, rollingImpulse.y));
+    }
+  }
+
+  if (ball.velocity.length() < 0.002 && ball.omega.length() < 0.2) {
+    ball.velocity.set(0, 0);
+    ball.omega.multiplyScalar(0.5);
+    if (ball.omega.length() < 0.05) {
+      ball.omega.set(0, 0, 0);
+    }
+  }
+};
+
+const resolveBallBallCollision = (a: BallState, b: BallState, params: PhysicsParams) => {
+  const delta = new THREE.Vector2().subVectors(b.position, a.position);
+  const dist = delta.length();
+  const minDist = a.radius + b.radius;
+  if (dist >= minDist || dist <= 0) return;
+
+  const normal = delta.clone().multiplyScalar(1 / dist);
+  const penetration = minDist - dist;
+  a.position.addScaledVector(normal, -penetration / 2);
+  b.position.addScaledVector(normal, penetration / 2);
+
+  const n3 = new THREE.Vector3(normal.x, 0, normal.y);
+  const rA = n3.clone().multiplyScalar(a.radius);
+  const rB = n3.clone().multiplyScalar(-b.radius);
+
+  const vRel = toVec3(a.velocity)
+    .add(new THREE.Vector3().crossVectors(a.omega, rA))
+    .sub(toVec3(b.velocity).add(new THREE.Vector3().crossVectors(b.omega, rB)));
+
+  const vn = vRel.dot(n3);
+  if (vn >= 0) return;
+
+  const invMassSum = 1 / a.mass + 1 / b.mass;
+  const jn = (-(1 + params.restitution) * vn) / invMassSum;
+  const impulseN = n3.clone().multiplyScalar(jn);
+
+  applyLinearImpulse(a, impulseN.clone().multiplyScalar(-1));
+  applyLinearImpulse(b, impulseN.clone().multiplyScalar(1));
+
+  const vt = vRel.clone().sub(n3.clone().multiplyScalar(vn));
+  const vtMag = vt.length();
+  if (vtMag < 1e-6) return;
+
+  const tDir = vt.multiplyScalar(1 / vtMag);
+  let jt = -vtMag / invMassSum;
+  const maxJt = params.muBall * jn;
+  jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+  const impulseT = tDir.clone().multiplyScalar(jt);
+
+  applyLinearImpulse(a, impulseT.clone().multiplyScalar(-1));
+  applyLinearImpulse(b, impulseT.clone().multiplyScalar(1));
+
+  applyAngularImpulse(a, new THREE.Vector3().crossVectors(rA, impulseT).multiplyScalar(-1));
+  applyAngularImpulse(b, new THREE.Vector3().crossVectors(rB, impulseT));
+};
+
+const resolveRailCollision = (ball: BallState, table: TableBounds, params: PhysicsParams) => {
+  const { radius } = ball;
+  const minX = table.minX + radius;
+  const maxX = table.maxX - radius;
+  const minZ = table.minZ + radius;
+  const maxZ = table.maxZ - radius;
+
+  const v3 = toVec3(ball.velocity);
+
+  const collisions: Array<{ normal: THREE.Vector3; position: THREE.Vector2 }> = [];
+
+  if (ball.position.x < minX) {
+    ball.position.x = minX;
+    collisions.push({ normal: new THREE.Vector3(1, 0, 0), position: ball.position });
+  } else if (ball.position.x > maxX) {
+    ball.position.x = maxX;
+    collisions.push({ normal: new THREE.Vector3(-1, 0, 0), position: ball.position });
+  }
+
+  if (ball.position.y < minZ) {
+    ball.position.y = minZ;
+    collisions.push({ normal: new THREE.Vector3(0, 0, 1), position: ball.position });
+  } else if (ball.position.y > maxZ) {
+    ball.position.y = maxZ;
+    collisions.push({ normal: new THREE.Vector3(0, 0, -1), position: ball.position });
+  }
+
+  for (const { normal } of collisions) {
+    const rContact = normal.clone().multiplyScalar(radius);
+    const vContact = v3.clone().add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+    const vn = vContact.dot(normal);
+    if (vn >= 0) continue;
+
+    const jn = -(1 + params.restitution) * vn * ball.mass;
+    const impulseN = normal.clone().multiplyScalar(jn);
+    applyLinearImpulse(ball, impulseN);
+
+    const vt = vContact.clone().sub(normal.clone().multiplyScalar(vn));
+    const vtMag = vt.length();
+    if (vtMag > 1e-6) {
+      const tDir = vt.multiplyScalar(1 / vtMag);
+      let jt = -vtMag * ball.mass;
+      const maxJt = params.muRail * jn;
+      jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+      const impulseT = tDir.multiplyScalar(jt);
+      applyLinearImpulse(ball, impulseT);
+      applyAngularImpulse(ball, new THREE.Vector3().crossVectors(rContact, impulseT));
+    }
+  }
+};
+
+export const stepPhysics = (
+  state: PhysicsState,
+  dt: number,
+  table: TableBounds = DEFAULT_TABLE
+) => {
+  state.balls.forEach((ball) => applyFriction(ball, state.params, dt));
+
+  state.balls.forEach((ball) => {
+    ball.position.addScaledVector(ball.velocity, dt);
+    resolveRailCollision(ball, table, state.params);
+  });
+
+  for (let i = 0; i < state.balls.length; i += 1) {
+    for (let j = i + 1; j < state.balls.length; j += 1) {
+      resolveBallBallCollision(state.balls[i], state.balls[j], state.params);
+    }
+  }
+};
+
+export const resetState = (state: PhysicsState) => {
+  const fresh = createInitialState(state.params);
+  state.balls = fresh.balls;
+};

--- a/webapp/src/pages/Games/poolRoyalePhysicsCore.ts
+++ b/webapp/src/pages/Games/poolRoyalePhysicsCore.ts
@@ -1,0 +1,196 @@
+import * as THREE from 'three';
+
+export type PoolPhysicsParams = {
+  muK: number;
+  muRoll: number;
+  muBall: number;
+  muRail: number;
+  restitutionBall: number;
+  restitutionRail: number;
+  eps: number;
+  g: number;
+  maxSpinOffset: number;
+  maxCueImpulse: number;
+};
+
+export const DEFAULT_POOL_PHYSICS_PARAMS: PoolPhysicsParams = {
+  muK: 0.2,
+  muRoll: 0.015,
+  muBall: 0.2,
+  muRail: 0.25,
+  restitutionBall: 0.92,
+  restitutionRail: 0.985,
+  eps: 0.02,
+  g: 9.81,
+  maxSpinOffset: 0.7,
+  maxCueImpulse: 2.8
+};
+
+type BallLike = {
+  pos: THREE.Vector2;
+  vel: THREE.Vector2;
+  omega?: THREE.Vector3;
+  mass?: number;
+  radius?: number;
+  inertia?: number;
+  lift?: number;
+};
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+const toVec3 = (v: THREE.Vector2) => new THREE.Vector3(v.x, 0, v.y);
+
+const applyLinearImpulse = (ball: BallLike, impulse: THREE.Vector3) => {
+  if (!ball.mass) return;
+  ball.vel.x += impulse.x / ball.mass;
+  ball.vel.y += impulse.z / ball.mass;
+};
+
+const applyAngularImpulse = (ball: BallLike, impulse: THREE.Vector3) => {
+  if (!ball.omega || !ball.inertia) return;
+  ball.omega.addScaledVector(impulse, 1 / ball.inertia);
+};
+
+export const ensureBallPhysics = (ball: BallLike, radius: number, mass: number) => {
+  if (!ball.omega) ball.omega = new THREE.Vector3();
+  if (!ball.radius) ball.radius = radius;
+  if (!ball.mass) ball.mass = mass;
+  if (!ball.inertia) ball.inertia = 0.4 * mass * radius * radius;
+};
+
+export const strikeCueBall = (
+  cueBall: BallLike,
+  direction: THREE.Vector2,
+  power: number,
+  spinOffset: { x: number; y: number },
+  params: PoolPhysicsParams
+) => {
+  if (!cueBall.radius || !cueBall.mass || !cueBall.inertia) return;
+  if (!cueBall.omega) cueBall.omega = new THREE.Vector3();
+
+  const dir3 = toVec3(direction).normalize();
+  if (!Number.isFinite(dir3.lengthSq()) || dir3.lengthSq() < 1e-6) return;
+
+  const clampedPower = Math.min(Math.max(power, 0), 1);
+  const impulse = dir3.multiplyScalar(params.maxCueImpulse * clampedPower);
+  applyLinearImpulse(cueBall, impulse);
+
+  const right = new THREE.Vector3(-dir3.z, 0, dir3.x).normalize();
+  const maxOffset = params.maxSpinOffset * cueBall.radius;
+  const offsetX = THREE.MathUtils.clamp(spinOffset.x, -1, 1) * maxOffset;
+  const offsetY = THREE.MathUtils.clamp(spinOffset.y, -1, 1) * maxOffset;
+  const rOffset = new THREE.Vector3()
+    .addScaledVector(right, offsetX)
+    .addScaledVector(UP, offsetY);
+
+  const torqueImpulse = new THREE.Vector3().crossVectors(rOffset, impulse);
+  applyAngularImpulse(cueBall, torqueImpulse);
+};
+
+export const applyTableFriction = (ball: BallLike, params: PoolPhysicsParams, dt: number) => {
+  if (!ball.radius || !ball.mass || !ball.omega) return;
+  if ((ball.lift ?? 0) > 0) return;
+
+  const rContact = new THREE.Vector3(0, -ball.radius, 0);
+  const vContact = toVec3(ball.vel).add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+  const vRel = new THREE.Vector3(vContact.x, 0, vContact.z);
+  const relSpeed = vRel.length();
+
+  if (relSpeed > params.eps) {
+    const frictionDir = vRel.normalize().multiplyScalar(-1);
+    const frictionForce = frictionDir.multiplyScalar(params.muK * ball.mass * params.g);
+    const linearImpulse = frictionForce.clone().multiplyScalar(dt);
+    applyLinearImpulse(ball, linearImpulse);
+
+    const torqueImpulse = new THREE.Vector3().crossVectors(rContact, linearImpulse);
+    applyAngularImpulse(ball, torqueImpulse);
+  } else {
+    const speed = ball.vel.length();
+    if (speed > 0) {
+      const rollingForce = ball.vel.clone().normalize().multiplyScalar(-params.muRoll * ball.mass * params.g);
+      const rollingImpulse = rollingForce.multiplyScalar(dt);
+      applyLinearImpulse(ball, new THREE.Vector3(rollingImpulse.x, 0, rollingImpulse.y));
+    }
+  }
+};
+
+export const resolveBallBallCollision = (
+  a: BallLike,
+  b: BallLike,
+  params: PoolPhysicsParams
+) => {
+  if (!a.radius || !b.radius || !a.mass || !b.mass || !a.omega || !b.omega) return null;
+  const delta = new THREE.Vector2().subVectors(b.pos, a.pos);
+  const dist = delta.length();
+  const minDist = a.radius + b.radius;
+  if (dist >= minDist || dist <= 0) return null;
+
+  const normal = delta.clone().multiplyScalar(1 / dist);
+  const penetration = minDist - dist;
+  a.pos.addScaledVector(normal, -penetration / 2);
+  b.pos.addScaledVector(normal, penetration / 2);
+
+  const n3 = new THREE.Vector3(normal.x, 0, normal.y);
+  const rA = n3.clone().multiplyScalar(a.radius);
+  const rB = n3.clone().multiplyScalar(-b.radius);
+
+  const vRel = toVec3(a.vel)
+    .add(new THREE.Vector3().crossVectors(a.omega, rA))
+    .sub(toVec3(b.vel).add(new THREE.Vector3().crossVectors(b.omega, rB)));
+
+  const vn = vRel.dot(n3);
+  if (vn >= 0) return null;
+
+  const invMassSum = 1 / a.mass + 1 / b.mass;
+  const jn = (-(1 + params.restitutionBall) * vn) / invMassSum;
+  const impulseN = n3.clone().multiplyScalar(jn);
+
+  applyLinearImpulse(a, impulseN.clone().multiplyScalar(-1));
+  applyLinearImpulse(b, impulseN.clone().multiplyScalar(1));
+
+  const vt = vRel.clone().sub(n3.clone().multiplyScalar(vn));
+  const vtMag = vt.length();
+  if (vtMag > 1e-6) {
+    const tDir = vt.multiplyScalar(1 / vtMag);
+    let jt = -vtMag / invMassSum;
+    const maxJt = params.muBall * jn;
+    jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+    const impulseT = tDir.clone().multiplyScalar(jt);
+
+    applyLinearImpulse(a, impulseT.clone().multiplyScalar(-1));
+    applyLinearImpulse(b, impulseT.clone().multiplyScalar(1));
+
+    applyAngularImpulse(a, new THREE.Vector3().crossVectors(rA, impulseT).multiplyScalar(-1));
+    applyAngularImpulse(b, new THREE.Vector3().crossVectors(rB, impulseT));
+  }
+
+  return { impulse: Math.abs(jn), normal };
+};
+
+export const applyRailImpulse = (ball: BallLike, normal2D: THREE.Vector2, params: PoolPhysicsParams) => {
+  if (!ball.radius || !ball.mass || !ball.omega) return null;
+  const normal = new THREE.Vector3(normal2D.x, 0, normal2D.y);
+  const rContact = normal.clone().multiplyScalar(ball.radius);
+  const vContact = toVec3(ball.vel).add(new THREE.Vector3().crossVectors(ball.omega, rContact));
+  const vn = vContact.dot(normal);
+  if (vn >= 0) return null;
+
+  const jn = -(1 + params.restitutionRail) * vn * ball.mass;
+  const impulseN = normal.clone().multiplyScalar(jn);
+  const preImpactVel = ball.vel.clone();
+  applyLinearImpulse(ball, impulseN);
+
+  const vt = vContact.clone().sub(normal.clone().multiplyScalar(vn));
+  const vtMag = vt.length();
+  if (vtMag > 1e-6) {
+    const tDir = vt.multiplyScalar(1 / vtMag);
+    let jt = -vtMag * ball.mass;
+    const maxJt = params.muRail * jn;
+    jt = THREE.MathUtils.clamp(jt, -maxJt, maxJt);
+    const impulseT = tDir.multiplyScalar(jt);
+    applyLinearImpulse(ball, impulseT);
+    applyAngularImpulse(ball, new THREE.Vector3().crossVectors(rContact, impulseT));
+  }
+
+  return { preImpactVel, normal: normal2D.clone() };
+};


### PR DESCRIPTION
### Motivation
- Provide a single, reusable physics core implementing cue strike, slip→roll friction, spin→angular velocity and impulse-based collisions so Pool Royale uses a consistent, realistic simulation.
- Replace ad-hoc spin/velocity patches with an explicit angular-velocity (`omega`) model to make rail responses, spin transfer and jump-lift behavior more accurate and easier to tune.
- Ship a small interactive demo to iterate on tuning and validate integration with rendering and input code.

### Description
- Added a new physics core `webapp/src/pages/Games/poolRoyalePhysicsCore.ts` exposing `ensureBallPhysics`, `strikeCueBall`, `applyTableFriction`, `resolveBallBallCollision` and `applyRailImpulse`, and `DEFAULT_POOL_PHYSICS_PARAMS` (separate ball/rail restitution parameters).
- Integrated the core into the main game by updating `webapp/src/pages/Games/PoolRoyale.jsx` to track `omega`, `mass`, `inertia` and `radius` on ball objects, call `strikeCueBall` for cue strikes, use `applyTableFriction` for slip→roll behavior, use `resolveBallBallCollision` for ball–ball impacts, and call `applyRailImpulse` from `reflectRails` for rail collisions.
- Reworked the physics loop to step friction, position, rail collisions and ball collisions with the new core and to update mesh rotation from `omega` for visually consistent rolling.
- Added a compact interactive demo under `webapp/src/pages/Games/PoolRoyalePhysicsDemo/` (route registered at `/games/poolroyale-physics`), including an R3F `Canvas`-based `App.tsx` and a standalone `physics.ts` for quick experimentation, and added `@react-three/fiber` to `webapp/package.json` for the demo.

### Testing
- No automated test suite was executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e612a7388329a0433c06f49beda5)