### PR TITLE
Air hockey: use PolyHaven marble textures; merge side cushions & hide snooker markings

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -137,6 +137,8 @@ const DEFAULT_HDRI_RESOLUTIONS = ['4k'];
 const LOCK_POOL_ROYALE_TABLE_STYLE = true;
 const PREFERRED_MARBLE_TEXTURE_SIZES = ['2k', '1k'];
 const MARBLE_TEXTURE_CACHE = new Map();
+const POLYHAVEN_TEXTURE_BASE =
+  'https://dl.polyhaven.org/file/ph-assets/Textures/jpg';
 
 const pickBestTextureUrls = (apiJson, preferredSizes = PREFERRED_MARBLE_TEXTURE_SIZES) => {
   const urls = [];
@@ -212,19 +214,44 @@ const createFallbackTexture = (color) => {
   return texture;
 };
 
+const buildPolyHavenMarbleUrls = (assetId, size) => ({
+  diffuse: `${POLYHAVEN_TEXTURE_BASE}/${size}/${assetId}/${assetId}_diff_${size}.jpg`,
+  normal: `${POLYHAVEN_TEXTURE_BASE}/${size}/${assetId}/${assetId}_nor_gl_${size}.jpg`,
+  roughness: `${POLYHAVEN_TEXTURE_BASE}/${size}/${assetId}/${assetId}_rough_${size}.jpg`
+});
+
+const resolveMarbleUrls = (assetId) => {
+  for (const size of PREFERRED_MARBLE_TEXTURE_SIZES) {
+    if (typeof size === 'string' && size.length) {
+      return buildPolyHavenMarbleUrls(assetId, size);
+    }
+  }
+  return buildPolyHavenMarbleUrls(assetId, '2k');
+};
+
 const loadMarbleTextureSet = (fieldOption) => {
   const assetId = fieldOption?.assetId;
   if (!assetId) return Promise.resolve(null);
   if (MARBLE_TEXTURE_CACHE.has(assetId)) return MARBLE_TEXTURE_CACHE.get(assetId);
   const promise = (async () => {
     try {
+      const loader = new THREE.TextureLoader();
+      loader.setCrossOrigin('anonymous');
+      const gltfUrls = resolveMarbleUrls(assetId);
+      const [gltfMap, gltfNormal, gltfRoughness] = await Promise.all([
+        loadTexture(loader, gltfUrls.diffuse, true),
+        loadTexture(loader, gltfUrls.normal, false),
+        loadTexture(loader, gltfUrls.roughness, false)
+      ]);
+      if (gltfMap) {
+        return { map: gltfMap, normal: gltfNormal, roughness: gltfRoughness };
+      }
+
       const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`);
       if (!response.ok) return null;
       const json = await response.json();
       const urls = pickBestTextureUrls(json, PREFERRED_MARBLE_TEXTURE_SIZES);
       if (!urls.diffuse) return null;
-      const loader = new THREE.TextureLoader();
-      loader.setCrossOrigin('anonymous');
       const [map, normal, roughness] = await Promise.all([
         loadTexture(loader, urls.diffuse, true),
         urls.normal ? loadTexture(loader, urls.normal, false) : Promise.resolve(null),
@@ -919,7 +946,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       null,
       selectionsRef.current.tableBase,
       renderer,
-      { enableSidePockets: false }
+      { enableSidePockets: false, mergeSideCushions: true, disableMarkings: true }
     );
     const poolTable = poolTableEntry?.group ?? new THREE.Group();
     const clothPlaneLocal =

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6370,6 +6370,8 @@ export function Table3D(
   const resolvedTableOptions =
     tableOptions && typeof tableOptions === 'object' ? tableOptions : null;
   const enableSidePockets = resolvedTableOptions?.enableSidePockets !== false;
+  const mergeSideCushions = resolvedTableOptions?.mergeSideCushions === true;
+  const disableMarkings = resolvedTableOptions?.disableMarkings === true;
   const resolveTablePocketCenters = () => {
     const centers = pocketCenters();
     return enableSidePockets ? centers : centers.slice(0, 4);
@@ -7013,68 +7015,70 @@ export function Table3D(
     clothEdgeMat.needsUpdate = true;
   }
 
-  const markingsGroup = new THREE.Group();
-  const markingMat = new THREE.MeshBasicMaterial({
-    color: palette.markings,
-    transparent: true,
-    opacity: 0.9,
-    side: THREE.DoubleSide
-  });
-  const markingHeight = clothPlaneLocal - CLOTH_DROP + MICRO_EPS * 2;
-  const lineThickness = Math.max(BALL_R * 0.08, 0.1);
-  const baulkLineLength = PLAY_W - SIDE_RAIL_INNER_THICKNESS * 0.4;
-  const baulkLineGeom = new THREE.PlaneGeometry(baulkLineLength, lineThickness);
-  const baulkLine = new THREE.Mesh(baulkLineGeom, markingMat);
-  baulkLine.rotation.x = -Math.PI / 2;
-  baulkLine.position.set(0, markingHeight, baulkLineZ);
-  markingsGroup.add(baulkLine);
+  if (!disableMarkings) {
+    const markingsGroup = new THREE.Group();
+    const markingMat = new THREE.MeshBasicMaterial({
+      color: palette.markings,
+      transparent: true,
+      opacity: 0.9,
+      side: THREE.DoubleSide
+    });
+    const markingHeight = clothPlaneLocal - CLOTH_DROP + MICRO_EPS * 2;
+    const lineThickness = Math.max(BALL_R * 0.08, 0.1);
+    const baulkLineLength = PLAY_W - SIDE_RAIL_INNER_THICKNESS * 0.4;
+    const baulkLineGeom = new THREE.PlaneGeometry(baulkLineLength, lineThickness);
+    const baulkLine = new THREE.Mesh(baulkLineGeom, markingMat);
+    baulkLine.rotation.x = -Math.PI / 2;
+    baulkLine.position.set(0, markingHeight, baulkLineZ);
+    markingsGroup.add(baulkLine);
 
-  const dRadius = D_RADIUS;
-  const dThickness = Math.max(lineThickness * 0.75, BALL_R * 0.07);
-  const dGeom = new THREE.RingGeometry(
-    Math.max(0.001, dRadius - dThickness),
-    dRadius,
-    64,
-    1,
-    0,
-    Math.PI
-  );
-  const dArc = new THREE.Mesh(dGeom, markingMat.clone());
-  dArc.rotation.x = -Math.PI / 2;
-  dArc.position.set(0, markingHeight, baulkLineZ);
-  markingsGroup.add(dArc);
+    const dRadius = D_RADIUS;
+    const dThickness = Math.max(lineThickness * 0.75, BALL_R * 0.07);
+    const dGeom = new THREE.RingGeometry(
+      Math.max(0.001, dRadius - dThickness),
+      dRadius,
+      64,
+      1,
+      0,
+      Math.PI
+    );
+    const dArc = new THREE.Mesh(dGeom, markingMat.clone());
+    dArc.rotation.x = -Math.PI / 2;
+    dArc.position.set(0, markingHeight, baulkLineZ);
+    markingsGroup.add(dArc);
 
-  const spotRadius = BALL_R * 0.26;
-  const spotMeshes = [];
-  const addSpot = (x, z) => {
-    const spotGeo = new THREE.CircleGeometry(spotRadius, 32);
-    const spot = new THREE.Mesh(spotGeo, markingMat.clone());
-    spot.rotation.x = -Math.PI / 2;
-    spot.position.set(x, markingHeight, z);
-    markingsGroup.add(spot);
-    spotMeshes.push(spot);
-  };
-  addSpot(-D_RADIUS, baulkLineZ);
-  addSpot(0, baulkLineZ);
-  addSpot(D_RADIUS, baulkLineZ);
-  addSpot(0, 0);
-  const topCushionZ = PLAY_H / 2;
-  addSpot(0, (topCushionZ + 0) / 2);
-  addSpot(0, topCushionZ - BLACK_FROM_TOP);
-  markingsGroup.traverse((child) => {
-    if (child.isMesh) {
-      child.renderOrder = cloth.renderOrder + 1;
-      child.castShadow = false;
-      child.receiveShadow = false;
-    }
-  });
-  table.add(markingsGroup);
-  table.userData.markings = {
-    group: markingsGroup,
-    baulkLine,
-    dArc,
-    spots: spotMeshes
-  };
+    const spotRadius = BALL_R * 0.26;
+    const spotMeshes = [];
+    const addSpot = (x, z) => {
+      const spotGeo = new THREE.CircleGeometry(spotRadius, 32);
+      const spot = new THREE.Mesh(spotGeo, markingMat.clone());
+      spot.rotation.x = -Math.PI / 2;
+      spot.position.set(x, markingHeight, z);
+      markingsGroup.add(spot);
+      spotMeshes.push(spot);
+    };
+    addSpot(-D_RADIUS, baulkLineZ);
+    addSpot(0, baulkLineZ);
+    addSpot(D_RADIUS, baulkLineZ);
+    addSpot(0, 0);
+    const topCushionZ = PLAY_H / 2;
+    addSpot(0, (topCushionZ + 0) / 2);
+    addSpot(0, topCushionZ - BLACK_FROM_TOP);
+    markingsGroup.traverse((child) => {
+      if (child.isMesh) {
+        child.renderOrder = cloth.renderOrder + 1;
+        child.castShadow = false;
+        child.receiveShadow = false;
+      }
+    });
+    table.add(markingsGroup);
+    table.userData.markings = {
+      group: markingsGroup,
+      baulkLine,
+      dArc,
+      spots: spotMeshes
+    };
+  }
   const pocketGeo = new THREE.CylinderGeometry(
     POCKET_TOP_R,
     POCKET_BOTTOM_R,
@@ -9380,7 +9384,7 @@ export function Table3D(
     const rightDistanceToSidePocket = Math.abs(worldZRight);
     const leftCloserToCenter = leftDistanceToSidePocket < rightDistanceToSidePocket;
     const side = horizontal ? (z >= 0 ? 1 : -1) : x >= 0 ? 1 : -1;
-    const sidePocketCuts = !horizontal
+    const sidePocketCuts = !horizontal && enableSidePockets && !mergeSideCushions
       ? {
           leftCutAngle: leftCloserToCenter
             ? CUSHION_CUT_ANGLE
@@ -9465,10 +9469,19 @@ export function Table3D(
   addCushion(0, bottomZ, horizontalCushionLength, true, false);
   addCushion(0, topZ, horizontalCushionLength, true, true);
 
-  addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
-  addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  if (mergeSideCushions) {
+    const sideCushionLength = Math.max(
+      MICRO_EPS,
+      (cornerIntersectionZ - SHORT_RAIL_CUSHION_LENGTH_TRIM) * 2
+    );
+    addCushion(leftX, 0, sideCushionLength, false, false);
+    addCushion(rightX, 0, sideCushionLength, false, true);
+  } else {
+    addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
+    addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  }
 
   const frameOuterX = outerHalfW;
   const frameOuterZ = outerHalfH;


### PR DESCRIPTION
### Motivation
- Replace procedural marble look with real marble scans for air hockey surfaces and keep Pool Royale unaffected by default.  
- Remove full snooker markings for the air hockey variant and keep only the central line + circle visual intent.  
- Connect the middle side cushions into a single piece for air hockey while preserving corner geometry.

### Description
- Updated `webapp/src/components/AirHockey3D.jsx` to prefer direct PolyHaven JPG texture URLs (helpers `buildPolyHavenMarbleUrls` / `resolveMarbleUrls`) and fall back to the PolyHaven API via `pickBestTextureUrls`; textures are cached in `MARBLE_TEXTURE_CACHE`.  
- Fixed local variable shadowing in the marble loader and ensured color/normal/roughness textures load correctly.  
- Pass table options from Air Hockey into the shared table builder: `PoolRoyaleTable3D(..., { enableSidePockets: false, mergeSideCushions: true, disableMarkings: true })` so air hockey can request merged side cushions and disabled snooker markings.  
- Extended `Table3D` in `webapp/src/pages/Games/PoolRoyale.jsx` to accept `tableOptions.mergeSideCushions` and `tableOptions.disableMarkings`, gating marking creation and altering side-cushion construction to build a single center side cushion when `mergeSideCushions` is true, preserving corner angles and default pool behavior when options are not provided.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (server start succeeded).  
- Attempted an automated Playwright screenshot of `/games/airhockey`; initial script errors were fixed and a later screenshot attempt timed out (screenshot capture failed).  
- Fixed a build-time duplicate identifier reported by the bundler (esbuild/Babel) and re-ran the dev server; the server relaunch succeeded and the code compiles for development, no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e0af50188329b206c55701386146)