### PR TITLE
Use Pool Royale table as Air Hockey base and match playfield size/height

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -341,44 +341,12 @@ const AIR_HOCKEY_TABLE_FINISHES = Object.freeze([
 
 const AIR_HOCKEY_TABLE_BASES = Object.freeze([
   Object.freeze({
-    id: 'classicCylinders',
-    name: 'Classic Cylinders',
-    description: 'Rounded skirt with six cylinder legs and subtle foot pads.',
+    id: 'blenderkitPoolTable',
+    name: 'Pool Royale Table',
+    description: 'Pool Royale table base model sized to the official tournament footprint.',
     base: '#8f6243',
     accent: '#6f3a2f',
     swatches: ['#8f6243', '#6f3a2f']
-  }),
-  Object.freeze({
-    id: 'openPortal',
-    name: 'Open Portal',
-    description: 'Twin portal legs with angled sides and negative space.',
-    base: '#f8fafc',
-    accent: '#e5e7eb',
-    swatches: ['#f8fafc', '#e5e7eb']
-  }),
-  Object.freeze({
-    id: 'coffeeTableRound01',
-    name: 'Coffee Table Round 01 Base',
-    description: 'Rounded Poly Haven coffee table legs tucked beneath the pool table.',
-    base: '#c5a47e',
-    accent: '#7a5534',
-    swatches: ['#c5a47e', '#7a5534']
-  }),
-  Object.freeze({
-    id: 'gothicCoffeeTable',
-    name: 'Gothic Coffee Table Base',
-    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
-    base: '#8f4a2b',
-    accent: '#3b2a1f',
-    swatches: ['#8f4a2b', '#3b2a1f']
-  }),
-  Object.freeze({
-    id: 'woodenTable02Alt',
-    name: 'Wooden Table 02 Alt Base',
-    description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
-    base: '#6f5140',
-    accent: '#caa07a',
-    swatches: ['#6f5140', '#caa07a']
   })
 ]);
 


### PR DESCRIPTION
### Motivation
- Replace the legacy air-hockey legs/base with the Pool Royale pool table so the air-hockey playfield sits visually above and matches the Pool Royale footprint and height.
- Keep a robust fallback when the BlenderKit table asset is unavailable so the arena remains playable.

### Description
- Added BlenderKit table support in `webapp/src/components/AirHockey3D.jsx` including `ensureBlenderkitBaseTemplate`, `cloneBlenderkitBaseTemplate`, and `pickBlenderkitModelUrl` and wired the Pool Royale asset id `84a78996-6ed0-4833-a110-b00c36c348a8` for loading.
- Replaced the classic leg/base builders with `buildBlenderkitPoolTable` and a simple `buildFallbackPoolBase`, and updated `rebuildTableBase` to prefer the BlenderKit Pool Royale base (with async fallback to the slab base).
- Raised and resized the air hockey playfield to sit above the pool table footprint by introducing `FIELD_SCALE` (playfield size) and `FIELD_LIFT` (vertical offset) and adjusted the table surface geometry accordingly in `AirHockey3D.jsx`.
- Updated inventory/config to expose only the Pool Royale base by changing `AIR_HOCKEY_TABLE_BASES` in `webapp/src/config/airHockeyInventoryConfig.js` to include `blenderkitPoolTable`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and the Vite server became ready (local dev server started successfully).
- Attempted an automated Playwright navigation/screenshot to verify the scene, but the headless Chromium process crashed with a SIGSEGV (Playwright run failed). No unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccf2d87e483298ecb814b8f743762)