### PR TITLE
Ludo: enable pinch zoom and modernize lobby (preload game view)

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4104,10 +4104,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.enableDamping = true;
     controls.dampingFactor = 0.08;
     controls.enablePan = false;
-    controls.enableZoom = false;
-    const lockedRadius = CAM.maxR;
-    controls.minDistance = lockedRadius;
-    controls.maxDistance = lockedRadius;
+    controls.enableZoom = true;
+    controls.zoomSpeed = CAMERA_DOLLY_FACTOR;
+    controls.minDistance = CAM.minR;
+    controls.maxDistance = CAM.maxR;
     controls.minPolarAngle = CAM.phiMin;
     controls.maxPolarAngle = CAM.phiMax;
     controls.target.copy(boardLookTarget);
@@ -4140,7 +4140,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const span = Math.max(tableSpan, boardSpan);
       const needed = span / (2 * Math.tan(THREE.MathUtils.degToRad(CAM.fov) / 2));
       const currentRadius = camera.position.distanceTo(boardLookTarget);
-      const radius = clamp(Math.max(needed, currentRadius), lockedRadius, lockedRadius);
+      const radius = clamp(Math.max(needed, currentRadius), CAM.minR, CAM.maxR);
       const dir = camera.position.clone().sub(boardLookTarget).normalize();
       camera.position.copy(boardLookTarget).addScaledVector(dir, radius);
       if (baseCameraRadiusRef.current == null) {

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -35,7 +35,11 @@ export default function LudoBattleRoyalLobby() {
   const [aiType, setAiType] = useState('flags');
   const [flags, setFlags] = useState([]);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
-  const [online, setOnline] = useState(0);
+  const [online, setOnline] = useState(null);
+
+  useEffect(() => {
+    import('./LudoBattleRoyal.jsx').catch(() => {});
+  }, []);
 
   useEffect(() => {
     try {
@@ -159,85 +163,174 @@ export default function LudoBattleRoyalLobby() {
   const flagPickerCount = table?.id === 'practice' ? aiCount || 1 : Math.max(aiCount || 1, 1);
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Ludo Battle Royal Lobby</h2>
-      <p className="text-center text-sm">Online users: {online}</p>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Select Table</h3>
-        <TableSelector tables={TABLES} selected={table} onSelect={setTable} />
-      </div>
-
-      <div className="space-y-2">
-        <h3 className="font-semibold">Select Stake</h3>
-        <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-        <p className="text-center text-subtext text-sm">Staking is handled via the on-chain contract.</p>
-      </div>
-
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext text-center">
-          Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents.
-        </p>
-        <button
-          type="button"
-          onClick={openAiFlagPicker}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-        >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flags</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">
-              {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
-            </span>
-            <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
+                Ludo Battle Royal
+              </p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+            </div>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              {online != null ? `${online} online` : 'Syncing…'}
+            </div>
           </div>
-        </button>
-      </div>
-
-      {table?.id === 'practice' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">How many AI opponents?</h3>
-          <div className="flex gap-2">
-            {[1, 2, 3].map((n) => (
-              <button
-                key={n}
-                onClick={() => setAiCount(n)}
-                className={`lobby-tile ${aiCount === n ? 'lobby-selected' : ''}`}
-              >
-                {n}
-              </button>
-            ))}
-          </div>
-          <h3 className="font-semibold mt-2">AI Avatars</h3>
-          <div className="flex gap-2">
-            {['flags'].map((t) => (
-              <button
-                key={t}
-                onClick={() => selectAiType(t)}
-                className={`lobby-tile ${aiType === t ? 'lobby-selected' : ''}`}
-              >
-                Flags
-              </button>
-            ))}
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🎲
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Battle Queue</p>
+                  <p className="text-xs text-white/60">
+                    Configure your match while the arena loads in the background.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant lobby</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Touch ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">Ready for battle</p>
+                  <p className="text-xs text-white/50">
+                    AI flags: {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : 'Auto'}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your lobby settings carry over as soon as the match loads.
+              </p>
+            </div>
           </div>
         </div>
-      )}
 
-      <button
-        onClick={startGame}
-        disabled={disabled}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
-      >
-        Start Game
-      </button>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Select Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Tables</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <TableSelector tables={TABLES} selected={table} onSelect={setTable} />
+          </div>
+        </div>
 
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={flagPickerCount}
-        selected={flags}
-        onSave={setFlags}
-        onClose={() => setShowFlagPicker(false)}
-        onComplete={(sel) => startGame(sel)}
-      />
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Select Stake</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">TPC</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            <p className="text-center text-white/60 text-xs mt-3">
+              Staking is handled via the on-chain contract.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+          <div className="flex items-start gap-3">
+            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                🧠
+              </div>
+            </div>
+            <div>
+              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+              <p className="text-xs text-white/60">
+                Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={openAiFlagPicker}
+            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+          >
+            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flags</div>
+            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">
+                {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
+              </span>
+              <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+            </div>
+          </button>
+        </div>
+
+        {table?.id === 'practice' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Practice Settings</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Solo</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-3">
+              <div>
+                <h4 className="font-semibold text-white text-sm">How many AI opponents?</h4>
+                <div className="mt-2 flex gap-2">
+                  {[1, 2, 3].map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setAiCount(n)}
+                      className={`lobby-tile ${aiCount === n ? 'lobby-selected' : ''}`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h4 className="font-semibold text-white text-sm">AI Avatars</h4>
+                <div className="mt-2 flex gap-2">
+                  {['flags'].map((t) => (
+                    <button
+                      key={t}
+                      onClick={() => selectAiType(t)}
+                      className={`lobby-tile ${aiType === t ? 'lobby-selected' : ''}`}
+                    >
+                      Flags
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <button
+          onClick={startGame}
+          disabled={disabled}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Start Game
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={flagPickerCount}
+          selected={flags}
+          onSave={setFlags}
+          onClose={() => setShowFlagPicker(false)}
+          onComplete={(sel) => startGame(sel)}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Let players pinch/drag to zoom the Ludo arena while keeping HDRI scaling synced to camera distance for a better mobile-first experience. 
- Replace the old Ludo lobby with a modern, chess-like lobby so the UI matches the Chess Battle Royal experience and the game can begin loading while players configure options.

### Description
- Enabled OrbitControls zoom in `LudoBattleRoyal.jsx` by setting `controls.enableZoom = true`, `controls.zoomSpeed = CAMERA_DOLLY_FACTOR`, and allowing `controls.minDistance`/`controls.maxDistance` to use `CAM.minR`/`CAM.maxR`, and updated the fit logic to clamp radius to `CAM.minR`/`CAM.maxR`.
- Reworked `LudoBattleRoyalLobby.jsx` into a modern Chess-style layout, moved existing table/stake/AI options into the new panels, and adjusted header online-count handling by initializing `online` to `null` so the header shows `Syncing…` until data arrives.
- Added a background preload import in the lobby (`import('./LudoBattleRoyal.jsx').catch(() => {});`) so the Ludo game begins loading while the user configures the lobby.
- Preserved the existing `startGame` flow, flag picker, and table/stake logic while restyling the UI.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully.
- Captured a mobile viewport screenshot with Playwright by navigating to `/games/ludobattleroyal/lobby`, which produced the artifact `artifacts/ludo-lobby.png` confirming the new lobby renders.
- No unit tests were added; this change is UI/UX focused and validated via the dev server and automated screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735be8b300832983fa545b4deed689)