### PR TITLE
Pool Royale: shift pockets & chrome, add cue-stick return, fix AI turn stall

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.66; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.72; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -1028,8 +1028,8 @@ const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
-const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.055; // move middle pocket centres a touch farther outward before biasing back
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.125; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
+const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.065; // move middle pocket centres a touch farther outward before biasing back
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.14; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
 const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.0025; // gently bias the middle pocket centres and cuts back toward the playfield
 const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.0015; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
 const CHALK_TOP_COLOR = 0xd9c489;
@@ -1060,7 +1060,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+  POCKET_VIS_R * 0.24 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
@@ -1271,7 +1271,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.52;
+const POCKET_CAM_EDGE_SCALE = 0.49;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -20523,9 +20523,11 @@ const powerRef = useRef(hud.power);
                 forwardBlend
               );
           const settleDuration = isAiStroke ? 40 : 50;
+          const returnDuration = isAiStroke ? 80 : 120;
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
+          const returnTime = settleTime + returnDuration;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -20618,6 +20620,12 @@ const powerRef = useRef(hud.power);
                 : 1;
               const eased = easeOutCubic(t);
               cueStick.position.lerpVectors(impactPos, followThroughPos, eased);
+            } else if (now <= returnTime) {
+              const t = returnDuration > 0
+                ? THREE.MathUtils.clamp((now - settleTime) / returnDuration, 0, 1)
+                : 1;
+              const eased = easeOutCubic(t);
+              cueStick.position.lerpVectors(followThroughPos, startPos, eased);
             } else {
               cueStick.visible = false;
               cueAnimating = false;
@@ -22253,7 +22261,7 @@ const powerRef = useRef(hud.power);
               return;
             }
           }
-          if (!allStopped(balls)) {
+          if (!allStopped(ballsList)) {
             aiRetryTimeoutRef.current = window.setTimeout(() => {
               aiRetryTimeoutRef.current = null;
               aiShoot.current();


### PR DESCRIPTION
### Motivation

- Align pocket visuals and chrome fascias slightly farther from the table center so the pockets read a bit more outward while keeping the existing look. 
- Avoid AI freeze when it is the AI's turn to shoot by ensuring we check the most up-to-date ball state. 
- Make the cue-stick visually return to its pull start after follow-through to avoid a frozen/stuck-looking stick and provide a simple push-back animation.

### Description

- Adjusted pocket and chrome layout constants to nudge pockets and middle chrome plates outward: updated `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `SIDE_POCKET_EXTRA_SHIFT`, `SIDE_POCKET_OUTWARD_BIAS`, and reduced `CORNER_POCKET_CENTER_INSET` to keep geometry consistent. 
- Pulled pocket-camera framing slightly inward by lowering `POCKET_CAM_EDGE_SCALE` so pocket views sit closer to the table center. 
- Added a cue-stick return phase after follow-through by introducing `returnDuration`/`returnTime` and a lerp from `followThroughPos` back to `startPos` in the shot animation so the stick pushes forward then returns to the pre-pull position. 
- Fixed AI turn motion checks to use the most current ball list (`ballsList`) when calling `allStopped(...)` to prevent AI shot logic from stalling while waiting for balls to stop. 

### Testing

- Started the dev server with `npm run dev` and confirmed Vite reported the app ready (served at `http://localhost:4173/`).
- Attempted a Playwright page load + screenshot of `/games/poolroyale`, but the screenshot timed out (attempts reported a timeout).
- No automated unit/test-suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2ff1bde88329902bc333e3586af4)