### PR TITLE
Set AI token colors for Snake & Ladder (Mint Vale, Royal Wave, Rose Mist)

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -101,6 +101,8 @@ const TOKEN_COLOR_OPTIONS = Object.freeze(
   }))
 );
 
+const AI_TOKEN_COLOR_IDS = Object.freeze(['mintVale', 'royalWave', 'roseMist']);
+
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
 // while keeping the total cell count at 100
@@ -168,6 +170,18 @@ function resolveTokenPalette(options, inventory, count) {
     deduped.push(option);
   });
   return shuffle(deduped).slice(0, count).map((option) => option.color);
+}
+
+function applyAiTokenColors(colors, aiCount) {
+  if (!Array.isArray(colors) || aiCount <= 0) return colors;
+  const next = [...colors];
+  AI_TOKEN_COLOR_IDS.slice(0, aiCount).forEach((id, index) => {
+    const match = TOKEN_COLOR_OPTIONS.find((option) => option.id === id);
+    if (match?.color) {
+      next[index + 1] = match.color;
+    }
+  });
+  return next;
 }
 
 const FALLBACK_SEAT_POSITIONS = [
@@ -1486,7 +1500,10 @@ export default function SnakeAndLadder() {
       );
     }
     const colors = resolveTokenPalette(TOKEN_COLOR_OPTIONS, snakeInventory, aiCount + 1);
-    setPlayerColors(colors);
+    const resolvedColors = !tableParam && aiCount > 0
+      ? applyAiTokenColors(colors, aiCount)
+      : colors;
+    setPlayerColors(resolvedColors);
 
     const storedTable = localStorage.getItem('snakeCurrentTable');
     const table = params.get("table") || storedTable || "snake-4";


### PR DESCRIPTION
### Motivation
- Ensure AI players use the requested token colors (green = Mint Vale, blue = Royal Wave, red = Rose Mist) so AI seats display consistent tokens in local single-player Snake & Ladder games.

### Description
- Added an `AI_TOKEN_COLOR_IDS` constant and `applyAiTokenColors` helper to map AI seats to `mintVale`, `royalWave`, and `roseMist` token IDs.  
- Applied the helper when resolving the token palette for local AI games (override occurs when `aiCount > 0` and no `table` param).  
- All changes were made in `webapp/src/pages/Games/SnakeAndLadder.jsx` and only affect client-side token color assignment for AI players.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready and serving the app (local and network URLs).  
- Attempted an automated Playwright screenshot of the AI game page, but the browser run timed out in this environment.  
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b3ebc52c832988e33a997996bc53)