### PR TITLE
Adjust cue strike follow-through for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20411,11 +20411,15 @@ const powerRef = useRef(hud.power);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const topspinStrength = Math.max(0, appliedSpin?.y ?? 0) * clampedPower;
-          const followThrough = Math.min(
-            CUE_FOLLOW_THROUGH_MAX,
-            topspinStrength * CUE_FOLLOW_THROUGH_MAX
+          const followExtra = THREE.MathUtils.clamp(
+            topspinStrength * (BALL_R * 0.29),
+            0,
+            BALL_R * 0.33
           );
-          const impactPos = buildCuePosition(-followThrough);
+          const strikeGapMin = BALL_R * 0.55;
+          const impactGap = Math.max(strikeGapMin, CUE_TIP_GAP - followExtra);
+          const impactPull = impactGap - CUE_TIP_GAP;
+          const impactPos = buildCuePosition(impactPull);
           impactPos.y -= CUE_STRIKE_DIP;
           cueStick.visible = true;
           cueStick.position.copy(startPos);


### PR DESCRIPTION
### Motivation
- Make the Pool Royale cue strike animation use a topspin-driven micro follow-through so the cue visibly pushes slightly past contact with the same timing/scale logic as the reference animation, and keep the impact gap clamped to a safe minimum relative to ball radius.

### Description
- Replaced the previous `followThrough` computation with a `followExtra` clamped to a fraction of `BALL_R`, then compute a safe `impactGap` (clamped to `BALL_R * 0.55`) and `impactPull` and use `buildCuePosition(impactPull)` to set the impact position; change applied in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Launched the local webapp using `npm --prefix webapp run dev` and captured a mobile-viewport screenshot via a Playwright script to verify the visual cue stroke behavior, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc7a1e184832980b7c1f5c3db77ab)