### PR TITLE
Style bottom-left quick action buttons to match Domino Royal

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -5,7 +5,7 @@ export default function BottomLeftIcons({
   onInfo,
   onChat,
   onGift,
-  className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
+  className = 'fixed z-20 flex flex-col gap-[0.6rem] pointer-events-auto',
   showInfo = true,
   showChat = true,
   showGift = true,
@@ -25,29 +25,49 @@ export default function BottomLeftIcons({
   };
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      style={{
+        left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
+      }}
+    >
       {showChat && onChat && (
-        <button onClick={onChat} className="p-1 flex flex-col items-center">
-          <AiOutlineMessage className="text-xl" />
-          <span className="text-xs">Chat</span>
+        <button
+          onClick={onChat}
+          className="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+        >
+          <AiOutlineMessage className="text-[1.1rem] leading-none" />
+          <span className="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]">Chat</span>
         </button>
       )}
       {showGift && onGift && (
-        <button onClick={onGift} className="p-1 flex flex-col items-center">
-          <span className="text-xl">🎁</span>
-          <span className="text-xs">Gift</span>
+        <button
+          onClick={onGift}
+          className="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+        >
+          <span className="text-[1.1rem] leading-none">🎁</span>
+          <span className="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]">Gift</span>
         </button>
       )}
       {showInfo && (
-        <button onClick={onInfo} className="p-1 flex flex-col items-center">
-          <AiOutlineInfoCircle className="text-xl" />
-          <span className="text-xs">Info</span>
+        <button
+          onClick={onInfo}
+          className="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+        >
+          <AiOutlineInfoCircle className="text-[1.1rem] leading-none" />
+          <span className="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]">Info</span>
         </button>
       )}
       {showMute && (
-        <button onClick={toggle} className="p-1 flex flex-col items-center">
-          <span className="text-lg">{muted ? '🔇' : '🔊'}</span>
-          <span className="text-xs">{muted ? 'Unmute' : 'Mute'}</span>
+        <button
+          onClick={toggle}
+          className="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+        >
+          <span className="text-[1.1rem] leading-none">{muted ? '🔇' : '🔊'}</span>
+          <span className="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]">
+            {muted ? 'Unmute' : 'Mute'}
+          </span>
         </button>
       )}
     </div>


### PR DESCRIPTION
### Motivation
- Make the bottom-left Chat/Gift/Info/Mute controls visually match the Domino Royal quick-action buttons and respect mobile safe-area insets.

### Description
- Restyled `BottomLeftIcons.jsx` to use 3.15rem square buttons with rounded corners, border, backdrop blur, shadow, tightened typography and uppercase labels to match Domino Royal sizing and layout.
- Consolidated layout classes and added inline safe-area positioning using `left: calc(0.75rem + env(safe-area-inset-left, 0px))` and `bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem)` for correct placement on phones.

### Testing
- Started the dev server with `npm run dev` and captured a mobile (430x932) screenshot using Playwright; both steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a00c1050883299c27f9269832cb4c)