### PR TITLE
Air Hockey: remove snooker markings, use PolyHaven marble textures, merge side cushions

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -384,11 +384,19 @@ const AIR_HOCKEY_TABLE_BASES = Object.freeze([
   })
 ]);
 
+const createMarbleTextureUrls = (assetId, size = '2k') =>
+  Object.freeze({
+    diffuse: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_diff_${size}.jpg`,
+    normal: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_nor_gl_${size}.jpg`,
+    roughness: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_rough_${size}.jpg`
+  });
+
 const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
   Object.freeze({
     id: 'carraraClassic',
     name: 'Carrara Classic',
     assetId: 'marble_01',
+    textureUrls: createMarbleTextureUrls('marble_01'),
     swatches: ['#f5f5f4', '#e7e5e4'],
     repeat: 1.1,
     lineColor: '#f8fafc',
@@ -401,6 +409,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'silverVein',
     name: 'Silver Vein',
     assetId: 'marble_02',
+    textureUrls: createMarbleTextureUrls('marble_02'),
     swatches: ['#e2e8f0', '#cbd5f5'],
     repeat: 1.1,
     lineColor: '#f8fafc',
@@ -413,6 +422,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'ivoryMist',
     name: 'Ivory Mist',
     assetId: 'marble_03',
+    textureUrls: createMarbleTextureUrls('marble_03'),
     swatches: ['#fef3c7', '#fde68a'],
     repeat: 1.05,
     lineColor: '#fff7ed',
@@ -425,6 +435,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'roseQuartz',
     name: 'Rose Quartz',
     assetId: 'marble_04',
+    textureUrls: createMarbleTextureUrls('marble_04'),
     swatches: ['#fecdd3', '#fda4af'],
     repeat: 1.05,
     lineColor: '#fff1f2',
@@ -437,6 +448,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'emeraldCascade',
     name: 'Emerald Cascade',
     assetId: 'marble_05',
+    textureUrls: createMarbleTextureUrls('marble_05'),
     swatches: ['#bbf7d0', '#4ade80'],
     repeat: 1.05,
     lineColor: '#dcfce7',
@@ -449,6 +461,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'noirOnyx',
     name: 'Noir Onyx',
     assetId: 'marble_06',
+    textureUrls: createMarbleTextureUrls('marble_06'),
     swatches: ['#111827', '#374151'],
     repeat: 1,
     lineColor: '#e5e7eb',
@@ -461,6 +474,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'glacierBlue',
     name: 'Glacier Blue',
     assetId: 'marble_07',
+    textureUrls: createMarbleTextureUrls('marble_07'),
     swatches: ['#dbeafe', '#93c5fd'],
     repeat: 1.1,
     lineColor: '#f8fafc',
@@ -473,6 +487,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'smokeSlate',
     name: 'Smoke Slate',
     assetId: 'marble_08',
+    textureUrls: createMarbleTextureUrls('marble_08'),
     swatches: ['#d1d5db', '#6b7280'],
     repeat: 1.1,
     lineColor: '#f3f4f6',
@@ -485,6 +500,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'goldenSand',
     name: 'Golden Sand',
     assetId: 'marble_09',
+    textureUrls: createMarbleTextureUrls('marble_09'),
     swatches: ['#fef3c7', '#facc15'],
     repeat: 1.08,
     lineColor: '#fff7ed',
@@ -497,6 +513,7 @@ const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
     id: 'violetStorm',
     name: 'Violet Storm',
     assetId: 'marble_10',
+    textureUrls: createMarbleTextureUrls('marble_10'),
     swatches: ['#ddd6fe', '#a78bfa'],
     repeat: 1.05,
     lineColor: '#f5f3ff',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6370,6 +6370,7 @@ export function Table3D(
   const resolvedTableOptions =
     tableOptions && typeof tableOptions === 'object' ? tableOptions : null;
   const enableSidePockets = resolvedTableOptions?.enableSidePockets !== false;
+  const mergeSideCushions = resolvedTableOptions?.mergeSideCushions === true;
   const resolveTablePocketCenters = () => {
     const centers = pocketCenters();
     return enableSidePockets ? centers : centers.slice(0, 4);
@@ -9465,10 +9466,19 @@ export function Table3D(
   addCushion(0, bottomZ, horizontalCushionLength, true, false);
   addCushion(0, topZ, horizontalCushionLength, true, true);
 
-  addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
-  addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  if (!enableSidePockets && mergeSideCushions) {
+    const mergedVerticalCushionLength = Math.max(
+      MICRO_EPS,
+      2 * cornerIntersectionZ - SHORT_RAIL_CUSHION_LENGTH_TRIM * 2
+    );
+    addCushion(leftX, 0, mergedVerticalCushionLength, false, false);
+    addCushion(rightX, 0, mergedVerticalCushionLength, false, true);
+  } else {
+    addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
+    addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  }
 
   const frameOuterX = outerHalfW;
   const frameOuterZ = outerHalfH;


### PR DESCRIPTION
### Motivation
- Align the Air Hockey table visuals with the requested design: remove snooker markings except for the center line and circle. 
- Replace procedural marble look with real PolyHaven texture assets for improved realism and variety. 
- Make side cushions join into a single continuous piece for Air Hockey while retaining corner geometry.

### Description
- Added `mergeSideCushions` table option and support in `Table3D` and used it to merge vertical cushions when side pockets are disabled in Pool Royale (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Enabled `mergeSideCushions` for the Air Hockey table and removed Pool Royale snooker markings at runtime by disposing of the `table.userData.markings` group so only Air Hockey’s own midline and circle remain (`webapp/src/components/AirHockey3D.jsx`).
- Added a small helper `createMarbleTextureUrls` and attached `textureUrls` entries to marble field options so marble variants reference PolyHaven JPGs (`webapp/src/config/airHockeyInventoryConfig.js`).
- Updated `loadMarbleTextureSet` to prefer `textureUrls` when present and fall back to the PolyHaven API; added a cache key that uses `fieldOption.id`/asset id/URL to avoid duplicate loads (`webapp/src/components/AirHockey3D.jsx`).

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully (Vite ready). 
- Captured a smoke screenshot of the Air Hockey page using Playwright (Firefox) to validate the scene loads and the new table visuals; the script completed and produced `artifacts/air-hockey-updates.png`. 
- No unit tests (`npm test` / `jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e0af50188329b206c55701386146)