### PR TITLE
Pool Royale: match chat/gift UI, nudge HUD, fix spin labels and slow/align replay/cue timing

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -10,7 +10,24 @@ import ConfirmPopup from './ConfirmPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 
 
-export default function GiftPopup({ open, onClose, players = [], senderIndex = 0, onGiftSent }) {
+export default function GiftPopup({
+  open,
+  onClose,
+  players = [],
+  senderIndex = 0,
+  onGiftSent,
+  overlayClassName = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70',
+  panelClassName = 'bg-surface border border-border rounded p-4 space-y-2 w-72',
+  titleClassName = 'text-center font-semibold mb-2',
+  playerButtonClassName = 'w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm',
+  playerButtonActiveClassName = 'bg-accent',
+  tierTitleClassName = 'text-sm font-bold',
+  giftButtonClassName = 'border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1',
+  giftButtonActiveClassName = 'bg-accent',
+  costClassName = 'text-xs text-center mt-2 flex items-center justify-center space-x-1',
+  sendButtonClassName = 'w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black',
+  noteClassName = 'text-xs text-center mt-1'
+}) {
   const validPlayers = players.filter((p) => p.id);
   const [selected, setSelected] = useState(NFT_GIFTS[0]);
   const [target, setTarget] = useState(validPlayers[0]?.index || 0);
@@ -81,21 +98,21 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
   return createPortal(
     <>
       <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+        className={overlayClassName}
         onClick={onClose}
       >
         <div
-          className="bg-surface border border-border rounded p-4 space-y-2 w-72"
+          className={panelClassName}
           onClick={(e) => e.stopPropagation()}
         >
-          <p className="text-center font-semibold mb-2">Send Gift</p>
+          <p className={titleClassName}>Send Gift</p>
           <div className="space-y-1 max-h-32 overflow-y-auto">
             {validPlayers.map((p) => (
               <button
                 key={p.index}
                 onClick={() => setTarget(p.index)}
-                className={`w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm ${
-                  target === p.index ? 'bg-accent' : ''
+                className={`${playerButtonClassName} ${
+                  target === p.index ? playerButtonActiveClassName : ''
                 }`}
               >
                 <img src={p.photoUrl} alt={`${p.name}'s avatar`} className="w-5 h-5 rounded-full" />
@@ -105,14 +122,14 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
           </div>
           {tiers.map((tier) => (
             <div key={tier} className="space-y-1">
-              <p className="text-sm font-bold">Tier {tier}</p>
+              <p className={tierTitleClassName}>Tier {tier}</p>
               <div className="grid grid-cols-2 gap-1">
                 {NFT_GIFTS.filter((g) => g.tier === tier).map((g) => (
                   <button
                     key={g.id}
                     onClick={() => setSelected(g)}
-                    className={`border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1 ${
-                      selected.id === g.id ? 'bg-accent' : ''
+                    className={`${giftButtonClassName} ${
+                      selected.id === g.id ? giftButtonActiveClassName : ''
                     }`}
                   >
                   <GiftIcon icon={g.icon} className="w-4 h-4" />
@@ -125,18 +142,18 @@ export default function GiftPopup({ open, onClose, players = [], senderIndex = 0
               </div>
             </div>
           ))}
-          <div className="text-xs text-center mt-2 flex items-center justify-center space-x-1">
+          <div className={costClassName}>
             <span>Cost:</span>
             <span>{selected.price}</span>
             <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-3 h-3" />
           </div>
           <button
-            className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+            className={sendButtonClassName}
             onClick={() => setConfirmOpen(true)}
           >
             Send <GiftIcon icon={selected.icon} className="w-4 h-4 inline" /> {selected.name}
           </button>
-          <p className="text-xs text-center mt-1">
+          <p className={noteClassName}>
             10% charge and the amount of the gift will be deducted from your balance.
           </p>
         </div>

--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -18,16 +18,25 @@ const MESSAGES = [
   'Great comeback 🏆',
 ];
 
-export default function QuickMessagePopup({ open, onClose, onSend }) {
+export default function QuickMessagePopup({
+  open,
+  onClose,
+  onSend,
+  overlayClassName = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70',
+  panelClassName = 'bg-surface border border-border rounded p-4 space-y-2 w-64',
+  messageButtonClassName = 'text-sm border border-border rounded px-1 py-0.5',
+  messageButtonActiveClassName = 'bg-accent',
+  sendButtonClassName = 'w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black',
+}) {
   const [message, setMessage] = useState(MESSAGES[0]);
   if (!open) return null;
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      className={overlayClassName}
       onClick={onClose}
     >
       <div
-        className="bg-surface border border-border rounded p-4 space-y-2 w-64"
+        className={panelClassName}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
@@ -35,8 +44,8 @@ export default function QuickMessagePopup({ open, onClose, onSend }) {
             <button
               key={m}
               onClick={() => setMessage(m)}
-              className={`text-sm border border-border rounded px-1 py-0.5 ${
-                message === m ? 'bg-accent' : ''
+              className={`${messageButtonClassName} ${
+                message === m ? messageButtonActiveClassName : ''
               }`}
             >
               {m}
@@ -44,7 +53,7 @@ export default function QuickMessagePopup({ open, onClose, onSend }) {
           ))}
         </div>
         <button
-          className="w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
+          className={sendButtonClassName}
           onClick={() => {
             onSend && onSend(message);
             onClose();


### PR DESCRIPTION
### Motivation
- Make the in-game Chat and Gift overlays match the look/placement of the on-screen chat/gift buttons and frame for a unified UI experience. 
- Slightly shift the player/opponent HUD toward the chat/gift controls in portrait so on-screen panels feel visually closer. 
- Improve replay fidelity so the Replay camera framing uses live in-game camera snapshots and cue animations are more visible. 
- Correct spin-controller direction labels so displayed directions match the visual aiming line.

### Description
- QuickMessagePopup and GiftPopup now accept class-name props and default to themed Pool Royale styles so the popup panels/buttons match the game chrome, and Pool Royale applies those styles when opening chat/gift popups. (updated `QuickMessagePopup.jsx` and `GiftPopup.jsx`) 
- Added themed constants and classes for chat/gift overlay/panel/button styles and applied them from the Pool Royale page to make the popups visually identical to in-game buttons/frames. (changes in `PoolRoyale.jsx`) 
- Replay camera framing now captures and stores a live camera snapshot for the recorded frames and uses the first recorded camera if present when starting playback, improving fidelity and matching the in-game view. (changed replay camera snapshot and startup logic in `PoolRoyale.jsx`) 
- Cue stroke timings for AI and player strokes were increased and a replay slowdown factor (`REPLAY_CUE_STROKE_SLOWDOWN`) was added and applied to replay cue stroke timings so the cue stick animation is slower and clearer on replay and during AI/player shots. (tweaked timing constants in `PoolRoyale.jsx`) 
- Reset `LOCK_REPLAY_CAMERA` to allow replay camera frames to be used, updated logic to prefer recorded frame cameras when available, and ensured replay FOV/position stays above table minimums. (changes in `PoolRoyale.jsx`) 
- Spin controller labels were reordered to match the on-screen aiming directions (label text → angle mapping adjusted). (updated spin ring label mapping in `PoolRoyale.jsx`) 
- Portrait HUD horizontal nudging was increased slightly to move the bottom HUD a bit closer to the chat/gift controls. (adjusted `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` in `PoolRoyale.jsx`) 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (local dev server started successfully). 
- Attempted an automated visual smoke check with Playwright to open `/games/poolroyale` and exercise the Chat button, but the Playwright run timed out so no screenshot was captured. 
- No unit/test-suite runs were executed against the modified files during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a140ca65083298bd4be0a30933762)