### PR TITLE
Use HUD power when firing Pool Royale shots (remove override path)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20118,7 +20118,7 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-      const fire = (overridePower) => {
+      const fire = () => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -20229,11 +20229,7 @@ const powerRef = useRef(hud.power);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = THREE.MathUtils.clamp(
-            overridePower ?? powerRef.current,
-            0,
-            1
-          );
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
@@ -24740,10 +24736,8 @@ const powerRef = useRef(hud.power);
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
-      onCommit: (value) => {
-        const nextPower = Number.isFinite(value) ? value / 100 : powerRef.current ?? 0;
-        applyPower(nextPower);
-        fireRef.current?.(nextPower);
+      onCommit: () => {
+        fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Restore the shooting behavior so a release-triggered shot uses the current HUD power value rather than any override value provided by the slider handler.
- Keep existing cue animation and camera behavior unchanged while making the power source consistent with the HUD state.

### Description
- Update the `fire` function in `webapp/src/pages/Games/PoolRoyale.jsx` to remove the `overridePower` parameter and always read power from `powerRef.current` when computing `clampedPower`.
- Change the power slider commit handler (`PoolRoyalePowerSlider` `onCommit`) to call `fireRef.current?.()` (no argument) so the slider triggers a shot that uses the HUD power, and then reset the slider with `slider.set(slider.min)` and `applyPower(0)`.
- Adjusted related call sites in the slider setup so there is no longer an override-power code path when firing from the slider.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db77307b08329a27d8db75592f35b)