### PR TITLE
Improve cue-spin input mapping and presets (deadzone + gamma scaling)

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,8 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const SPIN_INPUT_DEAD_ZONE = 0.015;
-export const SPIN_RESPONSE_EXPONENT = 1.9;
-export const SPIN_RESPONSE_EXPONENT_BACKSPIN = 1.65;
+export const SPIN_INPUT_DEAD_ZONE = 0.1;
+export const SPIN_RESPONSE_GAMMA = 1.8;
 export const MAX_SPIN_OFFSET = 0.7;
 
 export const SPIN_DIRECTIONS = [
@@ -16,56 +15,56 @@ export const SPIN_DIRECTIONS = [
   {
     id: 'topspin',
     label: 'TOPSPIN (follow)',
-    offset: { x: 0, y: MAX_SPIN_OFFSET },
+    offset: { x: 0, y: 0.55 },
     effect:
-      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball vazhdon përpara pas kontaktit.'
+      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball përshpejton në rolling dhe vazhdon përpara pas kontaktit.'
   },
   {
     id: 'backspin',
     label: 'BACKSPIN (draw)',
-    offset: { x: 0, y: -MAX_SPIN_OFFSET },
+    offset: { x: 0, y: -0.65 },
     effect:
-      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball ndalon dhe kthehet mbrapsht pas kontaktit.'
+      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball rrëshqet përpara, mund të bëjë stun, pastaj kthehet mbrapsht.'
   },
   {
     id: 'left-english',
     label: 'SIDESPIN LEFT',
-    offset: { x: -MAX_SPIN_OFFSET, y: 0 },
+    offset: { x: -0.5, y: 0 },
     effect:
       'Goditje majtas nga qendra: spin rreth boshtit vertikal, ndikon kryesisht në rebound me banda dhe në “throw”.'
   },
   {
     id: 'right-english',
     label: 'SIDESPIN RIGHT',
-    offset: { x: MAX_SPIN_OFFSET, y: 0 },
+    offset: { x: 0.5, y: 0 },
     effect:
       'Goditje djathtas nga qendra: spin rreth boshtit vertikal në drejtim të kundërt, me të njëjtat efekte anësore.'
   },
   {
     id: 'top-left',
     label: 'TOPSPIN + LEFT',
-    offset: { x: -0.45, y: 0.45 },
+    offset: { x: -0.4, y: 0.45 },
     effect:
       'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'top-right',
     label: 'TOPSPIN + RIGHT',
-    offset: { x: 0.45, y: 0.45 },
+    offset: { x: 0.4, y: 0.45 },
     effect:
       'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'back-left',
     label: 'BACKSPIN + LEFT',
-    offset: { x: -0.45, y: -0.45 },
+    offset: { x: -0.4, y: -0.45 },
     effect:
       'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   },
   {
     id: 'back-right',
     label: 'BACKSPIN + RIGHT',
-    offset: { x: 0.45, y: -0.45 },
+    offset: { x: 0.4, y: -0.45 },
     effect:
       'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   }
@@ -89,37 +88,40 @@ export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
   return { x: x * scale, y: y * scale };
 };
 
-export const normalizeSpinInput = (spin) => {
-  const x = spin?.x ?? 0;
-  const y = spin?.y ?? 0;
-  const magnitude = Math.hypot(x, y);
-  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+export const computeOffsetScaled = (
+  rawX,
+  rawY,
+  {
+    maxOffset = MAX_SPIN_OFFSET,
+    deadzone = SPIN_INPUT_DEAD_ZONE,
+    gamma = SPIN_RESPONSE_GAMMA
+  } = {}
+) => {
+  const clamped = clampToUnitCircle(rawX, rawY);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  if (!Number.isFinite(distance) || distance <= deadzone) {
     return { x: 0, y: 0 };
   }
-  return clampToMaxOffset(x, y);
-};
-
-export const applySpinResponseCurve = (spin) => {
-  const x = spin?.x ?? 0;
-  const y = spin?.y ?? 0;
-  const magnitude = Math.hypot(x, y);
-  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
-    return { x: 0, y: 0 };
-  }
-  const clamped = clampToUnitCircle(x, y);
-  const clampedMag = Math.hypot(clamped.x, clamped.y);
-  const exponent = clamped.y < 0 ? SPIN_RESPONSE_EXPONENT_BACKSPIN : SPIN_RESPONSE_EXPONENT;
-  const curvedMag = Math.pow(clampedMag, exponent);
-  const scale = clampedMag > 1e-6 ? curvedMag / clampedMag : 0;
+  const denom = Math.max(maxOffset - deadzone, 1e-6);
+  const t = clamp((distance - deadzone) / denom, 0, 1);
+  const scaledMagnitude = Math.pow(t, gamma);
+  const scaledOffset = scaledMagnitude * maxOffset;
+  const scale = distance > 1e-6 ? scaledOffset / distance : 0;
   return { x: clamped.x * scale, y: clamped.y * scale };
 };
+
+export const normalizeSpinInput = (spin) =>
+  computeOffsetScaled(spin?.x ?? 0, spin?.y ?? 0);
+
+export const applySpinResponseCurve = (spin) =>
+  computeOffsetScaled(spin?.x ?? 0, spin?.y ?? 0);
 
 export const mapSpinForPhysics = (spin) => {
   const adjusted = {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
   };
-  const limited = clampToMaxOffset(adjusted.x, adjusted.y);
+  const limited = computeOffsetScaled(adjusted.x, adjusted.y);
   return {
     // UI uses screen-space: +X is right, +Y is up. Flip X to align side spin to
     // the table axes, and flip Y so high/low spin matches the cue-ball roll.


### PR DESCRIPTION
### Motivation
- Provide a more realistic, tunable mapping from user spin input to physics spin that avoids arcade-like linear behavior and preserves correct draw/follow transitions.
- Expose clearer, more typical spin direction presets so gameplay examples (light/strong draw/follow/english) match expected physical outcomes.

### Description
- Replace tiny deadzone/exponent constants with `SPIN_INPUT_DEAD_ZONE = 0.1`, `SPIN_RESPONSE_GAMMA = 1.8` and keep `MAX_SPIN_OFFSET = 0.7` to drive scaling behavior.
- Add `computeOffsetScaled(rawX, rawY, {maxOffset, deadzone, gamma})` implementing deadzone + gamma curve mapping and use it as the canonical scaler for spin inputs.
- Route `normalizeSpinInput`, `applySpinResponseCurve`, and `mapSpinForPhysics` through `computeOffsetScaled` so UI inputs and physics mapping share the same behavior, and flip axes for physics as before.
- Tune `SPIN_DIRECTIONS` offsets and short effect descriptions to concrete example values (e.g. light draw ~ `(0,-0.25)`, strong draw set to `-0.65`, side spin `±0.5`, diagonal combos adjusted) in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a66017dc48329b2e4f1d5a16a4370)