### PR TITLE
Improve Pool Royale AI planning, cache plans, slow replay cue stroke, and increase max spin

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -56,6 +56,8 @@
  * Each entry: { success:number, attempts:number }
  */
 const shotMemory = new Map()
+const MIN_POT_PROBABILITY = 0.32
+const STRAIGHT_SHOT_THRESHOLD = Math.PI / 12 // ~15 degrees
 
 function normaliseColourKey (input) {
   const value = typeof input === 'string' ? input : input?.colour
@@ -723,6 +725,7 @@ function evaluateCandidates (state, colour, candidates) {
       const risk = foulRisk(c, state)
       if (risk > 0.65) continue
       const Ppot = estimatePotProbability(c, state)
+      if (Ppot < MIN_POT_PROBABILITY) continue
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
       target.pocketed = true
@@ -786,14 +789,13 @@ function chooseBestAction (state, colour) {
   }
   const qualityFiltered = candidates.filter(c => {
     if (c.actionType !== 'pot') return true
-    return estimatePotProbability(c, state) >= 0.2
+    return estimatePotProbability(c, state) >= MIN_POT_PROBABILITY
   })
   if (qualityFiltered.length > 0) {
     candidates = qualityFiltered
   }
-  const STRAIGHT_THRESHOLD = Math.PI / 12 // ~15 degrees
   const straightShots = candidates.filter(
-    c => typeof c.angle === 'number' && c.angle <= STRAIGHT_THRESHOLD
+    c => typeof c.angle === 'number' && c.angle <= STRAIGHT_SHOT_THRESHOLD
   )
   if (straightShots.length > 0) {
     candidates = straightShots

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -8,7 +8,7 @@ export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
 export const SPIN_LEVEL1_MAG = 0.25 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.5 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.8 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL3_MAG = 1.0 * MAX_SPIN_OFFSET;
 
 export const SPIN_DIRECTIONS = [
   {


### PR DESCRIPTION
### Motivation

- Reduce AI stalls and make UK advanced AI pick higher-success shots by tightening candidate filtering and preferring straighter plays.
- Avoid repeated expensive AI planning for identical table snapshots to improve responsiveness during AI turns and reduce per-frame work.
- Make replay cue-stick playback slower so the cue contact is more visible, and allow stronger maximum spin input from the spin controller.

### Description

- Add `MIN_POT_PROBABILITY` and `STRAIGHT_SHOT_THRESHOLD` constants to `lib/poolUkAdvancedAi.js` and filter out candidate pot shots with estimated pot probability below the new threshold before deeper evaluation.
- Tighten the candidate quality filter in `lib/poolUkAdvancedAi.js` to use the new `MIN_POT_PROBABILITY` and prefer straight shots using `STRAIGHT_SHOT_THRESHOLD`.
- Introduce a simple per-snapshot AI plan cache in `webapp/src/pages/Games/PoolRoyale.jsx` by computing `buildAiStateKey(aiState)`, storing `aiPlanCacheRef`, and returning a cloned cached plan when the key matches to avoid repeating `selectUkAiShot` for identical states.
- Increase replay cue stroke slowdown by changing `REPLAY_CUE_STROKE_SLOWDOWN` from `1.2` to `1.5` in `PoolRoyale.jsx` so replayed strokes are visibly slower.
- Increase the outer-ring spin magnitude in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by setting `SPIN_LEVEL3_MAG` from `0.8 * MAX_SPIN_OFFSET` to `1.0 * MAX_SPIN_OFFSET` to allow stronger max-spin input.

### Testing

- No automated tests were executed for this change in this rollout.
- Code changes were committed and the modified files are `lib/poolUkAdvancedAi.js`, `webapp/src/pages/Games/PoolRoyale.jsx`, and `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa00238c08329b6ee5f6cdd832737)