### PR TITLE
Nudge Pool Royale middle chrome plates outward and ensure cue pull visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.62; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.66; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -20045,7 +20045,10 @@ const powerRef = useRef(hud.power);
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
         const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
-        const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
+        const visualMax = Math.max(
+          effectiveMax + CUE_PULL_VISUAL_FUDGE,
+          CUE_PULL_MIN_VISUAL
+        );
         const target = amplifiedMax * ratio * CUE_PULL_VISUAL_MULTIPLIER;
         return Math.min(target, visualMax);
       };


### PR DESCRIPTION
### Motivation
- Small visual and UX fixes to match requested pocket chrome plate offset and to prevent the cue stick animation from disappearing on tight/fast shots.

### Description
- Increase `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `0.62` to `0.66` to nudge the middle (side) chrome plates slightly outward so they sit farther from the table centre.
- Tighten cue pull visibility by capping the computed visual maximum in `computePullTargetFromPower` with `Math.max(effectiveMax + CUE_PULL_VISUAL_FUDGE, CUE_PULL_MIN_VISUAL)` so the cue pull target always preserves a minimum visible stroke length.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f20d85bc0832989b73605bb11cd52)