### PR TITLE
Pool Royale: add BlenderKit table option and default BlenderKit cloth

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -47,7 +47,29 @@ const BLUE_SHADE_NAMES = ['Harbor', 'Fjord', 'Glacier', 'Sapphire', 'Midnight'];
 const NATURE_SHADE_NAMES = ['Fern', 'Grove', 'Canopy', 'Meadow', 'Wildwood'];
 const OCEAN_SHADE_NAMES = ['Crest', 'Current', 'Lagoon', 'Reef', 'Abyss'];
 
+const BLENDERKIT_CLOTH_ASSET_BASE_ID = '99fc871f-e793-4ad7-9ab2-fb5d08db4385';
+
 const MATERIAL_SERIES = [
+  {
+    prefix: 'blenderkitCloth',
+    label: 'BlenderKit Table Cloth',
+    sourceId: BLENDERKIT_CLOTH_ASSET_BASE_ID,
+    sourceType: 'blenderkit',
+    basePrice: 0,
+    priceStep: 0,
+    bluePremium: 0,
+    sparkle: 1.06,
+    stray: 1.04,
+    detail: {
+      bumpMultiplier: 1.18,
+      sheen: 0.62,
+      sheenRoughness: 0.5,
+      emissiveIntensity: 0.28,
+      envMapIntensity: 0.16
+    },
+    greens: ['#2e8b57'],
+    blues: []
+  },
   {
     prefix: 'caban',
     label: 'Caban Wool',
@@ -170,7 +192,8 @@ const createVariantsForMaterial = (material) => {
         detail: material.detail,
         price,
         swatches: createSwatches(hex),
-        description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`
+        description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`,
+        sourceType: material.sourceType || 'polyhaven'
       };
     });
 

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -325,6 +325,14 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     name: 'Wooden Table 02 Alt Base',
     description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
     swatches: ['#6f5140', '#caa07a']
+  },
+  {
+    id: 'blenderkitPoolTable',
+    name: 'BlenderKit Pool Table',
+    description: 'BlenderKit pool table model aligned beneath the pro playfield.',
+    swatches: ['#2b6f4f', '#1f3d2d'],
+    source: 'blenderkit',
+    assetBaseId: '84a78996-6ed0-4833-a110-b00c36c348a8'
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -14,6 +14,7 @@ import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
+const TABLE_THEME_STORAGE_KEY = 'poolRoyaleTableTheme';
 
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
@@ -37,6 +38,13 @@ export default function PoolRoyaleLobby() {
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
+  const [tableTheme, setTableTheme] = useState(() => {
+    try {
+      const stored = window.localStorage?.getItem(TABLE_THEME_STORAGE_KEY);
+      return stored === 'blenderkit' ? 'blenderkit' : 'classic';
+    } catch {}
+    return 'classic';
+  });
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
@@ -80,6 +88,12 @@ export default function PoolRoyaleLobby() {
       if (idx >= 0) setAiFlagIndex(idx);
     } catch {}
   }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(TABLE_THEME_STORAGE_KEY, tableTheme);
+    } catch {}
+  }, [tableTheme]);
 
   useEffect(() => {
     matchPlayersRef.current = matchPlayers;
@@ -128,6 +142,7 @@ export default function PoolRoyaleLobby() {
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     if (tableSize) params.set('tableSize', tableSize);
+    params.set('tableTheme', tableTheme);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -203,6 +218,7 @@ export default function PoolRoyaleLobby() {
     params.set('tableSize', tableSize);
     params.set('type', playType);
     params.set('mode', mode);
+    params.set('tableTheme', tableTheme);
     if (isOnlineMatch) {
       if (stake.token) params.set('token', stake.token);
       if (stake.amount) params.set('amount', stake.amount);
@@ -412,6 +428,26 @@ export default function PoolRoyaleLobby() {
           </div>
         </div>
       )}
+      <div className="space-y-2">
+        <h3 className="font-semibold">Table</h3>
+        <p className="text-xs text-subtext">
+          Choose the classic Pool Royale table or the BlenderKit table model for this match.
+        </p>
+        <div className="flex gap-2">
+          {[
+            { id: 'classic', label: 'Actual Table' },
+            { id: 'blenderkit', label: 'BlenderKit Table' }
+          ].map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setTableTheme(id)}
+              className={`lobby-tile ${tableTheme === id ? 'lobby-selected' : ''}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
       {playType === 'tournament' && (
         <div className="space-y-2">
           <h3 className="font-semibold">Players</h3>


### PR DESCRIPTION
### Motivation

- Provide a lobby option to let players choose between the existing in-game table and a new BlenderKit table model. 
- Use a scanned cloth material from BlenderKit as the default Pool Royale cloth to improve visual fidelity. 
- Reuse the existing asset-loading pipeline (Poly Haven style) and extend it to support BlenderKit assets for both cloth textures and table models.

### Description

- Added a BlenderKit cloth preset and made it the first material source so it becomes the default cloth (`BLENDERKIT_CLOTH_ASSET_BASE_ID` in `webapp/src/config/poolRoyaleClothPresets.js`).
- Extended the cloth pipeline to carry `sourceType` metadata and to support a new BlenderKit loading path (`fetchBlenderKitAsset`, `ensureBlenderKitTextures`) in `webapp/src/pages/Games/PoolRoyale.jsx` so scanned cloth thumbnails from BlenderKit can be used at runtime.
- Added BlenderKit model support and a new base variant `blenderkitPoolTable` (asset base id `84a78996-6ed0-4833-a110-b00c36c348a8`) with loader/fallback helpers (`ensureBlenderKitBaseTemplate`, `cloneBlenderKitBaseTemplate`, `createBlenderKitTableBaseBuilder`) and integrated it into the `baseBuilders` map so the BlenderKit table can be fitted under the playfield.
- Added a lobby UI control and persistent selection for the table theme (`Table` choice in `PoolRoyaleLobby.jsx`) which stores `tableTheme` in `localStorage` and appends `tableTheme` to the game URL; `PoolRoyale.jsx` reads the `tableTheme` URL param and forces the matching base variant when present.
- Minor UX/data updates: changed the cloth source label to `Scanned Cloth (4K)` and added safe fallback logic to use the default base if a custom base builder yields no meshes.

### Testing

- Dev server run: started the webapp dev server and navigated to the Pool Royale lobby page successfully, and a screenshot of the lobby showing the new `Table` selector was captured (artifact produced).
- BlenderKit lookups: BlenderKit API searches for the provided base IDs returned matching BlenderKit assets during rollout validation.
- Local validation: the change was built and the modified files were committed successfully; no automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9c2a053c8329b75e01af6d751e59)