### PR TITLE
Anchor cue strike animation and align follow-through push

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -17376,7 +17376,13 @@ const powerRef = useRef(hud.power);
             forwardDuration,
             settleDuration,
             rotationX,
-            rotationY
+            rotationY,
+            anchor,
+            dir,
+            spinWorld,
+            startPull,
+            followThrough,
+            strikeDip
           } = stroke;
           const baseRotationY = Number.isFinite(rotationY)
             ? rotationY
@@ -17404,7 +17410,24 @@ const powerRef = useRef(hud.power);
             const wobble = Math.sin(t * Math.PI) * CUE_STRIKE_WOBBLE;
             cueStick.rotation.y = baseRotationY + wobble;
             cueStick.rotation.x = baseRotationX;
-            cueStick.position.lerpVectors(startPos, impactPos, eased);
+            if (anchor && dir && spinWorld && Number.isFinite(startPull)) {
+              const pullAmount = THREE.MathUtils.lerp(
+                startPull,
+                -(followThrough ?? 0),
+                eased
+              );
+              const tipTarget = resolveCueTipTargetFromAnchor(
+                anchor,
+                dir,
+                pullAmount,
+                spinWorld,
+                (strikeDip ?? CUE_STRIKE_DIP) * eased
+              );
+              applyCueStickTransform(tipTarget);
+              clampCueButtAboveCushion(tipTarget);
+            } else {
+              cueStick.position.lerpVectors(startPos, impactPos, eased);
+            }
             syncCueShadow();
             return true;
           }
@@ -18937,6 +18960,16 @@ const powerRef = useRef(hud.power);
           CUE_Y + spinWorld.y,
           cue.pos.y - dir.z * (CUE_TIP_GAP + pullAmount) + spinWorld.z
         );
+      const resolveCueTipTargetFromAnchor = (anchor, dir, pullAmount, spinWorld, dip = 0) => {
+        const baseX = Number.isFinite(anchor?.x) ? anchor.x : cue.pos.x;
+        const baseZ = Number.isFinite(anchor?.z) ? anchor.z : cue.pos.y;
+        const baseY = Number.isFinite(anchor?.y) ? anchor.y : CUE_Y;
+        return TMP_VEC3_CUE_TIP_TARGET.set(
+          baseX - dir.x * (CUE_TIP_GAP + pullAmount) + spinWorld.x,
+          baseY + spinWorld.y - dip,
+          baseZ - dir.z * (CUE_TIP_GAP + pullAmount) + spinWorld.z
+        );
+      };
       const applyCueStickTransform = (tipTarget) => {
         TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
         TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
@@ -20405,6 +20438,7 @@ const powerRef = useRef(hud.power);
             return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
+          const cueAnchor = new THREE.Vector3(cue.pos.x, CUE_Y, cue.pos.y);
           const startPos = buildCuePosition(visualPull);
           const warmupPos = startPos.clone();
           cueStick.position.copy(startPos);
@@ -20514,7 +20548,13 @@ const powerRef = useRef(hud.power);
             forwardDuration,
             settleDuration,
             rotationX: cueStick.rotation.x,
-            rotationY: cueStick.rotation.y
+            rotationY: cueStick.rotation.y,
+            anchor: cueAnchor.clone(),
+            dir: dir.clone(),
+            spinWorld: spinWorld.clone(),
+            startPull: visualPull,
+            followThrough,
+            strikeDip: CUE_STRIKE_DIP
           };
         };
         let aiThinkingHandle = null;


### PR DESCRIPTION
### Motivation
- Make the cue push animation use a fixed world anchor and match the referenced push/follow-through behavior so the cue does not follow the moving cue ball and the forward push reads consistently at the same speed.
- Improve visual clarity for topspin/backspin follow-through and include strike dip for a more faithful and stable strike animation in cue view.

### Description
- Added `resolveCueTipTargetFromAnchor` to compute the cue tip target from a fixed anchor (including an optional dip) instead of using the live cue position. 
- Capture and store the strike `anchor`, `dir`, `spinWorld`, `startPull`, `followThrough`, and `strikeDip` into `cueStrokeStateRef` when the stroke is started so the forward push animation is driven from that anchor.
- Updated `updateCueStroke` to lerp the tip pullAmount from `startPull` to the negative follow-through using `easeOutCubic`, applying the anchored tip target during the forward phase and clamping the butt above cushions as before.
- Preserve the previous fallback behavior when anchor data is not available so existing cases remain unchanged.

### Testing
- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which launched Vite successfully (dev server ready). 
- Attempted a headless browser capture using Playwright to verify the visual change, but the screenshot run timed out (Playwright `Page.screenshot` timed out), so rendering verification via CI screenshot failed.
- No automated unit or integration tests were executed against the modified code in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc7a1e184832980b7c1f5c3db77ab)