### PR TITLE
Align Pool Royale spin center and shot speed with Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1382,11 +1382,10 @@ const SWERVE_PRE_IMPACT_DRIFT = 0.35; // allow a visible curve before the cue ba
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
-// Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
-// Pool Royale power pass: lift overall shot strength by another 25%.
-const SHOT_POWER_REDUCTION = 0.8;
-const SHOT_POWER_MULTIPLIER = 1.6875;
-const SHOT_SPEED_MULTIPLIER = 1.875; // boost overall shot speed by 87.5% for snappier ball travel
+// Snooker Royal feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
+// Snooker Royal power pass: lift overall shot strength by another 25%.
+const SHOT_POWER_REDUCTION = 0.85;
+const SHOT_POWER_MULTIPLIER = 1.25;
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1397,7 +1396,7 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_REDUCTION *
   SHOT_POWER_MULTIPLIER;
 const SHOT_BREAK_MULTIPLIER = 1.5;
-const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST * SHOT_SPEED_MULTIPLIER;
+const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
 const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = 0.25 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.5 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 1.0 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.08;
-export const STUN_TOPSPIN_BIAS = 0.04;
+export const STUN_TOPSPIN_BIAS = 0;
 
 export const SPIN_DIRECTIONS = [
   {


### PR DESCRIPTION
### Motivation
- Make Pool Royale cue-ball center (stun) behaviour match Snooker Royal so placing the red dot at the center produces a true no-spin/stun hit. 
- Ensure ball roll speeds in Pool Royale match Snooker Royal so shot feel and travel are consistent between modes. 

### Description
- Remove the center/topspin bias by setting `STUN_TOPSPIN_BIAS` to `0` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`, preserving all other spin rings and quantization logic. 
- Align power/speed tuning with the Snooker Royal profile in `webapp/src/pages/Games/PoolRoyale.jsx` by updating `SHOT_POWER_REDUCTION` to `0.85`, `SHOT_POWER_MULTIPLIER` to `1.25`, removing the `SHOT_SPEED_MULTIPLIER` usage, and computing `SHOT_BASE_SPEED` to match the Snooker Royal formula. 
- Changes are scoped to the spin center handling and global shot speed constants only and do not alter other spin-side or UI code. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e012e4220832993f8717674b9785b)