### PR TITLE
Redesign Murlan Royale lobby to match Chess Battle Royal styling

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -48,6 +48,10 @@ export default function MurlanRoyaleLobby() {
   }, []);
 
   useEffect(() => {
+    import('./MurlanRoyale.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
     setFlags((prev) => {
       if (prev.length === flagPickerCount) return prev;
       return pickRandomFlags(flagPickerCount);
@@ -98,108 +102,260 @@ export default function MurlanRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Murlan Royale Lobby</h2>
-      {mode === 'local' ? (
-        <div className="space-y-2 rounded-lg border border-border bg-background/60 p-3 text-sm text-subtext">
-          <h3 className="font-semibold text-text">Stake</h3>
-          <p className="text-sm text-subtext">Playing against AI is free — no stake required.</p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-        </div>
-      )}
-      <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online', disabled: true }
-          ].map(({ id, label, disabled }) => (
-            <div key={id} className="relative">
-              <button
-                onClick={() => !disabled && setMode(id)}
-                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                  disabled ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-                disabled={disabled}
-              >
-                {label}
-              </button>
-              {disabled && (
-                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Under development
-                </span>
-              )}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">
+                Murlan Royale
+              </p>
+              <h2 className="text-2xl font-bold text-white">Modern Air Hockey Lobby</h2>
             </div>
-          ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext text-center">
-          Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents and your seat.
-        </p>
-        <button
-          type="button"
-          onClick={openAiFlagPicker}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-        >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flags</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}</span>
-            <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              Arena preloading
+            </div>
           </div>
-        </button>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Game Type</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'single', label: 'Single Game' },
-            { id: 'points', label: 'Points' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setGameType(id)}
-              className={`lobby-tile ${gameType === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🏒
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Warmup Queue</p>
+                  <p className="text-xs text-white/60">
+                    Pick your Murlan options while the arena loads in the background.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant start</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">Player ready</p>
+                  <p className="text-xs text-white/50">AI flags: {flags.length ? 'Custom' : 'Auto'}</p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your lobby choices roll into the air hockey match intro.
+              </p>
+            </div>
+          </div>
         </div>
-        {gameType === 'points' && (
-          <div className="flex gap-2">
-            {[11, 21, 31].map((pts) => (
-              <button
-                key={pts}
-                onClick={() => setTargetPoints(pts)}
-                className={`lobby-tile ${targetPoints === pts ? 'lobby-selected' : ''}`}
-              >
-                {pts} pts
-              </button>
-            ))}
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                key: 'local',
+                label: 'Local (AI)',
+                desc: 'Instant practice',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🤖',
+                disabled: false
+              },
+              {
+                key: 'online',
+                label: 'Online',
+                desc: 'Stake & match',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '⚔️',
+                disabled: true
+              }
+            ].map(({ key, label, desc, accent, icon, disabled }) => {
+              const active = mode === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => !disabled && setMode(key)}
+                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                  disabled={disabled}
+                >
+                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                      {icon}
+                    </div>
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-base font-semibold">{label}</span>
+                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                    </div>
+                    <div className="text-xs text-white/60">
+                      {desc}
+                      {disabled ? ' · Under development' : ''}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline. Online mode will unlock once the air hockey queue is live.
+          </p>
+        </div>
+
+        {mode === 'local' ? (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-emerald-400/40 to-cyan-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🎯
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Stake</h3>
+                <p className="text-xs text-white/60">Playing against AI is free — no stake required.</p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
           </div>
         )}
-      </div>
-      <button
-        onClick={startGame}
-        disabled={mode === 'local' && flags.length !== flagPickerCount}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
-      >
-        START
-      </button>
 
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={flagPickerCount}
-        selected={flags}
-        onSave={setFlags}
-        onClose={() => setShowFlagPicker(false)}
-        onComplete={(sel) => startGame(sel)}
-      />
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Match</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              { id: 'single', label: 'Single Game', desc: 'One quick round', icon: '🏁' },
+              { id: 'points', label: 'Points', desc: 'Play to a target', icon: '🎯' }
+            ].map(({ id, label, desc, icon }) => {
+              const active = gameType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setGameType(id)}
+                  className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/5 text-xl">
+                    {icon}
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-base font-semibold">{label}</span>
+                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                    </div>
+                    <div className="text-xs text-white/60">{desc}</div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {gameType === 'points' && (
+            <div className="grid gap-3 sm:grid-cols-3">
+              {[11, 21, 31].map((pts) => (
+                <button
+                  key={pts}
+                  type="button"
+                  onClick={() => setTargetPoints(pts)}
+                  className={`rounded-2xl border px-4 py-3 text-sm font-semibold shadow transition ${
+                    targetPoints === pts
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  {pts} pts
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+          <div className="flex items-start gap-3">
+            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                🌍
+              </div>
+            </div>
+            <div>
+              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+              <p className="text-xs text-white/60">
+                Pick the flags for your AI opponents and your seat, just like the air hockey roster.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={openAiFlagPicker}
+            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+          >
+            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flags</div>
+            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">
+                {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
+              </span>
+              <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+            </div>
+          </button>
+        </div>
+
+        <button
+          onClick={startGame}
+          disabled={mode === 'local' && flags.length !== flagPickerCount}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Start Air Hockey
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={flagPickerCount}
+          selected={flags}
+          onSave={setFlags}
+          onClose={() => setShowFlagPicker(false)}
+          onComplete={(sel) => startGame(sel)}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale lobby visually match the modern Chess Battle Royal lobby so the air hockey experience is consistent with other games.
- Ensure the Murlan game can begin loading in the background from the lobby to improve transition speed and perceived responsiveness.
- Keep existing lobby options and flows (stake, mode, game type, AI flags) while updating layout and copy for air hockey.

### Description
- Rebuilt `MurlanRoyaleLobby.jsx` UI with a modern card/grid layout and updated copy to match the Chess Battle Royal lobby look while surfacing the same options.  
- Added a background preloader by importing the game page with `import('./MurlanRoyale.jsx').catch(() => {});` inside a `useEffect` so the arena code begins warming up from the lobby.  
- Preserved existing lobby behaviors (`startGame`, stake handling, flags, `FlagPickerModal`) and updated the start button/labels to reflect the Air Hockey experience.  
- Adjusted styling and component arrangement (player profile, mode cards, game-type controls, AI flags) to align with Chess Battle Royal visual patterns.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, which succeeded.  
- Ran an automated Playwright script that navigated to `/games/murlanroyale/lobby` in a 390x844 viewport and produced the screenshot `artifacts/murlan-royale-lobby.png`, which completed successfully.  
- No unit tests were executed as part of this change (`npm test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736255c7748329a7fbfef4217d35db)