### PR TITLE
Tint Snake & Ladder chess-piece tokens with player colors

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3179,9 +3179,11 @@ function updateTokens(
       const piecePrototype = basePiecePrototype;
       let coreMaterial = null;
       let accentMaterial = null;
+      let pieceMaterials = null;
       if (piecePrototype) {
         const piece = piecePrototype.clone(true);
         scaleChessPieceToToken(piece, TOKEN_HEIGHT * CHESS_TOKEN_HEIGHT_SCALE);
+        pieceMaterials = [];
         piece.traverse((child) => {
           if (child.isMesh) {
             if (Array.isArray(child.material)) {
@@ -3189,6 +3191,10 @@ function updateTokens(
             } else if (child.material?.clone) {
               child.material = child.material.clone();
             }
+            const mats = Array.isArray(child.material) ? child.material : [child.material];
+            mats.forEach((mat) => {
+              if (mat?.color?.set) pieceMaterials.push(mat);
+            });
             child.castShadow = true;
             child.receiveShadow = true;
           }
@@ -3270,6 +3276,7 @@ function updateTokens(
         material: piecePrototype ? null : coreMaterial,
         coreMaterial: piecePrototype ? null : coreMaterial,
         accentMaterial: piecePrototype ? null : accentMaterial,
+        pieceMaterials,
         isSliding: false,
         shapeId: desiredShapeId,
         pieceType: desiredPieceType,
@@ -3301,6 +3308,11 @@ function updateTokens(
       accentMat.metalness = accentMetalness;
       accentMat.clearcoat = accentClearcoat;
       accentMat.clearcoatRoughness = accentClearcoatRoughness;
+    }
+    if (token.userData.pieceMaterials?.length) {
+      token.userData.pieceMaterials.forEach((mat) => {
+        if (mat?.color?.set) mat.color.copy(targetColor);
+      });
     }
 
     let emissiveHex = 0x000000;


### PR DESCRIPTION
### Motivation
- Ensure AI/player tokens that reuse Chess Battle Royal piece prototypes keep their original chess textures while adopting the correct per-player color palettes (e.g. `mintVale`, `royalWave`, `roseMist`).

### Description
- Collect cloned materials from chess piece prototypes inside `updateTokens` in `webapp/src/components/SnakeBoard3D.jsx` and store them on `token.userData.pieceMaterials` for tokens that use `piecePrototype`.
- Apply the resolved player `targetColor` to those collected prototype materials so chess-piece tokens are tinted to the player's color without stripping textures. The change preserves existing token fallback material handling for non-prototype tokens.

### Testing
- Started the local dev server with `npm --prefix webapp run dev` and Vite reported the site ready at `http://localhost:4173/` (succeeded). 
- Attempted an automated Playwright screenshot flow to visually validate AI tokens on the Snake page, but the Playwright run timed out (failed). 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fc59fa8c8329bded1d50f8a42dcf)