### PR TITLE
Position Murlan Royale quick-action buttons at top-right and match Domino Royal styling

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2989,6 +2989,15 @@ export default function MurlanRoyaleArena({ search }) {
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
+            className="fixed right-3 top-4 z-50 flex flex-col items-center gap-2.5"
+            buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
+            iconClassName="text-[1.1rem] leading-none"
+            labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
+            chatIcon="💬"
+            giftIcon="🎁"
+            infoIcon="ℹ️"
+            muteIconOn="🔇"
+            muteIconOff="🔊"
           />
         </div>
         <div className="mt-auto px-4 pb-6 pointer-events-none">


### PR DESCRIPTION
### Motivation
- Move the quick-action controls (chat, gift, info, mute) in the Murlan Royale arena into a vertical stack at the top-right to match the Domino Royal layout and improve consistency across games.
- Apply the same look and spacing as Domino Royal so the buttons share identical framing, sizing and iconography.

### Description
- Updated `MurlanRoyaleArena.jsx` to pass layout and style props to `BottomLeftIcons` so the control stack is positioned at the top-right via `className="fixed right-3 top-4 ..."` and uses Domino Royal-like button styles via `buttonClassName`, `iconClassName` and `labelClassName`.
- Set the same quick-action icons for chat/gift/info/mute using `chatIcon`, `giftIcon`, `infoIcon`, `muteIconOn` and `muteIconOff` without changing any game logic or event handlers.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served the page successfully.
- Ran a Playwright script to load `/games/murlanroyale` in a 430×932 viewport and captured a screenshot (`artifacts/murlan-quick-actions.png`), and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a46605e4483299a194a794eec992e)