### PR TITLE
Trim cushions near middle pockets and add UK numeric/solid/stripe ball mapping

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -171,12 +171,30 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
 }
 
 function parseUkColour(value: unknown): UkColour | null {
+  if (typeof value === 'number') {
+    if (value === 0) return 'cue';
+    if (value === 8) return 'black';
+    if (value >= 1 && value <= 7) return 'blue';
+    if (value >= 9 && value <= 15) return 'red';
+    return null;
+  }
   if (typeof value !== 'string') return null;
   const lower = value.toLowerCase();
   if (lower.startsWith('yellow')) return 'blue';
   if (lower.startsWith('blue')) return 'blue';
   if (lower.startsWith('red')) return 'red';
   if (lower.startsWith('black')) return 'black';
+  if (lower.startsWith('solid')) return 'blue';
+  if (lower.startsWith('stripe')) return 'red';
+  if (lower.startsWith('ball_')) {
+    const match = lower.match(/ball_(\d+)/);
+    if (match) {
+      const numericId = Number.parseInt(match[1], 10);
+      if (numericId === 8) return 'black';
+      if (numericId >= 1 && numericId <= 7) return 'blue';
+      if (numericId >= 9 && numericId <= 15) return 'red';
+    }
+  }
   if (lower === 'cue') return 'cue';
   return null;
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -559,7 +559,7 @@ const CORNER_POCKET_INWARD_SCALE = 1.008; // ease the corner cuts back toward th
 const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
 const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
-const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.05; // pull the rounded corner cut slightly inward while keeping the notch aligned to the cloth
+const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.06; // pull the rounded corner cut slightly inward while keeping the notch aligned to the cloth
 const CHROME_CORNER_EXPANSION_SCALE = 1.002; // trim back the fascia so it now finishes flush with the pocket jaw edge along the long rail
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.002; // mirror the lighter reach so the chrome stops exactly where the jaw shoulder begins
 const CHROME_CORNER_FIELD_TRIM_SCALE = -0.03; // remove the base trim so the fascia rides the cushion edge without a gap
@@ -603,7 +603,7 @@ const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width furth
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.07; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.085; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.0506; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
@@ -945,8 +945,8 @@ const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome t
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.1; // thin the outer lips more aggressively while leaving the centre crown unchanged
 const POCKET_JAW_CENTER_TAPER_HOLD = 0.16; // start easing earlier so the mass flows gradually from the centre toward the chrome plates
 const POCKET_JAW_EDGE_TAPER_PROFILE_POWER = 1.15; // smooth the taper curve so thickness falls away progressively instead of dropping late
-const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = POCKET_JAW_CENTER_TAPER_HOLD; // keep the taper hold consistent so the middle jaw crown mirrors the corners
-const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = POCKET_JAW_EDGE_TAPER_SCALE; // reuse the corner taper scale so edge thickness matches exactly
+const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = 0.14; // start tapering earlier on middle jaws so they slim toward the cushions
+const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = 0.12; // ease the middle jaw edges thinner for a gentler taper toward the rails
 const POCKET_JAW_SIDE_EDGE_TAPER_PROFILE_POWER = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // maintain the identical taper curve across all six jaws
 const POCKET_JAW_CENTER_THICKNESS_MIN = 0.38; // let the inner arc sit leaner while preserving the curved silhouette across the pocket
 const POCKET_JAW_CENTER_THICKNESS_MAX = 0.7; // keep a pronounced middle section while slimming the jaw before tapering toward the edges
@@ -960,14 +960,14 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.78; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.4; // push the middle jaw reach a touch wider so the openings read larger
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.48; // push the middle jaw reach a touch wider so the openings read larger
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.072; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
-const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
-const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // taper the middle jaw edges sooner so they finish where the rails stop
+const SIDE_POCKET_JAW_EDGE_TRIM_START = 0.18; // begin trimming earlier so middle jaws taper before meeting the cushions
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
@@ -1538,7 +1538,7 @@ const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = 45; // keep side-pocket cuts aligned to the visual 45° cushion angle
 const VISUAL_SIDE_CUSHION_CUT_ANGLE = 45;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
@@ -7345,12 +7345,12 @@ export function Table3D(
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.07; // push the cushions further outward so they meet the wooden rails without a gap
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
-  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.4; // trim the cushion tips near middle pockets so they stop at the rail cut
-  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
+  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.44; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.62; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.88; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
   const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
-  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
+  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.12; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
@@ -21682,8 +21682,20 @@ const powerRef = useRef(hud.power);
 
         const mapBallIdToUkAiColour = (colorId) => {
           if (!colorId) return null;
-          const upper = colorId.toUpperCase();
+          const upper =
+            typeof colorId === 'string'
+              ? colorId.toUpperCase()
+              : String(colorId).toUpperCase();
           if (upper === 'CUE') return 'cue';
+          const numericMatch = upper.match(/BALL_(\d+)/);
+          const numericId = numericMatch ? Number.parseInt(numericMatch[1], 10) : null;
+          if (Number.isFinite(numericId)) {
+            if (numericId === 8) return 'black';
+            if (numericId >= 1 && numericId <= 7) return 'blue';
+            if (numericId >= 9 && numericId <= 15) return 'red';
+          }
+          if (upper.startsWith('SOLID')) return 'blue';
+          if (upper.startsWith('STRIPE')) return 'red';
           if (upper.startsWith('YELLOW') || upper.startsWith('BLUE')) return 'blue';
           if (upper.startsWith('RED')) return 'red';
           if (upper.startsWith('BLACK')) return 'black';


### PR DESCRIPTION
### Motivation
- Restore the intended cushion trimming so long-rail and side cushions no longer intrude into the middle-pocket perimeter and the cushion ends stop before the jaw edges. 
- Keep side-pocket cut alignment visually consistent by using the 45° side-cushion cut angle. 
- Make UK rules and AI interpret numeric, `solid` and `stripe` identifiers consistently with the table state.

### Description
- Reduced long-rail and side-cushion reach by updating constants in `webapp/src/pages/Games/PoolRoyale.jsx` (`CUSHION_CORNER_CLEARANCE_REDUCTION`, `SIDE_CUSHION_POCKET_REACH_REDUCTION`, `LONG_RAIL_CUSHION_LENGTH_TRIM`, `SIDE_CUSHION_CORNER_SHIFT`) and set `DEFAULT_SIDE_CUSHION_CUT_ANGLE` to `45` to align visual aiming. 
- Adjusted pocket/chrome and jaw tuning in `webapp/src/pages/Games/PoolRoyale.jsx` including `CHROME_CORNER_NOTCH_CENTER_SCALE`, `CHROME_CORNER_POCKET_CUT_SCALE`, `POCKET_JAW_SIDE_CENTER_TAPER_HOLD`, `POCKET_JAW_SIDE_EDGE_TAPER_SCALE`, `SIDE_POCKET_JAW_LATERAL_EXPANSION`, `SIDE_POCKET_JAW_EDGE_TRIM_START`, and `SIDE_POCKET_JAW_EDGE_TRIM_SCALE` to refine middle-jaw silhouette and chrome trimming. 
- Added numeric and pattern-aware UK colour parsing in `src/rules/PoolRoyaleRules.ts` by extending `parseUkColour` to accept numeric ids and `solid`/`stripe` names. 
- Mirrored the same numeric/solid/stripe parsing in the AI/UI mapping `mapBallIdToUkAiColour` inside `webapp/src/pages/Games/PoolRoyale.jsx` so AI planning and UI resolve the same UK colour categories.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready and served the app successfully. 
- Attempted Playwright visual checks to capture a screenshot, but the Playwright run timed out and the screenshot step failed. 
- No unit tests (`npm test` / `jest`) were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970faeef1708329a15df964866d539c)