### PR TITLE
Pool Royale: cushion cut angles, rail reflection & table height adjustments

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,7 +13,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 45,
+    cushionCutAngleDeg: 27,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
@@ -31,7 +31,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 45,
+    cushionCutAngleDeg: 27,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }


### PR DESCRIPTION
### Motivation
- Make cushion geometry and aiming/rail reflection logic match the requested physical table: corner cushion cuts should use 27°, side (middle) pocket cuts 45°, and the aiming line should reflect true bounce directions for angled cuts.
- Slightly shorten the long-side cushions near the middle pockets to match the visual trim in the reference artwork and avoid unrealistic pocket overlap.
- Restore the table playfield height to the prior stance by adjusting the table height scale so the visible table sits lower again.

### Description
- Updated table physical specs so Pool Royale playfields use `cushionCutAngleDeg: 27` while side-pocket cuts remain `sideCushionCutAngleDeg: 45` in `webapp/src/config/poolRoyaleTables.js`.
- Added angled cushion intersection checks into the aiming prediction function `calcTarget` to detect corner and side cushion cut reflections and return a proper `railNormal` so the aiming line and bank prediction follow the true cut geometry in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Trimmed side-pocket cushion reach by increasing `SIDE_CUSHION_POCKET_REACH_REDUCTION` from `TABLE.THICK * 0.32` to `TABLE.THICK * 0.36` to slightly shorten longer side cushions near middle pockets in `PoolRoyale.jsx`.
- Lowered the overall table stance by changing `TABLE_HEIGHT_SCALE` from `1.56 * 1.3` to `1.56` so the visible table height returns to the previous morning height in `PoolRoyale.jsx`.

### Testing
- Launched the local dev server with `npm run dev` and Vite started successfully (development server reachable), which confirms the app builds and serves after the edits.
- Attempted a headless browser smoke capture using Playwright to validate the visual table, but the Playwright run timed out / the headless Chromium crashed in this environment and the screenshot step failed.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709ccbb414832995a3b4c20ce41c39)