### PR TITLE
Adjust Pool Royale pocket cameras and round wooden rail edges

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -579,7 +579,7 @@ const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 0.16; // subtly round the wooden rail edges so the frame corners are no longer sharp
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 0.3; // round the wooden rail edges so the frame corners feel fully softened
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
@@ -1203,7 +1203,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops furthe
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep the exterior wooden rails straight with no rounding
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.28; // round the exterior wooden rail edges while keeping the rail angles intact
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_GRAVITY = 42; // steeper gravity for a natural fall into the leather cradle
@@ -1263,7 +1263,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.88;
+const POCKET_CAM_EDGE_SCALE = 0.72;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +


### PR DESCRIPTION
### Motivation
- Make the pocket camera framing sit visually closer to the wooden rails and soften the wooden rail edges while preserving existing rail angles and the playfield sides.

### Description
- Tighten pocket camera offsets by lowering `POCKET_CAM_EDGE_SCALE` from `0.88` to `0.72` in `webapp/src/pages/Games/PoolRoyale.jsx` so pocket cams move closer to the rails.
- Increase wooden rail corner rounding by changing `WOOD_RAIL_CORNER_RADIUS_SCALE` from `0.16` to `0.3` to soften frame corners.
- Round the exterior rail edges by setting `RAIL_OUTER_EDGE_RADIUS_RATIO` from `0` to `0.28` while leaving rail angles intact.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready (server started successfully). 
- Attempted an automated Playwright screenshot to validate visuals but the screenshot run timed out and failed. 
- No unit tests (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b6a6c85388329af2f3b7714e68b7c)