### PR TITLE
Adjust ball-in-hand indicator layout in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4917,7 +4917,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.38; // pull the orbit back while the cue ball is in-hand for a wider placement view
-const BIH_INDICATOR_LINE_PX = 22;
+const BIH_INDICATOR_LINE_PX = 32;
 const BIH_INDICATOR_HAND_SIZE_PX = 24;
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
@@ -26781,7 +26781,7 @@ const powerRef = useRef(hud.power);
           style={{
             left: 0,
             top: 0,
-            transform: 'translate(-50%, -50%)',
+            transform: 'translate(0, -50%)',
             transition: 'opacity 120ms ease'
           }}
         >
@@ -26792,7 +26792,7 @@ const powerRef = useRef(hud.power);
           <button
             type="button"
             aria-label="Move cue ball"
-            className="pointer-events-auto mx-1 flex items-center justify-center rounded-full border border-white/80 bg-white/95 text-lg shadow-[0_10px_18px_rgba(0,0,0,0.35)]"
+            className="pointer-events-auto ml-1 flex items-center justify-center rounded-full border border-white/80 bg-white/95 text-lg shadow-[0_10px_18px_rgba(0,0,0,0.35)]"
             style={{
               width: `${BIH_INDICATOR_HAND_SIZE_PX}px`,
               height: `${BIH_INDICATOR_HAND_SIZE_PX}px`
@@ -26804,10 +26804,6 @@ const powerRef = useRef(hud.power);
           >
             🖐
           </button>
-          <div
-            className="h-[2px] rounded-full bg-white/80 shadow-[0_4px_12px_rgba(255,255,255,0.45)]"
-            style={{ width: `${BIH_INDICATOR_LINE_PX}px` }}
-          />
         </div>
       )}
       {hud?.inHand && (


### PR DESCRIPTION
### Motivation
- Make the ball-in-hand (BIH) indicator match the aiming-line style so the line touches the cue ball and the hand icon sits at the other end for clearer placement feedback.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the BIH visuals were adjusted by increasing `BIH_INDICATOR_LINE_PX` from `22` to `32`, anchoring the indicator container by changing the transform from `'translate(-50%, -50%)'` to `'translate(0, -50%)'`, removing the mirrored trailing line, and shifting the hand button spacing from `mx-1` to `ml-1` so the hand sits at the line end.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` which served the app successfully, and an automated Playwright screenshot attempt timed out so no UI screenshot was captured; no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971a5fb67408329869356649cfe743c)