### PR TITLE
Pool Royale: tweak cushion/pocket geometry, jaw/chrome sizing and UK ball ID mapping

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -171,8 +171,22 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
 }
 
 function parseUkColour(value: unknown): UkColour | null {
+  if (typeof value === 'number') {
+    if (value === 0) return 'cue';
+    if (value === 8) return 'black';
+    if (value >= 1 && value <= 7) return 'blue';
+    if (value >= 9 && value <= 15) return 'red';
+  }
   if (typeof value !== 'string') return null;
   const lower = value.toLowerCase();
+  const numericMatch = lower.match(/ball_(\d+)/);
+  if (numericMatch) {
+    const num = Number.parseInt(numericMatch[1], 10);
+    if (num === 0) return 'cue';
+    if (num === 8) return 'black';
+    if (num >= 1 && num <= 7) return 'blue';
+    if (num >= 9 && num <= 15) return 'red';
+  }
   if (lower.startsWith('yellow')) return 'blue';
   if (lower.startsWith('blue')) return 'blue';
   if (lower.startsWith('red')) return 'red';

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -558,8 +558,8 @@ const POCKET_VISUAL_EXPANSION = 1.034;
 const CORNER_POCKET_INWARD_SCALE = 1.008; // ease the corner cuts back toward the rail so the mouth stays as wide as the bowl
 const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
 const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
-const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.01;
-const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.05; // pull the rounded corner cut slightly inward while keeping the notch aligned to the cloth
+const CHROME_CORNER_POCKET_RADIUS_SCALE = 1.012;
+const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.06; // pull the rounded corner cut slightly inward while keeping the notch aligned to the cloth
 const CHROME_CORNER_EXPANSION_SCALE = 1.002; // trim back the fascia so it now finishes flush with the pocket jaw edge along the long rail
 const CHROME_CORNER_SIDE_EXPANSION_SCALE = 1.002; // mirror the lighter reach so the chrome stops exactly where the jaw shoulder begins
 const CHROME_CORNER_FIELD_TRIM_SCALE = -0.03; // remove the base trim so the fascia rides the cushion edge without a gap
@@ -603,7 +603,7 @@ const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width furth
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.07; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.075; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.0506; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
@@ -960,14 +960,14 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.78; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.4; // push the middle jaw reach a touch wider so the openings read larger
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.48; // push the middle jaw reach a touch wider so the openings read larger
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.072; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
-const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.86; // taper the middle jaw edges sooner so they finish where the rails stop
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
@@ -1540,6 +1540,7 @@ const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 const VISUAL_SIDE_CUSHION_CUT_ANGLE = 45;
+const SIDE_POCKET_CUT_ANGLE_DEG = VISUAL_SIDE_CUSHION_CUT_ANGLE;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
@@ -5800,7 +5801,7 @@ function reflectRails(ball) {
   const sideGuardClearance = SIDE_POCKET_GUARD_CLEARANCE;
   const sideDepthLimit = SIDE_POCKET_DEPTH_LIMIT;
   const sidePocketCenters = pocketCenters().slice(4);
-  const sideCutRad = THREE.MathUtils.degToRad(SIDE_CUSHION_CUT_ANGLE);
+  const sideCutRad = THREE.MathUtils.degToRad(SIDE_POCKET_CUT_ANGLE_DEG);
   const sideCutCos = Math.cos(sideCutRad);
   const sideCutSin = Math.sin(sideCutRad);
   for (const center of sidePocketCenters) {
@@ -6061,7 +6062,7 @@ function calcTarget(cue, dir, balls) {
   const sideGuardClearance = SIDE_POCKET_GUARD_CLEARANCE;
   const sideDepthLimit = SIDE_POCKET_DEPTH_LIMIT;
   const sidePocketCenters = pocketCenters().slice(4);
-  const sideCutRad = THREE.MathUtils.degToRad(SIDE_CUSHION_CUT_ANGLE);
+  const sideCutRad = THREE.MathUtils.degToRad(SIDE_POCKET_CUT_ANGLE_DEG);
   const sideCutCos = Math.cos(sideCutRad);
   const sideCutSin = Math.sin(sideCutRad);
   for (const center of sidePocketCenters) {
@@ -7346,7 +7347,7 @@ export function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.4; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.48; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
   const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
@@ -21683,6 +21684,14 @@ const powerRef = useRef(hud.power);
         const mapBallIdToUkAiColour = (colorId) => {
           if (!colorId) return null;
           const upper = colorId.toUpperCase();
+          const numericMatch = upper.match(/^BALL_(\d+)$/);
+          if (numericMatch) {
+            const num = Number.parseInt(numericMatch[1], 10);
+            if (num === 0) return 'cue';
+            if (num === 8) return 'black';
+            if (num >= 1 && num <= 7) return 'blue';
+            if (num >= 9 && num <= 15) return 'red';
+          }
           if (upper === 'CUE') return 'cue';
           if (upper.startsWith('YELLOW') || upper.startsWith('BLUE')) return 'blue';
           if (upper.startsWith('RED')) return 'red';


### PR DESCRIPTION
### Motivation
- Reduce long-side cushion reach and align side-pocket cut handling so cushions no longer intrude into the pocket perimeter and the aiming line is symmetrical after previous cushion cut changes. 
- Expand and taper the middle pocket jaws and slightly adjust chrome corner cuts/centering to better match the requested visual/entry profile. 
- Restore consistent UK 8-ball rule/AI behavior by ensuring numeric ball IDs (and `BALL_#` strings) map correctly to UK colour groups for shot resolution and AI planning.

### Description
- Trimmed side-pocket/cushion geometry by increasing `SIDE_CUSHION_POCKET_REACH_REDUCTION` and introducing `SIDE_POCKET_CUT_ANGLE_DEG` for the side-pocket cut angle so aiming/rail logic uses a dedicated side-pocket cut value (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tuned chrome/corner pocket values: updated `CHROME_CORNER_POCKET_RADIUS_SCALE`, `CHROME_CORNER_NOTCH_CENTER_SCALE`, and `CHROME_CORNER_POCKET_CUT_SCALE` to slightly pull and expand corner cuts inward and outward as requested (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Expanded middle-pocket jaw geometry by increasing `SIDE_POCKET_JAW_LATERAL_EXPANSION` and adjusting `SIDE_POCKET_JAW_EDGE_TRIM_SCALE` so jaws are broader near the middle pockets and taper toward the cushions (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replaced uses of the side cushion cut angle in aim/rail calculations with the new `SIDE_POCKET_CUT_ANGLE_DEG` to keep the aiming line calibration symmetric and consistent with the cushion cut changes (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added numeric-ID -> UK colour mapping in the rules and AI: `parseUkColour` in `src/rules/PoolRoyaleRules.ts` now accepts numeric IDs and `ball_#` strings and `mapBallIdToUkAiColour` in the webapp AI code also handles `BALL_##` numeric strings so the rule engine and AI respect UK assignments and turns correctly.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported the dev server ready on the expected port, confirming the build runs locally (succeeded). 
- Attempted an automated visual smoke test via Playwright to capture the Pool Royale page, but the screenshot step timed out (failed). 
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971119542308329b63cba959fd7c759)