### PR TITLE
Air Hockey: use table-specific finish, match marble material to Pool Royale balls, remove rails option

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -559,9 +559,6 @@ export const AIR_HOCKEY_CUSTOMIZATION = Object.freeze({
     Object.freeze({ id: 'violet', name: 'Violet', color: '#a855f7', knob: '#312e81' }),
     Object.freeze({ id: 'lime', name: 'Lime', color: '#84cc16', knob: '#1a2e05' })
   ]),
-  rails: Object.freeze([
-    Object.freeze({ id: 'woodenRails', name: 'Wooden Rails', color: '#8f6243', opacity: 1 })
-  ]),
   goals: Object.freeze([
     Object.freeze({ id: 'mintNet', name: 'Mint Net', color: '#99ffd6', emissive: '#1aaf80' }),
     Object.freeze({ id: 'crimsonNet', name: 'Crimson Net', color: '#ef4444', emissive: '#7f1d1d' }),
@@ -620,7 +617,6 @@ export const AIR_HOCKEY_STORE_ITEMS = [
   { id: 'mallet-amber', type: 'mallet', optionId: 'amber', name: 'Amber Mallets', price: 280, description: 'Amber mallets with dark wood knobs.' },
   { id: 'mallet-violet', type: 'mallet', optionId: 'violet', name: 'Violet Mallets', price: 300, description: 'Violet mallets with indigo knobs.' },
   { id: 'mallet-lime', type: 'mallet', optionId: 'lime', name: 'Lime Mallets', price: 320, description: 'Lime mallets with forest knobs.' },
-  { id: 'rails-wooden', type: 'rails', optionId: 'woodenRails', name: 'Wooden Rails', price: 0, description: 'Solid wood rails fitted inside the Pool Royale frame.' },
   { id: 'goal-crimson', type: 'goals', optionId: 'crimsonNet', name: 'Crimson Net Goals', price: 330, description: 'Crimson goal nets with deep ember glow.' },
   { id: 'goal-cobalt', type: 'goals', optionId: 'cobaltNet', name: 'Cobalt Net Goals', price: 360, description: 'Cobalt nets with electric blue emissive.' },
   { id: 'goal-amber', type: 'goals', optionId: 'amberNet', name: 'Amber Net Goals', price: 390, description: 'Amber nets with warm metallic shine.' },
@@ -664,6 +660,5 @@ export const AIR_HOCKEY_DEFAULT_LOADOUT = [
   { type: 'environmentHdri', optionId: AIR_HOCKEY_CUSTOMIZATION.environmentHdri[0].id, label: AIR_HOCKEY_CUSTOMIZATION.environmentHdri[0].name },
   { type: 'puck', optionId: AIR_HOCKEY_CUSTOMIZATION.puck[0].id, label: AIR_HOCKEY_CUSTOMIZATION.puck[0].name },
   { type: 'mallet', optionId: AIR_HOCKEY_CUSTOMIZATION.mallet[0].id, label: AIR_HOCKEY_CUSTOMIZATION.mallet[0].name },
-  { type: 'rails', optionId: AIR_HOCKEY_CUSTOMIZATION.rails[0].id, label: AIR_HOCKEY_CUSTOMIZATION.rails[0].name },
   { type: 'goals', optionId: AIR_HOCKEY_CUSTOMIZATION.goals[0].id, label: AIR_HOCKEY_CUSTOMIZATION.goals[0].name }
 ];


### PR DESCRIPTION
### Motivation
- Make Air Hockey use its own table implementation while reusing Pool Royale visual quality for marble/playfield and table wood finishes.
- Ensure marble playfield materials match the brightness/shininess of Pool Royale balls for consistent appearance.
- Remove the separate "rails" customization so `table` finish controls wooden rails and table bases.

### Description
- Removed `rails` from `AIR_HOCKEY_CUSTOMIZATION`, store items and default loadout so rails are no longer a separate user option in the customizer UI (`webapp/src/config/airHockeyInventoryConfig.js`).
- Unlocked table finish application in Air Hockey by switching `LOCK_POOL_ROYALE_TABLE_STYLE` to `false` and wiring `poolTable.userData.finish.materials` into Air Hockey materials (`materialsRef`) so table finish textures are applied to rails/base/trim (`webapp/src/components/AirHockey3D.jsx`).
- Added `POOL_BALL_MARBLE_FINISH` marble material preset and applied those physical/material settings to the Air Hockey field material when loading marble textures so the playfield has the same clearcoat/roughness/sheen/env intensity profile as Pool Royale balls (`webapp/src/components/AirHockey3D.jsx`).
- Hid the rails option in the customizer by removing the `renderOptionRow('Rails', 'rails')` entry so users control rail appearance via `Table Finish` only (`webapp/src/components/AirHockey3D.jsx`).

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app (local dev server ready). (succeeded)
- Attempted a headless UI smoke check with Playwright to capture the Air Hockey customizer, but the Playwright run timed out; no further automated tests were executed. (timed out)
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fd7d591083299dd8d5cc572034f7)