### PR TITLE
Pool Royale: tune ball physics, cue stroke/camera timing, UI spacing, and cushion angle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1122,7 +1122,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.9,
-  mu: 0.2,
+  mu: 0.18,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
@@ -1440,8 +1440,8 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.06; // tighten the visible air gap so the tip reads as contacting the cue ball
-const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
-const CUE_IMPACT_OVERTRAVEL = BALL_R * 0.38; // push the cue slightly past the contact point so the strike is clearly visible
+const CUE_TIP_GAP = BALL_R * 1.02 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
+const CUE_IMPACT_OVERTRAVEL = BALL_R * 0.22; // push the cue slightly past the contact point so the strike is clearly visible
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -1499,8 +1499,8 @@ const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
-// middle pocket cushion cuts are sharpened to a 29° cut to align the side-rail cushions with the updated spec
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 34;
+// middle pocket cushion cuts are sharpened to a 28° cut to align the side-rail cushions with the updated spec
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 28;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -4750,7 +4750,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.52; // bring the standing camera nearer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.58; // bring the standing camera nearer while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -4947,13 +4947,13 @@ const AI_WARMUP_PULL_RATIO = 0.55;
 const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.62;
 const PLAYER_STROKE_TIME_SCALE = 2.4;
-const PLAYER_FORWARD_SLOWDOWN = 2.1;
+const PLAYER_FORWARD_SLOWDOWN = 2.5;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.5;
-const CAMERA_SWITCH_MIN_HOLD_MS = 220;
-const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 28;
+const CAMERA_SWITCH_MIN_HOLD_MS = 320;
+const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 18;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
@@ -20422,7 +20422,7 @@ const powerRef = useRef(hud.power);
           const impactTime = pullEndTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
           const impactHoldBuffer = Math.max(
-            220,
+            320,
             Math.min(settleDuration, Math.max(180, forwardDuration * 0.9))
           );
           const forwardPreviewHold = impactTime + impactHoldBuffer;
@@ -25964,7 +25964,7 @@ const powerRef = useRef(hud.power);
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
-            className="fixed left-1 bottom-3 z-50 flex flex-col gap-2.5"
+            className="fixed left-0 bottom-3 z-50 flex flex-col gap-2.5"
             buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Improve gameplay feel by speeding ball motion and making the cue strike visually precise in both live play and replays. 
- Reduce accidental middle-pocket deflections by tightening the middle-pocket cushion cut and trimming cushion geometry. 
- Move HUD chat/gift buttons slightly left and nudge the player/avatar frame to avoid overlap on portrait screens. 
- Make standing/shot camera and cue-forward timing hold longer so the push-through (forward stroke) is visible and symmetric with replay.

### Description
- Reduced friction in the physics profile by changing `PHYSICS_PROFILE.mu` from `0.2` to `0.18` to increase ball travel speed. 
- Tuned cue alignment: increased `CUE_TIP_GAP` and reduced `CUE_IMPACT_OVERTRAVEL` to better align the cue tip with the cue ball on impact, and increased stroke forward slowdown via `PLAYER_FORWARD_SLOWDOWN`. 
- Extended camera/stroke hold and preview timing by increasing `CAMERA_SWITCH_MIN_HOLD_MS` and related impact/hold buffers so the camera waits through the cue push and impact. 
- Sharpened middle-pocket cushion cuts by setting `DEFAULT_SIDE_CUSHION_CUT_ANGLE` to `28` degrees. 
- Adjusted standing camera framing by increasing `STANDING_VIEW_DISTANCE_SCALE` to bring the standing view slightly nearer the table. 
- Nudged HUD/icon layout for portrait: decreased `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` and adjusted the left chat/gift container class from `left-1` to `left-0` to move buttons leftward and create more space between buttons and avatars. 
- Small replay/cue-timing related change: updated the `impactHoldBuffer` threshold used when scheduling replay/shot camera/pocket views.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app at the local URL (server started successfully). 
- Attempted an automated screenshot of `/games/poolroyale` using Playwright, but the screenshot step timed out and did not complete. 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3162ca0083298dff57807aa64212)