### PR TITLE
Pin AI token colors for Snake & Ladder AI players

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -100,6 +100,7 @@ const TOKEN_COLOR_OPTIONS = Object.freeze(
     color: option.color
   }))
 );
+const AI_TOKEN_COLOR_ORDER = Object.freeze(['mintVale', 'royalWave', 'roseMist']);
 
 const PLAYERS = 4;
 // Adjusted board dimensions to show five columns
@@ -168,6 +169,14 @@ function resolveTokenPalette(options, inventory, count) {
     deduped.push(option);
   });
   return shuffle(deduped).slice(0, count).map((option) => option.color);
+}
+
+function resolveAiTokenColors(options, count) {
+  const resolved = AI_TOKEN_COLOR_ORDER.map((id) => options.find((option) => option.id === id));
+  return resolved
+    .filter(Boolean)
+    .slice(0, count)
+    .map((option) => option.color);
 }
 
 const FALLBACK_SEAT_POSITIONS = [
@@ -1486,7 +1495,17 @@ export default function SnakeAndLadder() {
       );
     }
     const colors = resolveTokenPalette(TOKEN_COLOR_OPTIONS, snakeInventory, aiCount + 1);
-    setPlayerColors(colors);
+    const isAiMode = aiCount > 0 && (!tableParam || aiParam);
+    if (isAiMode) {
+      const aiColors = resolveAiTokenColors(TOKEN_COLOR_OPTIONS, aiCount);
+      const merged = [...colors];
+      aiColors.forEach((color, index) => {
+        if (color) merged[index + 1] = color;
+      });
+      setPlayerColors(merged);
+    } else {
+      setPlayerColors(colors);
+    }
 
     const storedTable = localStorage.getItem('snakeCurrentTable');
     const table = params.get("table") || storedTable || "snake-4";


### PR DESCRIPTION
### Motivation
- Ensure AI players use a predictable set of token colors in single-player AI mode so green, blue and red AI tokens map to the requested visual tokens.

### Description
- Add `AI_TOKEN_COLOR_ORDER` constant set to `['mintVale','royalWave','roseMist']` and a `resolveAiTokenColors` helper to find color values from `TOKEN_COLOR_OPTIONS`.
- Detect AI mode (`ai` param / single-player) and merge the resolved AI colors into the token palette so AI seats (indices 1..) receive `mintVale`, `royalWave`, and `roseMist` in that order while leaving multiplayer behavior unchanged.
- Changes made in `webapp/src/pages/Games/SnakeAndLadder.jsx` where token palette initialization occurs.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and the server reported Vite ready (succeeded). 
- Ran a Playwright script to load `http://127.0.0.1:5173/games/snake?ai=3` and capture a screenshot (`artifacts/snake-ai-token-colors.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b3ebc52c832988e33a997996bc53)