### PR TITLE
Adjust Pool Royale middle-pocket cushions, jaws and chrome plates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,11 +601,11 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.08; // extend middle chrome p
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.995; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.14; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.46; // push the side fascias farther outward away from the table centreline
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.32; // pull the side fascias a bit closer to the table centreline
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.07; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open the rounded chrome cut slightly more on the middle pockets
-const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.06; // keep the rounded chrome cutouts closer to the outward plate shift
+const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.18; // hold the rounded chrome cutouts in place while shifting the plate inward
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
@@ -963,7 +963,7 @@ const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.54; // trim the middle jaw reach sli
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.9; // relax the middle jaw arc radius so the side-pocket jaws read wider
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.2; // pull the middle pocket jaws further outward away from the table center
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.12; // pull the middle pocket jaws slightly closer to the table center
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.82; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -1535,8 +1535,8 @@ const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 27;
-// keep side-pocket cushion cuts aligned to the corner angle
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
+// keep side-pocket cushion cuts straighter with only a small curve at the ends
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 52;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails


### PR DESCRIPTION
### Motivation
- Match the visual reference by making the side-rail cushions near the middle pockets appear straighter with only a small curve at the edge.
- Pull the pocket jaws and chrome fascia near the middle pockets slightly closer toward the table center so openings and chrome plates read like the reference photo.
- Keep chrome pocket cutouts’ rounded shape unchanged while shifting surrounding fascia placement for better alignment.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to change the side-pocket cushion profile by setting `DEFAULT_SIDE_CUSHION_CUT_ANGLE` to `52` (was linked to `DEFAULT_CUSHION_CUT_ANGLE`).
- Adjusted chrome fascia placement by changing `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `0.46` to `0.32` to pull side chrome plates slightly inward.
- Anchored chrome cutouts while moving plates by increasing `CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE` from `0.06` to `0.18` so the rounded pocket cuts remain aligned.
- Moved middle pocket jaws closer to center by reducing `SIDE_POCKET_JAW_OUTWARD_SHIFT` from `TABLE.THICK * 0.2` to `TABLE.THICK * 0.12`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and verified Vite served the site at `http://localhost:4173/` (successful).
- Attempted an automated visual check by launching a Playwright script to capture a screenshot of `/games/poolroyale`, but the headless browser crashed (SIGSEGV) so no screenshot was produced.
- No unit or CI tests were executed for this visual tweak; changes are primarily visual and should be validated in a running build or by a QA screenshot comparison.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697058721d608329b5898eae8072a872)