### PR TITLE
Sync power slider commit into shot power before firing (Pool & Snooker Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24774,12 +24774,13 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: () => {
-      fireRef.current?.();
-      requestAnimationFrame(() => {
-        slider.set(slider.min, { animate: true });
-        applyPower(0);
-      });
+      onCommit: (value) => {
+        applyPower((value ?? 0) / 100);
+        fireRef.current?.();
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -24708,12 +24708,13 @@ const powerRef = useRef(hud.power);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-      fireRef.current?.();
-      requestAnimationFrame(() => {
-        slider.set(slider.min, { animate: true });
-        applyPower(0);
-      });
+      onCommit: (value) => {
+        applyPower((value ?? 0) / 100);
+        fireRef.current?.();
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Ensure the power slider's committed value is applied to the game `power` state before the shot fires so the cue stroke uses the final pull value and visual/physics cue-forward behavior matches the player's release.

### Description
- Updated the power slider `onCommit` handler in `PoolRoyale.jsx` and `SnookerRoyal.jsx` to accept the committed `value`, call `applyPower((value ?? 0) / 100)` before invoking `fireRef.current()`, then reset the slider and power.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cde1a29f08329888aca92d30c91a5)