### PR TITLE
Fix Ludo GLTF token alignment, AI tinting, HUD layout, and store labels

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -5,6 +5,7 @@ import {
 } from './ludoBattleOptions.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
@@ -34,7 +35,9 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tokenPalette: Object.freeze(reduceLabels(TOKEN_PALETTE_OPTIONS)),
   tokenStyle: Object.freeze(reduceLabels(TOKEN_STYLE_OPTIONS)),
-  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS))
+  tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS)),
+  sideColor: Object.freeze(CHESS_BATTLE_OPTION_LABELS.sideColor),
+  headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
 export const LUDO_BATTLE_STORE_ITEMS = [
@@ -88,7 +91,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     name: option.label,
     price: 300 + idx * 20,
     description: 'Unlock an alternate piece identity for your pawns.'
-  }))
+  })),
+  ...CHESS_BATTLE_STORE_ITEMS.filter((item) => ['sideColor', 'headStyle'].includes(item.type))
 ];
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -165,7 +165,9 @@ const LUDO_TYPE_LABELS = {
   environmentHdri: 'HDR Environments',
   tokenPalette: 'Token Palette',
   tokenStyle: 'Token Style',
-  tokenPiece: 'Token Piece'
+  tokenPiece: 'Token Piece',
+  sideColor: 'Piece Colors',
+  headStyle: 'Pawn Heads'
 };
 
 const MURLAN_TYPE_LABELS = {


### PR DESCRIPTION
### Motivation
- Ensure GLTF (chess) pieces used in Ludo visually match the procedural rook tokens (height/placement and textures) and allow AI players to use GLTF pieces with appropriate tints. 
- Update the HUD to match requested layout (config/mute/chat row top-left, commentary below it) and remove the bottom status pill and top-right avatar. 
- Reuse Chess Battle Royal store labels/items (`sideColor`, `headStyle`) in the Ludo store so available options match across games.

### Description
- Align GLTF pieces with procedural tokens by measuring the procedural rook height and scaling/centering loaded GLTF prototypes in `abgPreparePiece` via a new `measureProceduralTokenHeight` helper. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Preserve original GLTF materials instead of wholesale replacing palettes, and add `tintGltfToken` to apply a color tint for AI pieces only so original textures remain. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Enable ABG/GLTF tokens for AI players even when the player's token style does not prefer ABG by introducing an `aiPlayerIndices` argument on `buildLudoBoard` and wiring callers to pass AI indices; tint GLTF tokens for AI players and set `token.userData.tokenColor` to the applied tint when present. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Rearranged HUD: moved the config + `BottomLeftIcons` row to the top-left in a horizontal line and placed the commentary/status block beneath it, removed the bottom status pill and removed the top-right avatar block; updated `BottomLeftIcons` usage/props to present icons inline. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, component `BottomLeftIcons` already supports props)
- Imported Chess Battle Royal labels/items into the Ludo inventory and added `sideColor` and `headStyle` to the Ludo store UI type labels so the Ludo store shows the same piece-related categories. (files: `webapp/src/config/ludoBattleInventoryConfig.js`, `webapp/src/pages/Store.jsx`)

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported ready on `http://localhost:4173/`. (succeeded)
- Attempted an automated Playwright screenshot that navigates to `/games/ludobattleroyal`, but the browser tool timed out and the screenshot run did not complete. (timed out)
- No unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fbf091548329937fb0ae504479c8)