### PR TITLE
Apply committed power value before firing (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24736,12 +24736,14 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: () => {
-      fireRef.current?.();
-      requestAnimationFrame(() => {
-        slider.set(slider.min, { animate: true });
-        applyPower(0);
-      });
+      onCommit: (value) => {
+        const nextPower = Number.isFinite(value) ? value / 100 : 0;
+        applyPower(nextPower);
+        fireRef.current?.();
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Ensure the final value from the big pull power slider is applied to the shot so the cue ball uses the intended power and avoids unexpected fouls or underpowered shots.

### Description
- Update the `onCommit` handler for the `PoolRoyalePowerSlider` in `webapp/src/pages/Games/PoolRoyale.jsx` to accept the committed `value`, compute `nextPower`, call `applyPower(nextPower)` before invoking `fireRef.current?.()`, and then reset the slider.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d3ef73eb883299ad61757b0d16b3f)