### PR TITLE
Murlan Royale: top-right quick-actions, transparent buttons, and free AI matches

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -18,7 +18,8 @@ export default function BottomLeftIcons({
   giftIcon,
   infoIcon,
   muteIconOn,
-  muteIconOff
+  muteIconOff,
+  order = ['chat', 'gift', 'info', 'mute']
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -33,42 +34,59 @@ export default function BottomLeftIcons({
     setMuted(isGameMuted());
   };
 
+  const actions = {
+    chat: showChat && onChat
+      ? (
+          <button type="button" onClick={onChat} className={buttonClassName}>
+            {chatIcon ? (
+              <span className={iconClassName}>{chatIcon}</span>
+            ) : (
+              <AiOutlineMessage className={iconClassName} />
+            )}
+            <span className={labelClassName}>Chat</span>
+          </button>
+        )
+      : null,
+    gift: showGift && onGift
+      ? (
+          <button type="button" onClick={onGift} className={buttonClassName}>
+            <span className={iconClassName}>{giftIcon ?? '🎁'}</span>
+            <span className={labelClassName}>Gift</span>
+          </button>
+        )
+      : null,
+    info: showInfo
+      ? (
+          <button type="button" onClick={onInfo} className={buttonClassName}>
+            {infoIcon ? (
+              <span className={iconClassName}>{infoIcon}</span>
+            ) : (
+              <AiOutlineInfoCircle className={iconClassName} />
+            )}
+            <span className={labelClassName}>Info</span>
+          </button>
+        )
+      : null,
+    mute: showMute
+      ? (
+          <button type="button" onClick={toggle} className={buttonClassName}>
+            <span className={iconClassName}>
+              {muted ? muteIconOn ?? '🔇' : muteIconOff ?? '🔊'}
+            </span>
+            <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
+          </button>
+        )
+      : null
+  };
+
   return (
     <div className={className} style={style}>
-      {showChat && onChat && (
-        <button type="button" onClick={onChat} className={buttonClassName}>
-          {chatIcon ? (
-            <span className={iconClassName}>{chatIcon}</span>
-          ) : (
-            <AiOutlineMessage className={iconClassName} />
-          )}
-          <span className={labelClassName}>Chat</span>
-        </button>
-      )}
-      {showGift && onGift && (
-        <button type="button" onClick={onGift} className={buttonClassName}>
-          <span className={iconClassName}>{giftIcon ?? '🎁'}</span>
-          <span className={labelClassName}>Gift</span>
-        </button>
-      )}
-      {showInfo && (
-        <button type="button" onClick={onInfo} className={buttonClassName}>
-          {infoIcon ? (
-            <span className={iconClassName}>{infoIcon}</span>
-          ) : (
-            <AiOutlineInfoCircle className={iconClassName} />
-          )}
-          <span className={labelClassName}>Info</span>
-        </button>
-      )}
-      {showMute && (
-        <button type="button" onClick={toggle} className={buttonClassName}>
-          <span className={iconClassName}>
-            {muted ? muteIconOn ?? '🔇' : muteIconOff ?? '🔊'}
-          </span>
-          <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
-        </button>
-      )}
+      {order
+        .map((key) => ({ key, node: actions[key] }))
+        .filter(({ node }) => node)
+        .map(({ key, node }) => (
+          <div key={key}>{node}</div>
+        ))}
     </div>
   );
 }

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2986,6 +2986,9 @@ export default function MurlanRoyaleArena({ search }) {
         </div>
         <div className="pointer-events-auto">
           <BottomLeftIcons
+            className="fixed right-4 top-4 flex flex-col items-center space-y-2 z-20"
+            buttonClassName="flex flex-col items-center bg-transparent p-1 text-white hover:bg-transparent focus-visible:ring-2 focus-visible:ring-sky-300"
+            order={['info', 'mute', 'chat', 'gift']}
             onInfo={() => setShowInfo(true)}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -59,24 +59,28 @@ export default function MurlanRoyaleLobby() {
     let accountId;
     try {
       accountId = await ensureAccountId();
-      const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
-        alert('Insufficient balance');
-        return;
+      if (mode !== 'local' && stake.amount > 0) {
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'murlanroyale',
+          accountId,
+        });
+      } else {
+        tgId = getTelegramId();
       }
-      tgId = getTelegramId();
-      await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'murlanroyale',
-        accountId,
-      });
     } catch {}
 
     const params = new URLSearchParams();
     params.set('mode', mode);
     params.set('game', gameType);
     if (gameType === 'points') params.set('points', targetPoints);
-    if (stake.token) params.set('token', stake.token);
-    if (stake.amount) params.set('amount', stake.amount);
+    if (mode !== 'local' && stake.token) params.set('token', stake.token);
+    if (mode !== 'local' && stake.amount) params.set('amount', stake.amount);
     if (avatar) params.set('avatar', avatar);
     const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;
     if (mode === 'local') {
@@ -96,10 +100,17 @@ export default function MurlanRoyaleLobby() {
   return (
     <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
       <h2 className="text-xl font-bold text-center">Murlan Royale Lobby</h2>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-      </div>
+      {mode === 'local' ? (
+        <div className="space-y-2 rounded-lg border border-border bg-background/60 p-3 text-sm text-subtext">
+          <h3 className="font-semibold text-text">Stake</h3>
+          <p className="text-sm text-subtext">Playing against AI is free — no stake required.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <h3 className="font-semibold">Stake</h3>
+          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+        </div>
+      )}
       <div className="space-y-2">
         <h3 className="font-semibold">Mode</h3>
         <div className="flex gap-2">


### PR DESCRIPTION
### Motivation
- Place the quick-action controls (info, mute, chat, gift) in a vertical stack at the top-right of the Murlan Royale arena and remove the default colored button background so the UI matches the requested portrait layout and visual style. 
- Ensure playing vs AI (local mode) does not charge a stake so AI matches are free-play.

### Description
- Added an `order` prop and action-mapping to `BottomLeftIcons.jsx` to allow configurable ordering and conditional rendering of the quick-action buttons via the keys `chat`, `gift`, `info`, and `mute`. 
- Reused `BottomLeftIcons` in `MurlanRoyaleArena.jsx` with `className` set to position the cluster at the top-right and `buttonClassName` changed to use transparent styling and no colored background, and passed `order={['info','mute','chat','gift']}` to create the requested vertical order. 
- Updated `MurlanRoyaleLobby.jsx` to skip balance checks and stake transactions when `mode === 'local'`, and to not include stake-related URL params for local AI games; added a lobby note shown when local mode is selected indicating AI play is free.

### Testing
- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully (Vite ready). 
- Captured a mobile-portrait screenshot of the Murlan Royale page using a Playwright script against `/games/murlanroyale?mode=local&game=single` and saved it to `artifacts/murlan-royale-buttons.png`, confirming the top-right vertical stack and transparent styling visually. 
- No unit tests were modified; no automated unit test failures were introduced by these UI and lobby logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734f0b964083298b4a7e85843c875c)