### PR TITLE
Trim side cushion reach near middle pockets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7444,9 +7444,13 @@ export function Table3D(
   const sidePocketReach = Math.sqrt(
     Math.max(sidePocketRadius * sidePocketRadius - sideDeltaX * sideDeltaX, 0)
   );
+  const sidePocketReachReduction = Math.max(
+    SIDE_CUSHION_POCKET_REACH_REDUCTION,
+    cornerCushionClearance
+  );
   const adjustedSidePocketReach = Math.max(
     0,
-    sidePocketReach - SIDE_CUSHION_POCKET_REACH_REDUCTION
+    sidePocketReach - sidePocketReachReduction
   );
   const verticalCushionLength = Math.max(
     MICRO_EPS,


### PR DESCRIPTION
### Motivation
- Ensure side-rail cushions near the middle pockets no longer intrude into the pocket perimeter by aligning their reach with the corner cushion clearance so pocket mouths read consistently.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` compute `sidePocketReachReduction = Math.max(SIDE_CUSHION_POCKET_REACH_REDUCTION, cornerCushionClearance)` and use it when deriving `adjustedSidePocketReach` so side cushions are trimmed relative to corner clearance; this replaces the previous fixed subtraction and updates the surrounding geometry math (small change: 5 insertions, 1 deletion).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970729f29448329ac1d545555549081)