### PR TITLE
Force pocket camera during shots and align cue stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1356,6 +1356,7 @@ const CAMERA_LATERAL_CLAMP = Object.freeze({
 const POCKET_VIEW_MIN_DURATION_MS = 560;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 300;
 const POCKET_VIEW_POST_POT_HOLD_MS = 160;
+const POCKET_VIEW_POST_RAIL_HOLD_MS = 220;
 const POCKET_VIEW_MAX_HOLD_MS = 3200;
 const SPIN_STRENGTH = BALL_R * 0.034;
 const SPIN_DECAY = Math.exp(-PHYSICS_PROFILE.spinDecay * PHYSICS_BASE_STEP);
@@ -1453,8 +1454,9 @@ const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while 
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
-const CUE_STROKE_MIN_MS = 150;
-const CUE_STROKE_MAX_MS = 560;
+const CUE_STROKE_PULLBACK_MS = 160;
+const CUE_STROKE_FORWARD_MS = 120;
+const CUE_STROKE_HOLD_MS = 50;
 const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
@@ -4885,6 +4887,7 @@ const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
 const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
+const POCKET_CAMERA_ONLY = true; // always use pocket cams during shots (no cue-ball follow)
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
 const LONG_SHOT_ACTIVATION_DELAY_MS = 220;
 const LONG_SHOT_ACTIVATION_TRAVEL = PLAY_H * 0.28;
@@ -4897,11 +4900,11 @@ const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
-const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
-const AI_CUE_PULLBACK_DURATION_MS = 3400;
-const AI_CUE_FORWARD_DURATION_MS = 3400;
+const CUE_STROKE_VISUAL_SLOWDOWN = 1;
+const AI_CUE_PULLBACK_DURATION_MS = CUE_STROKE_PULLBACK_MS;
+const AI_CUE_FORWARD_DURATION_MS = CUE_STROKE_FORWARD_MS;
 const AI_STROKE_VISIBLE_DURATION_MS =
-  (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
+  AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS + CUE_STROKE_HOLD_MS;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
 const AI_POST_SHOT_CAMERA_HOLD_MS = AI_STROKE_VISIBLE_DURATION_MS + AI_CAMERA_POST_STROKE_HOLD_MS;
 const SHOT_CAMERA_HOLD_MS = 2000;
@@ -4938,16 +4941,16 @@ const AI_CUE_VIEW_HOLD_MS = 180;
 // Ease the AI camera just partway toward cue view (still above the stick) so the shot preview
 // lingers in a mid-angle frame for a few seconds before firing.
 const AI_CAMERA_DROP_BLEND = 0.65;
-const AI_STROKE_TIME_SCALE = 2.15;
-const AI_STROKE_PULLBACK_FACTOR = 1.05;
+const AI_STROKE_TIME_SCALE = 1;
+const AI_STROKE_PULLBACK_FACTOR = 1;
 const AI_CUE_PULL_VISIBILITY_BOOST = 1.34;
 const AI_WARMUP_PULL_RATIO = 0.55;
 const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.62;
 const PLAYER_STROKE_TIME_SCALE = 1;
 const PLAYER_FORWARD_SLOWDOWN = 1;
-const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
-const PLAYER_PULLBACK_MIN_SCALE = 1.35;
+const PLAYER_STROKE_PULLBACK_FACTOR = 1;
+const PLAYER_PULLBACK_MIN_SCALE = 1;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
@@ -20192,7 +20195,7 @@ const powerRef = useRef(hud.power);
             (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD);
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
-          const suppressPocketCameras = broadcastSystem?.avoidPocketCameras;
+          const suppressPocketCameras = POCKET_CAMERA_ONLY ? false : broadcastSystem?.avoidPocketCameras;
           const forceActionActivation = broadcastSystem?.forceActionActivation;
           const orbitSnapshot = sphRef.current
             ? {
@@ -20219,18 +20222,19 @@ const powerRef = useRef(hud.power);
             : orbitSnapshot
               ? { orbitSnapshot }
               : null;
-          const actionView = allowLongShotCameraSwitch
-            ? makeActionCameraView(
-                cue,
-                shotPrediction.ballId,
-                followView,
-                shotPrediction.railNormal,
-                {
-                  longShot: isLongShot,
-                  travelDistance: predictedTravel
-                }
-              )
-            : null;
+          const actionView =
+            allowLongShotCameraSwitch && !POCKET_CAMERA_ONLY
+              ? makeActionCameraView(
+                  cue,
+                  shotPrediction.ballId,
+                  followView,
+                  shotPrediction.railNormal,
+                  {
+                    longShot: isLongShot,
+                    travelDistance: predictedTravel
+                  }
+                )
+              : null;
           const earlyPocketView =
             !suppressPocketCameras && shotPrediction.ballId && followView
               ? makePocketCameraView(shotPrediction.ballId, followView, {
@@ -20419,51 +20423,13 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
           const impactPos = buildCuePosition(0);
-          const forwardDistance = Math.max(0, startPos.distanceTo(impactPos));
-          const strokeDistance = Math.max(forwardDistance, CUE_PULL_MIN_VISUAL);
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
-          );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
+          const settlePos = impactPos.clone();
           cueStick.visible = true;
           cueStick.position.copy(warmupPos);
-          const cueBallSpeed = Math.max(predictedCueSpeed, 1e-4);
-          const forwardDurationBase = Math.max(
-            1,
-            (forwardDistance / cueBallSpeed) * 1000
-          );
-          const settleSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            curvedPower
-          );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const aiStrokeScale =
-            aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
-          const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
-          const forwardDuration =
-            forwardDurationBase * CUE_STROKE_VISUAL_SLOWDOWN;
-          const settleDuration = isAiStroke
-            ? 0
-            : settleDurationBase * aiStrokeScale * playerStrokeScale * CUE_STROKE_VISUAL_SLOWDOWN;
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : Math.max(
-                CUE_STROKE_MIN_MS * PLAYER_PULLBACK_MIN_SCALE,
-                forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR
-              );
+          const forwardDuration = CUE_STROKE_FORWARD_MS;
+          const settleDuration = CUE_STROKE_HOLD_MS;
+          const pullbackDuration = CUE_STROKE_PULLBACK_MS;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;
@@ -24005,8 +23971,10 @@ const powerRef = useRef(hud.power);
           }
         }
         const suppressPocketCameras =
-          (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
-            ?.avoidPocketCameras;
+          POCKET_CAMERA_ONLY
+            ? false
+            : (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
+              ?.avoidPocketCameras;
         const pocketHoldActive =
           powerImpactHoldRef.current &&
           performance.now() < powerImpactHoldRef.current;
@@ -24318,11 +24286,19 @@ const powerRef = useRef(hud.power);
               pocketView.lastRailHitAt = focusBall.lastRailHitAt;
               pocketView.lastRailHitType =
                 focusBall.lastRailHitType ?? pocketView.lastRailHitType ?? 'rail';
-              const extendTo = now + POCKET_VIEW_ACTIVE_EXTENSION_MS;
+              const extendTo = now + POCKET_VIEW_POST_RAIL_HOLD_MS;
               pocketView.holdUntil =
                 pocketView.holdUntil != null
                   ? Math.max(pocketView.holdUntil, extendTo)
                   : extendTo;
+              pocketView.completed = true;
+              if (now >= pocketView.holdUntil) {
+                resumeAfterPocket(pocketView, now);
+              }
+            } else if (pocketView.completed && pocketView.holdUntil != null) {
+              if (now >= pocketView.holdUntil) {
+                resumeAfterPocket(pocketView, now);
+              }
             } else {
               const toPocket = pocketView.pocketCenter.clone().sub(focusBall.pos);
               const dist = toPocket.length();


### PR DESCRIPTION
### Motivation
- Ensure the camera does not follow the cue ball after a strike and instead stays on a pocket view until the ball either drops or hits cushions. 
- Make the cue stick animation deterministic and match the reference pull/push/hold timing so player and AI strokes share the same visual timing and speed.

### Description
- Introduced explicit stroke timing constants `CUE_STROKE_PULLBACK_MS`, `CUE_STROKE_FORWARD_MS`, and `CUE_STROKE_HOLD_MS` and replaced the previous variable-duration logic with fixed pull/push/hold durations in the cue stroke flow (`computeCuePull` / stroke scheduling). 
- Normalized AI/player stroke timing/visibility by setting `AI_STROKE_TIME_SCALE`, `AI_STROKE_PULLBACK_FACTOR`, `PLAYER_STROKE_PULLBACK_FACTOR`, and `PLAYER_PULLBACK_MIN_SCALE` to 1 and adjusted `CUE_STROKE_VISUAL_SLOWDOWN` to `1` so stroke speed matches the reference pacing. 
- Added `POCKET_CAMERA_ONLY = true` to force pocket camera usage during shots and updated camera selection to avoid action/cue-follow views when this flag is set, and ensured `suppressPocketCameras` respects the new mode. 
- Added `POCKET_VIEW_POST_RAIL_HOLD_MS` and updated pocket-view hold/release logic so a pocket camera remains until the focused ball either stops, hits a rail (extended hold), or the configured post-pot/rail timeout expires.
- Simplified some cue-settle positioning (remove micro-follow retreat calculation) so the visual settle behavior aligns with the fixed timing approach and recorded replay stroke data still captures warmup/start/impact/settle snapshots.

### Testing
- No automated tests were run as part of this change (no CI/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b85121dc88329a59fa65114771514)