### PR TITLE
Increase Pool Royale shot power by 50%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1386,8 +1386,10 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
 // Pool Royale power pass: lift overall shot strength by another 25%.
+// Pool Royale request: increase shot power by an additional 50% for stronger strikes.
 const SHOT_POWER_REDUCTION = 0.85;
 const SHOT_POWER_MULTIPLIER = 1.25;
+const SHOT_POWER_BOOST = 1.5;
 const SHOT_SPEED_MULTIPLIER = 1;
 const SHOT_FORCE_BOOST =
   1.5 *
@@ -1397,7 +1399,8 @@ const SHOT_FORCE_BOOST =
   1.3 *
   0.85 *
   SHOT_POWER_REDUCTION *
-  SHOT_POWER_MULTIPLIER;
+  SHOT_POWER_MULTIPLIER *
+  SHOT_POWER_BOOST;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST * SHOT_SPEED_MULTIPLIER;
 const SHOT_MIN_FACTOR = 0.25;


### PR DESCRIPTION
### Motivation
- Raise overall shot strength for Pool Royale so player pulls produce noticeably stronger strikes, matching the request to increase power by 50%. 
- Keep existing tuning multipliers intact while applying an additional dedicated boost to avoid changing other balancing constants.

### Description
- Add a new constant `SHOT_POWER_BOOST = 1.5` in `webapp/src/pages/Games/PoolRoyale.jsx` to represent the 50% power increase. 
- Apply the boost by multiplying `SHOT_FORCE_BOOST` with `SHOT_POWER_BOOST` so the global force scaling includes the extra 50% factor. 
- Add a clarifying comment above the nearby power constants to indicate the Pool Royale request and the new boost.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e51e1b17c8329995c4db23faea209)