### PR TITLE
Reposition quick-action controls and adjust chat bubble for Texas Hold'em UI

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1525,6 +1525,12 @@ input:focus {
   transform: none;
 }
 
+.texas-holdem-chat-bubble {
+  left: calc(0.75rem + (3.15rem * 2) + 0.75rem);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem + 0.5rem);
+  transform: none;
+}
+
 
 /* Rolling dice animation */
 .dice-screen-animation {

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -4931,11 +4931,21 @@ function TexasHoldemArena({ search }) {
       )}
       <div className="pointer-events-auto">
         <BottomLeftIcons
-          onInfo={() => setShowInfo(true)}
           onChat={() => setShowChat(true)}
           onGift={() => setShowGift(true)}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
-          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 p-0 text-white shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
+          showInfo={false}
+          showMute={false}
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-row gap-2.5 z-20"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
+          iconClassName="text-lg leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
+        />
+        <BottomLeftIcons
+          onInfo={() => setShowInfo(true)}
+          showChat={false}
+          showGift={false}
+          className="fixed right-[0.75rem] top-[calc(env(safe-area-inset-top,0px)+0.75rem)] flex flex-row gap-2.5 z-20"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
         />
@@ -4978,7 +4988,7 @@ function TexasHoldemArena({ search }) {
         </div>
       )}
       {chatBubbles.map((bubble) => (
-        <div key={bubble.id} className="chat-bubble">
+        <div key={bubble.id} className="chat-bubble texas-holdem-chat-bubble">
           <span>{bubble.text}</span>
           <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
         </div>


### PR DESCRIPTION
### Motivation
- Improve mobile (portrait) UI by moving info/mute controls to the top-right and chat/gift controls to a bottom-left horizontal row. 
- Remove the opaque blue background on quick-action buttons so icons appear with a transparent, cleaner look.
- Ensure chat bubble appears aligned with the chat button when quick chat is used.

### Description
- Added a second instance of `BottomLeftIcons` in `webapp/src/pages/Games/TexasHoldemArena.jsx` and toggled `showInfo`, `showChat`, `showGift`, and `showMute` to split controls into a bottom-left row (chat/gift) and a top-right row (info/mute). 
- Replaced the per-instance `buttonClassName` background with `bg-transparent` in the Texas Hold'em arena to remove the blue background and use a cleaner icon-only style. 
- Updated chat rendering to add a `texas-holdem-chat-bubble` class to each bubble in `webapp/src/pages/Games/TexasHoldemArena.jsx`. 
- Added `.texas-holdem-chat-bubble` CSS to `webapp/src/index.css` to position chat bubbles next to the bottom-left quick chat buttons.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported it was ready on the local port. (succeeded)
- Captured a portrait viewport screenshot of the Texas Hold'em page using Playwright; output saved to `artifacts/texas-holdem-ui.png`. (succeeded)
- No unit tests were changed or required for this UI-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734fc66a948329a09e72aa6fde22dc)