### PR TITLE
Fix cue stick push animation in power slider

### DIFF
--- a/power-slider.css
+++ b/power-slider.css
@@ -173,6 +173,12 @@
   margin-top: 4px;
   width: 100%;
   height: auto;
+  --ps-cue-drop: 0px;
+  --ps-cue-forward: 0px;
+  --ps-cue-tilt: 0deg;
+  transform: translateY(calc(var(--ps-cue-drop) + var(--ps-cue-forward)))
+    rotate(var(--ps-cue-tilt));
+  transition: transform 0.12s ease-out;
 }
 
 .ps .ps-tooltip {
@@ -200,7 +206,8 @@
 }
 
 .ps.ps-no-animate .ps-handle,
-.ps.ps-no-animate .ps-tooltip {
+.ps.ps-no-animate .ps-tooltip,
+.ps.ps-no-animate .ps-cue-img {
   transition: none !important;
 }
 
@@ -245,7 +252,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .ps .ps-handle,
-  .ps .ps-tooltip {
+  .ps .ps-tooltip,
+  .ps .ps-cue-img {
     transition: none !important;
   }
 }

--- a/power-slider.js
+++ b/power-slider.js
@@ -24,6 +24,8 @@ export class PowerSlider {
     this.onStart = onStart;
     this.onCommit = onCommit;
     this.locked = false;
+    this.ratio = 0;
+    this.cueShootTimeout = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -53,6 +55,9 @@ export class PowerSlider {
     this.cueImg.className = 'ps-cue-img';
     this.cueImg.alt = '';
     if (cueSrc) this.cueImg.src = cueSrc;
+    this.cueImg.style.setProperty('--ps-cue-drop', '0px');
+    this.cueImg.style.setProperty('--ps-cue-forward', '0px');
+    this.cueImg.style.setProperty('--ps-cue-tilt', '0deg');
 
     this.handle.append(this.cueImg, this.handleText, this.powerBar);
     this.el.appendChild(this.handle);
@@ -133,6 +138,7 @@ export class PowerSlider {
     this.el.removeEventListener('pointerdown', this._onPointerDown);
     this.el.removeEventListener('wheel', this._onWheel);
     this.el.removeEventListener('keydown', this._onKeyDown);
+    this._clearCueShoot();
     this.el.remove();
   }
 
@@ -149,6 +155,7 @@ export class PowerSlider {
   _update(animate = true) {
     const range = this.max - this.min || 1;
     const ratio = (this.value - this.min) / range;
+    this.ratio = ratio;
     this.el.style.setProperty('--ps-ratio', String(ratio));
     const trackH = this.el.clientHeight;
     const handleH = this.handle.offsetHeight;
@@ -171,8 +178,31 @@ export class PowerSlider {
     if (this.theme === 'pool-royale' || this.theme === 'snooker-royale') {
       const drop = ratio * 28;
       const tilt = -8 - ratio * 10;
-      this.cueImg.style.transform = `translateY(${drop}px) rotate(${tilt}deg)`;
+      this.cueImg.style.setProperty('--ps-cue-drop', `${drop}px`);
+      this.cueImg.style.setProperty('--ps-cue-tilt', `${tilt}deg`);
     }
+  }
+
+  _setCueForward(px) {
+    this.cueImg.style.setProperty('--ps-cue-forward', `${px}px`);
+  }
+
+  _clearCueShoot() {
+    if (this.cueShootTimeout) {
+      window.clearTimeout(this.cueShootTimeout);
+      this.cueShootTimeout = null;
+    }
+  }
+
+  _triggerCueShoot() {
+    if (this.theme !== 'pool-royale' && this.theme !== 'snooker-royale') return;
+    this._clearCueShoot();
+    const distance = 8 + this.ratio * 18;
+    this._setCueForward(-distance);
+    this.cueShootTimeout = window.setTimeout(() => {
+      this._setCueForward(0);
+      this.cueShootTimeout = null;
+    }, 140);
   }
 
   _updateHandleColor(ratio) {
@@ -211,6 +241,8 @@ export class PowerSlider {
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
     this.pointerStartY = e.clientY;
+    this._clearCueShoot();
+    this._setCueForward(0);
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.addEventListener('pointermove', this._onPointerMove);
     this.el.addEventListener('pointerup', this._onPointerUp);
@@ -236,6 +268,7 @@ export class PowerSlider {
       this.set(this.dragStartValue, { animate: true });
       return;
     }
+    this._triggerCueShoot();
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
   }
 
@@ -244,6 +277,7 @@ export class PowerSlider {
     e.preventDefault();
     const dir = e.deltaY > 0 ? 1 : -1;
     this.set(this.value + dir * this.step, { animate: true });
+    this._triggerCueShoot();
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
   }
 
@@ -258,6 +292,7 @@ export class PowerSlider {
       this.set(this.value - inc);
       handled = true;
     } else if (e.key === 'Enter') {
+      this._triggerCueShoot();
       if (typeof this.onCommit === 'function') this.onCommit(this.value);
       handled = true;
     }


### PR DESCRIPTION
### Motivation
- Players and AI reported the cuestick never visually pushed forward or triggered a shoot animation when firing in Pool Royal and Snooker Royal themes.
- The power slider previously only showed a pull/back motion; a short forward push on commit is required for clear feedback. 

### Description
- Add CSS variables `--ps-cue-drop`, `--ps-cue-forward`, and `--ps-cue-tilt` and apply them to `.ps-cue-img` to drive both pull and forward motion with a transform and transition in `power-slider.css`.
- Respect `ps-no-animate` and `prefers-reduced-motion` by disabling cue transitions when animations are suppressed.
- Track current slider ratio in `power-slider.js` and expose helper methods `_setCueForward`, `_clearCueShoot`, and `_triggerCueShoot` to animate a short forward push and reset after a timeout.
- Wire `_triggerCueShoot` into release/commit code paths (`pointerup`, wheel commit and `Enter`) and clear the timeout on `destroy` and at pointer start to avoid stuck states.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cde1a29f08329888aca92d30c91a5)