### PR TITLE
Pool Royale: round wooden rail edges and tighten pocket camera proximity

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1203,7 +1203,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops furthe
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep the exterior wooden rails straight with no rounding
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.22; // round the exterior wooden rail edges for a softer profile while keeping rail angles unchanged
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_GRAVITY = 42; // steeper gravity for a natural fall into the leather cradle
@@ -1263,7 +1263,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.88;
+const POCKET_CAM_EDGE_SCALE = 0.68;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +


### PR DESCRIPTION
### Motivation
- Soften the visual profile of the wooden rails by rounding their exterior edges while preserving existing rail geometry and angles.
- Move the pocket cameras closer to the wooden rails so pocket cams frame the pocket mouths nearer the rail edge for the Pool Royale table.

### Description
- Updated `RAIL_OUTER_EDGE_RADIUS_RATIO` from `0` to `0.22` to apply a soft round-over to exterior wooden rail edges without changing rail angles (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Tightened pocket camera placement by changing `POCKET_CAM_EDGE_SCALE` from `0.88` to `0.68`, which reduces the computed `POCKET_CAM_BASE_MIN_OUTSIDE` and `POCKET_CAM_BASE_OUTWARD_OFFSET` used by the pocket camera placement logic (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No unit or integration test suites were executed for this change.
- Attempted an automated visual check with Playwright to capture a screenshot of the Pool Royale scene, but the Playwright run timed out and did not complete (visual verification failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b6a6c85388329af2f3b7714e68b7c)