### PR TITLE
Adjust Pool Royale corner pocket positions and align broadcast cameras to standing view

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1060,7 +1060,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+  POCKET_VIS_R * 0.27 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
@@ -4319,11 +4319,7 @@ function createBroadcastCameras({
   const panBarGeo = new THREE.CylinderGeometry(0.012, 0.012, 0.32, 12);
   const gripGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.2, 12);
 
-  const defaultFocus = new THREE.Vector3(
-    0,
-    TABLE_Y + TABLE.THICK + BALL_R * 2.5,
-    0
-  );
+  const defaultFocus = new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0);
 
   const fallbackDepth = Math.max(
     shortRailZ + BALL_R * 12,
@@ -13949,37 +13945,43 @@ const powerRef = useRef(hud.power);
         updateCueRackHighlights();
       }
 
-      const resolveBroadcastDistance = () => {
+      const resolveStandingCoords = () => {
         const hostAspect = host?.clientWidth && host?.clientHeight
           ? host.clientWidth / host.clientHeight
           : null;
-        const aspect = Number.isFinite(hostAspect) ? hostAspect : 9 / 16; // fall back to worst-case portrait when unknown
+        const aspect = Number.isFinite(hostAspect) ? hostAspect : 9 / 16;
         const tempCamera = new THREE.PerspectiveCamera(STANDING_VIEW_FOV, aspect);
-        const topDownRadius = Math.max(
-          fitRadius(tempCamera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE,
-          CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+        const zoomProfile = resolveCameraZoomProfile(aspect);
+        const standingPhi = THREE.MathUtils.clamp(
+          STANDING_VIEW.phi,
+          CAMERA.minPhi,
+          CAMERA.maxPhi
         );
-        return topDownRadius;
-      };
-      const resolveTopDownCoords = () => {
-        const radius = resolveBroadcastDistance();
-        const phi = TOP_VIEW_RESOLVED_PHI;
+        const standingRadius = clamp(
+          fitRadius(
+            tempCamera,
+            STANDING_VIEW.margin * zoomProfile.margin,
+            STANDING_VIEW_DISTANCE_SCALE
+          ),
+          CAMERA.minR,
+          CAMERA.maxR
+        );
         const focusY = ORBIT_FOCUS_BASE_Y * worldScaleFactor;
-        const height = focusY + Math.cos(phi) * radius;
-        const horizontal = Math.sin(phi) * radius;
-        return { radius, height, horizontal };
+        const height = focusY + Math.cos(standingPhi) * standingRadius;
+        const horizontal = Math.sin(standingPhi) * standingRadius;
+        return { radius: standingRadius, height, horizontal };
       };
-      const { height: topDownHeight, horizontal: topDownHorizontal } =
-        resolveTopDownCoords();
+      const { height: standingHeight, horizontal: standingHorizontal } =
+        resolveStandingCoords();
       const broadcastClearance = arenaMargin * 0.3 + BALL_R * 4;
       const shortRailTarget = Math.max(
-        topDownHorizontal,
+        standingHorizontal,
         arenaHalfDepth - broadcastClearance
       );
       const shortRailSlideLimit = 0;
       const broadcastRig = createBroadcastCameras({
         floorY,
-        cameraHeight: topDownHeight,
+        cameraHeight: standingHeight,
         shortRailZ: shortRailTarget,
         slideLimit: shortRailSlideLimit,
         arenaHalfDepth: Math.max(arenaHalfDepth - BALL_R * 4, BALL_R * 4)


### PR DESCRIPTION
### Motivation
- Make corner pocket assemblies (cutouts, jaws, nets, chrome plates, wood relief) visually sit slightly farther outward from the table centre while preserving middle-pocket geometry. 
- Ensure the broadcast rig uses the same starting coordinates as the standing camera and mounts on the short rails so broadcast framing matches the standing camera framing.

### Description
- Reduced corner pocket center inset by changing `CORNER_POCKET_CENTER_INSET` multiplier from `0.32` to `0.27` to push corner pocket centres outward while keeping middle pockets unchanged (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replaced the broadcast rig focus origin with the orbit/standing focus by switching `defaultFocus` to use `ORBIT_FOCUS_BASE_Y` so pocket/broadcast cameras reference the same vertical focus point (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added `resolveStandingCoords()` and used its `height` and `horizontal` results when creating the broadcast rig so the broadcast cameras derive their `cameraHeight` and short-rail placement from the initial standing camera parameters (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated short-rail broadcast placement to use the standing horizontal radius when computing `shortRailTarget`, ensuring broadcast heads are positioned on the short rails rather than side rails (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported the app ready on the local and network addresses, which indicates the build served correctly; this step succeeded.
- Attempted an automated Playwright screenshot of `/games/poolroyale` to verify visual placement, but the Chromium headless process crashed and the screenshot step failed, so no visual artifact was produced; the attempt failed.
- No unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f163de6cc832981e4b594846df91c)