### PR TITLE
Implement quantized spin controller and impulse/torque-based cue‑ball physics

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -10,13 +10,16 @@ public static class PhysicsConstants
     public const double ConnectorRestitution = CushionRestitution * 0.25;
     // pocket edges fully absorb balls (no bounce)
     public const double PocketRestitution = 0.0;
-    public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double Gravity = 9.81;                // m/s^2
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
-    public const double SpinDecay = 2.0;               // per-second decay for on-table spin
-    public const double AirSpinDecay = 0.6;            // per-second decay while airborne
-    public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
-    public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
+    public const double BallMass = 0.17;               // kg (typical pool ball)
+    public const double RollingEpsilon = 0.02;         // m/s
+    public const double KineticFriction = 0.22;        // sliding friction coefficient
+    public const double RollDamping = 0.10;            // per-second rolling drag
+    public const double SpinDamping = 0.04;            // per-second spin drag in rolling
+    public const double BallBallFriction = 0.20;       // tangential impulse cap for ball-ball
+    public const double RailFriction = 0.25;           // tangential impulse cap for cushions
+    public const double PowerToImpulseScale = 1.0;     // maps UI power to impulse (N·s)
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
     public const double JumpStopVelocity = 0.2;        // m/s below which vertical motion stops
     public const double AirborneHeightThreshold = BallRadius * 0.25; // height before ignoring cushions/balls
@@ -24,13 +27,7 @@ public static class PhysicsConstants
     public const double JumpTipOffsetBoost = 0.35;     // reduces jump threshold as tip offset increases
     public const double LandingHorizontalDamping = 0.85; // horizontal speed retained on landing
     public const double LandingSpinDamping = 0.8;      // spin retained on landing
-    public const double MasseAngleMin = 25.0;          // degrees where masse starts to show
-    public const double MasseAngleMax = 75.0;          // degrees where masse reaches full strength
-    public const double MasseSwerveBoost = 2.0;        // multiplier for swerve at max masse
-    public const double SwerveSpeedCutoff = 2.5;       // m/s after which swerve fades out
-    public const double SwerveSpeedFadeRange = 4.0;    // fade distance for swerve cutoff
     public const double MaxCueElevationDegrees = 85.0; // clamp to UI upper bound
-    public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
     public const double TableHeight = 1.3135;

--- a/billiards/SpinController.cs
+++ b/billiards/SpinController.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Billiards;
+
+/// <summary>Quantized spinning controller and UI-to-cue mapping helpers.</summary>
+public static class SpinController
+{
+    public const double MaxOffset = 0.70;
+    public const double StunRadius = 0.12;
+    public const double Ring1Radius = 0.32;
+    public const double Ring2Radius = 0.52;
+    public const double Ring3Radius = MaxOffset;
+
+    public const double Level0Mag = 0.00;
+    public const double Level1Mag = 0.25 * MaxOffset;
+    public const double Level2Mag = 0.50 * MaxOffset;
+    public const double Level3Mag = 0.80 * MaxOffset;
+
+    public static Vec2 ComputeQuantizedOffsetScaled(double rawX, double rawY)
+    {
+        var raw = new Vec2(rawX, rawY);
+        double distance = raw.Length;
+
+        if (distance > MaxOffset && distance > PhysicsConstants.Epsilon)
+        {
+            raw = raw.Normalized() * MaxOffset;
+            distance = MaxOffset;
+        }
+
+        double mag;
+        if (distance <= StunRadius)
+            mag = Level0Mag;
+        else if (distance <= Ring1Radius)
+            mag = Level1Mag;
+        else if (distance <= Ring2Radius)
+            mag = Level2Mag;
+        else
+            mag = Level3Mag;
+
+        if (mag <= PhysicsConstants.Epsilon)
+            return new Vec2(0, 0);
+
+        return raw.Normalized() * mag;
+    }
+
+    public static Vec2 MapUiOffsetToCueFrame(double uiX, double uiY, Vec3 cameraRight, Vec3 cameraUp, Vec3 cueRight, Vec3 cueUp)
+    {
+        var offsetWorld = cameraRight * uiX + cameraUp * uiY;
+        double x = Vec3.Dot(offsetWorld, cueRight);
+        double y = Vec3.Dot(offsetWorld, cueUp);
+        return new Vec2(x, y);
+    }
+}

--- a/billiards/Vec3.cs
+++ b/billiards/Vec3.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Billiards;
+
+/// <summary>Lightweight deterministic 3D vector using doubles.</summary>
+public readonly struct Vec3
+{
+    public readonly double X;
+    public readonly double Y;
+    public readonly double Z;
+
+    public Vec3(double x, double y, double z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    public static Vec3 operator +(Vec3 a, Vec3 b) => new Vec3(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+    public static Vec3 operator -(Vec3 a, Vec3 b) => new Vec3(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+    public static Vec3 operator *(Vec3 a, double s) => new Vec3(a.X * s, a.Y * s, a.Z * s);
+    public static Vec3 operator /(Vec3 a, double s) => new Vec3(a.X / s, a.Y / s, a.Z / s);
+
+    public double Length => Math.Sqrt(X * X + Y * Y + Z * Z);
+    public double LengthSquared => X * X + Y * Y + Z * Z;
+
+    public Vec3 Normalized()
+    {
+        var l = Length;
+        return l < PhysicsConstants.Epsilon ? new Vec3(0, 0, 0) : this / l;
+    }
+
+    public static double Dot(Vec3 a, Vec3 b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+
+    public static Vec3 Cross(Vec3 a, Vec3 b)
+    {
+        return new Vec3(
+            a.Y * b.Z - a.Z * b.Y,
+            a.Z * b.X - a.X * b.Z,
+            a.X * b.Y - a.Y * b.X);
+    }
+
+    public override string ToString() => $"({X}, {Y}, {Z})";
+}


### PR DESCRIPTION
### Motivation
- Provide a realistic cue‑ball spin system driven by contact offset (disk) and physics (linear impulse + torque) rather than artificial lateral curve forces. 
- Support all spin directions (stun, topspin, backspin, left/right english and diagonal combos) via a quantized 4‑ring controller for predictable tuning. 
- Move sliding→rolling and collision spin transfer into the physics layer so spin comes from impulse, torque and friction, and affects cushion/ball responses.

### Description
- Added a quantized spinning controller `SpinController` with constants (`MaxOffset`, `stunRadius`, ring radii, level magnitudes) and two helpers: `ComputeQuantizedOffsetScaled(rawX, rawY)` and `MapUiOffsetToCueFrame(uiX, uiY, cameraRight, cameraUp, cueRight, cueUp)`. 
- Introduced `Vec3` utility type and new physics constants in `PhysicsConstants` for mass, friction, rolling epsilon, damping and impulse scaling. 
- Reworked `BilliardsSolver`: replaced per‑axis Side/Forward spin fields with a 3D `AngularVelocity` and changed shot params to carry `Power` + quantized `ShotSpin` offsets; strike creates a linear impulse and a torque impulse computed from `r_offset`, updating linear velocity and `ω` via `J/m` and `torque/I`. 
- Replaced previous ad‑hoc spin forces with a deterministic stepper: `StepBall` uses `ApplyAirDrag` or `ApplyTableFriction` to handle sliding→rolling (based on `v_rel` at contact point) and spin/velocity damping, and added `ResolveCushionCollision` and `ResolveBallBallCollision` that compute normal impulse and limited tangential impulse (friction caps) to transfer spin consistently. 

### Testing
- No automated tests were executed in this rollout (no test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7a1a50e083299c1c4ff3ab9e6eaf)