### PR TITLE
Pool Royale: adjust pocket geometry, pocket cameras, AI planning reset, and cue follow-through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,17 +601,17 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.38; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.48; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.16; // keep the rounded chrome cutouts centred while nudging the plates outward
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.1; // keep the rounded chrome cutouts centred while nudging the plates outward
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.032; // push the middle rail rounded cuts slightly farther outward so they sit farther from the table centre while keeping their slim profile
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.08; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.11; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
 
 function buildChromePlateGeometry({
   width,
@@ -960,7 +960,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.22; // push the middle jaw reach a t
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.096; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.122; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -1028,10 +1028,10 @@ const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
-const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.02; // move middle pocket centres a touch farther outward before biasing back
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.038; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
-const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.018; // gently bias the middle pocket centres and cuts back toward the playfield
-const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.02; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
+const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.028; // move middle pocket centres a touch farther outward before biasing back
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.052; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
+const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.012; // gently bias the middle pocket centres and cuts back toward the playfield
+const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.012; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
 const CHALK_TOP_COLOR = 0xd9c489;
 const CHALK_SIDE_COLOR = 0x10141b;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1a2430;
@@ -1271,7 +1271,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.6;
+const POCKET_CAM_EDGE_SCALE = 0.55;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1472,6 +1472,10 @@ const PLAYER_CUE_STRIKE_MAX_MS = 1400;
 const PLAYER_CUE_FORWARD_MIN_MS = 140;
 const PLAYER_CUE_FORWARD_MAX_MS = 420;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
+const CUE_FORWARD_FOLLOW_THROUGH = BALL_R * 0.46;
+const PLAYER_CUE_FOLLOW_THROUGH_MS = 160;
+const AI_CUE_FOLLOW_THROUGH_MS = 220;
+const CUE_FOLLOW_THROUGH_HOLD_MS = 110;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
@@ -13460,6 +13464,17 @@ const powerRef = useRef(hud.power);
         shotStartedAt = shooting ? getNow() : 0;
         if (!shooting) {
           maxPowerLiftTriggered = false;
+          aiPlanCacheRef.current = { key: null, plan: null };
+          aiPlanRef.current = null;
+          aiTelemetryRef.current = null;
+          if (aiOpponentEnabled) {
+            const hudState = hudRef.current;
+            if (hudState?.turn === 1) {
+              startAiThinkingRef.current?.();
+            } else {
+              startUserSuggestionRef.current?.();
+            }
+          }
         }
         if (shotCameraHoldTimeoutRef.current) {
           clearTimeout(shotCameraHoldTimeoutRef.current);
@@ -20500,6 +20515,7 @@ const powerRef = useRef(hud.power);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const impactPos = buildCuePosition(0);
+          const followThroughPos = buildCuePosition(-CUE_FORWARD_FOLLOW_THROUGH);
           cueStick.visible = true;
           cueStick.position.copy(startPos);
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
@@ -20511,10 +20527,14 @@ const powerRef = useRef(hud.power);
                 PLAYER_CUE_FORWARD_MIN_MS,
                 forwardBlend
               );
-          const settleDuration = isAiStroke ? 40 : 50;
+          const followThroughDuration = isAiStroke
+            ? AI_CUE_FOLLOW_THROUGH_MS
+            : PLAYER_CUE_FOLLOW_THROUGH_MS;
+          const settleDuration = CUE_FOLLOW_THROUGH_HOLD_MS;
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;
-          const settleTime = impactTime + settleDuration;
+          const followThroughTime = impactTime + followThroughDuration;
+          const settleTime = followThroughTime + settleDuration;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -20586,11 +20606,11 @@ const powerRef = useRef(hud.power);
               warmup: serializeVector3Snapshot(startPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(impactPos),
+              settle: serializeVector3Snapshot(followThroughPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               forwardDuration,
-              settleDuration,
+              settleDuration: followThroughDuration + settleDuration,
               startOffset: strokeStartOffset
             };
           }
@@ -20601,8 +20621,18 @@ const powerRef = useRef(hud.power);
                 : 1;
               const eased = easeOutCubic(t);
               cueStick.position.lerpVectors(startPos, impactPos, eased);
+            } else if (now <= followThroughTime) {
+              const t = followThroughDuration > 0
+                ? THREE.MathUtils.clamp(
+                    (now - impactTime) / followThroughDuration,
+                    0,
+                    1
+                  )
+                : 1;
+              const eased = easeOutCubic(t);
+              cueStick.position.lerpVectors(impactPos, followThroughPos, eased);
             } else if (now <= settleTime) {
-              cueStick.position.copy(impactPos);
+              cueStick.position.copy(followThroughPos);
             } else {
               cueStick.visible = false;
               cueAnimating = false;


### PR DESCRIPTION
### Motivation
- Bring pocket cameras visually closer to the table edge and ensure chrome plates sit at the outside edge of the pocket jaws for the requested look. 
- Nudge middle pockets, cloth cutouts, chrome plates and wooden rail reliefs slightly outward so middle pockets read farther from center while retaining the current appearance. 
- Improve AI consistency by forcing a fresh shot evaluation after each shot and preserving the same first-shot logic for subsequent evaluations. 
- Make the cue forward stroke visibly show the forward/pushing section (follow-through) which was previously not obvious.

### Description
- Tuning constants updated to move pocket geometry and trims outward, including `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE`, `WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE`, `SIDE_POCKET_JAW_OUTWARD_SHIFT`, `SIDE_POCKET_EXTRA_SHIFT`, `SIDE_POCKET_OUTWARD_BIAS`, `SIDE_POCKET_FIELD_PULL`, and `SIDE_POCKET_CLOTH_INWARD_PULL` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Pulled pocket camera framing closer by reducing `POCKET_CAM_EDGE_SCALE` so `POCKET_CAM.minOutside`/`outwardOffset` compute closer camera positions.
- Reset AI planning and telemetry after each shot by clearing `aiPlanCacheRef.current`, `aiPlanRef.current`, and `aiTelemetryRef.current` in `setShootingState`, and restart either AI thinking or user suggestion accordingly to ensure a fresh evaluation per shot.
- Added cue follow-through constants (`CUE_FORWARD_FOLLOW_THROUGH`, `PLAYER_CUE_FOLLOW_THROUGH_MS`, `AI_CUE_FOLLOW_THROUGH_MS`, `CUE_FOLLOW_THROUGH_HOLD_MS`) and extended the cue animation to include a clear follow-through stage (compute `followThroughPos`, animate impact→follow-through then hold) so the pushing section is visible and recorded in shot replays.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 5173` and confirmed Vite reported the server ready (succeeded). 
- Ran a headless Playwright script to open `http://127.0.0.1:5173/games/poolroyale/lobby` at mobile portrait viewport and saved `artifacts/pool-royale-lobby.png` to verify the scene loads and camera/pocket visuals render (succeeded). 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e84cb28c08329846b8d9db68e7c08)