### PR TITLE
Guard Snooker Royal initialization on unsupported WebGL

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -13392,6 +13392,10 @@ const powerRef = useRef(hud.power);
     if (!host) return;
     setErr(null);
     const webglSupported = isWebGLAvailable();
+    if (!webglSupported) {
+      setErr('WebGL is not available on this device. Enable hardware acceleration to play.');
+      return;
+    }
     const cueRackDisposers = [];
     let disposed = false;
     let contextLost = false;
@@ -13408,11 +13412,9 @@ const powerRef = useRef(hud.power);
         setPocketCameraActive(active);
       };
       updatePocketCameraState(false);
-      screen.orientation?.lock?.('portrait').catch(() => {});
+      const orientationLock = screen.orientation?.lock?.('portrait');
+      orientationLock?.catch?.(() => {});
       // Renderer
-      if (!webglSupported) {
-        console.warn('WebGL availability check failed; attempting to init renderer anyway.');
-      }
       const renderer = new THREE.WebGLRenderer({
         antialias: true,
         alpha: false,


### PR DESCRIPTION
### Motivation
- Prevent Snooker Royal from attempting to initialize the 3D renderer on devices without WebGL support and avoid unhandled orientation-lock promise rejections that can cause errors during startup.

### Description
- Add an explicit WebGL availability check in the Snooker Royal init `useEffect` to set an error message and abort initialization when `isWebGLAvailable()` is false, and replace the direct `screen.orientation.lock('portrait').catch(...)` call with a safe promise capture to avoid thrown errors in environments that don't support orientation locking in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709d32e60083298440311e6d3306db)