### PR TITLE
Add King token option; align chess-piece tokens to procedural materials and improve prototype selection

### DIFF
--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -48,7 +48,8 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'knight', label: 'Knight Token' },
   { id: 'bishop', label: 'Bishop Token' },
   { id: 'rook', label: 'Rook Token' },
-  { id: 'queen', label: 'Queen Token' }
+  { id: 'queen', label: 'Queen Token' },
+  { id: 'king', label: 'King Token' }
 ]);
 
 export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -605,7 +605,8 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'knight', label: 'Knight', pieceType: 'knight', source: 'chessBattleRoyal' },
   { id: 'bishop', label: 'Bishop', pieceType: 'bishop', source: 'chessBattleRoyal' },
   { id: 'rook', label: 'Rook', pieceType: 'rook', source: 'chessBattleRoyal' },
-  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'chessBattleRoyal' }
+  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'chessBattleRoyal' },
+  { id: 'king', label: 'King', pieceType: 'king', source: 'chessBattleRoyal' }
 ]);
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([


### PR DESCRIPTION
### Motivation
- Add the missing King chess-piece token to the Snake & Ladder customization and store so chess-piece tokens match the rest of the selectable pieces. 
- Ensure chess-piece prototypes are selected robustly from GLTF scenes and avoid accidentally picking board/table meshes when extracting piece models. 
- Make chess-piece tokens use the same material mapping and sizing as procedural tokens so user-selected chess pieces visually match procedural tokens.

### Description
- Added a `king` entry to the `TOKEN_SHAPE_OPTIONS` and `SNAKE_TOKEN_SHAPE_OPTIONS` arrays so the King appears in the UI and store data. 
- Improved prototype extraction by skipping nodes named like `board|chessboard|table` and by resolving a suitable root for each piece via `resolveChessPieceRoot` to avoid pulling in surrounding board geometry. 
- When attaching loaded chess-piece prototypes, replaced per-mesh cloned materials with a shared `coreMaterial` (and preserved `accentMaterial` for procedural parts) and used `scaleChessPieceToToken` to match `TOKEN_HEIGHT` so chess-piece tokens use the same material and scale pipeline as procedural tokens. 
- Small user-data change to always populate `token.userData.material/coreMaterial/accentMaterial` consistently for downstream updates and highlights.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6d81ee308329add68f6fa50ad5b8)