### PR TITLE
Use glTF chess textures for Snake & Ludo tokens (preserve original materials)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -76,6 +76,8 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
 const CHESS_PIECE_URLS = [
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
@@ -3180,9 +3182,6 @@ function updateTokens(
       if (piecePrototype) {
         const piece = piecePrototype.clone(true);
         scaleChessPieceToToken(piece, TOKEN_HEIGHT * CHESS_TOKEN_HEIGHT_SCALE);
-        if (headPreset && desiredPieceType === 'pawn') {
-          applyHeadPresetToMeshes(piece, headPreset);
-        }
         piece.traverse((child) => {
           if (child.isMesh) {
             if (Array.isArray(child.material)) {
@@ -3278,16 +3277,6 @@ function updateTokens(
         headPresetId
       };
       tokensGroup.add(token);
-    }
-
-    if (
-      token.userData?.usesPrototype &&
-      headPreset &&
-      desiredPieceType === 'pawn' &&
-      token.userData?.headPresetId !== headPresetId
-    ) {
-      applyHeadPresetToMeshes(token, headPreset);
-      token.userData.headPresetId = headPresetId;
     }
 
     const mat = token.userData.coreMaterial || token.userData.material;


### PR DESCRIPTION
### Motivation
- Replace procedural token visuals with original glTF textures for Snake & Ladder and Ludo Battle Royal so tokens match the Chess Battle Royal appearance and do not use generated/procedural materials.

### Description
- SnakeBoard3D: add binary glTF fallbacks to `CHESS_PIECE_URLS` and stop overriding glTF piece head materials so loaded prototypes keep their original textures and material maps.
- SnakeBoard3D: avoid re-applying `applyHeadPresetToMeshes` to cloned glTF chess pieces to preserve authored materials when prototypes are used.
- LudoBattleRoyal: add small ABG helpers (`resolveAbgColorKey`, `resolveAbgPrototype`, `cloneAbgToken`) and load the A Beautiful Game glTF prototype set when the `tokenStyle` prefers ABG tokens.
- LudoBattleRoyal: when ABG prototypes are available, instantiate cloned glTF prototypes per player (choose white/black prototypes by seat), otherwise fall back to existing procedural/token rook creation; also disable head-preset application when using ABG prototypes to preserve original glTF textures.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported the server ready (smoke run succeeded).  
- Attempted a Playwright screenshot to validate the Ludo page, but Chromium crashed with a SIGSEGV in this environment so the screenshot step failed.  
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e41505d08329a234e8d1c4e0b12f)