### PR TITLE
Ensure Pool Royale slider commit passes final power to shot fire

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20118,7 +20118,7 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-      const fire = () => {
+      const fire = (overridePower) => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -20229,7 +20229,11 @@ const powerRef = useRef(hud.power);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
+          const clampedPower = THREE.MathUtils.clamp(
+            overridePower ?? powerRef.current,
+            0,
+            1
+          );
           const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
@@ -24736,12 +24740,14 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: () => {
-      fireRef.current?.();
-      requestAnimationFrame(() => {
-        slider.set(slider.min, { animate: true });
-        applyPower(0);
-      });
+      onCommit: (value) => {
+        const nextPower = Number.isFinite(value) ? value / 100 : powerRef.current ?? 0;
+        applyPower(nextPower);
+        fireRef.current?.(nextPower);
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Players reported that releasing the power slider did not always apply the chosen shot strength, causing weak shots and fouls; the slider must hand the final value to the firing logic. 

### Description
- Updated the slider commit handler in `webapp/src/pages/Games/PoolRoyale.jsx` to compute `nextPower`, call `applyPower(nextPower)`, and invoke `fireRef.current?.(nextPower)` so the committed slider value is passed through. 
- Changed the local `fire` function to accept an optional `overridePower` parameter and to use `overridePower` when computing the clamped/curved power used for the shot. 
- After commit the slider is reset to its minimum and HUD power is cleared via `slider.set(slider.min)` and `applyPower(0)`. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d3ef73eb883299ad61757b0d16b3f)