### PR TITLE
Add BlenderKit table finishes and runtime texture loading for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -337,6 +337,229 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
 
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
+export const POOL_ROYALE_BLENDERKIT_TABLE_FINISHES = Object.freeze([
+  {
+    id: 'blenderkit-35421bc9',
+    label: 'BlenderKit Finish 35421bc9',
+    assetBaseId: '35421bc9-a49d-4979-8d93-0c13e9eba371'
+  },
+  {
+    id: 'blenderkit-2c52be7f',
+    label: 'BlenderKit Finish 2c52be7f',
+    assetBaseId: '2c52be7f-8e46-4c6c-adc2-888449da931e'
+  },
+  {
+    id: 'blenderkit-3ecfdd76',
+    label: 'BlenderKit Finish 3ecfdd76',
+    assetBaseId: '3ecfdd76-6e15-4c3c-89c9-4a1cafdc3155'
+  },
+  {
+    id: 'blenderkit-f1036f94',
+    label: 'BlenderKit Finish f1036f94',
+    assetBaseId: 'f1036f94-c4a7-4c70-8694-3234f062d46d'
+  },
+  {
+    id: 'blenderkit-1fddce2a',
+    label: 'BlenderKit Finish 1fddce2a',
+    assetBaseId: '1fddce2a-4d76-45e4-b09e-e4605e10b873'
+  },
+  {
+    id: 'blenderkit-fb650615',
+    label: 'BlenderKit Finish fb650615',
+    assetBaseId: 'fb650615-ef11-4e19-bc68-abfbeddee561'
+  },
+  {
+    id: 'blenderkit-852ee40c',
+    label: 'BlenderKit Finish 852ee40c',
+    assetBaseId: '852ee40c-e967-4028-bb26-428e84933cab'
+  },
+  {
+    id: 'blenderkit-199ebe44',
+    label: 'BlenderKit Finish 199ebe44',
+    assetBaseId: '199ebe44-46ef-490d-99f6-93aa33b903b8'
+  },
+  {
+    id: 'blenderkit-e25066a1',
+    label: 'BlenderKit Finish e25066a1',
+    assetBaseId: 'e25066a1-aaba-4ff1-ab68-a67b413c5eaa'
+  },
+  {
+    id: 'blenderkit-a283a837',
+    label: 'BlenderKit Finish a283a837',
+    assetBaseId: 'a283a837-0e33-4182-b55d-2a8c742fda08'
+  },
+  {
+    id: 'blenderkit-46de7336',
+    label: 'BlenderKit Finish 46de7336',
+    assetBaseId: '46de7336-6072-4b85-8b99-ac2438829a08'
+  },
+  {
+    id: 'blenderkit-3c4de2d5',
+    label: 'BlenderKit Finish 3c4de2d5',
+    assetBaseId: '3c4de2d5-540e-4e1c-95dd-9b6721bba08f'
+  },
+  {
+    id: 'blenderkit-22585ff5',
+    label: 'BlenderKit Finish 22585ff5',
+    assetBaseId: '22585ff5-5c37-42c1-8fbe-be9429c2722b'
+  },
+  {
+    id: 'blenderkit-e4cdf7af',
+    label: 'BlenderKit Finish e4cdf7af',
+    assetBaseId: 'e4cdf7af-7789-4ef1-85a8-378956ceb79d'
+  },
+  {
+    id: 'blenderkit-fa7dacb7',
+    label: 'BlenderKit Finish fa7dacb7',
+    assetBaseId: 'fa7dacb7-3621-4c57-ad5b-b4178afc329b'
+  },
+  {
+    id: 'blenderkit-42682664',
+    label: 'BlenderKit Finish 42682664',
+    assetBaseId: '42682664-0da2-4d09-9d18-e0c7fbc61740'
+  },
+  {
+    id: 'blenderkit-784156cf',
+    label: 'BlenderKit Finish 784156cf',
+    assetBaseId: '784156cf-8f7a-4559-b388-4cdc66a237c7'
+  },
+  {
+    id: 'blenderkit-87170683',
+    label: 'BlenderKit Finish 87170683',
+    assetBaseId: '87170683-fda0-4121-b8fd-6a7874a1f060'
+  },
+  {
+    id: 'blenderkit-8f9b1321',
+    label: 'BlenderKit Finish 8f9b1321',
+    assetBaseId: '8f9b1321-c008-4e8b-bee2-bd71c3d96eca'
+  },
+  {
+    id: 'blenderkit-2a5a3947',
+    label: 'BlenderKit Finish 2a5a3947',
+    assetBaseId: '2a5a3947-6788-479a-930c-d8e0c46f5444'
+  },
+  {
+    id: 'blenderkit-7bb8b5ff',
+    label: 'BlenderKit Finish 7bb8b5ff',
+    assetBaseId: '7bb8b5ff-9414-41f6-912e-c7f7c7c199cd'
+  },
+  {
+    id: 'blenderkit-646e4223',
+    label: 'BlenderKit Finish 646e4223',
+    assetBaseId: '646e4223-0a0e-402c-83cb-771f80cb3b40'
+  },
+  {
+    id: 'blenderkit-739b5e5b',
+    label: 'BlenderKit Finish 739b5e5b',
+    assetBaseId: '739b5e5b-95a8-43b5-a87f-393e4bf07afa'
+  },
+  {
+    id: 'blenderkit-4abe5330',
+    label: 'BlenderKit Finish 4abe5330',
+    assetBaseId: '4abe5330-da7c-4297-9769-6e7e0acc8bc3'
+  },
+  {
+    id: 'blenderkit-43baa4e4',
+    label: 'BlenderKit Finish 43baa4e4',
+    assetBaseId: '43baa4e4-d20b-47c5-949b-a38fa6c15b51'
+  },
+  {
+    id: 'blenderkit-179f3e02',
+    label: 'BlenderKit Finish 179f3e02',
+    assetBaseId: '179f3e02-a17a-4b7f-8316-3504864282be'
+  },
+  {
+    id: 'blenderkit-42c90503',
+    label: 'BlenderKit Finish 42c90503',
+    assetBaseId: '42c90503-731b-46b6-a23e-019d06749d3a'
+  },
+  {
+    id: 'blenderkit-a167dd9e',
+    label: 'BlenderKit Finish a167dd9e',
+    assetBaseId: 'a167dd9e-f0a4-4384-8b81-2fbb87dd1728'
+  },
+  {
+    id: 'blenderkit-7c47beed',
+    label: 'BlenderKit Finish 7c47beed',
+    assetBaseId: '7c47beed-802f-449e-8db6-1e1a4af162cc'
+  },
+  {
+    id: 'blenderkit-42f8ed87',
+    label: 'BlenderKit Finish 42f8ed87',
+    assetBaseId: '42f8ed87-4d8b-4e2d-82b3-ec91c4b27231'
+  },
+  {
+    id: 'blenderkit-ec1358d7',
+    label: 'BlenderKit Finish ec1358d7',
+    assetBaseId: 'ec1358d7-5ea1-47f6-9171-6c57de898739'
+  },
+  {
+    id: 'blenderkit-36a2d185',
+    label: 'BlenderKit Finish 36a2d185',
+    assetBaseId: '36a2d185-faf0-4949-b473-c9bec980867f'
+  },
+  {
+    id: 'blenderkit-16bcdeeb',
+    label: 'BlenderKit Finish 16bcdeeb',
+    assetBaseId: '16bcdeeb-ae61-42fa-9f17-ee96ca77a6e5'
+  },
+  {
+    id: 'blenderkit-8e44c701',
+    label: 'BlenderKit Finish 8e44c701',
+    assetBaseId: '8e44c701-27cd-4d52-be1c-a9a7140354a4'
+  },
+  {
+    id: 'blenderkit-ade0f2da',
+    label: 'BlenderKit Finish ade0f2da',
+    assetBaseId: 'ade0f2da-ceed-431b-a372-ade7f969a230'
+  },
+  {
+    id: 'blenderkit-17a9260c',
+    label: 'BlenderKit Finish 17a9260c',
+    assetBaseId: '17a9260c-0355-4e50-b73e-9406e9f642b6'
+  },
+  {
+    id: 'blenderkit-c13bea13',
+    label: 'BlenderKit Finish c13bea13',
+    assetBaseId: 'c13bea13-d852-4e32-8971-57a7c5c93879'
+  },
+  {
+    id: 'blenderkit-511f0b04',
+    label: 'BlenderKit Finish 511f0b04',
+    assetBaseId: '511f0b04-dee5-47e2-b789-d518a735ab49'
+  },
+  {
+    id: 'blenderkit-bd1d17c7',
+    label: 'BlenderKit Finish bd1d17c7',
+    assetBaseId: 'bd1d17c7-ce71-4c9a-89e3-cbadf6fbb67f'
+  },
+  {
+    id: 'blenderkit-77777f54',
+    label: 'BlenderKit Finish 77777f54',
+    assetBaseId: '77777f54-71c1-4910-b534-3f00e3f9a574'
+  },
+  {
+    id: 'blenderkit-9a4f0337',
+    label: 'BlenderKit Finish 9a4f0337',
+    assetBaseId: '9a4f0337-b06e-4886-9460-455bf108be8d'
+  },
+  {
+    id: 'blenderkit-f4b039e7',
+    label: 'BlenderKit Finish f4b039e7',
+    assetBaseId: 'f4b039e7-d4d4-48c2-8799-23b6d8f09716'
+  },
+  {
+    id: 'blenderkit-a8a0525a',
+    label: 'BlenderKit Finish a8a0525a',
+    assetBaseId: 'a8a0525a-80d4-4e71-9249-4b3114b003bc'
+  },
+  {
+    id: 'blenderkit-1d275ed8',
+    label: 'BlenderKit Finish 1d275ed8',
+    assetBaseId: '1d275ed8-6c1e-4850-82ad-72e65749ab0b'
+  }
+]);
+
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['peelingPaintWeathered'],
   chromeColor: ['gold'],
@@ -360,7 +583,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.reduce((acc, finish) => {
+      acc[finish.id] = finish.label;
+      return acc;
+    }, {})
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -444,6 +671,14 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.'
   },
+  ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.map((finish) => ({
+    id: `finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: `${finish.label} Finish`,
+    price: 1120,
+    description: 'BlenderKit material finish with original texture mapping.'
+  })),
   {
     id: 'chrome-chrome',
     type: 'chromeColor',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -62,6 +62,7 @@ import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP,
   POOL_ROYALE_BASE_VARIANTS,
+  POOL_ROYALE_BLENDERKIT_TABLE_FINISHES,
   POOL_ROYALE_OPTION_LABELS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
@@ -2377,6 +2378,27 @@ const createStandardWoodFinish = ({
   }
 });
 
+const BLENDERKIT_TABLE_FINISH_MAP = POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.reduce(
+  (acc, entry) => {
+    const baseFinish = createStandardWoodFinish({
+      id: entry.id,
+      label: entry.label,
+      rail: 0xd8d2c8,
+      base: 0xc9c2b8,
+      trim: 0xf2eee8,
+      woodTextureId: null,
+      woodRepeatScale: 1
+    });
+    acc[entry.id] = {
+      ...baseFinish,
+      blenderkitAssetBaseId: entry.assetBaseId,
+      woodTextureId: null
+    };
+    return acc;
+  },
+  {}
+);
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2422,10 +2444,11 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
-  })
+  }),
+  ...BLENDERKIT_TABLE_FINISH_MAP
 });
 
-const TABLE_FINISH_OPTIONS = Object.freeze(
+const BASE_TABLE_FINISH_OPTIONS = Object.freeze(
   [
     TABLE_FINISHES.peelingPaintWeathered,
     TABLE_FINISHES.oakVeneer01,
@@ -2435,7 +2458,14 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   ].filter(Boolean)
 );
 
-const CUE_FINISH_OPTIONS = TABLE_FINISH_OPTIONS;
+const TABLE_FINISH_OPTIONS = Object.freeze(
+  [
+    ...BASE_TABLE_FINISH_OPTIONS,
+    ...POOL_ROYALE_BLENDERKIT_TABLE_FINISHES.map((entry) => TABLE_FINISHES[entry.id])
+  ].filter(Boolean)
+);
+
+const CUE_FINISH_OPTIONS = BASE_TABLE_FINISH_OPTIONS;
 const CUE_FINISH_PALETTE = Object.freeze(
   CUE_FINISH_OPTIONS.map(
     (finish) => finish?.colors?.rail ?? finish?.colors?.base ?? 0xdeb887
@@ -3031,6 +3061,169 @@ const upgradePolyHavenTextureUrlTo4k = (url) => {
   if (typeof url !== 'string' || url.length === 0) return url;
   if (!url.includes('/2k/') && !url.includes('_2k')) return url;
   return url.replace('/2k/', '/4k/').replace(/_2k(\.\w+)$/, '_4k$1');
+};
+
+const blenderkitFinishTextureCache = new Map();
+const pendingBlenderkitFinishTextureRequests = new Map();
+const blenderkitFinishTextureConsumers = new Map();
+const blenderkitFinishAssetCache = new Map();
+const pendingBlenderkitFinishAssets = new Map();
+
+const pickBlenderkitFinishThumbnailUrl = (asset) =>
+  asset?.thumbnailLargeUrl ||
+  asset?.thumbnailXlargeUrl ||
+  asset?.thumbnailLargeUrlNonsquared ||
+  asset?.thumbnailXlargeUrlNonsquared ||
+  asset?.thumbnailMiddleUrl ||
+  asset?.thumbnailSmallUrl ||
+  asset?.thumbnailLargeUrlWebp ||
+  asset?.thumbnailXlargeUrlWebp ||
+  asset?.thumbnailMiddleUrlWebp ||
+  asset?.thumbnailSmallUrlWebp ||
+  null;
+
+const collectBlenderkitFinishImageUrls = (asset) => {
+  const files = Array.isArray(asset?.files) ? asset.files : [];
+  return files
+    .map((file) => ({
+      url: file?.downloadUrl,
+      filename: file?.filename || '',
+      fileType: file?.fileType || ''
+    }))
+    .filter((file) => file.url && /\.(png|jpe?g|webp)$/i.test(file.filename));
+};
+
+const scoreBlenderkitFinishCandidate = (file, includes, excludes) => {
+  const name = `${file.filename || ''} ${file.fileType || ''}`.toLowerCase();
+  if (excludes.some((kw) => name.includes(kw))) return -Infinity;
+  let score = 0;
+  if (includes.some((kw) => name.includes(kw))) score += 6;
+  if (name.includes('4k')) score += 4;
+  if (name.includes('2k')) score += 3;
+  if (name.includes('1k')) score += 2;
+  if (name.includes('jpg') || name.includes('jpeg')) score += 2;
+  if (name.includes('png')) score += 1;
+  if (name.includes('webp')) score += 1;
+  return score;
+};
+
+const pickBlenderkitFinishTextureUrl = (files, includes, excludes) =>
+  files
+    .map((file) => ({
+      file,
+      score: scoreBlenderkitFinishCandidate(file, includes, excludes)
+    }))
+    .filter((entry) => Number.isFinite(entry.score))
+    .sort((a, b) => b.score - a.score)[0]?.file?.url || null;
+
+const pickBlenderkitFinishTextureUrls = (asset) => {
+  const files = collectBlenderkitFinishImageUrls(asset);
+  const excludeColor = ['normal', 'rough', 'roughness', 'metal', 'spec', 'ao', 'height'];
+  const includeColor = ['diff', 'diffuse', 'albedo', 'basecolor', 'color', 'col'];
+  const includeNormal = ['normal', 'nor', 'nrm'];
+  const includeRough = ['rough', 'roughness'];
+  return {
+    mapUrl:
+      pickBlenderkitFinishTextureUrl(files, includeColor, excludeColor) ||
+      pickBlenderkitFinishThumbnailUrl(asset),
+    normalMapUrl: pickBlenderkitFinishTextureUrl(files, includeNormal, []),
+    roughnessMapUrl: pickBlenderkitFinishTextureUrl(files, includeRough, [])
+  };
+};
+
+const fetchBlenderkitFinishAsset = async (assetBaseId) => {
+  if (!assetBaseId || typeof fetch !== 'function') return null;
+  if (blenderkitFinishAssetCache.has(assetBaseId)) {
+    return blenderkitFinishAssetCache.get(assetBaseId);
+  }
+  if (pendingBlenderkitFinishAssets.has(assetBaseId)) {
+    return pendingBlenderkitFinishAssets.get(assetBaseId);
+  }
+  const promise = (async () => {
+    try {
+      const response = await fetch(
+        `${BLENDERKIT_SEARCH_BASE_URL}${encodeURIComponent(assetBaseId)}`,
+        { mode: 'cors' }
+      );
+      if (!response?.ok) return null;
+      const data = await response.json();
+      const asset = data?.results?.[0] || null;
+      if (asset) {
+        blenderkitFinishAssetCache.set(assetBaseId, asset);
+      }
+      return asset;
+    } catch (error) {
+      return null;
+    } finally {
+      pendingBlenderkitFinishAssets.delete(assetBaseId);
+    }
+  })();
+  pendingBlenderkitFinishAssets.set(assetBaseId, promise);
+  return promise;
+};
+
+const ensureBlenderkitFinishTextureUrls = (assetBaseId) => {
+  if (!assetBaseId) return;
+  const cached = blenderkitFinishTextureCache.get(assetBaseId);
+  if (cached?.ready) return;
+  if (pendingBlenderkitFinishTextureRequests.has(assetBaseId)) return;
+  if (typeof window === 'undefined' || typeof fetch !== 'function') return;
+
+  const promise = (async () => {
+    try {
+      const asset = await fetchBlenderkitFinishAsset(assetBaseId);
+      if (!asset) return;
+      const urls = pickBlenderkitFinishTextureUrls(asset);
+      if (!urls?.mapUrl && !urls?.normalMapUrl && !urls?.roughnessMapUrl) return;
+      blenderkitFinishTextureCache.set(assetBaseId, {
+        urls,
+        ready: true
+      });
+      const consumers = blenderkitFinishTextureConsumers.get(assetBaseId);
+      if (consumers?.size) {
+        consumers.forEach((consumer) => consumer?.(urls));
+        consumers.clear();
+      }
+    } catch (error) {
+      console.warn('Failed to load BlenderKit finish textures', assetBaseId, error);
+    } finally {
+      pendingBlenderkitFinishTextureRequests.delete(assetBaseId);
+    }
+  })();
+  pendingBlenderkitFinishTextureRequests.set(assetBaseId, promise);
+};
+
+const registerBlenderkitFinishConsumer = (assetBaseId, consumer) => {
+  if (!assetBaseId || typeof consumer !== 'function') return;
+  const cached = blenderkitFinishTextureCache.get(assetBaseId);
+  if (cached?.ready && cached?.urls) {
+    consumer(cached.urls);
+    return;
+  }
+  let consumers = blenderkitFinishTextureConsumers.get(assetBaseId);
+  if (!consumers) {
+    consumers = new Set();
+    blenderkitFinishTextureConsumers.set(assetBaseId, consumers);
+  }
+  consumers.add(consumer);
+  ensureBlenderkitFinishTextureUrls(assetBaseId);
+};
+
+const applyBlenderkitFinishTextures = (assetBaseId, targets) => {
+  if (!assetBaseId || !Array.isArray(targets) || !targets.length) return;
+  const applyUrls = (urls) => {
+    if (!urls) return;
+    targets.forEach((target) => {
+      if (!target?.material) return;
+      applyWoodTextureToMaterial(target.material, {
+        ...target.surface,
+        mapUrl: urls.mapUrl,
+        roughnessMapUrl: urls.roughnessMapUrl,
+        normalMapUrl: urls.normalMapUrl
+      });
+    });
+  };
+  registerBlenderkitFinishConsumer(assetBaseId, applyUrls);
 };
 
 const createClothTextures = (() => {
@@ -7412,7 +7605,7 @@ function Table3D(
     resolvedWoodOption?.frame,
     initialFrameSurface
   );
-  applyWoodTextureToMaterial(railMat, {
+  const alignedRailSurfaceConfig = {
     repeat: new THREE.Vector2(
       alignedRailSurface.repeat.x,
       alignedRailSurface.repeat.y
@@ -7423,24 +7616,38 @@ function Table3D(
     roughnessMapUrl: alignedRailSurface.roughnessMapUrl,
     normalMapUrl: alignedRailSurface.normalMapUrl,
     woodRepeatScale
-  });
+  };
+  applyWoodTextureToMaterial(railMat, alignedRailSurfaceConfig);
+  const underlaySurface = initialFrameSurface;
+  const underlaySurfaceConfig = {
+    repeat: new THREE.Vector2(
+      underlaySurface.repeat.x,
+      underlaySurface.repeat.y
+    ),
+    rotation: underlaySurface.rotation,
+    textureSize: underlaySurface.textureSize,
+    mapUrl: underlaySurface.mapUrl,
+    roughnessMapUrl: underlaySurface.roughnessMapUrl,
+    normalMapUrl: underlaySurface.normalMapUrl,
+    woodRepeatScale
+  };
   finishParts.underlayMeshes.forEach((mesh) => {
     if (!mesh?.material || mesh.userData?.skipWoodTexture) return;
-    const underlaySurface = initialFrameSurface;
-    applyWoodTextureToMaterial(mesh.material, {
-      repeat: new THREE.Vector2(
-        underlaySurface.repeat.x,
-        underlaySurface.repeat.y
-      ),
-      rotation: underlaySurface.rotation,
-      textureSize: underlaySurface.textureSize,
-      mapUrl: underlaySurface.mapUrl,
-      roughnessMapUrl: underlaySurface.roughnessMapUrl,
-      normalMapUrl: underlaySurface.normalMapUrl,
-      woodRepeatScale
-    });
+    applyWoodTextureToMaterial(mesh.material, underlaySurfaceConfig);
     mesh.material.needsUpdate = true;
   });
+  if (resolvedFinish?.blenderkitAssetBaseId) {
+    const blenderkitTargets = [
+      { material: railMat, surface: alignedRailSurfaceConfig },
+      { material: frameMat, surface: synchronizedFrameSurface },
+      { material: legMat, surface: synchronizedFrameSurface },
+      ...finishParts.underlayMeshes.map((mesh) => ({
+        material: mesh?.material,
+        surface: underlaySurfaceConfig
+      }))
+    ];
+    applyBlenderkitFinishTextures(resolvedFinish.blenderkitAssetBaseId, blenderkitTargets);
+  }
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.07; // push the cushions further outward so they meet the wooden rails without a gap
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
@@ -10415,6 +10622,23 @@ function applyTableFinishToTable(table, finish) {
     }
     applyTableFinishDulling(legMat);
     applyTableWoodVisibilityTuning(legMat);
+    if (resolvedFinish?.blenderkitAssetBaseId) {
+      const underlayTargets = finishInfo.parts.underlayMeshes.map((mesh) => {
+        if (!mesh?.material) return null;
+        const baseMaterialKey =
+          mesh.userData?.baseMaterialKey === 'frame' ? 'frame' : 'rail';
+        const underlaySurface =
+          baseMaterialKey === 'frame' ? synchronizedFrameSurface : synchronizedRailSurface;
+        return { material: mesh.material, surface: underlaySurface };
+      });
+      const blenderkitTargets = [
+        { material: railMat, surface: synchronizedRailSurface },
+        { material: frameMat, surface: synchronizedFrameSurface },
+        { material: legMat, surface: synchronizedFrameSurface },
+        ...underlayTargets.filter(Boolean)
+      ];
+      applyBlenderkitFinishTextures(resolvedFinish.blenderkitAssetBaseId, blenderkitTargets);
+    }
     woodSurfaces.rail = cloneWoodSurfaceConfig(synchronizedRailSurface);
     woodSurfaces.frame = cloneWoodSurfaceConfig(synchronizedFrameSurface);
     finishInfo.woodTextureId = resolvedWoodOption?.id ?? DEFAULT_WOOD_GRAIN_ID;


### PR DESCRIPTION
### Motivation
- Expose a large set of BlenderKit-sourced table finishes (asset_base_id list) in the Pool Royale store so original GLTF/material textures can be fetched and applied at runtime. 
- Preserve existing wood finish behaviour while enabling optional BlenderKit texture overrides for table rails/underlays and table bases. 

### Description
- Added `POOL_ROYALE_BLENDERKIT_TABLE_FINISHES` with the provided `assetBaseId` entries and wired them into `POOL_ROYALE_STORE_ITEMS` and `POOL_ROYALE_OPTION_LABELS` so finishes appear in the store (`webapp/src/config/poolRoyaleInventoryConfig.js`).
- Extended Pool Royale table finish system to include BlenderKit entries by creating `BLENDERKIT_TABLE_FINISH_MAP` and merging it into `TABLE_FINISHES`, and limited cue finish options to the original base finishes (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Implemented BlenderKit texture lookup and application utilities: fetch asset metadata, pick candidate diffuse/normal/roughness images, caching, consumer registration, and `applyBlenderkitFinishTextures` to apply fetched textures to target materials (rail/frame/leg/underlay) while reusing existing `applyWoodTextureToMaterial` machinery (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Hooked BlenderKit texture application into table build and finish-application flows (both initial `Table3D` underlay setup and `applyTableFinishToTable`) so when a finish has `blenderkitAssetBaseId` textures are requested and applied to the materials.

### Testing
- No automated tests were run as part of this change; files were linted/compiled locally when authoring but no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb47993e0832980c099f2e177948c)