### PR TITLE
Adjust Pool Royale cushion cut angles to 45°

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1534,7 +1534,7 @@ const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
 const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets
-const DEFAULT_CUSHION_CUT_ANGLE = 27;
+const DEFAULT_CUSHION_CUT_ANGLE = 45;
 // keep side-pocket cushion cuts aligned to the corner angle
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;


### PR DESCRIPTION
### Motivation
- The pocket/cushion profile must match the reference photo so pocket edge angles and cushion nose geometry align precisely. 
- Ensure table physical specs and runtime defaults are consistent so rendered cushion shapes and collision math use the same cut angle. 

### Description
- Updated the Pool Royale table physical specs to use `cushionCutAngleDeg: 45` and `sideCushionCutAngleDeg: 45` for both `9ft` and `8ft` in `webapp/src/config/poolRoyaleTables.js`. 
- Aligned the runtime default by changing `DEFAULT_CUSHION_CUT_ANGLE` to `45` in `webapp/src/pages/Games/PoolRoyale.jsx` so `CUSHION_CUT_ANGLE` and `SIDE_CUSHION_CUT_ANGLE` initialize to the same sharper angle. 
- Left pocket mouth and pocket angle entries unchanged while making the cushion angles consistent between config and code. 

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server started successfully. 
- Loaded `http://127.0.0.1:4173/games/poolroyale/lobby` with a Playwright script and captured a screenshot to verify the lobby/table rendered; the navigation and screenshot run completed successfully. 
- No unit test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69708dc35ec883299001870fa101464e)