### PR TITLE
UK 8‑Ball: switch to ball‑in‑hand, add BIH drag UI, and refine pocket jaw profile

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,baulkLineY?:number}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -626,13 +626,6 @@ export function planShot (req) {
             cand.x > req.state.width - r ||
             cand.y < r ||
             cand.y > req.state.height - r
-          ) {
-            continue
-          }
-          if (
-            req.state.mustPlayFromBaulk &&
-            typeof req.state.baulkLineY === 'number' &&
-            cand.y < req.state.baulkLineY
           ) {
             continue
           }

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -31,7 +31,7 @@ export class UkPool {
       lastEvent: null,
       frameOver: false,
       winner: null,
-      mustPlayFromBaulk: false
+      ballInHand: false
     };
   }
 
@@ -74,11 +74,11 @@ export class UkPool {
     const first = shot.contactOrder && shot.contactOrder[0];
     const isBreak = s.lastEvent === 'BREAK_START' || s.lastEvent === null;
 
-    const mustBaulk = s.mustPlayFromBaulk;
-    s.mustPlayFromBaulk = false;
-    if (mustBaulk && !shot.placedFromHand) {
+    const mustPlace = s.ballInHand;
+    s.ballInHand = false;
+    if (mustPlace && !shot.placedFromHand) {
       foul = true;
-      reason = 'must play from baulk';
+      reason = 'must play from hand';
     }
 
     // no contact
@@ -207,10 +207,10 @@ export class UkPool {
 
     if (foul) {
       nextPlayer = opp;
-      shotsNext = 2;
+      shotsNext = 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = scratched;
+      s.ballInHand = true;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -26,7 +26,7 @@
  * @property {'blue'|'red'|null} [ballOn]   // group of current player; null on open table
  * @property {boolean} [isOpenTable]
  * @property {number} [shotsRemaining]
- * @property {boolean} [mustPlayFromBaulk]    // cue ball must be placed behind baulk line
+ * @property {boolean} [ballInHand]           // cue ball can be repositioned anywhere before the shot
  * @property {number} [baulkLineX]            // x coordinate of baulk line for ball in hand
  *
  * @typedef {Object} CandidateShot

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -27,7 +27,7 @@ type UkSerializedState = {
   lastEvent: string | null;
   frameOver: boolean;
   winner: 'A' | 'B' | null;
-  mustPlayFromBaulk: boolean;
+  ballInHand: boolean;
 };
 
 type AmericanSerializedState = {
@@ -101,7 +101,7 @@ function serializeUkState(state: UkPool['state']): UkSerializedState {
     lastEvent: state.lastEvent,
     frameOver: state.frameOver,
     winner: state.winner,
-    mustPlayFromBaulk: state.mustPlayFromBaulk
+    ballInHand: state.ballInHand
   };
 }
 
@@ -120,7 +120,7 @@ function applyUkState(game: UkPool, snapshot: UkSerializedState) {
     lastEvent: snapshot.lastEvent,
     frameOver: snapshot.frameOver,
     winner: snapshot.winner,
-    mustPlayFromBaulk: snapshot.mustPlayFromBaulk
+    ballInHand: snapshot.ballInHand
   };
 }
 

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -38,7 +38,7 @@ describe('PoolRoyaleRules', () => {
     const foulMeta = foulState.meta as any;
 
     expect(foulState.foul?.reason).toBe('scratch');
-    expect(foulMeta?.state?.mustPlayFromBaulk).toBe(true);
+    expect(foulMeta?.state?.ballInHand).toBe(true);
     expect(foulState.activePlayer).toBe('B');
     expect(foulMeta?.hud?.phase).toBe('groups');
     expect(foulState.ballOn).toContain('YELLOW');

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,baulkLineY?:number}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -626,13 +626,6 @@ export function planShot (req) {
             cand.x > req.state.width - r ||
             cand.y < r ||
             cand.y > req.state.height - r
-          ) {
-            continue
-          }
-          if (
-            req.state.mustPlayFromBaulk &&
-            typeof req.state.baulkLineY === 'number' &&
-            cand.y < req.state.baulkLineY
           ) {
             continue
           }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -942,20 +942,20 @@ const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.03; // allow the jaw extrusi
 const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.18; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.12; // start easing earlier so the jaw thins gradually toward the cushions
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
-const POCKET_JAW_EDGE_TAPER_SCALE = 0.1; // thin the outer lips more aggressively while leaving the centre crown unchanged
-const POCKET_JAW_CENTER_TAPER_HOLD = 0.16; // start easing earlier so the mass flows gradually from the centre toward the chrome plates
-const POCKET_JAW_EDGE_TAPER_PROFILE_POWER = 1.15; // smooth the taper curve so thickness falls away progressively instead of dropping late
+const POCKET_JAW_EDGE_TAPER_SCALE = 0.08; // thin the outer lips more aggressively while leaving the centre crown unchanged
+const POCKET_JAW_CENTER_TAPER_HOLD = 0.1; // start easing earlier so the mass flows gradually from the centre toward the chrome plates
+const POCKET_JAW_EDGE_TAPER_PROFILE_POWER = 1.35; // smooth the taper curve so thickness falls away progressively instead of dropping late
 const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = POCKET_JAW_CENTER_TAPER_HOLD; // keep the taper hold consistent so the middle jaw crown mirrors the corners
 const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = POCKET_JAW_EDGE_TAPER_SCALE; // reuse the corner taper scale so edge thickness matches exactly
 const POCKET_JAW_SIDE_EDGE_TAPER_PROFILE_POWER = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // maintain the identical taper curve across all six jaws
-const POCKET_JAW_CENTER_THICKNESS_MIN = 0.38; // let the inner arc sit leaner while preserving the curved silhouette across the pocket
+const POCKET_JAW_CENTER_THICKNESS_MIN = 0.32; // let the inner arc sit leaner while preserving the curved silhouette across the pocket
 const POCKET_JAW_CENTER_THICKNESS_MAX = 0.7; // keep a pronounced middle section while slimming the jaw before tapering toward the edges
 const POCKET_JAW_OUTER_EXPONENT_MIN = 0.58; // controls arc falloff toward the chrome rim
 const POCKET_JAW_OUTER_EXPONENT_MAX = 1.2;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.78; // controls inner lip easing toward the cushion
 const POCKET_JAW_INNER_EXPONENT_MAX = 1.34;
 const POCKET_JAW_SEGMENT_MIN = 144; // higher tessellation for crisper high-res pocket jaws
-const POCKET_JAW_CORNER_EDGE_FACTOR = 0.42; // widen the chamfer so the corner jaw shoulders carry the same mass as the photographed reference
+const POCKET_JAW_CORNER_EDGE_FACTOR = 0.34; // widen the chamfer so the corner jaw shoulders carry the same mass as the photographed reference
 const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the middle pocket chamfer identical to the corners
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
@@ -1755,7 +1755,7 @@ function deriveInHandFromFrame(frame) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === 'uk' && meta.state) {
-    return Boolean(meta.state.mustPlayFromBaulk);
+    return Boolean(meta.state.ballInHand);
   }
   return false;
 }
@@ -11847,6 +11847,7 @@ function PoolRoyaleGame({
   const shotCameraHoldTimeoutRef = useRef(null);
   const cueStrokeStateRef = useRef(null);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
+  const [inHandGrabActive, setInHandGrabActive] = useState(false);
   useEffect(
     () => () => {
       if (replayBannerTimeoutRef.current) {
@@ -11861,6 +11862,10 @@ function PoolRoyaleGame({
     []
   );
   const inHandPlacementModeRef = useRef(inHandPlacementMode);
+  const inHandGrabActiveRef = useRef(inHandGrabActive);
+  const inHandDragRef = useRef({ active: false, pointerId: null, lastPos: null });
+  const inHandProjectRef = useRef(null);
+  const inHandTryUpdateRef = useRef(null);
   const gameOverHandledRef = useRef(false);
   const userSuggestionRef = useRef(null);
   const startAiThinkingRef = useRef(() => {});
@@ -11908,6 +11913,9 @@ const [hudInsets, setHudInsets] = useState({ left: '0px', right: '0px' });
 const [bottomHudOffset, setBottomHudOffset] = useState(0);
 const leftControlsRef = useRef(null);
 const spinBoxRef = useRef(null);
+const inHandIndicatorRef = useRef(null);
+const inHandLineRef = useRef(null);
+const inHandHandRef = useRef(null);
 const showRuleToast = useCallback((message) => {
   if (!message) return;
   if (ruleToastTimeoutRef.current) {
@@ -11919,6 +11927,70 @@ const showRuleToast = useCallback((message) => {
     setRuleToast(null);
     ruleToastTimeoutRef.current = null;
   }, 3000);
+}, []);
+const handleInHandGrabStart = useCallback((event) => {
+  const currentHud = hudRef.current;
+  if (!currentHud?.inHand || currentHud?.turn !== 0) return;
+  if (event.button != null && event.button !== 0) return;
+  setInHandGrabActive(true);
+  inHandGrabActiveRef.current = true;
+  const project = inHandProjectRef.current;
+  const tryUpdate = inHandTryUpdateRef.current;
+  if (project && tryUpdate) {
+    const pos = project(event);
+    if (pos) {
+      tryUpdate(pos, false);
+      const dragState = inHandDragRef.current;
+      dragState.active = true;
+      dragState.pointerId = event.pointerId ?? 'hand';
+      dragState.lastPos = pos;
+    }
+  }
+  if (event.pointerId != null && event.currentTarget?.setPointerCapture) {
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {}
+  }
+  event.preventDefault?.();
+  event.stopPropagation?.();
+}, []);
+const handleInHandGrabMove = useCallback((event) => {
+  if (!inHandGrabActiveRef.current) return;
+  const dragState = inHandDragRef.current;
+  if (dragState.pointerId != null && event.pointerId != null && event.pointerId !== dragState.pointerId) {
+    return;
+  }
+  const project = inHandProjectRef.current;
+  const tryUpdate = inHandTryUpdateRef.current;
+  if (project && tryUpdate) {
+    const pos = project(event);
+    if (pos) {
+      tryUpdate(pos, false);
+      dragState.lastPos = pos;
+    }
+  }
+  event.preventDefault?.();
+  event.stopPropagation?.();
+}, []);
+const handleInHandGrabEnd = useCallback((event) => {
+  if (!inHandGrabActiveRef.current) return;
+  const dragState = inHandDragRef.current;
+  if (dragState.pointerId != null && event.pointerId != null && event.pointerId !== dragState.pointerId) {
+    return;
+  }
+  if (event.pointerId != null && event.currentTarget?.releasePointerCapture) {
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch {}
+  }
+  dragState.active = false;
+  if (dragState.lastPos) {
+    inHandTryUpdateRef.current?.(dragState.lastPos, true);
+  }
+  setInHandGrabActive(false);
+  inHandGrabActiveRef.current = false;
+  event.preventDefault?.();
+  event.stopPropagation?.();
 }, []);
 const powerRef = useRef(hud.power);
   const clampPower = useCallback((value, fallback = 0) => {
@@ -11933,6 +12005,9 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     inHandPlacementModeRef.current = inHandPlacementMode;
   }, [inHandPlacementMode]);
+  useEffect(() => {
+    inHandGrabActiveRef.current = inHandGrabActive;
+  }, [inHandGrabActive]);
   useEffect(() => {
     powerRef.current = hud.power;
   }, [hud.power]);
@@ -12021,12 +12096,15 @@ const powerRef = useRef(hud.power);
   const cueBallPlacedFromHandRef = useRef(false);
   useEffect(() => {
     const playerTurn = (hud.turn ?? 0) === 0;
-    const placing = Boolean(hud.inHand && playerTurn);
+    const placing = Boolean(hud.inHand && playerTurn && inHandGrabActiveRef.current);
     setInHandPlacementMode(placing);
     if (placing) {
       cueBallPlacedFromHandRef.current = false;
     }
-  }, [hud.inHand, hud.turn]);
+    if (!hud.inHand || !playerTurn) {
+      setInHandGrabActive(false);
+    }
+  }, [hud.inHand, hud.turn, inHandGrabActive]);
   const [shotActive, setShotActive] = useState(false);
   const shootingRef = useRef(shotActive);
   useEffect(() => {
@@ -19714,7 +19792,7 @@ const powerRef = useRef(hud.power);
 
       const allowFullTableInHand = () => {
         const id = variantId();
-        if (id === 'uk') return false;
+        if (id === 'uk') return true;
         if (id === 'american' || id === '9ball') {
           return !isBreakRestrictedInHand();
         }
@@ -19758,11 +19836,7 @@ const powerRef = useRef(hud.power);
         clampInHandPosition(
           new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
         );
-      const inHandDrag = {
-        active: false,
-        pointerId: null,
-        lastPos: null
-      };
+      const inHandDrag = inHandDragRef.current;
       const updateCuePlacement = (pos) => {
         if (!cue || !pos) return;
         cue.mesh.visible = true;
@@ -19784,18 +19858,15 @@ const powerRef = useRef(hud.power);
         cue.active = false;
         updateCuePlacement(clamped);
         inHandDrag.lastPos = clamped;
-      if (commit) {
-        cue.active = true;
-        inHandDrag.lastPos = null;
-        cueBallPlacedFromHandRef.current = true;
-        if (hudRef.current?.inHand) {
-          const nextHud = { ...hudRef.current, inHand: false };
-          hudRef.current = nextHud;
-          setHud(nextHud);
+        if (commit) {
+          cue.active = true;
+          inHandDrag.lastPos = null;
+          cueBallPlacedFromHandRef.current = true;
         }
-      }
-      return true;
-    };
+        return true;
+      };
+      inHandProjectRef.current = project;
+      inHandTryUpdateRef.current = tryUpdatePlacement;
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
         const forwardBias = Math.max(baulkZ - BALL_R * 0.6, -PLAY_H / 2 + BALL_R);
@@ -20024,7 +20095,7 @@ const powerRef = useRef(hud.power);
         const pos = inHandDrag.lastPos;
         if (pos) {
           tryUpdatePlacement(pos, true);
-          setInHandPlacementMode(false);
+          setInHandGrabActive(false);
           autoAimRequestRef.current = true;
         }
         e.preventDefault?.();
@@ -20321,6 +20392,8 @@ const powerRef = useRef(hud.power);
         if (currentHud?.inHand && (fullTableHandPlacement || inHandPlacementActive)) {
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
+          setInHandGrabActive(false);
+          inHandGrabActiveRef.current = false;
         }
         if (aiOpponentEnabled && currentHud?.turn === 1) {
           aiTurnShotCountRef.current += 1;
@@ -20345,7 +20418,7 @@ const powerRef = useRef(hud.power);
           } else if (meta.variant === '9ball' && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
           } else if (meta.variant === 'uk' && meta.state) {
-            placedFromHand = Boolean(meta.state.mustPlayFromBaulk);
+            placedFromHand = Boolean(meta.state.ballInHand);
           }
         }
         shotContextRef.current = {
@@ -21804,7 +21877,7 @@ const powerRef = useRef(hud.power);
             aiState.ballOn ?? 'open',
             aiState.isOpenTable ? '1' : '0',
             aiState.shotsRemaining ?? '0',
-            aiState.mustPlayFromBaulk ? '1' : '0',
+            aiState.ballInHand ? '1' : '0',
             Math.round((aiState.baulkLineX ?? 0) * 10)
           ].join('::');
         };
@@ -21854,7 +21927,7 @@ const powerRef = useRef(hud.power);
             ballOn: ballOnColour,
             isOpenTable: snapshot.isOpenTable,
             shotsRemaining: snapshot.shotsRemaining,
-            mustPlayFromBaulk: snapshot.mustPlayFromBaulk,
+            ballInHand: snapshot.ballInHand,
             baulkLineX: baulkLineLocal + height / 2
           };
           try {
@@ -22886,7 +22959,7 @@ const powerRef = useRef(hud.power);
               } else if (nextMeta.variant === '9ball' && nextMeta.state) {
                 nextInHand = Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === 'uk' && nextMeta.state) {
-                nextInHand = Boolean(nextMeta.state.mustPlayFromBaulk);
+                nextInHand = Boolean(nextMeta.state.ballInHand);
               }
             }
           }
@@ -23241,6 +23314,47 @@ const powerRef = useRef(hud.power);
           isOnlineMatch &&
           currentHud?.turn === 1 &&
           remoteAimFresh;
+        const inHandIndicator = inHandIndicatorRef.current;
+        if (inHandIndicator) {
+          const showIndicator = Boolean(
+            currentHud?.inHand && currentHud?.turn === 0 && !replayPlaybackRef.current
+          );
+          inHandIndicator.style.opacity = showIndicator ? '1' : '0';
+          inHandIndicator.style.pointerEvents = showIndicator ? 'auto' : 'none';
+          if (showIndicator && cue?.mesh) {
+            const rect = dom.getBoundingClientRect();
+            const cam = activeRenderCameraRef.current ?? camera;
+            TMP_VEC3_A.copy(cue.mesh.position).project(cam);
+            const cueScreenX = (TMP_VEC3_A.x * 0.5 + 0.5) * rect.width + rect.left;
+            const cueScreenY = (-TMP_VEC3_A.y * 0.5 + 0.5) * rect.height + rect.top;
+            inHandIndicator.style.left = `${cueScreenX}px`;
+            inHandIndicator.style.top = `${cueScreenY}px`;
+            TMP_VEC2_A.copy(aimDirRef.current);
+            if (TMP_VEC2_A.lengthSq() < 1e-6) {
+              TMP_VEC2_A.set(0, 1);
+            } else {
+              TMP_VEC2_A.normalize();
+            }
+            TMP_VEC3_B.set(
+              cue.mesh.position.x + TMP_VEC2_A.x * BALL_R * 3.4,
+              cue.mesh.position.y,
+              cue.mesh.position.z + TMP_VEC2_A.y * BALL_R * 3.4
+            ).project(cam);
+            const endX = (TMP_VEC3_B.x * 0.5 + 0.5) * rect.width + rect.left;
+            const endY = (-TMP_VEC3_B.y * 0.5 + 0.5) * rect.height + rect.top;
+            const dx = endX - cueScreenX;
+            const dy = endY - cueScreenY;
+            const length = THREE.MathUtils.clamp(Math.hypot(dx, dy), 18, 42);
+            const angle = Math.atan2(dy, dx);
+            if (inHandLineRef.current) {
+              inHandLineRef.current.style.width = `${length}px`;
+              inHandLineRef.current.style.transform = `translateY(-50%) rotate(${angle}rad)`;
+            }
+            if (inHandHandRef.current) {
+              inHandHandRef.current.style.transform = `translate(${length}px, -50%)`;
+            }
+          }
+        }
         function resolveCueObstruction(
           dirVec3,
           pullDistance = cuePullTargetRef.current ?? 0,
@@ -25531,6 +25645,7 @@ const powerRef = useRef(hud.power);
           ? '0 0 18px rgba(16,185,129,0.35), 14px 0 22px rgba(16,185,129,0.28)'
           : '0 6px 14px rgba(0,0,0,0.35)'
       };
+  const inHandAnywhere = ['american', '9ball', 'uk'].includes(variantKey);
   const renderFlagAvatar = useCallback(
     (flagEmoji, label, isActive) => (
       <span
@@ -25550,6 +25665,32 @@ const powerRef = useRef(hud.power);
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
+      {hud?.inHand && hud.turn === 0 && (
+        <div
+          ref={inHandIndicatorRef}
+          className="fixed z-50"
+          style={{ left: 0, top: 0, opacity: 0, transform: 'translate(-50%, -50%)', transition: 'opacity 150ms ease' }}
+          aria-hidden={!hud?.inHand}
+        >
+          <div
+            ref={inHandLineRef}
+            className="absolute left-0 top-1/2 h-[2px] bg-white/80 shadow-[0_0_6px_rgba(255,255,255,0.65)] pointer-events-none"
+          />
+          <button
+            ref={inHandHandRef}
+            type="button"
+            onPointerDown={handleInHandGrabStart}
+            onPointerMove={handleInHandGrabMove}
+            onPointerUp={handleInHandGrabEnd}
+            onPointerCancel={handleInHandGrabEnd}
+            onPointerLeave={handleInHandGrabEnd}
+            className="absolute left-0 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full bg-white/95 text-lg shadow-[0_6px_14px_rgba(0,0,0,0.35)] ring-1 ring-emerald-300/70 pointer-events-auto"
+            aria-label="Hold to move the cue ball"
+          >
+            🖐️
+          </button>
+        </div>
+      )}
 
       {replayBanner && (
         <div className="pointer-events-none absolute top-4 right-4 z-50">
@@ -26681,11 +26822,11 @@ const powerRef = useRef(hud.power);
           <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
             <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
             <span className="text-left leading-tight">
-              Drag the cue ball {['american', '9ball'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle'}
+              Hold the hand icon to move the cue ball {inHandAnywhere ? 'anywhere on the table' : 'inside the baulk semicircle'}
             </span>
           </div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
-            Tap and hold, then slide to place
+            Press and hold the hand, then drag to respot
           </span>
         </div>
       )}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1740,7 +1740,7 @@ function deriveInHandFromFrame(frame) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === 'uk' && meta.state) {
-    return Boolean(meta.state.mustPlayFromBaulk);
+    return Boolean(meta.state.ballInHand);
   }
   return false;
 }
@@ -20088,7 +20088,7 @@ const powerRef = useRef(hud.power);
           } else if (meta.variant === '9ball' && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
           } else if (meta.variant === 'uk' && meta.state) {
-            placedFromHand = Boolean(meta.state.mustPlayFromBaulk);
+            placedFromHand = Boolean(meta.state.ballInHand);
           }
         }
         shotContextRef.current = {
@@ -21608,7 +21608,7 @@ const powerRef = useRef(hud.power);
             ballOn: ballOnColour,
             isOpenTable: snapshot.isOpenTable,
             shotsRemaining: snapshot.shotsRemaining,
-            mustPlayFromBaulk: snapshot.mustPlayFromBaulk,
+            ballInHand: snapshot.ballInHand,
             baulkLineX: baulkLineLocal + height / 2
           };
           try {
@@ -22569,7 +22569,7 @@ const powerRef = useRef(hud.power);
               } else if (nextMeta.variant === '9ball' && nextMeta.state) {
                 nextInHand = Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === 'uk' && nextMeta.state) {
-                nextInHand = Boolean(nextMeta.state.mustPlayFromBaulk);
+                nextInHand = Boolean(nextMeta.state.ballInHand);
               }
             }
           }
@@ -26162,7 +26162,7 @@ const powerRef = useRef(hud.power);
           <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
             <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
             <span className="text-left leading-tight">
-              Drag the cue ball {['american', '9ball'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle'}
+              Drag the cue ball {['american', '9ball', 'uk'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle'}
             </span>
           </div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">


### PR DESCRIPTION
### Motivation
- Replace the UK 8‑ball “two shots”/baulk option with a proper ball‑in‑hand flow so fouls match the American/9‑ball behavior and allow the player to reposition the cue ball. 
- Provide an explicit, touch‑friendly BIH control (small hand icon + placement line) so users can press‑hold and drag the cue ball to their desired spot before shooting. 
- Tweak pocket jaw taper parameters so the pocket mouths/ jaws match the photographed top‑down profile more closely.

### Description
- Rules and engine: replace the UK state field `mustPlayFromBaulk` with `ballInHand` and update foul handling so fouls set `ballInHand: true` and grant one visit to the opponent (`lib/poolUk8Ball.js`).
- Serialization: update rule serialization/deserialization to use `ballInHand` ( `src/rules/PoolRoyaleRules.ts`).
- UI and input: add a BIH indicator with a small hand button and a short placement line, implement press‑and‑hold drag placement (hold to enable grab, move to respot, release to place) and update BIH messaging; adapt placement logic so UK variant now allows full‑table placement when BIH is active (`webapp/src/pages/Games/PoolRoyale.jsx`).
- AI and helpers: remove references to the old `mustPlayFromBaulk` gating in AI helper code and doc comments and map AI states to `ballInHand` where appropriate (`lib/poolAi.js`, `webapp/public/lib/poolAi.js`, `lib/poolUkAdvancedAi.js`).
- Tests and copy: update unit test expectation to check `ballInHand` and align snooker UI copy to mention BIH for UK (`test/poolRoyaleRules.test.ts`, `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Visuals: adjust pocket jaw constants used to generate pocket jaw geometry to better match the requested top‑down shape (taper scale, center thickness, edge factors) in `PoolRoyale.jsx`.

### Testing
- No automated test suite was executed in this rollout; changes include an updated unit test expectation in `test/poolRoyaleRules.test.ts` to match the new `ballInHand` field. 
- Manual smoke/checks were not run in this environment; please run `npm test` (or the project CI) and exercise BIH placement on mobile portrait to validate input, hand icon behavior, and pocket jaw appearance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697123b7862c8329bb06beb5da8b4fd3)