### PR TITLE
Improve Pool Royale backspin response

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23563,7 +23563,9 @@ const powerRef = useRef(hud.power);
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = Math.max(0, TMP_VEC2_SPIN.dot(launchDir));
+                  const rawForwardMag = TMP_VEC2_SPIN.dot(launchDir);
+                  const maxSlowdown = Math.max(0, b.vel.length() * 0.35);
+                  const forwardMag = Math.max(rawForwardMag, -maxSlowdown);
                   TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
                   b.vel.add(TMP_VEC2_AXIS);
                   TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
@@ -23708,6 +23710,8 @@ const powerRef = useRef(hud.power);
                 const nx = dx / d,
                   ny = dy / d;
                 const overlap = (BALL_R * 2 - d) / 2;
+                const preVelA = a.vel.clone();
+                const preVelB = b.vel.clone();
                 const pairKey =
                   (a.id ?? i) < (b.id ?? j)
                     ? `${a.id ?? i}:${b.id ?? j}`
@@ -23741,7 +23745,12 @@ const powerRef = useRef(hud.power);
                   if (volume > 0) playBallHit(volume);
                 }
                 const cueBall = a.id === 'cue' ? a : b.id === 'cue' ? b : null;
-                const cuePreImpactVel = cueBall?.vel?.clone?.() ?? null;
+                const cuePreImpactVel =
+                  a.id === 'cue'
+                    ? preVelA
+                    : b.id === 'cue'
+                      ? preVelB
+                      : null;
                 if (!firstHit) {
                   if (a.id === 'cue' && b.id !== 'cue') firstHit = b.id;
                   else if (b.id === 'cue' && a.id !== 'cue') firstHit = a.id;


### PR DESCRIPTION
### Motivation
- Make cue-ball draw/backspin feel realistic so a slightly low cue-tip produces backward rolling (draw) while the ball still travels forward and preserves expected spin-through-on-impact behavior.

### Description
- Cap the pre-impact forward component from spin to avoid reversing the cue-ball by clamping `TMP_VEC2_SPIN.dot(launchDir)` against a velocity-scaled slowdown and use pre-collision velocities when calling the spin impulse, implemented in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a503aa45c83298c3c0ff5acd285f8)