### PR TITLE
Refine cue-ball spin offsets and remove mid-flight swerve drift

### DIFF
--- a/docs/pool-royale-spin-controller.md
+++ b/docs/pool-royale-spin-controller.md
@@ -1,0 +1,37 @@
+# Pool Royale – Spin Controller Directions (Physical Offsets)
+
+Spin input is defined as a **2D offset on the cue ball contact disk** (cue-tip impact point).
+
+- **Coordinate frame (screen-space)**: `x` is right, `y` is up on the player’s screen.
+- **Normalized**: offsets are clamped to a circle with `|offset| ≤ 0.7`.
+- **Physics intent**: the offset only applies **impulse + torque at impact**; no artificial curve is added mid-flight.
+
+## Directions A–G (cue-tip contact offsets)
+
+**A) STUN (no spin)**  
+**Offset**: `(x=0, y=0)`  
+**Effect**: Cue strikes the centre of mass. The ball initially slides with no spin, then transitions to pure rolling from table friction. After contact, it neither follows nor draws noticeably.
+
+**B) TOPSPIN (follow)**  
+**Offset**: `(x=0, y=+0.7)`  
+**Effect**: Strike above centre creates forward roll (spin around horizontal axis). After contact, the cue ball continues forward.
+
+**C) BACKSPIN (draw)**  
+**Offset**: `(x=0, y=-0.7)`  
+**Effect**: Strike below centre creates backward roll (spin opposite travel). After contact, the cue ball slows, stops, and draws back.
+
+**D) SIDESPIN LEFT (left english)**  
+**Offset**: `(x=-0.7, y=0)`  
+**Effect**: Strike left of centre creates side spin around the vertical axis. Primary effect is on cushion rebounds and cut-induced throw.
+
+**E) SIDESPIN RIGHT (right english)**  
+**Offset**: `(x=+0.7, y=0)`  
+**Effect**: Strike right of centre creates side spin around the vertical axis in the opposite direction. Affects cushion rebounds and throw.
+
+**F) TOPSPIN + SIDESPIN (combination)**  
+**Offsets**: `(x=±0.5, y=+0.5)`  
+**Effect**: Follow plus english. The cue ball rolls forward after impact while side spin alters cushion rebound and cut throw.
+
+**G) BACKSPIN + SIDESPIN (combination)**  
+**Offsets**: `(x=±0.5, y=-0.5)`  
+**Effect**: Draw plus english. The cue ball draws back after impact while side spin changes cushion rebound and cut throw.

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1125,7 +1125,7 @@ const PHYSICS_PROFILE = Object.freeze({
   mu: 0.2,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
-  maxTipOffsetRatio: 0.9
+  maxTipOffsetRatio: 0.7
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = Math.exp(-PHYSICS_PROFILE.mu * PHYSICS_BASE_STEP);
@@ -1352,14 +1352,14 @@ const BACKSPIN_ROLL_BOOST = 1.9;
 const CUE_BACKSPIN_ROLL_BOOST = 2.8;
 const SPIN_ROLL_DECAY = Math.exp(-PHYSICS_PROFILE.spinDecay * PHYSICS_BASE_STEP);
 const SPIN_AIR_DECAY = Math.exp(-PHYSICS_PROFILE.airSpinDecay * PHYSICS_BASE_STEP); // hold spin energy while the cue ball travels straight pre-impact
-const LIFT_SPIN_AIR_DRIFT = SPIN_ROLL_STRENGTH * 1.45; // inject extra sideways carry while the cue ball is airborne
+const LIFT_SPIN_AIR_DRIFT = 0; // avoid artificial sideways curve while airborne
 const RAIL_SPIN_THROW_SCALE = BALL_R * 0.36; // let cushion contacts inherit noticeable throw from active side spin
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to keep the cue ball rolling after rebounds
 const SWERVE_THRESHOLD = 0.82; // outer 18% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
-const SWERVE_PRE_IMPACT_DRIFT = 0.35; // allow a visible curve before the cue ball hits the object ball
-const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
+const SWERVE_PRE_IMPACT_DRIFT = 0; // keep pre-impact travel straight (no artificial curve)
+const PRE_IMPACT_SPIN_DRIFT = 0; // avoid reapplying sideways drift after impact
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.


### PR DESCRIPTION
### Motivation
- Make cue-ball spin behaviour physically grounded by representing spin as a 2D contact-point offset on the cue-ball disk and capping extremes. 
- Remove artificial mid-flight curvature/swerve so pre-impact travel remains straight and all effects arise from impulse + torque at impact. 

### Description
- Clamp spin magnitude and apply a maximum contact offset by adding `SPIN_MAX_OFFSET = 0.7` and scaling the response curve in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`, and ensure inputs are clamped to the unit circle with `clampToUnitCircle`. 
- Map UI spin → physics using `mapSpinForPhysics` with the curved-and-clamped offset so physics receives offsets in the normalized disk (`x,y`) instead of arbitrary curves. 
- Reduce allowed tip offset and remove in-air/pre/post impact swerve by changing `PHYSICS_PROFILE.maxTipOffsetRatio` from `0.9` to `0.7` and setting `LIFT_SPIN_AIR_DRIFT`, `SWERVE_PRE_IMPACT_DRIFT`, and `PRE_IMPACT_SPIN_DRIFT` to `0` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Add documentation `docs/pool-royale-spin-controller.md` that enumerates directions A–G (Stun, Topspin, Backspin, Left/Right English, and the two combinations) with short physical effect descriptions and normalized offsets (examples use |offset| ≤ 0.7). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3f74cfc08329bddb5fed8524f0f1)