### PR TITLE
Align Pool Royale HUD, replay timing, and spin/aim behavior

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -14,6 +14,11 @@ export default function BottomLeftIcons({
   buttonClassName = 'p-1 flex flex-col items-center',
   iconClassName = 'text-xl',
   labelClassName = 'text-xs',
+  chatIcon,
+  giftIcon,
+  infoIcon,
+  muteIconOn,
+  muteIconOff
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -32,25 +37,35 @@ export default function BottomLeftIcons({
     <div className={className} style={style}>
       {showChat && onChat && (
         <button type="button" onClick={onChat} className={buttonClassName}>
-          <AiOutlineMessage className={iconClassName} />
+          {chatIcon ? (
+            <span className={iconClassName}>{chatIcon}</span>
+          ) : (
+            <AiOutlineMessage className={iconClassName} />
+          )}
           <span className={labelClassName}>Chat</span>
         </button>
       )}
       {showGift && onGift && (
         <button type="button" onClick={onGift} className={buttonClassName}>
-          <span className={iconClassName}>🎁</span>
+          <span className={iconClassName}>{giftIcon ?? '🎁'}</span>
           <span className={labelClassName}>Gift</span>
         </button>
       )}
       {showInfo && (
         <button type="button" onClick={onInfo} className={buttonClassName}>
-          <AiOutlineInfoCircle className={iconClassName} />
+          {infoIcon ? (
+            <span className={iconClassName}>{infoIcon}</span>
+          ) : (
+            <AiOutlineInfoCircle className={iconClassName} />
+          )}
           <span className={labelClassName}>Info</span>
         </button>
       )}
       {showMute && (
         <button type="button" onClick={toggle} className={buttonClassName}>
-          <span className={iconClassName}>{muted ? '🔇' : '🔊'}</span>
+          <span className={iconClassName}>
+            {muted ? muteIconOn ?? '🔇' : muteIconOff ?? '🔊'}
+          </span>
           <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
         </button>
       )}

--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -16,9 +16,16 @@ export default function GiftPopup({
   players = [],
   senderIndex = 0,
   onGiftSent,
+  title,
   overlayClassName = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70',
   panelClassName = 'bg-surface border border-border rounded p-4 space-y-2 w-72',
   titleClassName = 'text-center font-semibold mb-2',
+  headerClassName = 'flex items-center justify-between gap-2',
+  closeButtonClassName = 'rounded-full border border-white/15 bg-white/10 px-2 py-1 text-xs text-white/80',
+  showCloseButton = false,
+  playerListClassName = 'space-y-1 max-h-32 overflow-y-auto',
+  tierGroupClassName = 'space-y-1',
+  giftGridClassName = 'grid grid-cols-2 gap-1',
   playerButtonClassName = 'w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm',
   playerButtonActiveClassName = 'bg-accent',
   tierTitleClassName = 'text-sm font-bold',
@@ -34,6 +41,7 @@ export default function GiftPopup({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [infoMsg, setInfoMsg] = useState('');
   const [pendingGift, setPendingGift] = useState(null);
+  const resolvedTitle = title ?? 'Send Gift';
 
   const handleInfoClose = () => {
     setInfoMsg('');
@@ -105,8 +113,19 @@ export default function GiftPopup({
           className={panelClassName}
           onClick={(e) => e.stopPropagation()}
         >
-          <p className={titleClassName}>Send Gift</p>
-          <div className="space-y-1 max-h-32 overflow-y-auto">
+          {showCloseButton || title ? (
+            <div className={headerClassName}>
+              <p className={titleClassName}>{resolvedTitle}</p>
+              {showCloseButton && (
+                <button type="button" onClick={onClose} className={closeButtonClassName}>
+                  ✕
+                </button>
+              )}
+            </div>
+          ) : (
+            <p className={titleClassName}>{resolvedTitle}</p>
+          )}
+          <div className={playerListClassName}>
             {validPlayers.map((p) => (
               <button
                 key={p.index}
@@ -121,9 +140,9 @@ export default function GiftPopup({
             ))}
           </div>
           {tiers.map((tier) => (
-            <div key={tier} className="space-y-1">
+            <div key={tier} className={tierGroupClassName}>
               <p className={tierTitleClassName}>Tier {tier}</p>
-              <div className="grid grid-cols-2 gap-1">
+              <div className={giftGridClassName}>
                 {NFT_GIFTS.filter((g) => g.tier === tier).map((g) => (
                   <button
                     key={g.id}

--- a/webapp/src/components/QuickMessagePopup.jsx
+++ b/webapp/src/components/QuickMessagePopup.jsx
@@ -22,11 +22,17 @@ export default function QuickMessagePopup({
   open,
   onClose,
   onSend,
+  title,
   overlayClassName = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70',
   panelClassName = 'bg-surface border border-border rounded p-4 space-y-2 w-64',
+  messageGridClassName = 'grid grid-cols-2 gap-1 max-h-40 overflow-y-auto',
   messageButtonClassName = 'text-sm border border-border rounded px-1 py-0.5',
   messageButtonActiveClassName = 'bg-accent',
   sendButtonClassName = 'w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black',
+  headerClassName = 'flex items-center justify-between gap-2',
+  titleClassName = 'text-sm font-semibold',
+  closeButtonClassName = 'rounded-full border border-white/15 bg-white/10 px-2 py-1 text-xs text-white/80',
+  showCloseButton = false,
 }) {
   const [message, setMessage] = useState(MESSAGES[0]);
   if (!open) return null;
@@ -39,7 +45,17 @@ export default function QuickMessagePopup({
         className={panelClassName}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
+        {(title || showCloseButton) && (
+          <div className={headerClassName}>
+            {title ? <h3 className={titleClassName}>{title}</h3> : <span />}
+            {showCloseButton && (
+              <button type="button" onClick={onClose} className={closeButtonClassName}>
+                ✕
+              </button>
+            )}
+          </div>
+        )}
+        <div className={messageGridClassName}>
           {MESSAGES.map((m) => (
             <button
               key={m}

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -45,10 +45,9 @@ export const mapSpinForPhysics = (spin) => {
   };
   const curved = applySpinResponseCurve(adjusted);
   return {
-    // UI uses screen-space: +X is right, +Y is up. Keep Y aligned so topspin
-    // drives the cue ball forward; invert X to keep left/right aligned to the
-    // table axes for side spin.
+    // UI uses screen-space: +X is right, +Y is up. Flip X to align side spin to
+    // the table axes, and flip Y so high/low spin matches the cue-ball roll.
     x: -curved.x,
-    y: curved.y
+    y: -curved.y
   };
 };


### PR DESCRIPTION
### Motivation

- Make Pool Royale's chat/gift controls and popup styling match Domino Royal and nudge the player/opponent frame slightly toward those controls for better visual alignment on portrait mobile screens.  
- Improve Replay fidelity so the cue animation, camera framing and speed match recorded gameplay and make cue strokes easier to see.  
- Fix spin mapping and the aiming-line preview so left/right/top/bottom spin visually and physically match player input (swap high/low) and the aiming guide points the correct direction when side spin is applied.

### Description

- UI: add flexible HUD button and popup options and restyle Pool Royale quick actions by extending `BottomLeftIcons`, `QuickMessagePopup`, and `GiftPopup`, and wire the new classes in `webapp/src/pages/Games/PoolRoyale.jsx` to match Domino Royal layout and framing (new header/close controls, button sizes and class names).  
- HUD positioning: slightly increase `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` and point the bottom HUD toward the chat/gift controls by updating `bottomHudOffset` calculation in `PoolRoyale.jsx`.  
- Replay & stroke timing: slow down player/AI/replay cue stroke timing by increasing `AI_CUE_PULLBACK_DURATION_MS`, `AI_CUE_FORWARD_DURATION_MS`, `AI_STROKE_TIME_SCALE`, `PLAYER_STROKE_TIME_SCALE`, `PLAYER_FORWARD_SLOWDOWN` and `REPLAY_CUE_STROKE_SLOWDOWN` in `PoolRoyale.jsx`, and update replay camera frame handling to prefer recorded `frame.camera` snapshots (use the recorded `frameA/frameB/alpha` interpolation when available).  
- Aim line / spin mapping: change physics mapping in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so UI spin maps correctly for physics (flip Y and preserve side alignment) and keep the aiming-line logic separate by computing an `aimLineSpin` used to build the aiming curve and follow-line (adjusted in `PoolRoyale.jsx` for both local and remote aims).  
- Small component tweaks: allow `BottomLeftIcons` to accept custom `chatIcon`, `giftIcon`, `infoIcon`, and mute icons so Pool Royale can render the exact Domino-style icons and layout (and pass tailored className/buttonClassName overrides from `PoolRoyale.jsx`).

### Testing

- Started the Web dev server with `npm --prefix webapp run dev` and Vite reported ready at the requested port, indicating the app served successfully.  
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the browser run timed out and did not produce a screenshot.  
- No unit test suite (`npm test`) was executed during this change; changes were validated by running the local dev server only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1f1c4cdc83298e2042e5b78e7232)