### PR TITLE
Adjust cue spin deadzone and player cue forward timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1464,6 +1464,9 @@ const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes control
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
+const PLAYER_CUE_FORWARD_MIN_MS = 140;
+const PLAYER_CUE_FORWARD_MAX_MS = 420;
+const PLAYER_CUE_FORWARD_EASE = 0.65;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
@@ -20542,15 +20545,18 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const followThroughPull = THREE.MathUtils.clamp(
-            topSpinWeight * clampedPower * BALL_R * 0.35,
-            0,
-            BALL_R * 0.35
-          );
-          const impactPos = buildCuePosition(-followThroughPull);
+          const impactPos = buildCuePosition(0);
           cueStick.visible = true;
           cueStick.position.copy(startPos);
-          const forwardDuration = isAiStroke ? AI_CUE_FORWARD_DURATION_MS : 120;
+          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
+          const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
+          const forwardDuration = isAiStroke
+            ? AI_CUE_FORWARD_DURATION_MS
+            : THREE.MathUtils.lerp(
+                PLAYER_CUE_FORWARD_MAX_MS,
+                PLAYER_CUE_FORWARD_MIN_MS,
+                forwardBlend
+              );
           const settleDuration = isAiStroke ? 40 : 50;
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const MAX_SPIN_OFFSET = 0.7;
-export const SPIN_STUN_RADIUS = 0.12;
+export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.32;
 export const SPIN_RING2_RADIUS = 0.52;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;


### PR DESCRIPTION
### Motivation

- Reduce accidental topspin on centre hits by widening the neutral spin deadzone so a true centre strike registers as no-spin. 
- Make the visible cue-stick forward stroke speed match shot power so low-power shots push forward visibly slower and high-power shots push faster.

### Description

- Increased the centre-spin deadzone by updating `SPIN_STUN_RADIUS` from `0.12` to `0.16` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to make neutral hits less likely to register unintended spin. 
- Added new player timing constants `PLAYER_CUE_FORWARD_MIN_MS`, `PLAYER_CUE_FORWARD_MAX_MS`, and `PLAYER_CUE_FORWARD_EASE` to `webapp/src/pages/Games/PoolRoyale.jsx` to control forward stroke timing and easing. 
- Scale the player's cue forward animation duration by shot power using an eased blend so lower power yields longer (slower) forward durations and higher power yields shorter (faster) durations, implemented in the forward-duration calculation in `PoolRoyale.jsx`. 
- Simplified impact target construction to use the zero-pull impact position (`buildCuePosition(0)`) so the forward stroke reaches the release position consistently.

### Testing

- No automated tests were run for these changes.
- Changes were committed and verified in the working tree (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/poolRoyaleSpinUtils.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dde67e8b08329977b067cf0bb6b9f)