### PR TITLE
Ensure cue impact triggers shot and visible follow‑through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1442,17 +1442,9 @@ const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.02; // keep the tip aligned without overreaching the cue ball
 const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned while allowing visible contact on impact
-const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
-const CUE_PULL_MIN_VISUAL = BALL_R * 2.1; // guarantee a clear visible pull even when clearance is tight
-const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.85;
+const CUE_PULL_BASE = BALL_R * 6.2; // match the reference pull range (~0.34m at standard cue-ball size)
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
-const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
-const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
-const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
-const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.18; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_STRIKE_DURATION_MS = 120;
 const CUE_STRIKE_HOLD_MS = 50;
 const CUE_RETURN_SPEEDUP = 0.95;
@@ -4941,9 +4933,7 @@ const AI_CUE_VIEW_HOLD_MS = 180;
 const AI_CAMERA_DROP_BLEND = 0.65;
 const AI_STROKE_TIME_SCALE = 2.15;
 const AI_STROKE_PULLBACK_FACTOR = 1.05;
-const AI_CUE_PULL_VISIBILITY_BOOST = 1.34;
 const AI_WARMUP_PULL_RATIO = 0.55;
-const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.62;
 const PLAYER_STROKE_TIME_SCALE = 1;
 const PLAYER_FORWARD_SLOWDOWN = 1;
@@ -12149,6 +12139,7 @@ const powerRef = useRef(hud.power);
     lift: 0,
     moved: false
   });
+  const pendingImpactRef = useRef(null);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
@@ -17385,6 +17376,7 @@ const powerRef = useRef(hud.power);
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
               cueStrokeStateRef.current = null;
+              pendingImpactRef.current = null;
             }
             return true;
           }
@@ -17397,6 +17389,7 @@ const powerRef = useRef(hud.power);
             warmupPos,
             startPos,
             impactPos,
+            settlePos,
             idlePos,
             pullbackDuration,
             forwardDuration,
@@ -17405,6 +17398,11 @@ const powerRef = useRef(hud.power);
           } = stroke;
           cueStick.visible = true;
           cueAnimating = true;
+          const impactTriggerTime = impactTime - Math.min(forwardDuration * 0.1, 16);
+          if (!stroke.shotApplied && now >= impactTriggerTime) {
+            stroke.shotApplied = true;
+            stroke.onImpact?.();
+          }
           if (now <= pullEndTime && pullbackDuration > 0) {
             const t = THREE.MathUtils.clamp(
               (now - startTime) / Math.max(pullbackDuration, 1e-6),
@@ -17427,7 +17425,16 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (now <= settleTime && settleDuration > 0) {
-            cueStick.position.copy(impactPos);
+            const t = THREE.MathUtils.clamp(
+              (now - impactTime) / Math.max(settleDuration, 1e-6),
+              0,
+              1
+            );
+            cueStick.position.lerpVectors(
+              impactPos,
+              settlePos ?? impactPos,
+              t
+            );
             syncCueShadow();
             return true;
           }
@@ -17453,6 +17460,7 @@ const powerRef = useRef(hud.power);
           cuePullCurrentRef.current = 0;
           cuePullTargetRef.current = 0;
           cueStrokeStateRef.current = null;
+          pendingImpactRef.current = null;
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
             topViewLockedRef.current = false;
@@ -17583,6 +17591,7 @@ const powerRef = useRef(hud.power);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           cueStrokeStateRef.current = null;
+          pendingImpactRef.current = null;
           setReplayActive(true);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
@@ -19970,12 +19979,10 @@ const powerRef = useRef(hud.power);
         const slider = sliderInstanceRef.current;
         const dragging = Boolean(slider?.dragging);
         const cappedMax = Number.isFinite(maxPull) ? Math.max(0, maxPull) : CUE_PULL_BASE;
-        const effectiveMax = Math.max(cappedMax + CUE_PULL_VISUAL_FUDGE, CUE_PULL_MIN_VISUAL);
         const desiredTarget = preserveLarger
           ? Math.max(cuePullCurrentRef.current ?? 0, pullTarget ?? 0)
           : pullTarget ?? 0;
-        const boostedTarget = desiredTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
-        const clampedTarget = THREE.MathUtils.clamp(boostedTarget, 0, effectiveMax);
+        const clampedTarget = THREE.MathUtils.clamp(desiredTarget, 0, cappedMax);
         const smoothing = instant || dragging ? 1 : CUE_PULL_SMOOTHING;
         const nextPull =
           smoothing >= 1
@@ -19987,46 +19994,14 @@ const powerRef = useRef(hud.power);
       };
       const applyVisualPullCompensation = (pullValue, dirVec3) => {
         const basePull = Math.max(pullValue ?? 0, 0);
-        if (basePull <= 1e-6 || !dirVec3) return basePull;
-        const cam =
-          activeRenderCameraRef.current ??
-          cameraRef.current ??
-          camera;
-        TMP_VEC3_CUE_DIR.set(dirVec3.x, 0, dirVec3.z);
-        if (TMP_VEC3_CUE_DIR.lengthSq() > 1e-8) {
-          TMP_VEC3_CUE_DIR.normalize();
-        } else {
-          TMP_VEC3_CUE_DIR.set(0, 0, 1);
-        }
-        let alignment = 0;
-        if (cam?.getWorldDirection) {
-          cam.getWorldDirection(TMP_VEC3_CAM_DIR);
-          TMP_VEC3_CAM_DIR.y = 0;
-          if (TMP_VEC3_CAM_DIR.lengthSq() > 1e-8) {
-            TMP_VEC3_CAM_DIR.normalize();
-            alignment = Math.abs(TMP_VEC3_CAM_DIR.dot(TMP_VEC3_CUE_DIR));
-          }
-        }
-        const blend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
-        const cameraPullScale = THREE.MathUtils.lerp(
-          1 - CUE_PULL_CUE_CAMERA_DAMPING,
-          1 + CUE_PULL_STANDING_CAMERA_BONUS,
-          blend
-        );
-        const alignmentBoost = 1 + alignment * CUE_PULL_ALIGNMENT_BOOST;
-        const compensated =
-          basePull * alignmentBoost * cameraPullScale;
-        const maxScale = 1 + CUE_PULL_MAX_VISUAL_BONUS;
-        return Math.min(compensated, basePull * maxScale);
+        return basePull;
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const curved = Math.pow(ratio, CUE_POWER_GAMMA);
+        const eased = 1 - Math.pow(1 - ratio, 3);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
-        const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
-        const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const target = amplifiedMax * curved * CUE_PULL_VISUAL_MULTIPLIER;
-        return Math.min(target, visualMax);
+        const clampedMax = Math.min(effectiveMax, CUE_PULL_BASE);
+        return clampedMax * eased;
       };
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
@@ -20058,6 +20033,89 @@ const powerRef = useRef(hud.power);
           }
         }
         return { side, vert, hasSpin };
+      };
+
+      const applyShotAtImpact = (payload) => {
+        if (!payload || payload.applied) return;
+        payload.applied = true;
+        const { base, aimDir, physicsSpin, clampedPower, liftStrength } = payload;
+        const offsetScaled = {
+          x: physicsSpin?.x ?? 0,
+          y: physicsSpin?.y ?? 0
+        };
+        cue.vel.copy(base);
+        if (cue.spin) {
+          cue.spin.set(offsetScaled.x, offsetScaled.y);
+        }
+        if (cue.omega) {
+          cue.omega.set(0, 0, 0);
+        }
+        if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+        cue.spinMode = 'standard';
+        cue.swerveStrength = 0;
+        cue.swervePowerStrength = 0;
+        const shotDir = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
+        if (shotDir.lengthSq() > 1e-8) shotDir.normalize();
+        const sideAxis = TMP_VEC3_D.set(-shotDir.z, 0, shotDir.x);
+        if (sideAxis.lengthSq() > 1e-8) sideAxis.normalize();
+        const rOffset = TMP_VEC3_E
+          .copy(sideAxis)
+          .multiplyScalar(offsetScaled.x * BALL_R)
+          .addScaledVector(new THREE.Vector3(0, 1, 0), offsetScaled.y * BALL_R);
+        const impulseMag = BALL_MASS * base.length();
+        const impulse = TMP_VEC3_A.copy(shotDir).multiplyScalar(impulseMag);
+        const torqueImpulse = TMP_VEC3_B.copy(rOffset).cross(impulse);
+        if (cue.omega) {
+          cue.omega.addScaledVector(torqueImpulse, 1 / BALL_INERTIA);
+        }
+        resetSpinRef.current?.();
+        cueLiftRef.current.lift = 0;
+        cueLiftRef.current.startLift = 0;
+        cue.impacted = false;
+        cue.launchDir = aimDir.clone().normalize();
+        maxPowerLiftTriggered = false;
+        cue.lift = 0;
+        cue.liftVel = 0;
+        const topSpinWeight = Math.max(0, physicsSpin?.y || 0);
+        if (
+          clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+          liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+          topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+        ) {
+          const powerRatio = THREE.MathUtils.clamp(
+            (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const liftRatio = THREE.MathUtils.clamp(
+            (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const spinRatio = THREE.MathUtils.clamp(
+            (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const jumpStrength =
+            (0.25 + 0.75 * powerRatio) *
+            (0.4 + 0.6 * liftRatio) *
+            (0.55 + 0.45 * spinRatio);
+          const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+          const physicsHeight =
+            (jumpVelocity * jumpVelocity) /
+            (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+          const jumpHeight = Math.min(
+            MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+            physicsHeight
+          );
+          cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+          cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+        }
+        playCueHit(clampedPower * 0.6);
       };
 
       // Fire (slider triggers on release)
@@ -20280,11 +20338,11 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
-          const appliedSpin = applySpinConstraints(aimDir, true);
-          const liftAngle = resolveUserCueLift();
-          const liftStrength = normalizeCueLift(liftAngle);
-          const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-          const physicsSpin = mapSpinForPhysics(appliedSpin, {
+        const appliedSpin = applySpinConstraints(aimDir, true);
+        const liftAngle = resolveUserCueLift();
+        const liftStrength = normalizeCueLift(liftAngle);
+        const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
+        const physicsSpin = mapSpinForPhysics(appliedSpin, {
             cameraRight: cameraBasis?.right ?? null,
             cameraUp: cameraBasis?.up ?? null,
             cueForward: { x: aimDir.x, z: aimDir.y }
@@ -20293,79 +20351,14 @@ const powerRef = useRef(hud.power);
             x: physicsSpin?.x ?? 0,
             y: physicsSpin?.y ?? 0
           };
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(offsetScaled.x, offsetScaled.y);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          const shotDir = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
-          if (shotDir.lengthSq() > 1e-8) shotDir.normalize();
-          const sideAxis = TMP_VEC3_D.set(-shotDir.z, 0, shotDir.x);
-          if (sideAxis.lengthSq() > 1e-8) sideAxis.normalize();
-          const rOffset = TMP_VEC3_E
-            .copy(sideAxis)
-            .multiplyScalar(offsetScaled.x * BALL_R)
-            .addScaledVector(new THREE.Vector3(0, 1, 0), offsetScaled.y * BALL_R);
-          const impulseMag = BALL_MASS * base.length();
-          const impulse = TMP_VEC3_A.copy(shotDir).multiplyScalar(impulseMag);
-          const torqueImpulse = TMP_VEC3_B.copy(rOffset).cross(impulse);
-          if (cue.omega) {
-            cue.omega.addScaledVector(torqueImpulse, 1 / BALL_INERTIA);
-          }
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = aimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          const topSpinWeight = Math.max(0, physicsSpin.y || 0);
-          if (
-            clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
-            liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
-            topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
-          ) {
-            const powerRatio = THREE.MathUtils.clamp(
-              (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const liftRatio = THREE.MathUtils.clamp(
-              (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const spinRatio = THREE.MathUtils.clamp(
-              (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const jumpStrength =
-              (0.25 + 0.75 * powerRatio) *
-              (0.4 + 0.6 * liftRatio) *
-              (0.55 + 0.45 * spinRatio);
-            const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
-            const physicsHeight =
-              (jumpVelocity * jumpVelocity) /
-              (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
-            const jumpHeight = Math.min(
-              MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
-              physicsHeight
-            );
-            cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
-            cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
-          }
-          playCueHit(clampedPower * 0.6);
+          const shotPayload = {
+            base: base.clone(),
+            aimDir: aimDir.clone(),
+            physicsSpin: { x: offsetScaled.x, y: offsetScaled.y },
+            clampedPower,
+            liftStrength,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -20390,18 +20383,9 @@ const powerRef = useRef(hud.power);
           const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
           dir.normalize();
-          const backInfo = calcTarget(
-            cue,
-            aimDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
-          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
+          const maxPull = CUE_PULL_BASE;
           const isAiStroke = aiOpponentEnabled && hudRef.current?.turn === 1;
-          const pullVisibilityBoost = isAiStroke
-            ? AI_CUE_PULL_VISIBILITY_BOOST
-            : PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const pullTarget = computePullTargetFromPower(clampedPower, maxPull) * pullVisibilityBoost;
+          const pullTarget = computePullTargetFromPower(clampedPower, maxPull);
           const pull = computeCuePull(pullTarget, maxPull, {
             instant: true,
             preserveLarger: true
@@ -20463,9 +20447,10 @@ const powerRef = useRef(hud.power);
             0,
             BALL_R * 0.33
           );
-          const impactPos = buildCuePosition(-followExtra);
+          const impactPos = buildCuePosition(0);
           const idlePos = buildCuePosition(0);
-          const settlePos = impactPos.clone();
+          const settlePos =
+            followExtra > 1e-6 ? buildCuePosition(-followExtra) : impactPos.clone();
           cueStick.visible = true;
           cueStick.position.copy(warmupPos);
           const forwardDuration = CUE_STRIKE_DURATION_MS;
@@ -20574,11 +20559,18 @@ const powerRef = useRef(hud.power);
             warmupPos: warmupPos.clone(),
             startPos: startPos.clone(),
             impactPos: impactPos.clone(),
+            settlePos: settlePos.clone(),
             idlePos: idlePos.clone(),
             pullbackDuration,
             forwardDuration,
             settleDuration,
-            returnDuration
+            returnDuration,
+            onImpact: () => applyShotAtImpact(shotPayload),
+            shotApplied: false
+          };
+          pendingImpactRef.current = {
+            time: impactTime,
+            apply: () => applyShotAtImpact(shotPayload)
           };
         };
         let aiThinkingHandle = null;
@@ -22839,6 +22831,11 @@ const powerRef = useRef(hud.power);
         }
         const nowMs = now;
         updateCueStroke(nowMs);
+        const pendingImpact = pendingImpactRef.current;
+        if (pendingImpact && nowMs >= pendingImpact.time) {
+          pendingImpact.apply?.();
+          pendingImpactRef.current = null;
+        }
         if (remoteShotActiveRef.current && remoteShotUntilRef.current > 0 && nowMs > remoteShotUntilRef.current) {
           remoteShotActiveRef.current = false;
         }
@@ -23226,12 +23223,7 @@ const powerRef = useRef(hud.power);
           } else {
             impactRing.visible = false;
           }
-          const backInfo = calcTarget(
-            cue,
-            aimDir2D.clone().multiplyScalar(-1),
-            balls
-          );
-          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
+          const maxPull = CUE_PULL_BASE;
           const desiredPull = computePullTargetFromPower(
             powerRef.current,
             maxPull
@@ -23468,12 +23460,7 @@ const powerRef = useRef(hud.power);
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;
-          const backInfo = calcTarget(
-            cue,
-            remoteAimDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
+          const maxPull = CUE_PULL_BASE;
           const desiredPull = computePullTargetFromPower(powerStrength, maxPull);
           const pull = computeCuePull(desiredPull, maxPull);
           const visualPull = applyVisualPullCompensation(pull, baseDir);
@@ -23563,18 +23550,8 @@ const powerRef = useRef(hud.power);
           const perp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerTarget = THREE.MathUtils.clamp(activeAiPlan.power ?? powerRef.current ?? 0, 0, 1);
-          const backInfo = calcTarget(
-            cue,
-            planDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
-          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          const pullVisibilityBoost =
-            aiOpponentEnabled && hudRef.current?.turn === 1
-              ? AI_CUE_PULL_VISIBILITY_BOOST
-              : PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const desiredPull = computePullTargetFromPower(powerTarget, maxPull) * pullVisibilityBoost;
+          const maxPull = CUE_PULL_BASE;
+          const desiredPull = computePullTargetFromPower(powerTarget, maxPull);
           const pull = computeCuePull(desiredPull, maxPull, { preserveLarger: true });
           const visualPull = applyVisualPullCompensation(pull, dir);
           const planSpin = activeAiPlan.spin ?? spinRef.current ?? { x: 0, y: 0 };


### PR DESCRIPTION
### Motivation
- Guarantee the cue-ball impulse is applied exactly at the visual impact so shots always fire when the cue reaches the contact position.
- Make pull calculations deterministic and tied to a fixed canonical range so slider power and visual pull remain consistent across views and AI/remote code paths.
- Improve visible follow-through by interpolating a settle position during the strike hold so the cue displays realistic contact and follow-through.

### Description
- Add `pendingImpactRef` and enqueue a pending impact (`time` + `apply`) when a stroke is created, and check/flush it in the main render loop to ensure the shot is applied at impact.
- Introduce `applyShotAtImpact(payload)` which applies the physics impulse, spin/torque, lift logic and audio trigger, and mark payloads as applied to avoid double application.
- Trigger the impact callback slightly before the end of forward motion by using an `impactTriggerTime` and set a `shotApplied` flag on `cueStrokeStateRef.current` to avoid re-applying the shot.
- Interpolate a `settlePos` during the `settleDuration` to show a visible follow-through instead of snapping the cue to `impactPos` immediately.
- Simplify and standardize pull mapping by setting `CUE_PULL_BASE = BALL_R * 6.2`, removing camera/visibility boost constants, clamping `computeCuePull` to the real `maxPull`, returning the raw `basePull` from `applyVisualPullCompensation`, and using an ease-out power mapping in `computePullTargetFromPower` (`eased = 1 - Math.pow(1 - ratio, 3)`) capped to `CUE_PULL_BASE`.
- Replace ad-hoc per-shot backstop calculations with the fixed `CUE_PULL_BASE` in preview/AI/remote code paths and clear `pendingImpactRef` when strokes end or when starting replays.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf4450480832994b70d05539fe1b9)