### PR TITLE
Align Snooker Royale cue stroke animation with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1466,6 +1466,9 @@ const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while 
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
+const CUE_STRIKE_DURATION_MS = 260;
+const CUE_STRIKE_HOLD_MS = 80;
+const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_STROKE_MIN_MS = 95;
 const CUE_STROKE_MAX_MS = 420;
 const CUE_STROKE_SPEED_MIN = BALL_R * 18;
@@ -4908,6 +4911,7 @@ const AI_CUE_PULLBACK_DURATION_MS = 2500;
 const AI_CUE_FORWARD_DURATION_MS = 2500;
 const AI_STROKE_VISIBLE_DURATION_MS =
   AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS;
+const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
 const AI_POST_SHOT_CAMERA_HOLD_MS = AI_STROKE_VISIBLE_DURATION_MS + AI_CAMERA_POST_STROKE_HOLD_MS;
 const SHOT_CAMERA_HOLD_MS = 2000;
@@ -4921,6 +4925,8 @@ const REPLAY_BANNER_VARIANTS = {
 };
 const REPLAY_TRAIL_HEIGHT = BALL_CENTER_Y + BALL_R * 0.3;
 const REPLAY_TRAIL_COLOR = 0xffffff;
+const REPLAY_CUE_STICK_HOLD_MS = 620;
+const REPLAY_CUE_STROKE_SLOWDOWN = 1;
 const REPLAY_CUE_RETURN_WINDOW_MS = 260;
 const RAIL_NEAR_BUFFER = BALL_R * 3.5;
 const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 24; // keep camera in standing view for close shots
@@ -12310,6 +12316,8 @@ const powerRef = useRef(hud.power);
   const aimCurveControlRef = useRef(new THREE.Vector3());
   const cuePullTargetRef = useRef(0);
   const cuePullCurrentRef = useRef(0);
+  const cueStrokeStateRef = useRef(null);
+  const pendingImpactRef = useRef(null);
   const cueStickAnchorRef = useRef(new THREE.Vector3(0, BALL_CENTER_Y, 0));
   const cueLiftRef = useRef({
     active: false,
@@ -17395,9 +17403,48 @@ const powerRef = useRef(hud.power);
 
         const applyReplayCueStroke = (playback, targetTime) => {
           const stroke = playback?.cueStroke;
-          if (!stroke || !cueStick) {
-            if (cueStick) cueStick.visible = false;
+          if (!cueStick) {
             cueAnimating = false;
+            return;
+          }
+          if (!stroke) {
+            const cuePath = playback?.cuePath ?? [];
+            const cueBall = cueRef.current || cue;
+            const cueBallPos = cueBall?.mesh?.position ?? null;
+            const cuePos = cueBallPos ? TMP_VEC3_A.copy(cueBallPos) : cuePath[0]?.pos?.clone?.() ?? null;
+            if (!cuePos) {
+              cueStick.visible = false;
+              cueAnimating = false;
+              return;
+            }
+            const first = cuePath[0]?.pos ?? null;
+            const second = cuePath[1]?.pos ?? null;
+            if (first && second) {
+              TMP_VEC3_CUE_DIR.copy(second).sub(first);
+            } else if (cueBall?.vel) {
+              TMP_VEC3_CUE_DIR.set(cueBall.vel.x, 0, cueBall.vel.y);
+            } else {
+              TMP_VEC3_CUE_DIR.set(0, 0, 1);
+            }
+            TMP_VEC3_CUE_DIR.y = 0;
+            if (TMP_VEC3_CUE_DIR.lengthSq() > 1e-8) {
+              TMP_VEC3_CUE_DIR.normalize();
+            } else {
+              TMP_VEC3_CUE_DIR.set(0, 0, 1);
+            }
+            cuePos.y = CUE_Y;
+            cueStick.rotation.y = Math.atan2(TMP_VEC3_CUE_DIR.x, TMP_VEC3_CUE_DIR.z) + Math.PI;
+            cueStick.rotation.x = 0;
+            const showCue = targetTime <= REPLAY_CUE_STICK_HOLD_MS;
+            cueStick.visible = showCue;
+            cueAnimating = showCue;
+            if (showCue) {
+              cueStick.position.set(
+                cuePos.x - TMP_VEC3_CUE_DIR.x * CUE_TIP_GAP,
+                cuePos.y,
+                cuePos.z - TMP_VEC3_CUE_DIR.z * CUE_TIP_GAP
+              );
+            }
             return;
           }
           const warmupSnap =
@@ -17406,19 +17453,30 @@ const powerRef = useRef(hud.power);
           const startSnap = normalizeVector3Snapshot(stroke.start, warmupSnap);
           const impactSnap = normalizeVector3Snapshot(stroke.impact, startSnap);
           const settleSnap = normalizeVector3Snapshot(stroke.settle, impactSnap);
-          if (!warmupSnap || !startSnap || !impactSnap || !settleSnap) {
+          const idleSnap = normalizeVector3Snapshot(
+            stroke.idle ?? stroke.settle,
+            settleSnap
+          );
+          if (!warmupSnap || !startSnap || !impactSnap || !settleSnap || !idleSnap) {
             cueStick.visible = false;
             cueAnimating = false;
             return;
           }
-          const pullback = Math.max(0, stroke.pullback ?? stroke.pullbackDuration ?? 0);
-          const forward = Math.max(1e-6, stroke.forward ?? stroke.forwardDuration ?? 0);
-          const settleTime = Math.max(0, stroke.settleTime ?? stroke.settleDuration ?? 0);
+          const replayScale = REPLAY_CUE_STROKE_SLOWDOWN;
+          const pullback =
+            Math.max(0, stroke.pullback ?? stroke.pullbackDuration ?? 0) * replayScale;
+          const forward =
+            Math.max(1e-6, stroke.forward ?? stroke.forwardDuration ?? 0) * replayScale;
+          const settleTime =
+            Math.max(0, stroke.settleTime ?? stroke.settleDuration ?? 0) * replayScale;
+          const returnTime =
+            Math.max(0, stroke.returnTime ?? stroke.returnDuration ?? 0) * replayScale;
           const startOffset = Math.max(0, stroke.startOffset ?? 0);
           const localTime = targetTime - startOffset;
           const pullEnd = pullback;
           const impactEnd = pullEnd + forward;
           const settleEnd = impactEnd + settleTime;
+          const returnEnd = settleEnd + returnTime;
           tmpReplayCueA.set(warmupSnap.x, warmupSnap.y, warmupSnap.z);
           tmpReplayCueB.set(startSnap.x, startSnap.y, startSnap.z);
           cueStick.rotation.y = Number.isFinite(stroke.rotationY)
@@ -17461,8 +17519,125 @@ const powerRef = useRef(hud.power);
             cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
             return;
           }
+          if (localTime <= returnEnd && returnTime > 0) {
+            const t = THREE.MathUtils.clamp(
+              (localTime - settleEnd) / Math.max(returnTime, 1e-6),
+              0,
+              1
+            );
+            tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
+            tmpReplayCueB.set(idleSnap.x, idleSnap.y, idleSnap.z);
+            cueStick.visible = true;
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            return;
+          }
           cueStick.visible = false;
           cueAnimating = false;
+        };
+
+        const updateCueStroke = (now) => {
+          const stroke = cueStrokeStateRef.current;
+          if (!stroke || !cueStick) {
+            cueAnimating = false;
+            return false;
+          }
+          if (stroke.holdUntilStop) {
+            cueStick.visible = true;
+            cueAnimating = true;
+            cueStick.position.copy(stroke.idlePos);
+            if (allStopped(balls)) {
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              cueStrokeStateRef.current = null;
+              pendingImpactRef.current = null;
+            }
+            return true;
+          }
+          const {
+            startTime,
+            pullEndTime,
+            impactTime,
+            settleTime,
+            returnTime,
+            warmupPos,
+            startPos,
+            impactPos,
+            settlePos,
+            idlePos,
+            pullbackDuration,
+            forwardDuration,
+            settleDuration,
+            returnDuration
+          } = stroke;
+          cueStick.visible = true;
+          cueAnimating = true;
+          if (!stroke.shotApplied && now >= impactTime) {
+            stroke.shotApplied = true;
+            stroke.onImpact?.();
+          }
+          if (now <= pullEndTime && pullbackDuration > 0) {
+            const t = THREE.MathUtils.clamp(
+              (now - startTime) / Math.max(pullbackDuration, 1e-6),
+              0,
+              1
+            );
+            cueStick.position.lerpVectors(warmupPos, startPos, t);
+            return true;
+          }
+          if (now <= impactTime) {
+            const t = THREE.MathUtils.clamp(
+              (now - pullEndTime) / Math.max(forwardDuration, 1e-6),
+              0,
+              1
+            );
+            const eased = 1 - Math.pow(1 - t, 3);
+            cueStick.position.lerpVectors(startPos, impactPos, eased);
+            return true;
+          }
+          if (now <= settleTime && settleDuration > 0) {
+            const t = THREE.MathUtils.clamp(
+              (now - impactTime) / Math.max(settleDuration, 1e-6),
+              0,
+              1
+            );
+            cueStick.position.lerpVectors(
+              impactPos,
+              settlePos ?? impactPos,
+              t
+            );
+            return true;
+          }
+          if (now <= returnTime && returnDuration > 0) {
+            const t = THREE.MathUtils.clamp(
+              (now - settleTime) / Math.max(returnDuration, 1e-6),
+              0,
+              1
+            );
+            cueStick.position.lerpVectors(impactPos, idlePos, t);
+            return true;
+          }
+          cueStick.position.copy(idlePos);
+          if (!allStopped(balls)) {
+            stroke.holdUntilStop = true;
+            cueStrokeStateRef.current = stroke;
+            return true;
+          }
+          cueStick.visible = true;
+          cueAnimating = false;
+          cuePullCurrentRef.current = 0;
+          cuePullTargetRef.current = 0;
+          cueStrokeStateRef.current = null;
+          pendingImpactRef.current = null;
+          if (cameraRef.current && sphRef.current) {
+            topViewRef.current = false;
+            topViewLockedRef.current = false;
+            setIsTopDownView(false);
+            const sph = sphRef.current;
+            sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+            updateCamera();
+          }
+          return false;
         };
 
         const updateReplayTrail = (cuePath, targetTime) => {
@@ -17509,6 +17684,9 @@ const powerRef = useRef(hud.power);
                 start: normalizeStrokeVec(cueStrokeRaw.start ?? cueStrokeRaw.warmup),
                 impact: normalizeStrokeVec(cueStrokeRaw.impact ?? cueStrokeRaw.start),
                 settle: normalizeStrokeVec(cueStrokeRaw.settle ?? cueStrokeRaw.impact),
+                idle: normalizeStrokeVec(
+                  cueStrokeRaw.idle ?? cueStrokeRaw.settle ?? cueStrokeRaw.impact
+                ),
                 rotationX: Number.isFinite(cueStrokeRaw.rotationX) ? cueStrokeRaw.rotationX : 0,
                 rotationY: Number.isFinite(cueStrokeRaw.rotationY) ? cueStrokeRaw.rotationY : 0,
                 pullback: Math.max(0, cueStrokeRaw.pullbackDuration ?? cueStrokeRaw.pullback ?? 0),
@@ -17517,11 +17695,26 @@ const powerRef = useRef(hud.power);
                   0,
                   cueStrokeRaw.settleDuration ?? cueStrokeRaw.settleTime ?? 0
                 ),
+                returnTime: Math.max(
+                  0,
+                  cueStrokeRaw.returnDuration ?? cueStrokeRaw.returnTime ?? 0
+                ),
                 startOffset: Math.max(0, cueStrokeRaw.startOffset ?? 0)
               }
             : null;
           if (frames.length === 0) return { frames, cuePath, duration: 0, cueStroke };
-          const duration = frames[frames.length - 1]?.t ?? 0;
+          const frameDuration = frames[frames.length - 1]?.t ?? 0;
+          const strokeDuration = cueStroke
+            ? Math.max(
+                0,
+                (cueStroke.startOffset ?? 0) +
+                  (cueStroke.pullback ?? 0) +
+                  (cueStroke.forward ?? 0) +
+                  (cueStroke.settleTime ?? 0) +
+                  (cueStroke.returnTime ?? 0)
+              )
+            : 0;
+          const duration = Math.max(frameDuration, strokeDuration);
           return { frames, cuePath, duration, cueStroke };
         };
 
@@ -20047,6 +20240,91 @@ const powerRef = useRef(hud.power);
         return { side, vert, hasSpin };
       };
 
+      const applyShotAtImpact = (payload) => {
+        if (!payload || payload.applied) return;
+        payload.applied = true;
+        const {
+          base,
+          aimDir,
+          physicsSpin,
+          clampedPower,
+          liftStrength,
+          ranges,
+          spinMode
+        } = payload;
+        const powerSpinScale = 0.55 + clampedPower * 0.45;
+        const baseSide = (physicsSpin.x || 0) * (ranges.side ?? 0);
+        let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
+        let spinTop = (physicsSpin.y || 0) * (ranges.forward ?? 0) * powerSpinScale;
+        if (physicsSpin.y < 0) {
+          spinTop *= BACKSPIN_MULTIPLIER;
+        } else if (physicsSpin.y > 0) {
+          spinTop *= TOPSPIN_MULTIPLIER;
+        }
+        cue.vel.copy(base);
+        if (cue.spin) {
+          cue.spin.set(spinSide, spinTop);
+        }
+        if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+        cue.spinMode = spinMode;
+        const swerveSettings = resolveSwerveSettings(
+          physicsSpin,
+          clampedPower,
+          cue.spinMode === 'swerve',
+          liftStrength
+        );
+        cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
+        cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+        resetSpinRef.current?.();
+        cueLiftRef.current.lift = 0;
+        cueLiftRef.current.startLift = 0;
+        cue.impacted = false;
+        cue.launchDir = aimDir.clone().normalize();
+        maxPowerLiftTriggered = false;
+        cue.lift = 0;
+        cue.liftVel = 0;
+        const topSpinWeight = Math.max(0, physicsSpin.y || 0);
+        if (
+          clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+          liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+          topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+        ) {
+          const powerRatio = THREE.MathUtils.clamp(
+            (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const liftRatio = THREE.MathUtils.clamp(
+            (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const spinRatio = THREE.MathUtils.clamp(
+            (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const jumpStrength =
+            (0.25 + 0.75 * powerRatio) *
+            (0.4 + 0.6 * liftRatio) *
+            (0.55 + 0.45 * spinRatio);
+          const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+          const physicsHeight =
+            (jumpVelocity * jumpVelocity) /
+            (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+          const jumpHeight = Math.min(
+            MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+            physicsHeight
+          );
+          cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+          cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+        }
+        playCueHit(clampedPower * 0.6);
+      };
+
       // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
@@ -20315,78 +20593,21 @@ const powerRef = useRef(hud.power);
           const liftStrength = normalizeCueLift(liftAngle);
           const physicsSpin = mapSpinForPhysics(appliedSpin);
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const baseSide = physicsSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
-          if (physicsSpin.y < 0) {
-            spinTop *= BACKSPIN_MULTIPLIER;
-          } else if (physicsSpin.y > 0) {
-            spinTop *= TOPSPIN_MULTIPLIER;
-          }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode =
+          const spinMode =
             spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
-          const swerveSettings = resolveSwerveSettings(
-            physicsSpin,
+          const shotPayload = {
+            base: base.clone(),
+            aimDir: aimDir.clone(),
+            physicsSpin: {
+              x: physicsSpin.x || 0,
+              y: physicsSpin.y || 0
+            },
             clampedPower,
-            cue.spinMode === 'swerve',
-            liftStrength
-          );
-          cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
-          cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = aimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          const topSpinWeight = Math.max(0, physicsSpin.y || 0);
-          if (
-            clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
-            liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
-            topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
-          ) {
-            const powerRatio = THREE.MathUtils.clamp(
-              (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const liftRatio = THREE.MathUtils.clamp(
-              (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const spinRatio = THREE.MathUtils.clamp(
-              (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const jumpStrength =
-              (0.25 + 0.75 * powerRatio) *
-              (0.4 + 0.6 * liftRatio) *
-              (0.55 + 0.45 * spinRatio);
-            const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
-            const physicsHeight =
-              (jumpVelocity * jumpVelocity) /
-              (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
-            const jumpHeight = Math.min(
-              MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
-              physicsHeight
-            );
-            cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
-            cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
-          }
-          playCueHit(clampedPower * 0.6);
+            liftStrength,
+            ranges,
+            spinMode,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -20452,6 +20673,12 @@ const powerRef = useRef(hud.power);
           );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
+          const warmupRatio = isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO;
+          const minVisibleGap = Math.max(MIN_PULLBACK_GAP, visualPull * 0.08);
+          const warmupPull = Math.max(
+            0,
+            Math.min(visualPull - minVisibleGap, visualPull * warmupRatio)
+          );
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
           cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
@@ -20470,28 +20697,43 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const startPos = buildCuePosition(visualPull);
-          cueStick.position.copy(startPos);
+          const warmupPos = isAiStroke ? buildCuePosition(warmupPull) : startPos.clone();
+          cueStick.position.copy(warmupPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const followThroughPull = THREE.MathUtils.clamp(
-            topSpinWeight * clampedPower * BALL_R * 0.35,
+          const followTopSpinWeight = THREE.MathUtils.clamp(physicsSpin.y || 0, 0, 1);
+          const followExtra = THREE.MathUtils.clamp(
+            followTopSpinWeight * BALL_R * 0.33,
             0,
-            BALL_R * 0.35
+            BALL_R * 0.33
           );
-          const impactPos = buildCuePosition(-followThroughPull);
+          const impactPos = buildCuePosition(0);
+          const idlePos = buildCuePosition(0);
+          const settlePos =
+            followExtra > 1e-6 ? buildCuePosition(-followExtra) : impactPos.clone();
           cueStick.visible = true;
-          cueStick.position.copy(startPos);
-          const forwardDuration = isAiStroke ? AI_CUE_FORWARD_DURATION_MS : 120;
-          const settleDuration = isAiStroke ? 40 : 50;
+          cueStick.position.copy(warmupPos);
+          const forwardDuration = CUE_STRIKE_DURATION_MS;
+          const settleDuration = CUE_STRIKE_HOLD_MS;
+          const pullbackDuration = isAiStroke
+            ? AI_CUE_PULLBACK_DURATION_MS * CUE_STROKE_VISUAL_SLOWDOWN
+            : 0;
+          const baseReturnDuration =
+            pullbackDuration > 0 ? pullbackDuration : forwardDuration;
+          const returnDuration = Math.max(0, baseReturnDuration * CUE_RETURN_SPEEDUP);
           const startTime = performance.now();
-          const impactTime = startTime + forwardDuration;
+          const pullEndTime = startTime + pullbackDuration;
+          const impactTime = pullEndTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
-          const forwardPreviewHold =
-            impactTime +
+          const returnTime = settleTime + returnDuration;
+          const impactHoldBuffer = Math.max(
+            240,
             Math.min(
-              settleDuration,
-              Math.max(180, forwardDuration * 0.9)
-            );
+              Math.max(settleDuration, 240),
+              Math.max(240, forwardDuration * 1.05)
+            )
+          );
+          const forwardPreviewHold = impactTime + impactHoldBuffer;
           powerImpactHoldRef.current = Math.max(
             powerImpactHoldRef.current || 0,
             forwardPreviewHold
@@ -20528,45 +20770,42 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             const strokeStartOffset = Math.max(0, startTime - (shotRecording.startTime ?? startTime));
             shotRecording.cueStroke = {
-              warmup: serializeVector3Snapshot(startPos),
+              warmup: serializeVector3Snapshot(warmupPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(impactPos),
+              settle: serializeVector3Snapshot(settlePos),
+              idle: serializeVector3Snapshot(idlePos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
-              pullbackDuration: 0,
+              pullbackDuration,
               forwardDuration,
               settleDuration,
+              returnDuration,
               startOffset: strokeStartOffset
             };
           }
-          const animateStroke = (now) => {
-            if (now <= impactTime) {
-              const t = forwardDuration > 0
-                ? THREE.MathUtils.clamp((now - startTime) / forwardDuration, 0, 1)
-                : 1;
-              const eased = easeOutCubic(t);
-              cueStick.position.lerpVectors(startPos, impactPos, eased);
-            } else if (now <= settleTime) {
-              cueStick.position.copy(impactPos);
-            } else {
-              cueStick.visible = false;
-              cueAnimating = false;
-              cuePullCurrentRef.current = 0;
-              cuePullTargetRef.current = 0;
-              if (cameraRef.current && sphRef.current) {
-                topViewRef.current = false;
-                topViewLockedRef.current = false;
-                setIsTopDownView(false);
-                const sph = sphRef.current;
-                sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-                updateCamera();
-              }
-              return;
-            }
-            requestAnimationFrame(animateStroke);
+          cueStrokeStateRef.current = {
+            startTime,
+            pullEndTime,
+            impactTime,
+            settleTime,
+            returnTime,
+            warmupPos: warmupPos.clone(),
+            startPos: startPos.clone(),
+            impactPos: impactPos.clone(),
+            settlePos: settlePos.clone(),
+            idlePos: idlePos.clone(),
+            pullbackDuration,
+            forwardDuration,
+            settleDuration,
+            returnDuration,
+            onImpact: () => applyShotAtImpact(shotPayload),
+            shotApplied: false
           };
-          requestAnimationFrame(animateStroke);
+          pendingImpactRef.current = {
+            time: impactTime,
+            apply: () => applyShotAtImpact(shotPayload)
+          };
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -22759,6 +22998,12 @@ const powerRef = useRef(hud.power);
           return;
         }
         const nowMs = now;
+        updateCueStroke(nowMs);
+        const pendingImpact = pendingImpactRef.current;
+        if (pendingImpact && nowMs >= pendingImpact.time) {
+          pendingImpact.apply?.();
+          pendingImpactRef.current = null;
+        }
         if (remoteShotActiveRef.current && remoteShotUntilRef.current > 0 && nowMs > remoteShotUntilRef.current) {
           remoteShotActiveRef.current = false;
         }


### PR DESCRIPTION
### Motivation
- Make Snooker Royale cue-stick animation match Pool Royale by visibly pulling/warming up and then pushing forward on fire, and ensure the shot is applied at the cue impact moment rather than immediately on fire.
- Preserve existing power slider behaviour and UI while improving the visual timing and replay fidelity of strokes.

### Description
- Added new timing constants and replay timing helpers (`CUE_STRIKE_DURATION_MS`, `CUE_STRIKE_HOLD_MS`, `CUE_RETURN_SPEEDUP`, `CUE_STROKE_VISUAL_SLOWDOWN`, replay stick hold / slowdown constants) to match Pool Royale stroke pacing.
- Introduced `cueStrokeStateRef` and `pendingImpactRef` to drive a staged cue stroke lifecycle (warmup/pullback/forward/settle/return) and to defer applying the shot impulse until the visual impact time via `applyShotAtImpact`.
- Reworked the fire/stroke path to build a `shotPayload` and schedule visual stroke state (`cueStrokeStateRef`) and a pending impact; added `updateCueStroke` called each frame to animate the cue and trigger the pending impact when its time arrives.
- Extended replay recording and playback: capture idle/return frames in `shotRecording.cueStroke`, expand `trimReplayRecording` to compute durations including stroke return, and improved `applyReplayCueStroke` to play warmup/pullback/impact/settle/return consistently (including a fallback that positions the stick when no stroke exists).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db729b8a483299dce9660432e4d5b)