### PR TITLE
Adjust Pool Royale cushion cut angles to 27°

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 32,
-    sideCushionCutAngleDeg: 22,
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 32,
-    sideCushionCutAngleDeg: 22,
+    cushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1520,10 +1520,10 @@ const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
 const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
 const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
-// angle for cushion cuts guiding balls into corner pockets (trimmed further to widen the entrance)
-const DEFAULT_CUSHION_CUT_ANGLE = 32;
-// middle pocket cushion cuts are set to a 22° cut to soften the side-pocket entry
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 22;
+// angle for cushion cuts guiding balls into corner pockets
+const DEFAULT_CUSHION_CUT_ANGLE = 27;
+// keep side-pocket cushion cuts aligned to the same 27° spec
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 27;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails


### PR DESCRIPTION
### Motivation
- Align Pool Royale table geometry to the 27° cushion cut spec so corner and side cushion cuts match the desired design.

### Description
- Set `cushionCutAngleDeg` and `sideCushionCutAngleDeg` to `27` for both `9ft` and `8ft` entries in `webapp/src/config/poolRoyaleTables.js`.
- Update the Pool Royale defaults in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `DEFAULT_CUSHION_CUT_ANGLE` and `DEFAULT_SIDE_CUSHION_CUT_ANGLE` to `27`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the site served successfully.
- Ran an automated Playwright script to load the app at `http://127.0.0.1:4173/` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa01de9ec8329b0cf62026567d5bf)