### PR TITLE
Reposition air hockey action buttons

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -4,12 +4,12 @@ import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { bombSound, chatBeep } from '../assets/soundData.js';
-import BottomLeftIcons from './BottomLeftIcons.jsx';
 import GiftPopup from './GiftPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 import QuickMessagePopup from './QuickMessagePopup.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
-import { getGameVolume, isGameMuted } from '../utils/sound.js';
+import { AiOutlineInfoCircle, AiOutlineMessage } from 'react-icons/ai';
+import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 import { applyWoodTextures, WOOD_GRAIN_OPTIONS_BY_ID } from '../utils/woodMaterials.js';
 import { AIR_HOCKEY_CUSTOMIZATION } from '../config/airHockeyInventoryConfig.js';
@@ -2103,13 +2103,86 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           className="w-5 h-5 rounded-full object-cover"
         />
       </div>
-      <div className="absolute bottom-2 left-2 z-20 flex flex-col items-start gap-3 pointer-events-auto">
-        <BottomLeftIcons
-          onInfo={() => setShowInfo(true)}
-          onChat={() => setShowChat(true)}
-          onGift={() => setShowGift(true)}
-          className="flex flex-col items-center space-y-2"
-        />
+      <div
+        className={`absolute z-20 flex flex-col gap-3 pointer-events-auto ${
+          isTopDownView
+            ? 'left-3 top-[45%] -translate-y-1/2 items-center'
+            : 'bottom-2 left-2 items-start'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setShowChat(true)}
+          className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+        >
+          <AiOutlineMessage className="text-xl" />
+          <span>Chat</span>
+        </button>
+        {isTopDownView ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setShowInfo(true)}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <AiOutlineInfoCircle className="text-xl" />
+              <span>Info</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                toggleGameMuted();
+                setMuted(isGameMuted());
+              }}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+              <span>{muted ? 'Unmute' : 'Mute'}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowGift(true)}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <span className="text-xl">🎁</span>
+              <span>Gift</span>
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => setShowGift(true)}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <span className="text-xl">🎁</span>
+              <span>Gift</span>
+            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  toggleGameMuted();
+                  setMuted(isGameMuted());
+                }}
+                className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              >
+                <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+                <span>{muted ? 'Unmute' : 'Mute'}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowInfo(true)}
+                className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              >
+                <AiOutlineInfoCircle className="text-xl" />
+                <span>Info</span>
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+      <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
         <button
           type="button"
           aria-pressed={isTopDownView}
@@ -2125,16 +2198,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             <span>{isTopDownView ? '3D' : '2D'}</span>
           </span>
         </button>
-        {!gameOver && (
-          <button
-            onClick={() => (window.location.href = '/games/airhockey/lobby')}
-            className="text-white text-xs bg-white/10 hover:bg-white/20 rounded px-2 py-1"
-          >
-            Exit to Lobby
-          </button>
-        )}
-      </div>
-      <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
         <button
           onClick={() => setShowCustomizer((v) => !v)}
           className="rounded px-3 py-2 text-xs font-semibold text-white bg-white/10 hover:bg-white/20 backdrop-blur"


### PR DESCRIPTION
### Motivation
- Update the Air Hockey UI so chat/gift/info/mute buttons have transparent backgrounds and follow the new layout rules for portrait mobile play.
- Remove the `Exit to Lobby` control and relocate the 2D/3D toggle next to the customize control on the right side as requested.

### Description
- Replaced the `BottomLeftIcons` cluster with a custom inline layout in `webapp/src/components/AirHockey3D.jsx` that renders `Chat`, `Gift`, `Info`, and `Mute` buttons with `bg-transparent` styling and small labels. 
- Placed the action cluster at bottom-left in normal view and at a centered vertical position (`left-3 top-[45%] -translate-y-1/2`) when `isTopDownView` (2D) is active so buttons align vertically in the middle of the screen.
- Moved the 2D/3D toggle to the right panel above the `Customize table` control and removed the `Exit to Lobby` button from the main left cluster.
- Added imports for `AiOutlineInfoCircle`, `AiOutlineMessage` and `toggleGameMuted` and wired the mute button to call `toggleGameMuted()` and update local `muted` state.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev` and Vite reported ready and serving the site at the local and network URLs. (succeeded)
- Attempted a headless browser verification using Playwright to capture a screenshot of `/games/airhockey`, but the screenshot step timed out after several retries (Playwright `Page.screenshot` timeout). (failed)
- No automated unit tests were executed as part of this change. (none run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697356bb36c48329bef25b93e8eadcd0)