### PR TITLE
Fix Pool Royale side cushion cuts and restore aim/swerve logic

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 152.4
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -6,9 +6,9 @@ export const SPIN_RING1_RADIUS = 0.32;
 export const SPIN_RING2_RADIUS = 0.52;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL1_MAG = 0.1 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL2_MAG = 0.5 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL3_MAG = 1.0 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 


### PR DESCRIPTION
### Motivation
- Ensure side-rail cushion cuts place the 45° cut on the middle-pocket ends and match the photographed reference. 
- Restore the swerve/aim-line and spin-preview behavior that had been accidentally removed so aiming and spin feel return to the expected behavior. 
- Keep the visual pocket jaw adjustments intended for Pool Royale while keeping spin quantization consistent with the original feel.

### Description
- Fix cushion orientation logic in `addCushion` by computing `centerOnLeft` (handling `flip`) and using `SIDE_CUSHION_CUT_ANGLE` vs `CUSHION_CUT_ANGLE` for `leftCutAngle`/`rightCutAngle`, so side-rail 45° cuts land on the correct pocket ends (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Restore swerve/aim-line logic by reintroducing `resolveSwerveSettings`, `resolveSpinPreviewSettings`, `resolveSwerveAimDir` and full `buildSwerveAimLinePoints` implementations so aim curves and previews react to spin again (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Reset spin quantization tiers in `poolRoyaleSpinUtils.js` to the prior magnitudes (`SPIN_LEVEL1_MAG`, `SPIN_LEVEL2_MAG`, `SPIN_LEVEL3_MAG`) to preserve previous spin feel.
- Apply pocket jaw visual parameter tweaks: set `POCKET_JAW_EDGE_FLUSH_START`, `POCKET_JAW_EDGE_TAPER_SCALE`, `POCKET_JAW_CENTER_TAPER_HOLD`, `POCKET_JAW_EDGE_TAPER_PROFILE_POWER`, and expand lateral jaw reach constants (`CORNER_POCKET_JAW_LATERAL_EXPANSION`, `SIDE_POCKET_JAW_LATERAL_EXPANSION`) to achieve the intended jaw silhouette (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Set table config side cushion cut angles in `webapp/src/config/poolRoyaleTables.js` so side rails have `sideCushionCutAngleDeg: 45` for the affected table specs.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready (succeeded). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the screenshot timed out (Playwright timed out after the tool deadline). 
- No unit test suites (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970de3e4dec8329b47b2225634f67ba)