### PR TITLE
Resolve BlenderKit download URLs and preserve original finish mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3085,12 +3085,38 @@ const pickBlenderkitFinishThumbnailUrl = (asset) =>
 const collectBlenderkitFinishImageUrls = (asset) => {
   const files = Array.isArray(asset?.files) ? asset.files : [];
   return files
-    .map((file) => ({
-      url: file?.downloadUrl,
-      filename: file?.filename || '',
-      fileType: file?.fileType || ''
-    }))
+    .flatMap((file) => {
+      const entries = [
+        file?.filePath,
+        file?.downloadUrl,
+        file?.thumbnailXlargeUrl,
+        file?.thumbnailLargeUrl,
+        file?.thumbnailUrl
+      ].filter(Boolean);
+      return entries.map((url) => ({
+        url,
+        filename: file?.filename || String(url || ''),
+        fileType: file?.fileType || ''
+      }));
+    })
     .filter((file) => file.url && /\.(png|jpe?g|webp)$/i.test(file.filename));
+};
+
+const isBlenderkitDownloadUrl = (url) =>
+  typeof url === 'string' && url.includes('/api/v1/downloads/');
+
+const resolveBlenderkitDownloadUrl = async (url) => {
+  if (!url || typeof fetch !== 'function' || !isBlenderkitDownloadUrl(url)) {
+    return url;
+  }
+  try {
+    const response = await fetch(url, { mode: 'cors' });
+    if (!response?.ok) return url;
+    const data = await response.json();
+    return data?.filePath || url;
+  } catch (error) {
+    return url;
+  }
 };
 
 const scoreBlenderkitFinishCandidate = (file, includes, excludes) => {
@@ -3175,13 +3201,23 @@ const ensureBlenderkitFinishTextureUrls = (assetBaseId) => {
       if (!asset) return;
       const urls = pickBlenderkitFinishTextureUrls(asset);
       if (!urls?.mapUrl && !urls?.normalMapUrl && !urls?.roughnessMapUrl) return;
+      const [mapUrl, normalMapUrl, roughnessMapUrl] = await Promise.all([
+        resolveBlenderkitDownloadUrl(urls.mapUrl),
+        resolveBlenderkitDownloadUrl(urls.normalMapUrl),
+        resolveBlenderkitDownloadUrl(urls.roughnessMapUrl)
+      ]);
+      const resolvedUrls = {
+        mapUrl,
+        normalMapUrl,
+        roughnessMapUrl
+      };
       blenderkitFinishTextureCache.set(assetBaseId, {
-        urls,
+        urls: resolvedUrls,
         ready: true
       });
       const consumers = blenderkitFinishTextureConsumers.get(assetBaseId);
       if (consumers?.size) {
-        consumers.forEach((consumer) => consumer?.(urls));
+        consumers.forEach((consumer) => consumer?.(resolvedUrls));
         consumers.clear();
       }
     } catch (error) {
@@ -3215,8 +3251,18 @@ const applyBlenderkitFinishTextures = (assetBaseId, targets) => {
     if (!urls) return;
     targets.forEach((target) => {
       if (!target?.material) return;
+      const useOriginalMapping = Boolean(target.useOriginalMapping);
+      const surface = target.surface || {};
+      const resolvedSurface = useOriginalMapping
+        ? {
+            repeat: new THREE.Vector2(1, 1),
+            rotation: 0,
+            textureSize: surface.textureSize,
+            woodRepeatScale: 1
+          }
+        : surface;
       applyWoodTextureToMaterial(target.material, {
-        ...target.surface,
+        ...resolvedSurface,
         mapUrl: urls.mapUrl,
         roughnessMapUrl: urls.roughnessMapUrl,
         normalMapUrl: urls.normalMapUrl
@@ -7638,12 +7684,13 @@ function Table3D(
   });
   if (resolvedFinish?.blenderkitAssetBaseId) {
     const blenderkitTargets = [
-      { material: railMat, surface: alignedRailSurfaceConfig },
-      { material: frameMat, surface: synchronizedFrameSurface },
-      { material: legMat, surface: synchronizedFrameSurface },
+      { material: railMat, surface: alignedRailSurfaceConfig, useOriginalMapping: true },
+      { material: frameMat, surface: synchronizedFrameSurface, useOriginalMapping: true },
+      { material: legMat, surface: synchronizedFrameSurface, useOriginalMapping: true },
       ...finishParts.underlayMeshes.map((mesh) => ({
         material: mesh?.material,
-        surface: underlaySurfaceConfig
+        surface: underlaySurfaceConfig,
+        useOriginalMapping: true
       }))
     ];
     applyBlenderkitFinishTextures(resolvedFinish.blenderkitAssetBaseId, blenderkitTargets);
@@ -9970,6 +10017,19 @@ function Table3D(
     return modelFiles[0]?.downloadUrl || null;
   };
 
+  const resolveBlenderkitModelUrl = async (url) => {
+    if (!url || typeof fetch !== 'function') return url;
+    if (!isBlenderkitDownloadUrl(url)) return url;
+    try {
+      const response = await fetch(url, { mode: 'cors' });
+      if (!response?.ok) return url;
+      const data = await response.json();
+      return data?.filePath || url;
+    } catch (error) {
+      return url;
+    }
+  };
+
   const ensureBlenderkitBaseTemplate = (assetBaseId, renderer = null) => {
     if (!assetBaseId) {
       return Promise.reject(new Error('Missing BlenderKit asset id'));
@@ -9991,7 +10051,7 @@ function Table3D(
       }
       const data = await response.json();
       const asset = data?.results?.[0];
-      const url = pickBlenderkitModelUrl(asset);
+      const url = await resolveBlenderkitModelUrl(pickBlenderkitModelUrl(asset));
       if (!url) {
         throw new Error(`No GLTF payload found for BlenderKit asset ${assetBaseId}`);
       }
@@ -10629,12 +10689,16 @@ function applyTableFinishToTable(table, finish) {
           mesh.userData?.baseMaterialKey === 'frame' ? 'frame' : 'rail';
         const underlaySurface =
           baseMaterialKey === 'frame' ? synchronizedFrameSurface : synchronizedRailSurface;
-        return { material: mesh.material, surface: underlaySurface };
+        return {
+          material: mesh.material,
+          surface: underlaySurface,
+          useOriginalMapping: true
+        };
       });
       const blenderkitTargets = [
-        { material: railMat, surface: synchronizedRailSurface },
-        { material: frameMat, surface: synchronizedFrameSurface },
-        { material: legMat, surface: synchronizedFrameSurface },
+        { material: railMat, surface: synchronizedRailSurface, useOriginalMapping: true },
+        { material: frameMat, surface: synchronizedFrameSurface, useOriginalMapping: true },
+        { material: legMat, surface: synchronizedFrameSurface, useOriginalMapping: true },
         ...underlayTargets.filter(Boolean)
       ];
       applyBlenderkitFinishTextures(resolvedFinish.blenderkitAssetBaseId, blenderkitTargets);


### PR DESCRIPTION
### Motivation
- BlenderKit-sourced table finishes and base models were not loading correctly because BlenderKit download endpoints often return wrapper JSON; original UV/texture mapping on GLTF materials was being lost when applying finishes.

### Description
- Expand `collectBlenderkitFinishImageUrls` to consider `filePath`, `downloadUrl`, and thumbnail URLs so image candidates include direct file endpoints and thumbnails.  
- Add `isBlenderkitDownloadUrl` and `resolveBlenderkitDownloadUrl` to fetch BlenderKit download endpoints and extract the real `filePath` before using textures.  
- Ensure finish texture URLs are resolved (`ensureBlenderkitFinishTextureUrls`) and stored as resolved `mapUrl`, `normalMapUrl`, and `roughnessMapUrl` for consumers.  
- Add `useOriginalMapping` support to `applyBlenderkitFinishTextures` and mark BlenderKit targets (rails, frames, legs, underlays) to preserve original UV mapping when applying BlenderKit textures.  
- Add `resolveBlenderkitModelUrl` to resolve BlenderKit model download endpoints prior to GLTF loading so base table GLTF/GLB payloads load reliably.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and confirmed Vite served the site (server ready).  
- Attempted an automated headless render/screenshot with Playwright to verify the BlenderKit table model, but the headless Chromium process crashed and the Playwright run failed (TargetClosedError / SIGSEGV).  
- No unit test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccd544b708329869a40a4ccc5d1a0)