### PR TITLE
Pool Royale: ball-in-hand UI tweaks, aim-line inset, and cushion trim alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4853,6 +4853,7 @@ const AIM_LINE_MIN_Y = CUE_Y; // ensure the orbit never dips below the aiming li
 const AIM_LINE_SURFACE_OFFSET = BALL_R * 0.04; // keep the aim line grazing the cloth surface for more accurate depth reads
 const CAMERA_AIM_LINE_MARGIN = BALL_R * 0.075; // keep extra clearance above the aim line for the tighter orbit distance
 const AIM_LINE_WIDTH = Math.max(1, BALL_R * 0.12); // compensate for the 20% smaller cue ball when rendering the guide
+const AIM_LINE_EDGE_INSET = BALL_R * 0.15; // keep the guide slightly inside the cushions
 const AIM_TICK_HALF_LENGTH = Math.max(0.6, BALL_R * 0.975); // keep the impact tick proportional to the cue ball
 const AIM_DASH_SIZE = Math.max(0.45, BALL_R * 0.75);
 const AIM_GAP_SIZE = Math.max(0.45, BALL_R * 0.5);
@@ -4937,8 +4938,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.38; // pull the orbit back while the cue ball is in-hand for a wider placement view
-const BIH_INDICATOR_LINE_PX = 32;
-const BIH_INDICATOR_HAND_SIZE_PX = 24;
+const BIH_INDICATOR_HAND_SIZE_PX = 32;
 const BIH_INDICATOR_WORLD_OFFSET = BALL_R * 1.35;
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
@@ -6184,6 +6184,15 @@ function resolveRailIntersectionPoint(start, dir) {
   return start.clone().add(dir.clone().multiplyScalar(tHit));
 }
 
+function clampAimPoint(point) {
+  if (!point) return point;
+  const limitX = Math.max(0, RAIL_LIMIT_X - AIM_LINE_EDGE_INSET);
+  const limitY = Math.max(0, RAIL_LIMIT_Y - AIM_LINE_EDGE_INSET);
+  point.x = THREE.MathUtils.clamp(point.x, -limitX, limitX);
+  point.z = THREE.MathUtils.clamp(point.z, -limitY, limitY);
+  return point;
+}
+
 function Guret(parent, id, color, x, y, options = {}) {
   const pattern = options.pattern || (id === 'cue' ? 'cue' : 'solid');
   const number = options.number ?? null;
@@ -7389,9 +7398,9 @@ export function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.02; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28 + SIDE_CUSHION_POCKET_REACH_REDUCTION; // trim short-rail cushions by the same amount as side pockets
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -20109,9 +20118,13 @@ const powerRef = useRef(hud.power);
       const handleInHandDown = (e) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand)) return;
-        if (!inHandPlacementModeRef.current) return;
+        if (currentHud.turn !== 0) return;
         if (shooting) return;
         if (e.button != null && e.button !== 0) return;
+        if (!inHandPlacementModeRef.current) {
+          setInHandPlacementMode(true);
+          inHandPlacementModeRef.current = true;
+        }
         const p = project(e);
         if (!p) return;
         if (!tryUpdatePlacement(p, false)) return;
@@ -23486,6 +23499,7 @@ const powerRef = useRef(hud.power);
           const aimLineY = tableSurfaceY + AIM_LINE_SURFACE_OFFSET;
           const start = new THREE.Vector3(cue.pos.x, aimLineY, cue.pos.y);
           let end = new THREE.Vector3(impact.x, aimLineY, impact.y);
+          end = clampAimPoint(end);
           const dir = baseAimDir.clone();
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(dir.clone().multiplyScalar(BALL_R));
@@ -23826,6 +23840,7 @@ const powerRef = useRef(hud.power);
           const aimLineY = tableSurfaceY + AIM_LINE_SURFACE_OFFSET;
           const start = new THREE.Vector3(cue.pos.x, aimLineY, cue.pos.y);
           let end = new THREE.Vector3(impact.x, aimLineY, impact.y);
+          end = clampAimPoint(end);
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(baseDir.clone().multiplyScalar(BALL_R));
           }
@@ -26904,14 +26919,10 @@ const powerRef = useRef(hud.power);
             transition: 'opacity 120ms ease'
           }}
         >
-          <div
-            className="h-[2px] rounded-full bg-white/80 shadow-[0_4px_12px_rgba(255,255,255,0.45)]"
-            style={{ width: `${BIH_INDICATOR_LINE_PX}px` }}
-          />
           <button
             type="button"
             aria-label="Move cue ball"
-            className="pointer-events-auto ml-1 flex items-center justify-center rounded-full border border-white/80 bg-white/95 text-lg shadow-[0_10px_18px_rgba(0,0,0,0.35)]"
+            className="pointer-events-auto flex items-center justify-center rounded-full border border-white/80 bg-white/95 text-lg shadow-[0_10px_18px_rgba(0,0,0,0.35)]"
             style={{
               width: `${BIH_INDICATOR_HAND_SIZE_PX}px`,
               height: `${BIH_INDICATOR_HAND_SIZE_PX}px`
@@ -26923,19 +26934,6 @@ const powerRef = useRef(hud.power);
           >
             🖐
           </button>
-        </div>
-      )}
-      {hud?.inHand && (
-        <div className="pointer-events-none absolute left-1/2 top-4 z-40 flex -translate-x-1/2 flex-col items-center gap-2 px-3 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
-          <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
-            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
-            <span className="text-left leading-tight">
-              Drag the cue ball anywhere on the table
-            </span>
-          </div>
-          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
-            Hold the hand to move the cue ball
-          </span>
         </div>
       )}
       {/* Power Slider */}


### PR DESCRIPTION
### Motivation
- Make ball-in-hand placement easier and clearer by letting players start placement via table pointer and simplifying the hand indicator control.
- Prevent the aiming guide from drawing outside the playable rail area so the visual aiming line better matches table geometry.
- Keep cushion geometry consistent by removing the previously applied side-cushion pocket reach reduction and applying the same trim to short-rail cushions.

### Description
- Ball-in-hand UI: increased the hand indicator size (`BIH_INDICATOR_HAND_SIZE_PX`) and removed the decorative indicator line so the hand button is the primary control; allow starting placement from table clicks by updating `handleInHandDown` to enable `inHandPlacementMode` when a pointer down occurs and the HUD is in-hand.
- Aim-line clamping: added `AIM_LINE_EDGE_INSET` and a `clampAimPoint` helper, and applied it to both local and remote aim preview paths so the aiming end point is clamped inside `RAIL_LIMIT_X/Y` minus the inset.
- Cushion trim alignment: changed `SIDE_CUSHION_POCKET_REACH_REDUCTION` to `TABLE.THICK * 0.0` and adjusted `SHORT_RAIL_CUSHION_LENGTH_TRIM` to include the same reduction so the short-rail cushions are trimmed by the same amount as side cushions.
- Minor UI cleanup: removed the top info overlay for ball-in-hand placement (the explanatory text block) and adjusted a small layout class on the in-hand button.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev`, and Vite reported ready (local dev server up); this succeeded.
- Attempted an automated browser check (Playwright) to capture a screenshot of `/games/poolroyale`, but the headless Chromium process crashed in this environment so capture failed.
- No unit or integration test suites were executed as part of this change (no `jest`/`npm test` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720601e99483299492b41bdf0c0bdd)