### PR TITLE
Align Air Hockey table sizing/camera and add Pool Royale finishes/bases

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -288,53 +288,94 @@ const AIR_HOCKEY_HDRI_VARIANTS = Object.freeze(
 
 const AIR_HOCKEY_TABLE_FINISHES = Object.freeze([
   Object.freeze({
-    id: 'poolRoyaleClassic',
-    name: 'Pool Royale Classic',
-    wood: '#8f6243',
-    trim: '#a4724f',
+    id: 'peelingPaintWeathered',
+    name: 'Wood Peeling Paint Weathered',
+    wood: '#b8b3aa',
+    trim: '#d6d0c7',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    swatches: ['#a89f95', '#b8b3aa'],
+    price: 980,
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+  }),
+  Object.freeze({
+    id: 'oakVeneer01',
+    name: 'Oak Veneer 01',
+    wood: '#c89a64',
+    trim: '#e0bb7a',
+    woodTextureId: 'oak_veneer_01',
+    swatches: ['#b9854e', '#c89a64'],
+    price: 990,
+    description: 'Warm oak veneer rails with smooth satin polish.'
+  }),
+  Object.freeze({
+    id: 'woodTable001',
+    name: 'Wood Table 001',
+    wood: '#a4724f',
+    trim: '#c89a64',
+    woodTextureId: 'wood_table_001',
     swatches: ['#8f6243', '#a4724f'],
-    price: 0,
-    description: 'Pool Royale-style wood rails sized to frame the air hockey field.'
+    price: 1000,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+  }),
+  Object.freeze({
+    id: 'darkWood',
+    name: 'Dark Wood',
+    wood: '#3d2f2a',
+    trim: '#6a5a52',
+    woodTextureId: 'dark_wood',
+    swatches: ['#2f241f', '#3d2f2a'],
+    price: 1010,
+    description: 'Deep espresso rails with strong grain contrast.'
+  }),
+  Object.freeze({
+    id: 'rosewoodVeneer01',
+    name: 'Rosewood Veneer 01',
+    wood: '#6f3a2f',
+    trim: '#9b5a44',
+    woodTextureId: 'rosewood_veneer_01',
+    swatches: ['#5b2f26', '#6f3a2f'],
+    price: 1020,
+    description: 'Rosewood veneer rails with rich, reddish undertones.'
   })
 ]);
 
 const AIR_HOCKEY_TABLE_BASES = Object.freeze([
   Object.freeze({
-    id: 'poolRoyaleClassicCylinders',
-    name: 'Pool Royale Classic Cylinders',
-    description: 'Pool Royale pedestal skirt with six cylinder legs and subtle foot pads.',
+    id: 'classicCylinders',
+    name: 'Classic Cylinders',
+    description: 'Rounded skirt with six cylinder legs and subtle foot pads.',
     base: '#8f6243',
     accent: '#6f3a2f',
     swatches: ['#8f6243', '#6f3a2f']
   }),
   Object.freeze({
-    id: 'poolRoyaleOpenPortal',
-    name: 'Pool Royale Open Portal',
-    description: 'Pool Royale twin portal legs with angled sides and negative space.',
+    id: 'openPortal',
+    name: 'Open Portal',
+    description: 'Twin portal legs with angled sides and negative space.',
     base: '#f8fafc',
     accent: '#e5e7eb',
     swatches: ['#f8fafc', '#e5e7eb']
   }),
   Object.freeze({
-    id: 'poolRoyaleCoffeeTableRound01',
-    name: 'Pool Royale Coffee Table Round 01',
-    description: 'Rounded Poly Haven coffee table legs adapted to the Pool Royale base.',
+    id: 'coffeeTableRound01',
+    name: 'Coffee Table Round 01 Base',
+    description: 'Rounded Poly Haven coffee table legs tucked beneath the pool table.',
     base: '#c5a47e',
     accent: '#7a5534',
     swatches: ['#c5a47e', '#7a5534']
   }),
   Object.freeze({
-    id: 'poolRoyaleGothicCoffeeTable',
-    name: 'Pool Royale Gothic Coffee Table',
-    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted Pool Royale base.',
+    id: 'gothicCoffeeTable',
+    name: 'Gothic Coffee Table Base',
+    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
     base: '#8f4a2b',
     accent: '#3b2a1f',
     swatches: ['#8f4a2b', '#3b2a1f']
   }),
   Object.freeze({
-    id: 'poolRoyaleWoodenTable02Alt',
-    name: 'Pool Royale Wooden Table 02 Alt',
-    description: 'Alternate Wooden Table 02 variant resized to cradle the Pool Royale base.',
+    id: 'woodenTable02Alt',
+    name: 'Wooden Table 02 Alt Base',
+    description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
     base: '#6f5140',
     accent: '#caa07a',
     swatches: ['#6f5140', '#caa07a']


### PR DESCRIPTION
### Motivation
- Match the Air Hockey playfield footprint, vertical placement and camera framing to the existing Pool Royale table so visual scale, placement and standing / cue-level perspectives correspond.
- Reuse Pool Royale table finishes and base variants for Air Hockey so players can pick the same wood finishes and bases, while keeping Air Hockey code separate.

### Description
- Added Pool Royale table finish entries and table base variants to `webapp/src/config/airHockeyInventoryConfig.js`, including `woodTextureId` references and swatches so finishes and bases appear in the Air Hockey store and customization.
- Updated `webapp/src/components/AirHockey3D.jsx` to align table sizing and placement with Pool Royale math (new environment/table scale constants), removed the playfield inset so the playfield matches the table footprint, and set table elevation to use the Pool Royale surface Y.
- Implemented camera anchors for both standing and cue-level views, exposed a UI toggle for cue-level view, and updated `cameraViewRef.applyCurrent` to accept the cue-view flag and keep top-down behavior intact; resize handling now respects the selected cue/standing framing.
- Integrated wood texture application: imported `applyWoodTextures` and `WOOD_GRAIN_OPTIONS_BY_ID` and apply selected Pool Royale grain textures to Air Hockey frame/trim materials (with HSL fallback) so the table finish matches Pool Royale visual quality.
- Small cleanup: adjusted table base variant ids/names to match Pool Royale-style variants and ensured inventory/store items map to new finishes/bases.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server came up successfully at `http://localhost:4173/`.
- Ran a Playwright script that loaded `http://localhost:4173/games/airhockey` at a mobile portrait viewport and produced a screenshot artifact (`artifacts/airhockey-3d.png`), confirming the scene rendered and the new camera/table adjustments are visible; the script completed successfully.
- No unit or CI test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7944188883298244c43c708a1016)