### PR TITLE
Modernize Chess Battle Royal lobby; add camera zoom with HDRI sync

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -44,6 +44,10 @@ export default function ChessBattleRoyalLobby() {
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
   useEffect(() => {
+    import('./ChessBattleRoyal.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
@@ -238,197 +242,325 @@ export default function ChessBattleRoyalLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Chess Battle Royal Lobby</h2>
-      <p className="text-center text-sm">
-        Online users: {onlineCount != null ? onlineCount : 'Syncing…'}
-      </p>
-
-      <div className="space-y-2">
-        <h3 className="font-semibold">Choose Mode</h3>
-        <div className="grid grid-cols-2 gap-2">
-          {[
-            { key: 'ai', label: 'Vs AI', desc: 'Instant practice' },
-            { key: 'online', label: 'Online', desc: 'Stake & match' }
-          ].map(({ key, label, desc }) => {
-            const active = mode === key;
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setMode(key)}
-                className={`rounded-xl border px-3 py-3 text-left shadow transition hover:border-primary ${
-                  active
-                    ? 'border-primary bg-primary/10 text-primary'
-                    : 'border-border bg-background/70 text-text'
-                }`}
-              >
-                <div className="flex items-center justify-between">
-                  <span className="font-semibold">{label}</span>
-                  {active && <span className="text-xs font-bold">Selected</span>}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">
+                Chess Battle Royal
+              </p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+            </div>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              {onlineCount != null ? `${onlineCount} online` : 'Syncing…'}
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    ♟️
+                  </div>
                 </div>
-                <div className="text-xs text-subtext">{desc}</div>
-              </button>
-            );
-          })}
+                <div>
+                  <p className="text-sm font-semibold text-white">Battle Queue</p>
+                  <p className="text-xs text-white/60">
+                    Prep your pieces while the arena loads in the background.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant start</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+                  <p className="text-xs text-white/50">
+                    Flag: {selectedFlag || 'Auto'}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your lobby choices persist into the match start screen.
+              </p>
+            </div>
+          </div>
         </div>
-        <p className="text-xs text-subtext text-center">
-          AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
-        </p>
-      </div>
 
-      {mode === 'online' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Select Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-          <p className="text-center text-subtext text-sm">
-            Staking uses your TPC account{accountId ? ` #${accountId}` : ''} as escrow for every online round.
-          </p>
-        </div>
-      )}
-
-      {mode === 'online' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Pick Your Pieces</h3>
-          <div className="grid grid-cols-3 gap-2">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
             {[
-              { key: 'auto', label: 'Auto', desc: 'Random seats, no duplicates' },
-              { key: 'white', label: 'White', desc: 'You start first' },
-              { key: 'black', label: 'Black', desc: 'Opponent opens' }
-            ].map(({ key, label, desc }) => {
-              const active = preferredSide === key;
+              {
+                key: 'ai',
+                label: 'Vs AI',
+                desc: 'Instant practice',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🤖'
+              },
+              {
+                key: 'online',
+                label: 'Online',
+                desc: 'Stake & match',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '⚔️'
+              }
+            ].map(({ key, label, desc, accent, icon }) => {
+              const active = mode === key;
               return (
                 <button
                   key={key}
                   type="button"
-                  onClick={() => setPreferredSide(key)}
-                  className={`rounded-xl border px-3 py-3 text-left shadow transition hover:border-primary ${
+                  onClick={() => setMode(key)}
+                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
                     active
                       ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-border bg-background/70 text-text'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   }`}
                 >
-                  <div className="flex items-center justify-between">
-                    <span className="font-semibold">{label}</span>
-                    {active && <span className="text-xs font-bold">Selected</span>}
+                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                      {icon}
+                    </div>
                   </div>
-                  <div className="text-xs text-subtext">{desc}</div>
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-base font-semibold">{label}</span>
+                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                    </div>
+                    <div className="text-xs text-white/60">{desc}</div>
+                  </div>
                 </button>
               );
             })}
           </div>
-          <p className="text-xs text-subtext text-center">
-            Auto randomizes colors while ensuring both players get different sides.
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
           </p>
         </div>
-      )}
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">Your Flag & Avatar</h3>
-        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
-          <button
-            type="button"
-            onClick={() => setShowFlagPicker(true)}
-            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-          >
-            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
-            <div className="flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedFlag || '🌐'}</span>
-              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
-            </div>
-          </button>
-          {avatar && (
+        {mode === 'online' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
             <div className="flex items-center gap-3">
-              <img
-                src={avatar}
-                alt="Your avatar"
-                className="h-12 w-12 rounded-full border border-border object-cover"
-              />
-              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
             </div>
-          )}
-        </div>
-      </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+            <p className="text-center text-white/60 text-xs">
+              Staking uses your TPC account{accountId ? ` #${accountId}` : ''} as escrow for every online round.
+            </p>
+          </div>
+        )}
 
-      {mode === 'ai' && (
+        {mode === 'online' && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pick Your Pieces</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Sides</span>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {[
+                {
+                  key: 'auto',
+                  label: 'Auto',
+                  desc: 'Random seats, no duplicates',
+                  accent: 'from-slate-400/30 via-slate-500/10 to-transparent',
+                  icon: '🎲'
+                },
+                {
+                  key: 'white',
+                  label: 'White',
+                  desc: 'You start first',
+                  accent: 'from-white/40 via-white/10 to-transparent',
+                  icon: '♔'
+                },
+                {
+                  key: 'black',
+                  label: 'Black',
+                  desc: 'Opponent opens',
+                  accent: 'from-gray-500/30 via-gray-700/10 to-transparent',
+                  icon: '♚'
+                }
+              ].map(({ key, label, desc, accent, icon }) => {
+                const active = preferredSide === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setPreferredSide(key)}
+                    className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    }`}
+                  >
+                    <div className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                        {icon}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold">{label}</span>
+                        {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                      </div>
+                      <div className="text-xs text-white/60">{desc}</div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-white/60 text-center">
+              Auto randomizes colors while ensuring both players get different sides.
+            </p>
+          </div>
+        )}
+
         <div className="space-y-2">
-          <h3 className="font-semibold">AI Avatar Flags</h3>
-          <p className="text-sm text-subtext">
-            Pick the country flag for the AI rival so it matches the Snake &amp; Ladder experience.
-          </p>
-          <button
-            type="button"
-            onClick={() => setShowAiFlagPicker(true)}
-            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-          >
-            <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
-            <div className="flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-              <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
+              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            {avatar && (
+              <div className="mt-3 flex items-center gap-3">
+                <img
+                  src={avatar}
+                  alt="Your avatar"
+                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
+                />
+                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {mode === 'ai' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-start gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🤝
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+                <p className="text-xs text-white/60">
+                  Pick the country flag for the AI rival so it matches the Snake &amp; Ladder experience.
+                </p>
+              </div>
             </div>
-          </button>
-        </div>
-      )}
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
+              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
+              </div>
+            </button>
+          </div>
+        )}
 
-      {mode === 'online' && matching && (
-        <div className="space-y-2 rounded-xl border border-primary/40 bg-primary/5 p-3 shadow">
-          <h3 className="font-semibold text-primary">Matching players…</h3>
-          <p className="text-sm text-subtext">{matchStatus || 'Syncing with the lobby…'}</p>
-          {matchError && <p className="text-sm text-red-500">{matchError}</p>}
-          <button
-            type="button"
-            className="w-full rounded-lg border border-border bg-background/60 px-3 py-2 text-sm hover:border-primary"
-            onClick={() => cleanupLobby({ account: accountId })}
-          >
-            Cancel matchmaking
-          </button>
-        </div>
-      )}
+        {mode === 'online' && matching && (
+          <div className="space-y-2 rounded-2xl border border-primary/40 bg-primary/5 p-4 shadow">
+            <h3 className="font-semibold text-primary">Matching players…</h3>
+            <p className="text-sm text-white/60">{matchStatus || 'Syncing with the lobby…'}</p>
+            {matchError && <p className="text-sm text-red-400">{matchError}</p>}
+            <button
+              type="button"
+              className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white/80 hover:border-white/30"
+              onClick={() => cleanupLobby({ account: accountId })}
+            >
+              Cancel matchmaking
+            </button>
+          </div>
+        )}
 
-      <button
-        onClick={startGame}
-        disabled={matching}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-60 disabled:cursor-not-allowed"
-      >
-        {mode === 'online'
-          ? matching
-            ? 'Finding Online Match…'
-            : 'Find Online Match'
-          : 'Play vs AI'}
-      </button>
+        <button
+          onClick={startGame}
+          disabled={matching}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {mode === 'online'
+            ? matching
+              ? 'Finding Online Match…'
+              : 'Find Online Match'
+            : 'Play vs AI'}
+        </button>
 
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={1}
-        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setPlayerFlagIndex(idx);
-          try {
-            if (idx != null) {
-              window.localStorage?.setItem('chessBattleRoyalPlayerFlag', FLAG_EMOJIS[idx]);
-            }
-          } catch {}
-        }}
-        onClose={() => setShowFlagPicker(false)}
-      />
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) {
+                window.localStorage?.setItem('chessBattleRoyalPlayerFlag', FLAG_EMOJIS[idx]);
+              }
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
 
-      <FlagPickerModal
-        open={showAiFlagPicker}
-        count={1}
-        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setAiFlagIndex(idx);
-          try {
-            if (idx != null) {
-              window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-            }
-          } catch {}
-        }}
-        onClose={() => setShowAiFlagPicker(false)}
-      />
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) {
+                window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+              }
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Improve the Chess Battle Royal lobby UX with a modern, mobile-first lobby that shows thumbnails and profile information while preserving existing options and flow. 
- Reduce perceived load time by preloading the Chess game bundle while the player configures the lobby. 
- Give players direct camera control (zoom in/out) and keep HDRI skybox scaled correctly when zooming so the environment feels consistent.

### Description
- Reworked the lobby UI in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` to a modern, card/thumbnail-driven, mobile-friendly layout and preserved all existing options (mode, stake, pieces, flags, avatar, matchmaking). 
- Added a background preload call from the lobby with `import('./ChessBattleRoyal.jsx')` so the game bundle begins loading while the user remains in the lobby. 
- Enabled and constrained OrbitControls zoom, introduced new camera radius ranges (`CAMERA_3D_MIN_RADIUS`, `CAMERA_3D_MAX_RADIUS`, `CAMERA_2D_MIN_RADIUS`, `CAMERA_2D_MAX_RADIUS`) and ensured view-mode-specific min/max distances in `webapp/src/pages/Games/ChessBattleRoyal.jsx`. 
- Implemented `handleZoom(direction)` and UI zoom buttons (+ / −) in the in-game controls and exposed `syncSkyboxToCamera` on the arena so the HDRI skybox scales together with camera distance.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the lobby page loads in a mobile portrait viewport (automated). (succeeded) 
- Ran an automated Playwright smoke script that opened `/games/chessbattleroyal/lobby` at 430x932 and captured a screenshot to validate the new lobby layout; the script completed and produced an artifact image (succeeded). 
- No unit tests modified or run as part of this change; changes are primarily UI/UX and runtime behavior adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697352c12aac8329b8f9eff456795912)