### PR TITLE
Restore Pool Royale in-hand limits and pocket holder drops

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -17241,6 +17241,47 @@ const powerRef = useRef(hud.power);
               }
               if (meshState.visible != null) ball.mesh.visible = meshState.visible;
             }
+            if (state.active) {
+              removePocketDropEntry(ball.id);
+              return;
+            }
+            const meshVisible =
+              meshState?.visible ?? (ball.mesh ? ball.mesh.visible : false);
+            if (!meshVisible || !ball.mesh) {
+              removePocketDropEntry(ball.id);
+              return;
+            }
+            const snapshotPos =
+              normalizeVector3Snapshot(meshState?.position) ?? ball.mesh.position;
+            if (!snapshotPos) return;
+            if (!pocketDropRef.current.has(ball.id)) {
+              const now = performance.now();
+              pocketDropRef.current.set(ball.id, {
+                start: now,
+                fromY: snapshotPos.y,
+                currentY: snapshotPos.y,
+                targetY: snapshotPos.y,
+                fromX: snapshotPos.x,
+                fromZ: snapshotPos.z,
+                toX: snapshotPos.x,
+                toZ: snapshotPos.z,
+                runFromX: snapshotPos.x,
+                runFromZ: snapshotPos.z,
+                mesh: ball.mesh,
+                glowMesh: null,
+                glowTone: 'good',
+                entrySpeed: 0,
+                velocityY: 0,
+                runSpeed: POCKET_HOLDER_RUN_SPEED_MIN,
+                holderDir: new THREE.Vector3(0, 0, 1),
+                restDistance: 0,
+                settledAt: now,
+                rollStartAt: now,
+                rollProgress: 1,
+                pocketId: null,
+                resting: true
+              });
+            }
           });
         };
 
@@ -19792,7 +19833,7 @@ const powerRef = useRef(hud.power);
 
       const allowFullTableInHand = () => {
         const id = variantId();
-        if (id === 'uk') return true;
+        if (id === 'uk') return false;
         if (id === 'american' || id === '9ball') {
           return !isBreakRestrictedInHand();
         }


### PR DESCRIPTION
### Motivation
- Restore UK 8-ball behaviour and visual fidelity so the table/in-hand rules and pocket-holder potted-ball visuals match the expected morning build behaviour.
- Prevent snapshot sync from hiding potted balls that should remain visible in the pocket holders during replay or state updates.

### Description
- Limit full-table in-hand placement for the UK variant by changing `allowFullTableInHand()` to return `false` for the `'uk'` variant so cue placement remains constrained to the baulk/D area (`PoolRoyale.jsx`).
- Improve `applyBallSnapshot()` to preserve pocket-holder entries for inactive balls whose meshes remain visible by creating `pocketDropRef` entries when a snapshot shows a ball inactive but its mesh is visible, and removing pocket-drop entries when a ball is active again; this keeps potted balls visually present on the holder rails during layout syncs and replays (`PoolRoyale.jsx`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d135b3a48329bddb5ebb64ba5cb8)