### PR TITLE
Prevent cue preview from overriding active stroke animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22993,6 +22993,8 @@ const powerRef = useRef(hud.power);
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
+          !shooting &&
+          !cueAnimating &&
           (isPlayerTurn || previewingAiShot || aiCueViewActive);
         const remoteAimFresh =
           remoteAimState &&

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -22889,6 +22889,8 @@ const powerRef = useRef(hud.power);
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
+          !shooting &&
+          !cueAnimating &&
           (isPlayerTurn || previewingAiShot || aiCueViewActive);
         if (
           cue?.pos &&


### PR DESCRIPTION
### Motivation
- Fix a bug where cue preview/aim updates could override an active forward cue stroke so the cuestick did not visibly push forward or the shot failed to fire for player and AI.

### Description
- Add gating to the `canShowCue` condition in `PoolRoyale.jsx` and `SnookerRoyal.jsx` to require `!shooting && !cueAnimating`, preventing preview updates while a stroke animation is active.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cde1a29f08329888aca92d30c91a5)