### PR TITLE
Represent cue-ball spin as bounded 2D offsets and add spin direction catalog

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -3,6 +3,73 @@ const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 export const SPIN_INPUT_DEAD_ZONE = 0.015;
 export const SPIN_RESPONSE_EXPONENT = 1.9;
 export const SPIN_RESPONSE_EXPONENT_BACKSPIN = 1.65;
+export const MAX_SPIN_OFFSET = 0.7;
+
+export const SPIN_DIRECTIONS = [
+  {
+    id: 'stun',
+    label: 'STUN (no spin)',
+    offset: { x: 0, y: 0 },
+    effect:
+      'Goditje në qendër: cue ball rrëshqet fillimisht dhe kalon në rolling pa topspin/backspin.'
+  },
+  {
+    id: 'topspin',
+    label: 'TOPSPIN (follow)',
+    offset: { x: 0, y: MAX_SPIN_OFFSET },
+    effect:
+      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball vazhdon përpara pas kontaktit.'
+  },
+  {
+    id: 'backspin',
+    label: 'BACKSPIN (draw)',
+    offset: { x: 0, y: -MAX_SPIN_OFFSET },
+    effect:
+      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball ndalon dhe kthehet mbrapsht pas kontaktit.'
+  },
+  {
+    id: 'left-english',
+    label: 'SIDESPIN LEFT',
+    offset: { x: -MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje majtas nga qendra: spin rreth boshtit vertikal, ndikon kryesisht në rebound me banda dhe në “throw”.'
+  },
+  {
+    id: 'right-english',
+    label: 'SIDESPIN RIGHT',
+    offset: { x: MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje djathtas nga qendra: spin rreth boshtit vertikal në drejtim të kundërt, me të njëjtat efekte anësore.'
+  },
+  {
+    id: 'top-left',
+    label: 'TOPSPIN + LEFT',
+    offset: { x: -0.45, y: 0.45 },
+    effect:
+      'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'top-right',
+    label: 'TOPSPIN + RIGHT',
+    offset: { x: 0.45, y: 0.45 },
+    effect:
+      'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'back-left',
+    label: 'BACKSPIN + LEFT',
+    offset: { x: -0.45, y: -0.45 },
+    effect:
+      'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  },
+  {
+    id: 'back-right',
+    label: 'BACKSPIN + RIGHT',
+    offset: { x: 0.45, y: -0.45 },
+    effect:
+      'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  }
+];
 
 export const clampToUnitCircle = (x, y) => {
   const length = Math.hypot(x, y);
@@ -13,6 +80,15 @@ export const clampToUnitCircle = (x, y) => {
   return { x: x * scale, y: y * scale };
 };
 
+export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= maxOffset) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? maxOffset / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
 export const normalizeSpinInput = (spin) => {
   const x = spin?.x ?? 0;
   const y = spin?.y ?? 0;
@@ -20,7 +96,7 @@ export const normalizeSpinInput = (spin) => {
   if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
     return { x: 0, y: 0 };
   }
-  return clampToUnitCircle(x, y);
+  return clampToMaxOffset(x, y);
 };
 
 export const applySpinResponseCurve = (spin) => {
@@ -43,11 +119,11 @@ export const mapSpinForPhysics = (spin) => {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
   };
-  const curved = applySpinResponseCurve(adjusted);
+  const limited = clampToMaxOffset(adjusted.x, adjusted.y);
   return {
     // UI uses screen-space: +X is right, +Y is up. Flip X to align side spin to
     // the table axes, and flip Y so high/low spin matches the cue-ball roll.
-    x: -curved.x,
-    y: -curved.y
+    x: -limited.x,
+    y: -limited.y
   };
 };


### PR DESCRIPTION
### Motivation
- Make cue-ball spin input explicitly physical by representing tip contact as a 2D offset on the cue-ball disk and limit extremes so spin remains realistic. 
- Provide a clear, canonical list of supported spin directions (A–G) with short physical explanations to drive physics impulses/torques rather than adding artificial flight curves. 

### Description
- Added `MAX_SPIN_OFFSET = 0.7` and a structured `SPIN_DIRECTIONS` array that lists all required spin types (stun, topspin, backspin, left/right english and the four diagonal combinations) with explanatory `effect` strings and normalized `offset` `{x,y}` values in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Implemented `clampToMaxOffset(x,y, maxOffset)` to bound requested spin to the physical disk radius and replaced the previous unit-circle/clamp behaviour in `normalizeSpinInput` so inputs are clamped to `MAX_SPIN_OFFSET` instead of unconstrained scaling.
- Updated `mapSpinForPhysics` to use the bounded offset (`clampToMaxOffset`) when producing the physics spin vector (keeping the UI->physics axis flips), while leaving the existing response-curve function available for other uses.

### Testing
- No automated tests were executed for this change.
- The change is limited to `webapp/src/pages/Games/poolRoyaleSpinUtils.js` and compiles as a pure JS utility update in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3f74cfc08329bddb5fed8524f0f1)