### PR TITLE
Refine pocket cushion trim and pocket jaw alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -958,12 +958,12 @@ const POCKET_JAW_CORNER_EDGE_FACTOR = 0.36; // trim the chamfer so the jaw outli
 const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the middle pocket chamfer identical to the corners
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
-const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.55; // align corner jaw span to the reference pocket arc
+const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.62; // widen corner jaw span so it meets the cushions without changing radius
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.45; // keep middle jaw span consistent with the reference
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // match the middle jaw radius to the corner profile
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.04; // keep middle jaws aligned to the pocket center like the reference
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.02; // pull middle jaws slightly toward the table center
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.9; // keep the middle jaw edges fuller like the reference
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -7444,9 +7444,12 @@ export function Table3D(
   const sidePocketReach = Math.sqrt(
     Math.max(sidePocketRadius * sidePocketRadius - sideDeltaX * sideDeltaX, 0)
   );
+  const sidePocketReachReduction =
+    SIDE_CUSHION_POCKET_REACH_REDUCTION +
+    Math.max(0, cornerCushionClearance - SIDE_CUSHION_POCKET_REACH_REDUCTION) * 0.35;
   const adjustedSidePocketReach = Math.max(
     0,
-    sidePocketReach - SIDE_CUSHION_POCKET_REACH_REDUCTION
+    sidePocketReach - sidePocketReachReduction
   );
   const verticalCushionLength = Math.max(
     MICRO_EPS,


### PR DESCRIPTION
### Motivation
- Trim side-cushion reach only slightly instead of expanding it, while preserving the same visual angles for the side jaws.
- Ensure corner pocket jaws expand laterally until they contact the cushions without changing their radius or rim height.
- Pull the middle (side) pocket jaws a small amount toward the table center to improve clearance near the middle pockets.

### Description
- Replace the previous clamp with a tapered reduction so `sidePocketReachReduction` is now `SIDE_CUSHION_POCKET_REACH_REDUCTION + Math.max(0, cornerCushionClearance - SIDE_CUSHION_POCKET_REACH_REDUCTION) * 0.35` to reduce reach only a bit while keeping angles intact.
- Increase `CORNER_POCKET_JAW_LATERAL_EXPANSION` from `1.55` to `1.62` so corner jaw spans widen to meet cushions without altering radius/height.
- Decrease `SIDE_POCKET_JAW_OUTWARD_SHIFT` from `TABLE.THICK * 0.04` to `TABLE.THICK * 0.02` to nudge middle-pocket jaws slightly toward the table center.
- Updated related geometry usage in `webapp/src/pages/Games/PoolRoyale.jsx` and amended the commit message to reflect the alignment refinements.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970729f29448329ac1d545555549081)