### PR TITLE
Adjust Pool Royale pocket camera framing and focus toward incoming ball

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1263,7 +1263,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.72;
+const POCKET_CAM_EDGE_SCALE = 0.62;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1280,14 +1280,14 @@ const POCKET_CAM = Object.freeze({
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
   minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.02,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.15,
+  heightOffset: BALL_R * 0.85,
   heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
   outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
-  heightDrop: BALL_R * 0.2,
+  heightDrop: BALL_R * 0.45,
   distanceScale: 0.96,
   heightScale: 1.02,
-  focusBlend: 0,
+  focusBlend: 0.65,
   lateralFocusShift: 0,
   railFocusLong: BALL_R * 5.6,
   railFocusShort: BALL_R * 6.6
@@ -16090,10 +16090,28 @@ const powerRef = useRef(hud.power);
             const cueBounds = cameraBounds?.cueShot ?? null;
             const standingBounds = cameraBounds?.standing ?? null;
             const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.12;
+            const focusTarget2D = pocketCenter2D.clone();
+            const incomingBallPos = focusBall?.active
+              ? focusBall.pos
+              : activeShotView.lastBallPos;
+            const focusBlend = THREE.MathUtils.clamp(
+              POCKET_CAM.focusBlend ?? 0,
+              0,
+              1
+            );
+            if (
+              focusBlend > 0 &&
+              incomingBallPos &&
+              Number.isFinite(incomingBallPos.x) &&
+              Number.isFinite(incomingBallPos.y)
+            ) {
+              TMP_VEC2_VIEW.set(incomingBallPos.x, incomingBallPos.y);
+              focusTarget2D.lerp(TMP_VEC2_VIEW, focusBlend);
+            }
             const focusTarget = new THREE.Vector3(
-              pocketCenter2D.x * worldScaleFactor,
+              focusTarget2D.x * worldScaleFactor,
               focusHeightLocal,
-              pocketCenter2D.y * worldScaleFactor
+              focusTarget2D.y * worldScaleFactor
             );
             if (
               anchorType === 'short' &&


### PR DESCRIPTION
### Motivation
- Improve pocket camera framing to better match reference photos by tuning distance and height parameters for pocket views. 
- Ensure pocket cameras visually track the incoming ball so the pocket view looks down the shot path.

### Description
- Tweak pocket camera spacing/height constants in `webapp/src/pages/Games/PoolRoyale.jsx`: `POCKET_CAM_EDGE_SCALE` lowered from `0.72` to `0.62`, `POCKET_CAM.heightOffset` reduced, and `POCKET_CAM.heightDrop` increased to bring cameras closer to pocket geometry. 
- Enable blended focus toward the incoming ball by adding a `POCKET_CAM.focusBlend` value (`0.65`) and lerping the pocket view `focusTarget` toward the ball position when available. 
- Keep pocket camera creation and projection handling unchanged while applying the new focus and position smoothing logic so pocket cameras still use the existing `POCKET_CAMERA_FOV` and smoothing pipeline.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully. 
- Attempted an automated screenshot run with Playwright to verify visual framing, but the Chromium headless process crashed (Playwright `TargetClosedError` / SIGSEGV) so the visual smoke test did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b76bc7ba8832989d084a590fc4bbb)