### PR TITLE
Redesign Air Hockey lobby to modern Chess Battle Royal style

### DIFF
--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -36,6 +36,10 @@ export default function AirHockeyLobby() {
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
   useEffect(() => {
+    import('./AirHockey.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
@@ -111,171 +115,324 @@ export default function AirHockeyLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Air Hockey Lobby</h2>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Type</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'regular', label: 'Regular' },
-            { id: 'training', label: 'Training' },
-            { id: 'tournament', label: 'Tournament' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setPlayType(id)}
-              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-      {playType !== 'training' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Mode</h3>
-          <div className="flex gap-2">
-            {[
-              { id: 'ai', label: 'Vs AI' },
-              { id: 'online', label: '1v1 Online', disabled: true }
-            ].map(({ id, label, disabled }) => (
-              <div key={id} className="relative">
-                <button
-                  onClick={() => !disabled && setMode(id)}
-                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                    disabled ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
-                  disabled={disabled}
-                >
-                  {label}
-                </button>
-                {disabled && (
-                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                    Under development
-                  </span>
-                )}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Air Hockey</p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+            </div>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              Fast load
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🏒
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Match Setup</p>
+                  <p className="text-xs text-white/60">
+                    Configure your puck battle while the arena loads in the background.
+                  </p>
+                </div>
               </div>
-            ))}
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant play</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Neon rink</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+                  <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your lobby choices persist into the match intro.
+              </p>
+            </div>
           </div>
         </div>
-      )}
-      <div className="space-y-2">
-        <h3 className="font-semibold">Goals</h3>
-        <div className="flex gap-2">
-          {[11, 21, 31].map((g) => (
-            <button
-              key={g}
-              onClick={() => setGoal(g)}
-              className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
-            >
-              {g}
-            </button>
-          ))}
-        </div>
-      </div>
-      {playType === 'tournament' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Players</h3>
-          <div className="flex gap-2">
-            {[8, 16, 24].map((p) => (
-              <button
-                key={p}
-                onClick={() => setPlayers(p)}
-                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
-        </div>
-      )}
-      {playType !== 'training' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-        </div>
-      )}
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">Your Flag & Avatar</h3>
-        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Mode</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { id: 'regular', label: 'Regular', desc: 'Classic rink', icon: '🏒' },
+              { id: 'training', label: 'Training', desc: 'Practice hits', icon: '🎯' },
+              { id: 'tournament', label: 'Tournament', desc: 'Bracket battle', icon: '🏆' }
+            ].map(({ id, label, desc, icon }) => {
+              const active = playType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setPlayType(id)}
+                  className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-400/20 to-transparent p-[1px]">
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                      {icon}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{label}</span>
+                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                    </div>
+                    <div className="text-xs text-white/60">{desc}</div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {playType !== 'training' && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Match Mode</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                { id: 'ai', label: 'Vs AI', desc: 'Instant practice', icon: '🤖' },
+                { id: 'online', label: '1v1 Online', desc: 'Coming soon', icon: '⚔️', disabled: true }
+              ].map(({ id, label, desc, icon, disabled }) => {
+                const active = mode === id;
+                return (
+                  <div key={id} className="relative">
+                    <button
+                      type="button"
+                      onClick={() => !disabled && setMode(id)}
+                      className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                        active
+                          ? 'border-primary bg-primary/10 text-primary'
+                          : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                      } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                      disabled={disabled}
+                    >
+                      <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-emerald-400/30 via-sky-400/20 to-transparent p-[1px]">
+                        <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                          {icon}
+                        </div>
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between">
+                          <span className="text-base font-semibold">{label}</span>
+                          {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                        </div>
+                        <div className="text-xs text-white/60">{desc}</div>
+                      </div>
+                    </button>
+                    {disabled && (
+                      <span className="absolute inset-0 flex items-center justify-center rounded-2xl text-xs text-white/70">
+                        Under development
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Goal Target</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Score</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[11, 21, 31].map((g) => {
+              const active = goal === g;
+              return (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => setGoal(g)}
+                  className={`rounded-2xl border px-4 py-3 text-center font-semibold shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  First to {g}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {playType === 'tournament' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-amber-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🏆
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Tournament Players</h3>
+                <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
+              </div>
+            </div>
+            <div className="mt-3 grid gap-3 sm:grid-cols-3">
+              {[8, 16, 24].map((p) => {
+                const active = players === p;
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setPlayers(p)}
+                    className={`rounded-2xl border px-4 py-3 text-center font-semibold shadow transition ${
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    }`}
+                  >
+                    {p} Players
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {playType !== 'training' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-cyan-400/40 to-blue-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💎
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC for ranked play.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
+              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            {avatar && (
+              <div className="mt-3 flex items-center gap-3">
+                <img
+                  src={avatar}
+                  alt="Your avatar"
+                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
+                />
+                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+          <div className="flex items-start gap-3">
+            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                🤝
+              </div>
+            </div>
+            <div>
+              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+              <p className="text-xs text-white/60">
+                Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
+              </p>
+            </div>
+          </div>
           <button
             type="button"
-            onClick={() => setShowFlagPicker(true)}
-            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+            onClick={() => setShowAiFlagPicker(true)}
+            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
           >
-            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
-            <div className="flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedFlag || '🌐'}</span>
-              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
+            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+              <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
             </div>
           </button>
-          {avatar && (
-            <div className="flex items-center gap-3">
-              <img
-                src={avatar}
-                alt="Your avatar"
-                className="h-12 w-12 rounded-full border border-border object-cover"
-              />
-              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
-            </div>
-          )}
         </div>
-      </div>
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext">
-          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
-        </p>
         <button
-          type="button"
-          onClick={() => setShowAiFlagPicker(true)}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover"
         >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-          </div>
+          START
         </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
       </div>
-
-      <button
-        onClick={startGame}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
-      >
-        START
-      </button>
-
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={1}
-        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setPlayerFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowFlagPicker(false)}
-      />
-
-      <FlagPickerModal
-        open={showAiFlagPicker}
-        count={1}
-        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setAiFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowAiFlagPicker(false)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the Air Hockey lobby visually match the modern Chess Battle Royal (and Ludo) lobby so players see a consistent, modern UI while the game scene loads in the background.
- Preserve all existing gameplay options (type, mode, goals, players, stake, flags) so functionality is unchanged while improving UX.

### Description
- Preload the game scene by adding a dynamic import `import('./AirHockey.jsx').catch(() => {});` on mount to start background loading of the Air Hockey arena.
- Replace the previous simple lobby markup with a modern card-based layout and styling copied/adapted from the Chess Battle Royal lobby while keeping existing state and `startGame` parameter logic intact.
- Reorganized controls into modern cards (Game Type, Match Mode, Goal Target, Tournament, Stake, Profile, AI Flag) and preserved `FlagPickerModal` behavior and localStorage keys (`airHockeyPlayerFlag`, `airHockeyAiFlag`).
- Kept online mode disabled where appropriate and retained all URL param composition (stake, avatar, flags, account info) used when navigating into `./AirHockey` game route.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and Vite reported ready, which succeeded.
- Ran a Playwright script to load `http://127.0.0.1:5173/games/airhockey/lobby` and capture a screenshot, which completed and produced `artifacts/air-hockey-lobby.png` successfully.
- No unit tests were modified or required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697362310308832996f0d34215b3f2a7)