### PR TITLE
Trim side pocket cushion reach for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7388,7 +7388,7 @@ export function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.26; // shorten the corner cushions more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.22; // trim the cushion tips near middle pockets further for cleaner jaw clearance
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.25; // trim the cushion tips near middle pockets further for cleaner jaw clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation
- Keep the side-rail cushion noses from intruding into the middle pocket perimeter by increasing the trimmed reach so the side pockets match the corner pocket clearance visually and mechanically.

### Description
- Adjusted the side-cushion pocket reach constant by changing `SIDE_CUSHION_POCKET_REACH_REDUCTION` from `TABLE.THICK * 0.22` to `TABLE.THICK * 0.25` in `webapp/src/pages/Games/PoolRoyale.jsx` to shorten the cushion tips near the middle pockets.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the Vite server reported ready (local and network URLs), indicating the app served successfully; this succeeded. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to visually verify the change and it timed out, so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970729f29448329ac1d545555549081)