### PR TITLE
Trim Pool Royale cushions and normalize aim line for symmetry

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7347,6 +7347,8 @@ export function Table3D(
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.4; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -7394,7 +7396,7 @@ export function Table3D(
   );
   const horizontalCushionLength = Math.max(
     MICRO_EPS,
-    PLAY_W - 2 * cornerCushionClearance
+    PLAY_W - 2 * cornerCushionClearance - LONG_RAIL_CUSHION_LENGTH_TRIM
   );
   const sideLineX =
     halfW - CUSHION_RAIL_FLUSH - CUSHION_LONG_RAIL_CENTER_NUDGE + SIDE_CUSHION_RAIL_REACH;
@@ -7408,7 +7410,10 @@ export function Table3D(
   );
   const verticalCushionLength = Math.max(
     MICRO_EPS,
-    Math.max(0, cornerIntersectionZ - adjustedSidePocketReach)
+    Math.max(
+      0,
+      cornerIntersectionZ - adjustedSidePocketReach - SHORT_RAIL_CUSHION_LENGTH_TRIM
+    )
   );
   const verticalCushionCenter =
     adjustedSidePocketReach +
@@ -23169,6 +23174,9 @@ const powerRef = useRef(hud.power);
           : baseAimLerp;
         if (!lookModeRef.current) {
           aimDir.lerp(tmpAim, aimLerpFactor);
+          if (aimDir.lengthSq() > 1e-6) {
+            aimDir.normalize();
+          }
         }
         const appliedSpin = applySpinConstraints(aimDir, true);
         const liftStrength = normalizeCueLift(resolveUserCueLift());


### PR DESCRIPTION
### Motivation
- Prevent long and short rail cushions from intruding into the pocket perimeter by trimming their effective reach. 
- Make the aiming line visually stable and symmetric by ensuring the interpolated aim direction is normalized.

### Description
- Added `LONG_RAIL_CUSHION_LENGTH_TRIM` and `SHORT_RAIL_CUSHION_LENGTH_TRIM` and subtract them from the computed `horizontalCushionLength` and `verticalCushionLength` respectively in `PoolRoyale.jsx` to shorten cushion reach near pockets. 
- After aiming interpolation in the main render/update loop, normalize `aimDir` (when non-zero) to keep the aiming line precise and symmetric (`aimDir.normalize()` added where `aimDir.lerp(...)` is applied). 
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and are small, deterministic numeric adjustments to table geometry and the aim-vector handling.

### Testing
- Launched the dev server with `npm run dev` and the Vite dev server started successfully (local server reachable). 
- Attempted a visual smoke test via an automated Playwright screenshot, but Chromium crashed in this environment (SIGSEGV / TargetClosedError) so the screenshot step failed. 
- No unit test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f271b5e08329945829421c204abb)