### PR TITLE
Adjust Pool Royale corner pockets and align broadcast rig to standing camera

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1091,13 +1091,13 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+  POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
 const CORNER_RAIL_NOTCH_INSET =
-  POCKET_VIS_R * 0.078 * POCKET_VISUAL_EXPANSION; // let the rail and chrome cutouts follow the outward corner pocket shift
+  POCKET_VIS_R * 0.068 * POCKET_VISUAL_EXPANSION; // let the rail and chrome cutouts follow the outward corner pocket shift
 const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
@@ -14098,37 +14098,62 @@ const powerRef = useRef(hud.power);
         updateCueRackHighlights();
       }
 
-      const resolveBroadcastDistance = () => {
+      const resolveStandingBroadcastCoords = () => {
         const hostAspect = host?.clientWidth && host?.clientHeight
           ? host.clientWidth / host.clientHeight
           : null;
         const aspect = Number.isFinite(hostAspect) ? hostAspect : 9 / 16; // fall back to worst-case portrait when unknown
         const tempCamera = new THREE.PerspectiveCamera(STANDING_VIEW_FOV, aspect);
-        const topDownRadius = Math.max(
-          fitRadius(tempCamera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE,
-          CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+        const zoomProfile = resolveCameraZoomProfile(aspect);
+        const standingMargin = Math.max(
+          STANDING_VIEW.margin,
+          aspect < 1 ? STANDING_VIEW_MARGIN_PORTRAIT : STANDING_VIEW_MARGIN_LANDSCAPE
         );
-        return topDownRadius;
-      };
-      const resolveTopDownCoords = () => {
-        const radius = resolveBroadcastDistance();
-        const phi = TOP_VIEW_RESOLVED_PHI;
+        const standingRadiusRaw = fitRadius(
+          tempCamera,
+          Math.max(standingMargin * zoomProfile.margin, 1e-4)
+        );
+        const cueBase = clampOrbitRadius(BREAK_VIEW.radius);
+        const playerRadiusBase = Math.max(standingRadiusRaw, cueBase);
+        const shouldApplyBroadcastPullIn = aspect >= 1;
+        const broadcastBaseRadius = shouldApplyBroadcastPullIn
+          ? Math.max(
+              standingRadiusRaw,
+              playerRadiusBase * BROADCAST_DISTANCE_MULTIPLIER
+            )
+          : playerRadiusBase;
+        const baseBroadcastRadius =
+          broadcastBaseRadius + BROADCAST_RADIUS_PADDING;
+        const baseStandingRadius = Math.max(
+          standingRadiusRaw,
+          baseBroadcastRadius
+        );
+        const standingRadius = clamp(
+          Math.max(standingRadiusRaw, baseStandingRadius * zoomProfile.broadcast),
+          CAMERA.minR,
+          CAMERA.maxR
+        );
+        const standingPhi = THREE.MathUtils.clamp(
+          STANDING_VIEW.phi,
+          CAMERA.minPhi,
+          CAMERA.maxPhi - CAMERA_RAIL_SAFETY
+        );
         const focusY = ORBIT_FOCUS_BASE_Y * worldScaleFactor;
-        const height = focusY + Math.cos(phi) * radius;
-        const horizontal = Math.sin(phi) * radius;
-        return { radius, height, horizontal };
+        const height = focusY + Math.cos(standingPhi) * standingRadius;
+        const horizontal = Math.sin(standingPhi) * standingRadius;
+        return { radius: standingRadius, height, horizontal };
       };
-      const { height: topDownHeight, horizontal: topDownHorizontal } =
-        resolveTopDownCoords();
+      const { height: standingHeight, horizontal: standingHorizontal } =
+        resolveStandingBroadcastCoords();
       const broadcastClearance = arenaMargin * 0.3 + BALL_R * 4;
       const shortRailTarget = Math.max(
-        topDownHorizontal,
+        standingHorizontal,
         arenaHalfDepth - broadcastClearance
       );
       const shortRailSlideLimit = 0;
       const broadcastRig = createBroadcastCameras({
         floorY,
-        cameraHeight: topDownHeight,
+        cameraHeight: standingHeight,
         shortRailZ: shortRailTarget,
         slideLimit: shortRailSlideLimit,
         arenaHalfDepth: Math.max(arenaHalfDepth - BALL_R * 4, BALL_R * 4)


### PR DESCRIPTION
### Motivation
- Move the corner pocket geometry slightly outward so corner pocket mouths and rail cutouts sit farther from the table center while preserving the current look.
- Keep middle/side pockets unchanged to avoid altering play behavior for side pockets.
- Ensure broadcast/standing cameras placed on the short rails use the same starting coordinates so broadcast heads align with the player standing framing.

### Description
- Tweaked pocket layout constants in `webapp/src/pages/Games/SnookerRoyal.jsx` by reducing `CORNER_POCKET_CENTER_INSET` from `POCKET_VIS_R * 0.32` to `POCKET_VIS_R * 0.28` and `CORNER_RAIL_NOTCH_INSET` from `POCKET_VIS_R * 0.078` to `POCKET_VIS_R * 0.068` to push corner pocket centres and chrome/rail cutouts slightly outward.
- Replaced the previous top-down broadcast distance calculation with a standing-derived coordinate function `resolveStandingBroadcastCoords` that computes standing radius/height/horizontal using the standing camera parameters and zoom profile.
- Updated broadcast rig creation to use the new `standingHeight` and `standingHorizontal` values when calling `createBroadcastCameras`, so short-rail broadcast heads are positioned according to the standing camera start coordinates.
- All changes are contained in `webapp/src/pages/Games/SnookerRoyal.jsx` (code rework and constant updates).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f163de6cc832981e4b594846df91c)