### PR TITLE
Sanitize Pool Royale shot power with clampPower helper

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11781,11 +11781,15 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+  const clampPower = useCallback((value, fallback = 0) => {
+    if (!Number.isFinite(value)) return fallback;
+    return THREE.MathUtils.clamp(value, 0, 1);
+  }, []);
   const applyPower = useCallback((nextPower) => {
-    const clampedPower = THREE.MathUtils.clamp(nextPower ?? 0, 0, 1);
+    const clampedPower = clampPower(nextPower, 0);
     powerRef.current = clampedPower;
     setHud((prev) => ({ ...prev, power: clampedPower }));
-  }, []);
+  }, [clampPower]);
   useEffect(() => {
     inHandPlacementModeRef.current = inHandPlacementMode;
   }, [inHandPlacementMode]);
@@ -20237,7 +20241,7 @@ const powerRef = useRef(hud.power);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
+          const clampedPower = clampPower(powerRef.current, 0);
           const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
@@ -22249,8 +22253,9 @@ const powerRef = useRef(hud.power);
             // Reset the cue pull so AI strokes visibly wind up before firing.
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
-            powerRef.current = plan.power;
-            setHud((s) => ({ ...s, power: plan.power }));
+            const aiPower = clampPower(plan.power, 0.6);
+            powerRef.current = aiPower;
+            setHud((s) => ({ ...s, power: aiPower }));
             const spinToApply = plan.spin ?? { x: 0, y: 0 };
             spinRef.current = { ...spinToApply };
             spinRequestRef.current = { ...spinToApply };


### PR DESCRIPTION
### Motivation
- Prevent cases where non-finite or missing shot power results in a zero-magnitude cue impulse (cueball not moving and shots flagged as fouls). 

### Description
- Add a `clampPower(value, fallback)` helper in `webapp/src/pages/Games/PoolRoyale.jsx` to validate and clamp power to the [0,1] range. 
- Use `clampPower` in `applyPower` to ensure `powerRef` and HUD `power` are always valid. 
- Use `clampPower` when resolving shots (`clampedPower`) and when applying AI plan power (with a `0.6` fallback) to avoid non-finite inputs affecting physics. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc09bc0948329ad17face035e0a59)