### PR TITLE
Add chess-piece tokens to Ludo Battle Royal and expose pieces in store

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -81,7 +81,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     price: 450,
     description: 'Swap the token mesh set for a new silhouette.'
   })),
-  ...TOKEN_PIECE_OPTIONS.slice(1).map((option, idx) => ({
+  ...TOKEN_PIECE_OPTIONS.map((option, idx) => ({
     id: `ludo-piece-${option.id}`,
     type: 'tokenPiece',
     optionId: option.id,


### PR DESCRIPTION
### Motivation
- Provide the same Chess Battle Royal token options used elsewhere so Ludo Battle Royal players can select/purchase chess-piece tokens and get a consistent visual scale with procedural tokens. 
- Ensure the Battle Chess style uses actual chess GLTF prototypes so AI and players share the same default appearance.

### Description
- Exposed all `TOKEN_PIECE_OPTIONS` in the Ludo store by including every option in `LUDO_BATTLE_STORE_ITEMS` (`webapp/src/config/ludoBattleInventoryConfig.js`).
- Added runtime support to load chess piece prototypes (`getAbgAssets`) and build chess-token groups, introducing `scaleTokenToHeight`, `getProceduralTokenHeight`, and `buildChessToken` helpers in `LudoBattleRoyal.jsx` to size chess models to the procedural token height.
- Switched token construction in `buildLudoBoard` to use chess piece prototypes when the `battleChess` `tokenStyle` is selected, while falling back to the procedural `makeRook` when assets are unavailable.
- Simplified `abgPreparePiece` to return prepared clones and adjusted palette application so chess pieces receive the Ludo palette and proper shadow/receive settings.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server came up successfully. 
- Navigated to `/games/ludobattleroyal` and captured a browser screenshot with Playwright to verify tokens render (Playwright run succeeded and produced `artifacts/ludo-battle-royal-tokens.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971cd599d6883298ea0349b9738ddc9)