### PR TITLE
Update Pool Royale cue stroke animation timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -195,6 +195,8 @@ function detectHighRefreshDisplay() {
 }
 
 const randomPick = (list) => list[Math.floor(Math.random() * list.length)];
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const wait = (ms = 0) =>
   new Promise((resolve) => {
@@ -1459,6 +1461,8 @@ const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 20.5;
+const CUE_STRIKE_DURATION_MS = 120;
+const CUE_STRIKE_HOLD_MS = 50;
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.085; // rest the cue a touch lower so the tip lines up with the cue-ball centre on portrait screens
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
@@ -17324,22 +17328,17 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
+            const eased = easeOutCubic(t);
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
           if (localTime <= settleEnd && settleTime > 0) {
-            const t = THREE.MathUtils.clamp(
-              (localTime - impactEnd) / Math.max(settleTime, 1e-6),
-              0,
-              1
-            );
             tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            tmpReplayCueB.set(settleSnap.x, settleSnap.y, settleSnap.z);
             cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            cueStick.position.copy(tmpReplayCueA);
             syncCueShadow();
             return;
           }
@@ -17370,32 +17369,24 @@ const powerRef = useRef(hud.power);
           cueStick.visible = true;
           cueAnimating = true;
           if (now <= pullEndTime && pullbackDuration > 0) {
-            const t = THREE.MathUtils.clamp(
-              (now - startTime) / Math.max(pullbackDuration, 1e-6),
-              0,
-              1
+            const t = clamp01(
+              (now - startTime) / Math.max(pullbackDuration, 1e-6)
             );
             cueStick.position.lerpVectors(warmupPos, startPos, t);
             syncCueShadow();
             return true;
           }
           if (now <= impactTime) {
-            const t = THREE.MathUtils.clamp(
-              (now - pullEndTime) / Math.max(forwardDuration, 1e-6),
-              0,
-              1
+            const t = clamp01(
+              (now - pullEndTime) / Math.max(forwardDuration, 1e-6)
             );
-            cueStick.position.lerpVectors(startPos, impactPos, t);
+            const eased = easeOutCubic(t);
+            cueStick.position.lerpVectors(startPos, impactPos, eased);
             syncCueShadow();
             return true;
           }
           if (now <= settleTime && settleDuration > 0) {
-            const t = THREE.MathUtils.clamp(
-              (now - impactTime) / Math.max(settleDuration, 1e-6),
-              0,
-              1
-            );
-            cueStick.position.lerpVectors(impactPos, settlePos, t);
+            cueStick.position.copy(impactPos);
             syncCueShadow();
             return true;
           }
@@ -20373,12 +20364,6 @@ const powerRef = useRef(hud.power);
           );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
-          const minVisibleGap = Math.max(MIN_PULLBACK_GAP, visualPull * 0.08);
-          const warmupPull = Math.max(
-            0,
-            Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
-          );
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
@@ -20397,67 +20382,21 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const startPos = buildCuePosition(visualPull);
-          const warmupPos = buildCuePosition(warmupPull);
-          cueStick.position.copy(warmupPos);
+          const warmupPos = startPos.clone();
+          cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
           const impactPos = buildCuePosition(0);
-          const forwardDistance = Math.max(0, startPos.distanceTo(impactPos));
-          const strokeDistance = Math.max(forwardDistance, CUE_PULL_MIN_VISUAL);
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
-          );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
           cueStick.visible = true;
-          cueStick.position.copy(warmupPos);
-          const cueBallSpeed = Math.max(predictedCueSpeed, 1e-4);
-          const forwardDurationBase = Math.max(
-            1,
-            (forwardDistance / cueBallSpeed) * 1000
-          );
-          const settleSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            curvedPower
-          );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const aiStrokeScale =
-            aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
-          const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
-          const forwardDuration =
-            forwardDurationBase * CUE_STROKE_VISUAL_SLOWDOWN;
-          const settleDuration = isAiStroke
-            ? 0
-            : settleDurationBase * aiStrokeScale * playerStrokeScale * CUE_STROKE_VISUAL_SLOWDOWN;
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : Math.max(
-                CUE_STROKE_MIN_MS * PLAYER_PULLBACK_MIN_SCALE,
-                forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR
-              );
+          cueStick.position.copy(startPos);
+          const pullbackDuration = 0;
+          const forwardDuration = CUE_STRIKE_DURATION_MS;
+          const settleDuration = CUE_STRIKE_HOLD_MS;
           const startTime = performance.now();
-          const pullEndTime = startTime + pullbackDuration;
-          const impactTime = pullEndTime + forwardDuration;
+          const pullEndTime = startTime;
+          const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
-          const impactHoldBuffer = Math.max(
-            240,
-            Math.min(
-              Math.max(settleDuration, 240),
-              Math.max(240, forwardDuration * 1.05)
-            )
-          );
-          const forwardPreviewHold = impactTime + impactHoldBuffer;
+          const forwardPreviewHold = impactTime + settleDuration;
           powerImpactHoldRef.current = Math.max(
             powerImpactHoldRef.current || 0,
             forwardPreviewHold
@@ -20523,7 +20462,7 @@ const powerRef = useRef(hud.power);
               warmup: serializeVector3Snapshot(warmupPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(settlePos),
+              settle: serializeVector3Snapshot(impactPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               pullbackDuration,
@@ -20540,7 +20479,7 @@ const powerRef = useRef(hud.power);
             warmupPos: warmupPos.clone(),
             startPos: startPos.clone(),
             impactPos: impactPos.clone(),
-            settlePos: settlePos.clone(),
+            settlePos: impactPos.clone(),
             pullbackDuration,
             forwardDuration,
             settleDuration


### PR DESCRIPTION
### Motivation
- Replace the existing variable-duration cue animation with a fixed pull/push cadence and ease-out push so live and replay strokes match the reference pull/push motion and feel consistent.

### Description
- Add small helper utilities `clamp01` and `easeOutCubic` and new timing constants `CUE_STRIKE_DURATION_MS` and `CUE_STRIKE_HOLD_MS` to drive the new cadence.
- Update replay stroke code to use `easeOutCubic` for the forward push and hold the cue at the impact position instead of blending through a separate settle lerp.
- Simplify live stroke animation: collapse warmup/pullback variability, set `pullbackDuration = 0`, `forwardDuration = CUE_STRIKE_DURATION_MS` and `settleDuration = CUE_STRIKE_HOLD_MS`, and use the same easing for the push so live/replay animations match.
- Replace a few per-shot dynamic duration calculations and related backspin/warmup visual branching with the fixed-ease model so behavior is deterministic and consistent.

### Testing
- Started the dev server with `npm run dev` and Vite reported the app served (Local/Network URLs); startup succeeded.
- Attempted an automated Playwright screenshot of `/games/poolroyale` to visually verify the cue animation, but the screenshot run timed out and did not complete.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bae3098d0832981bf1061e3683a3b)