### PR TITLE
Pool Royale: final-shot replay, cue timing, and chat UI tweaks

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1519,6 +1519,12 @@ input:focus {
   font-size: 1.2rem;
 }
 
+.pool-royale-chat-bubble {
+  left: calc(0.75rem + 3.15rem + 0.5rem);
+  bottom: calc(0.75rem + 5.35rem);
+  transform: none;
+}
+
 
 /* Rolling dice animation */
 .dice-screen-animation {


### PR DESCRIPTION
### Motivation
- Prevent a blank/black screen at match end by ensuring the final shot shows the replay + winner overlay long enough for the player to see the last ball, the winner avatar/name, and the coin burst.
- Improve visibility of the cue stroke so the cuestick animation is readable during shots and replays.
- Move the chat/gift controls slightly left and down on portrait screens and align chat messages visually with the chat button while increasing message visibility time.

### Description
- Replay / end-of-match: added a `final` replay tag and banner variant and updated the replay-decision flow so final-frame wins force a replay (`PoolRoyale.jsx` changes around `resolveReplayDecision` and post-shot logic). 
- Winner overlay timing: extended the post-match overlay delay from `2200ms` to `3200ms` to keep the winner avatar + coin burst visible before navigating to the lobby (`PoolRoyale.jsx`).
- Cue timing: increased `REPLAY_CUE_STICK_HOLD_MS` from `320` to `620` and tuned player stroke timing constants by raising `PLAYER_STROKE_TIME_SCALE`, `PLAYER_FORWARD_SLOWDOWN`, and `PLAYER_PULLBACK_MIN_SCALE` so the forward stroke and replay cue visibility is slower and more readable (`PoolRoyale.jsx`).
- Chat / gift UI: nudged the bottom-left controls toward `left-1 bottom-3` and added a `.pool-royale-chat-bubble` CSS rule to horizontally align chat bubbles with the chat button; chat bubble lifetime increased from `3000ms` to `4500ms` (`PoolRoyale.jsx`, `index.css`).
- Minor: added a new final-shot banner set to `REPLAY_BANNER_VARIANTS` used when a frame ends in a winner (`PoolRoyale.jsx`).

### Testing
- Started the web dev server via `npm --prefix webapp run dev` (Vite) which launched successfully and served the site (available at the dev URL). 
- Attempted a visual smoke test using Playwright to load `/games/poolroyale` and capture a screenshot, but the screenshot attempt timed out (Playwright `Page.screenshot` timed out). 
- No unit tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa5adbb6483298420fdbb8b1934d7)