### PR TITLE
Pool Royale: tweak chrome plates & pocket cuts, restore baulk/2D camera, and harden exit navigation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -596,14 +596,14 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2; // push the side fascia farther
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.62; // trim fascia span further so the middle plates finish before intruding into the pocket zone while keeping the rounded edge intact
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.68; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.52; // trim the outside edge slightly so the middle fascia keeps its curve without overreaching
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to run farther toward the pocket entry
-const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.986; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
+const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.982; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.22; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.28; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.085; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.095; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
@@ -984,7 +984,7 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const WIDTH_REF = 2540;
   const HEIGHT_REF = 1270;
   const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
+  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string distance from the baulk cushion (1/4 of the playing length)
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
@@ -4872,11 +4872,11 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
-const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // restore the pre-tweak overhead camera tilt
+const TOP_VIEW_RADIUS_SCALE = 1.26; // restore the 2D top view height to the earlier framing
+const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
@@ -27170,10 +27170,13 @@ export default function PoolRoyale() {
     });
   }, [exitMessage]);
   const exitToLobby = useCallback(() => {
-    navigate('/games/poolroyale/lobby', { replace: true });
-    if (window.location.pathname !== '/games/poolroyale/lobby') {
-      window.location.assign('/games/poolroyale/lobby');
-    }
+    const target = '/games/poolroyale/lobby';
+    navigate(target, { replace: true });
+    window.requestAnimationFrame(() => {
+      if (window.location.pathname !== target) {
+        window.location.replace(target);
+      }
+    });
   }, [navigate]);
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {


### PR DESCRIPTION
### Motivation
- Improve table visuals by shifting the middle chrome fascia slightly outward and trimming excess so the plates keep their curved profile while moving away from the table centre. 
- Make the rounded chrome corner cut a touch larger to better match the corner pockets visually. 
- Ensure the baulk (head string) and 2D/top-down camera framing match the intended/previous layout and avoid a black page when exiting to the lobby.

### Description
- Adjusted chrome fascia geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx`, including `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`, `CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE`, `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, and `CHROME_CORNER_POCKET_CUT_SCALE` to nudge middle plates outward, trim excess, and slightly enlarge corner cuts. 
- Replaced the hard-coded baulk reference with a proportional value by setting `BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25` so the baulk/head-string aligns to one-quarter of the playing length. 
- Restored the previous 2D/top-down camera constants (`TOP_VIEW_*` values) to recover the earlier overhead framing and updated the exit-to-lobby logic to use `navigate(...)` plus `window.requestAnimationFrame` and `window.location.replace(...)` as a safer fallback to avoid navigation producing a blank/black page. 
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and are limited to table layout/camera/navigation configuration and related helper calculations.

### Testing
- Started the web app dev server via `npm --prefix webapp run dev` and observed Vite start and serve the site (Local: http://localhost:4173/). (succeeded)
- Tried an automated visual smoke check using Playwright to open `/games/poolroyale?mode=ai&type=regular` and take a screenshot, but Playwright failed in this environment with a Chromium crash / timeout, preventing a screenshot capture (failed). 
- No unit or integration tests were run as part of this change in this session; changes are configuration/constant updates that can be validated by loading the Pool Royale page in-browser and visually confirming the chrome plates, corner cuts, baulk line placement, top-down camera framing, and that exiting to the lobby no longer produces a black page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697314314e948329815af1c811df386e)