### PR TITLE
Pool Royale: align HUD/buttons, fix spin mapping, seed replay camera and slow cue stroke

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -45,10 +45,9 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI uses screen-space: +X is right, +Y is up. Keep Y aligned so topspin
-    // drives the cue ball forward; invert X to keep left/right aligned to the
-    // table axes for side spin.
-    x: -curved.x,
-    y: curved.y
+    // UI uses screen-space: +X is right, +Y is up. Flip Y so topspin maps
+    // forward in world space while keeping left/right aligned to the UI.
+    x: curved.x,
+    y: -curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Improve visual consistency and usability of Pool Royale's chat/gift controls so they match the framed button style used elsewhere. 
- Make replay playback camera and framing match the live view so replays read from the same direction and framing as the game. 
- Slow and make cue-stick animation more visible in both live play and replay playback. 
- Correct spin UI ↔ physics mapping so the spin controller and aiming line show the true directions players expect.

### Description
- Restyled the chat/gift quick actions and replaced the previous `BottomLeftIcons` usage with framed portrait buttons to match the desired look, and nudged the portrait HUD inward by increasing `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` from `24` to `30`. (file: `PoolRoyale.jsx`)
- Adjusted spin dot UI positioning by removing an inverted display Y and scaled the dot using the computed spin ranges so the on-screen dot moves in the same visual directions as input. (file: `PoolRoyale.jsx`)
- Fixed the spin → physics mapping in `mapSpinForPhysics` by flipping the Y mapping so topspin in UI maps forward in world space while preserving left/right alignment. (file: `poolRoyaleSpinUtils.js`)
- Introduced `CUE_STROKE_VISIBILITY_SCALE` and multiplied cue stroke timings (`forward`, `settle`, `pullback`) by that scale to slow the cue stick animation for clearer visibility in both player and AI strokes. (file: `PoolRoyale.jsx`)
- Reworked replay camera capture so recorded frames seed the replay camera: `captureReplayCameraSnapshot` now captures the active camera position/target and `startShotReplay` seeds playback camera from the first recorded frame when available, making replay framing match the live camera direction. Also adjusted `resetCameraForReplay` to avoid immediate `updateCamera` to let the replay sequencing control transitions. (file: `PoolRoyale.jsx`)

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready and serving locally (succeeded). 
- Attempted an automated visual check via Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot step timed out (Playwright timed out / failed). 
- No unit or CI tests were executed as part of this change in the rollout (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a140ca65083298bd4be0a30933762)