### PR TITLE
Pool Royale: nudge side chrome plates outward and avoid camera hold during cue animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.62; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.66; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -15564,7 +15564,8 @@ const powerRef = useRef(hud.power);
           const cameraHoldActive =
             shooting &&
             powerImpactHoldRef.current &&
-            performance.now() < powerImpactHoldRef.current;
+            performance.now() < powerImpactHoldRef.current &&
+            !cueAnimating;
           const galleryState = cueGalleryStateRef.current;
           if (replayPlaybackActive) {
             const storedReplayCamera = replayCameraRef.current;


### PR DESCRIPTION
### Motivation
- Middle-pocket chrome fascia needed a slight outward push so the side chrome plates sit farther from the table centerline and visually match the pocket mouth.
- The game was freezing briefly during shots at middle pockets and on the break because the camera-hold logic could block updates while the cue stroke playback (`cueAnimating`) is running, making the cue stick animation invisible and causing a perceived freeze.

### Description
- Increased `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `0.62` to `0.66` to nudge the middle-pocket chrome plates outward. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Tightened the shot camera hold predicate by adding `!cueAnimating` so camera-hold behavior does not block visual updates while the cue stroke animation is playing, ensuring the cue stick animation remains visible during shots. (`webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Launched the dev server with `npm --prefix webapp run dev` and Vite reported the site ready on the configured port (server started successfully). (succeeded)
- Attempted an automated Playwright page screenshot of `/games/poolroyale` to visually verify changes, but the screenshot run timed out (Playwright timed out). (failed)
- No unit tests (`npm test` / `jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f20d85bc0832989b73605bb11cd52)