### PR TITLE
Add BlenderKit-backed table finishes and texture loading for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -335,6 +335,63 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
   }
 ]);
 
+const BLENDERKIT_TABLE_FINISH_ASSET_IDS = Object.freeze([
+  '35421bc9-a49d-4979-8d93-0c13e9eba371',
+  '2c52be7f-8e46-4c6c-adc2-888449da931e',
+  '3ecfdd76-6e15-4c3c-89c9-4a1cafdc3155',
+  'f1036f94-c4a7-4c70-8694-3234f062d46d',
+  '1fddce2a-4d76-45e4-b09e-e4605e10b873',
+  'fb650615-ef11-4e19-bc68-abfbeddee561',
+  '852ee40c-e967-4028-bb26-428e84933cab',
+  '199ebe44-46ef-490d-99f6-93aa33b903b8',
+  'e25066a1-aaba-4ff1-ab68-a67b413c5eaa',
+  'a283a837-0e33-4182-b55d-2a8c742fda08',
+  '46de7336-6072-4b85-8b99-ac2438829a08',
+  '3c4de2d5-540e-4e1c-95dd-9b6721bba08f',
+  '22585ff5-5c37-42c1-8fbe-be9429c2722b',
+  'e4cdf7af-7789-4ef1-85a8-378956ceb79d',
+  'fa7dacb7-3621-4c57-ad5b-b4178afc329b',
+  '42682664-0da2-4d09-9d18-e0c7fbc61740',
+  '784156cf-8f7a-4559-b388-4cdc66a237c7',
+  '87170683-fda0-4121-b8fd-6a7874a1f060',
+  '8f9b1321-c008-4e8b-bee2-bd71c3d96eca',
+  '2a5a3947-6788-479a-930c-d8e0c46f5444',
+  '7bb8b5ff-9414-41f6-912e-c7f7c7c199cd',
+  '646e4223-0a0e-402c-83cb-771f80cb3b40',
+  '739b5e5b-95a8-43b5-a87f-393e4bf07afa',
+  '4abe5330-da7c-4297-9769-6e7e0acc8bc3',
+  '43baa4e4-d20b-47c5-949b-a38fa6c15b51',
+  '179f3e02-a17a-4b7f-8316-3504864282be',
+  '42c90503-731b-46b6-a23e-019d06749d3a',
+  'a167dd9e-f0a4-4384-8b81-2fbb87dd1728',
+  '7c47beed-802f-449e-8db6-1e1a4af162cc',
+  '42f8ed87-4d8b-4e2d-82b3-ec91c4b27231',
+  'ec1358d7-5ea1-47f6-9171-6c57de898739',
+  '36a2d185-faf0-4949-b473-c9bec980867f',
+  '16bcdeeb-ae61-42fa-9f17-ee96ca77a6e5',
+  '8e44c701-27cd-4d52-be1c-a9a7140354a4',
+  'ade0f2da-ceed-431b-a372-ade7f969a230',
+  '17a9260c-0355-4e50-b73e-9406e9f642b6',
+  'c13bea13-d852-4e32-8971-57a7c5c93879',
+  '511f0b04-dee5-47e2-b789-d518a735ab49',
+  'bd1d17c7-ce71-4c9a-89e3-cbadf6fbb67f',
+  '77777f54-71c1-4910-b534-3f00e3f9a574',
+  '9a4f0337-b06e-4886-9460-455bf108be8d',
+  'f4b039e7-d4d4-48c2-8799-23b6d8f09716',
+  'a8a0525a-80d4-4e71-9249-4b3114b003bc',
+  '1d275ed8-6c1e-4850-82ad-72e65749ab0b'
+]);
+
+export const POOL_ROYALE_BLENDERKIT_TABLE_FINISHES = Object.freeze(
+  BLENDERKIT_TABLE_FINISH_ASSET_IDS.map((assetBaseId, index) => ({
+    id: `blenderkit-${assetBaseId}`,
+    label: `BlenderKit Finish ${String(index + 1).padStart(2, '0')}`,
+    assetBaseId,
+    price: 1200,
+    description: 'BlenderKit table finish using the original glTF material textures.'
+  }))
+);
+
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
@@ -360,7 +417,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.reduce((acc, finish) => {
+      acc[finish.id] = finish.label;
+      return acc;
+    }, {})
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -444,6 +505,14 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.'
   },
+  ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.map((finish) => ({
+    id: `finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price,
+    description: finish.description
+  })),
   {
     id: 'chrome-chrome',
     type: 'chromeColor',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -62,6 +62,7 @@ import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP,
   POOL_ROYALE_BASE_VARIANTS,
+  POOL_ROYALE_BLENDERKIT_TABLE_FINISHES,
   POOL_ROYALE_OPTION_LABELS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
@@ -2377,6 +2378,39 @@ const createStandardWoodFinish = ({
   }
 });
 
+const BLENDERKIT_TABLE_FINISH_PALETTE = Object.freeze({
+  rail: 0xd3c5b4,
+  base: 0xc2b2a0,
+  trim: 0xf0e6d8
+});
+
+const createBlenderkitWoodSurface = (assetBaseId) => ({
+  repeat: { x: 1, y: 1 },
+  rotation: 0,
+  textureSize: 2048,
+  blenderkitAssetBaseId: assetBaseId
+});
+
+const createBlenderkitTableFinish = (finish) => ({
+  ...createStandardWoodFinish({
+    id: finish.id,
+    label: finish.label,
+    rail: BLENDERKIT_TABLE_FINISH_PALETTE.rail,
+    base: BLENDERKIT_TABLE_FINISH_PALETTE.base,
+    trim: BLENDERKIT_TABLE_FINISH_PALETTE.trim,
+    woodRepeatScale: 1
+  }),
+  woodTexture: {
+    id: finish.id,
+    rail: createBlenderkitWoodSurface(finish.assetBaseId),
+    frame: createBlenderkitWoodSurface(finish.assetBaseId)
+  }
+});
+
+const BLENDERKIT_TABLE_FINISHES = Object.freeze(
+  POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.map(createBlenderkitTableFinish)
+);
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2422,7 +2456,11 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
-  })
+  }),
+  ...BLENDERKIT_TABLE_FINISHES.reduce((acc, finish) => {
+    acc[finish.id] = finish;
+    return acc;
+  }, {})
 });
 
 const TABLE_FINISH_OPTIONS = Object.freeze(
@@ -2431,7 +2469,8 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    ...BLENDERKIT_TABLE_FINISHES
   ].filter(Boolean)
 );
 
@@ -3902,6 +3941,11 @@ function ensureMaterialWoodOptions(material, targetSettings) {
     targetSettings.normalMapUrl.trim().length > 0
       ? targetSettings.normalMapUrl.trim()
       : undefined;
+  const blenderkitAssetBaseId =
+    typeof targetSettings?.blenderkitAssetBaseId === 'string' &&
+    targetSettings.blenderkitAssetBaseId.trim().length > 0
+      ? targetSettings.blenderkitAssetBaseId.trim()
+      : undefined;
   applyWoodTextures(material, {
     hue: preset.hue,
     sat: preset.sat,
@@ -3913,6 +3957,7 @@ function ensureMaterialWoodOptions(material, targetSettings) {
     mapUrl,
     roughnessMapUrl,
     normalMapUrl,
+    blenderkitAssetBaseId,
     sharedKey: `pool-wood-${preset.id}`,
     ...SHARED_WOOD_SURFACE_PROPS
   });
@@ -3937,6 +3982,11 @@ function applyWoodTextureToMaterial(material, repeat) {
     typeof repeat?.normalMapUrl === 'string' && repeat.normalMapUrl.trim().length > 0
       ? repeat.normalMapUrl.trim()
       : undefined;
+  const blenderkitAssetBaseId =
+    typeof repeat?.blenderkitAssetBaseId === 'string' &&
+    repeat.blenderkitAssetBaseId.trim().length > 0
+      ? repeat.blenderkitAssetBaseId.trim()
+      : undefined;
   const repeatScale = clampWoodRepeatScaleValue(repeat?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE);
   const scaledRepeat = scaleWoodRepeatVector(repeatVec, repeatScale);
   const hadOptions = Boolean(material.userData?.__woodOptions);
@@ -3957,21 +4007,23 @@ function applyWoodTextureToMaterial(material, repeat) {
     const textureSizeChanged =
       typeof textureSize === 'number' &&
       Math.abs((options.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE) - textureSize) > 1e-6;
-    const mapChanged =
-      options.mapUrl !== mapUrl ||
-      options.roughnessMapUrl !== roughnessMapUrl ||
-      options.normalMapUrl !== normalMapUrl;
-    if (hadOptions && (repeatChanged || rotationChanged || textureSizeChanged || mapChanged)) {
-      applyWoodTextures(material, {
-        ...options,
-        repeat: { x: scaledRepeat.x, y: scaledRepeat.y },
-        rotation,
-        textureSize: textureSize ?? options.textureSize,
-        mapUrl: mapUrl ?? options.mapUrl,
-        roughnessMapUrl: roughnessMapUrl ?? options.roughnessMapUrl,
-        normalMapUrl: normalMapUrl ?? options.normalMapUrl
-      });
-    }
+  const mapChanged =
+    options.mapUrl !== mapUrl ||
+    options.roughnessMapUrl !== roughnessMapUrl ||
+    options.normalMapUrl !== normalMapUrl ||
+    options.blenderkitAssetBaseId !== blenderkitAssetBaseId;
+  if (hadOptions && (repeatChanged || rotationChanged || textureSizeChanged || mapChanged)) {
+    applyWoodTextures(material, {
+      ...options,
+      repeat: { x: scaledRepeat.x, y: scaledRepeat.y },
+      rotation,
+      textureSize: textureSize ?? options.textureSize,
+      mapUrl: mapUrl ?? options.mapUrl,
+      roughnessMapUrl: roughnessMapUrl ?? options.roughnessMapUrl,
+      normalMapUrl: normalMapUrl ?? options.normalMapUrl,
+      blenderkitAssetBaseId: blenderkitAssetBaseId ?? options.blenderkitAssetBaseId
+    });
+  }
   } else {
     if (material.map) {
       material.map = material.map.clone();
@@ -4013,6 +4065,7 @@ function toPlainWoodSurfaceConfig(settings) {
   let mapUrl = null;
   let roughnessMapUrl = null;
   let normalMapUrl = null;
+  let blenderkitAssetBaseId = null;
   if (repeatSource?.isVector2) {
     repeatX = repeatSource.x;
     repeatY = repeatSource.y;
@@ -4039,6 +4092,12 @@ function toPlainWoodSurfaceConfig(settings) {
   if (typeof settings.normalMapUrl === 'string' && settings.normalMapUrl.trim().length > 0) {
     normalMapUrl = settings.normalMapUrl.trim();
   }
+  if (
+    typeof settings.blenderkitAssetBaseId === 'string' &&
+    settings.blenderkitAssetBaseId.trim().length > 0
+  ) {
+    blenderkitAssetBaseId = settings.blenderkitAssetBaseId.trim();
+  }
   return {
     repeat: {
       x: Number.isFinite(repeatX) ? repeatX : 1,
@@ -4048,7 +4107,8 @@ function toPlainWoodSurfaceConfig(settings) {
     textureSize,
     mapUrl,
     roughnessMapUrl,
-    normalMapUrl
+    normalMapUrl,
+    blenderkitAssetBaseId
   };
 }
 
@@ -4066,7 +4126,9 @@ function resolveWoodSurfaceConfig(option, fallback) {
     textureSize: resolvedOption?.textureSize ?? base.textureSize,
     mapUrl: resolvedOption?.mapUrl ?? base.mapUrl,
     roughnessMapUrl: resolvedOption?.roughnessMapUrl ?? base.roughnessMapUrl,
-    normalMapUrl: resolvedOption?.normalMapUrl ?? base.normalMapUrl
+    normalMapUrl: resolvedOption?.normalMapUrl ?? base.normalMapUrl,
+    blenderkitAssetBaseId:
+      resolvedOption?.blenderkitAssetBaseId ?? base.blenderkitAssetBaseId
   };
 }
 
@@ -4084,6 +4146,10 @@ function cloneWoodSurfaceConfig(config) {
     roughnessMapUrl:
       typeof config.roughnessMapUrl === 'string' ? config.roughnessMapUrl : undefined,
     normalMapUrl: typeof config.normalMapUrl === 'string' ? config.normalMapUrl : undefined,
+    blenderkitAssetBaseId:
+      typeof config.blenderkitAssetBaseId === 'string'
+        ? config.blenderkitAssetBaseId
+        : undefined,
     woodRepeatScale: clampWoodRepeatScaleValue(config.woodRepeatScale)
   };
 }

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -41,6 +41,10 @@ export const setWoodTextureAnisotropyCap = (value) => {
 const woodTextureLoader = new THREE.TextureLoader();
 woodTextureLoader.setCrossOrigin?.('anonymous');
 const WOOD_EXTERNAL_TEXTURE_CACHE = new Map();
+const BLENDERKIT_SEARCH_BASE_URL = 'https://www.blenderkit.com/api/v1/search/?query=asset_base_id:';
+const BLENDERKIT_TEXTURE_CACHE = new Map();
+const BLENDERKIT_TEXTURE_PENDING = new Map();
+const BLENDERKIT_TEXTURE_SUBSCRIBERS = new Map();
 
 const normalizeExternalTexture = (texture, isColor = false, anisotropy = WOOD_TEXTURE_ANISOTROPY) => {
   if (!texture) return;
@@ -88,6 +92,161 @@ const resolveExternalWoodTextureUrls = ({ mapUrl, roughnessMapUrl, normalMapUrl 
     }
   }
   return { color: mapUrl };
+};
+
+const pickBlenderkitThumbnailUrl = (asset) => {
+  if (!asset) return null;
+  return (
+    asset.thumbnailLargeUrl ||
+    asset.thumbnailXlargeUrl ||
+    asset.thumbnailLargeUrlNonsquared ||
+    asset.thumbnailXlargeUrlNonsquared ||
+    asset.thumbnailMiddleUrl ||
+    asset.thumbnailSmallUrl ||
+    asset.thumbnailLargeUrlWebp ||
+    asset.thumbnailXlargeUrlWebp ||
+    asset.thumbnailMiddleUrlWebp ||
+    asset.thumbnailSmallUrlWebp ||
+    null
+  );
+};
+
+const collectBlenderkitImageUrls = (asset) => {
+  const files = Array.isArray(asset?.files) ? asset.files : [];
+  return files
+    .map((file) => ({
+      url: file?.downloadUrl,
+      filename: file?.filename || '',
+      fileType: file?.fileType || ''
+    }))
+    .filter((file) => file.url && /\.(png|jpe?g|webp)$/i.test(file.filename));
+};
+
+const loadTextureFromUrl = (url, isColor = false) =>
+  new Promise((resolve) => {
+    if (!url) {
+      resolve(null);
+      return;
+    }
+    woodTextureLoader.load(
+      url,
+      (texture) => {
+        normalizeExternalTexture(texture, isColor);
+        resolve(texture);
+      },
+      undefined,
+      () => resolve(null)
+    );
+  });
+
+const loadTextureWithFallbacks = async (urls, isColor = false) => {
+  for (const url of urls) {
+    // eslint-disable-next-line no-await-in-loop
+    const texture = await loadTextureFromUrl(url, isColor);
+    if (texture) return texture;
+  }
+  return null;
+};
+
+const applyWoodTextureOverrides = (material, textures, repeat, rotation) => {
+  if (!material || !textures) return;
+  disposeWoodTextures(material);
+  const repeatVec = new THREE.Vector2(repeat?.x ?? 1, repeat?.y ?? 1);
+  const map = cloneWoodTexture(textures.map, repeatVec, rotation);
+  const roughnessMap = cloneWoodTexture(textures.roughnessMap, repeatVec, rotation);
+  const normalMap = cloneWoodTexture(textures.normalMap, repeatVec, rotation);
+  if (map) {
+    map.wrapS = map.wrapT = THREE.RepeatWrapping;
+    boostWoodTextureSampling(map, { isColor: true });
+  }
+  if (roughnessMap) {
+    roughnessMap.wrapS = roughnessMap.wrapT = THREE.RepeatWrapping;
+    boostWoodTextureSampling(roughnessMap);
+  }
+  if (normalMap) {
+    normalMap.wrapS = normalMap.wrapT = THREE.RepeatWrapping;
+    boostWoodTextureSampling(normalMap);
+  }
+  material.map = map;
+  material.roughnessMap = roughnessMap;
+  material.normalMap = normalMap;
+  material.color.setHex(0xffffff);
+  material.needsUpdate = true;
+  material.userData = material.userData || {};
+  material.userData.__woodTextures = { map, roughnessMap, normalMap };
+};
+
+const registerBlenderkitSubscriber = (assetBaseId, material, options = {}) => {
+  if (!assetBaseId || !material) return;
+  let subscribers = BLENDERKIT_TEXTURE_SUBSCRIBERS.get(assetBaseId);
+  if (!subscribers) {
+    subscribers = new Map();
+    BLENDERKIT_TEXTURE_SUBSCRIBERS.set(assetBaseId, subscribers);
+  }
+  subscribers.set(material, {
+    repeat: options.repeat,
+    rotation: options.rotation
+  });
+};
+
+const broadcastBlenderkitTextures = (assetBaseId) => {
+  const entry = BLENDERKIT_TEXTURE_CACHE.get(assetBaseId);
+  if (!entry?.ready) return;
+  const subscribers = BLENDERKIT_TEXTURE_SUBSCRIBERS.get(assetBaseId);
+  if (!subscribers) return;
+  subscribers.forEach((options, material) => {
+    if (!material) return;
+    applyWoodTextureOverrides(material, entry, options?.repeat, options?.rotation);
+  });
+};
+
+const ensureBlenderkitTextures = (assetBaseId) => {
+  if (!assetBaseId || typeof fetch !== 'function') return;
+  const cached = BLENDERKIT_TEXTURE_CACHE.get(assetBaseId);
+  if (cached?.ready) return;
+  if (BLENDERKIT_TEXTURE_PENDING.has(assetBaseId)) return;
+  const promise = (async () => {
+    try {
+      const response = await fetch(
+        `${BLENDERKIT_SEARCH_BASE_URL}${encodeURIComponent(assetBaseId)}`,
+        { mode: 'cors' }
+      );
+      if (!response?.ok) return;
+      const data = await response.json();
+      const asset = data?.results?.[0];
+      if (!asset) return;
+      const imageFiles = collectBlenderkitImageUrls(asset);
+      const thumb = pickBlenderkitThumbnailUrl(asset);
+      const diffuseCandidates = [thumb, ...imageFiles.map((file) => file.url)].filter(Boolean);
+      const normalCandidates = imageFiles
+        .filter((file) =>
+          /normal|nor|nrm/i.test(file.filename) || /normal/i.test(file.fileType)
+        )
+        .map((file) => file.url);
+      const roughnessCandidates = imageFiles
+        .filter((file) =>
+          /rough|roughness/i.test(file.filename) || /rough/i.test(file.fileType)
+        )
+        .map((file) => file.url);
+
+      const [map, normalMap, roughnessMap] = await Promise.all([
+        loadTextureWithFallbacks(diffuseCandidates, true),
+        loadTextureWithFallbacks(normalCandidates, false),
+        loadTextureWithFallbacks(roughnessCandidates, false)
+      ]);
+
+      BLENDERKIT_TEXTURE_CACHE.set(assetBaseId, {
+        map,
+        normalMap,
+        roughnessMap,
+        ready: Boolean(map || normalMap || roughnessMap)
+      });
+      broadcastBlenderkitTextures(assetBaseId);
+    } finally {
+      BLENDERKIT_TEXTURE_PENDING.delete(assetBaseId);
+    }
+  })();
+  BLENDERKIT_TEXTURE_PENDING.set(assetBaseId, promise);
 };
 
 const loadExternalTexture = (url, isColor, anisotropy, onError) => {
@@ -606,6 +765,7 @@ export const applyWoodTextures = (
     mapUrl,
     roughnessMapUrl,
     normalMapUrl,
+    blenderkitAssetBaseId,
     repeat = { x: 1, y: 1 },
     rotation = 0,
     textureSize = DEFAULT_WOOD_TEXTURE_SIZE,
@@ -639,6 +799,21 @@ export const applyWoodTextures = (
       roughnessMap: external?.roughnessMap ?? fallbackTextures.roughnessMap,
       normalMap: external?.normalMap ?? fallbackTextures.normalMap
     };
+  } else if (blenderkitAssetBaseId) {
+    const cached = BLENDERKIT_TEXTURE_CACHE.get(blenderkitAssetBaseId);
+    if (cached?.ready) {
+      baseTextures = {
+        map: cached.map ?? fallbackTextures.map,
+        roughnessMap: cached.roughnessMap ?? fallbackTextures.roughnessMap,
+        normalMap: cached.normalMap ?? fallbackTextures.normalMap
+      };
+    } else {
+      registerBlenderkitSubscriber(blenderkitAssetBaseId, material, {
+        repeat,
+        rotation
+      });
+      ensureBlenderkitTextures(blenderkitAssetBaseId);
+    }
   } else if (sharedKey) {
     baseTextures = ensureSharedWoodTextures({
       hue,
@@ -652,6 +827,9 @@ export const applyWoodTextures = (
       sharedKey
     });
   } else {
+    baseTextures = fallbackTextures;
+  }
+  if (!baseTextures) {
     baseTextures = fallbackTextures;
   }
   const repeatVec = new THREE.Vector2(repeat?.x ?? 1, repeat?.y ?? 1);
@@ -688,6 +866,7 @@ export const applyWoodTextures = (
     mapUrl,
     roughnessMapUrl,
     normalMapUrl,
+    blenderkitAssetBaseId,
     repeat: { x: repeatVec.x, y: repeatVec.y },
     rotation,
     textureSize,


### PR DESCRIPTION
### Motivation
- Provide a set of BlenderKit-sourced table finishes for Pool Royale and load their original glTF textures so store items can reference authentic material textures.
- Allow the existing table finish pipeline to accept an external `blenderkitAssetBaseId` and asynchronously fetch/cached BlenderKit image textures for wood maps.

### Description
- Added a frozen list of BlenderKit asset IDs and exported `POOL_ROYALE_BLENDERKIT_TABLE_FINISHES` in `webapp/src/config/poolRoyaleInventoryConfig.js` and merged those finishes into the store labels and `POOL_ROYALE_STORE_ITEMS` so they appear in the store catalog.
- Extended Pool Royale finish construction in `webapp/src/pages/Games/PoolRoyale.jsx` by creating `BLENDERKIT_TABLE_FINISHES`, mapping them into `TABLE_FINISHES`/`TABLE_FINISH_OPTIONS`, and plumbing a `blenderkitAssetBaseId` through surface config helpers and `ensureMaterialWoodOptions` so finishes can reference BlenderKit assets.
- Implemented BlenderKit texture loading, caching and subscription in `webapp/src/utils/woodMaterials.js` (BLENDERKIT search URL, fetch metadata, select diffuse/normal/roughness candidates, load with fallbacks, cache and broadcast to waiting materials), plus helpers to apply those textures to material maps when ready.
- Integrated the new pipeline into `applyWoodTextures` so a `blenderkitAssetBaseId` will either apply cached BlenderKit textures or register the material as a subscriber and trigger `ensureBlenderkitTextures` to fetch them asynchronously; added small defensive fallbacks for missing textures.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb47993e0832980c099f2e177948c)