### PR TITLE
Fix cue pullback timing to match forward stroke in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20412,7 +20412,7 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const startPos = buildCuePosition(visualPull);
-          const warmupPos = isAiStroke ? buildCuePosition(warmupPull) : startPos.clone();
+          const warmupPos = buildCuePosition(warmupPull);
           cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -20429,9 +20429,17 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(warmupPos);
           const forwardDuration = CUE_STRIKE_DURATION_MS;
           const settleDuration = CUE_STRIKE_HOLD_MS;
+          const forwardDistance = startPos.distanceTo(impactPos);
+          const pullbackDistance = warmupPos.distanceTo(startPos);
+          const matchedSpeed =
+            forwardDistance > 1e-6 ? forwardDistance / forwardDuration : 0;
+          const playerPullbackDuration =
+            matchedSpeed > 0
+              ? (pullbackDistance / matchedSpeed)
+              : 0;
           const pullbackDuration = isAiStroke
             ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
-            : 0;
+            : playerPullbackDuration;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;


### PR DESCRIPTION
### Motivation

- The visible player cue pullback did not match the forward push timing, causing inconsistent animation speed compared to the intended cue behaviour.  
- The change aims to make the player's pullback motion match the forward strike speed so pull and push feel temporally consistent (AI timing remains unchanged).  

### Description

- Compute a concrete `warmupPos` for player strokes (removed the conditional that previously used `startPos.clone()` for non-AI) and use it as the visual pull start point in `PoolRoyale.jsx`.  
- Calculate `forwardDistance` and `pullbackDistance`, derive a `matchedSpeed` from the forward stroke, and compute `playerPullbackDuration` from those distances.  
- Use `playerPullbackDuration` for player strokes while preserving the existing long AI pullback duration path.  
- Changes made in `webapp/src/pages/Games/PoolRoyale.jsx` to align pullback/push speeds and durations.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6d1fbbf883299e9402eb43ace833)