### PR TITLE
Slow cue strike and normalize aim vector in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1445,7 +1445,7 @@ const CUE_TIP_GAP = BALL_R * 0.95 + CUE_TIP_CLEARANCE; // keep the tip aligned w
 const CUE_PULL_BASE = BALL_R * 6.2; // match the reference pull range (~0.34m at standard cue-ball size)
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
-const CUE_STRIKE_DURATION_MS = 180;
+const CUE_STRIKE_DURATION_MS = 230;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
@@ -20181,6 +20181,11 @@ const powerRef = useRef(hud.power);
         firstHit = null;
         clearInterval(timerRef.current);
         const aimDir = aimDirRef.current.clone();
+        if (aimDir.lengthSq() < 1e-6) {
+          aimDir.set(0, 1);
+        } else {
+          aimDir.normalize();
+        }
         const prediction = calcTarget(cue, aimDir.clone(), balls);
         const predictedTravelRaw = prediction.targetBall
           ? cue.pos.distanceTo(prediction.targetBall.pos)


### PR DESCRIPTION
### Motivation
- Make the cue push-forward feel slightly slower to address the "too fast" visual push and fix cases where the cue ball didn't move due to a zero-length aim vector.

### Description
- Increased `CUE_STRIKE_DURATION_MS` from `180` to `230` in `webapp/src/pages/Games/PoolRoyale.jsx` to slow the forward strike animation. 
- Normalize the shot aim before computing the target by guarding `aimDir` (set to `new THREE.Vector2(0,1)` when zero-length, otherwise `normalize()`) right before `calcTarget()` in `webapp/src/pages/Games/PoolRoyale.jsx` to prevent zero-direction launches.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2c09cf5c8329849f9c1bdb895f6b)