### PR TITLE
Apply committed Pool Royale power slider value before firing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24736,12 +24736,13 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: () => {
-      fireRef.current?.();
-      requestAnimationFrame(() => {
-        slider.set(slider.min, { animate: true });
-        applyPower(0);
-      });
+      onCommit: (v) => {
+        applyPower(v / 100);
+        fireRef.current?.();
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- The power slider previously fired the shot then reset without applying the committed value, causing the cue ball to launch with incorrect power and sometimes causing fouls; the intent is to ensure the slider release determines shot power.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the slider `onCommit` handler now calls `applyPower(v / 100)` before invoking `fire()` and still resets the slider afterwards so the released slider value is used for the shot.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d3ef73eb883299ad61757b0d16b3f)