### PR TITLE
Adjust Pool Royale pocket geometry and HUD spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,16 +601,16 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.3; // push the side fascias slightly outward away from the table centreline
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.38; // push the side fascias slightly outward away from the table centreline
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.07; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.05; // open the rounded chrome cut slightly more on the middle pockets
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open the rounded chrome cut slightly more on the middle pockets
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.06; // keep the rounded chrome cutouts closer to the outward plate shift
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.99; // keep the middle rail rounded cuts slightly tighter to match the jaw radius
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.975; // keep the middle rail rounded cuts slightly tighter to match the jaw radius
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0; // keep the wood cutouts centered so the rounded relief stands straight
 
 function buildChromePlateGeometry({
@@ -926,9 +926,9 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.35; // expand wooden frame rails outward by 35% on all sides
 const RAIL_HEIGHT = TABLE.THICK * 1.82; // return rail height to the lower stance used previously so cushions no longer sit too tall
-const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.01; // pull the corner jaws inward slightly so the mouth radius reads tighter
+const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.005; // pull the corner jaws inward slightly so the mouth radius reads tighter
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE = 1.035; // pull middle jaws inward so their radius and reach sit closer to the center
-const POCKET_JAW_CORNER_INNER_SCALE = 1.22; // tighten the corner jaw inner lip for a slightly smaller radius
+const POCKET_JAW_CORNER_INNER_SCALE = 1.26; // tighten the corner jaw inner lip for a slightly smaller radius
 const POCKET_JAW_SIDE_INNER_SCALE = 1.3; // tighten the middle jaw inner lip for a smaller radius
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.72; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
@@ -26229,7 +26229,7 @@ const powerRef = useRef(hud.power);
         ref={leftControlsRef}
         className={`pointer-events-none absolute right-1 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${SPIN_CONTROL_DIAMETER_PX + 8 + chromeUiLiftPx - viewButtonsOffsetPx}px`,
+          bottom: `${SPIN_CONTROL_DIAMETER_PX + 2 + chromeUiLiftPx - viewButtonsOffsetPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}
@@ -26269,7 +26269,7 @@ const powerRef = useRef(hud.power);
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
-            className="fixed left-0 bottom-3 z-50 flex flex-col gap-2.5 -translate-x-1"
+            className="fixed left-0 bottom-2 z-50 flex flex-col gap-2.5 -translate-x-1"
             buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Refine pocket appearance and chrome plate placement so the wooden side-rail cuts, corner jaw radii and middle chrome cut feel slightly tighter and better aligned with reference photos.
- Move the view toggle and chat/2D buttons slightly lower on screen to improve layout on portrait mobile.

### Description
- Tweaked pocket/chrome geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx` including `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `CHROME_SIDE_POCKET_CUT_SCALE`, `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE`, `POCKET_JAW_CORNER_OUTER_LIMIT_SCALE`, and `POCKET_JAW_CORNER_INNER_SCALE` to tighten cuts and shift chrome plates outward.
- Adjusted left control stack vertical offset from `SPIN_CONTROL_DIAMETER_PX + 8` to `SPIN_CONTROL_DIAMETER_PX + 2` to nudge the view buttons down slightly.
- Lowered the bottom placement of the `BottomLeftIcons` control by changing the Tailwind class from `bottom-3` to `bottom-2` to move chat/gift/info controls downward on the page.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev`, which launched Vite successfully and served the app (ready at `http://localhost:4173/`).
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the screenshot operation timed out and failed.
- No unit or integration test suite was executed for these UI-only tweaks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe490742483299c5eb8fc36b118e2)