### PR TITLE
Align Pool Royale aiming, shot & broadcast behavior with Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1250,7 +1250,7 @@ const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 1.05; // drop deeper so potted ball
 const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall slightly above the ring/strap junction
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
-const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.1; // lift the ring so the holder assembly sits higher
+const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
 const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.26; // raise the net so the weave meets the pocket mouth
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
@@ -1259,21 +1259,21 @@ const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.
 const POCKET_GUIDE_DROP = BALL_R * 0.12;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
-const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.18; // allow the L-arms to peek past the ring without blocking the pocket mouth
+const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
 const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = -BALL_R * 0.26; // lift the chrome holder rails so the short L segments meet the ring
-const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.16; // nudge the L segments toward the leather strap
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
-const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER; // tighter spacing so potted balls touch on the holder rails
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 3.6; // let potted balls roll farther until they meet the leather strap
-const POCKET_HOLDER_RUN_SURFACE_LIFT = BALL_R * 1.12 + POCKET_GUIDE_RADIUS; // keep the ball resting on top of the center chrome holder
+const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.78; // keep the ball rest point unchanged while the chrome guides extend
+const POCKET_HOLDER_REST_DROP = BALL_R * 2.18; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
 const POCKET_MIDDLE_HOLDER_SWAY = 0.32; // add a slight diagonal so middle-pocket holders angle like the reference photos
 const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve past the felt base so it meets the pocket walls cleanly
-const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.98; // extend the short L section so it reaches the ring and guides balls like the reference trays
+const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
 const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.62; // lift the leather strap so it meets the raised holder rails
@@ -1486,7 +1486,6 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slig
 const CUE_PULL_RETURN_PUSH = 0.78; // push the cue forward to its start point more decisively after a pull
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // ensure the forward push is visible even on short strokes
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
-const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -4906,10 +4905,9 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
   const lengthDistance = (halfLength / Math.tan(halfVertical)) * TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
+const RAIL_OVERHEAD_DISTANCE_BIAS = 0.9; // pull the broadcast overhead camera closer to the table like the original framing
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
-const USE_STANDING_BROADCAST_CAMERA = true; // keep broadcast cuts aligned with the standing camera instead of side-rail rigs
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
@@ -4945,7 +4943,7 @@ const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.04; // add a touch more overhead bias while holding the rail angle
 const BACKSPIN_DIRECTION_PREVIEW = 0.68; // lerp strength that pulls the cue-ball follow line toward a draw path
-const AIM_SPIN_PREVIEW_SIDE = 0;
+const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
 const POCKET_VIEW_SMOOTH_TIME = 0.08; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
@@ -5961,12 +5959,29 @@ function resolveSwerveSettings(
   forceSwerve = false,
   liftStrength = 0
 ) {
+  const sideSpin = spin?.x ?? 0;
   const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
+  const active =
+    (forceSwerve || magnitude >= SWERVE_THRESHOLD) &&
+    Math.abs(sideSpin) >= 1e-3;
+  if (!active) {
+    return {
+      active: false,
+      sideSpin: 0,
+      magnitude,
+      intensity: 0
+    };
+  }
+  const threshold = Math.max(1 - SWERVE_THRESHOLD, 1e-6);
+  const normalized = clamp((magnitude - SWERVE_THRESHOLD) / threshold, 0, 1);
+  const liftBoost = 0.75 + Math.max(0, liftStrength) * 0.5;
+  const powerBoost = 0.7 + powerStrength * 0.85;
+  const spinBoost = 0.75 + Math.min(Math.abs(sideSpin), 1) * 0.6;
   return {
-    active: false,
-    sideSpin: 0,
+    active: true,
+    sideSpin,
     magnitude,
-    intensity: 0
+    intensity: normalized * powerBoost * spinBoost * liftBoost
   };
 }
 
@@ -5978,12 +5993,24 @@ function resolveSpinPreviewSettings(
 ) {
   const swerve = resolveSwerveSettings(spin, powerStrength, forceSwerve, liftStrength);
   if (swerve.active) return swerve;
-  const magnitude = Math.abs(spin?.x ?? 0);
+  const sideSpin = spin?.x ?? 0;
+  const magnitude = Math.abs(sideSpin);
+  if (magnitude < 1e-3) {
+    return {
+      active: false,
+      sideSpin: 0,
+      magnitude,
+      intensity: 0
+    };
+  }
+  const powerBoost = 0.55 + powerStrength * 0.35;
+  const liftBoost = 0.8 + Math.max(0, liftStrength) * 0.3;
+  const intensity = Math.min(magnitude, 1) * powerBoost * liftBoost * 0.35;
   return {
     active: false,
-    sideSpin: 0,
+    sideSpin,
     magnitude,
-    intensity: 0
+    intensity
   };
 }
 
@@ -5994,7 +6021,30 @@ function resolveSwerveAimDir(
   forceSwerve = false,
   liftStrength = 0
 ) {
-  return aimDir;
+  if (!aimDir || aimDir.lengthSq() < 1e-8) return aimDir;
+  const swerve = resolveSpinPreviewSettings(
+    spin,
+    powerStrength,
+    forceSwerve,
+    liftStrength
+  );
+  if (swerve.intensity <= 0 || Math.abs(swerve.sideSpin) < 1e-3) return aimDir;
+  const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
+  const curveBase =
+    (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
+  const powerScale = 4 + powerStrength * 6;
+  const swerveScale = 0.6 + swerve.intensity * 0.9;
+  const sideSpin = -swerve.sideSpin;
+  const adjust =
+    sideSpin *
+    swerve.intensity *
+    curveBase *
+    powerScale *
+    AIM_SPIN_PREVIEW_SIDE *
+    swerveScale;
+  const adjusted = aimDir.clone().add(perp.multiplyScalar(adjust));
+  if (adjusted.lengthSq() > 1e-8) adjusted.normalize();
+  return adjusted;
 }
 
 function buildSwerveAimLinePoints(
@@ -6010,11 +6060,59 @@ function buildSwerveAimLinePoints(
   liftStrength = 0
 ) {
   if (!points) return [start, end];
-  points.length = 2;
-  if (!points[0]) points[0] = new THREE.Vector3();
-  if (!points[1]) points[1] = new THREE.Vector3();
-  points[0].copy(start);
-  points[1].copy(end);
+  const swerve = resolveSpinPreviewSettings(
+    spin,
+    powerStrength,
+    swerveActive,
+    liftStrength
+  );
+  const sideSpin = -swerve.sideSpin;
+  const travel = start.distanceTo(end);
+  if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
+    points.length = 2;
+    if (!points[0]) points[0] = new THREE.Vector3();
+    if (!points[1]) points[1] = new THREE.Vector3();
+    points[0].copy(start);
+    points[1].copy(end);
+    return points;
+  }
+  const segments = clamp(Math.round(travel / (BALL_R * 1.6)), 6, 14);
+  const curveBase =
+    (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
+  const swerveScale = 0.6 + swerve.intensity * 0.9;
+  const curveScale =
+    curveBase *
+    (4 + powerStrength * 6.5) *
+    AIM_SPIN_PREVIEW_SIDE *
+    swerveScale;
+  const curveAmount = sideSpin * curveScale * travel;
+  controlPoint
+    .copy(start)
+    .addScaledVector(dir, travel * 0.5)
+    .addScaledVector(perp, curveAmount);
+  points.length = segments + 1;
+  const ax = start.x;
+  const ay = start.y;
+  const az = start.z;
+  const bx = controlPoint.x;
+  const by = controlPoint.y;
+  const bz = controlPoint.z;
+  const cx = end.x;
+  const cy = end.y;
+  const cz = end.z;
+  for (let i = 0; i <= segments; i += 1) {
+    const t = segments === 0 ? 0 : i / segments;
+    const omt = 1 - t;
+    const omt2 = omt * omt;
+    const t2 = t * t;
+    const point = points[i] ?? new THREE.Vector3();
+    point.set(
+      omt2 * ax + 2 * omt * t * bx + t2 * cx,
+      omt2 * ay + 2 * omt * t * by + t2 * cy,
+      omt2 * az + 2 * omt * t * bz + t2 * cz
+    );
+    points[i] = point;
+  }
   return points;
 }
 
@@ -15628,25 +15726,6 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
-          if (USE_STANDING_BROADCAST_CAMERA) {
-            const fallbackTarget =
-              focusOverride?.clone?.() ??
-              lastCameraTargetRef.current?.clone?.() ??
-              new THREE.Vector3(
-                0,
-                TABLE_Y + TABLE.THICK + BALL_R * 2.5,
-                0
-              );
-            if (fallbackTarget && Number.isFinite(minTargetY)) {
-              fallbackTarget.y = Math.max(fallbackTarget.y ?? minTargetY, minTargetY);
-            }
-            return {
-              position: camera.position.clone(),
-              target: fallbackTarget,
-              fov: STANDING_VIEW_FOV,
-              minTargetY
-            };
-          }
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
           const activeRail =
@@ -20092,13 +20171,12 @@ const powerRef = useRef(hud.power);
       const handleInHandDown = (e) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand) || currentHud.turn !== 0) return;
+        if (!inHandPlacementModeRef.current) return;
         if (shooting) return;
         if (e.button != null && e.button !== 0) return;
         const p = project(e);
         if (!p) return;
         if (!tryUpdatePlacement(p, false)) return;
-        setInHandPlacementMode(true);
-        inHandPlacementModeRef.current = true;
         inHandDrag.active = true;
         inHandDrag.pointerId = e.pointerId ?? 'mouse';
         if (e.pointerId != null && dom.setPointerCapture) {
@@ -20533,16 +20611,12 @@ const powerRef = useRef(hud.power);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = clampPower(powerRef.current, 0);
-          const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
-          if (isMaxPowerShot) {
-            powerImpactHoldRef.current = Math.max(
-              powerImpactHoldRef.current || 0,
-              performance.now() + MAX_POWER_CAMERA_HOLD_MS
-            );
-          }
+          powerImpactHoldRef.current = isMaxPowerShot
+            ? performance.now() + MAX_POWER_CAMERA_HOLD_MS
+            : 0;
           if (aiOpponentEnabled && hudRef.current?.turn === 1) {
             powerImpactHoldRef.current = Math.max(
               powerImpactHoldRef.current || 0,
@@ -20561,32 +20635,20 @@ const powerRef = useRef(hud.power);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
+          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = aimDir
             .clone()
             .multiplyScalar(speedBase * powerScale);
           const predictedCueSpeed = base.length();
-          const maxShotSpeed = speedBase * (SHOT_MIN_FACTOR + SHOT_POWER_RANGE);
-          const strokeSpeedRatio =
-            maxShotSpeed > 1e-6
-              ? THREE.MathUtils.clamp(predictedCueSpeed / maxShotSpeed, 0, 1)
-              : powerStrength;
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {
-            const frameTiming = frameTimingRef.current;
-            const frameTimeMs =
-              frameTiming && Number.isFinite(frameTiming.targetMs) && frameTiming.targetMs > 0
-                ? frameTiming.targetMs
-                : 1000 / 60;
             shotRecording = {
               longShot: replayTags.has('long'),
-              targetBallId: shotPrediction.ballId ?? null,
               startTime: performance.now(),
               startState: captureBallSnapshot(),
               frames: [],
               cuePath: [],
-              frameTimeMs,
               replayTags: Array.from(replayTags),
               zoomOnly: preferZoomReplay
             };
@@ -20651,28 +20713,140 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
-        const appliedSpin = applySpinConstraints(aimDir, true);
-        const liftAngle = resolveUserCueLift();
-        const liftStrength = normalizeCueLift(liftAngle);
-        const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-        const physicsSpin = mapSpinForPhysics(appliedSpin, {
-            cameraRight: cameraBasis?.right ?? null,
-            cameraUp: cameraBasis?.up ?? null,
-            cueForward: { x: aimDir.x, z: aimDir.y }
-          });
-          const offsetScaled = {
-            x: physicsSpin?.x ?? 0,
-            y: physicsSpin?.y ?? 0
-          };
-          const shotPayload = {
-            base: base.clone(),
-            aimDir: aimDir.clone(),
-            physicsSpin: { x: offsetScaled.x, y: offsetScaled.y },
+          let pocketViewActivated = false;
+          if (earlyPocketView && !isMaxPowerShot) {
+            const now = performance.now();
+            earlyPocketView.lastUpdate = now;
+            if (cameraRef.current) {
+              const cam = cameraRef.current;
+              earlyPocketView.smoothedPos = cam.position.clone();
+              const storedTarget = lastCameraTargetRef.current?.clone();
+              if (storedTarget) {
+                earlyPocketView.smoothedTarget = storedTarget;
+              }
+            }
+            if (actionView) {
+              earlyPocketView.resumeAction = actionView;
+              suspendedActionView = actionView;
+            } else {
+              suspendedActionView = null;
+            }
+            const holdUntil = powerImpactHoldRef.current || 0;
+            const holdActive = holdUntil > performance.now();
+            if (holdUntil > 0) {
+              const baseDelay = earlyPocketView.activationDelay ?? 0;
+              earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
+            }
+            earlyPocketView.pendingActivation = holdActive;
+            if (holdActive) {
+              queuedPocketView = earlyPocketView;
+              pocketViewActivated = true;
+            } else {
+              queuedPocketView = null;
+              updatePocketCameraState(true);
+              activeShotView = earlyPocketView;
+              pocketViewActivated = true;
+            }
+          }
+          if (!pocketViewActivated && actionView) {
+            const shouldActivateActionView =
+              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
+            const holdUntil = powerImpactHoldRef.current || 0;
+            const holdActive = holdUntil > performance.now();
+            if (shouldActivateActionView && !holdActive) {
+              suspendedActionView = null;
+              activeShotView = actionView;
+              updateCamera();
+            } else {
+              actionView.pendingActivation = true;
+              const baseDelay = actionView.activationDelay ?? null;
+              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
+              actionView.activationDelay = delayed > 0 ? delayed : null;
+              const baseTravel = actionView.activationTravel ?? 0;
+              actionView.activationTravel = Math.max(
+                baseTravel,
+                isMaxPowerShot ? BALL_R * 6 : 0
+              );
+              suspendedActionView = actionView;
+            }
+          }
+          const appliedSpin = applySpinConstraints(aimDir, true);
+          const liftAngle = resolveUserCueLift();
+          const liftStrength = normalizeCueLift(liftAngle);
+          const physicsSpin = mapSpinForPhysics(appliedSpin);
+          const ranges = spinRangeRef.current || {};
+          const powerSpinScale = 0.55 + clampedPower * 0.45;
+          const baseSide = physicsSpin.x * (ranges.side ?? 0);
+          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
+          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+          if (physicsSpin.y < 0) {
+            spinTop *= BACKSPIN_MULTIPLIER;
+          } else if (physicsSpin.y > 0) {
+            spinTop *= TOPSPIN_MULTIPLIER;
+          }
+          cue.vel.copy(base);
+          if (cue.spin) {
+            cue.spin.set(spinSide, spinTop);
+          }
+          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+          cue.spinMode =
+            spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
+          const swerveSettings = resolveSwerveSettings(
+            physicsSpin,
             clampedPower,
-            liftStrength,
-            applied: false
-          };
-          const triggerImpact = () => applyShotAtImpact(shotPayload);
+            cue.spinMode === 'swerve',
+            liftStrength
+          );
+          cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
+          cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+          resetSpinRef.current?.();
+          cueLiftRef.current.lift = 0;
+          cueLiftRef.current.startLift = 0;
+          cue.impacted = false;
+          cue.launchDir = aimDir.clone().normalize();
+          maxPowerLiftTriggered = false;
+          cue.lift = 0;
+          cue.liftVel = 0;
+          const topSpinWeight = Math.max(0, physicsSpin.y || 0);
+          if (
+            clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+            liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+            topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+          ) {
+            const powerRatio = THREE.MathUtils.clamp(
+              (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
+              0,
+              1
+            );
+            const liftRatio = THREE.MathUtils.clamp(
+              (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+              0,
+              1
+            );
+            const spinRatio = THREE.MathUtils.clamp(
+              (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+              0,
+              1
+            );
+            const jumpStrength =
+              (0.25 + 0.75 * powerRatio) *
+              (0.4 + 0.6 * liftRatio) *
+              (0.55 + 0.45 * spinRatio);
+            const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+            const physicsHeight =
+              (jumpVelocity * jumpVelocity) /
+              (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+            const jumpHeight = Math.min(
+              MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+              physicsHeight
+            );
+            cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+            cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+          }
+          playCueHit(clampedPower * 0.6);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -20716,8 +20890,9 @@ const powerRef = useRef(hud.power);
             instant: true,
             preserveLarger: true
           });
-          const startPull = Math.max(cuePullCurrentRef.current ?? 0, pull);
-          const visualPull = applyVisualPullCompensation(startPull, dir);
+          const visualPull = applyVisualPullCompensation(pull, dir);
+          cuePullCurrentRef.current = pull;
+          cuePullTargetRef.current = pull;
           const cuePerp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (cuePerp.lengthSq() > 1e-8) cuePerp.normalize();
           const { side: contactSide, vert: contactVert, hasSpin } = computeSpinOffsets(
@@ -20754,50 +20929,23 @@ const powerRef = useRef(hud.power);
             return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
-          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
-          const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const strokeBlend = Math.max(forwardBlend, strokeSpeedRatio ?? 0);
-          const followThrough = Math.min(
-            CUE_FOLLOW_THROUGH_MAX,
-            Math.max(
-              CUE_FOLLOW_THROUGH_MIN,
-              visualPull * (0.22 + 0.28 * strokeBlend)
-            )
-          );
-          const followThroughPos = buildCuePosition(-followThrough);
-          const forwardDuration = isAiStroke
-            ? AI_CUE_FORWARD_DURATION_MS
-            : THREE.MathUtils.lerp(
-                PLAYER_CUE_FORWARD_MAX_MS,
-                PLAYER_CUE_FORWARD_MIN_MS,
-                strokeBlend
-              );
-          const settleDuration = isAiStroke ? 40 : 50;
-          const returnDuration = isAiStroke ? 120 : 160;
-          const pullbackScale = isAiStroke
-            ? AI_STROKE_PULLBACK_FACTOR
-            : PLAYER_STROKE_PULLBACK_FACTOR;
-          const minPullback = Math.max(MIN_PULLBACK_GAP, visualPull * PLAYER_PULLBACK_MIN_SCALE);
-          const pullbackDistance = Math.max(visualPull * pullbackScale, minPullback);
-          const warmupPull = pullbackDistance * (isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO);
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS
-            : Math.max(PLAYER_CUE_FORWARD_MIN_MS, forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR);
-          const warmupPos = buildCuePosition(warmupPull);
-          const startPos = buildCuePosition(pullbackDistance);
-          const impactPos = buildCuePosition(0);
-          const idlePos = startPos.clone();
-          cuePullCurrentRef.current = pullbackDistance;
-          cuePullTargetRef.current = pullbackDistance;
-          cueStick.visible = true;
-          cueStick.position.copy(warmupPos);
+          const startPos = buildCuePosition(visualPull);
+          cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
+          const followThroughPull = THREE.MathUtils.clamp(
+            topSpinWeight * clampedPower * BALL_R * 0.35,
+            0,
+            BALL_R * 0.35
+          );
+          const impactPos = buildCuePosition(-followThroughPull);
+          cueStick.visible = true;
+          cueStick.position.copy(startPos);
+          const forwardDuration = isAiStroke ? AI_CUE_FORWARD_DURATION_MS : 120;
+          const settleDuration = isAiStroke ? 40 : 50;
           const startTime = performance.now();
-          const pullEndTime = startTime + pullbackDuration;
-          const impactTime = pullEndTime + forwardDuration;
+          const impactTime = startTime + forwardDuration;
           const settleTime = impactTime + settleDuration;
-          const returnTime = settleTime + returnDuration;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -20810,111 +20958,75 @@ const powerRef = useRef(hud.power);
           );
           const holdUntil = powerImpactHoldRef.current || 0;
           const holdActive = holdUntil > performance.now();
-          let pocketViewActivated = false;
-          if (earlyPocketView && !isMaxPowerShot) {
-            const now = performance.now();
-            earlyPocketView.lastUpdate = now;
-            if (cameraRef.current) {
-              const cam = cameraRef.current;
-              earlyPocketView.smoothedPos = cam.position.clone();
-              const storedTarget = lastCameraTargetRef.current?.clone();
-              if (storedTarget) {
-                earlyPocketView.smoothedTarget = storedTarget;
-              }
-            }
-            if (actionView) {
-              earlyPocketView.resumeAction = actionView;
-              suspendedActionView = actionView;
-            } else {
-              suspendedActionView = null;
-            }
-            if (holdUntil > 0) {
-              const baseDelay = earlyPocketView.activationDelay ?? 0;
-              earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
-            }
-            earlyPocketView.pendingActivation = holdActive;
-            if (holdActive) {
-              queuedPocketView = earlyPocketView;
-              pocketViewActivated = true;
-            } else {
-              queuedPocketView = null;
-              updatePocketCameraState(true);
-              activeShotView = earlyPocketView;
-              pocketViewActivated = true;
-            }
-          }
-          if (!pocketViewActivated && actionView) {
-            const shouldActivateActionView =
-              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
-            if (shouldActivateActionView && !holdActive) {
-              suspendedActionView = null;
-              activeShotView = actionView;
-              updateCamera();
-            } else {
-              actionView.pendingActivation = true;
-              const baseDelay = actionView.activationDelay ?? null;
-              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
-              actionView.activationDelay = delayed > 0 ? delayed : null;
-              const baseTravel = actionView.activationTravel ?? 0;
-              actionView.activationTravel = Math.max(
-                baseTravel,
-                isMaxPowerShot ? BALL_R * 6 : 0
+          if (holdActive) {
+            if (activeShotView?.mode === 'pocket') {
+              queuedPocketView = activeShotView;
+              queuedPocketView.pendingActivation = true;
+              queuedPocketView.activationDelay = Math.max(
+                queuedPocketView.activationDelay ?? 0,
+                holdUntil
               );
-              suspendedActionView = actionView;
+              activeShotView = null;
+              updatePocketCameraState(false);
+            } else if (queuedPocketView) {
+              queuedPocketView.pendingActivation = true;
+              queuedPocketView.activationDelay = Math.max(
+                queuedPocketView.activationDelay ?? 0,
+                holdUntil
+              );
+            }
+            if (activeShotView?.mode === 'action') {
+              suspendedActionView = activeShotView;
+              activeShotView = null;
+            }
+            if (suspendedActionView?.mode === 'action') {
+              suspendedActionView.pendingActivation = true;
+              const baseDelay = suspendedActionView.activationDelay ?? 0;
+              suspendedActionView.activationDelay = Math.max(baseDelay, holdUntil);
             }
           }
-          if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
+          if (shotRecording) {
             const strokeStartOffset = Math.max(0, startTime - (shotRecording.startTime ?? startTime));
             shotRecording.cueStroke = {
-              warmup: serializeVector3Snapshot(warmupPos),
+              warmup: serializeVector3Snapshot(startPos),
               start: serializeVector3Snapshot(startPos),
               impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(followThroughPos),
-              idle: serializeVector3Snapshot(idlePos),
+              settle: serializeVector3Snapshot(impactPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
-              pullbackDuration,
+              pullbackDuration: 0,
               forwardDuration,
               settleDuration,
-              returnDuration,
               startOffset: strokeStartOffset
             };
           }
-          if (ENABLE_CUE_STROKE_ANIMATION) {
-            cueStrokeStateRef.current = {
-              startTime,
-              pullEndTime,
-              impactTime,
-              settleTime,
-              returnTime,
-              warmupPos,
-              startPos,
-              impactPos,
-              settlePos: followThroughPos,
-              idlePos,
-              pullbackDuration,
-              forwardDuration,
-              settleDuration,
-              returnDuration,
-              holdUntilStop: false,
-              shotApplied: false,
-              onImpact: triggerImpact
-            };
-          } else {
-            triggerImpact();
-            cueStick.visible = false;
-            cueAnimating = false;
-            cuePullCurrentRef.current = 0;
-            cuePullTargetRef.current = 0;
-            if (cameraRef.current && sphRef.current) {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
-              const sph = sphRef.current;
-              sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-              updateCamera();
+          const animateStroke = (now) => {
+            if (now <= impactTime) {
+              const t = forwardDuration > 0
+                ? THREE.MathUtils.clamp((now - startTime) / forwardDuration, 0, 1)
+                : 1;
+              const eased = 1 - Math.pow(1 - t, 3);
+              cueStick.position.lerpVectors(startPos, impactPos, eased);
+            } else if (now <= settleTime) {
+              cueStick.position.copy(impactPos);
+            } else {
+              cueStick.visible = false;
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              if (cameraRef.current && sphRef.current) {
+                topViewRef.current = false;
+                topViewLockedRef.current = false;
+                setIsTopDownView(false);
+                const sph = sphRef.current;
+                sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+                updateCamera();
+              }
+              return;
             }
-          }
+            requestAnimationFrame(animateStroke);
+          };
+          requestAnimationFrame(animateStroke);
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -23310,16 +23422,7 @@ const powerRef = useRef(hud.power);
         }
         const appliedSpin = applySpinConstraints(aimDir, true);
         const liftStrength = normalizeCueLift(resolveUserCueLift());
-        const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-        const physicsSpin = mapSpinForPhysics(appliedSpin, {
-          cameraRight: cameraBasis?.right ?? null,
-          cameraUp: cameraBasis?.up ?? null,
-          cueForward: { x: aimDir.x, z: aimDir.y }
-        });
-        const aimLineSpin = {
-          x: physicsSpin.x || 0,
-          y: physicsSpin.y || 0
-        };
+        const physicsSpin = mapSpinForPhysics(appliedSpin);
         const ranges = spinRangeRef.current || {};
         const newCollisions = new Set();
         let shouldSlowAim = false;
@@ -23464,7 +23567,7 @@ const powerRef = useRef(hud.power);
           const aimDir2D = new THREE.Vector2(baseAimDir.x, baseAimDir.z);
           const guideAimDir2D = resolveSwerveAimDir(
             aimDir2D,
-            aimLineSpin,
+            physicsSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -23489,7 +23592,7 @@ const powerRef = useRef(hud.power);
             end,
             dir,
             perp,
-            aimLineSpin,
+            physicsSpin,
             powerStrength,
             swerveActive,
             liftStrength
@@ -23564,8 +23667,8 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const spinSideInfluence = 0;
-          const spinVerticalInfluence = (aimLineSpin.y || 0) * (0.68 + 0.45 * powerStrength);
+          const spinSideInfluence = (physicsSpin.x || 0) * (0.4 + 0.42 * powerStrength);
+          const spinVerticalInfluence = (physicsSpin.y || 0) * (0.68 + 0.45 * powerStrength);
           const cueFollowDirSpinAdjusted = cueFollowDir
             .clone()
             .add(perp.clone().multiplyScalar(spinSideInfluence))
@@ -23573,7 +23676,7 @@ const powerRef = useRef(hud.power);
           if (cueFollowDirSpinAdjusted.lengthSq() > 1e-8) {
             cueFollowDirSpinAdjusted.normalize();
           }
-          const backSpinWeight = Math.max(0, -(aimLineSpin.y || 0));
+          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
           if (backSpinWeight > 1e-8) {
             const drawLerp = Math.min(1, backSpinWeight * BACKSPIN_DIRECTION_PREVIEW);
             const drawDir = dir.clone().negate();
@@ -23603,7 +23706,12 @@ const powerRef = useRef(hud.power);
           } else {
             impactRing.visible = false;
           }
-          const maxPull = CUE_PULL_BASE;
+          const backInfo = calcTarget(
+            cue,
+            aimDir2D.clone().multiplyScalar(-1),
+            balls
+          );
+          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const desiredPull = computePullTargetFromPower(
             powerRef.current,
             maxPull
@@ -23782,19 +23890,10 @@ const powerRef = useRef(hud.power);
           const remoteSpin = remoteAimState?.spin ?? { x: 0, y: 0 };
           const remoteSpinMagnitude = Math.hypot(remoteSpin.x ?? 0, remoteSpin.y ?? 0);
           const remoteSwerveActive = remoteSpinMagnitude >= SWERVE_THRESHOLD;
-          const remoteCameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-          const remotePhysicsSpin = mapSpinForPhysics(remoteSpin, {
-            cameraRight: remoteCameraBasis?.right ?? null,
-            cameraUp: remoteCameraBasis?.up ?? null,
-            cueForward: { x: remoteAimDir.x, z: remoteAimDir.y }
-          });
-          const remoteAimSpin = {
-            x: remotePhysicsSpin.x || 0,
-            y: remotePhysicsSpin.y || 0
-          };
+          const remotePhysicsSpin = mapSpinForPhysics(remoteSpin);
           const guideAimDir2D = resolveSwerveAimDir(
             remoteAimDir,
-            remoteAimSpin,
+            remotePhysicsSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -23815,7 +23914,7 @@ const powerRef = useRef(hud.power);
             end,
             baseDir,
             perp,
-            remoteAimSpin,
+            remotePhysicsSpin,
             powerStrength,
             remoteSwerveActive
           );
@@ -23840,7 +23939,12 @@ const powerRef = useRef(hud.power);
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;
-          const maxPull = CUE_PULL_BASE;
+          const backInfo = calcTarget(
+            cue,
+            remoteAimDir.clone().multiplyScalar(-1),
+            balls
+          );
+          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const desiredPull = computePullTargetFromPower(powerStrength, maxPull);
           const pull = computeCuePull(desiredPull, maxPull);
           const visualPull = applyVisualPullCompensation(pull, baseDir);
@@ -23855,8 +23959,7 @@ const powerRef = useRef(hud.power);
           const obstructionStrength = resolveCueObstruction(
             baseDir,
             pull,
-            activeRenderCameraRef.current ?? cameraRef.current ?? camera,
-            spinWorld
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera
           );
           const { obstructionTilt, obstructionTiltFromLift } =
             resolveCueObstructionTilt(obstructionStrength);
@@ -23930,8 +24033,18 @@ const powerRef = useRef(hud.power);
           const perp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerTarget = THREE.MathUtils.clamp(activeAiPlan.power ?? powerRef.current ?? 0, 0, 1);
-          const maxPull = CUE_PULL_BASE;
-          const desiredPull = computePullTargetFromPower(powerTarget, maxPull);
+          const backInfo = calcTarget(
+            cue,
+            planDir.clone().multiplyScalar(-1),
+            balls
+          );
+          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
+          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
+          const pullVisibilityBoost =
+            aiOpponentEnabled && hudRef.current?.turn === 1
+              ? AI_CUE_PULL_VISIBILITY_BOOST
+              : PLAYER_CUE_PULL_VISIBILITY_BOOST;
+          const desiredPull = computePullTargetFromPower(powerTarget, maxPull) * pullVisibilityBoost;
           const pull = computeCuePull(desiredPull, maxPull, { preserveLarger: true });
           const visualPull = applyVisualPullCompensation(pull, dir);
           const planSpin = activeAiPlan.spin ?? spinRef.current ?? { x: 0, y: 0 };
@@ -24631,7 +24744,7 @@ const powerRef = useRef(hud.power);
                   )
                 );
               const restY =
-                railRunStart.y + POCKET_HOLDER_RUN_SURFACE_LIFT - tiltDrop;
+                railRunStart.y - POCKET_HOLDER_REST_DROP - tiltDrop;
               const glowMesh = table ? createPocketGlowMesh('good') : null;
               if (glowMesh) {
                 glowMesh.position.set(fromX, BALL_CENTER_Y - POCKET_GLOW_LIFT, fromZ);


### PR DESCRIPTION
### Motivation
- Make Pool Royale share the same shooting, aiming-line, pocket-holder visuals and broadcast behavior as Snooker Royal so player experience and replay/broadcast semantics match across both games.  

### Description
- Updated aiming/swerve preview and aim-line math to use the same physics-spin mapping and swerve preview logic as Snooker Royal by switching to `mapSpinForPhysics`/`resolveSwerve*` flows and feeding `physicsSpin` into aim helpers.  
- Aligned shot firing / cue-application logic and cue-stroke timing to the Snooker Royal implementation, consolidating payload handling, impact triggering and follow-through rendering in `PoolRoyale.jsx`.  
- Matched pocket-holder and pocket-drop constants and resting logic (chrome rails, strap, spacing and drop/rest Y) so potted balls settle on chrome holders like Snooker Royal.  
- Changed broadcast/replay overhead framing to mirror Snooker Royal (adjusted `RAIL_OVERHEAD_DISTANCE_BIAS`, removed the standing-broadcast short-circuit and updated rail-replay camera resolution).  
- Tightened ball-in-hand placement UX so the user must engage the hand control while dragging (gated in-hand pointer handling).  
- All edits made in `webapp/src/pages/Games/PoolRoyale.jsx` to mirror SnookerRoyal behaviors and constants.  

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which started successfully and served the app.  
- Attempted an automated Playwright run to open `http://127.0.0.1:4173/games/poolroyale` and capture a screenshot, but the headless Chromium process crashed (SIGSEGV) so the page capture failed.  
- No unit test suite (`npm test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972268d91748329b08ba1072fa84a2a)