### PR TITLE
Restore UK foul visits and in-hand placement rules

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -2,6 +2,7 @@ export const DEFAULT_RULES = {
   blackOnBreak: 're-rack',
   allowCombinations: false,
   requireCushionIfNoPot: false,
+  twoVisitsOnFoul: true,
   twoVisitsCarryOnBlack: false,
   stalemateTurns: 6
 };
@@ -201,7 +202,7 @@ export class UkPool {
 
     if (foul) {
       nextPlayer = opp;
-      shotsNext = 1;
+      shotsNext = this.rules.twoVisitsOnFoul ? 2 : 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
       ballInHandNext = true;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19792,7 +19792,7 @@ const powerRef = useRef(hud.power);
 
       const allowFullTableInHand = () => {
         const id = variantId();
-        if (id === 'uk') return true;
+        if (id === 'uk') return false;
         if (id === 'american' || id === '9ball') {
           return !isBreakRestrictedInHand();
         }
@@ -23978,6 +23978,8 @@ const powerRef = useRef(hud.power);
           if (!ball.active) {
             if (dropEntry) {
               ball.mesh.visible = true;
+              if (ball.shadow) ball.shadow.visible = false;
+            } else if (ball.mesh?.visible) {
               if (ball.shadow) ball.shadow.visible = false;
             } else {
               ball.mesh.visible = false;


### PR DESCRIPTION
### Motivation
- Restore gameplay behavior from the earlier morning build for UK 8‑ball fouls and in‑hand placement so the table and spin controller remain as before while bringing back expected UK rules and potted-ball visuals.

### Description
- Add a new default rule flag `twoVisitsOnFoul` and use it to award two visits to the incoming player on fouls in `lib/poolUk8Ball.js` by setting `shotsNext = this.rules.twoVisitsOnFoul ? 2 : 1` in `UkPool.shotTaken`.
- Limit full-table ball‑in‑hand placement for the UK variant by changing `allowFullTableInHand()` in `webapp/src/pages/Games/PoolRoyale.jsx` to return `false` when `variantId() === 'uk'` so placement is constrained to the baulk area.
- Preserve meshes for pocketed / holder-mounted balls by adjusting the visibility handling in the game loop so inactive balls that are intentionally visible (e.g., on pocket holders) remain rendered while hiding shadows only when appropriate in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d135b3a48329bddb5ebb64ba5cb8)