### PR TITLE
Adjust Pool Royale table visuals, baulk placement and exit/top-view behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -596,14 +596,14 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2; // push the side fascia farther
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.62; // trim fascia span further so the middle plates finish before intruding into the pocket zone while keeping the rounded edge intact
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.68; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.6; // trim the outer edge slightly so the fascia stays tidy while preserving the rounded cut
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to run farther toward the pocket entry
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.986; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.22; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.28; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.085; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.095; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
@@ -984,7 +984,7 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const WIDTH_REF = 2540;
   const HEIGHT_REF = 1270;
   const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
+  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length from the baulk cushion (25")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
@@ -4872,14 +4872,14 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
-const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // reduce angle toward a flatter overhead
+const TOP_VIEW_RADIUS_SCALE = 1.26; // lift the 2D top view slightly higher so the overhead camera clears the rails on portrait
+const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
-  z: PLAY_H * -0.078 // keep the existing vertical alignment
+  x: PLAY_W * 0.006, // bias the top view so the table sits slightly lower on screen
+  z: PLAY_H * 0.006 // bias the top view so the table sits slightly more to the right
 });
 const REPLAY_TOP_VIEW_MARGIN = 1.15;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = 1.08;
@@ -27171,9 +27171,6 @@ export default function PoolRoyale() {
   }, [exitMessage]);
   const exitToLobby = useCallback(() => {
     navigate('/games/poolroyale/lobby', { replace: true });
-    if (window.location.pathname !== '/games/poolroyale/lobby') {
-      window.location.assign('/games/poolroyale/lobby');
-    }
   }, [navigate]);
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {


### PR DESCRIPTION
### Motivation
- Fix several visual and UX issues for Pool Royale: nudge middle chrome plates outward and trim their outer edge, slightly enlarge the rounded chrome cuts near corner pockets, place the white/baulk line at the official position, ensure the 2D top view uses the intended framing, and remove the navigation path that produced a black page when exiting to the lobby.

### Description
- Tweak chrome fascia and pocket sizing constants in `webapp/src/pages/Games/PoolRoyale.jsx`: reduced `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` to `1.6`, increased `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` to `0.28`, and opened corner chrome cut via `CHROME_CORNER_POCKET_CUT_SCALE = 1.095`.
- Move the baulk/white line to the official quarter-length by setting `BAULK_FROM_BAULK_REF` to `WIDTH_REF * 0.25` so the computed `BAULK_FROM_BAULK` aligns with the standard head string.
- Restore the 2D/top-view framing and offsets by updating `TOP_VIEW_*` constants (`TOP_VIEW_MARGIN`, `TOP_VIEW_MIN_RADIUS_SCALE`, `TOP_VIEW_PHI`, `TOP_VIEW_RADIUS_SCALE`, `TOP_VIEW_RESOLVED_PHI`, and `TOP_VIEW_SCREEN_OFFSET`) so the 2D camera returns to the previous/resolved coordinates.
- Simplify exit navigation in `PoolRoyale.jsx` by removing the forced `window.location.assign` fallback from `exitToLobby` and relying on `navigate('/games/poolroyale/lobby', { replace: true })` to avoid the black page on exit.

### Testing
- Brought up the development environment with `npm run dev` which started Vite and began build tasks and succeeded in writing build metadata (dev server reported ready); that step succeeded.
- Attempted an automated Playwright screenshot run to validate the page at `http://127.0.0.1:5173/games/poolroyale?mode=ai`, but the headless Chromium process crashed with a `SIGSEGV`, so the Playwright check failed and no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697314314e948329815af1c811df386e)