### PR TITLE
Adjust table height and refine pocket jaw geometry and collisions

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -67,7 +67,11 @@ public class BilliardsSolver
         double sideMouth = PhysicsConstants.SidePocketMouth;
         double cornerCut = cornerMouth / Math.Sqrt(2.0);
         double sideCut = sideMouth / 2.0;
-        double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8);
+        double cornerJawRadius = cornerCut * PhysicsConstants.CornerJawRadiusScale;
+        double cornerJawInset = PhysicsConstants.CornerJawInset;
+        double cornerJawCenter = cornerCut + cornerJawInset;
+        double sideJawInset = PhysicsConstants.SideJawInset;
+        double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8) * PhysicsConstants.SideJawDepthScale;
         double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
 
         // Straight cushion spans (long rails)
@@ -83,16 +87,82 @@ public class BilliardsSolver
         AddCushionSegment(new Vec2(width, height / 2 + sideCut), new Vec2(width, height - cornerCut), new Vec2(-1, 0));
 
         int cornerSegments = Math.Max(8, PhysicsConstants.CornerJawSegments);
-        AddCornerJaw(new Vec2(cornerCut, cornerCut), cornerCut, Math.PI, 1.5 * Math.PI, cornerSegments);
-        AddCornerJaw(new Vec2(width - cornerCut, cornerCut), cornerCut, 1.5 * Math.PI, 2.0 * Math.PI, cornerSegments);
-        AddCornerJaw(new Vec2(width - cornerCut, height - cornerCut), cornerCut, 0, 0.5 * Math.PI, cornerSegments);
-        AddCornerJaw(new Vec2(cornerCut, height - cornerCut), cornerCut, 0.5 * Math.PI, Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(cornerJawCenter, cornerJawCenter), cornerJawRadius, Math.PI, 1.5 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(width - cornerJawCenter, cornerJawCenter), cornerJawRadius, 1.5 * Math.PI, 2.0 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(width - cornerJawCenter, height - cornerJawCenter), cornerJawRadius, 0, 0.5 * Math.PI, cornerSegments);
+        AddCornerJaw(new Vec2(cornerJawCenter, height - cornerJawCenter), cornerJawRadius, 0.5 * Math.PI, Math.PI, cornerSegments);
+
+        AddConnectorSegment(
+            new Vec2(cornerCut, 0),
+            new Vec2(cornerJawCenter, cornerJawCenter - cornerJawRadius),
+            new Vec2(0, 1));
+        AddConnectorSegment(
+            new Vec2(0, cornerCut),
+            new Vec2(cornerJawCenter - cornerJawRadius, cornerJawCenter),
+            new Vec2(1, 0));
+        AddConnectorSegment(
+            new Vec2(width - cornerCut, 0),
+            new Vec2(width - cornerJawCenter, cornerJawCenter - cornerJawRadius),
+            new Vec2(0, 1));
+        AddConnectorSegment(
+            new Vec2(width, cornerCut),
+            new Vec2(width - cornerJawCenter + cornerJawRadius, cornerJawCenter),
+            new Vec2(-1, 0));
+        AddConnectorSegment(
+            new Vec2(width - cornerCut, height),
+            new Vec2(width - cornerJawCenter, height - cornerJawCenter + cornerJawRadius),
+            new Vec2(0, -1));
+        AddConnectorSegment(
+            new Vec2(width, height - cornerCut),
+            new Vec2(width - cornerJawCenter + cornerJawRadius, height - cornerJawCenter),
+            new Vec2(-1, 0));
+        AddConnectorSegment(
+            new Vec2(cornerCut, height),
+            new Vec2(cornerJawCenter, height - cornerJawCenter + cornerJawRadius),
+            new Vec2(0, -1));
+        AddConnectorSegment(
+            new Vec2(0, height - cornerCut),
+            new Vec2(cornerJawCenter - cornerJawRadius, height - cornerJawCenter),
+            new Vec2(1, 0));
 
         int sideSegments = Math.Max(6, PhysicsConstants.SideJawSegments);
-        AddSidePocketJaw(new Vec2(width / 2, 0 - sideOutset), sideCut, sideDepth, true, sideSegments);
-        AddSidePocketJaw(new Vec2(width / 2, height + sideOutset), sideCut, sideDepth, false, sideSegments);
-        AddSidePocketJaw(new Vec2(0 - sideOutset, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
-        AddSidePocketJaw(new Vec2(width + sideOutset, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width / 2, sideJawInset), sideCut, sideDepth, true, sideSegments);
+        AddSidePocketJaw(new Vec2(width / 2, height - sideJawInset), sideCut, sideDepth, false, sideSegments);
+        AddSidePocketJaw(new Vec2(sideJawInset, height / 2), sideCut, sideDepth, true, sideSegments, vertical: true);
+        AddSidePocketJaw(new Vec2(width - sideJawInset, height / 2), sideCut, sideDepth, false, sideSegments, vertical: true);
+
+        AddConnectorSegment(
+            new Vec2(width / 2 - sideCut, 0),
+            new Vec2(width / 2 - sideCut, sideJawInset),
+            new Vec2(0, 1));
+        AddConnectorSegment(
+            new Vec2(width / 2 + sideCut, 0),
+            new Vec2(width / 2 + sideCut, sideJawInset),
+            new Vec2(0, 1));
+        AddConnectorSegment(
+            new Vec2(width / 2 - sideCut, height),
+            new Vec2(width / 2 - sideCut, height - sideJawInset),
+            new Vec2(0, -1));
+        AddConnectorSegment(
+            new Vec2(width / 2 + sideCut, height),
+            new Vec2(width / 2 + sideCut, height - sideJawInset),
+            new Vec2(0, -1));
+        AddConnectorSegment(
+            new Vec2(0, height / 2 - sideCut),
+            new Vec2(sideJawInset, height / 2 - sideCut),
+            new Vec2(1, 0));
+        AddConnectorSegment(
+            new Vec2(0, height / 2 + sideCut),
+            new Vec2(sideJawInset, height / 2 + sideCut),
+            new Vec2(1, 0));
+        AddConnectorSegment(
+            new Vec2(width, height / 2 - sideCut),
+            new Vec2(width - sideJawInset, height / 2 - sideCut),
+            new Vec2(-1, 0));
+        AddConnectorSegment(
+            new Vec2(width, height / 2 + sideCut),
+            new Vec2(width - sideJawInset, height / 2 + sideCut),
+            new Vec2(-1, 0));
 
         double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
         Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });
@@ -134,7 +204,7 @@ public class BilliardsSolver
                 blended = normal;
             var edge = new Edge { A = prev, B = next, Normal = blended };
             if (i <= cushionBands || i > segments - cushionBands)
-                CushionEdges.Add(edge);
+                ConnectorEdges.Add(edge);
             else
                 PocketEdges.Add(edge);
             prev = next;
@@ -189,10 +259,21 @@ public class BilliardsSolver
             var edge = new Edge { A = a, B = b, Normal = normal };
             bool nearMouth = i < cushionBands || i >= pts.Count - 1 - cushionBands;
             if (nearMouth)
-                CushionEdges.Add(edge);
+                ConnectorEdges.Add(edge);
             else
                 PocketEdges.Add(edge);
         }
+    }
+
+    private void AddConnectorSegment(Vec2 a, Vec2 b, Vec2 interiorHint)
+    {
+        if ((b - a).Length < PhysicsConstants.Epsilon)
+            return;
+        Vec2 dir = (b - a).Normalized();
+        Vec2 normal = new Vec2(-dir.Y, dir.X);
+        if (Vec2.Dot(normal, interiorHint) < 0)
+            normal = -normal;
+        ConnectorEdges.Add(new Edge { A = a, B = b, Normal = normal.Normalized() });
     }
 
     private static Vec2 PointOnCircle(Vec2 center, double radius, double angle)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -33,7 +33,7 @@ public static class PhysicsConstants
     public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
-    public const double TableHeight = 1.3135;
+    public const double TableHeight = 1.07707;
     public const double FixedDt = 1.0 / 120.0;         // simulation step
     public const double Epsilon = 1e-9;                // numerical epsilon
     public const double MaxPreviewTime = 30.0;         // safeguard for CCD
@@ -42,11 +42,15 @@ public static class PhysicsConstants
     public const int MaxSubSteps = 64;                 // hard cap per integration step
 
     // Pocket geometry derived from WPA spec (metres)
-    public const double CornerPocketMouth = 0.1057275; // scaled with table reduction
-    public const double SidePocketMouth = 0.117475;    // scaled with table reduction
+    public const double CornerPocketMouth = 0.1014984; // scaled with table reduction
+    public const double SidePocketMouth = 0.1116013;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    // Keep side pockets aligned with the rail line so they behave identically to corner pockets.
-    public const double SidePocketOutset = 0.0;
+    public const double CornerJawRadiusScale = 0.94;
+    public const double CornerJawInset = 0.006;
+    public const double SideJawInset = 0.006;
+    public const double SideJawDepthScale = 1.08;
+    // Shift the pocket capture center outward for the chrome plate cut.
+    public const double SidePocketOutset = 0.006;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
### Motivation
- Implement the visual/physical changes requested for the Pool Royale table: lower the playfield, tighten and inward-offset middle/corner pocket jaws, enlarge/move chrome plate cuts outward, and make stones collide at pocket cuts more naturally.  
- Make the collision geometry match the visual jaw/cut adjustments so pocket-facing impacts use connector restitution and look/feel more realistic.

### Description
- Lowered the table playfield by updating `PhysicsConstants.TableHeight` from `1.3135` to `1.07707` and tightened pocket mouth widths by updating `CornerPocketMouth` and `SidePocketMouth`.  
- Added new tuning constants in `PhysicsConstants.cs`: `CornerJawRadiusScale`, `CornerJawInset`, `SideJawInset`, `SideJawDepthScale`, and `SidePocketOutset` to control jaw radius, insets and mid-pocket offsets.  
- Reworked pocket/jaw geometry in `BilliardsSolver.InitStandardTable()` to compute `cornerJawRadius`/`cornerJawCenter`, move side-jaw centers inward, deepen side-jaw depth, and shift side pocket capture centers outward.  
- Introduced `ConnectorEdges` and `AddConnectorSegment(...)` and routed near-mouth edges into `ConnectorEdges` (instead of cushion edges) so jaw/cut impacts use connector restitution and produce more natural pocket-facing bounces.  
- Added connector segments around corner and side pocket cuts to model the rounded chrome-plate cut and the small inward/outward offsets for connector geometry.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fcd63d90c8329802017b3ecf434f7)