### PR TITLE
UK 8‑Ball: switch fouls to Ball‑In‑Hand, add BIH hand indicator UI, and refine pocket jaw profile

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,baulkLineY?:number}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -626,13 +626,6 @@ export function planShot (req) {
             cand.x > req.state.width - r ||
             cand.y < r ||
             cand.y > req.state.height - r
-          ) {
-            continue
-          }
-          if (
-            req.state.mustPlayFromBaulk &&
-            typeof req.state.baulkLineY === 'number' &&
-            cand.y < req.state.baulkLineY
           ) {
             continue
           }

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -27,11 +27,11 @@ export class UkPool {
       assignments: { A: null, B: null },
       currentPlayer: 'A',
       shotsRemaining: 1,
+      ballInHand: false,
       isOpenTable: true,
       lastEvent: null,
       frameOver: false,
-      winner: null,
-      mustPlayFromBaulk: false
+      winner: null
     };
   }
 
@@ -73,13 +73,6 @@ export class UkPool {
 
     const first = shot.contactOrder && shot.contactOrder[0];
     const isBreak = s.lastEvent === 'BREAK_START' || s.lastEvent === null;
-
-    const mustBaulk = s.mustPlayFromBaulk;
-    s.mustPlayFromBaulk = false;
-    if (mustBaulk && !shot.placedFromHand) {
-      foul = true;
-      reason = 'must play from baulk';
-    }
 
     // no contact
     if (!foul && !first) {
@@ -202,15 +195,16 @@ export class UkPool {
     // post-shot updates
     let nextPlayer = current;
     let shotsNext = s.shotsRemaining;
+    let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
 
     if (foul) {
       nextPlayer = opp;
-      shotsNext = 2;
+      shotsNext = 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = scratched;
+      ballInHandNext = true;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;
@@ -250,6 +244,7 @@ export class UkPool {
       s.shotsRemaining = shotsNext;
       s.lastEvent = 'SHOT_TAKEN';
     }
+    s.ballInHand = ballInHandNext;
 
     return {
       legal: !foul,

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -26,7 +26,7 @@
  * @property {'blue'|'red'|null} [ballOn]   // group of current player; null on open table
  * @property {boolean} [isOpenTable]
  * @property {number} [shotsRemaining]
- * @property {boolean} [mustPlayFromBaulk]    // cue ball must be placed behind baulk line
+ * @property {boolean} [ballInHand]           // cue ball can be placed before the shot
  * @property {number} [baulkLineX]            // x coordinate of baulk line for ball in hand
  *
  * @typedef {Object} CandidateShot

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -23,11 +23,11 @@ type UkSerializedState = {
   assignments: { A: UkColour | null; B: UkColour | null };
   currentPlayer: 'A' | 'B';
   shotsRemaining: number;
+  ballInHand: boolean;
   isOpenTable: boolean;
   lastEvent: string | null;
   frameOver: boolean;
   winner: 'A' | 'B' | null;
-  mustPlayFromBaulk: boolean;
 };
 
 type AmericanSerializedState = {
@@ -97,11 +97,11 @@ function serializeUkState(state: UkPool['state']): UkSerializedState {
     assignments: { ...state.assignments },
     currentPlayer: state.currentPlayer,
     shotsRemaining: state.shotsRemaining,
+    ballInHand: state.ballInHand,
     isOpenTable: state.isOpenTable,
     lastEvent: state.lastEvent,
     frameOver: state.frameOver,
-    winner: state.winner,
-    mustPlayFromBaulk: state.mustPlayFromBaulk
+    winner: state.winner
   };
 }
 
@@ -116,11 +116,11 @@ function applyUkState(game: UkPool, snapshot: UkSerializedState) {
     assignments: { ...snapshot.assignments },
     currentPlayer: snapshot.currentPlayer,
     shotsRemaining: snapshot.shotsRemaining,
+    ballInHand: snapshot.ballInHand,
     isOpenTable: snapshot.isOpenTable,
     lastEvent: snapshot.lastEvent,
     frameOver: snapshot.frameOver,
-    winner: snapshot.winner,
-    mustPlayFromBaulk: snapshot.mustPlayFromBaulk
+    winner: snapshot.winner
   };
 }
 

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -38,7 +38,7 @@ describe('PoolRoyaleRules', () => {
     const foulMeta = foulState.meta as any;
 
     expect(foulState.foul?.reason).toBe('scratch');
-    expect(foulMeta?.state?.mustPlayFromBaulk).toBe(true);
+    expect(foulMeta?.state?.ballInHand).toBe(true);
     expect(foulState.activePlayer).toBe('B');
     expect(foulMeta?.hud?.phase).toBe('groups');
     expect(foulState.ballOn).toContain('YELLOW');

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,baulkLineY?:number}} state
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -626,13 +626,6 @@ export function planShot (req) {
             cand.x > req.state.width - r ||
             cand.y < r ||
             cand.y > req.state.height - r
-          ) {
-            continue
-          }
-          if (
-            req.state.mustPlayFromBaulk &&
-            typeof req.state.baulkLineY === 'number' &&
-            cand.y < req.state.baulkLineY
           ) {
             continue
           }


### PR DESCRIPTION
### Motivation
- Align UK 8‑Ball behavior with American/9‑Ball by replacing the legacy "two shots" approach with a ball‑in‑hand (BIH) mechanic so fouls allow cue placement before the next shot. 
- Provide a clear, touch‑friendly UI affordance to place the cue ball (a small hand button + guide line) that supports hold‑to‑drag placement on portrait phones.
- Tweak pocket jaw geometry parameters so the rendered pocket lips match the photographic reference more closely from above.

### Description
- Rules and state: added `ballInHand` to UK game state and serialization, removed the two‑shot/baulk enforcement logic, and set `ballInHand` on fouls in the UK engine (`lib/poolUk8Ball.js`) and updated the TS rules layer to serialize/apply the new field (`src/rules/PoolRoyaleRules.ts`).
- UI / input: implemented a BIH indicator (hand button + short vertical guide line) that is positioned each frame above the cue ball and supports hold→drag to place the cue ball; hooked the indicator to existing in‑hand pointer handlers and placement logic (`webapp/src/pages/Games/PoolRoyale.jsx`).
- AI & tooling adjustments: updated AI planning and helpers to use `ballInHand` instead of `mustPlayFromBaulk` (samples and key building) across server and public AI modules (`lib/poolAi.js`, `webapp/public/lib/poolAi.js`, `lib/poolUkAdvancedAi.js`).
- Pocket visual tweak: adjusted several pocket jaw/taper constants to match the requested top‑down silhouette while preserving size/height (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tests updated: adjusted the UK rules unit test expectation to check `ballInHand` instead of the removed baulk flag (`test/poolRoyaleRules.test.ts`).

### Testing
- Started the local dev server with `npm --prefix webapp run dev` and it reported Vite ready and served the app (success). 
- Attempted an automated visual capture using Playwright to validate the BIH indicator on the running dev server, but the Playwright run timed out / crashed before a screenshot could be captured (failure). 
- No unit test suite was executed in this rollout; an existing unit test was updated to reflect the new serialized state field (`test/poolRoyaleRules.test.ts`) but was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697123b7862c8329bb06beb5da8b4fd3)