### PR TITLE
Snake & Ladder: pawn-head customization, AI token shapes, and smaller 3D tokens

### DIFF
--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -52,6 +52,14 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'king', label: 'King Token' }
 ]);
 
+export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
+  { id: 'current', label: 'Current' },
+  { id: 'headRuby', label: 'Ruby' },
+  { id: 'headSapphire', label: 'Sapphire' },
+  { id: 'headChrome', label: 'Chrome' },
+  { id: 'headGold', label: 'Gold' }
+]);
+
 export const SNAKE_TOKEN_COLOR_OPTIONS = Object.freeze([
   { id: 'marble', label: 'Marble', color: '#f8fafc' },
   { id: 'darkForest', label: 'Dark Forest', color: '#14532d' },
@@ -75,6 +83,7 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   floorTexture: [SNAKE_FLOOR_TEXTURE_OPTIONS[0].id],
   wallTexture: [SNAKE_WALL_TEXTURE_OPTIONS[0].id],
+  headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
@@ -113,6 +122,7 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
     holographicPulse: 'Holographic Pulse'
   }),
   tokenColor: mapLabels(SNAKE_TOKEN_COLOR_OPTIONS),
+  headStyle: mapLabels(SNAKE_PAWN_HEAD_OPTIONS),
   tableFinish: mapLabels(SNAKE_TABLE_FINISH_OPTIONS),
   floorTexture: mapLabels(SNAKE_FLOOR_TEXTURE_OPTIONS),
   wallTexture: mapLabels(SNAKE_WALL_TEXTURE_OPTIONS),
@@ -224,6 +234,38 @@ export const SNAKE_STORE_ITEMS = [
     price: 520,
     description: 'Holographic core with shimmering pulse highlights for each token.'
   },
+  {
+    id: 'snake-head-ruby',
+    type: 'headStyle',
+    optionId: 'headRuby',
+    name: 'Ruby Pawn Heads',
+    price: 310,
+    description: 'Unlocks an additional pawn head glass preset.'
+  },
+  {
+    id: 'snake-head-sapphire',
+    type: 'headStyle',
+    optionId: 'headSapphire',
+    name: 'Sapphire Pawn Heads',
+    price: 335,
+    description: 'Unlocks an additional pawn head glass preset.'
+  },
+  {
+    id: 'snake-head-chrome',
+    type: 'headStyle',
+    optionId: 'headChrome',
+    name: 'Chrome Pawn Heads',
+    price: 360,
+    description: 'Unlocks an additional pawn head glass preset.'
+  },
+  {
+    id: 'snake-head-gold',
+    type: 'headStyle',
+    optionId: 'headGold',
+    name: 'Gold Pawn Heads',
+    price: 385,
+    description: 'Unlocks an additional pawn head glass preset.'
+  },
   ...SNAKE_TOKEN_COLOR_OPTIONS.map((option, idx) => ({
     id: `snake-token-color-${option.id}`,
     type: 'tokenColor',
@@ -304,6 +346,7 @@ export const SNAKE_DEFAULT_LOADOUT = [
   { type: 'railTheme', optionId: 'platinumOak', label: 'Platinum & Oak Rails' },
   { type: 'tokenFinish', optionId: 'ceramicSheen', label: 'Ceramic Sheen Tokens' },
   { type: 'tokenColor', optionId: 'amberGlow', label: 'Amber Glow Tokens' },
+  { type: 'headStyle', optionId: 'current', label: 'Current Pawn Heads' },
   {
     type: 'tableFinish',
     optionId: SNAKE_TABLE_FINISH_OPTIONS[0].id,

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -195,6 +195,7 @@ const SNAKE_TYPE_LABELS = {
   railTheme: 'Rails & Nets',
   tokenFinish: 'Token Finish',
   tokenColor: 'Token Colors',
+  headStyle: 'Pawn Heads',
   tokenShape: 'Token Shape',
   tableFinish: 'Table Finish',
   tables: 'Table Models',


### PR DESCRIPTION
### Motivation
- Add the same token/head customization variants used by Chess Battle Royal to Snake & Ladder so players can pick pawn head presets and token palettes. 
- Ensure AI opponents use fixed token palettes/textures (mintVale, royalWave, roseMist) and can have randomized token shapes per game while keeping their own textures independent of player swaps. 
- Reduce the visual size of in-game 3D tokens so they are ~30% smaller for a better board fit.

### Description
- Added pawn-head configuration and store metadata in `webapp/src/config/snakeInventoryConfig.js` (`SNAKE_PAWN_HEAD_OPTIONS`, defaults and store items) and exposed `headStyle` in the Snake store labels in `webapp/src/pages/Store.jsx`.
- Introduced head preset data and UI integration in `webapp/src/pages/Games/SnakeAndLadder.jsx` (`PAWN_HEAD_PRESET_OPTIONS`, added `headStyle` to `SNAKE_CUSTOMIZATION_SECTIONS`, `DEFAULT_APPEARANCE`, appearance resolution, and a preview renderer for `headStyle`).
- Implemented per-player token/head selection and AI token handling by adding `resolveAiTokenShapes`, `aiTokenShapes` state, and including `tokenShape`, `headPreset` and `headPresetId` on the `players` objects so AI tokens/tokens for each seat can be kept independent.
- Updated 3D token pipeline in `webapp/src/components/SnakeBoard3D.jsx`: reduced `TOKEN_SCALE` (from `1.7` to `1.19`), added `clamp01`, and added `makeHeadMaterial`, `collectHeadMeshes`, and `applyHeadPresetToMeshes` to apply pawn-head presets to chess piece prototypes; preserved and tracked `headPresetId` on token `userData` so applied head materials persist and do not get overridden by unrelated appearance changes.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite served the site successfully (server ready). 
- Attempted an automated Playwright page load and screenshot of `/games/snake?ai=1`, but the Playwright run timed out and did not complete (failed). 
- No unit or integration test suite was executed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d2477f308329ab15e69b7187744c)