### PR TITLE
Match Texas Hold'em bottom-left buttons to Domino Royal styling

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -10,6 +10,9 @@ export default function BottomLeftIcons({
   showChat = true,
   showGift = true,
   showMute = true,
+  buttonClassName = 'p-1 flex flex-col items-center',
+  iconClassName = 'text-xl',
+  labelClassName = 'text-xs',
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -27,27 +30,27 @@ export default function BottomLeftIcons({
   return (
     <div className={className}>
       {showChat && onChat && (
-        <button onClick={onChat} className="p-1 flex flex-col items-center">
-          <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+        <button type="button" onClick={onChat} className={buttonClassName}>
+          <AiOutlineMessage className={iconClassName} />
+          <span className={labelClassName}>Chat</span>
         </button>
       )}
       {showGift && onGift && (
-        <button onClick={onGift} className="p-1 flex flex-col items-center">
-          <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+        <button type="button" onClick={onGift} className={buttonClassName}>
+          <span className={iconClassName}>🎁</span>
+          <span className={labelClassName}>Gift</span>
         </button>
       )}
       {showInfo && (
-        <button onClick={onInfo} className="p-1 flex flex-col items-center">
-          <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+        <button type="button" onClick={onInfo} className={buttonClassName}>
+          <AiOutlineInfoCircle className={iconClassName} />
+          <span className={labelClassName}>Info</span>
         </button>
       )}
       {showMute && (
-        <button onClick={toggle} className="p-1 flex flex-col items-center">
-          <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+        <button type="button" onClick={toggle} className={buttonClassName}>
+          <span className={iconClassName}>{muted ? '🔇' : '🔊'}</span>
+          <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
         </button>
       )}
     </div>

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -4934,6 +4934,10 @@ function TexasHoldemArena({ search }) {
           onInfo={() => setShowInfo(true)}
           onChat={() => setShowChat(true)}
           onGift={() => setShowGift(true)}
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+          iconClassName="text-lg leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
         />
       </div>
       {actor?.isHuman && gameState.stage !== 'showdown' && (


### PR DESCRIPTION
### Motivation
- Make the bottom-left quick-action buttons in the Texas Hold'em arena match the look and layout used by Domino Royal so the UI is consistent across games.

### Description
- Added configurable class props (`buttonClassName`, `iconClassName`, `labelClassName`) to `BottomLeftIcons` and updated `TexasHoldemArena` to pass Domino-style layout and styling to the component.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and ran a headless navigation + screenshot of `/games/texasholdem` using Playwright to verify the layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0099668483299040d5f1753799f0)