### PR TITLE
Align Ludo tokens with Chess GLTF assets and add Chess store items to Ludo store

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -5,6 +5,7 @@ import {
 } from './ludoBattleOptions.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
@@ -34,7 +35,9 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tokenPalette: Object.freeze(reduceLabels(TOKEN_PALETTE_OPTIONS)),
   tokenStyle: Object.freeze(reduceLabels(TOKEN_STYLE_OPTIONS)),
-  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS))
+  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS)),
+  sideColor: Object.freeze(CHESS_BATTLE_OPTION_LABELS.sideColor),
+  headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
 export const LUDO_BATTLE_STORE_ITEMS = [
@@ -88,7 +91,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     name: option.label,
     price: 300 + idx * 20,
     description: 'Unlock an alternate piece identity for your pawns.'
-  }))
+  })),
+  ...CHESS_BATTLE_STORE_ITEMS.filter((item) => ['sideColor', 'headStyle'].includes(item.type))
 ];
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -165,7 +165,9 @@ const LUDO_TYPE_LABELS = {
   environmentHdri: 'HDR Environments',
   tokenPalette: 'Token Palette',
   tokenStyle: 'Token Style',
-  tokenPiece: 'Token Piece'
+  tokenPiece: 'Token Piece',
+  sideColor: 'Piece Colors',
+  headStyle: 'Pawn Heads'
 };
 
 const MURLAN_TYPE_LABELS = {


### PR DESCRIPTION
### Motivation
- Make Ludo Battle Royal use the same GLTF chess tokens (coordinates, heights and tints) as Chess Battle Royal for parity and ensure AI players use the GLTF chess pieces with the correct textures and colors. 
- Expose the same chess piece store options (side colors / pawn heads) in the Ludo store so the Ludo store matches the Chess Battle Royal catalog.

### Description
- Adjusted GLTF token preparation so cloned Chess GLTF pieces align vertically with procedural Ludo tokens by changing `abgPreparePiece` base lift calculation (`-box.min.y` instead of adding `TOKEN_TRACK_HEIGHT`). (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Added `CHESS_TOKEN_TINTS` map and logic to tint GLTF token palettes for specific players (Mint Vale / Royal Wave / Rose Mist) and to fall back to palette when no tint is required. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Enabled GLTF (ABG) tokens to be used for AI players even when the Ludo token style does not prefer ABG, and applied palette tinting when cloning ABG prototypes; exposed a new `aiPlayerIndices` argument on `buildLudoBoard` and wired calls to pass AI player indices. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Ensured token userData `tokenColor` uses the applied tint where present so highlights/labels match the chosen GLTF/Chess palettes. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Imported Chess Battle Royal piece-related labels/items into the Ludo inventory config and added `sideColor` and `headStyle` items from Chess to the Ludo store items list. (file: `webapp/src/config/ludoBattleInventoryConfig.js`)
- Added `sideColor` and `headStyle` type labels for the store UI so Ludo store displays those categories correctly. (file: `webapp/src/pages/Store.jsx`)

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported ready on `http://localhost:4173/` . (succeeded)
- Ran an automated Playwright script that opened `http://127.0.0.1:4173/games/ludobattleroyal` with a mobile portrait viewport and captured a screenshot; the script completed and produced `artifacts/ludo-battle-royal.png`. (succeeded)
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fbf091548329937fb0ae504479c8)