### PR TITLE
Add BlenderKit Original table finish and BlenderKit wood texture support for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -360,7 +360,8 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    blenderkitOriginal: 'BlenderKit Original'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -443,6 +444,14 @@ export const POOL_ROYALE_STORE_ITEMS = [
     name: 'Rosewood Veneer 01 Finish',
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.'
+  },
+  {
+    id: 'finish-blenderkitOriginal',
+    type: 'tableFinish',
+    optionId: 'blenderkitOriginal',
+    name: 'BlenderKit Original Finish',
+    price: 1030,
+    description: 'Original BlenderKit wood finish with authentic GLTF textures.'
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2422,6 +2422,15 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  blenderkitOriginal: createStandardWoodFinish({
+    id: 'blenderkitOriginal',
+    label: 'BlenderKit Original',
+    rail: 0x7a5a41,
+    base: 0x6a4a33,
+    trim: 0x9a7752,
+    woodTextureId: 'blenderkit_pool_royale_original',
+    woodRepeatScale: 1
   })
 });
 
@@ -2431,7 +2440,8 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.blenderkitOriginal
   ].filter(Boolean)
 );
 
@@ -3031,6 +3041,159 @@ const upgradePolyHavenTextureUrlTo4k = (url) => {
   if (typeof url !== 'string' || url.length === 0) return url;
   if (!url.includes('/2k/') && !url.includes('_2k')) return url;
   return url.replace('/2k/', '/4k/').replace(/_2k(\.\w+)$/, '_4k$1');
+};
+
+const blenderkitMaterialAssetCache = new Map();
+const blenderkitMaterialAssetPromises = new Map();
+const blenderkitMaterialCache = new Map();
+const blenderkitMaterialConsumers = new Map();
+const blenderkitWoodTexturePromises = new Map();
+
+const collectBlenderkitMaterialFiles = (asset) => {
+  const files = Array.isArray(asset?.files) ? asset.files : [];
+  return files
+    .map((file) => ({
+      url: file?.downloadUrl || null,
+      filename: file?.filename || '',
+      fileType: file?.fileType || ''
+    }))
+    .filter((file) => file.url && /\.(png|jpe?g|webp)$/i.test(file.filename));
+};
+
+const scoreBlenderkitMaterialFile = (file, tokens) => {
+  const filename = file?.filename?.toLowerCase?.() ?? '';
+  const fileType = file?.fileType?.toLowerCase?.() ?? '';
+  let score = 0;
+  tokens.forEach((token) => {
+    if (filename.includes(token) || fileType.includes(token)) {
+      score += 4;
+    }
+  });
+  if (filename.includes('preview') || filename.includes('thumbnail')) score -= 5;
+  if (filename.includes('ao')) score -= 2;
+  return score;
+};
+
+const pickBlenderkitMaterialTextureUrls = (asset) => {
+  if (!asset) return { mapUrl: null, normalMapUrl: null, roughnessMapUrl: null };
+  const files = collectBlenderkitMaterialFiles(asset);
+  const pickBest = (tokens) => {
+    const scored = files
+      .map((file) => ({ file, score: scoreBlenderkitMaterialFile(file, tokens) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score);
+    return scored[0]?.file?.url ?? null;
+  };
+  const mapUrl =
+    pickBest(['basecolor', 'albedo', 'diffuse', 'diff', 'color', 'col']) ||
+    asset.thumbnailLargeUrl ||
+    asset.thumbnailXlargeUrl ||
+    asset.thumbnailLargeUrlNonsquared ||
+    asset.thumbnailXlargeUrlNonsquared ||
+    asset.thumbnailMiddleUrl ||
+    asset.thumbnailSmallUrl ||
+    null;
+  const normalMapUrl = pickBest(['normal', 'nor_gl', 'normal_gl', 'nor', 'nrm']);
+  const roughnessMapUrl = pickBest(['roughness', 'rough']);
+  return { mapUrl, normalMapUrl, roughnessMapUrl };
+};
+
+const fetchBlenderkitMaterialAsset = async (assetBaseId) => {
+  if (!assetBaseId || typeof fetch !== 'function') return null;
+  if (blenderkitMaterialAssetCache.has(assetBaseId)) {
+    return blenderkitMaterialAssetCache.get(assetBaseId);
+  }
+  if (blenderkitMaterialAssetPromises.has(assetBaseId)) {
+    return blenderkitMaterialAssetPromises.get(assetBaseId);
+  }
+  const promise = (async () => {
+    try {
+      const response = await fetch(
+        `${BLENDERKIT_SEARCH_BASE_URL}${encodeURIComponent(assetBaseId)}`,
+        { mode: 'cors' }
+      );
+      if (!response?.ok) return null;
+      const data = await response.json();
+      const asset = data?.results?.[0] ?? null;
+      if (asset) {
+        blenderkitMaterialAssetCache.set(assetBaseId, asset);
+      }
+      return asset;
+    } catch (error) {
+      return null;
+    } finally {
+      blenderkitMaterialAssetPromises.delete(assetBaseId);
+    }
+  })();
+  blenderkitMaterialAssetPromises.set(assetBaseId, promise);
+  return promise;
+};
+
+const resolveBlenderkitMaterialUrls = async (assetBaseIds) => {
+  if (!Array.isArray(assetBaseIds) || assetBaseIds.length === 0) return null;
+  for (const assetBaseId of assetBaseIds) {
+    // eslint-disable-next-line no-await-in-loop
+    const asset = await fetchBlenderkitMaterialAsset(assetBaseId);
+    if (!asset) continue;
+    const urls = pickBlenderkitMaterialTextureUrls(asset);
+    if (urls?.mapUrl) return urls;
+  }
+  return null;
+};
+
+const registerBlenderkitWoodConsumer = (cacheKey, material, surfaceConfig) => {
+  if (!cacheKey || !material) return;
+  let consumers = blenderkitMaterialConsumers.get(cacheKey);
+  if (!consumers) {
+    consumers = new Set();
+    blenderkitMaterialConsumers.set(cacheKey, consumers);
+  }
+  consumers.add({
+    material,
+    surface: cloneWoodSurfaceConfig(surfaceConfig)
+  });
+};
+
+const broadcastBlenderkitWoodTextures = (cacheKey) => {
+  const entry = blenderkitMaterialCache.get(cacheKey);
+  if (!entry?.ready) return;
+  const consumers = blenderkitMaterialConsumers.get(cacheKey);
+  if (!consumers?.size) return;
+  consumers.forEach(({ material, surface }) => {
+    if (!material || !surface) return;
+    applyWoodTextureToMaterial(material, {
+      ...surface,
+      mapUrl: entry.mapUrl ?? surface.mapUrl,
+      roughnessMapUrl: entry.roughnessMapUrl ?? surface.roughnessMapUrl,
+      normalMapUrl: entry.normalMapUrl ?? surface.normalMapUrl
+    });
+  });
+};
+
+const ensureBlenderkitWoodTextures = (assetBaseIds, cacheKey) => {
+  if (!Array.isArray(assetBaseIds) || assetBaseIds.length === 0) return;
+  const cached = blenderkitMaterialCache.get(cacheKey);
+  if (cached?.ready) return;
+  if (blenderkitWoodTexturePromises.has(cacheKey)) return;
+  if (typeof window === 'undefined' || typeof fetch !== 'function') return;
+  const promise = (async () => {
+    try {
+      const urls = await resolveBlenderkitMaterialUrls(assetBaseIds);
+      if (!urls?.mapUrl) return;
+      blenderkitMaterialCache.set(cacheKey, {
+        mapUrl: urls.mapUrl,
+        normalMapUrl: urls.normalMapUrl ?? null,
+        roughnessMapUrl: urls.roughnessMapUrl ?? null,
+        ready: true
+      });
+      broadcastBlenderkitWoodTextures(cacheKey);
+    } catch (error) {
+      console.warn('Failed to load BlenderKit wood textures', assetBaseIds, error);
+    } finally {
+      blenderkitWoodTexturePromises.delete(cacheKey);
+    }
+  })();
+  blenderkitWoodTexturePromises.set(cacheKey, promise);
 };
 
 const createClothTextures = (() => {
@@ -3937,6 +4100,26 @@ function applyWoodTextureToMaterial(material, repeat) {
     typeof repeat?.normalMapUrl === 'string' && repeat.normalMapUrl.trim().length > 0
       ? repeat.normalMapUrl.trim()
       : undefined;
+  const blenderkitMaterialIds = Array.isArray(repeat?.blenderkitMaterialIds)
+    ? repeat.blenderkitMaterialIds.filter(Boolean)
+    : null;
+  const blenderkitCacheKey = blenderkitMaterialIds?.length
+    ? blenderkitMaterialIds.join('|')
+    : null;
+  let resolvedMapUrl = mapUrl;
+  let resolvedRoughnessMapUrl = roughnessMapUrl;
+  let resolvedNormalMapUrl = normalMapUrl;
+  if (!resolvedMapUrl && blenderkitCacheKey) {
+    const cached = blenderkitMaterialCache.get(blenderkitCacheKey);
+    if (cached?.ready) {
+      resolvedMapUrl = cached.mapUrl ?? resolvedMapUrl;
+      resolvedRoughnessMapUrl = cached.roughnessMapUrl ?? resolvedRoughnessMapUrl;
+      resolvedNormalMapUrl = cached.normalMapUrl ?? resolvedNormalMapUrl;
+    } else {
+      registerBlenderkitWoodConsumer(blenderkitCacheKey, material, repeat);
+      ensureBlenderkitWoodTextures(blenderkitMaterialIds, blenderkitCacheKey);
+    }
+  }
   const repeatScale = clampWoodRepeatScaleValue(repeat?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE);
   const scaledRepeat = scaleWoodRepeatVector(repeatVec, repeatScale);
   const hadOptions = Boolean(material.userData?.__woodOptions);
@@ -3944,9 +4127,9 @@ function applyWoodTextureToMaterial(material, repeat) {
     repeat: scaledRepeat,
     rotation,
     textureSize,
-    mapUrl,
-    roughnessMapUrl,
-    normalMapUrl
+    mapUrl: resolvedMapUrl,
+    roughnessMapUrl: resolvedRoughnessMapUrl,
+    normalMapUrl: resolvedNormalMapUrl
   });
   if (options) {
     const repeatChanged =
@@ -3958,18 +4141,18 @@ function applyWoodTextureToMaterial(material, repeat) {
       typeof textureSize === 'number' &&
       Math.abs((options.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE) - textureSize) > 1e-6;
     const mapChanged =
-      options.mapUrl !== mapUrl ||
-      options.roughnessMapUrl !== roughnessMapUrl ||
-      options.normalMapUrl !== normalMapUrl;
+      options.mapUrl !== resolvedMapUrl ||
+      options.roughnessMapUrl !== resolvedRoughnessMapUrl ||
+      options.normalMapUrl !== resolvedNormalMapUrl;
     if (hadOptions && (repeatChanged || rotationChanged || textureSizeChanged || mapChanged)) {
       applyWoodTextures(material, {
         ...options,
         repeat: { x: scaledRepeat.x, y: scaledRepeat.y },
         rotation,
         textureSize: textureSize ?? options.textureSize,
-        mapUrl: mapUrl ?? options.mapUrl,
-        roughnessMapUrl: roughnessMapUrl ?? options.roughnessMapUrl,
-        normalMapUrl: normalMapUrl ?? options.normalMapUrl
+        mapUrl: resolvedMapUrl ?? options.mapUrl,
+        roughnessMapUrl: resolvedRoughnessMapUrl ?? options.roughnessMapUrl,
+        normalMapUrl: resolvedNormalMapUrl ?? options.normalMapUrl
       });
     }
   } else {
@@ -4013,6 +4196,7 @@ function toPlainWoodSurfaceConfig(settings) {
   let mapUrl = null;
   let roughnessMapUrl = null;
   let normalMapUrl = null;
+  let blenderkitMaterialIds = null;
   if (repeatSource?.isVector2) {
     repeatX = repeatSource.x;
     repeatY = repeatSource.y;
@@ -4039,6 +4223,9 @@ function toPlainWoodSurfaceConfig(settings) {
   if (typeof settings.normalMapUrl === 'string' && settings.normalMapUrl.trim().length > 0) {
     normalMapUrl = settings.normalMapUrl.trim();
   }
+  if (Array.isArray(settings.blenderkitMaterialIds) && settings.blenderkitMaterialIds.length > 0) {
+    blenderkitMaterialIds = settings.blenderkitMaterialIds.filter(Boolean);
+  }
   return {
     repeat: {
       x: Number.isFinite(repeatX) ? repeatX : 1,
@@ -4048,7 +4235,8 @@ function toPlainWoodSurfaceConfig(settings) {
     textureSize,
     mapUrl,
     roughnessMapUrl,
-    normalMapUrl
+    normalMapUrl,
+    blenderkitMaterialIds
   };
 }
 
@@ -4066,7 +4254,9 @@ function resolveWoodSurfaceConfig(option, fallback) {
     textureSize: resolvedOption?.textureSize ?? base.textureSize,
     mapUrl: resolvedOption?.mapUrl ?? base.mapUrl,
     roughnessMapUrl: resolvedOption?.roughnessMapUrl ?? base.roughnessMapUrl,
-    normalMapUrl: resolvedOption?.normalMapUrl ?? base.normalMapUrl
+    normalMapUrl: resolvedOption?.normalMapUrl ?? base.normalMapUrl,
+    blenderkitMaterialIds:
+      resolvedOption?.blenderkitMaterialIds ?? base.blenderkitMaterialIds ?? null
   };
 }
 
@@ -4084,6 +4274,9 @@ function cloneWoodSurfaceConfig(config) {
     roughnessMapUrl:
       typeof config.roughnessMapUrl === 'string' ? config.roughnessMapUrl : undefined,
     normalMapUrl: typeof config.normalMapUrl === 'string' ? config.normalMapUrl : undefined,
+    blenderkitMaterialIds: Array.isArray(config.blenderkitMaterialIds)
+      ? [...config.blenderkitMaterialIds]
+      : null,
     woodRepeatScale: clampWoodRepeatScaleValue(config.woodRepeatScale)
   };
 }
@@ -4107,7 +4300,10 @@ function orientRailWoodSurface(surface) {
     roughnessMapUrl:
       typeof surface.roughnessMapUrl === 'string' ? surface.roughnessMapUrl : undefined,
     normalMapUrl:
-      typeof surface.normalMapUrl === 'string' ? surface.normalMapUrl : undefined
+      typeof surface.normalMapUrl === 'string' ? surface.normalMapUrl : undefined,
+    blenderkitMaterialIds: Array.isArray(surface.blenderkitMaterialIds)
+      ? [...surface.blenderkitMaterialIds]
+      : null
   };
 }
 

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -314,6 +314,52 @@ const FRAME_SLAB_REPEAT_X = LARGE_SLAB_REPEAT_X * 1.18;
 const POLYHAVEN_ASSET_ALIASES = {
   rosewood_veneer_01: 'rosewood_veneer1'
 };
+const BLENDERKIT_POOL_ROYALE_MATERIAL_IDS = Object.freeze([
+  '35421bc9-a49d-4979-8d93-0c13e9eba371',
+  '2c52be7f-8e46-4c6c-adc2-888449da931e',
+  '3ecfdd76-6e15-4c3c-89c9-4a1cafdc3155',
+  'f1036f94-c4a7-4c70-8694-3234f062d46d',
+  '1fddce2a-4d76-45e4-b09e-e4605e10b873',
+  'fb650615-ef11-4e19-bc68-abfbeddee561',
+  '852ee40c-e967-4028-bb26-428e84933cab',
+  '199ebe44-46ef-490d-99f6-93aa33b903b8',
+  'e25066a1-aaba-4ff1-ab68-a67b413c5eaa',
+  'a283a837-0e33-4182-b55d-2a8c742fda08',
+  '46de7336-6072-4b85-8b99-ac2438829a08',
+  '3c4de2d5-540e-4e1c-95dd-9b6721bba08f',
+  '22585ff5-5c37-42c1-8fbe-be9429c2722b',
+  'e4cdf7af-7789-4ef1-85a8-378956ceb79d',
+  'fa7dacb7-3621-4c57-ad5b-b4178afc329b',
+  '42682664-0da2-4d09-9d18-e0c7fbc61740',
+  '784156cf-8f7a-4559-b388-4cdc66a237c7',
+  '87170683-fda0-4121-b8fd-6a7874a1f060',
+  '8f9b1321-c008-4e8b-bee2-bd71c3d96eca',
+  '2a5a3947-6788-479a-930c-d8e0c46f5444',
+  '7bb8b5ff-9414-41f6-912e-c7f7c7c199cd',
+  '646e4223-0a0e-402c-83cb-771f80cb3b40',
+  '739b5e5b-95a8-43b5-a87f-393e4bf07afa',
+  '4abe5330-da7c-4297-9769-6e7e0acc8bc3',
+  '43baa4e4-d20b-47c5-949b-a38fa6c15b51',
+  '179f3e02-a17a-4b7f-8316-3504864282be',
+  '42c90503-731b-46b6-a23e-019d06749d3a',
+  'a167dd9e-f0a4-4384-8b81-2fbb87dd1728',
+  '7c47beed-802f-449e-8db6-1e1a4af162cc',
+  '42f8ed87-4d8b-4e2d-82b3-ec91c4b27231',
+  'ec1358d7-5ea1-47f6-9171-6c57de898739',
+  '36a2d185-faf0-4949-b473-c9bec980867f',
+  '16bcdeeb-ae61-42fa-9f17-ee96ca77a6e5',
+  '8e44c701-27cd-4d52-be1c-a9a7140354a4',
+  'ade0f2da-ceed-431b-a372-ade7f969a230',
+  '17a9260c-0355-4e50-b73e-9406e9f642b6',
+  'c13bea13-d852-4e32-8971-57a7c5c93879',
+  '511f0b04-dee5-47e2-b789-d518a735ab49',
+  'bd1d17c7-ce71-4c9a-89e3-cbadf6fbb67f',
+  '77777f54-71c1-4910-b534-3f00e3f9a574',
+  '9a4f0337-b06e-4886-9460-455bf108be8d',
+  'f4b039e7-d4d4-48c2-8799-23b6d8f09716',
+  'a8a0525a-80d4-4e71-9249-4b3114b003bc',
+  '1d275ed8-6c1e-4850-82ad-72e65749ab0b'
+]);
 
 const polyHavenTextureSet = (assetId) => {
   const resolvedId = POLYHAVEN_ASSET_ALIASES[assetId] ?? assetId;
@@ -439,6 +485,23 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'blenderkit_pool_royale_original',
+    label: 'BlenderKit Pool Royale Original',
+    source: 'BlenderKit materials (original GLTF mapping)',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      blenderkitMaterialIds: BLENDERKIT_POOL_ROYALE_MATERIAL_IDS
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      blenderkitMaterialIds: BLENDERKIT_POOL_ROYALE_MATERIAL_IDS
     }
   }),
   Object.freeze({


### PR DESCRIPTION
### Motivation
- Provide the original BlenderKit GLTF material textures for the Pool Royale table so the store can offer an authentic "original" finish and the renderer can apply the GLTF-provided maps. 
- Support a long list of BlenderKit `asset_base_id` material IDs so the wood surfaces can attempt to resolve the original color/normal/roughness textures from BlenderKit when available.

### Description
- Added a frozen list `BLENDERKIT_POOL_ROYALE_MATERIAL_IDS` in `webapp/src/utils/woodMaterials.js` and registered a new wood grain option `blenderkit_pool_royale_original` that references those BlenderKit material IDs. 
- Introduced a new table finish `blenderkitOriginal` and included it in `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` in `webapp/src/pages/Games/PoolRoyale.jsx`, and added a corresponding store item and label in `webapp/src/config/poolRoyaleInventoryConfig.js`. 
- Implemented BlenderKit material asset fetching, scoring and URL picking utilities in `webapp/src/pages/Games/PoolRoyale.jsx` (`fetchBlenderkitMaterialAsset`, `pickBlenderkitMaterialTextureUrls`, `resolveBlenderkitMaterialUrls`), plus caching, consumer registration and async broadcast (`registerBlenderkitWoodConsumer`, `ensureBlenderkitWoodTextures`, `broadcastBlenderkitWoodTextures`). 
- Integrated the BlenderKit material flow into the wood-texture application path by extending wood surface config parsing to accept `blenderkitMaterialIds` and resolving `mapUrl`/`normalMapUrl`/`roughnessMapUrl` from the BlenderKit cache before calling `applyWoodTextures`/`applyWoodTextureToMaterial` so materials update once BlenderKit textures are loaded.

### Testing
- No automated tests were executed as part of this change (no CI/test run requested).
- Manual verification recommended: load Pool Royale, select the new `BlenderKit Original` finish, and confirm wood surfaces update with BlenderKit textures once the BlenderKit lookup completes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb47993e0832980c099f2e177948c)