### PR TITLE
Align Snooker Royal HUD with Pool Royale portrait layout

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -11125,7 +11125,7 @@ function SnookerRoyalGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const viewButtonsOffsetPx = 32;
+  const viewButtonsOffsetPx = 38;
   const viewToggleButtonDropPx = 56 * 0.18;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
@@ -24643,7 +24643,11 @@ const powerRef = useRef(hud.power);
         : 0;
       const fallbackLeftWidth = uiScale * 120;
       const fallbackSpinWidth = uiScale * (SPIN_CONTROL_DIAMETER_PX + 64);
-      const leftInset = (leftBox?.width ?? fallbackLeftWidth) + 12;
+      const leftBoxIsLeft =
+        viewportWidth > 0 ? (leftBox?.left ?? 0) < viewportWidth * 0.5 : true;
+      const leftInset = leftBoxIsLeft
+      ? (leftBox?.width ?? fallbackLeftWidth) + 12
+      : uiScale * 24;
       const rightInset =
       (spinBox?.width ?? fallbackSpinWidth) +
       uiScale * 32 +
@@ -24655,7 +24659,9 @@ const powerRef = useRef(hud.power);
       if (viewportWidth > 0) {
       const sideMargin = 16;
       const leftCenter =
-        (leftBox ? leftBox.left + leftBox.width / 2 : leftInset / 2 + sideMargin);
+        leftBox && leftBoxIsLeft
+          ? leftBox.left + leftBox.width / 2
+          : leftInset / 2 + sideMargin;
       const spinWidth = spinBox?.width ?? fallbackSpinWidth;
       const spinLeft = spinBox?.left ?? viewportWidth - (spinWidth + sideMargin);
       const spinCenter = spinLeft + spinWidth / 2;


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal player HUD (avatars, names, scores, potted tokens) match the positioning and inset behaviour used by Pool Royale in portrait so UI elements align identically between modes.
- Slightly lower the 2D/3D view toggle stack to better match the Pool Royale placement in portrait.

### Description
- Adjusted the view toggle stack offset by changing `viewButtonsOffsetPx` from `32` to `38` to nudge the 2D/3D control group downwards.
- Reworked the portrait HUD inset calculation to match Pool Royale logic by adding `leftBoxIsLeft` detection and using a smaller left inset fallback when the left controls are not on the left side, and by computing `leftCenter` from `leftBoxIsLeft` before calculating `bottomHudOffset`.
- Applied the new inset logic in `useLayoutEffect` so `hudInsets` and `bottomHudOffset` are computed consistently with Pool Royale for portrait screens.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which launched Vite and served the app successfully.
- Attempted a Playwright UI screenshot of `/games/snookerroyale` to verify layout, but the screenshot run timed out and did not complete. 
- No unit or integration test suites were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697214a544b0832986063ff448f7009a)