### PR TITLE
Fix Snooker Royal loading overlay fallback

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10422,6 +10422,7 @@ function SnookerRoyalGame({
   const [winnerOverlay, setWinnerOverlay] = useState(null);
   const [loadingProgress, setLoadingProgress] = useState(0);
   const [loadingActive, setLoadingActive] = useState(true);
+  const firstFrameRenderedRef = useRef(false);
   useEffect(() => {
     const manager = THREE.DefaultLoadingManager;
     let cancelled = false;
@@ -13391,6 +13392,7 @@ const powerRef = useRef(hud.power);
     const host = mountRef.current;
     if (!host) return;
     setErr(null);
+    firstFrameRenderedRef.current = false;
     const webglSupported = isWebGLAvailable();
     const cueRackDisposers = [];
     let disposed = false;
@@ -24410,6 +24412,11 @@ const powerRef = useRef(hud.power);
           }
           const frameCamera = updateCamera();
           renderer.render(scene, frameCamera ?? camera);
+          if (!firstFrameRenderedRef.current) {
+            firstFrameRenderedRef.current = true;
+            setLoadingProgress(1);
+            setLoadingActive(false);
+          }
           const shouldStreamAim =
             isOnlineMatch &&
             tableId &&


### PR DESCRIPTION
### Motivation
- The Snooker Royal loading overlay could remain visible when the Three.js `DefaultLoadingManager` doesn't reach a clear completion state, so we need a renderer-based fallback to dismiss the overlay once the first frame renders.

### Description
- Add `firstFrameRenderedRef` and reset it before renderer initialization in `webapp/src/pages/Games/SnookerRoyal.jsx`, and on the first successful `renderer.render` set `loadingProgress` to `1` and `loadingActive` to `false` to hide the loading UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d32e60083298440311e6d3306db)