### PR TITLE
Adjust Pool Royale pockets and AI turn handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.66; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.72; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.02; // open the rounded chrome corner cut a little more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = CHROME_CORNER_POCKET_CUT_SCALE * 1.012; // open the rounded chrome cut slightly wider on the middle pockets only
@@ -610,8 +610,8 @@ const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.032; // push the middle rail rounded cuts slightly farther outward so they sit farther from the table centre while keeping their slim profile
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.22; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.048; // push the middle rail rounded cuts slightly farther outward so they sit farther from the table centre while keeping their slim profile
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.26; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
 
 function buildChromePlateGeometry({
   width,
@@ -1028,8 +1028,8 @@ const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
-const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.055; // move middle pocket centres a touch farther outward before biasing back
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.125; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
+const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.07; // move middle pocket centres a touch farther outward before biasing back
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.155; // push the middle pocket centres and cloth cutouts slightly outward away from the table midpoint
 const SIDE_POCKET_FIELD_PULL = TABLE.THICK * 0.0025; // gently bias the middle pocket centres and cuts back toward the playfield
 const SIDE_POCKET_CLOTH_INWARD_PULL = TABLE.THICK * 0.0015; // pull only the middle pocket cloth cutouts slightly toward the playfield centre
 const CHALK_TOP_COLOR = 0xd9c489;
@@ -1060,7 +1060,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.28 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+  POCKET_VIS_R * 0.255 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
@@ -1271,7 +1271,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.52;
+const POCKET_CAM_EDGE_SCALE = 0.49;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -20523,9 +20523,11 @@ const powerRef = useRef(hud.power);
                 forwardBlend
               );
           const settleDuration = isAiStroke ? 40 : 50;
+          const returnDuration = isAiStroke ? 160 : 120;
           const startTime = performance.now();
           const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
+          const returnTime = settleTime + returnDuration;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -20597,11 +20599,13 @@ const powerRef = useRef(hud.power);
               warmup: serializeVector3Snapshot(startPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(impactPos),
+              settle: serializeVector3Snapshot(followThroughPos),
+              idle: serializeVector3Snapshot(impactPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               forwardDuration,
               settleDuration,
+              returnDuration,
               startOffset: strokeStartOffset
             };
           }
@@ -20618,6 +20622,12 @@ const powerRef = useRef(hud.power);
                 : 1;
               const eased = easeOutCubic(t);
               cueStick.position.lerpVectors(impactPos, followThroughPos, eased);
+            } else if (now <= returnTime) {
+              const t = returnDuration > 0
+                ? THREE.MathUtils.clamp((now - settleTime) / returnDuration, 0, 1)
+                : 1;
+              const eased = easeOutCubic(t);
+              cueStick.position.lerpVectors(followThroughPos, impactPos, eased);
             } else {
               cueStick.visible = false;
               cueAnimating = false;
@@ -21877,7 +21887,9 @@ const powerRef = useRef(hud.power);
             return;
           }
           if (!cue?.active) {
+            aiPlanRef.current = null;
             setAiPlanning(null);
+            aiThinkingHandle = requestAnimationFrame(startAiThinking);
             return;
           }
           const started = performance.now();
@@ -22235,6 +22247,13 @@ const powerRef = useRef(hud.power);
           const ballsList =
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           if (!allStopped(ballsList)) {
+            aiRetryTimeoutRef.current = window.setTimeout(() => {
+              aiRetryTimeoutRef.current = null;
+              aiShoot.current();
+            }, 120);
+            return;
+          }
+          if (!cue?.active) {
             aiRetryTimeoutRef.current = window.setTimeout(() => {
               aiRetryTimeoutRef.current = null;
               aiShoot.current();


### PR DESCRIPTION
### Motivation
- Move the pocket geometry and surrounding trim slightly outward so pocket mouths, chrome plates and wooden rail cutouts visually sit farther from the table center.
- Pull pocket cameras inward a little so pocket camera framing reads closer to the table center on portrait screens.
- Prevent AI turns from stalling when the cue model is not active and ensure the AI cue stroke returns cleanly for replay accuracy.

### Description
- Tuned pocket & rail constants in `PoolRoyale.jsx` to shift pockets and trims: updated `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE`, `WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE`, `SIDE_POCKET_EXTRA_SHIFT`, `SIDE_POCKET_OUTWARD_BIAS` and `CORNER_POCKET_CENTER_INSET`.
- Reduced pocket camera edge scale by changing `POCKET_CAM_EDGE_SCALE` to bring pocket cameras slightly closer to the table.
- Added a cue-stick return segment (return duration / motion) and recorded `idle`/`settle` positions in the replay `cueStroke` so the cue pushes forward and then returns to the original position without freezing the frame (adds `returnDuration`, `returnTime`, and lerp back to impact position in the stroke animator).
- Hardened AI turn flow by retrying planning/shooting when `cue` is inactive and clearing `aiPlanRef` when necessary, and by restarting the AI thinking loop instead of blocking so AI turns no longer freeze waiting on an inactive cue.

### Testing
- Built the webapp with Vite (`npm run dev` / dev build step) and the production build step completed successfully; this was used as a smoke check for the changes and succeeded.
- Started the local dev server to exercise runtime behavior and confirmed the dev server came up (manual/automated dev run); this completed but full end-to-end interaction was not verified.
- Attempted an automated Playwright capture of the Pool Royale page to validate pocket/camera layout, but the Playwright run timed out while the scene loaded; screenshot capture failed. No unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2ff1bde88329902bc333e3586af4)