### PR TITLE
Adjust Pool Royale pocket geometry and aim-line alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -601,7 +601,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to r
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.986; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.16; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.22; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.085; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
@@ -930,7 +930,7 @@ const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.008; // push the corner jaws outwa
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.46; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.02; // round the middle jaws slightly more while keeping the corner match
+const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.04; // round the middle jaws slightly more while keeping the corner match
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.84; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
@@ -945,9 +945,9 @@ const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome t
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.08; // thin the outer lips more aggressively while leaving the centre crown unchanged
 const POCKET_JAW_CENTER_TAPER_HOLD = 0.1; // start easing earlier so the mass flows gradually from the centre toward the chrome plates
 const POCKET_JAW_EDGE_TAPER_PROFILE_POWER = 1; // smooth the taper curve so thickness falls away progressively instead of dropping late
-const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = POCKET_JAW_CENTER_TAPER_HOLD; // keep the taper hold consistent so the middle jaw crown mirrors the corners
-const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = POCKET_JAW_EDGE_TAPER_SCALE; // reuse the corner taper scale so edge thickness matches exactly
-const POCKET_JAW_SIDE_EDGE_TAPER_PROFILE_POWER = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // maintain the identical taper curve across all six jaws
+const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = 0.06; // start thinning sooner on the middle jaws so they taper toward the cushions
+const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = 0.14; // slim the middle jaw edges more aggressively than the corners
+const POCKET_JAW_SIDE_EDGE_TAPER_PROFILE_POWER = 1.18; // smooth the side jaw taper so it fades gradually into the cushions
 const POCKET_JAW_CENTER_THICKNESS_MIN = 0.38; // let the inner arc sit leaner while preserving the curved silhouette across the pocket
 const POCKET_JAW_CENTER_THICKNESS_MAX = 0.7; // keep a pronounced middle section while slimming the jaw before tapering toward the edges
 const POCKET_JAW_OUTER_EXPONENT_MIN = 0.58; // controls arc falloff toward the chrome rim
@@ -960,14 +960,14 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.78; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.48; // push the middle jaw reach a touch wider so the openings read larger
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.62; // push the middle jaw reach wider so both sides open up more
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.072; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
-const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.68; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
@@ -1267,7 +1267,7 @@ const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.16; // nudge the L segments to
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER; // tighter spacing so potted balls touch on the holder rails
 const POCKET_HOLDER_REST_PULLBACK = BALL_R * 3.6; // let potted balls roll farther until they meet the leather strap
-const POCKET_HOLDER_RUN_SURFACE_LIFT = BALL_R + POCKET_GUIDE_RADIUS; // keep the ball resting on top of the center chrome holder
+const POCKET_HOLDER_RUN_SURFACE_LIFT = BALL_R * 1.18 + POCKET_GUIDE_RADIUS; // keep the ball resting on top of the center chrome holder
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
@@ -1383,7 +1383,7 @@ const CAMERA_LATERAL_CLAMP = Object.freeze({
 const POCKET_VIEW_MIN_DURATION_MS = 420;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 220;
 const POCKET_VIEW_POST_POT_HOLD_MS = 80;
-const POCKET_VIEW_MAX_HOLD_MS = 1400;
+const POCKET_VIEW_MAX_HOLD_MS = 900;
 const SPIN_STRENGTH = BALL_R * 0.034;
 const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021;
@@ -4853,6 +4853,7 @@ const AIM_LINE_MIN_Y = CUE_Y; // ensure the orbit never dips below the aiming li
 const CAMERA_AIM_LINE_MARGIN = BALL_R * 0.075; // keep extra clearance above the aim line for the tighter orbit distance
 const AIM_LINE_WIDTH = Math.max(1, BALL_R * 0.12); // compensate for the 20% smaller cue ball when rendering the guide
 const AIM_TICK_HALF_LENGTH = Math.max(0.6, BALL_R * 0.975); // keep the impact tick proportional to the cue ball
+const AIM_LINE_SURFACE_LIFT = Math.max(0.001, BALL_R * 0.02); // keep the aim line aligned to the playfield surface without z-fighting
 const AIM_DASH_SIZE = Math.max(0.45, BALL_R * 0.75);
 const AIM_GAP_SIZE = Math.max(0.45, BALL_R * 0.5);
 const AIM_LINE_OPACITY = 0.95; // restore the brighter aiming line from the morning build
@@ -23429,8 +23430,20 @@ const powerRef = useRef(hud.power);
             guideAimDir2D,
             balls
           );
-          const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-          let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
+          const aimLineY = tableSurfaceY + AIM_LINE_SURFACE_LIFT;
+          const start = new THREE.Vector3(cue.pos.x, aimLineY, cue.pos.y);
+          let end = new THREE.Vector3(impact.x, aimLineY, impact.y);
+          if (targetBall && targetDir) {
+            const contactDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
+            if (contactDir.lengthSq() > 1e-8) {
+              contactDir.normalize();
+              end = new THREE.Vector3(
+                targetBall.pos.x,
+                aimLineY,
+                targetBall.pos.y
+              ).add(contactDir.multiplyScalar(-BALL_R));
+            }
+          }
           const dir = baseAimDir.clone();
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(dir.clone().multiplyScalar(BALL_R));
@@ -23458,11 +23471,7 @@ const powerRef = useRef(hud.power);
           if (precisionArea) {
             precisionArea.visible = hasTarget;
             if (hasTarget) {
-              precisionArea.position.set(
-                end.x,
-                tableSurfaceY + 0.005,
-                end.z
-              );
+              precisionArea.position.set(end.x, tableSurfaceY + 0.005, end.z);
               precisionArea.material.color.setHex(
                 targetBall ? CHALK_ACTIVE_COLOR : CHALK_SIDE_ACTIVE_COLOR
               );
@@ -23693,7 +23702,7 @@ const powerRef = useRef(hud.power);
             }
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
-              BALL_CENTER_Y,
+              aimLineY,
               targetBall.pos.y
             );
             const distanceScale = travelScale;
@@ -23702,7 +23711,7 @@ const powerRef = useRef(hud.power);
               new THREE.Vector2(tDir.x, tDir.z)
             );
             const tEnd = targetRailPoint
-              ? new THREE.Vector3(targetRailPoint.x, BALL_CENTER_Y, targetRailPoint.y)
+              ? new THREE.Vector3(targetRailPoint.x, aimLineY, targetRailPoint.y)
               : targetStart
                   .clone()
                   .add(tDir.clone().multiplyScalar(distanceScale));
@@ -23719,7 +23728,7 @@ const powerRef = useRef(hud.power);
               new THREE.Vector2(bounceDir.x, bounceDir.z)
             );
             const bounceEnd = bounceRailPoint
-              ? new THREE.Vector3(bounceRailPoint.x, BALL_CENTER_Y, bounceRailPoint.y)
+              ? new THREE.Vector3(bounceRailPoint.x, aimLineY, bounceRailPoint.y)
               : end.clone().add(bounceDir.clone().multiplyScalar(bounceLength));
             targetGeom.setFromPoints([end, bounceEnd]);
             target.material.color.setHex(0x7ce7ff);
@@ -23768,8 +23777,20 @@ const powerRef = useRef(hud.power);
             guideAimDir2D,
             balls
           );
-          const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-          let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
+          const aimLineY = tableSurfaceY + AIM_LINE_SURFACE_LIFT;
+          const start = new THREE.Vector3(cue.pos.x, aimLineY, cue.pos.y);
+          let end = new THREE.Vector3(impact.x, aimLineY, impact.y);
+          if (targetBall && targetDir) {
+            const contactDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
+            if (contactDir.lengthSq() > 1e-8) {
+              contactDir.normalize();
+              end = new THREE.Vector3(
+                targetBall.pos.x,
+                aimLineY,
+                targetBall.pos.y
+              ).add(contactDir.multiplyScalar(-BALL_R));
+            }
+          }
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(baseDir.clone().multiplyScalar(BALL_R));
           }
@@ -23850,7 +23871,7 @@ const powerRef = useRef(hud.power);
             }
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
-              BALL_CENTER_Y,
+              aimLineY,
               targetBall.pos.y
             );
             const distanceScale = travelScale;
@@ -23859,7 +23880,7 @@ const powerRef = useRef(hud.power);
               new THREE.Vector2(tDir.x, tDir.z)
             );
             const tEnd = targetRailPoint
-              ? new THREE.Vector3(targetRailPoint.x, BALL_CENTER_Y, targetRailPoint.y)
+              ? new THREE.Vector3(targetRailPoint.x, aimLineY, targetRailPoint.y)
               : targetStart
                   .clone()
                   .add(tDir.clone().multiplyScalar(distanceScale));
@@ -23876,7 +23897,7 @@ const powerRef = useRef(hud.power);
               new THREE.Vector2(bounceDir.x, bounceDir.z)
             );
             const bounceEnd = bounceRailPoint
-              ? new THREE.Vector3(bounceRailPoint.x, BALL_CENTER_Y, bounceRailPoint.y)
+              ? new THREE.Vector3(bounceRailPoint.x, aimLineY, bounceRailPoint.y)
               : end.clone().add(bounceDir.clone().multiplyScalar(bounceLength));
             targetGeom.setFromPoints([end, bounceEnd]);
             target.material.color.setHex(0x7ce7ff);
@@ -24855,7 +24876,7 @@ const powerRef = useRef(hud.power);
               const screenY =
                 rect.top + (-TMP_VEC3_A.y * 0.5 + 0.5) * rect.height;
               inHandIndicator.style.opacity = '1';
-              inHandIndicator.style.transform = `translate(-50%, -50%) translate(${screenX}px, ${screenY}px)`;
+              inHandIndicator.style.transform = `translate(${screenX}px, ${screenY}px) translate(0, -50%)`;
             }
           }
           renderer.render(scene, frameCamera ?? camera);


### PR DESCRIPTION
### Motivation
- Match table/UX requests to widen and taper the middle pocket jaws, pull middle chrome plates subtly outward, and keep corner pocket geometry unchanged. 
- Improve aiming precision by aligning the aim guide to the playfield surface and making the aim endpoint better reflect the true contact point on a target ball. 
- Make potted balls and pocket presentation clearer (holder height) and tighten pocket camera hold / in‑hand indicator placement for smoother feedback.

### Description
- Tuned pocket jaw geometry constants for middle pockets (increase inner scale, lateral expansion, and sharper tapering) so middle jaws thin toward the cushions while leaving corner jaws untouched. 
- Increased the middle chrome plate outward shift (`CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`) so middle chrome plates sit slightly farther from the centre without altering the rounded cut. 
- Added `AIM_LINE_SURFACE_LIFT` and updated aim-line construction so start/end/tick/follow lines are placed at the playfield surface and the aim end snaps to the target contact offset (accounts for object-ball radius). 
- Raised pocket holder run surface lift (`POCKET_HOLDER_RUN_SURFACE_LIFT`) so potted balls visibly rest on the holders beneath pockets. 
- Shortened pocket-camera maximum hold (`POCKET_VIEW_MAX_HOLD_MS`) and adjusted the ball-in-hand indicator transform so the hand indicator anchors beside the cue ball on screen. 
- All changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and scoped to middle-pocket/chrome/aim UI; corner pocket constants and rule/AI logic were not modified.

### Testing
- Started the development server with `npm --prefix webapp run dev`, and Vite served the site successfully. 
- Attempted an automated visual check by launching a headless browser via Playwright to capture a screenshot, but the Chromium process crashed (SIGSEGV) so no screenshot was produced. 
- No unit or integration test suites were run for this change (`npm test` was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971bac8b634832986b69be6681c045f)