### PR TITLE
Improve pre-impact backspin roll in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23563,15 +23563,16 @@ const powerRef = useRef(hud.power);
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = Math.max(0, TMP_VEC2_SPIN.dot(launchDir));
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  const signedSpinMag = TMP_VEC2_SPIN.dot(launchDir);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(signedSpinMag);
                   b.vel.add(TMP_VEC2_AXIS);
                   TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
                   if (b.spinMode === 'swerve' && b.pendingSpin && swerveScale > 0) {
                     b.pendingSpin.addScaledVector(TMP_VEC2_LATERAL, swerveScale);
                   }
                   const alignedSpeed = b.vel.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
+                  const clampedSpeed = Math.max(0, alignedSpeed);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(clampedSpeed);
                   b.vel.copy(TMP_VEC2_AXIS);
                   if (b.spinMode === 'swerve' && swerveScale > 0) {
                     b.vel.addScaledVector(


### PR DESCRIPTION
### Motivation
- Fix unrealistic cue-ball behaviour when hitting slightly below centre so light backspin produces a rolling draw instead of acting like a stun. 
- Make the cue ball keep rolling-backwards rhythm through contact while preserving the intended launch alignment and swerve behaviour.

### Description
- Modified pre-impact spin handling in `webapp/src/pages/Games/PoolRoyale.jsx` to apply the signed projection of `TMP_VEC2_SPIN` onto the `launchDir` (use `signedSpinMag` instead of clamped forward-only value). 
- Clamp the resulting forward component so the post-adjustment forward speed cannot become negative by replacing the direct projection with a `clampedSpeed = Math.max(0, alignedSpeed)` before writing `b.vel`. 
- This change still preserves lateral `pendingSpin` and `swerve` adjustments and decay logic while allowing backspin to reduce forward velocity and produce a draw/rollback effect pre-impact.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a503aa45c83298c3c0ff5acd285f8)