### PR TITLE
Adjust Pool Royale cue stroke pullback animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20412,7 +20412,7 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const startPos = buildCuePosition(visualPull);
-          const warmupPos = isAiStroke ? buildCuePosition(warmupPull) : startPos.clone();
+          const warmupPos = buildCuePosition(warmupPull);
           cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -20431,7 +20431,7 @@ const powerRef = useRef(hud.power);
           const settleDuration = CUE_STRIKE_HOLD_MS;
           const pullbackDuration = isAiStroke
             ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : 0;
+            : forwardDuration * PLAYER_STROKE_TIME_SCALE;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;


### PR DESCRIPTION
### Motivation
- Restore a visible pullback for the player cue and make the pull and push phases share timing so the cue's pull/push motion matches the intended feel and timing.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the cue warmup position is now built from the computed `warmupPull` (so the player sees the pullback) and the player `pullbackDuration` is set to `forwardDuration * PLAYER_STROKE_TIME_SCALE` instead of `0` to give the forward/back timing parity.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6d1fbbf883299e9402eb43ace833)