### PR TITLE
Add BlenderKit table model + default BlenderKit cloth to Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -33,6 +33,30 @@ const createSwatches = (baseHex) => [
   adjustHex(baseHex, 0.3)
 ];
 
+const BLENDERKIT_DEFAULT_CLOTH_HEX = '#2f7d4d';
+const BLENDERKIT_DEFAULT_CLOTH = Object.freeze({
+  id: 'blenderkitSnookerCloth',
+  name: 'BlenderKit Snooker Cloth',
+  sourceId: '99fc871f-e793-4ad7-9ab2-fb5d08db4385',
+  assetBaseId: '99fc871f-e793-4ad7-9ab2-fb5d08db4385',
+  sourceType: 'blenderkit',
+  tone: 'green',
+  baseColor: toNumber(BLENDERKIT_DEFAULT_CLOTH_HEX),
+  palette: buildPalette(BLENDERKIT_DEFAULT_CLOTH_HEX),
+  sparkle: 1.1,
+  stray: 1.12,
+  detail: {
+    bumpMultiplier: 1.18,
+    sheen: 0.62,
+    sheenRoughness: 0.48,
+    emissiveIntensity: 0.28,
+    envMapIntensity: 0.18
+  },
+  price: 720,
+  swatches: createSwatches(BLENDERKIT_DEFAULT_CLOTH_HEX),
+  description: 'Premium BlenderKit snooker cloth tuned for vivid green table surfaces.'
+});
+
 const CABAN_GREEN_SWATCHES = Object.freeze(['#33b46a', '#2ca85f', '#42c47a', '#4fd184', '#238f4a']);
 const CABAN_OCEAN_BLUE_SWATCHES = Object.freeze([
   '#0b74c6',
@@ -181,5 +205,5 @@ const createVariantsForMaterial = (material) => {
 };
 
 export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
-  MATERIAL_SERIES.flatMap((material) => createVariantsForMaterial(material))
+  [BLENDERKIT_DEFAULT_CLOTH, ...MATERIAL_SERIES.flatMap((material) => createVariantsForMaterial(material))]
 );

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -325,6 +325,13 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     name: 'Wooden Table 02 Alt Base',
     description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
     swatches: ['#6f5140', '#caa07a']
+  },
+  {
+    id: 'blenderkitPoolTable',
+    name: 'BlenderKit Pool Table Base',
+    description: 'BlenderKit pool table model base, fitted to the Pool Royale playfield.',
+    swatches: ['#2f7d4d', '#0f3d24'],
+    assetBaseId: '84a78996-6ed0-4833-a110-b00c36c348a8'
   }
 ]);
 

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,0 +1,24 @@
+const TABLE_MODELS = [
+  {
+    id: 'standard',
+    label: 'Actual Table',
+    description: 'Use the current Pool Royale table build.',
+    baseVariantId: 'classicCylinders'
+  },
+  {
+    id: 'blenderkit',
+    label: 'BlenderKit Table',
+    description: 'Pool table model sourced from BlenderKit.',
+    baseVariantId: 'blenderkitPoolTable',
+    assetBaseId: '84a78996-6ed0-4833-a110-b00c36c348a8'
+  }
+];
+
+export const POOL_ROYALE_TABLE_MODELS = Object.freeze(TABLE_MODELS);
+export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID = 'standard';
+
+export function resolvePoolRoyaleTableModel(modelId) {
+  if (!modelId) return POOL_ROYALE_TABLE_MODELS[0];
+  const match = POOL_ROYALE_TABLE_MODELS.find((model) => model.id === modelId);
+  return match || POOL_ROYALE_TABLE_MODELS[0];
+}


### PR DESCRIPTION
### Motivation
- Provide an optional BlenderKit table model for Pool Royale and use a BlenderKit-sourced cloth as the default cloth texture source to enable richer external assets.

### Description
- Added a new BlenderKit cloth preset `blenderkitSnookerCloth` with `assetBaseId: 99fc871f-e793-4ad7-9ab2-fb5d08db4385` and prepended it to `POOL_ROYALE_CLOTH_VARIANTS` so it is available in the cloth library (`webapp/src/config/poolRoyaleClothPresets.js`).
- Added a new table model registry with `blenderkit` model and `assetBaseId: 84a78996-6ed0-4833-a110-b00c36c348a8` (`webapp/src/config/poolRoyaleTableModels.js`) and registered a corresponding base variant `blenderkitPoolTable` in `poolRoyaleInventoryConfig.js`.
- Wired a lobby UI selector so players can pick between the existing table or the new BlenderKit table (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) and persist the choice to URL/localStorage.
- Surface the chosen table model to the game via the `tableModel` param and apply it in-game by resolving the model to a `tableBase` variant when available (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Implemented BlenderKit cloth/model loading support alongside PolyHaven and procedural sources: new `blenderkit` cloth texture source option, fetching BlenderKit search results, selecting thumbnail/image URLs for cloth textures, and selecting GLTF/GLB payloads for table base models; the cloth pipeline falls back to procedural/PolyHaven as before (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added safe fallbacks so if BlenderKit assets are not available the existing builders/materials are used (fallback builder for base geometry and procedural cloth fallback).

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed the site reached the lobby page; this succeeded (dev server running). 
- Performed an automated browser check using Playwright that opened `/games/poolroyale/lobby` (mobile viewport) and produced a screenshot showing the new Table selection UI; the screenshot was generated successfully. 
- Queried BlenderKit search endpoints (`https://www.blenderkit.com/api/v1/search/?query=asset_base_id:<id>`) to confirm the cloth and table asset records exist and are reachable; the API returned matching entries for the provided `asset_base_id`s. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9c2a053c8329b75e01af6d751e59)