### PR TITLE
Revert "Pool Royale: use 27° corner / 45° side cushion cuts, trim side cushions and lower table; add angled-cut detection for aiming"

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,7 +13,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 45,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
@@ -31,7 +31,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 45,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#13242