### PR TITLE
Tune Pool Royale pocket cameras, broadcast framing and shot pacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1271,7 +1271,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.72;
+const POCKET_CAM_EDGE_SCALE = 0.6;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1283,18 +1283,18 @@ const POCKET_CAM_BASE_OUTWARD_OFFSET =
     BALL_R * 1.05) *
   POCKET_CAM_EDGE_SCALE;
 const POCKET_CAM = Object.freeze({
-  triggerDist: CAPTURE_R * 12,
-  dotThreshold: 0.22,
+  triggerDist: CAPTURE_R * 18,
+  dotThreshold: 0.12,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.02,
-  maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.15,
-  heightOffsetShortMultiplier: 0.9,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE,
+  maxOutside: BALL_R * 26,
+  heightOffset: BALL_R * 0.85,
+  heightOffsetShortMultiplier: 0.85,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
   outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
   heightDrop: BALL_R * 0.2,
-  distanceScale: 0.96,
-  heightScale: 1.02,
+  distanceScale: 0.82,
+  heightScale: 0.98,
   focusBlend: 0,
   lateralFocusShift: 0,
   railFocusLong: BALL_R * 5.6,
@@ -1303,8 +1303,8 @@ const POCKET_CAM = Object.freeze({
 const POCKET_POPUP_DURATION_MS = 2000;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
-const POCKET_GUARANTEED_ALIGNMENT = 0.92;
-const POCKET_EARLY_ALIGNMENT = 0.82;
+const POCKET_GUARANTEED_ALIGNMENT = 0.88;
+const POCKET_EARLY_ALIGNMENT = 0.72;
 const POCKET_INTENT_TIMEOUT_MS = 4200;
 const ACTION_CAM = Object.freeze({
   pairMinDistance: BALL_R * 28,
@@ -1382,13 +1382,10 @@ const SWERVE_THRESHOLD = 0.82; // outer 18% of the spin control activates swerve
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const SWERVE_PRE_IMPACT_DRIFT = 0.35; // allow a visible curve before the cue ball hits the object ball
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
-// Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
-// Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
-// Pool Royale power pass: lift overall shot strength by another 25%.
+// Align shot strength to Snooker Royal so ball pace/shot power feel identical between modes.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_POWER_MULTIPLIER = 1.5;
-const SHOT_SPEED_MULTIPLIER = 1.08;
+const SHOT_POWER_MULTIPLIER = 1.25;
+const SHOT_SPEED_MULTIPLIER = 1;
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -4899,7 +4896,7 @@ const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.04; // add a touch more overhead bias while
 const BACKSPIN_DIRECTION_PREVIEW = 0.68; // lerp strength that pulls the cue-ball follow line toward a draw path
 const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
-const POCKET_VIEW_SMOOTH_TIME = 0.24; // seconds to ease pocket camera transitions
+const POCKET_VIEW_SMOOTH_TIME = 0.14; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
 const LONG_SHOT_ACTIVATION_DELAY_MS = 220;
@@ -13949,31 +13946,33 @@ const powerRef = useRef(hud.power);
           : null;
         const aspect = Number.isFinite(hostAspect) ? hostAspect : 9 / 16; // fall back to worst-case portrait when unknown
         const tempCamera = new THREE.PerspectiveCamera(STANDING_VIEW_FOV, aspect);
-        const topDownRadius = Math.max(
-          fitRadius(tempCamera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE,
-          CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+        const zoomProfile = resolveCameraZoomProfile(aspect);
+        const standingRadius = fitRadius(
+          tempCamera,
+          Math.max(STANDING_VIEW_MARGIN * zoomProfile.broadcast, 1e-4),
+          STANDING_VIEW_DISTANCE_SCALE
         );
-        return topDownRadius;
+        return clampOrbitRadius(Math.max(standingRadius, CAMERA.minR));
       };
-      const resolveTopDownCoords = () => {
+      const resolveStandingBroadcastCoords = () => {
         const radius = resolveBroadcastDistance();
-        const phi = TOP_VIEW_RESOLVED_PHI;
+        const phi = STANDING_VIEW_PHI;
         const focusY = ORBIT_FOCUS_BASE_Y * worldScaleFactor;
         const height = focusY + Math.cos(phi) * radius;
         const horizontal = Math.sin(phi) * radius;
         return { radius, height, horizontal };
       };
-      const { height: topDownHeight, horizontal: topDownHorizontal } =
-        resolveTopDownCoords();
+      const { height: standingHeight, horizontal: standingHorizontal } =
+        resolveStandingBroadcastCoords();
       const broadcastClearance = arenaMargin * 0.3 + BALL_R * 4;
       const shortRailTarget = Math.max(
-        topDownHorizontal,
+        standingHorizontal,
         arenaHalfDepth - broadcastClearance
       );
       const shortRailSlideLimit = 0;
       const broadcastRig = createBroadcastCameras({
         floorY,
-        cameraHeight: topDownHeight,
+        cameraHeight: standingHeight,
         shortRailZ: shortRailTarget,
         slideLimit: shortRailSlideLimit,
         arenaHalfDepth: Math.max(arenaHalfDepth - BALL_R * 4, BALL_R * 4)


### PR DESCRIPTION
### Motivation
- Make Pool Royale ball pace and shot feel match Snooker Royal by aligning shot power and base speed tuning. 
- Move pocket cameras closer to the table (edge of chrome plates) and make pocket views trigger earlier and switch faster. 
- Use pocket cameras together with standing/broadcast cameras so short-rail standing shots keep the whole table in frame for broadcast.

### Description
- Tuned pocket camera placement and behavior in `PoolRoyale.jsx` by lowering `POCKET_CAM_EDGE_SCALE`, increasing `POCKET_CAM.triggerDist`, lowering `POCKET_CAM.dotThreshold`, and adjusting `minOutsideShort`, `maxOutside`, `heightOffset`, `distanceScale`, and `heightScale` to bring pocket views closer and earlier.  
- Reduced smoothing for pocket transitions by changing `POCKET_VIEW_SMOOTH_TIME` from `0.24` to `0.14`.  
- Relaxed pocket alignment requirements by changing `POCKET_GUARANTEED_ALIGNMENT` and `POCKET_EARLY_ALIGNMENT` to make pocket cameras activate sooner.  
- Aligned shot pacing with Snooker Royal by changing `SHOT_POWER_MULTIPLIER` to `1.25` and `SHOT_SPEED_MULTIPLIER` to `1` and updated the explanatory comment to reflect the intent.  
- Rebased broadcast short-rail camera placement to use standing-view framing by replacing the top-down broadcast distance/coords logic with a `resolveBroadcastDistance` / `resolveStandingBroadcastCoords` flow and passing `standingHeight` into the broadcast rig (`createBroadcastCameras`) so short-rail standing cameras sit nearer the cloth and keep the table on frame.  
- Single modified file: `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e49308a1c83299d0122c6ca02be11)