### PR TITLE
Pool Royale: tune physics, cue/replay timing, cushion cuts and mobile HUD spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1122,7 +1122,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.9,
-  mu: 0.2,
+  mu: 0.18,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
@@ -1377,7 +1377,7 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 // Pool Royale power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_POWER_MULTIPLIER = 1.25;
+const SHOT_POWER_MULTIPLIER = 1.35;
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1439,9 +1439,9 @@ const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.06; // tighten the visible air gap so the tip reads as contacting the cue ball
+const CUE_TIP_CLEARANCE = BALL_R * 0.085; // keep the tip aligned without overreaching the cue ball
 const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
-const CUE_IMPACT_OVERTRAVEL = BALL_R * 0.38; // push the cue slightly past the contact point so the strike is clearly visible
+const CUE_IMPACT_OVERTRAVEL = BALL_R * 0.22; // keep the cue closer to the contact point for precise tip alignment
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -1499,8 +1499,8 @@ const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
-// middle pocket cushion cuts are sharpened to a 29° cut to align the side-rail cushions with the updated spec
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 34;
+// middle pocket cushion cuts are set to a 28° cut to align the side-rail cushions with the updated spec
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 28;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -4750,7 +4750,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.52; // bring the standing camera nearer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.58; // move the standing camera slightly farther and higher while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -4899,7 +4899,7 @@ const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
-const CUE_STROKE_VISUAL_SLOWDOWN = 2.05;
+const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CUE_PULLBACK_DURATION_MS = 3400;
 const AI_CUE_FORWARD_DURATION_MS = 3400;
 const AI_STROKE_VISIBLE_DURATION_MS =
@@ -4946,14 +4946,14 @@ const AI_CUE_PULL_VISIBILITY_BOOST = 1.34;
 const AI_WARMUP_PULL_RATIO = 0.55;
 const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.62;
-const PLAYER_STROKE_TIME_SCALE = 2.4;
-const PLAYER_FORWARD_SLOWDOWN = 2.1;
+const PLAYER_STROKE_TIME_SCALE = 1;
+const PLAYER_FORWARD_SLOWDOWN = 1;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1.5;
+const REPLAY_CUE_STROKE_SLOWDOWN = 1;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
-const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 28;
+const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 12;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
@@ -7278,7 +7278,7 @@ function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.26; // shorten the corner cushions more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.14; // trim the cushion tips near middle pockets slightly further while keeping their cut angle intact
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.22; // trim the cushion tips near middle pockets further for cleaner jaw clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -20422,8 +20422,11 @@ const powerRef = useRef(hud.power);
           const impactTime = pullEndTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
           const impactHoldBuffer = Math.max(
-            220,
-            Math.min(settleDuration, Math.max(180, forwardDuration * 0.9))
+            240,
+            Math.min(
+              Math.max(settleDuration, 240),
+              Math.max(240, forwardDuration * 1.05)
+            )
           );
           const forwardPreviewHold = impactTime + impactHoldBuffer;
           powerImpactHoldRef.current = Math.max(
@@ -25964,7 +25967,7 @@ const powerRef = useRef(hud.power);
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
-            className="fixed left-1 bottom-3 z-50 flex flex-col gap-2.5"
+            className="fixed left-0 bottom-3 z-50 flex flex-col gap-2.5 -translate-x-1"
             buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Improve game feel by making balls move noticeably faster and more responsive during play and replays. 
- Fix cue stick alignment and timing in replays and live strokes so the cue tip visually and physically matches the impact point. 
- Reduce unwanted middle-pocket deflections by tightening the middle-pocket cushion geometry. 
- Slightly shift HUD/chat/gift controls and standing camera framing to avoid overlaps on portrait mobile layouts.

### Description
- Tuned physics and shot power: lowered `PHYSICS_PROFILE.mu` from `0.2` to `0.18` and raised `SHOT_POWER_MULTIPLIER` from `1.25` to `1.35` to speed up ball motion and breaks. 
- Cue tip / stroke and replay alignment: increased `CUE_TIP_CLEARANCE` to `BALL_R * 0.085`, reduced `CUE_IMPACT_OVERTRAVEL` to `BALL_R * 0.22`, adjusted `impactHoldBuffer` logic to hold the camera longer through impact, and unified slowdown/time-scale settings (`CUE_STROKE_VISUAL_SLOWDOWN`, `PLAYER_STROKE_TIME_SCALE`, `PLAYER_FORWARD_SLOWDOWN`, `REPLAY_CUE_STROKE_SLOWDOWN`) so replay and gameplay strokes match more closely. 
- Cushion / pocket geometry: set `DEFAULT_SIDE_CUSHION_CUT_ANGLE` to `28` degrees and increased `SIDE_CUSHION_POCKET_REACH_REDUCTION` (trim) to `TABLE.THICK * 0.22` to tighten middle-pocket jaw clearance. 
- UI / camera spacing: nudged `STANDING_VIEW_DISTANCE_SCALE` from `0.52` to `0.58`, reduced `PORTRAIT_HUD_HORIZONTAL_NUDGE_PX` from `28` to `12`, and shifted the bottom-left chat/gift button container to `left-0` with `-translate-x-1` so the gift/chat buttons move slightly left away from the avatar area. 
- File changed: `webapp/src/pages/Games/PoolRoyale.jsx` (constants and related stroke / replay / cushion / HUD/camera adjustments). 

### Testing
- Built the webapp using the dev script which produced a Vite build successfully (build completed, assets generated). 
- Attempted to run the dev server and capture a Playwright screenshot, but Playwright failed to load the local server (`net::ERR_EMPTY_RESPONSE`) so UI screenshot verification did not complete. 
- The bot process logged an in-memory MongoDB download error during concurrent dev startup, but the webapp build step itself completed; no automated unit or integration tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3162ca0083298dff57807aa64212)