### PR TITLE
Air Hockey: connect mid-rails, add corner-pocket possession, and gate Pool Royale side-pocket geometry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6770,10 +6770,14 @@ export function Table3D(
     0,
     baseSidePocketShift + extraSidePocketShift - fieldPull
   );
-  sidePocketShift = Math.min(
-    maxSidePocketShift,
-    rawSidePocketShift + SIDE_POCKET_OUTWARD_BIAS
-  );
+  if (enableSidePockets) {
+    sidePocketShift = Math.min(
+      maxSidePocketShift,
+      rawSidePocketShift + SIDE_POCKET_OUTWARD_BIAS
+    );
+  } else {
+    sidePocketShift = 0;
+  }
   const sidePocketCenterX = halfW + sidePocketShift;
   const pocketPositions = resolveTablePocketCenters();
   const clothPocketPositions = pocketPositions.map((center, index) => {
@@ -7304,7 +7308,9 @@ export function Table3D(
   const cornerPocketRadius = CORNER_CHROME_NOTCH_RADIUS;
   const cornerChamfer = POCKET_VIS_R * 0.34 * POCKET_VISUAL_EXPANSION;
   const cornerInset = innerHalfW - (halfW - CORNER_POCKET_CENTER_INSET);
-  const sidePocketRadius = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
+  const sidePocketRadius = enableSidePockets
+    ? SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION
+    : 0;
 
   // Derive exact cushion extents from the chrome pocket arcs so the rails stop
   // precisely where each pocket begins.
@@ -7632,6 +7638,7 @@ export function Table3D(
   };
 
   const sideNotchMP = (sx) => {
+    if (!enableSidePockets) return null;
     const cx = sx * sidePocketCenterX;
     const radius = sidePocketRadius * CHROME_SIDE_POCKET_RADIUS_SCALE;
     const throatLength = Math.max(0, radius * CHROME_SIDE_NOTCH_THROAT_SCALE);
@@ -8037,55 +8044,57 @@ export function Table3D(
     outerHalfW - chromePlateInset + sideChromeOuterExtension
   );
 
-  [
-    { id: 'sideLeft', sx: -1 },
-    { id: 'sideRight', sx: 1 }
-  ].forEach(({ id, sx }) => {
-    let plateWidth = sideChromePlateWidth + sideChromeOuterExtension;
-    const baseCenterX =
-      sx *
-      (outerHalfW - sideChromePlateWidth / 2 - chromePlateInset + sideChromePlateOutwardShift +
-        (sideChromePlateWidthExpansion * CHROME_SIDE_PLATE_CORNER_BIAS_SCALE) / 2);
-    let centerX = baseCenterX + sx * (sideChromeOuterExtension / 2);
-    const baseOuterEdge = Math.abs(centerX) + plateWidth / 2;
-    if (baseOuterEdge > sideChromeOuterEdgeLimit) {
-      const overrun = baseOuterEdge - sideChromeOuterEdgeLimit;
-      plateWidth = Math.max(MICRO_EPS, plateWidth - overrun * 2);
-      centerX = Math.sign(centerX) * Math.max(0, Math.abs(centerX) - overrun);
-    }
-    const centerZ = 0;
-    const notchMP = scaleChromeSidePocketCut(sideNotchMP(sx));
-    const sidePocketCutCenterPull =
-      TABLE.THICK * CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE;
-    const notchLocalMP = notchMP.map((poly) =>
-      poly.map((ring) =>
-        ring.map(([x, z]) => [x - centerX - sx * sidePocketCutCenterPull, -(z - centerZ)])
-      )
-    );
-    const plate = new THREE.Mesh(
-      buildChromePlateGeometry({
-        width: plateWidth,
-        height: sideChromePlateHeight,
-        radius: sideChromePlateRadius,
-        thickness: sideChromePlateThickness,
-        corner: id,
-        notchMP: notchLocalMP,
-        shapeSegments: chromePlateShapeSegments
-      }),
-      chromePlateMat
-    );
-    plate.userData.isChromePlate = true;
-    plate.position.set(
-      centerX,
-      sideChromePlateY + sideChromePlateThickness,
-      centerZ
-    );
-    plate.castShadow = false;
-    plate.receiveShadow = false;
-    plate.renderOrder = CHROME_PLATE_RENDER_ORDER;
-    chromePlates.add(plate);
-    finishParts.trimMeshes.push(plate);
-  });
+  if (enableSidePockets) {
+    [
+      { id: 'sideLeft', sx: -1 },
+      { id: 'sideRight', sx: 1 }
+    ].forEach(({ id, sx }) => {
+      let plateWidth = sideChromePlateWidth + sideChromeOuterExtension;
+      const baseCenterX =
+        sx *
+        (outerHalfW - sideChromePlateWidth / 2 - chromePlateInset + sideChromePlateOutwardShift +
+          (sideChromePlateWidthExpansion * CHROME_SIDE_PLATE_CORNER_BIAS_SCALE) / 2);
+      let centerX = baseCenterX + sx * (sideChromeOuterExtension / 2);
+      const baseOuterEdge = Math.abs(centerX) + plateWidth / 2;
+      if (baseOuterEdge > sideChromeOuterEdgeLimit) {
+        const overrun = baseOuterEdge - sideChromeOuterEdgeLimit;
+        plateWidth = Math.max(MICRO_EPS, plateWidth - overrun * 2);
+        centerX = Math.sign(centerX) * Math.max(0, Math.abs(centerX) - overrun);
+      }
+      const centerZ = 0;
+      const notchMP = scaleChromeSidePocketCut(sideNotchMP(sx));
+      const sidePocketCutCenterPull =
+        TABLE.THICK * CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE;
+      const notchLocalMP = notchMP.map((poly) =>
+        poly.map((ring) =>
+          ring.map(([x, z]) => [x - centerX - sx * sidePocketCutCenterPull, -(z - centerZ)])
+        )
+      );
+      const plate = new THREE.Mesh(
+        buildChromePlateGeometry({
+          width: plateWidth,
+          height: sideChromePlateHeight,
+          radius: sideChromePlateRadius,
+          thickness: sideChromePlateThickness,
+          corner: id,
+          notchMP: notchLocalMP,
+          shapeSegments: chromePlateShapeSegments
+        }),
+        chromePlateMat
+      );
+      plate.userData.isChromePlate = true;
+      plate.position.set(
+        centerX,
+        sideChromePlateY + sideChromePlateThickness,
+        centerZ
+      );
+      plate.castShadow = false;
+      plate.receiveShadow = false;
+      plate.renderOrder = CHROME_PLATE_RENDER_ORDER;
+      chromePlates.add(plate);
+      finishParts.trimMeshes.push(plate);
+    });
+  }
   railsGroup.add(chromePlates);
 
   const pocketJawGroup = new THREE.Group();
@@ -8569,7 +8578,7 @@ export function Table3D(
     });
   }
 
-  if (sideBaseRadius && sideBaseRadius > MICRO_EPS) {
+  if (enableSidePockets && sideBaseRadius && sideBaseRadius > MICRO_EPS) {
     [-1, 1].forEach((sx) => {
       const baseMP = sideNotchMP(sx);
       const fallbackCenter = new THREE.Vector2(sx * sidePocketCenterX, 0);
@@ -8602,11 +8611,14 @@ export function Table3D(
   }
 
   // Rail openings simply reuse the chrome plate cuts; wood never dictates alternate pocket sizing.
-  let openingMP = safePolygonUnion(
-    rectPoly(innerHalfW * 2, innerHalfH * 2),
-    ...scaleWoodRailSidePocketCut(sideNotchMP(-1), -1),
-    ...scaleWoodRailSidePocketCut(sideNotchMP(1), 1)
-  );
+  let openingMP = safePolygonUnion(rectPoly(innerHalfW * 2, innerHalfH * 2));
+  if (enableSidePockets) {
+    openingMP = safePolygonUnion(
+      openingMP,
+      ...scaleWoodRailSidePocketCut(sideNotchMP(-1), -1),
+      ...scaleWoodRailSidePocketCut(sideNotchMP(1), 1)
+    );
+  }
   openingMP = safePolygonUnion(
     openingMP,
     ...translatePocketCutMP(


### PR DESCRIPTION
### Motivation
- Make the Air Hockey table have continuous cushions at the middle pockets (no chrome plates/jaws/gaps) while preserving Pool Royale table behavior. 
- Allow the puck to be captured by corner pockets and implement last-touch possession rules: if the player was the last to touch the puck and it goes into a corner, the puck respawns on the opponent side; otherwise the player receives possession.

### Description
- Added last-touch tracking in `AirHockey3D.jsx` via `lastTouchRef` and updated `handleCollision` to record whether the player or AI last touched the puck. 
- Implemented corner pocket detection in `AirHockey3D.jsx` with `CORNER_POCKET_RADIUS`, `CORNER_POCKET_CAPTURE`, and `cornerPocketCenters`, and updated the game loop to reset the puck to the correct side using `reset(..., spawnZ)` when a corner capture occurs. 
- Modified `reset` to accept an optional `spawnZ` so corner-capture respawns can place the puck toward the appropriate side. 
- Made Pool Royale pocket/rail generation conditional on the `enableSidePockets` table option in `PoolRoyale.jsx`, gating: side-pocket shift, side-pocket radius, side pocket chrome plates, side pocket jaws, and wood rail openings so calling code (Air Hockey) can instantiate a table without middle-pocket hardware and produce straight-connected rails.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app (local network URL printed), which started successfully. 
- Attempted an automated page render / screenshot using Playwright to validate the Air Hockey scene, but the screenshot run timed out (Playwright timeout). 
- No unit or integration test suite was run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dca8176688329bc3e10c395952989)