### PR TITLE
Fix Pool Royale spin ring mapping and use standing camera for broadcast replay

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4867,6 +4867,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
 const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
+const USE_STANDING_BROADCAST_CAMERA = true; // keep broadcast cuts aligned with the standing camera instead of side-rail rigs
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
@@ -15442,6 +15443,25 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
+          if (USE_STANDING_BROADCAST_CAMERA) {
+            const fallbackTarget =
+              focusOverride?.clone?.() ??
+              lastCameraTargetRef.current?.clone?.() ??
+              new THREE.Vector3(
+                0,
+                TABLE_Y + TABLE.THICK + BALL_R * 2.5,
+                0
+              );
+            if (fallbackTarget && Number.isFinite(minTargetY)) {
+              fallbackTarget.y = Math.max(fallbackTarget.y ?? minTargetY, minTargetY);
+            }
+            return {
+              position: camera.position.clone(),
+              target: fallbackTarget,
+              fov: STANDING_VIEW_FOV,
+              minTargetY
+            };
+          }
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
           const activeRail =

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -133,10 +133,8 @@ export const computeQuantizedOffsetScaled = (
 export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
-  if (Math.abs(x) < STRAIGHT_SPIN_DEADZONE) x = 0;
-  if (Math.abs(y) < STRAIGHT_SPIN_DEADZONE) y = 0;
   const distance = Math.hypot(x, y);
-  if (distance <= SPIN_STUN_RADIUS) {
+  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
   return computeQuantizedOffsetScaled(x, y);


### PR DESCRIPTION
### Motivation
- Players reported that spin inputs near the center (inner ring) always produced `topspin` direction instead of preserving the intended diagonal/side direction. 
- The broadcast replay/rail camera starts from a side-rail tripod angle that should instead match the standing camera framing at the beginning of play.

### Description
- Adjusted spin normalization in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by removing per-axis deadzone zeroing and treating the deadzone as a combined magnitude threshold via `Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)` so inner-ring directions are preserved and only truly-stun inputs collapse to the stun preset.
- Replaced the earlier per-axis zeroing behavior to keep the UI direction information around the center while still quantizing magnitude via `computeQuantizedOffsetScaled`.
- Added a configuration flag `USE_STANDING_BROADCAST_CAMERA` and a standing-camera override in `webapp/src/pages/Games/PoolRoyale.jsx` inside `resolveRailOverheadReplayCamera` so replay/broadcast camera requests default to the standing camera position/target when enabled, preventing side-rail tripod framing at start.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7ff167308329bdb0a365f0c29f8e)