### PR TITLE
Pool Royale: Immediate pocket camera and fixed cue stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4897,9 +4897,12 @@ const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
-const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
-const AI_CUE_PULLBACK_DURATION_MS = 3400;
-const AI_CUE_FORWARD_DURATION_MS = 3400;
+const CUE_STROKE_PULLBACK_MS = 120;
+const CUE_STROKE_FORWARD_MS = 120;
+const CUE_STROKE_HOLD_MS = 50;
+const CUE_STROKE_VISUAL_SLOWDOWN = 1;
+const AI_CUE_PULLBACK_DURATION_MS = CUE_STROKE_PULLBACK_MS;
+const AI_CUE_FORWARD_DURATION_MS = CUE_STROKE_FORWARD_MS;
 const AI_STROKE_VISIBLE_DURATION_MS =
   (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -20187,13 +20190,9 @@ const powerRef = useRef(hud.power);
             shotRecording = null;
             shotReplayRef.current = null;
           }
-          const allowLongShotCameraSwitch =
-            !isShortShot &&
-            (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD);
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
           const suppressPocketCameras = broadcastSystem?.avoidPocketCameras;
-          const forceActionActivation = broadcastSystem?.forceActionActivation;
           const orbitSnapshot = sphRef.current
             ? {
                 radius: sphRef.current.radius,
@@ -20219,29 +20218,13 @@ const powerRef = useRef(hud.power);
             : orbitSnapshot
               ? { orbitSnapshot }
               : null;
-          const actionView = allowLongShotCameraSwitch
-            ? makeActionCameraView(
-                cue,
-                shotPrediction.ballId,
-                followView,
-                shotPrediction.railNormal,
-                {
-                  longShot: isLongShot,
-                  travelDistance: predictedTravel
-                }
-              )
-            : null;
           const earlyPocketView =
             !suppressPocketCameras && shotPrediction.ballId && followView
               ? makePocketCameraView(shotPrediction.ballId, followView, {
                   forceEarly: true
                 })
               : null;
-          if (actionView && cameraRef.current) {
-            actionView.smoothedPos = cameraRef.current.position.clone();
-            const storedTarget = lastCameraTargetRef.current?.clone();
-            if (storedTarget) actionView.smoothedTarget = storedTarget;
-          }
+          suspendedActionView = null;
           const appliedSpin = applySpinConstraints(aimDir, true);
           const liftAngle = resolveUserCueLift();
           const liftStrength = normalizeCueLift(liftAngle);
@@ -20419,51 +20402,14 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
           const impactPos = buildCuePosition(0);
           const forwardDistance = Math.max(0, startPos.distanceTo(impactPos));
-          const strokeDistance = Math.max(forwardDistance, CUE_PULL_MIN_VISUAL);
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
-          );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
+          const settlePos = impactPos.clone();
           cueStick.visible = true;
           cueStick.position.copy(warmupPos);
-          const cueBallSpeed = Math.max(predictedCueSpeed, 1e-4);
-          const forwardDurationBase = Math.max(
-            1,
-            (forwardDistance / cueBallSpeed) * 1000
-          );
-          const settleSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            curvedPower
-          );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const aiStrokeScale =
-            aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
-          const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
-          const forwardDuration =
-            forwardDurationBase * CUE_STROKE_VISUAL_SLOWDOWN;
-          const settleDuration = isAiStroke
-            ? 0
-            : settleDurationBase * aiStrokeScale * playerStrokeScale * CUE_STROKE_VISUAL_SLOWDOWN;
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : Math.max(
-                CUE_STROKE_MIN_MS * PLAYER_PULLBACK_MIN_SCALE,
-                forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR
-              );
+          const forwardDuration = CUE_STROKE_FORWARD_MS * CUE_STROKE_VISUAL_SLOWDOWN;
+          const settleDuration = CUE_STROKE_HOLD_MS * CUE_STROKE_VISUAL_SLOWDOWN;
+          const pullbackDuration = CUE_STROKE_PULLBACK_MS * CUE_STROKE_VISUAL_SLOWDOWN;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;
@@ -20480,8 +20426,6 @@ const powerRef = useRef(hud.power);
             powerImpactHoldRef.current || 0,
             forwardPreviewHold
           );
-          const holdUntil = powerImpactHoldRef.current || 0;
-          const holdActive = holdUntil > performance.now();
           let pocketViewActivated = false;
           if (earlyPocketView && !isMaxPowerShot) {
             const now = performance.now();
@@ -20494,46 +20438,10 @@ const powerRef = useRef(hud.power);
                 earlyPocketView.smoothedTarget = storedTarget;
               }
             }
-            if (actionView) {
-              earlyPocketView.resumeAction = actionView;
-              suspendedActionView = actionView;
-            } else {
-              suspendedActionView = null;
-            }
-            if (holdUntil > 0) {
-              const baseDelay = earlyPocketView.activationDelay ?? 0;
-              earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
-            }
-            earlyPocketView.pendingActivation = holdActive;
-            if (holdActive) {
-              queuedPocketView = earlyPocketView;
-              pocketViewActivated = true;
-            } else {
-              queuedPocketView = null;
-              updatePocketCameraState(true);
-              activeShotView = earlyPocketView;
-              pocketViewActivated = true;
-            }
-          }
-          if (!pocketViewActivated && actionView) {
-            const shouldActivateActionView =
-              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
-            if (shouldActivateActionView && !holdActive) {
-              suspendedActionView = null;
-              activeShotView = actionView;
-              updateCamera();
-            } else {
-              actionView.pendingActivation = true;
-              const baseDelay = actionView.activationDelay ?? null;
-              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
-              actionView.activationDelay = delayed > 0 ? delayed : null;
-              const baseTravel = actionView.activationTravel ?? 0;
-              actionView.activationTravel = Math.max(
-                baseTravel,
-                isMaxPowerShot ? BALL_R * 6 : 0
-              );
-              suspendedActionView = actionView;
-            }
+            queuedPocketView = null;
+            updatePocketCameraState(true);
+            activeShotView = earlyPocketView;
+            pocketViewActivated = true;
           }
           if (shotRecording) {
             const strokeStartOffset = Math.max(0, startTime - (shotRecording.startTime ?? startTime));
@@ -24318,11 +24226,7 @@ const powerRef = useRef(hud.power);
               pocketView.lastRailHitAt = focusBall.lastRailHitAt;
               pocketView.lastRailHitType =
                 focusBall.lastRailHitType ?? pocketView.lastRailHitType ?? 'rail';
-              const extendTo = now + POCKET_VIEW_ACTIVE_EXTENSION_MS;
-              pocketView.holdUntil =
-                pocketView.holdUntil != null
-                  ? Math.max(pocketView.holdUntil, extendTo)
-                  : extendTo;
+              resumeAfterPocket(pocketView, now);
             } else {
               const toPocket = pocketView.pocketCenter.clone().sub(focusBall.pos);
               const dist = toPocket.length();


### PR DESCRIPTION
### Motivation
- Improve shot cinematics so the camera switches to the pocket view immediately and stays until the incoming ball either pockets or hits cushions, instead of following the cue ball. 
- Standardize cue stroke animation timing so both player and AI strokes use deterministic pull/push/hold durations matching the desired visual rhythm.

### Description
- Introduced fixed timing constants `CUE_STROKE_PULLBACK_MS`, `CUE_STROKE_FORWARD_MS`, and `CUE_STROKE_HOLD_MS` and set `CUE_STROKE_VISUAL_SLOWDOWN` to `1` to centralize stroke timing. 
- Replaced dynamic duration math with the new fixed durations when building the cue stroke (`pullbackDuration`, `forwardDuration`, `settleDuration`).
- Disabled the long-shot/action follow camera path for shot activation and forced immediate pocket camera activation by creating and activating `earlyPocketView` without queuing or resuming an `actionView`. 
- Made pocket camera resume behavior explicit: pocket view is now exited via `resumeAfterPocket` when the focused ball contacts a rail or when post-pot hold conditions expire. 
- Removed some visual follow-through/backspin retreat calculations that extended the cue follow path so the cue stroke matches the fixed pull/push/hold behavior. 
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b85121dc88329a59fa65114771514)