### PR TITLE
Align cue stick stroke with power slider

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1443,19 +1443,9 @@ const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned wi
 const CUE_TIP_CLEARANCE = BALL_R * 0.02; // keep the tip aligned without overreaching the cue ball
 const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
-const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
-const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.85;
-const CUE_PULL_SMOOTHING = 0.55;
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
-const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
-const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
-const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
-const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_STRIKE_DURATION_MS = 120;
 const CUE_STRIKE_HOLD_MS = 50;
-const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 9.5;
@@ -19962,71 +19952,30 @@ const powerRef = useRef(hud.power);
         );
       };
 
+      const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
       const computeCuePull = (
         pullTarget = 0,
         maxPull = CUE_PULL_BASE,
-        { instant = false, preserveLarger = false } = {}
+        { preserveLarger = false } = {}
       ) => {
-        const slider = sliderInstanceRef.current;
-        const dragging = Boolean(slider?.dragging);
         const cappedMax = Number.isFinite(maxPull) ? Math.max(0, maxPull) : CUE_PULL_BASE;
-        const effectiveMax = Math.max(cappedMax + CUE_PULL_VISUAL_FUDGE, CUE_PULL_MIN_VISUAL);
         const desiredTarget = preserveLarger
           ? Math.max(cuePullCurrentRef.current ?? 0, pullTarget ?? 0)
           : pullTarget ?? 0;
-        const boostedTarget = desiredTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
-        const clampedTarget = THREE.MathUtils.clamp(boostedTarget, 0, effectiveMax);
-        const smoothing = instant || dragging ? 1 : CUE_PULL_SMOOTHING;
-        const nextPull =
-          smoothing >= 1
-            ? clampedTarget
-            : THREE.MathUtils.lerp(cuePullCurrentRef.current ?? 0, clampedTarget, smoothing);
+        const clampedTarget = THREE.MathUtils.clamp(desiredTarget, 0, cappedMax);
         cuePullTargetRef.current = clampedTarget;
-        cuePullCurrentRef.current = nextPull;
-        return nextPull;
+        cuePullCurrentRef.current = clampedTarget;
+        return clampedTarget;
       };
       const applyVisualPullCompensation = (pullValue, dirVec3) => {
         const basePull = Math.max(pullValue ?? 0, 0);
-        if (basePull <= 1e-6 || !dirVec3) return basePull;
-        const cam =
-          activeRenderCameraRef.current ??
-          cameraRef.current ??
-          camera;
-        TMP_VEC3_CUE_DIR.set(dirVec3.x, 0, dirVec3.z);
-        if (TMP_VEC3_CUE_DIR.lengthSq() > 1e-8) {
-          TMP_VEC3_CUE_DIR.normalize();
-        } else {
-          TMP_VEC3_CUE_DIR.set(0, 0, 1);
-        }
-        let alignment = 0;
-        if (cam?.getWorldDirection) {
-          cam.getWorldDirection(TMP_VEC3_CAM_DIR);
-          TMP_VEC3_CAM_DIR.y = 0;
-          if (TMP_VEC3_CAM_DIR.lengthSq() > 1e-8) {
-            TMP_VEC3_CAM_DIR.normalize();
-            alignment = Math.abs(TMP_VEC3_CAM_DIR.dot(TMP_VEC3_CUE_DIR));
-          }
-        }
-        const blend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
-        const cameraPullScale = THREE.MathUtils.lerp(
-          1 - CUE_PULL_CUE_CAMERA_DAMPING,
-          1 + CUE_PULL_STANDING_CAMERA_BONUS,
-          blend
-        );
-        const alignmentBoost = 1 + alignment * CUE_PULL_ALIGNMENT_BOOST;
-        const compensated =
-          basePull * alignmentBoost * cameraPullScale;
-        const maxScale = 1 + CUE_PULL_MAX_VISUAL_BONUS;
-        return Math.min(compensated, basePull * maxScale);
+        return basePull;
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const curved = Math.pow(ratio, CUE_POWER_GAMMA);
+        const eased = easeOutCubic(ratio);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
-        const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
-        const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const target = amplifiedMax * curved * CUE_PULL_VISUAL_MULTIPLIER;
-        return Math.min(target, visualMax);
+        return effectiveMax * eased;
       };
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
@@ -20403,7 +20352,6 @@ const powerRef = useRef(hud.power);
             : PLAYER_CUE_PULL_VISIBILITY_BOOST;
           const pullTarget = computePullTargetFromPower(clampedPower, maxPull) * pullVisibilityBoost;
           const pull = computeCuePull(pullTarget, maxPull, {
-            instant: true,
             preserveLarger: true
           });
           const visualPull = applyVisualPullCompensation(pull, dir);
@@ -20473,9 +20421,7 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = isAiStroke
             ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
             : 0;
-          const baseReturnDuration =
-            pullbackDuration > 0 ? pullbackDuration : forwardDuration;
-          const returnDuration = Math.max(0, baseReturnDuration * CUE_RETURN_SPEEDUP);
+          const returnDuration = 0;
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + forwardDuration;
@@ -23236,9 +23182,7 @@ const powerRef = useRef(hud.power);
             powerRef.current,
             maxPull
           );
-          const pull = computeCuePull(desiredPull, maxPull, {
-            instant: Boolean(sliderInstanceRef.current?.dragging)
-          });
+          const pull = computeCuePull(desiredPull, maxPull);
           const visualPull = applyVisualPullCompensation(pull, dir);
           const { side, vert, hasSpin } = computeSpinOffsets(appliedSpin, ranges);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);


### PR DESCRIPTION
### Motivation
- Make the visual cue stroke match the power slider exactly so pull/strike timing and distances are deterministic and predictable.
- Remove camera- and view-dependent pull compensation which caused mismatch between slider value and cue motion.
- Snap the cue back to idle after the strike hold to match the reference micro-follow behavior and avoid lingering cue motion.

### Description
- Replaced the previous `computeCuePull` implementation with a deterministic clamp that applies the computed pull target directly to `cuePullCurrentRef` and `cuePullTargetRef`, removing smoothing, global visibility boosts, and the `instant` branch.
- Reworked `computePullTargetFromPower` to use an `easeOutCubic` easing for power→pull mapping and simplified it to `effectiveMax * eased` instead of the previous multi-step visual amplification and fudging logic.
- Disabled visual camera-based pull compensation by making `applyVisualPullCompensation` return the raw pull value and removed related compensation constants usage.
- Force the stroke to snap back immediately by setting the cue stroke `returnDuration` to `0`, and removed the return-duration blending logic; updated call sites to drop the removed `instant` option where appropriate.
- Removed a number of unused visual-pull constants and eliminated code paths that applied view-dependent scaling so the cue motion is driven directly by the slider value.

### Testing
- No automated tests were executed for this change in this rollout. If desired, run the project's unit/UI tests and verify cue pull behavior in the `PoolRoyale` scene to confirm slider/visual sync.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf4450480832994b70d05539fe1b9)