### PR TITLE
Pool Royale: delay pocket popups, restore UK rules, and add in‑hand press‑and‑hold

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1251,7 +1251,7 @@ const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall sligh
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
 const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
-const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.26; // raise the net so the weave meets the pocket mouth
+const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.16; // match Snooker Royal pocket net lift for identical potted-ball framing
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
@@ -1276,7 +1276,7 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.62; // lift the leather strap so it meets the raised holder rails
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // align strap height with Snooker Royal for identical potted-ball rests
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -1556,7 +1556,7 @@ const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale wit
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
-const DEFAULT_POOL_VARIANT = 'american';
+const DEFAULT_POOL_VARIANT = 'uk';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
@@ -6267,6 +6267,19 @@ function resolveRailIntersectionPoint(start, dir) {
   if (dir.y < -1e-8) tHit = Math.min(tHit, (-limY - start.y) / dir.y);
   if (!Number.isFinite(tHit) || tHit <= 0) return null;
   return start.clone().add(dir.clone().multiplyScalar(tHit));
+}
+
+function resolveAimLineEnd(start, impact, dir, targetBall) {
+  if (!start || !impact) return impact;
+  if (targetBall) return impact;
+  const railImpact = resolveRailIntersectionPoint(start, dir);
+  if (!railImpact) return impact;
+  const impactDistance = start.distanceTo(impact);
+  const railDistance = start.distanceTo(railImpact);
+  if (!Number.isFinite(impactDistance) || !Number.isFinite(railDistance)) {
+    return impact;
+  }
+  return railDistance > impactDistance + BALL_R * 0.1 ? railImpact : impact;
 }
 
 function Guret(parent, id, color, x, y, options = {}) {
@@ -12004,6 +12017,11 @@ const initialFrame = useMemo(() => {
   );
   const inHandPlacementModeRef = useRef(inHandPlacementMode);
   const inHandIndicatorRef = useRef(null);
+  const IN_HAND_HOLD_DELAY_MS = 180;
+  const inHandHoldTimerRef = useRef(null);
+  const inHandHoldPointerRef = useRef(null);
+  const inHandHoldEventRef = useRef(null);
+  const inHandHoldTargetRef = useRef(null);
   const inHandPointerHandlersRef = useRef({
     onDown: null,
     onMove: null,
@@ -12100,6 +12118,10 @@ const powerRef = useRef(hud.power);
       if (shotCameraHoldTimeoutRef.current) {
         clearTimeout(shotCameraHoldTimeoutRef.current);
         shotCameraHoldTimeoutRef.current = null;
+      }
+      if (inHandHoldTimerRef.current) {
+        clearTimeout(inHandHoldTimerRef.current);
+        inHandHoldTimerRef.current = null;
       }
     },
     []
@@ -17355,7 +17377,9 @@ const powerRef = useRef(hud.power);
                 rollStartAt: now,
                 rollProgress: 1,
                 pocketId: null,
-                resting: true
+                resting: true,
+                popupShown: true,
+                popupCenter: null
               });
             }
           });
@@ -23462,7 +23486,8 @@ const powerRef = useRef(hud.power);
             balls
           );
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-          let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
+          const aimEnd2D = resolveAimLineEnd(cue.pos, impact, guideAimDir2D, targetBall);
+          let end = new THREE.Vector3(aimEnd2D.x, BALL_CENTER_Y, aimEnd2D.y);
           const dir = baseAimDir.clone();
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(dir.clone().multiplyScalar(BALL_R));
@@ -23786,7 +23811,8 @@ const powerRef = useRef(hud.power);
             balls
           );
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-          let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
+          const aimEnd2D = resolveAimLineEnd(cue.pos, impact, guideAimDir2D, targetBall);
+          let end = new THREE.Vector3(aimEnd2D.x, BALL_CENTER_Y, aimEnd2D.y);
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(baseDir.clone().multiplyScalar(BALL_R));
           }
@@ -24642,34 +24668,18 @@ const powerRef = useRef(hud.power);
                 rollStartAt: null,
                 rollProgress: 0,
                 pocketId,
-                resting: false
+                resting: false,
+                popupShown: false,
+                popupCenter: new THREE.Vector3(
+                  c.x,
+                  BALL_CENTER_Y + POCKET_POPUP_LIFT,
+                  c.y
+                )
               };
               b.mesh.visible = true;
               b.mesh.scale.set(1, 1, 1);
               b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
               pocketDropRef.current.set(b.id, dropEntry);
-              if (table && POCKET_POPUP_DURATION_MS > 0 && b.mesh) {
-                const popupMesh = b.mesh.clone(true);
-                popupMesh.traverse((child) => {
-                  if (!child.isMesh) return;
-                  if (child.material?.clone) {
-                    child.material = child.material.clone();
-                  }
-                  child.castShadow = false;
-                  child.receiveShadow = false;
-                });
-                popupMesh.position.set(
-                  c.x,
-                  BALL_CENTER_Y + POCKET_POPUP_LIFT,
-                  c.y
-                );
-                popupMesh.renderOrder = 6;
-                table.add(popupMesh);
-                pocketPopupRef.current.push({
-                  mesh: popupMesh,
-                  expiresAt: dropStart + POCKET_POPUP_DURATION_MS
-                });
-              }
               const mappedColor = toBallColorId(b.id);
               const colorId =
                 mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
@@ -24828,6 +24838,30 @@ const powerRef = useRef(hud.power);
                 posZ = THREE.MathUtils.lerp(runFromZ, entry.toZ ?? runFromZ, rollProgress);
                 if (rollProgress >= 1 && entry.settledAt && now - entry.settledAt >= POCKET_DROP_REST_HOLD_MS) {
                   entry.resting = true;
+                  if (
+                    !entry.popupShown &&
+                    entry.popupCenter &&
+                    table &&
+                    POCKET_POPUP_DURATION_MS > 0
+                  ) {
+                    const popupMesh = mesh.clone(true);
+                    popupMesh.traverse((child) => {
+                      if (!child.isMesh) return;
+                      if (child.material?.clone) {
+                        child.material = child.material.clone();
+                      }
+                      child.castShadow = false;
+                      child.receiveShadow = false;
+                    });
+                    popupMesh.position.copy(entry.popupCenter);
+                    popupMesh.renderOrder = 6;
+                    table.add(popupMesh);
+                    pocketPopupRef.current.push({
+                      mesh: popupMesh,
+                      expiresAt: now + POCKET_POPUP_DURATION_MS
+                    });
+                    entry.popupShown = true;
+                  }
                 }
               }
               mesh.position.set(posX, entry.currentY, posZ);
@@ -25700,28 +25734,69 @@ const powerRef = useRef(hud.power);
     ),
     [avatarSizeClass]
   );
+  const snapshotPointerEvent = useCallback(
+    (event) => ({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      pointerId: event.pointerId,
+      button: event.button,
+      preventDefault: () => {}
+    }),
+    []
+  );
+  const clearInHandHoldTimer = useCallback(() => {
+    if (inHandHoldTimerRef.current) {
+      clearTimeout(inHandHoldTimerRef.current);
+      inHandHoldTimerRef.current = null;
+    }
+  }, []);
   const handleInHandIndicatorDown = useCallback(
     (event) => {
       const currentHud = hudRef.current;
       if (!currentHud?.inHand || currentHud.turn !== 0) return;
       event.preventDefault?.();
-      setInHandPlacementMode(true);
-      inHandPlacementModeRef.current = true;
-      inHandPointerHandlersRef.current?.onDown?.(event);
-      if (event.pointerId != null && event.currentTarget?.setPointerCapture) {
-        try {
-          event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {}
-      }
+      clearInHandHoldTimer();
+      inHandHoldPointerRef.current = event.pointerId ?? 'mouse';
+      inHandHoldEventRef.current = snapshotPointerEvent(event);
+      inHandHoldTargetRef.current = event.currentTarget ?? null;
+      inHandHoldTimerRef.current = window.setTimeout(() => {
+        if (!inHandHoldPointerRef.current) return;
+        setInHandPlacementMode(true);
+        inHandPlacementModeRef.current = true;
+        const pendingEvent = inHandHoldEventRef.current;
+        if (pendingEvent) {
+          inHandPointerHandlersRef.current?.onDown?.(pendingEvent);
+        }
+        if (
+          pendingEvent?.pointerId != null &&
+          inHandHoldTargetRef.current?.setPointerCapture
+        ) {
+          try {
+            inHandHoldTargetRef.current.setPointerCapture(pendingEvent.pointerId);
+          } catch {}
+        }
+      }, IN_HAND_HOLD_DELAY_MS);
     },
-    []
+    [IN_HAND_HOLD_DELAY_MS, clearInHandHoldTimer, snapshotPointerEvent]
   );
   const handleInHandIndicatorMove = useCallback((event) => {
+    if (
+      inHandHoldPointerRef.current != null &&
+      event.pointerId != null &&
+      event.pointerId === inHandHoldPointerRef.current &&
+      !inHandPlacementModeRef.current
+    ) {
+      inHandHoldEventRef.current = snapshotPointerEvent(event);
+    }
     if (!inHandPlacementModeRef.current) return;
     inHandPointerHandlersRef.current?.onMove?.(event);
-  }, []);
+  }, [snapshotPointerEvent]);
   const handleInHandIndicatorUp = useCallback((event) => {
     inHandPointerHandlersRef.current?.onUp?.(event);
+    clearInHandHoldTimer();
+    inHandHoldPointerRef.current = null;
+    inHandHoldEventRef.current = null;
+    inHandHoldTargetRef.current = null;
     setInHandPlacementMode(false);
     inHandPlacementModeRef.current = false;
     if (event.pointerId != null && event.currentTarget?.releasePointerCapture) {
@@ -25729,7 +25804,7 @@ const powerRef = useRef(hud.power);
         event.currentTarget.releasePointerCapture(event.pointerId);
       } catch {}
     }
-  }, []);
+  }, [clearInHandHoldTimer]);
 
   return (
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">


### PR DESCRIPTION
### Motivation
- Fix pocket visuals so potted balls drop through the net/ring and then roll onto the chrome holder rails and stop at the leather strap, and avoid spawning popup clones prematurely during replay or mid‑roll.  
- Show the potted‑ball popup copy only after the ball has settled on the holder (matching Snooker Royal behavior).  
- Restore expected 8‑ball turn logic by defaulting Pool Royale to the UK ruleset and reduce accidental cue‑ball repositioning by requiring a press‑and‑hold to enter in‑hand placement.

### Description
- Default variant changed to UK by setting `DEFAULT_POOL_VARIANT` to `'uk'` so unresolved variant requests use the original UK 8‑ball rules.  
- Pocket drop entries now carry `popupShown` and `popupCenter` metadata and no longer spawn a popup at drop time, and the popup clone is created only when the drop entry finishes rolling and becomes `resting` to prevent replay artifacts.  
- `applyBallSnapshot` now initializes replay/resting pocket entries with `popupShown` to avoid duplicate popups when restoring snapshots.  
- Added `resolveAimLineEnd(start, impact, dir, targetBall)` and used the result when building local and remote aim endpoints so the aim guide can extend to the rail intersection when no target ball blocks the path.  
- Implemented press‑and‑hold in‑hand placement handling with `IN_HAND_HOLD_DELAY_MS`, timer/pointer/event snapshot refs, pointer capture handling, and cleanup to require an explicit hold before entering placement mode.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 5173` and confirmed Vite served the app (`VITE ready`). (succeeded)  
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate visuals but the run timed out while rendering the page. (failed / timed out)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972874da974832987c3d4f9930bfbdb)