### PR TITLE
Add BlenderKit table finishes and BlenderKit texture support to Pool Royale store

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,4 +1,5 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { POOL_ROYALE_BLENDERKIT_TABLE_FINISHES } from './poolRoyaleTableFinishBlenderkit.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -360,7 +361,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.reduce((acc, finish) => {
+      acc[finish.id] = finish.label;
+      return acc;
+    }, {})
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -444,6 +449,15 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.'
   },
+  ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.map((finish) => ({
+    id: `finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: `${finish.label} Finish`,
+    price: finish.price ?? 1200,
+    description:
+      finish.description ?? 'BlenderKit wood finish with layered grain depth.'
+  })),
   {
     id: 'chrome-chrome',
     type: 'chromeColor',

--- a/webapp/src/config/poolRoyaleTableFinishBlenderkit.js
+++ b/webapp/src/config/poolRoyaleTableFinishBlenderkit.js
@@ -1,0 +1,310 @@
+export const POOL_ROYALE_BLENDERKIT_TABLE_FINISHES = Object.freeze([
+  {
+    id: 'blenderkitFinish01',
+    label: 'BlenderKit Finish 01',
+    assetBaseId: '35421bc9-a49d-4979-8d93-0c13e9eba371',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish02',
+    label: 'BlenderKit Finish 02',
+    assetBaseId: '2c52be7f-8e46-4c6c-adc2-888449da931e',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish03',
+    label: 'BlenderKit Finish 03',
+    assetBaseId: '3ecfdd76-6e15-4c3c-89c9-4a1cafdc3155',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish04',
+    label: 'BlenderKit Finish 04',
+    assetBaseId: 'f1036f94-c4a7-4c70-8694-3234f062d46d',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish05',
+    label: 'BlenderKit Finish 05',
+    assetBaseId: '1fddce2a-4d76-45e4-b09e-e4605e10b873',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish06',
+    label: 'BlenderKit Finish 06',
+    assetBaseId: 'fb650615-ef11-4e19-bc68-abfbeddee561',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish07',
+    label: 'BlenderKit Finish 07',
+    assetBaseId: '852ee40c-e967-4028-bb26-428e84933cab',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish08',
+    label: 'BlenderKit Finish 08',
+    assetBaseId: '199ebe44-46ef-490d-99f6-93aa33b903b8',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish09',
+    label: 'BlenderKit Finish 09',
+    assetBaseId: 'e25066a1-aaba-4ff1-ab68-a67b413c5eaa',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish10',
+    label: 'BlenderKit Finish 10',
+    assetBaseId: 'a283a837-0e33-4182-b55d-2a8c742fda08',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish11',
+    label: 'BlenderKit Finish 11',
+    assetBaseId: '46de7336-6072-4b85-8b99-ac2438829a08',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish12',
+    label: 'BlenderKit Finish 12',
+    assetBaseId: '3c4de2d5-540e-4e1c-95dd-9b6721bba08f',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish13',
+    label: 'BlenderKit Finish 13',
+    assetBaseId: '22585ff5-5c37-42c1-8fbe-be9429c2722b',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish14',
+    label: 'BlenderKit Finish 14',
+    assetBaseId: 'e4cdf7af-7789-4ef1-85a8-378956ceb79d',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish15',
+    label: 'BlenderKit Finish 15',
+    assetBaseId: 'fa7dacb7-3621-4c57-ad5b-b4178afc329b',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish16',
+    label: 'BlenderKit Finish 16',
+    assetBaseId: '42682664-0da2-4d09-9d18-e0c7fbc61740',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish17',
+    label: 'BlenderKit Finish 17',
+    assetBaseId: '784156cf-8f7a-4559-b388-4cdc66a237c7',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish18',
+    label: 'BlenderKit Finish 18',
+    assetBaseId: '87170683-fda0-4121-b8fd-6a7874a1f060',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish19',
+    label: 'BlenderKit Finish 19',
+    assetBaseId: '8f9b1321-c008-4e8b-bee2-bd71c3d96eca',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish20',
+    label: 'BlenderKit Finish 20',
+    assetBaseId: '2a5a3947-6788-479a-930c-d8e0c46f5444',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish21',
+    label: 'BlenderKit Finish 21',
+    assetBaseId: '7bb8b5ff-9414-41f6-912e-c7f7c7c199cd',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish22',
+    label: 'BlenderKit Finish 22',
+    assetBaseId: '646e4223-0a0e-402c-83cb-771f80cb3b40',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish23',
+    label: 'BlenderKit Finish 23',
+    assetBaseId: '739b5e5b-95a8-43b5-a87f-393e4bf07afa',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish24',
+    label: 'BlenderKit Finish 24',
+    assetBaseId: '4abe5330-da7c-4297-9769-6e7e0acc8bc3',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish25',
+    label: 'BlenderKit Finish 25',
+    assetBaseId: '43baa4e4-d20b-47c5-949b-a38fa6c15b51',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish26',
+    label: 'BlenderKit Finish 26',
+    assetBaseId: '179f3e02-a17a-4b7f-8316-3504864282be',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish27',
+    label: 'BlenderKit Finish 27',
+    assetBaseId: '42c90503-731b-46b6-a23e-019d06749d3a',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish28',
+    label: 'BlenderKit Finish 28',
+    assetBaseId: 'a167dd9e-f0a4-4384-8b81-2fbb87dd1728',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish29',
+    label: 'BlenderKit Finish 29',
+    assetBaseId: '7c47beed-802f-449e-8db6-1e1a4af162cc',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish30',
+    label: 'BlenderKit Finish 30',
+    assetBaseId: '42f8ed87-4d8b-4e2d-82b3-ec91c4b27231',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish31',
+    label: 'BlenderKit Finish 31',
+    assetBaseId: 'ec1358d7-5ea1-47f6-9171-6c57de898739',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish32',
+    label: 'BlenderKit Finish 32',
+    assetBaseId: '36a2d185-faf0-4949-b473-c9bec980867f',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish33',
+    label: 'BlenderKit Finish 33',
+    assetBaseId: '16bcdeeb-ae61-42fa-9f17-ee96ca77a6e5',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish34',
+    label: 'BlenderKit Finish 34',
+    assetBaseId: '8e44c701-27cd-4d52-be1c-a9a7140354a4',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish35',
+    label: 'BlenderKit Finish 35',
+    assetBaseId: 'ade0f2da-ceed-431b-a372-ade7f969a230',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish36',
+    label: 'BlenderKit Finish 36',
+    assetBaseId: '17a9260c-0355-4e50-b73e-9406e9f642b6',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish37',
+    label: 'BlenderKit Finish 37',
+    assetBaseId: 'c13bea13-d852-4e32-8971-57a7c5c93879',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish38',
+    label: 'BlenderKit Finish 38',
+    assetBaseId: '511f0b04-dee5-47e2-b789-d518a735ab49',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish39',
+    label: 'BlenderKit Finish 39',
+    assetBaseId: 'bd1d17c7-ce71-4c9a-89e3-cbadf6fbb67f',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish40',
+    label: 'BlenderKit Finish 40',
+    assetBaseId: '77777f54-71c1-4910-b534-3f00e3f9a574',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish41',
+    label: 'BlenderKit Finish 41',
+    assetBaseId: '9a4f0337-b06e-4886-9460-455bf108be8d',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish42',
+    label: 'BlenderKit Finish 42',
+    assetBaseId: 'f4b039e7-d4d4-48c2-8799-23b6d8f09716',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish43',
+    label: 'BlenderKit Finish 43',
+    assetBaseId: 'a8a0525a-80d4-4e71-9249-4b3114b003bc',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  },
+  {
+    id: 'blenderkitFinish44',
+    label: 'BlenderKit Finish 44',
+    assetBaseId: '1d275ed8-6c1e-4850-82ad-72e65749ab0b',
+    price: 1200,
+    description: 'BlenderKit wood finish with layered grain depth.'
+  }
+]);


### PR DESCRIPTION
### Motivation
- Add a set of new table finishes sourced from BlenderKit to the Pool Royale store and enable the game to fetch BlenderKit textures by `asset_base_id` so those finishes display correctly in-game.
- Keep the store/catalog data separate and lightweight while wiring BlenderKit assets into the existing wood/finish pipeline.

### Description
- Added `webapp/src/config/poolRoyaleTableFinishBlenderkit.js` containing the BlenderKit finishes list and their `assetBaseId`s and metadata. 
- Wired the new finishes into the store UI and listings by importing `POOL_ROYALE_BLENDERKIT_TABLE_FINISHES` in `webapp/src/config/poolRoyaleInventoryConfig.js` and appending labels and `POOL_ROYALE_STORE_ITEMS` entries for each finish.
- Extended the Pool Royale table finish data in `webapp/src/pages/Games/PoolRoyale.jsx` to include the BlenderKit finishes in `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS`, and to propagate `assetBaseId` through surface configs and synchronized surfaces.
- Added BlenderKit texture lookup and consumer logic in `webapp/src/utils/woodMaterials.js` to: fetch BlenderKit asset metadata (`fetchBlenderkitAsset`), collect image candidates, cache resolved map/normal/roughness URLs, register material consumers, and broadcast resolved URLs so `applyWoodTextures` can load external textures; and accepted `assetBaseId` in `applyWoodTextures` and `createWoodMaterial` parameters.

### Testing
- No automated tests were executed for this change (`not run`).
- Manual verification recommended: open Pool Royale store to see new finish entries, and launch a table using a BlenderKit finish to confirm texture fetching and application (not performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca771c8f083298b9f1c550fcbf11a)