### PR TITLE
Adjust Pool Royale pocket geometry, pocket cameras, cue follow-through, and AI shot reset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,17 +601,17 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.38; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.46; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.16; // keep the rounded chrome cutouts centred while nudging the plates outward
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.12; // keep the rounded chrome cutouts centred while nudging the plates outward
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.032; // push the middle rail rounded cuts slightly farther outward so they sit farther from the table centre while keeping their slim profile
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.08; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.12; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
 
 function buildChromePlateGeometry({
   width,
@@ -960,7 +960,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.22; // push the middle jaw reach a t
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.096; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.12; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -1029,9 +1029,9 @@ const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
 const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.02; // move middle pocket centres a touch farther outward before biasing back
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.038; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
-const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.018; // gently bias the middle pocket centres and cuts back toward the playfield
-const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.02; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.056; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
+const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.012; // gently bias the middle pocket centres and cuts back toward the playfield
+const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.012; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
 const CHALK_TOP_COLOR = 0xd9c489;
 const CHALK_SIDE_COLOR = 0x10141b;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1a2430;
@@ -1271,7 +1271,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.6;
+const POCKET_CAM_EDGE_SCALE = 0.52;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1465,6 +1465,8 @@ const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while 
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // ensure the forward push is visible even on short strokes
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -20504,6 +20506,14 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(startPos);
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
           const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
+          const followThrough = Math.min(
+            CUE_FOLLOW_THROUGH_MAX,
+            Math.max(
+              CUE_FOLLOW_THROUGH_MIN,
+              visualPull * (0.22 + 0.28 * powerStrength)
+            )
+          );
+          const followThroughPos = buildCuePosition(-followThrough);
           const forwardDuration = isAiStroke
             ? AI_CUE_FORWARD_DURATION_MS
             : THREE.MathUtils.lerp(
@@ -20602,7 +20612,11 @@ const powerRef = useRef(hud.power);
               const eased = easeOutCubic(t);
               cueStick.position.lerpVectors(startPos, impactPos, eased);
             } else if (now <= settleTime) {
-              cueStick.position.copy(impactPos);
+              const t = settleDuration > 0
+                ? THREE.MathUtils.clamp((now - impactTime) / settleDuration, 0, 1)
+                : 1;
+              const eased = easeOutCubic(t);
+              cueStick.position.lerpVectors(impactPos, followThroughPos, eased);
             } else {
               cueStick.visible = false;
               cueAnimating = false;
@@ -22761,6 +22775,8 @@ const powerRef = useRef(hud.power);
             shotRecording = null;
           }
           aiPlanRef.current = null;
+          aiPlanCacheRef.current = { key: null, plan: null };
+          clearEarlyAiShot();
           setAiPlanning(null);
           window.setTimeout(() => {
             const hudState = hudRef.current;
@@ -22768,6 +22784,9 @@ const powerRef = useRef(hud.power);
               autoAimRequestRef.current = true;
               suggestionAimKeyRef.current = null;
               startUserSuggestionRef.current?.();
+            }
+            if (aiOpponentEnabled && hudState?.turn === 1 && !hudState.over) {
+              startAiThinkingRef.current?.();
             }
           }, 0);
           if (cameraRef.current && sphRef.current) {


### PR DESCRIPTION
### Motivation
- Bring middle pocket assemblies visually a little farther outward and align chrome/wood/jaw cutouts to match the new pocket placement.  
- Pull pocket cameras slightly closer to the table edge so pocket views read tighter on-screen.  
- Make the cue stick stroke show the crucial forward/follow-through motion so the impact is visually clear.  
- Ensure the AI re-evaluates after each shot so planning/state does not persist stale decisions.

### Description
- Tweaked pocket geometry and layout constants in `PoolRoyale.jsx`, including `SIDE_POCKET_OUTWARD_BIAS`, `SIDE_POCKET_FIELD_PULL`, and `SIDE_POCKET_CLOTH_INWARD_PULL` to move middle pockets outward and adjust cloth/rail pulls.  
- Adjusted chrome/wood pocket cut and jaw parameters (`CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE`, `WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE`, `SIDE_POCKET_JAW_OUTWARD_SHIFT`) so chrome plates, jaws, and wooden cutouts track the new pocket line.  
- Reduced `POCKET_CAM` edge scale (`POCKET_CAM_EDGE_SCALE`) so pocket cameras sit a bit closer to the table rim.  
- Added visible cue follow-through: introduced `CUE_FOLLOW_THROUGH_MIN`/`MAX`, computed a `followThroughPos` in the stroke code and updated the stroke animator to lerp from `impactPos` to `followThroughPos` during settle so the forward push is shown.  
- Reset AI planning state after shots by clearing `aiPlanRef`/`aiPlanCacheRef`, calling `clearEarlyAiShot()`, and scheduling `startAiThinking` if the opponent is AI so the AI always recomputes on the next turn.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` (Vite) and the server came up successfully.  
- Attempted an automated Playwright screenshot of `/games/poolroyale` to visually verify pocket/cue changes, but the screenshot attempt timed out and failed.  
- No automated unit test suite (`npm test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e84cb28c08329846b8d9db68e7c08)