### PR TITLE
Match Pool Royale cue stick animation timing

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -9,6 +9,8 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
+      onStart,
+      onEnd,
       theme = 'default',
       labels = false
     } = opts;
@@ -21,6 +23,8 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
+    this.onStart = onStart;
+    this.onEnd = onEnd;
     this.locked = false;
 
     this.el = document.createElement('div');
@@ -206,6 +210,7 @@ export class PowerSlider {
     this.dragging = true;
     this.dragMoved = false;
     this.dragStartValue = this.value;
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
     this.pointerStartY = e.clientY;
@@ -231,9 +236,11 @@ export class PowerSlider {
     const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
     if (!moved) {
       this.set(this.dragStartValue, { animate: true });
+      if (typeof this.onEnd === 'function') this.onEnd(this.value);
       return;
     }
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
+    if (typeof this.onEnd === 'function') this.onEnd(this.value);
   }
 
   _wheel(e) {


### PR DESCRIPTION
### Motivation
- Make the Pool Royale cue animation visually identical to the provided reference by matching idle breathing, pull dip and anchored strike behaviors for fidelity with the existing cue stick and spin controller logic.

### Description
- Added `onStart`/`onEnd` hooks to the `PowerSlider` API (`power-slider.js`) so callers can capture pull start/end events and anchor the cue during a pull. The slider now calls `onStart` when dragging begins and `onEnd` when the drag ends.
- Introduced an anchored cue workflow in `PoolRoyale.jsx`: added `cueAnchorRef`, extended `resolveCueTipTarget` to accept an `anchorPos`, and capture the current cue position when the slider pull starts or when the shot `fire` begins so the cue does not follow the moving ball.
- Matched the reference animation timing and feel by adding `easeInOutQuad`, idle breathe parameters (`CUE_IDLE_BREATHE_SPEED`, `CUE_IDLE_BREATHE`) and a pull dip (`CUE_PULL_DIP`), and applying these to `visualPull` and the tip offsets so pull/backspin follow-through and micro-breathing match the reference.
- Wired the slider into the game UI: the `PoolRoyalePowerSlider` instance is created with `onStart` to capture the cue anchor; the existing commit flow still calls `fire` on release.

### Testing
- Dev server: started the web app dev server with `npm run dev` and Vite reported ready (local/network URLs), which confirms the app compiles and serves after changes.
- Playwright screenshot: attempted automated page screenshot of `/games/poolroyale` with Playwright, but the screenshot run timed out (screenshot failed); no visual regression image was produced.
- Unit / automated tests: none run for this change (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd581c40483298ec9b9dab732c6eb)