### PR TITLE
Adjust Pool Royale cue stroke timing and normalize aim direction

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1445,7 +1445,7 @@ const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned w
 const CUE_PULL_BASE = BALL_R * 6.2; // match the reference pull range (~0.34m at standard cue-ball size)
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
-const CUE_STRIKE_DURATION_MS = 180;
+const CUE_STRIKE_DURATION_MS = 220;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
@@ -20181,6 +20181,21 @@ const powerRef = useRef(hud.power);
         firstHit = null;
         clearInterval(timerRef.current);
         const aimDir = aimDirRef.current.clone();
+        if (aimDir.lengthSq() < 1e-8) {
+          const fallbackCam =
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera;
+          if (fallbackCam?.getWorldDirection) {
+            fallbackCam.getWorldDirection(camFwd);
+            aimDir.set(camFwd.x, camFwd.z);
+          } else {
+            aimDir.set(0, 1);
+          }
+        }
+        if (aimDir.lengthSq() < 1e-8) {
+          aimDir.set(0, 1);
+        } else {
+          aimDir.normalize();
+        }
         const prediction = calcTarget(cue, aimDir.clone(), balls);
         const predictedTravelRaw = prediction.targetBall
           ? cue.pos.distanceTo(prediction.targetBall.pos)


### PR DESCRIPTION
### Motivation
- Improve the feel of Pool Royale strokes by making the forward cue strike visibly slower while preserving the same shot power, and prevent shots from failing to impart velocity when the aim vector is zero or missing.

### Description
- Increased the forward strike duration by changing `CUE_STRIKE_DURATION_MS` from `180` to `220` in `webapp/src/pages/Games/PoolRoyale.jsx` to slow the visual push animation.
- Added a fallback and normalization for the shot direction by computing a fallback camera world direction when `aimDir` is near-zero and ensuring `aimDir` is normalized before using it, preventing zero-length aim vectors from producing no motion.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2c09cf5c8329849f9c1bdb895f6b)