### PR TITLE
Tighten side-pocket cushion cuts and use angled normals for side-pocket rail reflections

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 34,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 152.4
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 34,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1521,8 +1521,8 @@ const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
-// middle pocket cushion cuts are set to a 28° cut to align the side-rail cushions with the updated spec
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 28;
+// middle pocket cushion cuts are set to a 34° cut to tighten the side-pocket entry
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 34;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -5092,6 +5092,7 @@ const CORNER_SIGNS = [
   { sx: -1, sy: 1 },
   { sx: 1, sy: 1 }
 ];
+const SIDE_POCKET_CUT_SIGNS = [-1, 1];
 const fitRadius = (camera, margin = 1.1, distanceScale = 0.65) => {
   const a = camera.aspect,
     f = THREE.MathUtils.degToRad(camera.fov);
@@ -5782,36 +5783,41 @@ function reflectRails(ball) {
   const sideGuardClearance = SIDE_POCKET_GUARD_CLEARANCE;
   const sideDepthLimit = SIDE_POCKET_DEPTH_LIMIT;
   const sidePocketCenters = pocketCenters().slice(4);
+  const sideCutRad = THREE.MathUtils.degToRad(SIDE_CUSHION_CUT_ANGLE);
+  const sideCutCos = Math.cos(sideCutRad);
+  const sideCutSin = Math.sin(sideCutRad);
   for (const center of sidePocketCenters) {
     TMP_VEC2_A.copy(ball.pos).sub(center);
-    TMP_VEC2_C.copy(center).multiplyScalar(-1);
-    if (TMP_VEC2_C.lengthSq() < MICRO_EPS * MICRO_EPS) {
-      TMP_VEC2_C.set(center.x >= 0 ? -1 : 1, 0);
+    const distToCenterSq = TMP_VEC2_A.lengthSq();
+    if (distToCenterSq < sidePocketGuard * sidePocketGuard) continue;
+    const signX = center.x >= 0 ? 1 : -1;
+    for (const signY of SIDE_POCKET_CUT_SIGNS) {
+      if (TMP_VEC2_A.y * signY < 0) continue;
+      TMP_VEC2_C.set(signX * limX, center.y + signY * sideSpan);
+      TMP_VEC2_B.set(-signX * sideCutCos, signY * sideCutSin);
+      TMP_VEC2_D.set(-TMP_VEC2_B.y, TMP_VEC2_B.x);
+      TMP_VEC2_LIMIT.copy(ball.pos).sub(TMP_VEC2_C);
+      const distNormal = TMP_VEC2_LIMIT.dot(TMP_VEC2_B);
+      if (distNormal >= BALL_R) continue;
+      if (distNormal < -sideDepthLimit) continue;
+      const lateral = Math.abs(TMP_VEC2_LIMIT.dot(TMP_VEC2_D));
+      if (lateral < sideGuardClearance) continue;
+      const push = BALL_R - distNormal;
+      ball.pos.addScaledVector(TMP_VEC2_B, push);
+      preImpactVel = ball.vel.clone();
+      const stamp =
+        typeof performance !== 'undefined' && performance.now
+          ? performance.now()
+          : Date.now();
+      ball.lastRailHitAt = stamp;
+      ball.lastRailHitType = 'rail';
+      return {
+        type: 'rail',
+        normal: TMP_VEC2_B.clone(),
+        tangent: TMP_VEC2_D.clone(),
+        preImpactVel
+      };
     }
-    TMP_VEC2_C.normalize();
-    const normal = TMP_VEC2_C;
-    const tangent = TMP_VEC2_D.set(-normal.y, normal.x);
-    const distNormal = TMP_VEC2_A.dot(normal);
-    if (distNormal >= BALL_R) continue;
-    const lateral = Math.abs(TMP_VEC2_A.dot(tangent));
-    if (lateral < sideGuardClearance) continue;
-    if (lateral <= sideSpan) continue;
-    if (distNormal < -sideDepthLimit) continue;
-    const push = BALL_R - distNormal;
-    ball.pos.addScaledVector(normal, push);
-    preImpactVel = ball.vel.clone();
-    const stamp =
-      typeof performance !== 'undefined' && performance.now
-        ? performance.now()
-        : Date.now();
-    ball.lastRailHitAt = stamp;
-    ball.lastRailHitType = 'rail';
-    return {
-      type: 'rail',
-      normal: normal.clone(),
-      tangent: tangent.clone(),
-      preImpactVel
-    };
   }
 
   // If the ball is entering a pocket capture zone, skip straight rail reflections


### PR DESCRIPTION
### Motivation
- Reduce the effective mouth of middle (side) pockets by tightening the side-cushion cut angle to produce a smaller, more realistic pocket entrance.
- Improve physics fidelity for rail-first cuts at the middle pockets by using angled cushion-cut normals instead of the previous simplified lateral checks.
- Prevent unexpected pocket/sponge behavior by better gating rail reflections near pocket capture zones.

### Description
- Updated table specs in `webapp/src/config/poolRoyaleTables.js` to change `sideCushionCutAngleDeg` from `27` to `34` for both `9ft` and `8ft` table presets. 
- Aligned the default in-code constant in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `DEFAULT_SIDE_CUSHION_CUT_ANGLE` from `28` to `34`.
- Reworked side-pocket reflection logic in `reflectRails` (in `webapp/src/pages/Games/PoolRoyale.jsx`) to compute an angled cushion-cut normal using `SIDE_CUSHION_CUT_ANGLE` and to test against that angled plane; added `SIDE_POCKET_CUT_SIGNS` and per-pocket sign handling so the side-pocket cut geometry is evaluated correctly for both sides.
- Added guard checks so angled-side reflections skip when inside pocket-capture radius and maintain previous clearance/depth checks, and return the correct `normal`, `tangent`, and `preImpactVel` when a rail impact is detected.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported the site served at `http://localhost:4173/` (dev server start succeeded).
- Attempted an automated visual smoke capture with Playwright to validate side-pocket appearance, but the Playwright screenshot timed out (rendering/tool timeout).
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f50381eb083299f79cbf12f0a3118)