### PR TITLE
Restore Pool Royale pot visuals, 2D-button camera framing, and in‑hand/replay behaviour

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -340,9 +340,6 @@ export class PoolRoyaleRules {
     } else {
       game.startBreak();
     }
-    if (state.activePlayer && game.state.currentPlayer !== state.activePlayer) {
-      game.state.currentPlayer = state.activePlayer;
-    }
     const contactOrder: UkColour[] = [];
     for (const ev of events) {
       if (ev.type !== 'HIT') continue;
@@ -454,9 +451,6 @@ export class PoolRoyaleRules {
     } else {
       game.state.ballInHand = true;
     }
-    if (state.activePlayer && game.state.currentPlayer !== state.activePlayer) {
-      game.state.currentPlayer = state.activePlayer;
-    }
     const contactOrder: number[] = [];
     for (const ev of events) {
       if (ev.type !== 'HIT') continue;
@@ -543,9 +537,6 @@ export class PoolRoyaleRules {
       applyNineState(game, previous.state);
     } else {
       game.state.ballInHand = true;
-    }
-    if (state.activePlayer && game.state.currentPlayer !== state.activePlayer) {
-      game.state.currentPlayer = state.activePlayer;
     }
     const contactOrder: number[] = [];
     for (const ev of events) {


### PR DESCRIPTION
### Motivation
- Restore the previous Pool Royale pot visuals so potted balls remain visible on the pocket holder rails and also show a short popup copy above the pocket like the prior build. 
- Re-align the 2D/top-view camera coordinates used by the small 2D button so the button reproduces the exact framing used previously while leaving broadcast cameras unchanged. 
- Return the in-hand placement interaction and replay-triggering behaviour to the earlier, simpler flow so ball-in-hand placement is immediate and potted shots are eligible for replay.

### Description
- Pocket visuals: re-added immediate pocket popup clones and made the popup visible for `2500ms` by restoring clone creation at pot time and pushing them into `pocketPopupRef` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- 2D button camera: introduced dedicated `TOP_VIEW_BUTTON_*` constants and wired top-view entry / fit logic to use those constants so the 2D button framing matches the previous build without changing broadcast rigs (`webapp/src/pages/Games/PoolRoyale.jsx`).
- In-hand / input: removed the long-press hold timer and snapshot-pointer logic for the in-hand indicator and reverted to immediate in-hand placement handlers (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replay gating: relaxed replay decision gating so potted shots are considered for replays (removed the early `nonPotTags` guard) to restore replay triggers for pot events (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Baulk/head string: realigned the baulk/head-string reference by setting `BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25` to match the official quarter-table head string placement (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Rules cleanup: removed the previous forced overrides that set `game.state.currentPlayer = state.activePlayer` inside shot application so rule processing uses the internal game state as intended (`src/rules/PoolRoyaleRules.ts`).

### Testing
- Started the dev site with `npm --prefix webapp run dev` and confirmed Vite reported the dev server ready at the local URL.  
- Attempted an automated visual check with Playwright to capture the Pool Royale page, but the screenshot attempt timed out in this environment.  
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735a6435ec83299f5cf211fea388bf)