### PR TITLE
Align Pool Royale HUD with Domino, slow cue/replay, and fix spin & aim preview

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1440,12 +1440,12 @@ const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while 
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
-const CUE_STROKE_MIN_MS = 150;
-const CUE_STROKE_MAX_MS = 560;
+const CUE_STROKE_MIN_MS = 190;
+const CUE_STROKE_MAX_MS = 720;
 const CUE_STROKE_SPEED_MIN = BALL_R * 11.8;
 const CUE_STROKE_SPEED_MAX = BALL_R * 21.5;
-const CUE_FOLLOW_MIN_MS = 250;
-const CUE_FOLLOW_MAX_MS = 560;
+const CUE_FOLLOW_MIN_MS = 320;
+const CUE_FOLLOW_MAX_MS = 720;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 20.5;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.085; // rest the cue a touch lower so the tip lines up with the cue-ball centre on portrait screens
@@ -4886,8 +4886,8 @@ const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
-const AI_CUE_PULLBACK_DURATION_MS = 3000;
-const AI_CUE_FORWARD_DURATION_MS = 3000;
+const AI_CUE_PULLBACK_DURATION_MS = 3600;
+const AI_CUE_FORWARD_DURATION_MS = 3600;
 const AI_STROKE_VISIBLE_DURATION_MS =
   AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -4936,9 +4936,9 @@ const PLAYER_FORWARD_SLOWDOWN = 1.35;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.2;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1.45;
+const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
-const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 30;
+const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 36;
 const REPLAY_CAMERA_SWITCH_THRESHOLD = BALL_R * 0.35;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
@@ -22719,21 +22719,16 @@ const powerRef = useRef(hud.power);
             applyReplayCueStroke(playback, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);
             if (!LOCK_REPLAY_CAMERA) {
-              const nextFrameCamera = frameB?.camera ?? frameA?.camera ?? null;
-              const previousFrameCamera =
-                replayFrameCameraRef.current?.frameB ??
-                replayFrameCameraRef.current?.frameA ??
-                null;
-              if (
-                nextFrameCamera &&
-                (!replayFrameCameraRef.current ||
-                  hasReplayCameraChanged(previousFrameCamera, nextFrameCamera))
-              ) {
+              const cameraA = frameA?.camera ?? frameB?.camera ?? null;
+              const cameraB = frameB?.camera ?? frameA?.camera ?? null;
+              if (cameraA || cameraB) {
                 replayFrameCameraRef.current = {
-                  frameA: nextFrameCamera,
-                  frameB: nextFrameCamera,
-                  alpha: 0
+                  frameA: cameraA,
+                  frameB: cameraB,
+                  alpha
                 };
+              } else {
+                replayFrameCameraRef.current = null;
               }
             } else {
               replayFrameCameraRef.current = null;
@@ -22855,6 +22850,7 @@ const powerRef = useRef(hud.power);
         const appliedSpin = applySpinConstraints(aimDir, true);
         const liftStrength = normalizeCueLift(resolveUserCueLift());
         const physicsSpin = mapSpinForPhysics(appliedSpin);
+        const previewSpin = { x: -physicsSpin.x, y: physicsSpin.y };
         const ranges = spinRangeRef.current || {};
         const newCollisions = new Set();
         let shouldSlowAim = false;
@@ -22982,7 +22978,7 @@ const powerRef = useRef(hud.power);
           const aimDir2D = new THREE.Vector2(baseAimDir.x, baseAimDir.z);
           const guideAimDir2D = resolveSwerveAimDir(
             aimDir2D,
-            physicsSpin,
+            previewSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -23007,7 +23003,7 @@ const powerRef = useRef(hud.power);
             end,
             dir,
             perp,
-            physicsSpin,
+            previewSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -23082,8 +23078,8 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const spinSideInfluence = (physicsSpin.x || 0) * (0.4 + 0.42 * powerStrength);
-          const spinVerticalInfluence = (physicsSpin.y || 0) * (0.68 + 0.45 * powerStrength);
+          const spinSideInfluence = (previewSpin.x || 0) * (0.4 + 0.42 * powerStrength);
+          const spinVerticalInfluence = (previewSpin.y || 0) * (0.68 + 0.45 * powerStrength);
           const cueFollowDirSpinAdjusted = cueFollowDir
             .clone()
             .add(perp.clone().multiplyScalar(spinSideInfluence))
@@ -23306,9 +23302,10 @@ const powerRef = useRef(hud.power);
           const remoteSpinMagnitude = Math.hypot(remoteSpin.x ?? 0, remoteSpin.y ?? 0);
           const remoteSwerveActive = remoteSpinMagnitude >= SWERVE_THRESHOLD;
           const remotePhysicsSpin = mapSpinForPhysics(remoteSpin);
+          const remotePreviewSpin = { x: -remotePhysicsSpin.x, y: remotePhysicsSpin.y };
           const guideAimDir2D = resolveSwerveAimDir(
             remoteAimDir,
-            remotePhysicsSpin,
+            remotePreviewSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -23329,7 +23326,7 @@ const powerRef = useRef(hud.power);
             end,
             baseDir,
             perp,
-            remotePhysicsSpin,
+            remotePreviewSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -25971,6 +25968,14 @@ const powerRef = useRef(hud.power);
           onInfo={() => setShowInfo(true)}
           onChat={() => setShowChat(true)}
           onGift={() => setShowGift(true)}
+          className="fixed z-50 flex flex-col gap-[0.6rem]"
+          style={{
+            left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
+            bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
+          }}
+          buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
+          iconClassName="text-[1.1rem] leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
           showInfo={false}
           showMute={false}
         />

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -47,8 +47,9 @@ export const mapSpinForPhysics = (spin) => {
   return {
     // UI uses screen-space: +X is right, +Y is up. Keep Y aligned so topspin
     // drives the cue ball forward; invert X to keep left/right aligned to the
-    // table axes for side spin.
+    // table axes for side spin. Flip Y so top/back spin aligns with the
+    // expected cue ball roll direction.
     x: -curved.x,
-    y: curved.y
+    y: -curved.y
   };
 };


### PR DESCRIPTION
### Motivation
- Make the Pool Royale quick-action UI match the Domino Royal style and nudge the player panel slightly toward the chat/gift controls for consistent layout on portrait screens.
- Make strokes and replays easier to read by slowing cue pull/forward/follow timings and slowing the replay cue stroke playback.
- Fix aiming-preview direction and top/back spin behavior so the aiming line and physics match player intent and the visual preview.

### Description
- Updated HUD/quick-action layout by passing styling props into `BottomLeftIcons` and nudging portrait HUD placement via `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` in `PoolRoyale.jsx` to match Domino Royal layout and appearance.
- Slowed cue stroke and follow timings by increasing `CUE_STROKE_MIN_MS`, `CUE_STROKE_MAX_MS`, `CUE_FOLLOW_MIN_MS`, and `CUE_FOLLOW_MAX_MS`, and increased AI pull/forward durations with `AI_CUE_PULLBACK_DURATION_MS` / `AI_CUE_FORWARD_DURATION_MS`, and increased `REPLAY_CUE_STROKE_SLOWDOWN` to make replay strokes more visible in `PoolRoyale.jsx`.
- Improved replay camera behavior by using per-frame camera snapshots (`frameA`, `frameB`) with interpolation (`alpha`) when stepping replay frames so the replay view follows the recorded framing more closely in `PoolRoyale.jsx`.
- Fixed spin → physics mapping by flipping the Y component in `mapSpinForPhysics` (now `y: -curved.y`) so top/back spin maps to forward/back roll correctly in `poolRoyaleSpinUtils.js`.
- Adjusted aiming-preview code to use a `previewSpin` (flip of side sign) for the visual aiming line and swerve preview, and applied the same change for remote-aim visuals so the aiming line now points the expected direction in `PoolRoyale.jsx`.

### Testing
- No automated tests were executed as part of this change; no test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1f1c4cdc83298e2042e5b78e7232)