### PR TITLE
Pool Royale: Replace cue stroke with ease‑out pull/push, add wobble and topspin follow‑through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -195,6 +195,8 @@ function detectHighRefreshDisplay() {
 }
 
 const randomPick = (list) => list[Math.floor(Math.random() * list.length)];
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const wait = (ms = 0) =>
   new Promise((resolve) => {
@@ -1443,9 +1445,9 @@ const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned wi
 const CUE_TIP_CLEARANCE = BALL_R * 0.02; // keep the tip aligned without overreaching the cue ball
 const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
+const CUE_PULL_RANGE = BALL_R * 6.2; // match the reference pull distance used for the new cue animation
 const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.85;
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
@@ -1459,6 +1461,11 @@ const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 20.5;
+const CUE_STRIKE_DURATION_MS = 120;
+const CUE_STRIKE_HOLD_MS = 50;
+const CUE_STRIKE_DIP = BALL_R * 0.06; // subtle downward dip during the forward push
+const CUE_STRIKE_WOBBLE = 0.0018; // match the slight cue wobble from the reference animation
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 0.3; // small follow-through for topspin shots
 const CUE_Y = BALL_CENTER_Y - BALL_R * 0.085; // rest the cue a touch lower so the tip lines up with the cue-ball centre on portrait screens
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
@@ -17299,12 +17306,14 @@ const powerRef = useRef(hud.power);
           const settleEnd = impactEnd + settleTime;
           tmpReplayCueA.set(warmupSnap.x, warmupSnap.y, warmupSnap.z);
           tmpReplayCueB.set(startSnap.x, startSnap.y, startSnap.z);
-          cueStick.rotation.y = Number.isFinite(stroke.rotationY)
+          const baseRotationY = Number.isFinite(stroke.rotationY)
             ? stroke.rotationY
             : cueStick.rotation.y;
-          cueStick.rotation.x = Number.isFinite(stroke.rotationX)
+          const baseRotationX = Number.isFinite(stroke.rotationX)
             ? stroke.rotationX
             : cueStick.rotation.x;
+          cueStick.rotation.y = baseRotationY;
+          cueStick.rotation.x = baseRotationX;
           cueStick.visible = true;
           cueAnimating = true;
           if (localTime <= 0) {
@@ -17324,22 +17333,22 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
+            const eased = easeOutCubic(t);
+            const wobble = Math.sin(t * Math.PI) * CUE_STRIKE_WOBBLE;
+            cueStick.rotation.y = baseRotationY + wobble;
+            cueStick.rotation.x = baseRotationX;
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
           if (localTime <= settleEnd && settleTime > 0) {
-            const t = THREE.MathUtils.clamp(
-              (localTime - impactEnd) / Math.max(settleTime, 1e-6),
-              0,
-              1
-            );
+            cueStick.rotation.y = baseRotationY;
+            cueStick.rotation.x = baseRotationX;
             tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            tmpReplayCueB.set(settleSnap.x, settleSnap.y, settleSnap.z);
             cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            cueStick.position.copy(tmpReplayCueA);
             syncCueShadow();
             return;
           }
@@ -17365,37 +17374,44 @@ const powerRef = useRef(hud.power);
             settlePos,
             pullbackDuration,
             forwardDuration,
-            settleDuration
+            settleDuration,
+            rotationX,
+            rotationY
           } = stroke;
+          const baseRotationY = Number.isFinite(rotationY)
+            ? rotationY
+            : cueStick.rotation.y;
+          const baseRotationX = Number.isFinite(rotationX)
+            ? rotationX
+            : cueStick.rotation.x;
+          cueStick.rotation.y = baseRotationY;
+          cueStick.rotation.x = baseRotationX;
           cueStick.visible = true;
           cueAnimating = true;
           if (now <= pullEndTime && pullbackDuration > 0) {
-            const t = THREE.MathUtils.clamp(
-              (now - startTime) / Math.max(pullbackDuration, 1e-6),
-              0,
-              1
+            const t = clamp01(
+              (now - startTime) / Math.max(pullbackDuration, 1e-6)
             );
             cueStick.position.lerpVectors(warmupPos, startPos, t);
             syncCueShadow();
             return true;
           }
           if (now <= impactTime) {
-            const t = THREE.MathUtils.clamp(
-              (now - pullEndTime) / Math.max(forwardDuration, 1e-6),
-              0,
-              1
+            const t = clamp01(
+              (now - pullEndTime) / Math.max(forwardDuration, 1e-6)
             );
-            cueStick.position.lerpVectors(startPos, impactPos, t);
+            const eased = easeOutCubic(t);
+            const wobble = Math.sin(t * Math.PI) * CUE_STRIKE_WOBBLE;
+            cueStick.rotation.y = baseRotationY + wobble;
+            cueStick.rotation.x = baseRotationX;
+            cueStick.position.lerpVectors(startPos, impactPos, eased);
             syncCueShadow();
             return true;
           }
           if (now <= settleTime && settleDuration > 0) {
-            const t = THREE.MathUtils.clamp(
-              (now - impactTime) / Math.max(settleDuration, 1e-6),
-              0,
-              1
-            );
-            cueStick.position.lerpVectors(impactPos, settlePos, t);
+            cueStick.rotation.y = baseRotationY;
+            cueStick.rotation.x = baseRotationX;
+            cueStick.position.copy(impactPos);
             syncCueShadow();
             return true;
           }
@@ -19965,11 +19981,10 @@ const powerRef = useRef(hud.power);
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const curved = Math.pow(ratio, CUE_POWER_GAMMA);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
-        const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
         const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const target = amplifiedMax * curved * CUE_PULL_VISUAL_MULTIPLIER;
+        const eased = easeOutCubic(ratio);
+        const target = CUE_PULL_RANGE * eased;
         return Math.min(target, visualMax);
       };
       const clampCueTipOffset = (vec, limit = BALL_R) => {
@@ -20373,12 +20388,6 @@ const powerRef = useRef(hud.power);
           );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
-          const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
-          const minVisibleGap = Math.max(MIN_PULLBACK_GAP, visualPull * 0.08);
-          const warmupPull = Math.max(
-            0,
-            Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
-          );
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
@@ -20397,67 +20406,27 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const startPos = buildCuePosition(visualPull);
-          const warmupPos = buildCuePosition(warmupPull);
-          cueStick.position.copy(warmupPos);
+          const warmupPos = startPos.clone();
+          cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
-          const impactPos = buildCuePosition(0);
-          const forwardDistance = Math.max(0, startPos.distanceTo(impactPos));
-          const strokeDistance = Math.max(forwardDistance, CUE_PULL_MIN_VISUAL);
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
+          const topspinStrength = Math.max(0, appliedSpin?.y ?? 0) * clampedPower;
+          const followThrough = Math.min(
+            CUE_FOLLOW_THROUGH_MAX,
+            topspinStrength * CUE_FOLLOW_THROUGH_MAX
           );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
+          const impactPos = buildCuePosition(-followThrough);
+          impactPos.y -= CUE_STRIKE_DIP;
           cueStick.visible = true;
-          cueStick.position.copy(warmupPos);
-          const cueBallSpeed = Math.max(predictedCueSpeed, 1e-4);
-          const forwardDurationBase = Math.max(
-            1,
-            (forwardDistance / cueBallSpeed) * 1000
-          );
-          const settleSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            curvedPower
-          );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const aiStrokeScale =
-            aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
-          const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
-          const forwardDuration =
-            forwardDurationBase * CUE_STROKE_VISUAL_SLOWDOWN;
-          const settleDuration = isAiStroke
-            ? 0
-            : settleDurationBase * aiStrokeScale * playerStrokeScale * CUE_STROKE_VISUAL_SLOWDOWN;
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : Math.max(
-                CUE_STROKE_MIN_MS * PLAYER_PULLBACK_MIN_SCALE,
-                forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR
-              );
+          cueStick.position.copy(startPos);
+          const pullbackDuration = 0;
+          const forwardDuration = CUE_STRIKE_DURATION_MS;
+          const settleDuration = CUE_STRIKE_HOLD_MS;
           const startTime = performance.now();
-          const pullEndTime = startTime + pullbackDuration;
-          const impactTime = pullEndTime + forwardDuration;
+          const pullEndTime = startTime;
+          const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
-          const impactHoldBuffer = Math.max(
-            240,
-            Math.min(
-              Math.max(settleDuration, 240),
-              Math.max(240, forwardDuration * 1.05)
-            )
-          );
-          const forwardPreviewHold = impactTime + impactHoldBuffer;
+          const forwardPreviewHold = impactTime + settleDuration;
           powerImpactHoldRef.current = Math.max(
             powerImpactHoldRef.current || 0,
             forwardPreviewHold
@@ -20523,7 +20492,7 @@ const powerRef = useRef(hud.power);
               warmup: serializeVector3Snapshot(warmupPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(settlePos),
+              settle: serializeVector3Snapshot(impactPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               pullbackDuration,
@@ -20540,10 +20509,12 @@ const powerRef = useRef(hud.power);
             warmupPos: warmupPos.clone(),
             startPos: startPos.clone(),
             impactPos: impactPos.clone(),
-            settlePos: settlePos.clone(),
+            settlePos: impactPos.clone(),
             pullbackDuration,
             forwardDuration,
-            settleDuration
+            settleDuration,
+            rotationX: cueStick.rotation.x,
+            rotationY: cueStick.rotation.y
           };
         };
         let aiThinkingHandle = null;


### PR DESCRIPTION
### Motivation
- Replace the existing variable-duration cue animation with a new pull/push cadence that matches the provided reference (same pull curve and forward push timing/feel). 
- Ensure live shots and replay strokes use the same easing and impact pose so visual feedback is consistent between play and replay. 
- Add a subtle visual polish (downward dip, slight wobble, and small topspin follow-through) to match the reference motion.

### Description
- Added new constants `CUE_PULL_RANGE`, `CUE_STRIKE_DIP`, `CUE_STRIKE_WOBBLE`, `CUE_FOLLOW_THROUGH_MAX` and kept fixed strike timing with `CUE_STRIKE_DURATION_MS` / `CUE_STRIKE_HOLD_MS` to drive the new cadence. 
- Rewrote `computePullTargetFromPower` to use `easeOutCubic` over `CUE_PULL_RANGE` (removed previous visual multiplier logic) so pull distance follows the reference ease-out curve. 
- Updated live shot flow to: use zero visual pullback, use fixed forward/hold durations, compute `impactPos` with a small topspin follow-through and a downward dip, and apply a small rotation wobble during the forward push. 
- Updated replay stroke logic to store/read `rotationX/rotationY`, apply the same ease-out forward interpolation and wobble on playback, and hold at impact for the settle period to match the live stroke.

### Testing
- Started the development server with `npm run dev` and Vite reported the app served successfully (local dev server up). 
- Ran an automated Playwright page script to capture a screenshot of `/games/poolroyale`; initial attempts timed out but a final run produced a screenshot artifact (`artifacts/pool-royale-cue.png`). 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bae3098d0832981bf1061e3683a3b)