### PR TITLE
Match Snake & Ladder bottom-left quick actions to Domino Royal style

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -5,6 +5,7 @@ export default function BottomLeftIcons({
   onInfo,
   onChat,
   onGift,
+  style,
   className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
   showInfo = true,
   showChat = true,
@@ -28,7 +29,7 @@ export default function BottomLeftIcons({
   };
 
   return (
-    <div className={className}>
+    <div className={className} style={style}>
       {showChat && onChat && (
         <button type="button" onClick={onChat} className={buttonClassName}>
           <AiOutlineMessage className={iconClassName} />

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3072,6 +3072,14 @@ export default function SnakeAndLadder() {
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
+            style={{
+              left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
+            }}
+            className="fixed z-20 flex flex-col items-center gap-2"
+            buttonClassName="w-[3.15rem] h-[3.15rem] rounded-[14px] bg-black/60 border border-white/20 text-white flex flex-col items-center justify-center gap-1 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+            iconClassName="text-[1.1rem] leading-none"
+            labelClassName="text-[0.6rem] font-extrabold tracking-[0.08em] uppercase"
           />
         </div>
         {/* Player photos stacked vertically */}


### PR DESCRIPTION
### Motivation
- Make the four bottom-left action buttons on the Snake & Ladder screen match the Domino Royal quick-actions look and safe-area positioning for a consistent UI across games.

### Description
- Allow `BottomLeftIcons` to accept an inline `style` prop so callers can adjust positioning per-screen without forking the component.
- Restyle the Snake & Ladder usage of `BottomLeftIcons` to mirror Domino Royal: moved to safe-area offsets, changed to fixed compact layout, and applied tile-like `buttonClassName`, `iconClassName`, and `labelClassName` for size/spacing/typography/backdrop consistency.
- Files changed: `webapp/src/components/BottomLeftIcons.jsx` and `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing
- Started the dev server with `npm run dev` which reported Vite ready and served the app successfully. (Succeeded)
- Ran a Playwright script that loaded `http://127.0.0.1:4173/games/snake` in a 390x844 viewport and captured a screenshot of the updated bottom-left controls; the script completed and produced `artifacts/snake-bottom-left-buttons.png`. (Succeeded)
- No unit tests were modified or required for this purely UI/layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0929ebc483298676345c27dac513)