### PR TITLE
Anchor cue during power pull and align Snooker Royal stroke animation

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -8,6 +8,7 @@ export class PowerSlider {
       step = 1,
       cueSrc = '',
       onChange,
+      onStart,
       onCommit,
       theme = 'default',
       labels = false
@@ -20,6 +21,7 @@ export class PowerSlider {
     this.max = max;
     this.step = step;
     this.onChange = onChange;
+    this.onStart = onStart;
     this.onCommit = onCommit;
     this.locked = false;
 
@@ -209,6 +211,7 @@ export class PowerSlider {
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
     this.pointerStartY = e.clientY;
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.addEventListener('pointermove', this._onPointerMove);
     this.el.addEventListener('pointerup', this._onPointerUp);
   }


### PR DESCRIPTION
### Motivation

- Match the reference cue behavior where the cue is anchored at the start of a pull (does not follow the moving cue ball) and provides a short eased forward strike with a topspin follow-through.

### Description

- Add an `onStart` hook to the power slider (`power-slider.js`) and call it from Snooker Royal to capture the fixed cue anchor when the player begins a pull.
- Introduce `cueStickAnchorRef` and `captureCueStickAnchor` in `SnookerRoyal.jsx` and refresh the anchor while idle so the cue placement stays in sync when not dragging.
- Update `resolveCueTipTarget` to use the captured anchor during slider dragging, shooting, or replay playback so the visual cue tip remains anchored instead of following the ball.
- Replace the previous warmup/pullback-based stroke with a shorter forward stroke using an `easeOutCubic` easing and a topspin follow-through offset, and simplify related timing values to match the referenced animation style.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c75c71760832996973a418bfddde4)