### PR TITLE
Resolve BlenderKit download URLs and update Pool Royale table asset

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -331,7 +331,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
     name: 'BlenderKit Pool Table Base',
     description: 'BlenderKit pool table model base, fitted to the Pool Royale playfield.',
     swatches: ['#2f7d4d', '#0f3d24'],
-    assetBaseId: '84a78996-6ed0-4833-a110-b00c36c348a8'
+    assetBaseId: '30785e01-959c-47a0-8491-9471dd926581'
   }
 ]);
 

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -10,7 +10,7 @@ const TABLE_MODELS = [
     label: 'BlenderKit Table',
     description: 'Pool table model sourced from BlenderKit.',
     baseVariantId: 'blenderkitPoolTable',
-    assetBaseId: '84a78996-6ed0-4833-a110-b00c36c348a8'
+    assetBaseId: '30785e01-959c-47a0-8491-9471dd926581'
   }
 ];
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3063,6 +3063,55 @@ const upgradePolyHavenTextureUrlTo4k = (url) => {
   return url.replace('/2k/', '/4k/').replace(/_2k(\.\w+)$/, '_4k$1');
 };
 
+const BLENDERKIT_DOWNLOAD_PATH = '/api/v1/downloads/';
+const blenderkitDownloadUrlCache = new Map();
+const pendingBlenderkitDownloadUrlRequests = new Map();
+
+const resolveBlenderkitDownloadUrl = async (url) => {
+  if (!url || typeof url !== 'string') return null;
+  if (!url.includes(BLENDERKIT_DOWNLOAD_PATH)) return url;
+  if (blenderkitDownloadUrlCache.has(url)) {
+    return blenderkitDownloadUrlCache.get(url);
+  }
+  if (pendingBlenderkitDownloadUrlRequests.has(url)) {
+    return pendingBlenderkitDownloadUrlRequests.get(url);
+  }
+  if (typeof fetch !== 'function') return url;
+  const promise = (async () => {
+    try {
+      const response = await fetch(url, { mode: 'cors' });
+      if (!response?.ok) return url;
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const json = await response.json();
+        const filePath = json?.filePath || json?.url || json?.downloadUrl || null;
+        if (filePath) {
+          blenderkitDownloadUrlCache.set(url, filePath);
+          return filePath;
+        }
+      }
+      blenderkitDownloadUrlCache.set(url, response.url || url);
+      return response.url || url;
+    } catch (error) {
+      return url;
+    } finally {
+      pendingBlenderkitDownloadUrlRequests.delete(url);
+    }
+  })();
+  pendingBlenderkitDownloadUrlRequests.set(url, promise);
+  return promise;
+};
+
+const resolveBlenderkitTextureUrls = async (urls) => {
+  if (!urls) return null;
+  const [mapUrl, normalMapUrl, roughnessMapUrl] = await Promise.all([
+    resolveBlenderkitDownloadUrl(urls.mapUrl),
+    resolveBlenderkitDownloadUrl(urls.normalMapUrl),
+    resolveBlenderkitDownloadUrl(urls.roughnessMapUrl)
+  ]);
+  return { mapUrl, normalMapUrl, roughnessMapUrl };
+};
+
 const blenderkitFinishTextureCache = new Map();
 const pendingBlenderkitFinishTextureRequests = new Map();
 const blenderkitFinishTextureConsumers = new Map();
@@ -3174,14 +3223,17 @@ const ensureBlenderkitFinishTextureUrls = (assetBaseId) => {
       const asset = await fetchBlenderkitFinishAsset(assetBaseId);
       if (!asset) return;
       const urls = pickBlenderkitFinishTextureUrls(asset);
-      if (!urls?.mapUrl && !urls?.normalMapUrl && !urls?.roughnessMapUrl) return;
+      const resolvedUrls = await resolveBlenderkitTextureUrls(urls);
+      if (!resolvedUrls?.mapUrl && !resolvedUrls?.normalMapUrl && !resolvedUrls?.roughnessMapUrl) {
+        return;
+      }
       blenderkitFinishTextureCache.set(assetBaseId, {
-        urls,
+        urls: resolvedUrls,
         ready: true
       });
       const consumers = blenderkitFinishTextureConsumers.get(assetBaseId);
       if (consumers?.size) {
-        consumers.forEach((consumer) => consumer?.(urls));
+        consumers.forEach((consumer) => consumer?.(resolvedUrls));
         consumers.clear();
       }
     } catch (error) {
@@ -3691,18 +3743,26 @@ const createClothTextures = (() => {
         const asset = await fetchBlenderkitAsset(preset.assetBaseId);
         if (!asset) return;
         const imageFiles = collectBlenderkitImageUrls(asset);
+        const resolvedImageFiles = (
+          await Promise.all(
+            imageFiles.map(async (file) => ({
+              ...file,
+              url: await resolveBlenderkitDownloadUrl(file.url)
+            }))
+          )
+        ).filter((file) => file.url);
         const thumb = pickBlenderkitThumbnailUrl(asset);
         const diffuseCandidates = [
           thumb,
-          ...imageFiles.map((file) => file.url)
+          ...resolvedImageFiles.map((file) => file.url)
         ].filter(Boolean);
 
-        const normalCandidates = imageFiles
+        const normalCandidates = resolvedImageFiles
           .filter((file) =>
             /normal|nor|nrm/i.test(file.filename) || /normal/i.test(file.fileType)
           )
           .map((file) => file.url);
-        const roughnessCandidates = imageFiles
+        const roughnessCandidates = resolvedImageFiles
           .filter((file) =>
             /rough|roughness/i.test(file.filename) || /rough/i.test(file.fileType)
           )
@@ -9866,7 +9926,7 @@ function Table3D(
   const polyhavenBasePromises = new Map();
   const blenderkitBaseTemplates = new Map();
   const blenderkitBasePromises = new Map();
-  const BLENDERKIT_POOL_TABLE_ASSET_BASE_ID = '84a78996-6ed0-4833-a110-b00c36c348a8';
+  const BLENDERKIT_POOL_TABLE_ASSET_BASE_ID = '30785e01-959c-47a0-8491-9471dd926581';
 
   const ensurePolyhavenKtx2Loader = (renderer = null) => {
     if (!polyhavenKtx2Loader) {
@@ -9992,10 +10052,11 @@ function Table3D(
       const data = await response.json();
       const asset = data?.results?.[0];
       const url = pickBlenderkitModelUrl(asset);
-      if (!url) {
+      const resolvedUrl = await resolveBlenderkitDownloadUrl(url);
+      if (!resolvedUrl) {
         throw new Error(`No GLTF payload found for BlenderKit asset ${assetBaseId}`);
       }
-      const gltf = await loader.loadAsync(url);
+      const gltf = await loader.loadAsync(resolvedUrl);
       const scene = gltf?.scene || gltf?.scenes?.[0];
       if (!scene) throw new Error('Missing scene for BlenderKit base');
       blenderkitBaseTemplates.set(assetBaseId, scene);
@@ -10208,7 +10269,6 @@ function Table3D(
       footprintDepthScale: 1,
       heightFill: 0.86,
       topInsetScale: 0.96,
-      materialKey: 'trim',
       matchTableFootprint: true,
       fallbackBuilder: buildClassicCylindersBase
     }),


### PR DESCRIPTION
### Motivation
- BlenderKit-sourced table finishes and cloth textures were not loading because the downloader endpoints returned redirect/JSON download payloads instead of direct file URLs, preventing GLTF materials and original texture UV mappings from showing.
- The Pool Royale table model reference needed to be moved to the correct BlenderKit asset so the in-game BlenderKit table and finishes can be resolved reliably.

### Description
- Added `resolveBlenderkitDownloadUrl` and `resolveBlenderkitTextureUrls` helpers in `webapp/src/pages/Games/PoolRoyale.jsx` to resolve BlenderKit `/api/v1/downloads/` endpoints into usable file URLs before passing them to Three texture and GLTF loaders.
- Updated BlenderKit finish and cloth loaders to resolve download URLs (used by `ensureBlenderkitFinishTextureUrls` and `ensureBlenderkitTextures`) so `map`, `normalMap`, and `roughnessMap` are actual fetchable paths.
- Changed BlenderKit base model loading to call `resolveBlenderkitDownloadUrl` for the GLTF/GLB payload and load the resolved URL with the configured `GLTFLoader` to preserve original GLTF materials and UV mappings.
- Switched the BlenderKit pool table asset ID in `webapp/src/config/poolRoyaleTableModels.js` and `webapp/src/config/poolRoyaleInventoryConfig.js` to the updated asset base ID `30785e01-959c-47a0-8491-9471dd926581` and adjusted the base builder to avoid overwriting GLTF materials so original material mappings remain visible.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and received a successful Vite startup (`Local: http://localhost:4173/`).
- Attempted an automated visual smoke check using Playwright to open `/games/poolroyale` and capture a screenshot, but the browser process crashed/closed (SIGSEGV) and the screenshot step failed.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccd544b708329869a40a4ccc5d1a0)