### PR TITLE
Add bottom-left chat/gift/info/mute controls to Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -22,8 +22,9 @@ import {
   getTelegramUsername,
   getTelegramPhotoUrl
 } from '../../utils/telegram.js';
-import { bombSound, timerBeep } from '../../assets/soundData.js';
-import { getGameVolume } from '../../utils/sound.js';
+import { bombSound, chatBeep, timerBeep } from '../../assets/soundData.js';
+import { getGameVolume, isGameMuted, setGameMuted } from '../../utils/sound.js';
+import { giftSounds } from '../../utils/giftSounds.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import { TABLE_WOOD_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_BASE_OPTIONS } from '../../utils/tableCustomizationOptions.js';
 import {
@@ -45,6 +46,10 @@ import { avatarToName } from '../../utils/avatarUtils.js';
 import { getAIOpponentFlag } from '../../utils/aiOpponentFlag.js';
 import { ipToFlag } from '../../utils/conflictMatchmaking.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import InfoPopup from '../../components/InfoPopup.jsx';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import { socket } from '../../utils/socket.js';
 
 /**
@@ -5869,7 +5874,11 @@ function Chess3D({
   const initialWhiteTimeRef = useRef(60);
   const initialBlackTimeRef = useRef(5);
   const [configOpen, setConfigOpen] = useState(false);
-  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [soundEnabled, setSoundEnabled] = useState(() => !isGameMuted());
+  const [showInfo, setShowInfo] = useState(false);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
   const [showHighlights, setShowHighlights] = useState(true);
   const [graphicsId, setGraphicsId] = useState(() => {
     const fallback = resolveDefaultGraphicsId();
@@ -5894,6 +5903,11 @@ function Chess3D({
   const lastMoveRef = useRef(null);
   const replayLastMoveRef = useRef(() => {});
   const isReplayingRef = useRef(false);
+  useEffect(() => {
+    const handler = () => setSoundEnabled(!isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
   const activeGraphicsOption = useMemo(
     () =>
       GRAPHICS_OPTIONS.find((opt) => opt.id === graphicsId) ||
@@ -8870,7 +8884,11 @@ function Chess3D({
                     type="checkbox"
                     className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
                     checked={soundEnabled}
-                    onChange={(event) => setSoundEnabled(event.target.checked)}
+                    onChange={(event) => {
+                      const next = event.target.checked;
+                      setSoundEnabled(next);
+                      setGameMuted(!next);
+                    }}
                   />
                 </label>
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
@@ -9137,11 +9155,152 @@ function Chess3D({
             );
           })}
         </div>
+        <div className="pointer-events-auto">
+          <BottomLeftIcons
+            onInfo={() => setShowInfo(true)}
+            onChat={() => setShowChat(true)}
+            onGift={() => setShowGift(true)}
+          />
+        </div>
         <div className="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-none">
           <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
             {ui.winner ? `${ui.winner} Wins` : ui.status}
           </div>
         </div>
+      </div>
+      {chatBubbles.map((bubble) => (
+        <div key={bubble.id} className="chat-bubble">
+          <span>{bubble.text}</span>
+          <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <div className="pointer-events-auto">
+        <InfoPopup
+          open={showInfo}
+          onClose={() => setShowInfo(false)}
+          title="Chess Battle Royal"
+          info="Tap a piece to see legal moves, then select a highlighted square to move. Checkmate the opponent's king to win."
+        />
+      </div>
+      <div className="pointer-events-auto">
+        <QuickMessagePopup
+          open={showChat}
+          onClose={() => setShowChat(false)}
+          onSend={(text) => {
+            const id = Date.now();
+            setChatBubbles((bubbles) => [...bubbles, { id, text, photoUrl: avatar || '🙂' }]);
+            if (soundEnabled) {
+              const audio = new Audio(chatBeep);
+              audio.volume = getGameVolume();
+              audio.play().catch(() => {});
+            }
+            setTimeout(
+              () => setChatBubbles((bubbles) => bubbles.filter((bubble) => bubble.id !== id)),
+              3000,
+            );
+          }}
+        />
+      </div>
+      <div className="pointer-events-auto">
+        <GiftPopup
+          open={showGift}
+          onClose={() => setShowGift(false)}
+          players={players.map((player) => ({
+            ...player,
+            id: player.id ?? (player.index === 0 ? resolvedAccountId : `chess-ai-${player.index}`),
+            name: player.name
+          }))}
+          senderIndex={0}
+          onGiftSent={({ from, to, gift }) => {
+            const start = document.querySelector(`[data-player-index="${from}"]`);
+            const end = document.querySelector(`[data-player-index="${to}"]`);
+            if (start && end) {
+              const s = start.getBoundingClientRect();
+              const e = end.getBoundingClientRect();
+              const cx = window.innerWidth / 2;
+              const cy = window.innerHeight / 2;
+              let icon;
+              if (typeof gift.icon === 'string' && gift.icon.match(/\\.(png|jpg|jpeg|webp|svg)$/)) {
+                icon = document.createElement('img');
+                icon.src = gift.icon;
+                icon.className = 'w-5 h-5';
+              } else {
+                icon = document.createElement('div');
+                icon.textContent = gift.icon;
+                icon.style.fontSize = '24px';
+              }
+              icon.style.position = 'fixed';
+              icon.style.left = '0px';
+              icon.style.top = '0px';
+              icon.style.pointerEvents = 'none';
+              icon.style.transform = `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`;
+              icon.style.zIndex = '9999';
+              document.body.appendChild(icon);
+              const giftSound = giftSounds[gift.id];
+              if (gift.id === 'laugh_bomb' && soundEnabled) {
+                bombSoundRef.current.currentTime = 0;
+                bombSoundRef.current.play().catch(() => {});
+                laughSoundRef.current.currentTime = 0;
+                laughSoundRef.current.play().catch(() => {});
+                setTimeout(() => {
+                  laughSoundRef.current.pause();
+                }, 5000);
+              } else if (gift.id === 'coffee_boost' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.currentTime = 4;
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 4000);
+              } else if (gift.id === 'baby_chick' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+              } else if (gift.id === 'magic_trick' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 4000);
+              } else if (gift.id === 'fireworks' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 6000);
+              } else if (gift.id === 'surprise_box' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 5000);
+              } else if (gift.id === 'bullseye' && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                setTimeout(() => {
+                  audio.play().catch(() => {});
+                }, 2500);
+              } else if (giftSound && soundEnabled) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+              }
+              const animation = icon.animate(
+                [
+                  { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },
+                  { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
+                  { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` },
+                ],
+                { duration: 3500, easing: 'linear' },
+              );
+              animation.onfinish = () => icon.remove();
+            }
+          }}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation

- Provide the same bottom-left quick controls used by other board games (chat, gift, info, mute) for the Chess Battle Royal scene so players can chat, send gifts, view info and mute audio without leaving the match.

### Description

- Wired shared UI components into the chess page by importing `BottomLeftIcons`, `GiftPopup`, `InfoPopup`, and `QuickMessagePopup` and `giftSounds` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Added local state for `showInfo`, `showChat`, `showGift`, `chatBubbles` and connected to the global mute state via `isGameMuted()` and `setGameMuted()` so the mute button matches app-wide behavior.
- Rendered `BottomLeftIcons` in the bottom-left of the chess UI and hooked handlers to open the respective popups; added transient chat bubble UI and gift animation playback (reusing existing sound/play logic and `bombSound`/`laughSound` usage consistent with other games).
- Kept all behavior consistent with Snake/Ludo implementations: popup usage, chat beep playback (`chatBeep`), gift sound handling (`giftSounds`), and animation lifecycle for gift icons.

### Testing

- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (local network URL printed); server started successfully.
- Captured an automated screenshot of the Chess Battle Royal page using Playwright visiting `/games/chessbattleroyal`, which completed successfully and produced a screenshot artifact showing the new controls.
- No unit tests were executed as part of this change (UI integration only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f6cf016c832998010592fbed68c9)