### PR TITLE
Air Hockey: straight cushions by disabling side pockets and remove field customization

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -23,7 +23,6 @@ import {
 } from '../utils/airHockeyInventory.js';
 
 const CUSTOMIZATION_KEYS = Object.freeze([
-  'field',
   'table',
   'tableBase',
   'environmentHdri',
@@ -802,7 +801,8 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       null,
       null,
       selectionsRef.current.tableBase,
-      renderer
+      renderer,
+      { enableSidePockets: false }
     );
     const poolTable = poolTableEntry?.group ?? new THREE.Group();
     const clothPlaneLocal =
@@ -828,19 +828,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       rebuild: (variantId) => poolTableEntry?.setBaseVariant?.(variantId),
       clear: () => {}
     };
-
-    const lineMat = new THREE.MeshStandardMaterial({
-      color: 0xffffff,
-      roughness: 0.6
-    });
-    materialsRef.current.line = lineMat;
-    const lineThickness = 0.02 * SCALE_WIDTH;
-    const midLine = new THREE.Mesh(
-      new THREE.BoxGeometry(PLAYFIELD.w, lineThickness * 0.5, lineThickness),
-      lineMat
-    );
-    midLine.position.y = lineThickness * 0.25;
-    tableGroup.add(midLine);
 
     const goalGeometry = new THREE.BoxGeometry(
       PLAYFIELD.goalW,
@@ -1543,14 +1530,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     const mats = materialsRef.current;
     if (!mats) return;
 
-    const fieldTheme = getOption('field', selections.field);
     const puckTheme = getOption('puck', selections.puck);
     const malletTheme = getOption('mallet', selections.mallet);
     const railTheme = getOption('rails', selections.rails);
     const goalTheme = getOption('goals', selections.goals);
-
-    if (mats.line) mats.line.color.set(fieldTheme.lines);
-    mats.rings.forEach((material) => material.color.set(fieldTheme.rings || fieldTheme.lines));
 
     if (!LOCK_POOL_ROYALE_TABLE_STYLE) {
       const tableTheme = getOption('table', selections.table);
@@ -1600,7 +1583,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         });
       };
 
-      if (mats.tableSurface) mats.tableSurface.color.set(fieldTheme.surface);
       if (tableGrain) {
         applyTableTexture(mats.frame, 'frame');
         applyTableTexture(mats.trim, 'rail');
@@ -1793,7 +1775,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
                 })}
               </div>
             </div>
-            {renderOptionRow('Field', 'field')}
             {renderOptionRow('Table Finish', 'table')}
             {renderOptionRow('Table Base', 'tableBase')}
             {renderOptionRow('HDRI Environment', 'environmentHdri')}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6321,11 +6321,19 @@ export function Table3D(
   tableSpecMeta = null,
   railMarkerStyle = null,
   baseVariant = null,
-  renderer = null
+  renderer = null,
+  tableOptions = null
 ) {
   const tableSizeMeta =
     tableSpecMeta && typeof tableSpecMeta === 'object' ? tableSpecMeta : null;
   applyTablePhysicsSpec(tableSizeMeta);
+  const resolvedTableOptions =
+    tableOptions && typeof tableOptions === 'object' ? tableOptions : null;
+  const enableSidePockets = resolvedTableOptions?.enableSidePockets !== false;
+  const resolveTablePocketCenters = () => {
+    const centers = pocketCenters();
+    return enableSidePockets ? centers : centers.slice(0, 4);
+  };
 
   const table = new THREE.Group();
   table.userData = table.userData || {};
@@ -6767,7 +6775,7 @@ export function Table3D(
     rawSidePocketShift + SIDE_POCKET_OUTWARD_BIAS
   );
   const sidePocketCenterX = halfW + sidePocketShift;
-  const pocketPositions = pocketCenters();
+  const pocketPositions = resolveTablePocketCenters();
   const clothPocketPositions = pocketPositions.map((center, index) => {
     if (index < 4 || !center) return center;
     const direction = Math.sign(center.x || 1);
@@ -7070,7 +7078,7 @@ export function Table3D(
   );
   const pocketMeshes = [];
   table.userData.pocketHolderAnchors = [];
-  pocketCenters().forEach((p, index) => {
+  resolveTablePocketCenters().forEach((p, index) => {
     const pocketId = POCKET_IDS[index] ?? null;
     const isMiddlePocket = index >= 4;
     const pocketLift = isMiddlePocket ? SIDE_POCKET_PLYWOOD_LIFT : 0;
@@ -9844,7 +9852,7 @@ export function Table3D(
   const clothPlaneWorld = cloth.position.y;
 
   table.userData.pockets = [];
-  pocketCenters().forEach((p, index) => {
+  resolveTablePocketCenters().forEach((p, index) => {
     const marker = new THREE.Object3D();
     marker.position.set(p.x, clothPlaneWorld - POCKET_VIS_R, p.y);
     marker.userData.captureRadius = index >= 4 ? SIDE_CAPTURE_R : CAPTURE_R;
@@ -9872,7 +9880,7 @@ export function Table3D(
   const baulkZ = baulkLineZ;
 
   return {
-    centers: pocketCenters(),
+    centers: resolveTablePocketCenters(),
     baulkZ,
     group: table,
     clothMat,


### PR DESCRIPTION
### Motivation
- Make the Air Hockey table use the Pool Royale table geometry but with straight cushions (no middle/side pockets) while keeping corner pockets intact. 
- Remove the Air Hockey playfield markings and the `field` customization option so the game plays directly on the pool table surface visuals. 
- Ensure Pool Royale behavior remains unchanged by adding a new opt-in control to the shared `Table3D` builder.

### Description
- AirHockey: removed `field` from `CUSTOMIZATION_KEYS` and removed midline/field rendering so the playfield markings are not drawn in `AirHockey3D.jsx`. 
- AirHockey: call `PoolRoyaleTable3D(..., { enableSidePockets: false })` so the reused pool table is built without side/middle pocket geometry, preserving corner pockets and goal placement. 
- PoolRoyale: extended `Table3D` signature with an optional `tableOptions` parameter and added `enableSidePockets` handling via `resolveTablePocketCenters()` so callers can opt out of middle/side pockets without changing default Pool Royale behavior. 
- Replaced internal uses of `pocketCenters()` with `resolveTablePocketCenters()` and updated pocket-related geometry and markers to respect the new option.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and the Vite server reported ready (local/network URLs). 
- Attempted an automated headless capture with Playwright, but Chromium crashed with a SIGSEGV/dbus error so the screenshot run failed. 
- No unit test runner (`npm test`) or additional automated game tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc19d68fc832993825ec2e36f1add)