### PR TITLE
Pool Royale: pocket popup timing, top-view/camera offsets, rail limits and cushion trim

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1306,7 +1306,7 @@ const POCKET_CAM = Object.freeze({
   railFocusLong: BALL_R * 8,
   railFocusShort: BALL_R * 5.4
 });
-const POCKET_POPUP_DURATION_MS = 0;
+const POCKET_POPUP_DURATION_MS = 1200;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_GLOW_ENABLED = false;
 const POCKET_GLOW_RADIUS = BALL_R * 1.32;
@@ -4862,7 +4862,7 @@ const DEFAULT_RAIL_LIMIT_X = PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET;
 const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
-const RAIL_LIMIT_PADDING = 0.1;
+const RAIL_LIMIT_PADDING = 0.02;
 const BREAK_VIEW = Object.freeze({
   radius: CAMERA.minR, // start the intro framing closer to the table surface
   phi: CAMERA.maxPhi - 0.01
@@ -4874,8 +4874,8 @@ const TOP_VIEW_PHI = Math.max(CAMERA_ABS_MIN_PHI * 0.45, CAMERA.minPhi * 0.22); 
 const TOP_VIEW_RADIUS_SCALE = 1.26; // restore the 2D top view height to the earlier framing
 const TOP_VIEW_RESOLVED_PHI = Math.max(TOP_VIEW_PHI, CAMERA_ABS_MIN_PHI * 0.5);
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
-  z: PLAY_H * -0.078 // keep the existing vertical alignment
+  x: PLAY_W * 0.006, // return to the early-morning 2D framing
+  z: PLAY_H * 0.006 // return to the early-morning 2D framing
 });
 const REPLAY_TOP_VIEW_MARGIN = 1.15;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = 1.08;
@@ -6395,13 +6395,13 @@ function updateRailLimitsFromTable(table) {
   if (minAbsX !== Infinity) {
     const computedX = Math.max(0, minAbsX - BALL_R - RAIL_LIMIT_PADDING);
     if (computedX > 0) {
-      RAIL_LIMIT_X = Math.max(DEFAULT_RAIL_LIMIT_X, computedX);
+      RAIL_LIMIT_X = computedX;
     }
   }
   if (minAbsZ !== Infinity) {
     const computedZ = Math.max(0, minAbsZ - BALL_R - RAIL_LIMIT_PADDING);
     if (computedZ > 0) {
-      RAIL_LIMIT_Y = Math.max(DEFAULT_RAIL_LIMIT_Y, computedZ);
+      RAIL_LIMIT_Y = computedZ;
     }
   }
 }
@@ -7486,7 +7486,7 @@ export function Table3D(
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
   const SHORT_RAIL_POCKET_REACH_REDUCTION = TABLE.THICK * 0.02; // match the trimmed amount removed from the side cushions
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.34; // lightly trim short-rail cushions to shorten the long side without changing shape
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation
- Make Pool Royale pocket and post-pot visuals match the Snooker Royal behaviour so potted balls settle on the chrome holders and a popup is shown after the ball has stopped on the holder. 
- Restore the earlier 2D/top-view camera framing so pocket framing and player view match the previous morning configuration. 
- Improve cushion/rail mapping precision so ball-to-cushion perimeter interactions are more accurate and trim short-rail cushions slightly to correct a long nose.

### Description
- Enabled a delayed pocket popup by setting `POCKET_POPUP_DURATION_MS` to `1200` so the potted-ball popup appears only after the ball has settled on the holder rails. (file: `webapp/src/pages/Games/PoolRoyale.jsx`) 
- Restored the top-view screen offset to the previous framing by updating `TOP_VIEW_SCREEN_OFFSET` to `{ x: PLAY_W * 0.006, z: PLAY_H * 0.006 }`. (file: `webapp/src/pages/Games/PoolRoyale.jsx`) 
- Tightened the rail mapping by reducing `RAIL_LIMIT_PADDING` from `0.1` to `0.02` and changed `updateRailLimitsFromTable` so `RAIL_LIMIT_X` / `RAIL_LIMIT_Y` are set directly from computed cushion extents (removing the prior max-with-default clamp). (file: `webapp/src/pages/Games/PoolRoyale.jsx`) 
- Trimmed short-rail cushion length slightly by changing `SHORT_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.28` to `BALL_R * 0.34` to shorten the long side without altering cushion shape. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Launched the local dev server with `npm --prefix webapp run dev` and confirmed the Vite process started (dev server run attempted). 
- Attempted an automated visual capture using Playwright (`playwright` script to screenshot `/games/poolroyale`), but the screenshot step timed out (Playwright timeout). 
- No unit tests or test suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697333d25248832999d9028c158d032e)