### PR TITLE
Lazy-load MeshoptDecoder and add graceful fallback for Royale GLTF loaders

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15,7 +15,6 @@ import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -89,6 +88,18 @@ import {
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+let meshoptDecoderPromise = null;
+const loadMeshoptDecoder = async () => {
+  if (!meshoptDecoderPromise) {
+    meshoptDecoderPromise = import('three/examples/jsm/libs/meshopt_decoder.module.js')
+      .then((module) => module.MeshoptDecoder)
+      .catch((error) => {
+        console.warn('Pool Royale meshopt decoder failed to load', error);
+        return null;
+      });
+  }
+  return meshoptDecoderPromise;
+};
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -9665,7 +9676,7 @@ export function Table3D(
     return polyhavenKtx2Loader;
   };
 
-  const createConfiguredGLTFLoader = (renderer = null) => {
+  const createConfiguredGLTFLoader = async (renderer = null) => {
     const loader = new GLTFLoader();
     loader.setCrossOrigin('anonymous');
     const draco = new DRACOLoader();
@@ -9673,7 +9684,10 @@ export function Table3D(
     loader.setDRACOLoader(draco);
     const ktx2 = ensurePolyhavenKtx2Loader(renderer);
     loader.setKTX2Loader(ktx2);
-    loader.setMeshoptDecoder?.(MeshoptDecoder);
+    const meshoptDecoder = await loadMeshoptDecoder();
+    if (meshoptDecoder) {
+      loader.setMeshoptDecoder?.(meshoptDecoder);
+    }
     return loader;
   };
 
@@ -9697,7 +9711,7 @@ export function Table3D(
       return polyhavenBasePromises.get(assetId);
     }
     const promise = (async () => {
-      const loader = createConfiguredGLTFLoader(renderer);
+      const loader = await createConfiguredGLTFLoader(renderer);
       let lastError = null;
       const urls = buildPolyhavenModelUrls(assetId);
       for (const url of urls) {

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -15,7 +15,6 @@ import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { SnookerRoyalPowerSlider } from '../../../../snooker-royale-power-slider.js';
 import '../../../../snooker-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -81,6 +80,18 @@ import { chatBeep } from '../../assets/soundData.js';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+let meshoptDecoderPromise = null;
+const loadMeshoptDecoder = async () => {
+  if (!meshoptDecoderPromise) {
+    meshoptDecoderPromise = import('three/examples/jsm/libs/meshopt_decoder.module.js')
+      .then((module) => module.MeshoptDecoder)
+      .catch((error) => {
+        console.warn('Snooker Royal meshopt decoder failed to load', error);
+        return null;
+      });
+  }
+  return meshoptDecoderPromise;
+};
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -9612,7 +9623,7 @@ function Table3D(
     return polyhavenKtx2Loader;
   };
 
-  const createConfiguredGLTFLoader = (renderer = null) => {
+  const createConfiguredGLTFLoader = async (renderer = null) => {
     const loader = new GLTFLoader();
     loader.setCrossOrigin('anonymous');
     const draco = new DRACOLoader();
@@ -9620,7 +9631,10 @@ function Table3D(
     loader.setDRACOLoader(draco);
     const ktx2 = ensurePolyhavenKtx2Loader(renderer);
     loader.setKTX2Loader(ktx2);
-    loader.setMeshoptDecoder?.(MeshoptDecoder);
+    const meshoptDecoder = await loadMeshoptDecoder();
+    if (meshoptDecoder) {
+      loader.setMeshoptDecoder?.(meshoptDecoder);
+    }
     return loader;
   };
 
@@ -9645,7 +9659,7 @@ function Table3D(
       return polyhavenBasePromises.get(assetId);
     }
     const promise = (async () => {
-      const loader = createConfiguredGLTFLoader(renderer);
+      const loader = await createConfiguredGLTFLoader(renderer);
       let lastError = null;
       const urls = buildPolyhavenModelUrls(assetId);
       for (const url of urls) {


### PR DESCRIPTION
### Motivation
- Prevent runtime initialization failures on devices/bundles where the Meshopt decoder module cannot evaluate, and keep GLTF model loading working for Royale game modes.

### Description
- Add an async `loadMeshoptDecoder` helper that dynamically imports `three/examples/jsm/libs/meshopt_decoder.module.js` and returns `MeshoptDecoder` or `null` on error, logging a warning when the import fails.
- Convert `createConfiguredGLTFLoader` to `async` and call `await loadMeshoptDecoder()`, invoking `loader.setMeshoptDecoder(...)` only if the decoder is available, so loading continues without the decoder.
- Update `ensurePolyhavenBaseTemplate` call sites to await the async loader and handle fallback behavior when GLTF model loading fails.
- Applied the changes to both `webapp/src/pages/Games/SnookerRoyal.jsx` and `webapp/src/pages/Games/PoolRoyale.jsx`, and removed direct static import of `MeshoptDecoder` to avoid init-time crashes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707d08cf608329b7ba5ea25b680cb2)