### PR TITLE
Allow firing when cue ball is already in a valid in-hand position

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20163,6 +20163,21 @@ const powerRef = useRef(hud.power);
         const inHandPlacementActive = Boolean(
           currentHud?.inHand && !fullTableHandPlacement
         );
+        if (inHandPlacementActive && !cueBallPlacedFromHandRef.current) {
+          const cuePos =
+            cue?.pos && Number.isFinite(cue.pos.x) && Number.isFinite(cue.pos.y)
+              ? new THREE.Vector2(cue.pos.x, cue.pos.y)
+              : null;
+          const clampedPos = cuePos ? clampInHandPosition(cuePos) : null;
+          const isValidPlacement =
+            cuePos &&
+            clampedPos &&
+            cuePos.distanceToSquared(clampedPos) <= 1e-6 &&
+            isSpotFree(cuePos);
+          if (isValidPlacement) {
+            cueBallPlacedFromHandRef.current = true;
+          }
+        }
         if (
           !cue?.active ||
           (inHandPlacementActive && !cueBallPlacedFromHandRef.current) ||


### PR DESCRIPTION
### Motivation
- Prevent players being blocked from firing when the cue ball is already placed correctly during in-hand placement so a drag is not required to unlock the shot.

### Description
- Add a validation in `fire()` to check the current cue position against `clampInHandPosition()` and `isSpotFree()` and set `cueBallPlacedFromHandRef.current = true` when the placement is valid, allowing the shot to proceed without an extra placement drag.
- The change is localized to `webapp/src/pages/Games/PoolRoyale.jsx` and only adjusts the in-hand placement gating logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd1bf913c8329818a05bda72d2e55)