### PR TITLE
Make Murlan bottom-left controls match Domino Royal style

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -6,6 +6,9 @@ export default function BottomLeftIcons({
   onChat,
   onGift,
   className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
+  buttonClassName = 'p-1 flex flex-col items-center',
+  labelClassName = 'text-xs',
+  iconClassName = '',
   showInfo = true,
   showChat = true,
   showGift = true,
@@ -27,27 +30,27 @@ export default function BottomLeftIcons({
   return (
     <div className={className}>
       {showChat && onChat && (
-        <button onClick={onChat} className="p-1 flex flex-col items-center">
-          <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+        <button onClick={onChat} className={buttonClassName}>
+          <AiOutlineMessage className={`text-xl ${iconClassName}`.trim()} />
+          <span className={labelClassName}>Chat</span>
         </button>
       )}
       {showGift && onGift && (
-        <button onClick={onGift} className="p-1 flex flex-col items-center">
-          <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+        <button onClick={onGift} className={buttonClassName}>
+          <span className={`text-xl ${iconClassName}`.trim()}>🎁</span>
+          <span className={labelClassName}>Gift</span>
         </button>
       )}
       {showInfo && (
-        <button onClick={onInfo} className="p-1 flex flex-col items-center">
-          <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+        <button onClick={onInfo} className={buttonClassName}>
+          <AiOutlineInfoCircle className={`text-xl ${iconClassName}`.trim()} />
+          <span className={labelClassName}>Info</span>
         </button>
       )}
       {showMute && (
-        <button onClick={toggle} className="p-1 flex flex-col items-center">
-          <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+        <button onClick={toggle} className={buttonClassName}>
+          <span className={`text-lg ${iconClassName}`.trim()}>{muted ? '🔇' : '🔊'}</span>
+          <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
         </button>
       )}
     </div>

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2989,6 +2989,10 @@ export default function MurlanRoyaleArena({ search }) {
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
+            className="fixed left-3 bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] z-20 flex flex-col gap-2"
+            buttonClassName="w-[3.15rem] h-[3.15rem] rounded-[14px] bg-black/60 border border-white/20 text-white flex flex-col items-center justify-center gap-1 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+            labelClassName="text-[0.6rem] font-extrabold tracking-[0.08em] uppercase"
+            iconClassName="text-[1.1rem] leading-none"
           />
         </div>
         <div className="mt-auto px-4 pb-6 pointer-events-none">


### PR DESCRIPTION
### Motivation
- Align Murlan Royale's bottom-left action buttons with the Domino Royal visual style and layout so the four controls share consistent sizing, spacing and visual treatment.

### Description
- Add configurable class props to `BottomLeftIcons` (`buttonClassName`, `labelClassName`, `iconClassName`) to allow per-game styling without changing the component internals.
- Replace hardcoded button markup with the new props so icons, labels and button wrapper classes can be overridden.
- Apply Domino-style classes when rendering `BottomLeftIcons` in `MurlanRoyaleArena.jsx` to set fixed position, sizing (`w-[3.15rem] h-[3.15rem]`), rounded corners, backdrop blur, border and compact label styling.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported the site as ready.
- Performed a UI smoke test by navigating to `/games/murlanroyale` and capturing a Playwright screenshot (`artifacts/murlan-bottom-left-controls.png`) which shows the updated bottom-left controls.
- No unit or integration test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a00a99118832992ffd340058ab88f)