### PR TITLE
Trim middle pocket cushion reach

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7347,7 +7347,7 @@ export function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.48; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.56; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
   const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap


### PR DESCRIPTION
### Motivation
- Prevent long‑rail cushion noses from intruding into the middle pocket perimeter so the 45° cushion cut no longer overlaps the pocket mouth.

### Description
- Adjust `SIDE_CUSHION_POCKET_REACH_REDUCTION` from `TABLE.THICK * 0.48` to `TABLE.THICK * 0.56` in `webapp/src/pages/Games/PoolRoyale.jsx` to shorten the cushion tips near the middle pockets.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and verified the build served via Vite successfully; a Playwright screenshot was captured to validate the visual change.
- No unit tests were run as this is a visual/tweak change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971205dc3148329b01ad31a78adda04)