### PR TITLE
Air hockey: use glTF marble textures, remove snooker markings, merge side cushions

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -384,126 +384,155 @@ const AIR_HOCKEY_TABLE_BASES = Object.freeze([
   })
 ]);
 
+const buildMarbleTextureUrls = (assetId, size = '2k') => {
+  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}`;
+  return {
+    diffuse: `${base}_diff_${size}.jpg`,
+    normal: `${base}_nor_gl_${size}.jpg`,
+    roughness: `${base}_rough_${size}.jpg`
+  };
+};
+
 const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
   Object.freeze({
     id: 'carraraClassic',
     name: 'Carrara Classic',
     assetId: 'marble_01',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_01'),
     swatches: ['#f5f5f4', '#e7e5e4'],
     repeat: 1.1,
     lineColor: '#f8fafc',
     roughness: 0.22,
     clearcoat: 0.32,
     clearcoatRoughness: 0.2,
-    description: 'Open-source Carrara marble texture sourced from Poly Haven.'
+    description: 'glTF-ready Carrara marble textures sourced from Poly Haven (CC0).'
   }),
   Object.freeze({
     id: 'silverVein',
     name: 'Silver Vein',
     assetId: 'marble_02',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_02'),
     swatches: ['#e2e8f0', '#cbd5f5'],
     repeat: 1.1,
     lineColor: '#f8fafc',
     roughness: 0.24,
     clearcoat: 0.3,
     clearcoatRoughness: 0.22,
-    description: 'Cool silver marble texture with soft veining from Poly Haven.'
+    description: 'glTF-ready silver marble textures with soft veining (Poly Haven CC0).'
   }),
   Object.freeze({
     id: 'ivoryMist',
     name: 'Ivory Mist',
     assetId: 'marble_03',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_03'),
     swatches: ['#fef3c7', '#fde68a'],
     repeat: 1.05,
     lineColor: '#fff7ed',
     roughness: 0.2,
     clearcoat: 0.34,
     clearcoatRoughness: 0.2,
-    description: 'Warm ivory marble texture with open-source scan detail.'
+    description: 'glTF-ready ivory marble textures with warm, creamy veining (CC0).'
   }),
   Object.freeze({
     id: 'roseQuartz',
     name: 'Rose Quartz',
     assetId: 'marble_04',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_04'),
     swatches: ['#fecdd3', '#fda4af'],
     repeat: 1.05,
     lineColor: '#fff1f2',
     roughness: 0.23,
     clearcoat: 0.34,
     clearcoatRoughness: 0.22,
-    description: 'Soft rose marble texture from Poly Haven’s open collection.'
+    description: 'glTF-ready rose marble textures from Poly Haven’s open collection.'
   }),
   Object.freeze({
     id: 'emeraldCascade',
     name: 'Emerald Cascade',
     assetId: 'marble_05',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_05'),
     swatches: ['#bbf7d0', '#4ade80'],
     repeat: 1.05,
     lineColor: '#dcfce7',
     roughness: 0.25,
     clearcoat: 0.3,
     clearcoatRoughness: 0.24,
-    description: 'Green marble texture with lively veins (Poly Haven CC0).'
+    description: 'glTF-ready green marble textures with lively veins (Poly Haven CC0).'
   }),
   Object.freeze({
     id: 'noirOnyx',
     name: 'Noir Onyx',
     assetId: 'marble_06',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_06'),
     swatches: ['#111827', '#374151'],
     repeat: 1,
     lineColor: '#e5e7eb',
     roughness: 0.28,
     clearcoat: 0.28,
     clearcoatRoughness: 0.24,
-    description: 'Deep onyx marble with bold contrast from Poly Haven.'
+    description: 'glTF-ready onyx marble textures with bold contrast (Poly Haven CC0).'
   }),
   Object.freeze({
     id: 'glacierBlue',
     name: 'Glacier Blue',
     assetId: 'marble_07',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_07'),
     swatches: ['#dbeafe', '#93c5fd'],
     repeat: 1.1,
     lineColor: '#f8fafc',
     roughness: 0.21,
     clearcoat: 0.34,
     clearcoatRoughness: 0.2,
-    description: 'Icy blue marble texture with open-source scan quality.'
+    description: 'glTF-ready icy blue marble textures with open-source scan quality.'
   }),
   Object.freeze({
     id: 'smokeSlate',
     name: 'Smoke Slate',
     assetId: 'marble_08',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_08'),
     swatches: ['#d1d5db', '#6b7280'],
     repeat: 1.1,
     lineColor: '#f3f4f6',
     roughness: 0.26,
     clearcoat: 0.28,
     clearcoatRoughness: 0.24,
-    description: 'Smoky slate marble texture from Poly Haven (CC0).'
+    description: 'glTF-ready smoky slate marble textures from Poly Haven (CC0).'
   }),
   Object.freeze({
     id: 'goldenSand',
     name: 'Golden Sand',
     assetId: 'marble_09',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_09'),
     swatches: ['#fef3c7', '#facc15'],
     repeat: 1.08,
     lineColor: '#fff7ed',
     roughness: 0.22,
     clearcoat: 0.32,
     clearcoatRoughness: 0.22,
-    description: 'Golden sand marble with warm veining (open-source).'
+    description: 'glTF-ready golden sand marble textures with warm veining (CC0).'
   }),
   Object.freeze({
     id: 'violetStorm',
     name: 'Violet Storm',
     assetId: 'marble_10',
+    textureSize: '2k',
+    textureUrls: buildMarbleTextureUrls('marble_10'),
     swatches: ['#ddd6fe', '#a78bfa'],
     repeat: 1.05,
     lineColor: '#f5f3ff',
     roughness: 0.24,
     clearcoat: 0.32,
     clearcoatRoughness: 0.22,
-    description: 'Violet marble texture with expressive veins from Poly Haven.'
+    description: 'glTF-ready violet marble textures with expressive veins (CC0).'
   })
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6370,6 +6370,7 @@ export function Table3D(
   const resolvedTableOptions =
     tableOptions && typeof tableOptions === 'object' ? tableOptions : null;
   const enableSidePockets = resolvedTableOptions?.enableSidePockets !== false;
+  const mergeSideCushions = resolvedTableOptions?.mergeSideCushions === true;
   const resolveTablePocketCenters = () => {
     const centers = pocketCenters();
     return enableSidePockets ? centers : centers.slice(0, 4);
@@ -9371,7 +9372,7 @@ export function Table3D(
     return geo;
   }
 
-  function addCushion(x, z, len, horizontal, flip = false) {
+  function addCushion(x, z, len, horizontal, flip = false, cutAnglesOverride = null) {
     const halfLen = len / 2;
     const orientationSign = flip ? -1 : 1;
     const worldZLeft = z + -halfLen * orientationSign;
@@ -9381,7 +9382,7 @@ export function Table3D(
     const leftCloserToCenter = leftDistanceToSidePocket < rightDistanceToSidePocket;
     const side = horizontal ? (z >= 0 ? 1 : -1) : x >= 0 ? 1 : -1;
     const sidePocketCuts = !horizontal
-      ? {
+      ? cutAnglesOverride || {
           leftCutAngle: leftCloserToCenter
             ? CUSHION_CUT_ANGLE
             : VISUAL_SIDE_CUSHION_CUT_ANGLE,
@@ -9389,8 +9390,8 @@ export function Table3D(
             ? VISUAL_SIDE_CUSHION_CUT_ANGLE
             : CUSHION_CUT_ANGLE
         }
-      : undefined;
-    const geo = cushionProfileAdvanced(len, horizontal, sidePocketCuts);
+      : cutAnglesOverride;
+    const geo = cushionProfileAdvanced(len, horizontal, sidePocketCuts ?? undefined);
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
     const orientationScale = horizontal ? SHORT_CUSHION_HEIGHT_SCALE : 1;
@@ -9465,10 +9466,20 @@ export function Table3D(
   addCushion(0, bottomZ, horizontalCushionLength, true, false);
   addCushion(0, topZ, horizontalCushionLength, true, true);
 
-  addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
-  addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  if (mergeSideCushions && !enableSidePockets) {
+    const mergedLength = Math.max(MICRO_EPS, verticalCushionLength * 2);
+    const mergedCuts = {
+      leftCutAngle: CUSHION_CUT_ANGLE,
+      rightCutAngle: CUSHION_CUT_ANGLE
+    };
+    addCushion(leftX, 0, mergedLength, false, false, mergedCuts);
+    addCushion(rightX, 0, mergedLength, false, true, mergedCuts);
+  } else {
+    addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
+    addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  }
 
   const frameOuterX = outerHalfW;
   const frameOuterZ = outerHalfH;


### PR DESCRIPTION
### Motivation
- Replace procedural/ambiguous marble/textures with glTF-ready texture URLs so air-hockey field visuals use proper marble maps and match exported/glTF assets.
- Remove snooker/pool marking clutter from the air hockey playfield while keeping the center line and circle for the hockey layout.
- Make side cushions join into a single continuous piece in the middle (while preserving corner angles) to match air-hockey table geometry and visual intent.

### Description
- Added `buildMarbleTextureUrls` and per-field `textureUrls`/`textureSize` entries in `webapp/src/config/airHockeyInventoryConfig.js` so `AIR_HOCKEY_MARBLE_FIELDS` reference explicit PolyHaven JPG sets.
- Updated `loadMarbleTextureSet` in `webapp/src/components/AirHockey3D.jsx` to prefer explicit `textureUrls` (or a deterministic URL builder) and to cache by a `cacheKey`, removing the previous API-walker and fallback canvas texture use.
- Hid pool/snooker markings on the air-hockey surface by toggling `poolTable.userData.markings` visibility in `AirHockey3D.jsx` while preserving the center `line` and `circle` meshes that are created for the hockey table.
- Added an opt-in `mergeSideCushions` table option propagated from `AirHockey3D` into the pool table builder, and implemented support in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `addCushion` to accept `cutAnglesOverride` and creating merged side cushions when `mergeSideCushions && !enableSidePockets` so side cushions appear as one piece without altering corner chamfers.
- Minor material handling change: when no textures are available `tableSurface.map` is left `null` and the fallback color is used on the material instead of constructing a canvas texture.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (local server listening), which confirmed the build/dev pipeline stayed functional (succeeded).
- Attempted an automated visual smoke check with Playwright to capture `/games/airhockey` but the headless screenshot timed out (failed); no visual regression image could be captured.
- No unit tests were executed as part of this change (`npm test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e0af50188329b206c55701386146)