### PR TITLE
Fix UK pool ball color parsing to prefer named IDs

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -179,19 +179,17 @@ function parseUkColour(value: unknown): UkColour | null {
   }
   if (typeof value !== 'string') return null;
   const lower = value.toLowerCase();
-  const numericMatch = lower.match(/ball_(\d+)/);
-  if (numericMatch) {
-    const num = Number.parseInt(numericMatch[1], 10);
-    if (num === 0) return 'cue';
-    if (num === 8) return 'black';
-    if (num >= 1 && num <= 7) return 'blue';
-    if (num >= 9 && num <= 15) return 'red';
-  }
-  if (lower.startsWith('yellow')) return 'blue';
-  if (lower.startsWith('blue')) return 'blue';
+  if (lower === 'cue' || lower === 'cue_ball') return 'cue';
+  if (lower.startsWith('yellow') || lower.startsWith('blue')) return 'blue';
   if (lower.startsWith('red')) return 'red';
   if (lower.startsWith('black')) return 'black';
-  if (lower === 'cue') return 'cue';
+  const numericMatch = lower.match(/ball_(\d+)/) ?? lower.match(/(\d+)/);
+  if (!numericMatch) return null;
+  const num = Number.parseInt(numericMatch[1], 10);
+  if (num === 0) return 'cue';
+  if (num === 8) return 'black';
+  if (num >= 1 && num <= 7) return 'blue';
+  if (num >= 9 && num <= 15) return 'red';
   return null;
 }
 


### PR DESCRIPTION
### Motivation
- Restore correct UK 8‑ball rule handling and ball‑in‑hand behavior by improving how ball IDs are interpreted in the rules engine.  

### Description
- Change `parseUkColour` in `src/rules/PoolRoyaleRules.ts` to prioritise explicit name prefixes (`cue`, `cue_ball`, `yellow`, `blue`, `red`, `black`) before attempting numeric parsing.  
- Add a more robust numeric fallback that matches `ball_<n>` or bare numbers and maps them to UK groups (`1–7` → `blue`, `9–15` → `red`, `8` → `black`, `0` → `cue`).  
- Commit updates to `src/rules/PoolRoyaleRules.ts` implementing the above logic to keep American-style numeric IDs supported while restoring named-ID behavior.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e2ff36108329a862aa0733f4af5e)