### PR TITLE
Tweak Pool Royale cue spin deadzone and cue stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20455,7 +20455,6 @@ const powerRef = useRef(hud.power);
           };
 
           applyShotAtImpact(shotPayload);
-          const topSpinWeight = Math.max(0, physicsSpin?.y || 0);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -20542,15 +20541,16 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const followThroughPull = THREE.MathUtils.clamp(
-            topSpinWeight * clampedPower * BALL_R * 0.35,
-            0,
-            BALL_R * 0.35
-          );
-          const impactPos = buildCuePosition(-followThroughPull);
+          const impactPos = buildCuePosition(0);
           cueStick.visible = true;
           cueStick.position.copy(startPos);
-          const forwardDuration = isAiStroke ? AI_CUE_FORWARD_DURATION_MS : 120;
+          const forwardDuration = isAiStroke
+            ? AI_CUE_FORWARD_DURATION_MS
+            : THREE.MathUtils.lerp(
+                PLAYER_CUE_STRIKE_MAX_MS,
+                PLAYER_CUE_STRIKE_MIN_MS,
+                THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1)
+              );
           const settleDuration = isAiStroke ? 40 : 50;
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const MAX_SPIN_OFFSET = 0.7;
-export const SPIN_STUN_RADIUS = 0.12;
+export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.32;
 export const SPIN_RING2_RADIUS = 0.52;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
@@ -9,7 +9,7 @@ export const SPIN_LEVEL0_MAG = 0;
 export const SPIN_LEVEL1_MAG = 0.25 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.5 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 1.0 * MAX_SPIN_OFFSET;
-export const STRAIGHT_SPIN_DEADZONE = 0.08;
+export const STRAIGHT_SPIN_DEADZONE = 0.1;
 
 export const SPIN_DIRECTIONS = [
   {


### PR DESCRIPTION
### Motivation
- Reduce accidental topspin from what should be a centre hit by widening the neutral spin region.  
- Make the cue-stick forward push more visible and have its forward animation speed scale with shot power so low-power shots push forward slower and high-power shots push faster.  

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the cue forward animation now uses a power-based duration: non-AI strokes interpolate between `PLAYER_CUE_STRIKE_MAX_MS` and `PLAYER_CUE_STRIKE_MIN_MS` using the clamped shot power, and the impact position no longer applies an additional follow-through offset so the forward motion returns to the pull start.  
- In `webapp/src/pages/Games/poolRoyaleSpinUtils.js` the neutral spin thresholds were widened by increasing `SPIN_STUN_RADIUS` from `0.12` to `0.16` and `STRAIGHT_SPIN_DEADZONE` from `0.08` to `0.1` to reduce unintended topspin/backspin on near-center hits.  
- Minor cleanup: removed an unused intermediate `topSpinWeight` usage in the firing path to simplify the stroke logic.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dde67e8b08329977b067cf0bb6b9f)