### PR TITLE
Restore Pool Royale shot trigger behavior and power tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1377,8 +1377,8 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 // Pool Royale power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_POWER_MULTIPLIER = 1.6875;
-const SHOT_SPEED_MULTIPLIER = 1.875; // boost overall shot speed by 87.5% for snappier ball travel
+const SHOT_POWER_MULTIPLIER = 1.35;
+const SHOT_SPEED_MULTIPLIER = 1.5; // boost overall shot speed by 50% for snappier ball travel
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -24740,10 +24740,8 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: (value) => {
-        const nextPower = Number.isFinite(value) ? value / 100 : powerRef.current ?? 0;
-        applyPower(nextPower);
-        fireRef.current?.(nextPower);
+      onCommit: () => {
+        fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale shooting behavior so the power slider only triggers `fire()` on release while preserving the existing pull animation and to revert shot power/speed tuning to the previous (yesterday 5pm) levels.

### Description
- Adjusted the Pool Royale power tuning constants by setting `SHOT_POWER_MULTIPLIER` to `1.35` and `SHOT_SPEED_MULTIPLIER` to `1.5` in `webapp/src/pages/Games/PoolRoyale.jsx` to restore prior shot strength/speed balance.
- Reworked the power slider `onCommit` handler to stop overriding the stored power value and instead call the shot trigger directly via `fireRef.current?.()` while still resetting the slider and clearing the HUD power.
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve the slider animation and visual feedback.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db77307b08329a27d8db75592f35b)