### PR TITLE
Adjust cue stick follow-through positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20415,7 +20415,10 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_THROUGH_MAX,
             topspinStrength * CUE_FOLLOW_THROUGH_MAX
           );
-          const impactPos = buildCuePosition(-followThrough);
+          const contactBack = BALL_R + CUE_TIP_CLEARANCE;
+          const endBack = Math.max(BALL_R * 0.55, contactBack - followThrough);
+          const impactPull = endBack - CUE_TIP_GAP;
+          const impactPos = buildCuePosition(impactPull);
           impactPos.y -= CUE_STRIKE_DIP;
           cueStick.visible = true;
           cueStick.position.copy(startPos);


### PR DESCRIPTION
### Motivation
- Ensure the cue stick forward push reads correctly by accounting for the physical contact distance and topspin follow-through when computing the impact position.

### Description
- Replace the previous `buildCuePosition(-followThrough)` impact calc with an explicit contact-aware computation that derives `contactBack`, clamps the follow-through, computes `impactPull = endBack - CUE_TIP_GAP`, and uses `buildCuePosition(impactPull)` for the impact target.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc7a1e184832980b7c1f5c3db77ab)