### PR TITLE
Fix Snooker Royal HDRI init order

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -13447,6 +13447,7 @@ const powerRef = useRef(hud.power);
       const world = new THREE.Group();
       scene.add(world);
       worldRef.current = world;
+      let worldScaleFactor = WORLD_SCALE * (tableSizeRef.current?.scale ?? 1);
       const applyEnvironmentMaps = (envMap, skyboxMap, activeVariant) => {
         const sceneInstance = sceneRef.current;
         if (!envMap || !sceneInstance) return;
@@ -13584,7 +13585,6 @@ const powerRef = useRef(hud.power);
       };
       updateEnvironmentRef.current = applyHdriEnvironment;
       void applyHdriEnvironment(activeEnvironmentVariantRef.current);
-      let worldScaleFactor = WORLD_SCALE * (tableSizeRef.current?.scale ?? 1);
       let cue;
       let clothMat;
       let cushionMat;


### PR DESCRIPTION
### Motivation
- Prevent a startup initialization error where HDRI environment setup accessed `worldScaleFactor` before it was defined, which could trigger TDZ/read-before-initialize issues during renderer/HDRI initialization.

### Description
- Move the `let worldScaleFactor = WORLD_SCALE * (tableSizeRef.current?.scale ?? 1);` declaration so it is initialized before `applyHdriEnvironment` / `applyEnvironmentMaps` are invoked, ensuring the HDRI setup reads a defined value.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707d08cf608329b7ba5ea25b680cb2)