### PR TITLE
Fix Pool Royale cue stroke animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -194,6 +194,10 @@ function detectHighRefreshDisplay() {
   return false;
 }
 
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOutQuad = (t) =>
+  t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+
 const randomPick = (list) => list[Math.floor(Math.random() * list.length)];
 
 const wait = (ms = 0) =>
@@ -1455,6 +1459,8 @@ const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_STROKE_MIN_MS = 150;
 const CUE_STROKE_MAX_MS = 560;
+const CUE_STRIKE_DURATION_MS = 120;
+const CUE_STRIKE_HOLD_MS = 50;
 const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
@@ -11707,6 +11713,7 @@ function PoolRoyaleGame({
   );
   const shotCameraHoldTimeoutRef = useRef(null);
   const cueStrokeStateRef = useRef(null);
+  const cueHoldRef = useRef(null);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
   useEffect(
     () => () => {
@@ -17313,8 +17320,13 @@ const powerRef = useRef(hud.power);
             return;
           }
           if (localTime <= pullEnd && pullback > 0) {
-            const t = THREE.MathUtils.clamp(localTime / Math.max(pullback, 1e-6), 0, 1);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            const t = THREE.MathUtils.clamp(
+              localTime / Math.max(pullback, 1e-6),
+              0,
+              1
+            );
+            const eased = easeInOutQuad(t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -17324,9 +17336,10 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
+            const eased = easeOutCubic(t);
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -17363,6 +17376,7 @@ const powerRef = useRef(hud.power);
             startPos,
             impactPos,
             settlePos,
+            idlePos,
             pullbackDuration,
             forwardDuration,
             settleDuration
@@ -17375,7 +17389,8 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            cueStick.position.lerpVectors(warmupPos, startPos, t);
+            const eased = easeInOutQuad(t);
+            cueStick.position.lerpVectors(warmupPos, startPos, eased);
             syncCueShadow();
             return true;
           }
@@ -17385,21 +17400,24 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            cueStick.position.lerpVectors(startPos, impactPos, t);
+            const eased = easeOutCubic(t);
+            cueStick.position.lerpVectors(startPos, impactPos, eased);
             syncCueShadow();
             return true;
           }
           if (now <= settleTime && settleDuration > 0) {
-            const t = THREE.MathUtils.clamp(
-              (now - impactTime) / Math.max(settleDuration, 1e-6),
-              0,
-              1
-            );
-            cueStick.position.lerpVectors(impactPos, settlePos, t);
+            cueStick.position.copy(impactPos);
             syncCueShadow();
             return true;
           }
-          cueStick.visible = false;
+          if (idlePos) {
+            cueStick.position.copy(idlePos);
+            cueHoldRef.current = {
+              position: idlePos.clone(),
+              rotationX: cueStick.rotation.x,
+              rotationY: cueStick.rotation.y
+            };
+          }
           cueAnimating = false;
           cuePullCurrentRef.current = 0;
           cuePullTargetRef.current = 0;
@@ -20401,51 +20419,24 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          const backSpinRetreat =
-            BALL_R * (1 + 2.25 * clampedPower) * backSpinWeight;
-          const impactPos = buildCuePosition(0);
-          const forwardDistance = Math.max(0, startPos.distanceTo(impactPos));
-          const strokeDistance = Math.max(forwardDistance, CUE_PULL_MIN_VISUAL);
-          const retreatDistance = Math.max(
-            BALL_R * 1.5,
-            Math.min(strokeDistance, BALL_R * 8)
+          const topspinFactor = Math.max(0, physicsSpin.y || 0) * clampedPower;
+          const minTipGap = BALL_R * 0.55;
+          const maxForward = Math.max(0, CUE_TIP_GAP - minTipGap);
+          const followExtra = THREE.MathUtils.clamp(
+            topspinFactor * BALL_R * (0.016 / 0.055),
+            0,
+            maxForward
           );
-          const totalRetreat = retreatDistance + backSpinRetreat;
-          const settlePos = impactPos
-            .clone()
-            .sub(dir.clone().multiplyScalar(totalRetreat));
+          const impactPull = -followExtra;
+          const impactPos = buildCuePosition(impactPull);
+          const idlePos = buildCuePosition(0);
           cueStick.visible = true;
           cueStick.position.copy(warmupPos);
-          const cueBallSpeed = Math.max(predictedCueSpeed, 1e-4);
-          const forwardDurationBase = Math.max(
-            1,
-            (forwardDistance / cueBallSpeed) * 1000
-          );
-          const settleSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            curvedPower
-          );
-          const settleDurationBase = THREE.MathUtils.clamp(
-            (totalRetreat / Math.max(settleSpeed, 1e-4)) * 1000 * (backSpinWeight > 0 ? 0.82 : 1),
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const aiStrokeScale =
-            aiOpponentEnabled && hudRef.current?.turn === 1 ? AI_STROKE_TIME_SCALE : 1;
-          const playerStrokeScale = isAiStroke ? 1 : PLAYER_STROKE_TIME_SCALE;
-          const forwardDuration =
-            forwardDurationBase * CUE_STROKE_VISUAL_SLOWDOWN;
-          const settleDuration = isAiStroke
-            ? 0
-            : settleDurationBase * aiStrokeScale * playerStrokeScale * CUE_STROKE_VISUAL_SLOWDOWN;
+          const forwardDuration = CUE_STRIKE_DURATION_MS;
           const pullbackDuration = isAiStroke
             ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : Math.max(
-                CUE_STROKE_MIN_MS * PLAYER_PULLBACK_MIN_SCALE,
-                forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR
-              );
+            : 0;
+          const settleDuration = CUE_STRIKE_HOLD_MS;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;
@@ -20523,7 +20514,7 @@ const powerRef = useRef(hud.power);
               warmup: serializeVector3Snapshot(warmupPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(settlePos),
+              settle: serializeVector3Snapshot(impactPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               pullbackDuration,
@@ -20540,7 +20531,8 @@ const powerRef = useRef(hud.power);
             warmupPos: warmupPos.clone(),
             startPos: startPos.clone(),
             impactPos: impactPos.clone(),
-            settlePos: settlePos.clone(),
+            settlePos: impactPos.clone(),
+            idlePos: idlePos.clone(),
             pullbackDuration,
             forwardDuration,
             settleDuration
@@ -23038,6 +23030,7 @@ const powerRef = useRef(hud.power);
 
         sidePocketAimRef.current = false;
         if (canShowCue && (isPlayerTurn || previewingAiShot)) {
+          cueHoldRef.current = null;
           const baseAimDir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (baseAimDir.lengthSq() < 1e-8) baseAimDir.set(0, 0, 1);
           else baseAimDir.normalize();
@@ -23358,6 +23351,7 @@ const powerRef = useRef(hud.power);
             target.visible = false;
           }
         } else if (showingRemoteAim) {
+          cueHoldRef.current = null;
           aimFocusRef.current = null;
           const remoteAimDir = new THREE.Vector2(
             remoteAimState?.dir?.x ?? 0,
@@ -23510,6 +23504,7 @@ const powerRef = useRef(hud.power);
             target.visible = false;
           }
         } else if (canShowCue && activeAiPlan && !previewingAiShot) {
+          cueHoldRef.current = null;
           aim.visible = false;
           tick.visible = false;
           target.visible = false;
@@ -23573,7 +23568,27 @@ const powerRef = useRef(hud.power);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
           cueStick.visible = true;
+        } else if (
+          cueHoldRef.current &&
+          cue?.active &&
+          !currentHud?.over &&
+          !(inHandPlacementModeRef.current) &&
+          (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current)
+        ) {
+          aimFocusRef.current = null;
+          aim.visible = false;
+          tick.visible = false;
+          target.visible = false;
+          cueAfter.visible = false;
+          impactRing.visible = false;
+          const hold = cueHoldRef.current;
+          cueStick.visible = true;
+          if (Number.isFinite(hold.rotationY)) cueStick.rotation.y = hold.rotationY;
+          if (Number.isFinite(hold.rotationX)) cueStick.rotation.x = hold.rotationX;
+          cueStick.position.copy(hold.position);
+          syncCueShadow();
         } else {
+          cueHoldRef.current = null;
           aimFocusRef.current = null;
           aim.visible = false;
           tick.visible = false;


### PR DESCRIPTION
### Motivation
- Bring Pool Royale cue stroke visuals and timing in line with the provided reference (match push/pull cadence, follow-through and hold behavior).
- Ensure the cue remains visible and correctly posed after impact so the visual stroke matches the spinning controller and ball interactions.

### Description
- Added easing helpers `easeOutCubic` and `easeInOutQuad` and new timing constants `CUE_STRIKE_DURATION_MS` and `CUE_STRIKE_HOLD_MS` to `webapp/src/pages/Games/PoolRoyale.jsx` for consistent animation curves and durations.
- Reworked the cue stroke playback and live stroke update logic (`updateCueStroke` / replay path) to use the new easing functions for pull, forward strike and impact interpolation, replacing linear lerps with eased interpolation.
- Implemented topspin follow-through by computing a small forward tip offset at impact and using that for the impact pose, and replaced the previous multi-phase settle with an immediate impact-hold then an idle pose.
- Added `cueHoldRef` to cache an idle cue pose after the stroke so the cue stays visible and positioned while the balls roll, and hooked that cached pose into the main rendering branch when normal cue rendering would be hidden.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bee86366c8329869cdc503fe6b3b5)