### PR TITLE
Reduce Pool Royale cushions near pockets and align aim projection to cue-ball plane

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7345,8 +7345,8 @@ export function Table3D(
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.07; // push the cushions further outward so they meet the wooden rails without a gap
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
-  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.4; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.38; // shorten the short-rail cushions a touch more so they stay clear of the pocket openings
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.52; // trim the side-rail cushion tips further so they stop before the pocket perimeter
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -19601,10 +19601,8 @@ const powerRef = useRef(hud.power);
       // Pointer → XZ plane
       const pointer = new THREE.Vector2();
       const ray = new THREE.Raycaster();
-      const plane = new THREE.Plane(
-        new THREE.Vector3(0, 1, 0),
-        -TABLE_Y * worldScaleFactor
-      );
+      const planeHeight = (TABLE_Y + BALL_CENTER_Y) * worldScaleFactor;
+      const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -planeHeight);
       project = (ev) => {
         const r = dom.getBoundingClientRect();
         const cx =


### PR DESCRIPTION
### Motivation
- Cushions on the long/side rails visually intruded into pocket perimeters and caused aiming/pocketing inconsistencies, so the cushion geometry needs tightening. 
- The top-down pointer/aim projection needed to be aligned to the cue-ball plane so aiming lines and touch input are symmetric and consistent on portrait mobile screens. 

### Description
- Trimmed short-rail corner clearance by increasing `CUSHION_CORNER_CLEARANCE_REDUCTION` from `TABLE.THICK * 0.34` to `TABLE.THICK * 0.38` and reduced middle/side cushion reach by changing `SIDE_CUSHION_POCKET_REACH_REDUCTION` from `TABLE.THICK * 0.4` to `TABLE.THICK * 0.52` in `webapp/src/pages/Games/PoolRoyale.jsx` to keep cushion noses clear of pocket entrances. 
- Reworked the pointer projection plane so the raycast intersects a plane placed at the cue-ball height by computing `planeHeight = (TABLE_Y + BALL_CENTER_Y) * worldScaleFactor` and constructing `new THREE.Plane(new THREE.Vector3(0,1,0), -planeHeight)` to improve aiming-line placement and symmetry. 
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and do not alter rule/AI logic. 

### Testing
- No automated tests were executed for this change in CI as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f271b5e08329945829421c204abb)