### PR TITLE
Align Pool Royale aiming, broadcast, pocket holders and shot flow with Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -81,7 +81,6 @@ import {
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
-  mapSpinForPhysics,
   normalizeSpinInput,
   SPIN_STUN_RADIUS
 } from './poolRoyaleSpinUtils.js';
@@ -1181,7 +1180,7 @@ const POCKET_INTERIOR_CAPTURE_R =
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
 const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the true bowl opening
-const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.08; // give middle pockets a touch more capture so shots don't hang in the jaws
+const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R; // middle pocket capture now mirrors the bowl radius
 const POCKET_GUARD_RADIUS = Math.max(0, POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.04); // align the rail guard to the playable capture bowl instead of the visual rim
 const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.18); // shrink the safety margin so angled cushion cuts register sooner
 const CORNER_POCKET_DEPTH_LIMIT =
@@ -1250,8 +1249,8 @@ const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 1.05; // drop deeper so potted ball
 const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall slightly above the ring/strap junction
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
-const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.1; // lift the ring so the holder assembly sits higher
-const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.26; // raise the net so the weave meets the pocket mouth
+const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
+const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.16; // raise the net so the weave sits higher on screen
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
@@ -1259,24 +1258,24 @@ const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.
 const POCKET_GUIDE_DROP = BALL_R * 0.12;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
-const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.18; // allow the L-arms to peek past the ring without blocking the pocket mouth
+const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
 const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = -BALL_R * 0.26; // lift the chrome holder rails so the short L segments meet the ring
-const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.16; // nudge the L segments toward the leather strap
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
-const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER; // tighter spacing so potted balls touch on the holder rails
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 3.6; // let potted balls roll farther until they meet the leather strap
-const POCKET_HOLDER_RUN_SURFACE_LIFT = BALL_R * 1.12 + POCKET_GUIDE_RADIUS; // keep the ball resting on top of the center chrome holder
+const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.78; // keep the ball rest point unchanged while the chrome guides extend
+const POCKET_HOLDER_REST_DROP = BALL_R * 2.18; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
 const POCKET_MIDDLE_HOLDER_SWAY = 0.32; // add a slight diagonal so middle-pocket holders angle like the reference photos
 const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve past the felt base so it meets the pocket walls cleanly
-const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.98; // extend the short L section so it reaches the ring and guides balls like the reference trays
+const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.62; // lift the leather strap so it meets the raised holder rails
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so it meets the raised holder rails
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -1486,7 +1485,6 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slig
 const CUE_PULL_RETURN_PUSH = 0.78; // push the cue forward to its start point more decisively after a pull
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // ensure the forward push is visible even on short strokes
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
-const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -4793,12 +4791,12 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.82; // lift the standing orbit slightly higher for a clearer top surface view
+const STANDING_VIEW_PHI = 0.86; // raise the standing orbit a touch for a clearer overview
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
-const CAMERA_ABS_MIN_PHI = 0.08;
-const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.22; // keep the cue view a touch higher while staying above the cue
+const CAMERA_ABS_MIN_PHI = 0.1;
+const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.14; // let the cue view drop to the same rail-hugging height used by AI shots while staying above the cue
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.48);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
@@ -4807,9 +4805,8 @@ const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
-const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
-const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.54; // pull the standing camera slightly closer while keeping the angle unchanged
+const STANDING_VIEW_MARGIN_LANDSCAPE = 1.0013;
+const STANDING_VIEW_MARGIN_PORTRAIT = 1.0011;
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -4878,6 +4875,13 @@ const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // raise the camera a touch to ensure fu
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const BROADCAST_TOP_VIEW_MARGIN = 1.15;
+const BROADCAST_TOP_VIEW_RADIUS_SCALE = 1.26;
+const BROADCAST_TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22);
+const BROADCAST_TOP_VIEW_RESOLVED_PHI = Math.max(
+  BROADCAST_TOP_VIEW_PHI,
+  CAMERA_ABS_MIN_PHI * 0.5
+);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
@@ -4893,23 +4897,22 @@ const REPLAY_TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
-const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI; // align broadcast overhead with the 2D top-view angle
-const BROADCAST_MARGIN_WIDTH = (PLAY_W / 2) * (TOP_VIEW_MARGIN - 1);
-const BROADCAST_MARGIN_LENGTH = (PLAY_H / 2) * (TOP_VIEW_MARGIN - 1);
+const RAIL_OVERHEAD_PHI = BROADCAST_TOP_VIEW_RESOLVED_PHI; // align broadcast overhead with the snooker TV angle
+const BROADCAST_MARGIN_WIDTH = (PLAY_W / 2) * (BROADCAST_TOP_VIEW_MARGIN - 1);
+const BROADCAST_MARGIN_LENGTH = (PLAY_H / 2) * (BROADCAST_TOP_VIEW_MARGIN - 1);
 const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) => {
   const verticalFov = THREE.MathUtils.degToRad(fov || STANDING_VIEW_FOV);
   const halfVertical = Math.max(verticalFov / 2, 1e-3);
   const halfHorizontal = Math.max(Math.atan(Math.tan(halfVertical) * aspect), 1e-3);
   const halfWidth = PLAY_W / 2 + BROADCAST_MARGIN_WIDTH;
   const halfLength = PLAY_H / 2 + BROADCAST_MARGIN_LENGTH;
-  const widthDistance = (halfWidth / Math.tan(halfHorizontal)) * TOP_VIEW_RADIUS_SCALE;
-  const lengthDistance = (halfLength / Math.tan(halfVertical)) * TOP_VIEW_RADIUS_SCALE;
+  const widthDistance = (halfWidth / Math.tan(halfHorizontal)) * BROADCAST_TOP_VIEW_RADIUS_SCALE;
+  const lengthDistance = (halfLength / Math.tan(halfVertical)) * BROADCAST_TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
+const RAIL_OVERHEAD_DISTANCE_BIAS = 0.9; // pull the broadcast overhead camera closer to the table like the original framing
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
-const USE_STANDING_BROADCAST_CAMERA = true; // keep broadcast cuts aligned with the standing camera instead of side-rail rigs
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
@@ -4917,7 +4920,7 @@ const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
 );
-const CUE_VIEW_PHI_LIFT = 0.06; // keep the cue camera slightly higher before it bottoms out
+const CUE_VIEW_PHI_LIFT = 0.075; // nudge the cue camera lower so the stroke and cue pull stay in frame
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -4935,7 +4938,7 @@ const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.38; // pull the orbit back while the 
 const BIH_INDICATOR_HAND_SIZE_PX = 34;
 const BIH_INDICATOR_WORLD_OFFSET = BALL_R * 1.35;
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
-const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
+const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.22; // nudge forward slightly at the floor of the cue view, then stop
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;
 const CUE_VIEW_FORWARD_SLIDE_RESET_BLEND = 0.45;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
@@ -4945,7 +4948,7 @@ const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.04; // add a touch more overhead bias while holding the rail angle
 const BACKSPIN_DIRECTION_PREVIEW = 0.68; // lerp strength that pulls the cue-ball follow line toward a draw path
-const AIM_SPIN_PREVIEW_SIDE = 0;
+const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
 const POCKET_VIEW_SMOOTH_TIME = 0.08; // seconds to ease pocket camera transitions
 const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
@@ -5160,8 +5163,42 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
+const SPIN_INPUT_DEAD_ZONE = 0.02;
+const SPIN_RESPONSE_EXPONENT = 1.65;
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
 const SPIN_VIEW_BLOCK_THRESHOLD = -0.18;
+
+const clampToUnitCircle = (x, y) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= 1) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? 1 / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+const applySpinResponseCurve = (spin) => {
+  const x = spin?.x ?? 0;
+  const y = spin?.y ?? 0;
+  const magnitude = Math.hypot(x, y);
+  if (!Number.isFinite(magnitude) || magnitude < SPIN_INPUT_DEAD_ZONE) {
+    return { x: 0, y: 0 };
+  }
+  const clamped = clampToUnitCircle(x, y);
+  const clampedMag = Math.hypot(clamped.x, clamped.y);
+  if (clampedMag < 1e-6) return { x: 0, y: 0 };
+  const curvedMag = Math.pow(clampedMag, SPIN_RESPONSE_EXPONENT);
+  const scale = curvedMag / clampedMag;
+  return { x: clamped.x * scale, y: clamped.y * scale };
+};
+
+const mapSpinForPhysicsSnooker = (spin) => {
+  const curved = applySpinResponseCurve(spin);
+  return {
+    x: curved?.x ?? 0,
+    y: -(curved?.y ?? 0)
+  };
+};
 
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
@@ -15216,11 +15253,7 @@ const powerRef = useRef(hud.power);
         CAMERA.maxPhi
       );
       const standingRadius = clamp(
-        fitRadius(
-          camera,
-          STANDING_VIEW.margin * zoomProfile.margin,
-          STANDING_VIEW_DISTANCE_SCALE
-        ),
+        fitRadius(camera, STANDING_VIEW.margin * zoomProfile.margin),
         CAMERA.minR,
         CAMERA.maxR
       );
@@ -15628,25 +15661,6 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
-          if (USE_STANDING_BROADCAST_CAMERA) {
-            const fallbackTarget =
-              focusOverride?.clone?.() ??
-              lastCameraTargetRef.current?.clone?.() ??
-              new THREE.Vector3(
-                0,
-                TABLE_Y + TABLE.THICK + BALL_R * 2.5,
-                0
-              );
-            if (fallbackTarget && Number.isFinite(minTargetY)) {
-              fallbackTarget.y = Math.max(fallbackTarget.y ?? minTargetY, minTargetY);
-            }
-            return {
-              position: camera.position.clone(),
-              target: fallbackTarget,
-              fov: STANDING_VIEW_FOV,
-              minTargetY
-            };
-          }
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
           const activeRail =
@@ -15710,7 +15724,7 @@ const powerRef = useRef(hud.power);
           const focusTarget = target ?? lastCameraTargetRef.current ?? null;
           if (!focusTarget) return;
           const baseDistance = Math.max(
-            fitRadius(renderCamera, STANDING_VIEW.margin, STANDING_VIEW_DISTANCE_SCALE),
+            fitRadius(renderCamera, STANDING_VIEW.margin),
             1e-3
           );
           const currentDistance = renderCamera.position.distanceTo(focusTarget);
@@ -17053,8 +17067,7 @@ const powerRef = useRef(hud.power);
           const zoomProfile = resolveCameraZoomProfile(aspect);
           const standingRadiusRaw = fitRadius(
             camera,
-            Math.max(m * zoomProfile.margin, 1e-4),
-            STANDING_VIEW_DISTANCE_SCALE
+            Math.max(m * zoomProfile.margin, 1e-4)
           );
           const cueBase = clampOrbitRadius(BREAK_VIEW.radius);
           const playerRadiusBase = Math.max(standingRadiusRaw, cueBase);
@@ -20092,13 +20105,12 @@ const powerRef = useRef(hud.power);
       const handleInHandDown = (e) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand) || currentHud.turn !== 0) return;
+        if (!inHandPlacementModeRef.current) return;
         if (shooting) return;
         if (e.button != null && e.button !== 0) return;
         const p = project(e);
         if (!p) return;
         if (!tryUpdatePlacement(p, false)) return;
-        setInHandPlacementMode(true);
-        inHandPlacementModeRef.current = true;
         inHandDrag.active = true;
         inHandDrag.pointerId = e.pointerId ?? 'mouse';
         if (e.pointerId != null && dom.setPointerCapture) {
@@ -20338,89 +20350,6 @@ const powerRef = useRef(hud.power);
         return { side, vert, hasSpin };
       };
 
-      const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { base, aimDir, physicsSpin, clampedPower, liftStrength } = payload;
-        const offsetScaled = {
-          x: physicsSpin?.x ?? 0,
-          y: physicsSpin?.y ?? 0
-        };
-        cue.vel.copy(base);
-        if (cue.spin) {
-          cue.spin.set(offsetScaled.x, offsetScaled.y);
-        }
-        if (cue.omega) {
-          cue.omega.set(0, 0, 0);
-        }
-        if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-        cue.spinMode = 'standard';
-        cue.swerveStrength = 0;
-        cue.swervePowerStrength = 0;
-        const shotDir = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
-        if (shotDir.lengthSq() > 1e-8) shotDir.normalize();
-        const sideAxis = TMP_VEC3_D.set(-shotDir.z, 0, shotDir.x);
-        if (sideAxis.lengthSq() > 1e-8) sideAxis.normalize();
-        const rOffset = TMP_VEC3_E
-          .copy(sideAxis)
-          .multiplyScalar(offsetScaled.x * BALL_R)
-          .addScaledVector(new THREE.Vector3(0, 1, 0), offsetScaled.y * BALL_R);
-        const impulseMag = BALL_MASS * base.length();
-        const impulse = TMP_VEC3_A.copy(shotDir).multiplyScalar(impulseMag);
-        const torqueImpulse = TMP_VEC3_B.copy(rOffset).cross(impulse);
-        if (cue.omega) {
-          cue.omega.addScaledVector(torqueImpulse, 1 / BALL_INERTIA);
-        }
-        resetSpinRef.current?.();
-        cueLiftRef.current.lift = 0;
-        cueLiftRef.current.startLift = 0;
-        cue.impacted = false;
-        cue.launchDir = aimDir.clone().normalize();
-        maxPowerLiftTriggered = false;
-        cue.lift = 0;
-        cue.liftVel = 0;
-        const topSpinWeight = Math.max(0, physicsSpin?.y || 0);
-        if (
-          clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
-          liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
-          topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
-        ) {
-          const powerRatio = THREE.MathUtils.clamp(
-            (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
-              Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
-            0,
-            1
-          );
-          const liftRatio = THREE.MathUtils.clamp(
-            (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
-              Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
-            0,
-            1
-          );
-          const spinRatio = THREE.MathUtils.clamp(
-            (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
-              Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
-            0,
-            1
-          );
-          const jumpStrength =
-            (0.25 + 0.75 * powerRatio) *
-            (0.4 + 0.6 * liftRatio) *
-            (0.55 + 0.45 * spinRatio);
-          const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
-          const physicsHeight =
-            (jumpVelocity * jumpVelocity) /
-            (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
-          const jumpHeight = Math.min(
-            MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
-            physicsHeight
-          );
-          cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
-          cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
-        }
-        playCueHit(clampedPower * 0.6);
-      };
-
       // Fire (slider triggers on release)
       const fire = () => {
         const currentHud = hudRef.current;
@@ -20533,16 +20462,12 @@ const powerRef = useRef(hud.power);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = clampPower(powerRef.current, 0);
-          const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
-          if (isMaxPowerShot) {
-            powerImpactHoldRef.current = Math.max(
-              powerImpactHoldRef.current || 0,
-              performance.now() + MAX_POWER_CAMERA_HOLD_MS
-            );
-          }
+          powerImpactHoldRef.current = isMaxPowerShot
+            ? performance.now() + MAX_POWER_CAMERA_HOLD_MS
+            : 0;
           if (aiOpponentEnabled && hudRef.current?.turn === 1) {
             powerImpactHoldRef.current = Math.max(
               powerImpactHoldRef.current || 0,
@@ -20561,17 +20486,12 @@ const powerRef = useRef(hud.power);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
+          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = aimDir
             .clone()
             .multiplyScalar(speedBase * powerScale);
           const predictedCueSpeed = base.length();
-          const maxShotSpeed = speedBase * (SHOT_MIN_FACTOR + SHOT_POWER_RANGE);
-          const strokeSpeedRatio =
-            maxShotSpeed > 1e-6
-              ? THREE.MathUtils.clamp(predictedCueSpeed / maxShotSpeed, 0, 1)
-              : powerStrength;
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {
             const frameTiming = frameTimingRef.current;
@@ -20654,254 +20574,269 @@ const powerRef = useRef(hud.power);
         const appliedSpin = applySpinConstraints(aimDir, true);
         const liftAngle = resolveUserCueLift();
         const liftStrength = normalizeCueLift(liftAngle);
-        const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-        const physicsSpin = mapSpinForPhysics(appliedSpin, {
-            cameraRight: cameraBasis?.right ?? null,
-            cameraUp: cameraBasis?.up ?? null,
-            cueForward: { x: aimDir.x, z: aimDir.y }
-          });
-          const offsetScaled = {
-            x: physicsSpin?.x ?? 0,
-            y: physicsSpin?.y ?? 0
-          };
-          const shotPayload = {
-            base: base.clone(),
-            aimDir: aimDir.clone(),
-            physicsSpin: { x: offsetScaled.x, y: offsetScaled.y },
-            clampedPower,
-            liftStrength,
-            applied: false
-          };
-          const triggerImpact = () => applyShotAtImpact(shotPayload);
+        const physicsSpin = mapSpinForPhysicsSnooker(appliedSpin);
+        const ranges = spinRangeRef.current || {};
+        const powerSpinScale = 0.55 + clampedPower * 0.45;
+        const baseSide = physicsSpin.x * (ranges.side ?? 0);
+        let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
+        let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+        if (physicsSpin.y < 0) {
+          spinTop *= BACKSPIN_MULTIPLIER;
+        } else if (physicsSpin.y > 0) {
+          spinTop *= TOPSPIN_MULTIPLIER;
+        }
+        cue.vel.copy(base);
+        if (cue.spin) {
+          cue.spin.set(spinSide, spinTop);
+        }
+        if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+        cue.spinMode =
+          spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
+        const swerveSettings = resolveSwerveSettings(
+          physicsSpin,
+          clampedPower,
+          cue.spinMode === 'swerve',
+          liftStrength
+        );
+        cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
+        cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+        resetSpinRef.current?.();
+        cueLiftRef.current.lift = 0;
+        cueLiftRef.current.startLift = 0;
+        cue.impacted = false;
+        cue.launchDir = aimDir.clone().normalize();
+        maxPowerLiftTriggered = false;
+        cue.lift = 0;
+        cue.liftVel = 0;
+        const topSpinWeight = Math.max(0, physicsSpin.y || 0);
+        if (
+          clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+          liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+          topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+        ) {
+          const powerRatio = THREE.MathUtils.clamp(
+            (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const liftRatio = THREE.MathUtils.clamp(
+            (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const spinRatio = THREE.MathUtils.clamp(
+            (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const jumpStrength =
+            (0.25 + 0.75 * powerRatio) *
+            (0.4 + 0.6 * liftRatio) *
+            (0.55 + 0.45 * spinRatio);
+          const jumpVelocity =
+            MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+          const physicsHeight =
+            (jumpVelocity * jumpVelocity) /
+            (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+          const jumpHeight = Math.min(
+            MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+            physicsHeight
+          );
+          cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+          cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+        }
+        playCueHit(clampedPower * 0.6);
 
-          if (cameraRef.current && sphRef.current) {
-            topViewRef.current = false;
-            topViewLockedRef.current = false;
-            setIsTopDownView(false);
-            const sph = sphRef.current;
-            const bounds = cameraBoundsRef.current;
-            const standingView = bounds?.standing;
-            if (standingView) {
-              sph.radius = clampOrbitRadius(standingView.radius);
-              sph.phi = THREE.MathUtils.clamp(
-                standingView.phi,
-                CAMERA.minPhi,
-                CAMERA.maxPhi
-              );
-              syncBlendToSpherical();
-            }
-            updateCamera();
-          }
-
-          // animate cue stick forward
-          const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
-          if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
-          dir.normalize();
-          if (cue?.pos) {
-            cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
-          }
-          const backInfo = calcTarget(
-            cue,
-            aimDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
-          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          const isAiStroke = aiOpponentEnabled && hudRef.current?.turn === 1;
-          const pullVisibilityBoost = isAiStroke
-            ? AI_CUE_PULL_VISIBILITY_BOOST
-            : PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const pullTarget = computePullTargetFromPower(clampedPower, maxPull) * pullVisibilityBoost;
-          const pull = computeCuePull(pullTarget, maxPull, {
-            instant: true,
-            preserveLarger: true
-          });
-          const startPull = Math.max(cuePullCurrentRef.current ?? 0, pull);
-          const visualPull = applyVisualPullCompensation(startPull, dir);
-          const cuePerp = new THREE.Vector3(-dir.z, 0, dir.x);
-          if (cuePerp.lengthSq() > 1e-8) cuePerp.normalize();
-          const { side: contactSide, vert: contactVert, hasSpin } = computeSpinOffsets(
-            appliedSpin,
-            ranges
-          );
-          const spinWorld = new THREE.Vector3(
-            cuePerp.x * contactSide,
-            contactVert,
-            cuePerp.z * contactSide
-          );
-          clampCueTipOffset(spinWorld);
-          const obstructionStrength = resolveCueObstruction(
-            dir,
-            pull,
-            activeRenderCameraRef.current ?? cameraRef.current ?? camera
-          );
-          const { obstructionTilt, obstructionTiltFromLift } =
-            resolveCueObstructionTilt(obstructionStrength);
-          const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
-          const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
-          cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
-          applyCueButtTilt(
-            cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
-          );
-          if (tipGroupRef.current) {
-            tipGroupRef.current.position.set(0, 0, -cueLen / 2);
-          }
-          TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
-          TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
-          const buildCuePosition = (pullAmount = visualPull) => {
-            const tipTarget = resolveCueTipTarget(dir, pullAmount, spinWorld);
-            return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
-              .sub(TMP_VEC3_CUE_TIP_OFFSET);
-          };
-          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
-          const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const strokeBlend = Math.max(forwardBlend, strokeSpeedRatio ?? 0);
-          const followThrough = Math.min(
-            CUE_FOLLOW_THROUGH_MAX,
-            Math.max(
-              CUE_FOLLOW_THROUGH_MIN,
-              visualPull * (0.22 + 0.28 * strokeBlend)
-            )
-          );
-          const followThroughPos = buildCuePosition(-followThrough);
-          const forwardDuration = isAiStroke
-            ? AI_CUE_FORWARD_DURATION_MS
-            : THREE.MathUtils.lerp(
-                PLAYER_CUE_FORWARD_MAX_MS,
-                PLAYER_CUE_FORWARD_MIN_MS,
-                strokeBlend
-              );
-          const settleDuration = isAiStroke ? 40 : 50;
-          const returnDuration = isAiStroke ? 120 : 160;
-          const pullbackScale = isAiStroke
-            ? AI_STROKE_PULLBACK_FACTOR
-            : PLAYER_STROKE_PULLBACK_FACTOR;
-          const minPullback = Math.max(MIN_PULLBACK_GAP, visualPull * PLAYER_PULLBACK_MIN_SCALE);
-          const pullbackDistance = Math.max(visualPull * pullbackScale, minPullback);
-          const warmupPull = pullbackDistance * (isAiStroke ? AI_WARMUP_PULL_RATIO : PLAYER_WARMUP_PULL_RATIO);
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS
-            : Math.max(PLAYER_CUE_FORWARD_MIN_MS, forwardDuration * PLAYER_STROKE_PULLBACK_FACTOR);
-          const warmupPos = buildCuePosition(warmupPull);
-          const startPos = buildCuePosition(pullbackDistance);
-          const impactPos = buildCuePosition(0);
-          const idlePos = startPos.clone();
-          cuePullCurrentRef.current = pullbackDistance;
-          cuePullTargetRef.current = pullbackDistance;
-          cueStick.visible = true;
-          cueStick.position.copy(warmupPos);
-          TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
-          cueAnimating = true;
-          const startTime = performance.now();
-          const pullEndTime = startTime + pullbackDuration;
-          const impactTime = pullEndTime + forwardDuration;
-          const settleTime = impactTime + settleDuration;
-          const returnTime = settleTime + returnDuration;
-          const forwardPreviewHold =
-            impactTime +
-            Math.min(
-              settleDuration,
-              Math.max(180, forwardDuration * 0.9)
+        if (cameraRef.current && sphRef.current) {
+          topViewRef.current = false;
+          topViewLockedRef.current = false;
+          setIsTopDownView(false);
+          const sph = sphRef.current;
+          const bounds = cameraBoundsRef.current;
+          const standingView = bounds?.standing;
+          if (standingView) {
+            sph.radius = clampOrbitRadius(standingView.radius);
+            sph.phi = THREE.MathUtils.clamp(
+              standingView.phi,
+              CAMERA.minPhi,
+              CAMERA.maxPhi
             );
-          powerImpactHoldRef.current = Math.max(
-            powerImpactHoldRef.current || 0,
-            forwardPreviewHold
-          );
-          const holdUntil = powerImpactHoldRef.current || 0;
-          const holdActive = holdUntil > performance.now();
-          let pocketViewActivated = false;
-          if (earlyPocketView && !isMaxPowerShot) {
-            const now = performance.now();
-            earlyPocketView.lastUpdate = now;
-            if (cameraRef.current) {
-              const cam = cameraRef.current;
-              earlyPocketView.smoothedPos = cam.position.clone();
-              const storedTarget = lastCameraTargetRef.current?.clone();
-              if (storedTarget) {
-                earlyPocketView.smoothedTarget = storedTarget;
-              }
-            }
-            if (actionView) {
-              earlyPocketView.resumeAction = actionView;
-              suspendedActionView = actionView;
-            } else {
-              suspendedActionView = null;
-            }
-            if (holdUntil > 0) {
-              const baseDelay = earlyPocketView.activationDelay ?? 0;
-              earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
-            }
-            earlyPocketView.pendingActivation = holdActive;
-            if (holdActive) {
-              queuedPocketView = earlyPocketView;
-              pocketViewActivated = true;
-            } else {
-              queuedPocketView = null;
-              updatePocketCameraState(true);
-              activeShotView = earlyPocketView;
-              pocketViewActivated = true;
+            syncBlendToSpherical();
+          }
+          updateCamera();
+        }
+
+        // animate cue stick forward
+        const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
+        if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
+        dir.normalize();
+        if (cue?.pos) {
+          cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
+        }
+        const backInfo = calcTarget(
+          cue,
+          aimDir.clone().multiplyScalar(-1),
+          balls
+        );
+        const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
+        const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
+        const isAiStroke = aiOpponentEnabled && hudRef.current?.turn === 1;
+        const pullVisibilityBoost = isAiStroke
+          ? AI_CUE_PULL_VISIBILITY_BOOST
+          : PLAYER_CUE_PULL_VISIBILITY_BOOST;
+        const pullTarget =
+          computePullTargetFromPower(clampedPower, maxPull) * pullVisibilityBoost;
+        const pull = computeCuePull(pullTarget, maxPull, {
+          instant: true,
+          preserveLarger: true
+        });
+        const visualPull = applyVisualPullCompensation(pull, dir);
+        const cuePerp = new THREE.Vector3(-dir.z, 0, dir.x);
+        if (cuePerp.lengthSq() > 1e-8) cuePerp.normalize();
+        const { side: contactSide, vert: contactVert, hasSpin } = computeSpinOffsets(
+          appliedSpin,
+          ranges
+        );
+        const spinWorld = new THREE.Vector3(
+          cuePerp.x * contactSide,
+          contactVert,
+          cuePerp.z * contactSide
+        );
+        clampCueTipOffset(spinWorld);
+        const obstructionStrength = resolveCueObstruction(
+          dir,
+          pull,
+          activeRenderCameraRef.current ?? cameraRef.current ?? camera
+        );
+        const { obstructionTilt, obstructionTiltFromLift } =
+          resolveCueObstructionTilt(obstructionStrength);
+        const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
+        const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftAngle;
+        cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
+        applyCueButtTilt(
+          cueStick,
+          extraTilt + obstructionTilt + obstructionTiltFromLift
+        );
+        if (tipGroupRef.current) {
+          tipGroupRef.current.position.set(0, 0, -cueLen / 2);
+        }
+        TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
+        TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
+        const buildCuePosition = (pullAmount = visualPull) => {
+          const tipTarget = resolveCueTipTarget(dir, pullAmount, spinWorld);
+          return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
+            .sub(TMP_VEC3_CUE_TIP_OFFSET);
+        };
+        const startPos = buildCuePosition(visualPull);
+        cueStick.position.copy(startPos);
+        TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
+        cueAnimating = true;
+        const followThroughPull = THREE.MathUtils.clamp(
+          topSpinWeight * clampedPower * BALL_R * 0.35,
+          0,
+          BALL_R * 0.35
+        );
+        const impactPos = buildCuePosition(-followThroughPull);
+        cueStick.visible = true;
+        cueStick.position.copy(startPos);
+        const forwardDuration = isAiStroke ? AI_CUE_FORWARD_DURATION_MS : 120;
+        const settleDuration = isAiStroke ? 40 : 50;
+        const startTime = performance.now();
+        const impactTime = startTime + forwardDuration;
+        const settleTime = impactTime + settleDuration;
+        const forwardPreviewHold =
+          impactTime +
+          Math.min(settleDuration, Math.max(180, forwardDuration * 0.9));
+        powerImpactHoldRef.current = Math.max(
+          powerImpactHoldRef.current || 0,
+          forwardPreviewHold
+        );
+        const holdUntil = powerImpactHoldRef.current || 0;
+        const holdActive = holdUntil > performance.now();
+        let pocketViewActivated = false;
+        if (earlyPocketView && !isMaxPowerShot) {
+          const now = performance.now();
+          earlyPocketView.lastUpdate = now;
+          if (cameraRef.current) {
+            const cam = cameraRef.current;
+            earlyPocketView.smoothedPos = cam.position.clone();
+            const storedTarget = lastCameraTargetRef.current?.clone();
+            if (storedTarget) {
+              earlyPocketView.smoothedTarget = storedTarget;
             }
           }
-          if (!pocketViewActivated && actionView) {
-            const shouldActivateActionView =
-              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
-            if (shouldActivateActionView && !holdActive) {
-              suspendedActionView = null;
-              activeShotView = actionView;
-              updateCamera();
-            } else {
-              actionView.pendingActivation = true;
-              const baseDelay = actionView.activationDelay ?? null;
-              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
-              actionView.activationDelay = delayed > 0 ? delayed : null;
-              const baseTravel = actionView.activationTravel ?? 0;
-              actionView.activationTravel = Math.max(
-                baseTravel,
-                isMaxPowerShot ? BALL_R * 6 : 0
-              );
-              suspendedActionView = actionView;
-            }
-          }
-          if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
-            const strokeStartOffset = Math.max(0, startTime - (shotRecording.startTime ?? startTime));
-            shotRecording.cueStroke = {
-              warmup: serializeVector3Snapshot(warmupPos),
-              start: serializeVector3Snapshot(startPos),
-              impact: serializeVector3Snapshot(impactPos),
-              settle: serializeVector3Snapshot(followThroughPos),
-              idle: serializeVector3Snapshot(idlePos),
-              rotationX: cueStick.rotation.x,
-              rotationY: cueStick.rotation.y,
-              pullbackDuration,
-              forwardDuration,
-              settleDuration,
-              returnDuration,
-              startOffset: strokeStartOffset
-            };
-          }
-          if (ENABLE_CUE_STROKE_ANIMATION) {
-            cueStrokeStateRef.current = {
-              startTime,
-              pullEndTime,
-              impactTime,
-              settleTime,
-              returnTime,
-              warmupPos,
-              startPos,
-              impactPos,
-              settlePos: followThroughPos,
-              idlePos,
-              pullbackDuration,
-              forwardDuration,
-              settleDuration,
-              returnDuration,
-              holdUntilStop: false,
-              shotApplied: false,
-              onImpact: triggerImpact
-            };
+          if (actionView) {
+            earlyPocketView.resumeAction = actionView;
+            suspendedActionView = actionView;
           } else {
-            triggerImpact();
+            suspendedActionView = null;
+          }
+          if (holdUntil > 0) {
+            const baseDelay = earlyPocketView.activationDelay ?? 0;
+            earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
+          }
+          earlyPocketView.pendingActivation = holdActive;
+          if (holdActive) {
+            queuedPocketView = earlyPocketView;
+            pocketViewActivated = true;
+          } else {
+            queuedPocketView = null;
+            updatePocketCameraState(true);
+            activeShotView = earlyPocketView;
+            pocketViewActivated = true;
+          }
+        }
+        if (!pocketViewActivated && actionView) {
+          const shouldActivateActionView =
+            (!isLongShot || forceActionActivation) && !isMaxPowerShot;
+          if (shouldActivateActionView && !holdActive) {
+            suspendedActionView = null;
+            activeShotView = actionView;
+            updateCamera();
+          } else {
+            actionView.pendingActivation = true;
+            const baseDelay = actionView.activationDelay ?? null;
+            const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
+            actionView.activationDelay = delayed > 0 ? delayed : null;
+            const baseTravel = actionView.activationTravel ?? 0;
+            actionView.activationTravel = Math.max(
+              baseTravel,
+              isMaxPowerShot ? BALL_R * 6 : 0
+            );
+            suspendedActionView = actionView;
+          }
+        }
+        if (shotRecording) {
+          const strokeStartOffset = Math.max(
+            0,
+            startTime - (shotRecording.startTime ?? startTime)
+          );
+          shotRecording.cueStroke = {
+            warmup: serializeVector3Snapshot(startPos),
+            start: serializeVector3Snapshot(startPos),
+            impact: serializeVector3Snapshot(impactPos),
+            settle: serializeVector3Snapshot(impactPos),
+            rotationX: cueStick.rotation.x,
+            rotationY: cueStick.rotation.y,
+            pullbackDuration: 0,
+            forwardDuration,
+            settleDuration,
+            startOffset: strokeStartOffset
+          };
+        }
+        const animateStroke = (now) => {
+          if (now <= impactTime) {
+            const t = forwardDuration > 0
+              ? THREE.MathUtils.clamp((now - startTime) / forwardDuration, 0, 1)
+              : 1;
+            const eased = 1 - Math.pow(1 - t, 3);
+            cueStick.position.lerpVectors(startPos, impactPos, eased);
+          } else if (now <= settleTime) {
+            cueStick.position.copy(impactPos);
+          } else {
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -20914,7 +20849,11 @@ const powerRef = useRef(hud.power);
               sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
               updateCamera();
             }
+            return;
           }
+          requestAnimationFrame(animateStroke);
+        };
+        requestAnimationFrame(animateStroke);
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -23199,12 +23138,6 @@ const powerRef = useRef(hud.power);
           return;
         }
         const nowMs = now;
-        updateCueStroke(nowMs);
-        const pendingImpact = pendingImpactRef.current;
-        if (pendingImpact && nowMs >= pendingImpact.time) {
-          pendingImpact.apply?.();
-          pendingImpactRef.current = null;
-        }
         if (remoteShotActiveRef.current && remoteShotUntilRef.current > 0 && nowMs > remoteShotUntilRef.current) {
           remoteShotActiveRef.current = false;
         }
@@ -23304,18 +23237,10 @@ const powerRef = useRef(hud.power);
           : baseAimLerp;
         if (!lookModeRef.current) {
           aimDir.lerp(tmpAim, aimLerpFactor);
-          if (aimDir.lengthSq() > 1e-6) {
-            aimDir.normalize();
-          }
         }
         const appliedSpin = applySpinConstraints(aimDir, true);
         const liftStrength = normalizeCueLift(resolveUserCueLift());
-        const cameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-        const physicsSpin = mapSpinForPhysics(appliedSpin, {
-          cameraRight: cameraBasis?.right ?? null,
-          cameraUp: cameraBasis?.up ?? null,
-          cueForward: { x: aimDir.x, z: aimDir.y }
-        });
+        const physicsSpin = mapSpinForPhysicsSnooker(appliedSpin);
         const aimLineSpin = {
           x: physicsSpin.x || 0,
           y: physicsSpin.y || 0
@@ -23564,7 +23489,7 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const spinSideInfluence = 0;
+          const spinSideInfluence = (aimLineSpin.x || 0) * (0.4 + 0.42 * powerStrength);
           const spinVerticalInfluence = (aimLineSpin.y || 0) * (0.68 + 0.45 * powerStrength);
           const cueFollowDirSpinAdjusted = cueFollowDir
             .clone()
@@ -23603,7 +23528,12 @@ const powerRef = useRef(hud.power);
           } else {
             impactRing.visible = false;
           }
-          const maxPull = CUE_PULL_BASE;
+          const backInfo = calcTarget(
+            cue,
+            aimDir2D.clone().multiplyScalar(-1),
+            balls
+          );
+          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const desiredPull = computePullTargetFromPower(
             powerRef.current,
             maxPull
@@ -23782,12 +23712,7 @@ const powerRef = useRef(hud.power);
           const remoteSpin = remoteAimState?.spin ?? { x: 0, y: 0 };
           const remoteSpinMagnitude = Math.hypot(remoteSpin.x ?? 0, remoteSpin.y ?? 0);
           const remoteSwerveActive = remoteSpinMagnitude >= SWERVE_THRESHOLD;
-          const remoteCameraBasis = resolveCameraBasis(activeRenderCameraRef.current ?? cameraRef.current);
-          const remotePhysicsSpin = mapSpinForPhysics(remoteSpin, {
-            cameraRight: remoteCameraBasis?.right ?? null,
-            cameraUp: remoteCameraBasis?.up ?? null,
-            cueForward: { x: remoteAimDir.x, z: remoteAimDir.y }
-          });
+          const remotePhysicsSpin = mapSpinForPhysicsSnooker(remoteSpin);
           const remoteAimSpin = {
             x: remotePhysicsSpin.x || 0,
             y: remotePhysicsSpin.y || 0
@@ -23840,7 +23765,12 @@ const powerRef = useRef(hud.power);
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;
-          const maxPull = CUE_PULL_BASE;
+          const backInfo = calcTarget(
+            cue,
+            remoteAimDir.clone().multiplyScalar(-1),
+            balls
+          );
+          const maxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const desiredPull = computePullTargetFromPower(powerStrength, maxPull);
           const pull = computeCuePull(desiredPull, maxPull);
           const visualPull = applyVisualPullCompensation(pull, baseDir);
@@ -23930,8 +23860,18 @@ const powerRef = useRef(hud.power);
           const perp = new THREE.Vector3(-dir.z, 0, dir.x);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerTarget = THREE.MathUtils.clamp(activeAiPlan.power ?? powerRef.current ?? 0, 0, 1);
-          const maxPull = CUE_PULL_BASE;
-          const desiredPull = computePullTargetFromPower(powerTarget, maxPull);
+          const backInfo = calcTarget(
+            cue,
+            planDir.clone().multiplyScalar(-1),
+            balls
+          );
+          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
+          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
+          const pullVisibilityBoost =
+            aiOpponentEnabled && hudRef.current?.turn === 1
+              ? AI_CUE_PULL_VISIBILITY_BOOST
+              : PLAYER_CUE_PULL_VISIBILITY_BOOST;
+          const desiredPull = computePullTargetFromPower(powerTarget, maxPull) * pullVisibilityBoost;
           const pull = computeCuePull(desiredPull, maxPull, { preserveLarger: true });
           const visualPull = applyVisualPullCompensation(pull, dir);
           const planSpin = activeAiPlan.spin ?? spinRef.current ?? { x: 0, y: 0 };
@@ -24631,7 +24571,7 @@ const powerRef = useRef(hud.power);
                   )
                 );
               const restY =
-                railRunStart.y + POCKET_HOLDER_RUN_SURFACE_LIFT - tiltDrop;
+                railRunStart.y - POCKET_HOLDER_REST_DROP - tiltDrop;
               const glowMesh = table ? createPocketGlowMesh('good') : null;
               if (glowMesh) {
                 glowMesh.position.set(fromX, BALL_CENTER_Y - POCKET_GLOW_LIFT, fromZ);


### PR DESCRIPTION
### Motivation
- Make Pool Royale behave like Snooker Royal for shot mechanics, aiming visuals and broadcast framing while keeping Pool-specific pocket cams and 2D top view handling.
- Match the chrome pocket holders and potted-ball presentation to the Snooker Royal appearance and roll behavior.
- Require explicit click-and-drag from the in-hand indicator to place the cue ball (click-hold semantics) so placement flow matches the Snooker experience.

### Description
- Camera & broadcast: adjusted broadcast/top-view constants and framing (e.g. `RAIL_OVERHEAD_PHI`, broadcast margin/radius scaling, standing view margins and fit radius usage) to mirror Snooker Royal TV framing and behavior; updated `resolveRailOverheadReplayCamera` accordingly, and removed reliance on the old standing-broadcast fallback. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Aiming / shot flow: switched Pool Royale spin mapping and aiming-line preview to use the Snooker-style spin response (`mapSpinForPhysicsSnooker` / response curve), tightened pull/power logic (use clamped power directly, removed legacy gamma curve), and aligned cue stroke and impact sequencing to the Snooker shot lifecycle (visual pull, cue animation, impact timing and replay recording). (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Pocket holders & potted balls: updated pocket geometry and pocket-drop resting math (ring vertical offsets, guide overlap/vertical drop, holder rest spacing/pullback/drop, strap lift and run speeds) so potted balls roll onto chrome holders and rest points match the Snooker presentation. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- In-hand placement: require the hand indicator to initiate in-hand drag (click-and-hold semantics) and gate placement handlers so the user must start dragging from the in-hand indicator; on release control returns to the aiming line. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Small UX/visual tweaks: enabled side spin influence in the aim preview (`AIM_SPIN_PREVIEW_SIDE`), adjusted cue view phi lift/forward slide values, and tuned various constants for consistency with Snooker Royal aiming visuals. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Automated tests: none executed in this rollout; no unit or CI runs were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972268d91748329b08ba1072fa84a2a)