### PR TITLE
Mirror Chess Battle Royal piece colors for Snake & Ladder tokens

### DIFF
--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -52,6 +52,18 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'king', label: 'King Token' }
 ]);
 
+export const SNAKE_TOKEN_COLOR_OPTIONS = Object.freeze([
+  { id: 'marble', label: 'Marble', color: '#f8fafc' },
+  { id: 'darkForest', label: 'Dark Forest', color: '#14532d' },
+  { id: 'amberGlow', label: 'Amber Glow', color: '#f59e0b' },
+  { id: 'mintVale', label: 'Mint Vale', color: '#10b981' },
+  { id: 'royalWave', label: 'Royal Wave', color: '#3b82f6' },
+  { id: 'roseMist', label: 'Rose Mist', color: '#ef4444' },
+  { id: 'amethyst', label: 'Amethyst', color: '#8b5cf6' },
+  { id: 'cinderBlaze', label: 'Cinder Blaze', color: '#ff6b35' },
+  { id: 'arcticDrift', label: 'Arctic Drift', color: '#bcd7ff' }
+]);
+
 export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   arenaTheme: ['nebulaAtrium'],
   boardPalette: ['desertMarble'],
@@ -59,6 +71,7 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   diceTheme: ['imperialIvory'],
   railTheme: ['platinumOak'],
   tokenFinish: ['ceramicSheen'],
+  tokenColor: ['amberGlow', 'mintVale', 'royalWave', 'roseMist'],
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   floorTexture: [SNAKE_FLOOR_TEXTURE_OPTIONS[0].id],
   wallTexture: [SNAKE_WALL_TEXTURE_OPTIONS[0].id],
@@ -99,6 +112,7 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
     matteVelvet: 'Matte Velvet',
     holographicPulse: 'Holographic Pulse'
   }),
+  tokenColor: mapLabels(SNAKE_TOKEN_COLOR_OPTIONS),
   tableFinish: mapLabels(SNAKE_TABLE_FINISH_OPTIONS),
   floorTexture: mapLabels(SNAKE_FLOOR_TEXTURE_OPTIONS),
   wallTexture: mapLabels(SNAKE_WALL_TEXTURE_OPTIONS),
@@ -210,6 +224,15 @@ export const SNAKE_STORE_ITEMS = [
     price: 520,
     description: 'Holographic core with shimmering pulse highlights for each token.'
   },
+  ...SNAKE_TOKEN_COLOR_OPTIONS.map((option, idx) => ({
+    id: `snake-token-color-${option.id}`,
+    type: 'tokenColor',
+    optionId: option.id,
+    name: `${option.label} Tokens`,
+    price: 420 + idx * 35,
+    description: `Chess Battle Royal ${option.label.toLowerCase()} palette for snake tokens.`,
+    swatches: [option.color, '#0f172a']
+  })),
   ...SNAKE_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `finish-${finish.id}`,
     type: 'tableFinish',
@@ -280,6 +303,7 @@ export const SNAKE_DEFAULT_LOADOUT = [
   { type: 'diceTheme', optionId: 'imperialIvory', label: 'Imperial Ivory Dice' },
   { type: 'railTheme', optionId: 'platinumOak', label: 'Platinum & Oak Rails' },
   { type: 'tokenFinish', optionId: 'ceramicSheen', label: 'Ceramic Sheen Tokens' },
+  { type: 'tokenColor', optionId: 'amberGlow', label: 'Amber Glow Tokens' },
   {
     type: 'tableFinish',
     optionId: SNAKE_TABLE_FINISH_OPTIONS[0].id,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -38,6 +38,7 @@ import {
 } from "../../utils/api.js";
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from "../../config/poolRoyaleInventoryConfig.js";
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from "../../config/murlanThemes.js";
+import { SNAKE_TOKEN_COLOR_OPTIONS } from "../../config/snakeInventoryConfig.js";
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -92,12 +93,13 @@ import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
 
-const TOKEN_COLORS = [
-  { name: "blue", color: "#60a5fa" },
-  { name: "red", color: "#ef4444" },
-  { name: "green", color: "#4ade80" },
-  { name: "yellow", color: "#facc15" },
-];
+const TOKEN_COLOR_OPTIONS = Object.freeze(
+  SNAKE_TOKEN_COLOR_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    color: option.color
+  }))
+);
 
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
@@ -152,6 +154,20 @@ function shuffle(arr) {
     [copy[i], copy[j]] = [copy[j], copy[i]];
   }
   return copy;
+}
+
+function resolveTokenPalette(options, inventory, count) {
+  const unlocked = new Set(inventory?.tokenColor || []);
+  const unlockedOptions = options.filter((option) => unlocked.has(option.id));
+  const base = unlockedOptions.length ? unlockedOptions : options;
+  const deduped = [];
+  const seen = new Set();
+  [...base, ...options].forEach((option) => {
+    if (seen.has(option.id)) return;
+    seen.add(option.id);
+    deduped.push(option);
+  });
+  return shuffle(deduped).slice(0, count).map((option) => option.color);
 }
 
 const FALLBACK_SEAT_POSITIONS = [
@@ -1469,7 +1485,7 @@ export default function SnakeAndLadder() {
         )
       );
     }
-    const colors = shuffle(TOKEN_COLORS).slice(0, aiCount + 1).map(c => c.color);
+    const colors = resolveTokenPalette(TOKEN_COLOR_OPTIONS, snakeInventory, aiCount + 1);
     setPlayerColors(colors);
 
     const storedTable = localStorage.getItem('snakeCurrentTable');

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -194,6 +194,7 @@ const SNAKE_TYPE_LABELS = {
   diceTheme: 'Dice Finish',
   railTheme: 'Rails & Nets',
   tokenFinish: 'Token Finish',
+  tokenColor: 'Token Colors',
   tokenShape: 'Token Shape',
   tableFinish: 'Table Finish',
   tables: 'Table Models',
@@ -289,6 +290,7 @@ const TYPE_SWATCHES = {
   diceTheme: ['#f8fafc', '#e11d48'],
   railTheme: ['#1e293b', '#64748b'],
   tokenFinish: ['#facc15', '#fb7185'],
+  tokenColor: ['#f59e0b', '#10b981'],
   default: ['#22c55e', '#0ea5e9']
 };
 
@@ -325,6 +327,13 @@ const OPTION_SWATCH_OVERRIDES = {
   'carbon-matrix': ['#0f172a', '#94a3b8'],
   'maple-horizon': ['#fef3c7', '#fbbf24'],
   'graphite-aurora': ['#111827', '#22d3ee'],
+  amberGlow: ['#f59e0b', '#fbbf24'],
+  mintVale: ['#10b981', '#34d399'],
+  royalWave: ['#3b82f6', '#60a5fa'],
+  roseMist: ['#ef4444', '#f87171'],
+  amethyst: ['#8b5cf6', '#c4b5fd'],
+  marble: ['#f8fafc', '#e2e8f0'],
+  darkForest: ['#14532d', '#22c55e'],
   arcticRidge: ['#bae6fd', '#38bdf8'],
   basaltStone: ['#1f2937', '#0f172a'],
   emeraldSide: ['#22c55e', '#16a34a'],


### PR DESCRIPTION
### Motivation
- Provide the same personalization options for Snake & Ladder tokens as exist for Chess Battle Royal so player tokens can be customized and match player colors rather than default repeating colors.

### Description
- Added a new `SNAKE_TOKEN_COLOR_OPTIONS` palette in `webapp/src/config/snakeInventoryConfig.js` and wired it into `SNAKE_OPTION_LABELS`, `SNAKE_STORE_ITEMS`, `SNAKE_DEFAULT_UNLOCKS` and `SNAKE_DEFAULT_LOADOUT` to expose token colors in the store and default loadout. 
- Exposed the new `tokenColor` type in the store UI by adding `tokenColor` to `SNAKE_TYPE_LABELS` and adding swatch overrides in `webapp/src/pages/Store.jsx` so previews and swatches match the Chess palettes. 
- In `webapp/src/pages/Games/SnakeAndLadder.jsx` introduced `TOKEN_COLOR_OPTIONS` (from the shared config), implemented `resolveTokenPalette(...)` to pick unlocked token colors, and replaced the old hard-coded token color assignment with `resolveTokenPalette(...)` so player tokens are assigned distinct colors using unlocked Chess-like palettes. 
- Kept token shape integration (chess piece prototypes) intact; added swatches/descriptions for each new token color store item.

### Testing
- No automated tests were executed for this change; manual/local verification is expected after checkout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f83c7a36483298be96b9596a932c5)