### PR TITLE
Align Pool Royale cushions/pockets and chrome with Snooker Royal; fix pocket holders & exit navigation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -596,14 +596,14 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 2.2; // push the side fascia farther
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 2.62; // trim fascia span further so the middle plates finish before intruding into the pocket zone while keeping the rounded edge intact
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.68; // widen the middle fascia outward so it blankets the exposed wood like the corner plates without altering the rounded cut
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.4; // trim the outside edge slightly so the middle fascia keeps its curve without overreaching
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to run farther toward the pocket entry
-const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.986; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
+const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.976; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.22; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.34; // push the side fascias farther outward so their outer edge follows the relocated middle pocket cuts
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.085; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.102; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
@@ -984,7 +984,7 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const WIDTH_REF = 2540;
   const HEIGHT_REF = 1270;
   const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
+  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string distance from the baulk cushion (1/4 of the playing length)
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
@@ -1181,18 +1181,18 @@ const POCKET_INTERIOR_CAPTURE_R =
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
 const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the true bowl opening
-const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.08; // give middle pockets a touch more capture so shots don't hang in the jaws
+const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R; // middle pocket capture now mirrors the bowl radius
 const POCKET_GUARD_RADIUS = Math.max(0, POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.04); // align the rail guard to the playable capture bowl instead of the visual rim
-const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.18); // shrink the safety margin so angled cushion cuts register sooner
+const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.08); // keep a slim safety margin so clean entries aren't rejected
 const CORNER_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.58 * POCKET_VISUAL_EXPANSION; // clamp corner reflections to the actual pocket depth
 const SIDE_POCKET_GUARD_RADIUS =
   SIDE_POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.06; // use the middle-pocket bowl to gate reflections with a tighter inset
 const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
-  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.18
+  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.08
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 0.82; // damp angled-cushion rebounds so they feel less punchy than straight rails
+const CUSHION_CUT_RESTITUTION_SCALE = 1; // keep cushion rebounds aligned with Snooker Royal mapping
 const SIDE_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.52 * POCKET_VISUAL_EXPANSION; // reduce the invisible pocket wall so rail-first cuts fall naturally
 let SIDE_POCKET_SPAN =
@@ -1220,7 +1220,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops furthe
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.28; // round the exterior wooden rail edges while keeping the rail angles intact
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep the exterior wooden rails straight with no rounding
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_GRAVITY = 42; // steeper gravity for a natural fall into the leather cradle
@@ -1276,40 +1276,37 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // align strap height with Snooker Royal for identical potted-ball rests
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so it meets the raised holder rails
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.46;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
-  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
-    POCKET_VIS_R * 1.95 +
-    BALL_R * 1.1) *
-  POCKET_CAM_EDGE_SCALE;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.18 +
+  POCKET_VIS_R * 2.25 +
+  BALL_R * 1.6;
 const POCKET_CAM_BASE_OUTWARD_OFFSET =
-  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.05 +
-    POCKET_VIS_R * 1.95 +
-    BALL_R * 1.05) *
-  POCKET_CAM_EDGE_SCALE;
+  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.34 +
+  POCKET_VIS_R * 2.28 +
+  BALL_R * 1.54;
 const POCKET_CAM = Object.freeze({
-  triggerDist: CAPTURE_R * 18,
-  dotThreshold: 0.15,
+  triggerDist: CAPTURE_R * 12,
+  dotThreshold: 0.22,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 0.98,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.06,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 0.9,
-  heightOffsetShortMultiplier: 0.9,
+  heightOffset: BALL_R * 1.9,
+  heightOffsetShortMultiplier: 0.96,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
-  heightDrop: BALL_R * 0.2,
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.04,
+  heightDrop: BALL_R * 0.45,
   distanceScale: 0.96,
-  heightScale: 0.98,
-  focusBlend: 0,
-  lateralFocusShift: 0,
-  railFocusLong: BALL_R * 5.6,
-  railFocusShort: BALL_R * 6.6
+  heightScale: 1.06,
+  focusBlend: 0.22,
+  lateralFocusShift: POCKET_VIS_R * 0.32,
+  railFocusLong: BALL_R * 8,
+  railFocusShort: BALL_R * 5.4
 });
-const POCKET_POPUP_DURATION_MS = 2000;
+const POCKET_POPUP_DURATION_MS = 0;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_GLOW_ENABLED = false;
 const POCKET_GLOW_RADIUS = BALL_R * 1.32;
@@ -1320,8 +1317,7 @@ const POCKET_GLOW_COLORS = Object.freeze({
   foul: 0xff4b4b
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
-const POCKET_GUARANTEED_ALIGNMENT = 0.85;
-const POCKET_EARLY_ALIGNMENT = 0.7;
+const POCKET_GUARANTEED_ALIGNMENT = 0.95;
 const POCKET_INTENT_TIMEOUT_MS = 4200;
 const ACTION_CAM = Object.freeze({
   pairMinDistance: BALL_R * 28,
@@ -4872,11 +4868,11 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // raise the camera a touch to ensure full end-rail coverage
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
-const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_MARGIN = 1.15; // lift the top view slightly to keep both near pockets visible on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // raise the camera a touch to ensure full end-rail coverage
+const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); // restore the pre-tweak overhead camera tilt
+const TOP_VIEW_RADIUS_SCALE = 1.26; // restore the 2D top view height to the earlier framing
+const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
@@ -7486,7 +7482,7 @@ export function Table3D(
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.07; // push the cushions further outward so they meet the wooden rails without a gap
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
-  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
+  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.26; // keep the cushion clearance aligned with Snooker Royal mapping
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
   const SHORT_RAIL_POCKET_REACH_REDUCTION = TABLE.THICK * 0.02; // match the trimmed amount removed from the side cushions
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
@@ -17038,10 +17034,7 @@ const powerRef = useRef(hud.power);
             shotPrediction?.ballId === ballId &&
             predictedAlignment != null &&
             predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
-          const allowEarly =
-            forceEarly &&
-            bestScore >= POCKET_EARLY_ALIGNMENT;
-          if (!isGuaranteedPocket && !allowEarly) return null;
+          if (!isGuaranteedPocket) return null;
           const predictedTravelForBall =
             shotPrediction?.ballId === ballId
               ? shotPrediction?.travel ?? null
@@ -27169,16 +27162,10 @@ export default function PoolRoyale() {
       resolve(window.confirm(exitMessage));
     });
   }, [exitMessage]);
-  const exitToLobby = useCallback(() => {
-    navigate('/games/poolroyale/lobby', { replace: true });
-    if (window.location.pathname !== '/games/poolroyale/lobby') {
-      window.location.assign('/games/poolroyale/lobby');
-    }
-  }, [navigate]);
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {
       if (confirmed) {
-        exitToLobby();
+        navigate('/games/poolroyale/lobby');
       }
     });
   });
@@ -27189,12 +27176,11 @@ export default function PoolRoyale() {
       return exitMessage;
     };
     const handlePopState = () => {
-      window.history.pushState(null, '', window.location.href);
       confirmExit().then((confirmed) => {
         if (!confirmed) {
-          return;
+          window.history.pushState(null, '', window.location.href);
         } else {
-          exitToLobby();
+          navigate('/games/poolroyale/lobby');
         }
       });
     };
@@ -27205,7 +27191,7 @@ export default function PoolRoyale() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [confirmExit, exitMessage, exitToLobby]);
+  }, [confirmExit, exitMessage, navigate]);
   const opponentName = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('opponent') || '';


### PR DESCRIPTION
### Motivation
- The Pool Royale table needed to match the Snooker Royal pocket/holder behavior so potted balls sit on the chrome holders and show identically to the Snooker Royal game.
- Balls were clipping into cushions and sometimes entering pockets partially, so cushion cut/clearance and pocket capture needed to be aligned to the working SnookerRoyal mapping.
- The pocket camera/top-down framing and exit-to-lobby flow needed restoring/hardening to avoid black pages and preserve previous overhead framing.

### Description
- Aligned pocket capture and guard tuning by updating `SIDE_CAPTURE_R`, `POCKET_GUARD_CLEARANCE`, and related `SIDE_POCKET_GUARD_CLEARANCE` to mirror Snooker Royal, and set `CUSHION_CUT_RESTITUTION_SCALE = 1` to match cushion rebound behavior (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Restored pocket camera constants to the Snooker Royal values by updating `POCKET_CAM` and related `POCKET_CAM_BASE_*` constants so pocket views and top-down framing behave consistently.
- Refined chrome fascia constants to match requested visuals by adjusting `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`, `CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE`, `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, and `CHROME_CORNER_POCKET_CUT_SCALE` so the middle chrome plates and corner cuts match the reference.
- Fixed pocket-holder visibility and UX: disabled the popup hold (`POCKET_POPUP_DURATION_MS = 0`) so potted-balls settle on the holder rails like Snooker Royal, set `POCKET_GUARANTEED_ALIGNMENT = 0.95`, tightened early pocket logic to require guaranteed alignment, adjusted cushion clearance constants, and simplified the exit navigation/popstate handler to use `navigate(...)` to avoid blank pages.
- Restored the baulk/head-string reference to a proportional value by using `BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25` and restored the 2D/top-down framing constants (`TOP_VIEW_*`) to previous settings.

### Testing
- Started the web app dev server via `npm --prefix webapp run dev` and verified Vite started and served on `http://localhost:4173/` (succeeded).
- Attempted an automated visual smoke check using Playwright to open `/games/poolroyale?mode=ai&type=regular` and capture a screenshot, but the Playwright run timed out in this environment (failed).
- No unit tests were added; changes are layout/constant updates in `webapp/src/pages/Games/PoolRoyale.jsx` and should be validated by loading the Pool Royale page in-browser and visually confirming pocket-holder presence, cushion collisions, aim-line height, and that exiting to the lobby no longer produces a blank/black page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697314314e948329815af1c811df386e)