### PR TITLE
Shift Pool Royale pockets slightly outward

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1028,10 +1028,10 @@ const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
-const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.04; // move middle pocket centres a touch farther outward before biasing back
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.095; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
-const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.004; // gently bias the middle pocket centres and cuts back toward the playfield
-const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.003; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
+const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.055; // move middle pocket centres a touch farther outward before biasing back
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.125; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
+const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.0025; // gently bias the middle pocket centres and cuts back toward the playfield
+const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.0015; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
 const CHALK_TOP_COLOR = 0xd9c489;
 const CHALK_SIDE_COLOR = 0x10141b;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1a2430;
@@ -1060,7 +1060,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+  POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;


### PR DESCRIPTION
### Motivation
- Move the playfield pocket geometry a bit farther away from the table center so the pocket mouths and all attached pieces (cloth cutouts, nets, holders, wooden rail reliefs, jaws and chrome plates) keep their current appearance but sit visually more outward.

### Description
- Updated pocket offset/math constants in `webapp/src/pages/Games/PoolRoyale.jsx`, increasing side-pocket outward offsets (`SIDE_POCKET_EXTRA_SHIFT`, `SIDE_POCKET_OUTWARD_BIAS`), reducing side pocket inward pulls (`SIDE_POCKET_FIELD_PULL`, `SIDE_POCKET_CLOTH_INWARD_PULL`), and reducing the corner pocket center inset (`CORNER_POCKET_CENTER_INSET`) so corner and side pockets shift slightly outward while preserving existing proportions.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev` and Vite reported ready, and an automated Playwright screenshot attempt failed due to a headless Chromium crash so a visual smoke capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f29f8cc048329a010aa4268f4d869)