### PR TITLE
Pool Royale: ensure final-shot replay + winner overlay, anchor chat UI and improve cue-stick visibility

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -6,6 +6,7 @@ export default function BottomLeftIcons({
   onChat,
   onGift,
   style,
+  chatButtonRef,
   className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
   showInfo = true,
   showChat = true,
@@ -36,7 +37,12 @@ export default function BottomLeftIcons({
   return (
     <div className={className} style={style}>
       {showChat && onChat && (
-        <button type="button" onClick={onChat} className={buttonClassName}>
+        <button
+          type="button"
+          onClick={onChat}
+          className={buttonClassName}
+          ref={chatButtonRef}
+        >
           {chatIcon ? (
             <span className={iconClassName}>{chatIcon}</span>
           ) : (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1519,6 +1519,12 @@ input:focus {
   font-size: 1.2rem;
 }
 
+.chat-bubble--pool-royale {
+  bottom: auto;
+  left: auto;
+  transform: translateY(-50%);
+}
+
 
 /* Rolling dice animation */
 .dice-screen-animation {


### PR DESCRIPTION
### Motivation
- Prevent a black screen at match end by showing the last-shot replay together with the winner avatar/name and coin burst, and ensure the final shot replay always runs when a frame ends. 
- Improve HUD layout so chat/gift buttons move slightly left and down on portrait screens and chat messages appear aligned horizontally with the chat button and remain visible longer. 
- Make the cue-stick stroke visuals easier to see by slowing and slightly amplifying pullback/forward timing.

### Description
- Add a `chatButtonRef` prop to `BottomLeftIcons` and pass a `ref` from `PoolRoyale.jsx` so the chat button can be anchored (`webapp/src/components/BottomLeftIcons.jsx`, `webapp/src/pages/Games/PoolRoyale.jsx`).
- Compute and store the chat button bounds in `PoolRoyale.jsx` and position Pool Royale chat bubbles next to the chat button via `chatBubblePosition` state and a new `.chat-bubble--pool-royale` CSS rule (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/index.css`).
- Increase chat bubble lifetime from `3000ms` to `4500ms` so messages persist 1.5s longer (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Nudge the bottom-left icon container slightly left/down by updating its class to `left-1 bottom-3` to visually separate chat/gift from avatars (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Ensure the winner overlay and coin burst show immediately at frame end and wait for any active replay to complete before navigating back to the lobby by reordering/wrapping `waitForActiveReplay` and `triggerCoinBurst` calls and forcing a final replay when the frame ends (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Make cue stick animations more visible by increasing `CUE_STROKE_VISUAL_SLOWDOWN` and raising `PLAYER_CUE_PULL_VISIBILITY_BOOST` to slow and amplify player stroke visuals (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were executed for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa5adbb6483298420fdbb8b1934d7)