### PR TITLE
Adjust Pool Royale cushions, chrome trim, and pocket jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -596,7 +596,7 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.45; // tighten the middle fascia s
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 1.8; // reduce fascia reach so the middle pocket chrome reads compact like the reference
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.24; // widen the middle plates to match the photo reference span
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.98; // extend the outward chrome reach so the sides feel broader
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0; // trim the middle-pocket chrome flush with the outer wood rail edge
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to run farther toward the pocket entry
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 1; // keep the widened fascia width intact
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1; // keep the chrome plate centered between pocket shoulders
@@ -964,6 +964,7 @@ const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // match the middle jaw radius to th
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.04; // keep middle jaws aligned to the pocket center like the reference
+const POCKET_JAW_CENTER_INWARD_SHIFT = TABLE.THICK * 0.025; // pull the jaws slightly toward the table center
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.84; // trim the jaw edges so they stop at the wood rail curve
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -1537,6 +1538,7 @@ const SPIN_DECORATION_OFFSET_PERCENT = 58;
 const DEFAULT_CUSHION_CUT_ANGLE = 27;
 // use a sharper default cut on side-pocket cushions
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 45;
+const SIDE_RAIL_CORNER_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -8717,6 +8719,18 @@ export function Table3D(
     return new THREE.Vector2(fallbackX, fallbackZ);
   };
 
+  const pullJawCenterInward = (center, amount) => {
+    if (!(center instanceof THREE.Vector2)) return center;
+    if (!Number.isFinite(amount) || amount <= 0) return center;
+    const len = center.length();
+    if (!Number.isFinite(len) || len <= MICRO_EPS) return center;
+    const shift = Math.min(amount, len - MICRO_EPS);
+    if (shift <= 0) return center;
+    const inward = center.clone().normalize().multiplyScalar(shift);
+    center.sub(inward);
+    return center;
+  };
+
   if (cornerBaseRadius && cornerBaseRadius > MICRO_EPS) {
     [
       { sx: 1, sz: 1 },
@@ -8730,6 +8744,7 @@ export function Table3D(
         sz * (innerHalfH - cornerInset)
       );
       const center = resolvePocketCenter(baseMP, fallbackCenter.x, fallbackCenter.y);
+      pullJawCenterInward(center, POCKET_JAW_CENTER_INWARD_SHIFT);
       const orientationAngle = Math.atan2(sz, sx);
       addPocketJaw({
         center,
@@ -8750,6 +8765,7 @@ export function Table3D(
       const fallbackCenter = new THREE.Vector2(sx * sidePocketCenterX, 0);
       const center = resolvePocketCenter(baseMP, fallbackCenter.x, fallbackCenter.y);
       center.x += sx * SIDE_POCKET_JAW_OUTWARD_SHIFT;
+      pullJawCenterInward(center, POCKET_JAW_CENTER_INWARD_SHIFT);
       const orientationAngle = Math.atan2(0, sx);
       addPocketJaw({
         center,
@@ -9421,9 +9437,9 @@ export function Table3D(
       ? {
           leftCutAngle: leftCloserToCenter
             ? SIDE_CUSHION_CUT_ANGLE
-            : CUSHION_CUT_ANGLE,
+            : SIDE_RAIL_CORNER_CUSHION_CUT_ANGLE,
           rightCutAngle: leftCloserToCenter
-            ? CUSHION_CUT_ANGLE
+            ? SIDE_RAIL_CORNER_CUSHION_CUT_ANGLE
             : SIDE_CUSHION_CUT_ANGLE
         }
       : undefined;


### PR DESCRIPTION
### Motivation
- Align Pool Royale table visuals to reference: corner-facing side cushions should use the 27° cut, middle-pocket chrome must finish flush with the wood rails, and pocket jaws should sit slightly more toward the table center for a tighter look.

### Description
- Added `SIDE_RAIL_CORNER_CUSHION_CUT_ANGLE` and wired per-end cushion logic so the cushions adjacent to corner pockets use the 27° corner cut while middle-pocket cushions keep the sharper side cut.
- Trimmed the middle-pocket chrome reach by setting `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` to `0` so the chrome plates finish flush with the outer wooden rail edge.
- Introduced `POCKET_JAW_CENTER_INWARD_SHIFT` and `pullJawCenterInward()` helper and applied it to corner and side pocket jaw center positions to nudge jaws slightly toward the table center.
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and only affect pocket/cushion/chrome geometry and layout calculations.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched Vite successfully and served the app (server ready).
- Attempted an automated visual capture using Playwright to verify the table changes, but the screenshot step timed out and no image was produced.
- No unit tests were run for these visual/layout-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ac7ebd548329ba21ff20d4984956)