### PR TITLE
Air Hockey: replace marble field textures with Poly Haven finishes and reduce puck size

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -134,8 +134,8 @@ function selectPerformanceProfile(option = null) {
 
 const DEFAULT_HDRI_RESOLUTIONS = ['4k'];
 const LOCK_POOL_ROYALE_TABLE_STYLE = false;
-const PREFERRED_MARBLE_TEXTURE_SIZES = ['2k', '1k'];
-const MARBLE_TEXTURE_CACHE = new Map();
+const PREFERRED_FIELD_TEXTURE_SIZES = ['2k', '1k'];
+const FIELD_TEXTURE_CACHE = new Map();
 const POOL_BALL_MARBLE_FINISH = Object.freeze({
   clearcoat: 1,
   clearcoatRoughness: 0.03,
@@ -147,7 +147,7 @@ const POOL_BALL_MARBLE_FINISH = Object.freeze({
   envMapIntensity: 1.05
 });
 
-const pickBestTextureUrls = (apiJson, preferredSizes = PREFERRED_MARBLE_TEXTURE_SIZES) => {
+const pickBestTextureUrls = (apiJson, preferredSizes = PREFERRED_FIELD_TEXTURE_SIZES) => {
   const urls = [];
   const walk = (value) => {
     if (!value) return;
@@ -221,12 +221,12 @@ const createFallbackTexture = (color) => {
   return texture;
 };
 
-const loadMarbleTextureSet = (fieldOption) => {
+const loadFieldTextureSet = (fieldOption) => {
   const assetId = fieldOption?.assetId;
   const textureUrls = fieldOption?.textureUrls;
   const cacheKey = fieldOption?.id || assetId || textureUrls?.diffuse;
   if (!cacheKey) return Promise.resolve(null);
-  if (MARBLE_TEXTURE_CACHE.has(cacheKey)) return MARBLE_TEXTURE_CACHE.get(cacheKey);
+  if (FIELD_TEXTURE_CACHE.has(cacheKey)) return FIELD_TEXTURE_CACHE.get(cacheKey);
   const promise = (async () => {
     try {
       let urls = textureUrls;
@@ -234,7 +234,7 @@ const loadMarbleTextureSet = (fieldOption) => {
         const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`);
         if (!response.ok) return null;
         const json = await response.json();
-        urls = pickBestTextureUrls(json, PREFERRED_MARBLE_TEXTURE_SIZES);
+        urls = pickBestTextureUrls(json, PREFERRED_FIELD_TEXTURE_SIZES);
       }
       if (!urls?.diffuse) return null;
       const loader = new THREE.TextureLoader();
@@ -246,11 +246,11 @@ const loadMarbleTextureSet = (fieldOption) => {
       ]);
       return { map, normal, roughness };
     } catch (error) {
-      console.warn('Failed to load marble texture set', error);
+      console.warn('Failed to load field texture set', error);
       return null;
     }
   })();
-  MARBLE_TEXTURE_CACHE.set(cacheKey, promise);
+  FIELD_TEXTURE_CACHE.set(cacheKey, promise);
   return promise;
 };
 
@@ -904,7 +904,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       height: MALLET_HEIGHT,
       knobHeight: MALLET_KNOB_HEIGHT
     };
-    const PUCK_RADIUS = PLAYFIELD.w * 0.0295;
+    const PUCK_RADIUS = PLAYFIELD.w * 0.0275;
     const PUCK_HEIGHT = PUCK_RADIUS * 1.05;
     const CORNER_POCKET_RADIUS = Math.max(PUCK_RADIUS * 2.3, PLAYFIELD.w * 0.055);
     const CORNER_POCKET_CAPTURE = Math.max(PUCK_RADIUS * 0.6, CORNER_POCKET_RADIUS - PUCK_RADIUS * 0.25);
@@ -1674,7 +1674,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       mat.needsUpdate = true;
     };
 
-    loadMarbleTextureSet(fieldOption).then((textures) => {
+    loadFieldTextureSet(fieldOption).then((textures) => {
       if (cancelled) return;
       applyFieldMaterial(textures);
     });
@@ -2091,7 +2091,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
                 })}
               </div>
             </div>
-            {renderOptionRow('Field Marble', 'field')}
+            {renderOptionRow('Field Finish', 'field')}
             {renderOptionRow('Cushion Cloth', 'cushionCloth')}
             {renderOptionRow('Table Finish', 'table')}
             {renderOptionRow('Table Base', 'tableBase')}

--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -384,143 +384,91 @@ const AIR_HOCKEY_TABLE_BASES = Object.freeze([
   })
 ]);
 
-const createMarbleTextureUrls = (assetId, size = '2k') =>
+const createSurfaceTextureUrls = (assetId, size = '2k') =>
   Object.freeze({
     diffuse: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_diff_${size}.jpg`,
     normal: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_nor_gl_${size}.jpg`,
     roughness: `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${size}/${assetId}/${assetId}_rough_${size}.jpg`
   });
 
-const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
+const AIR_HOCKEY_FIELD_FINISHES = Object.freeze([
   Object.freeze({
-    id: 'carraraClassic',
-    name: 'Carrara Classic',
-    assetId: 'marble_01',
-    textureUrls: createMarbleTextureUrls('marble_01'),
-    swatches: ['#f5f5f4', '#e7e5e4'],
-    repeat: 1.1,
-    lineColor: '#f8fafc',
-    roughness: 0.22,
-    clearcoat: 0.32,
-    clearcoatRoughness: 0.2,
-    description: 'Open-source Carrara marble texture sourced from Poly Haven.'
-  }),
-  Object.freeze({
-    id: 'silverVein',
-    name: 'Silver Vein',
-    assetId: 'marble_02',
-    textureUrls: createMarbleTextureUrls('marble_02'),
-    swatches: ['#e2e8f0', '#cbd5f5'],
-    repeat: 1.1,
+    id: 'marbleMosaic',
+    name: 'Marble Mosaic',
+    assetId: 'marble_mosaic_tiles',
+    textureUrls: createSurfaceTextureUrls('marble_mosaic_tiles'),
+    swatches: ['#f5f3f4', '#e7e5e4'],
+    repeat: 1.2,
     lineColor: '#f8fafc',
     roughness: 0.24,
-    clearcoat: 0.3,
-    clearcoatRoughness: 0.22,
-    description: 'Cool silver marble texture with soft veining from Poly Haven.'
-  }),
-  Object.freeze({
-    id: 'ivoryMist',
-    name: 'Ivory Mist',
-    assetId: 'marble_03',
-    textureUrls: createMarbleTextureUrls('marble_03'),
-    swatches: ['#fef3c7', '#fde68a'],
-    repeat: 1.05,
-    lineColor: '#fff7ed',
-    roughness: 0.2,
     clearcoat: 0.34,
     clearcoatRoughness: 0.2,
-    description: 'Warm ivory marble texture with open-source scan detail.'
+    description: 'Open-source marble mosaic tiles from Poly Haven (CC0).'
   }),
   Object.freeze({
-    id: 'roseQuartz',
-    name: 'Rose Quartz',
-    assetId: 'marble_04',
-    textureUrls: createMarbleTextureUrls('marble_04'),
-    swatches: ['#fecdd3', '#fda4af'],
-    repeat: 1.05,
-    lineColor: '#fff1f2',
-    roughness: 0.23,
-    clearcoat: 0.34,
-    clearcoatRoughness: 0.22,
-    description: 'Soft rose marble texture from Poly Haven’s open collection.'
-  }),
-  Object.freeze({
-    id: 'emeraldCascade',
-    name: 'Emerald Cascade',
-    assetId: 'marble_05',
-    textureUrls: createMarbleTextureUrls('marble_05'),
-    swatches: ['#bbf7d0', '#4ade80'],
-    repeat: 1.05,
-    lineColor: '#dcfce7',
-    roughness: 0.25,
-    clearcoat: 0.3,
-    clearcoatRoughness: 0.24,
-    description: 'Green marble texture with lively veins (Poly Haven CC0).'
-  }),
-  Object.freeze({
-    id: 'noirOnyx',
-    name: 'Noir Onyx',
-    assetId: 'marble_06',
-    textureUrls: createMarbleTextureUrls('marble_06'),
-    swatches: ['#111827', '#374151'],
-    repeat: 1,
-    lineColor: '#e5e7eb',
-    roughness: 0.28,
-    clearcoat: 0.28,
-    clearcoatRoughness: 0.24,
-    description: 'Deep onyx marble with bold contrast from Poly Haven.'
-  }),
-  Object.freeze({
-    id: 'glacierBlue',
-    name: 'Glacier Blue',
-    assetId: 'marble_07',
-    textureUrls: createMarbleTextureUrls('marble_07'),
-    swatches: ['#dbeafe', '#93c5fd'],
-    repeat: 1.1,
+    id: 'marbleTiles',
+    name: 'Marble Tiles',
+    assetId: 'marble_tiles',
+    textureUrls: createSurfaceTextureUrls('marble_tiles'),
+    swatches: ['#f1f5f9', '#e2e8f0'],
+    repeat: 1.15,
     lineColor: '#f8fafc',
-    roughness: 0.21,
-    clearcoat: 0.34,
-    clearcoatRoughness: 0.2,
-    description: 'Icy blue marble texture with open-source scan quality.'
-  }),
-  Object.freeze({
-    id: 'smokeSlate',
-    name: 'Smoke Slate',
-    assetId: 'marble_08',
-    textureUrls: createMarbleTextureUrls('marble_08'),
-    swatches: ['#d1d5db', '#6b7280'],
-    repeat: 1.1,
-    lineColor: '#f3f4f6',
     roughness: 0.26,
-    clearcoat: 0.28,
-    clearcoatRoughness: 0.24,
-    description: 'Smoky slate marble texture from Poly Haven (CC0).'
+    clearcoat: 0.32,
+    clearcoatRoughness: 0.2,
+    description: 'Open-source honed marble tile texture from Poly Haven (CC0).'
   }),
   Object.freeze({
-    id: 'goldenSand',
-    name: 'Golden Sand',
-    assetId: 'marble_09',
-    textureUrls: createMarbleTextureUrls('marble_09'),
-    swatches: ['#fef3c7', '#facc15'],
-    repeat: 1.08,
-    lineColor: '#fff7ed',
+    id: 'graphiteMetallic',
+    name: 'Graphite Metallic',
+    assetId: 'metal_plate_02',
+    textureUrls: createSurfaceTextureUrls('metal_plate_02'),
+    swatches: ['#1f2937', '#4b5563'],
+    repeat: 1,
+    lineColor: '#e2e8f0',
+    roughness: 0.18,
+    clearcoat: 0.48,
+    clearcoatRoughness: 0.18,
+    description: 'Dark metallic automotive paint finish inspired by CC0 metal plate textures.'
+  }),
+  Object.freeze({
+    id: 'cobaltMetallic',
+    name: 'Cobalt Metallic',
+    assetId: 'blue_metal_plate',
+    textureUrls: createSurfaceTextureUrls('blue_metal_plate'),
+    swatches: ['#1e3a8a', '#60a5fa'],
+    repeat: 1.02,
+    lineColor: '#e0f2fe',
+    roughness: 0.2,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.2,
+    description: 'Blue metallic paint finish built from CC0 Poly Haven metal textures.'
+  }),
+  Object.freeze({
+    id: 'crimsonMetallic',
+    name: 'Crimson Metallic',
+    assetId: 'rusty_painted_metal',
+    textureUrls: createSurfaceTextureUrls('rusty_painted_metal'),
+    swatches: ['#7f1d1d', '#ef4444'],
+    repeat: 1,
+    lineColor: '#fee2e2',
     roughness: 0.22,
-    clearcoat: 0.32,
+    clearcoat: 0.46,
     clearcoatRoughness: 0.22,
-    description: 'Golden sand marble with warm veining (open-source).'
+    description: 'Crimson automotive paint vibe from open-source painted metal textures.'
   }),
   Object.freeze({
-    id: 'violetStorm',
-    name: 'Violet Storm',
-    assetId: 'marble_10',
-    textureUrls: createMarbleTextureUrls('marble_10'),
-    swatches: ['#ddd6fe', '#a78bfa'],
+    id: 'pearlMetallic',
+    name: 'Pearl Metallic',
+    assetId: 'painted_metal_shutter',
+    textureUrls: createSurfaceTextureUrls('painted_metal_shutter'),
+    swatches: ['#f8fafc', '#cbd5f5'],
     repeat: 1.05,
-    lineColor: '#f5f3ff',
-    roughness: 0.24,
-    clearcoat: 0.32,
-    clearcoatRoughness: 0.22,
-    description: 'Violet marble texture with expressive veins from Poly Haven.'
+    lineColor: '#f1f5f9',
+    roughness: 0.2,
+    clearcoat: 0.5,
+    clearcoatRoughness: 0.18,
+    description: 'Bright pearlescent metallic paint feel using CC0 painted metal textures.'
   })
 ]);
 
@@ -540,7 +488,7 @@ const AIR_HOCKEY_CUSHION_CLOTH_OPTIONS = Object.freeze(
 );
 
 export const AIR_HOCKEY_CUSTOMIZATION = Object.freeze({
-  field: AIR_HOCKEY_MARBLE_FIELDS,
+  field: AIR_HOCKEY_FIELD_FINISHES,
   cushionCloth: AIR_HOCKEY_CUSHION_CLOTH_OPTIONS,
   table: AIR_HOCKEY_TABLE_FINISHES,
   tableBase: AIR_HOCKEY_TABLE_BASES,
@@ -592,11 +540,11 @@ export const AIR_HOCKEY_OPTION_LABELS = Object.freeze(
 );
 
 export const AIR_HOCKEY_STORE_ITEMS = [
-  ...AIR_HOCKEY_MARBLE_FIELDS.map((field, idx) => ({
+  ...AIR_HOCKEY_FIELD_FINISHES.map((field, idx) => ({
     id: `field-${field.id}`,
     type: 'field',
     optionId: field.id,
-    name: `${field.name} Marble`,
+    name: `${field.name} Finish`,
     price: 520 + idx * 20,
     description: field.description,
     swatches: field.swatches


### PR DESCRIPTION
### Motivation
- Replace the existing marble-only playfield visuals with higher-fidelity open-source surface textures (marble tiles + metallic/car-paint finishes) so field materials look more realistic with real texture maps. 
- Expose those new finishes in the customization/store UI as a generic `Field Finish` option instead of `Field Marble` so non-marble metallic paints are supported. 
- Slightly reduce the puck size to match the requested gameplay feel.

### Description
- Replaced marble-specific configuration with a generalized field finishes list in `webapp/src/config/airHockeyInventoryConfig.js`, adding Poly Haven texture asset references such as `marble_mosaic_tiles`, `marble_tiles`, `metal_plate_02`, `blue_metal_plate`, `rusty_painted_metal`, and `painted_metal_shutter`, and renamed helper to `createSurfaceTextureUrls` (previously marble-specific). 
- Updated customization wiring to use `AIR_HOCKEY_FIELD_FINISHES` and changed store item labels from `${field.name} Marble` to `${field.name} Finish` so items reflect the broader finish set. 
- In `webapp/src/components/AirHockey3D.jsx` renamed marble-related loading/cache symbols to field-general names (e.g. `PREFERRED_FIELD_TEXTURE_SIZES`, `FIELD_TEXTURE_CACHE`, `loadFieldTextureSet`) and updated `pickBestTextureUrls` defaults and load paths to use the new names and behavior. 
- Updated UI label from `Field Marble` to `Field Finish` and replaced all calls to `loadMarbleTextureSet` with `loadFieldTextureSet`. 
- Reduced the in-play puck radius by changing `PUCK_RADIUS` from `PLAYFIELD.w * 0.0295` to `PLAYFIELD.w * 0.0275` to make the puck slightly smaller.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697215a2eb7c83298e1b4ef00503f0d9)