### PR TITLE
Add King token option and isolate chess piece loading

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -449,7 +449,8 @@ function pickChessPieceTargets(scene) {
     knight: null,
     bishop: null,
     rook: null,
-    queen: null
+    queen: null,
+    king: null
   };
   if (!scene) return targets;
   scene.traverse((node) => {
@@ -465,8 +466,23 @@ function pickChessPieceTargets(scene) {
     maybeAssign('bishop', /bishop/);
     maybeAssign('rook', /rook|castle/);
     maybeAssign('queen', /queen/);
+    maybeAssign('king', /king/);
   });
   return targets;
+}
+
+function findChessPieceRoot(node, key) {
+  if (!node) return null;
+  const keyRegex = new RegExp(key, 'i');
+  let current = node;
+  let candidate = node;
+  while (current.parent) {
+    if (current.parent.name && keyRegex.test(current.parent.name)) {
+      candidate = current.parent;
+    }
+    current = current.parent;
+  }
+  return candidate;
 }
 
 function buildChessPiecePrototypes(scene) {
@@ -474,7 +490,7 @@ function buildChessPiecePrototypes(scene) {
   const prototypes = {};
   Object.entries(candidates).forEach(([key, node]) => {
     if (!node) return;
-    const root = node.isMesh ? node.parent || node : node;
+    const root = findChessPieceRoot(node, key) ?? node;
     const clone = root.clone(true);
     prepareLoadedModel(clone);
     prototypes[key] = clone;

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -48,7 +48,8 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'knight', label: 'Knight Token' },
   { id: 'bishop', label: 'Bishop Token' },
   { id: 'rook', label: 'Rook Token' },
-  { id: 'queen', label: 'Queen Token' }
+  { id: 'queen', label: 'Queen Token' },
+  { id: 'king', label: 'King Token' }
 ]);
 
 export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -605,7 +605,8 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'knight', label: 'Knight', pieceType: 'knight', source: 'chessBattleRoyal' },
   { id: 'bishop', label: 'Bishop', pieceType: 'bishop', source: 'chessBattleRoyal' },
   { id: 'rook', label: 'Rook', pieceType: 'rook', source: 'chessBattleRoyal' },
-  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'chessBattleRoyal' }
+  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'chessBattleRoyal' },
+  { id: 'king', label: 'King', pieceType: 'king', source: 'chessBattleRoyal' }
 ]);
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([


### PR DESCRIPTION
### Motivation
- Expose the King chess piece as a selectable/buyable token shape for the Snake & Ladder game to match other chess-derived token options. 
- Avoid loading or cloning the entire chess scene when using chess-derived tokens by isolating and cloning only the specific piece required.

### Description
- Added a `king` entry to `TOKEN_SHAPE_OPTIONS` in `SnakeAndLadder.jsx` and to `SNAKE_TOKEN_SHAPE_OPTIONS` in `snakeInventoryConfig.js` so the King appears in customization and store lists. 
- Extended `pickChessPieceTargets` to detect the `king` node when parsing loaded chess models. 
- Introduced `findChessPieceRoot` and updated `buildChessPiecePrototypes` to locate and clone the nearest named root for a specific piece so only the selected piece model is prepared instead of cloning a larger parent that may contain other pieces. 

### Testing
- Started the webapp dev server (`npm --prefix webapp run dev`) which successfully served the app. 
- Automated UI check: launched a headless browser against `/games/snake` and captured a screenshot showing the updated token options, which completed successfully after initial retries. 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6d81ee308329add68f6fa50ad5b8)