### PR TITLE
Pool Royale: Align side cushion cuts to 22°, trim pocket jaws and adjust chrome plate offsets

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 22,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 152.4
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 22,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.24; // ease the side fascias back toward the table centreline so the middle plates sit closer to the pocket mouth
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.18; // ease the side fascias back toward the table centreline so the middle plates sit closer to the pocket mouth
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.07; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.0525; // keep the rounded chrome cut width on the middle pockets consistent while the corner cut grows slightly
@@ -925,8 +925,8 @@ const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.18;
 const RAIL_HEIGHT = TABLE.THICK * 1.82; // return rail height to the lower stance used previously so cushions no longer sit too tall
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.045; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.065; // push middle jaws slightly farther so the sides meet the cushions
-const POCKET_JAW_CORNER_INNER_SCALE = 1.28; // pull the inner lip slightly tighter so the jaw radius reads smaller against the expanded chrome cuts
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1; // keep the middle jaw inner radius tighter so the side jaws read smaller
+const POCKET_JAW_CORNER_INNER_SCALE = 1.24; // pull the inner lip slightly tighter so the jaw radius reads smaller against the expanded chrome cuts
+const POCKET_JAW_SIDE_INNER_SCALE = 1.28; // keep the middle jaw inner radius unchanged so side jaws keep their radius
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.72; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
@@ -956,7 +956,7 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.82; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.6; // push the middle jaw reach wider so both sides meet the cushions
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.54; // trim the middle jaw reach slightly while keeping the same radius and height
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.88; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
@@ -1522,7 +1522,7 @@ const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 27;
-// keep side-pocket cushion cuts aligned to the same 27° spec
+// keep side-pocket cushion cuts aligned to the 22° spec
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 22;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;


### PR DESCRIPTION
### Motivation
- Match the Pool Royale table visuals to the supplied reference by tightening the side-pocket cushion cuts to 22° and nudging pocket/jaw/chrome geometry so the middle pockets read like the photo.
- Reduce the middle pocket jaw lateral reach and slightly tighten corner jaw radius so pocket mouths and jaws keep the same radius/height while appearing trimmed.
- Pull middle chrome plates slightly toward the table centre so the chrome surround sits closer to the adjusted middle-pocket cuts.

### Description
- Set side cushion cut spec to 22° for both table sizes by updating `sideCushionCutAngleDeg` in `webapp/src/config/poolRoyaleTables.js`.
- Tuned pocket/jaw and chrome constants in `webapp/src/pages/Games/PoolRoyale.jsx`, specifically adjusting `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `POCKET_JAW_CORNER_INNER_SCALE`, `POCKET_JAW_SIDE_INNER_SCALE`, and `SIDE_POCKET_JAW_LATERAL_EXPANSION`, and updated the side-pocket cushion comment to reflect the new 22° spec.
- Changes are scoped to visual/geometry constants so runtime code paths remain the same and the cushion angle defaults feed existing cushion/reflection logic.
- Files modified: `webapp/src/config/poolRoyaleTables.js` and `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev` and Vite started successfully serving the app (accessible at the reported local/network URL). (Succeeded)
- Attempted an automated visual capture of `/games/poolroyale` with Playwright to verify the visual adjustments, but the screenshot timed out in this environment. (Failed)
- No unit tests were executed for these visual constant changes during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faec11a5c8329b3bb4f7757952051)