### PR TITLE
Fix snooker frame sequencing, match spin controller size to Pool and nudge HUD to avoid chat button

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -255,11 +255,11 @@ export class SnookerRoyalRules {
       nextActivePlayer = state.activePlayer === 'A' ? 'B' : 'A';
       nextBreak = 0;
       if (state.phase === 'REDS_AND_COLORS') {
-        if (redsRemaining === 0) {
+        if (redsRemaining === 0 && !state.colorOnAfterRed) {
           nextPhase = 'COLORS_ORDER';
           colorOnAfterRed = false;
         } else {
-          colorOnAfterRed = false;
+          colorOnAfterRed = state.colorOnAfterRed ?? false;
         }
       }
     } else {
@@ -270,12 +270,7 @@ export class SnookerRoyalRules {
         scores[state.activePlayer] += scored;
         nextBreak = (state.currentBreak ?? 0) + scored;
         if (pottedReds.length > 0 || freeBallPotted) {
-          if (redsRemaining === 0) {
-            nextPhase = 'COLORS_ORDER';
-            colorOnAfterRed = false;
-          } else {
-            colorOnAfterRed = true;
-          }
+          colorOnAfterRed = true;
         }
       } else if (state.phase === 'REDS_AND_COLORS' && state.colorOnAfterRed) {
         const color = declaredBall ?? pottedColors[0] ?? nominatedFreeBall;

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1504,7 +1504,7 @@ const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 1.85 * 1.35 * 1.5;
 const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
-const SPIN_CONTROL_DIAMETER_PX = 138;
+const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
 const SPIN_RING_THICKNESS_PX = 14;
 const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
@@ -24626,50 +24626,53 @@ const powerRef = useRef(hud.power);
   useLayoutEffect(() => {
     const computeInsets = () => {
       if (!isPortrait) {
-      const left = uiScale * 150;
-      const right = uiScale * (SPIN_CONTROL_DIAMETER_PX + 150);
-      setHudInsets({
-        left: `${left}px`,
-        right: `${right}px`
-      });
-      setBottomHudOffset(0);
-      return;
+        const left = uiScale * 150;
+        const right = uiScale * (SPIN_CONTROL_DIAMETER_PX + 150);
+        setHudInsets({
+          left: `${left}px`,
+          right: `${right}px`
+        });
+        setBottomHudOffset(0);
+        return;
       }
       const leftBox = leftControlsRef.current?.getBoundingClientRect();
       const spinBox = spinBoxRef.current?.getBoundingClientRect();
       const viewportWidth =
-      typeof window !== 'undefined'
-        ? window.innerWidth || document.documentElement?.clientWidth || 0
-        : 0;
+        typeof window !== 'undefined'
+          ? window.innerWidth || document.documentElement?.clientWidth || 0
+          : 0;
       const fallbackLeftWidth = uiScale * 120;
       const fallbackSpinWidth = uiScale * (SPIN_CONTROL_DIAMETER_PX + 64);
       const leftBoxIsLeft =
         viewportWidth > 0 ? (leftBox?.left ?? 0) < viewportWidth * 0.5 : true;
       const leftInset = leftBoxIsLeft
-      ? (leftBox?.width ?? fallbackLeftWidth) + 12
-      : uiScale * 24;
+        ? (leftBox?.width ?? fallbackLeftWidth) + 12
+        : uiScale * 24;
       const rightInset =
-      (spinBox?.width ?? fallbackSpinWidth) +
-      uiScale * 32 +
-      12;
+        (spinBox?.width ?? fallbackSpinWidth) +
+        uiScale * 32 +
+        12;
       setHudInsets({
-      left: `${leftInset}px`,
-      right: `${rightInset}px`
+        left: `${leftInset}px`,
+        right: `${rightInset}px`
       });
       if (viewportWidth > 0) {
-      const sideMargin = 16;
-      const leftCenter =
-        leftBox && leftBoxIsLeft
-          ? leftBox.left + leftBox.width / 2
-          : leftInset / 2 + sideMargin;
-      const spinWidth = spinBox?.width ?? fallbackSpinWidth;
-      const spinLeft = spinBox?.left ?? viewportWidth - (spinWidth + sideMargin);
-      const spinCenter = spinLeft + spinWidth / 2;
-      const desiredCenter = (leftCenter + spinCenter) / 2;
-      const screenCenter = viewportWidth / 2;
-      setBottomHudOffset(desiredCenter - screenCenter - PORTRAIT_HUD_HORIZONTAL_NUDGE_PX);
+        const sideMargin = 16;
+        const leftCenter =
+          leftBox && leftBoxIsLeft
+            ? leftBox.left + leftBox.width / 2
+            : leftInset / 2 + sideMargin;
+        const spinWidth = spinBox?.width ?? fallbackSpinWidth;
+        const spinLeft = spinBox?.left ?? viewportWidth - (spinWidth + sideMargin);
+        const spinCenter = spinLeft + spinWidth / 2;
+        const desiredCenter = (leftCenter + spinCenter) / 2;
+        const screenCenter = viewportWidth / 2;
+        const chatButtonOffset = 3.15 * 16;
+        setBottomHudOffset(
+          desiredCenter - screenCenter - PORTRAIT_HUD_HORIZONTAL_NUDGE_PX + chatButtonOffset
+        );
       } else {
-      setBottomHudOffset(0);
+        setBottomHudOffset(0);
       }
     };
     computeInsets();


### PR DESCRIPTION
### Motivation
- Bring Snooker Royal frame logic closer to official snooker sequencing for last-red / colour transitions and free-ball handling so gameplay follows real-world rules.
- Make the spin controller identical in size to the Pool Royale variant for consistent UI/UX across modes.
- Prevent the bottom HUD/player frame from overlapping the chat button by shifting it right by an equivalent width.

### Description
- Adjusted snooker frame state transitions and scoring in `src/rules/SnookerRoyalRules.ts` so `COLORS_ORDER` is entered only when appropriate and `colorOnAfterRed` / free-ball scoring behave correctly during misses and pot sequences.
- Matched the spin controller diameter to Pool Royale by changing `SPIN_CONTROL_DIAMETER_PX` from `138` to `124` in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Updated the HUD inset computation in `webapp/src/pages/Games/SnookerRoyal.jsx` (`useLayoutEffect` computeInsets) to add a `chatButtonOffset` equal to the chat button width so the portrait HUD frame shifts right and clears the chat control.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported ready (Local/Network URLs), which succeeded.
- Attempted an automated Playwright UI screenshot of `/games/snookerroyale`, but the Playwright run crashed (target closed / SIGSEGV) so no screenshot was captured.
- No unit tests were executed in this rollout (`npm test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972220b89a88329b04b127099b782dc)