### PR TITLE
Pool Royale: camera, cue stroke and power tuning; AI in‑hand fallback and UI tweak

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1122,7 +1122,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.9,
-  mu: 0.18,
+  mu: 0.16,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
@@ -1376,9 +1376,10 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 // Pool Royale power pass: lift overall shot strength by another 25%.
+// Extra power pass: increase overall force another 25% and nudge travel speed to match.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_POWER_MULTIPLIER = 1.35;
-const SHOT_SPEED_MULTIPLIER = 1.5; // boost overall shot speed by 50% for snappier ball travel
+const SHOT_POWER_MULTIPLIER = 1.6875;
+const SHOT_SPEED_MULTIPLIER = 1.65; // boost overall shot speed by 65% for snappier ball travel
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -4735,7 +4736,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.88; // lift the standing orbit slightly higher for a clearer top surface view
+const STANDING_VIEW_PHI = 0.85; // lift the standing orbit slightly higher for a clearer top surface view
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -19703,11 +19704,14 @@ const powerRef = useRef(hud.power);
         if (fallback && isSpotFree(fallback, 2.0)) {
           return fallback;
         }
+        if (fallback && isSpotFree(fallback, 1.65)) {
+          return fallback;
+        }
         const baulkCenter = defaultInHandPosition();
         if (baulkCenter && isSpotFree(baulkCenter, 2.0)) {
           return baulkCenter;
         }
-        return null;
+        return fallback ?? baulkCenter ?? null;
       };
       const autoPlaceAiCueBall = () => {
         const currentHud = hudRef.current;
@@ -20355,36 +20359,23 @@ const powerRef = useRef(hud.power);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const strokeDistance = Math.max(visualPull, CUE_PULL_MIN_VISUAL);
-          const topSpinFollowThrough =
-            BALL_R * (1 + 3 * clampedPower) * topSpinWeight;
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
-          const forwardDistance = strokeDistance + topSpinFollowThrough;
-          const impactPos = startPos
-            .clone()
-            .add(
-              dir
-                .clone()
-                .multiplyScalar(Math.max(forwardDistance + CUE_IMPACT_OVERTRAVEL, 0))
-            );
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
-          );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
+          const impactPos = buildCuePosition(0);
+          const forwardDistance = startPos.distanceTo(impactPos);
+          const totalRetreat = 0;
+          const settlePos = impactPos.clone();
           cueStick.visible = true;
           cueStick.position.copy(warmupPos);
-          const forwardSpeed = THREE.MathUtils.lerp(
+          const forwardSpeedFallback = THREE.MathUtils.lerp(
             CUE_STROKE_SPEED_MIN,
             CUE_STROKE_SPEED_MAX,
             curvedPower
           );
+          const cueSpeed =
+            Number.isFinite(predictedCueSpeed) && predictedCueSpeed > 1e-4
+              ? predictedCueSpeed
+              : forwardSpeedFallback;
           const forwardDurationBase = THREE.MathUtils.clamp(
-            (forwardDistance / Math.max(forwardSpeed, 1e-4)) * 1000,
+            (forwardDistance / Math.max(cueSpeed, 1e-4)) * 1000,
             CUE_STROKE_MIN_MS,
             CUE_STROKE_MAX_MS
           );
@@ -20393,11 +20384,16 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_SPEED_MAX,
             curvedPower
           );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
+          const settleDurationBase =
+            totalRetreat > 1e-4
+              ? THREE.MathUtils.clamp(
+                  (totalRetreat / Math.max(settleSpeed, 1e-4)) *
+                    1000 *
+                    (backSpinWeight > 0 ? 0.82 : 1),
+                  CUE_FOLLOW_MIN_MS,
+                  CUE_FOLLOW_MAX_MS
+                )
+              : 0;
           const aiStrokeScale =
             aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
           const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
@@ -26292,7 +26288,7 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-2 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute right-1 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
             bottom: `${6 + chromeUiLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,


### PR DESCRIPTION
### Motivation
- Improve visual framing for standing camera so the orbit sits slightly higher and reads better on portrait screens. 
- Fix/clarify cue animation and shot feel so the cue stick stops at contact and forward motion matches physics, and increase shot power to make ball travel more realistic. 
- Reduce cases where AI turns stall during cue‑ball in‑hand placement and move the spin control slightly away from avatars for clearer UI.

### Description
- Tuning: reduced physics surface friction by lowering `PHYSICS_PROFILE.mu` and increased shot force/speed by raising `SHOT_POWER_MULTIPLIER` to `1.6875` and `SHOT_SPEED_MULTIPLIER` to `1.65` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Camera: nudged standing camera angle by setting `STANDING_VIEW_PHI` to `0.85` to lift the standing orbit framing. 
- Cue stroke/animation: revised forward stroke math so the impact position uses the resolved cue tip target (`buildCuePosition(0)`), computes `forwardDuration` from `predictedCueSpeed` if available (falling back to stroke speed), and guards settle durations when no retreat is needed so the cue visually stops at contact. 
- AI in‑hand: improved `findAiInHandPlacement` fallback by rechecking the fallback position with a lower clearance and returning a sensible fallback before failing to avoid stalls near the rack side. 
- UI: nudged the spin controller a few pixels right by changing its container class from `right-2` to `right-1` so it sits slightly away from avatars.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and confirmed Vite reported the site ready (server start succeeded). 
- Attempted an automated Playwright screenshot of the running game page, but the screenshot operation timed out (Playwright timed out while rendering). 
- No unit or E2E test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b424eaa988329a58ae862c52a95be)