### PR TITLE
Increase Pool Royale shot power by 50%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1386,8 +1386,9 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 // Pool Royale power pass: lift overall shot strength by another 25%.
+// Pool Royale tuning: increase shot power by 50% for stronger breaks and deeper travel.
 const SHOT_POWER_REDUCTION = 0.85;
-const SHOT_POWER_MULTIPLIER = 1.25;
+const SHOT_POWER_MULTIPLIER = 1.875;
 const SHOT_SPEED_MULTIPLIER = 1;
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Raise Pool Royale shot strength so breaks and long shots feel stronger and travel deeper by adjusting the tuning multiplier.

### Description
- Update `SHOT_POWER_MULTIPLIER` from `1.25` to `1.875` and add a short comment documenting the 50% tuning change in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e51e1b17c8329995c4db23faea209)