### PR TITLE
Add Domino-style quick actions (chat/gift/info/mute) to Murlan Royale UI

### DIFF
--- a/webapp/public/murlan-royale.html
+++ b/webapp/public/murlan-royale.html
@@ -242,9 +242,9 @@
       }
 
       .top-controls {
-        position: absolute;
-        top: 4px;
-        right: 8px;
+        position: fixed;
+        top: calc(0.75rem + env(safe-area-inset-top, 0px));
+        left: calc(0.75rem + env(safe-area-inset-left, 0px));
         display: flex;
         gap: 4px;
         z-index: 10;
@@ -262,6 +262,42 @@
         color: #fff;
         font-weight: 600;
         font-size: 14px;
+        line-height: 1;
+      }
+      #quickActions {
+        position: fixed;
+        top: calc(0.75rem + env(safe-area-inset-top, 0px));
+        right: calc(0.75rem + env(safe-area-inset-right, 0px));
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+        z-index: 10;
+        pointer-events: auto;
+      }
+      #quickActions .quick-action {
+        width: 3.15rem;
+        height: 3.15rem;
+        border-radius: 14px;
+        background: rgba(0, 0, 0, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        color: #fff;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.25rem;
+        box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(8px);
+        padding: 0;
+      }
+      #quickActions .quick-action span {
+        font-size: 0.6rem;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      #quickActions .quick-action .icon {
+        font-size: 1.1rem;
         line-height: 1;
       }
       .settings-panel {
@@ -687,6 +723,25 @@
       src="/assets/sounds/wooden-door-knock-102902.mp3"
     ></audio>
 
+    <div id="quickActions" aria-label="Quick actions">
+      <button class="quick-action" type="button" data-action="chat">
+        <span class="icon" aria-hidden="true">💬</span>
+        <span>Chat</span>
+      </button>
+      <button class="quick-action" type="button" data-action="gift">
+        <span class="icon" aria-hidden="true">🎁</span>
+        <span>Gift</span>
+      </button>
+      <button class="quick-action" type="button" data-action="info">
+        <span class="icon" aria-hidden="true">ℹ️</span>
+        <span>Info</span>
+      </button>
+      <button class="quick-action" type="button" data-action="mute">
+        <span class="icon" id="muteIcon" aria-hidden="true">🔊</span>
+        <span id="muteLabel">Mute</span>
+      </button>
+    </div>
+
     <div class="top-controls">
       <button id="settingsBtn">⚙️</button>
     </div>
@@ -799,12 +854,17 @@
         const winnerOverlay = el('#winnerOverlay');
         const settingsBtn = el('#settingsBtn');
         const settingsPanel = el('#settingsPanel');
+        const quickActions = el('#quickActions');
+        const muteIcon = el('#muteIcon');
+        const muteLabel = el('#muteLabel');
+        const audioEls = Array.from(document.querySelectorAll('audio'));
         const styleSelect = el('#playerFrameStyle');
         const colorSelect = el('#playerColor');
         const saveSettingsBtn = el('#saveSettings');
         const closeSettingsBtn = el('#closeSettings');
         let lobbyBtn;
         let arrangeVariant = 0;
+        let audioEnabled = true;
 
         function coinConfetti(
           count = 50,
@@ -896,6 +956,40 @@
           toastEl.style.display = 'block';
           setTimeout(() => (toastEl.style.display = 'none'), 1400);
         }
+
+        function updateMuteLabel() {
+          if (!muteIcon || !muteLabel) return;
+          const muted = !audioEnabled;
+          muteIcon.textContent = muted ? '🔇' : '🔊';
+          muteLabel.textContent = muted ? 'Unmute' : 'Mute';
+        }
+
+        function setAudioEnabled(enabled) {
+          audioEnabled = enabled;
+          audioEls.forEach((el) => {
+            el.muted = !enabled;
+          });
+          updateMuteLabel();
+        }
+
+        function handleQuickAction(action) {
+          if (action === 'mute') {
+            setAudioEnabled(!audioEnabled);
+            toast(audioEnabled ? 'Sound on' : 'Sound muted');
+            return;
+          }
+          const label = action.charAt(0).toUpperCase() + action.slice(1);
+          toast(`${label} coming soon`);
+        }
+
+        if (quickActions) {
+          quickActions.addEventListener('click', (event) => {
+            const btn = event.target.closest('button[data-action]');
+            if (!btn) return;
+            handleQuickAction(btn.dataset.action);
+          });
+        }
+        setAudioEnabled(true);
 
         function applyFrameSettings() {
           document.body.className = document.body.className.replace(/frame-style-\d+/g, '');


### PR DESCRIPTION
### Motivation
- Align Murlan Royale quick-action UI with Domino Royal by moving the quick action buttons to the top-right in a vertical stack and matching button look/behavior. 
- Provide a single, consistent place for `chat`, `gift`, `info`, and `mute` actions on portrait mobile screens.
- Add an immediate, lightweight implementation for mute control and placeholders for the other quick actions to enable UX testing.

### Description
- Added a new `#quickActions` vertical container and Domino-style button CSS in `webapp/public/murlan-royale.html` to match the Domino Royal look and layout. 
- Inserted quick-action markup for `chat`, `gift`, `info`, and `mute` in `webapp/public/murlan-royale.html` and kept the settings control at top-left to avoid overlap. 
- Wired up a lightweight mute implementation that toggles `audio` elements' `muted` state via `setAudioEnabled` and updates the label/icon with `updateMuteLabel`, and added `handleQuickAction` to show placeholder toasts for non-implemented actions. 
- Kept all changes contained to the single page file `webapp/public/murlan-royale.html` (CSS, markup, and small JS wiring). 

### Testing
- Served the modified `webapp/public` directory with `python -m http.server 8000` and loaded `/murlan-royale.html` in a headless Chromium via Playwright at viewport `390x844` and captured a screenshot, which completed successfully. 
- No automated unit tests were added or required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a46605e4483299a194a794eec992e)