### PR TITLE
Redesign Goal Rush lobby to modern Chess Battle Royal style and preload game

### DIFF
--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -36,6 +36,10 @@ export default function GoalRushLobby() {
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
 
   useEffect(() => {
+    import('./GoalRush.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
@@ -115,171 +119,269 @@ export default function GoalRushLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Goal Rush Lobby</h2>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Type</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'regular', label: 'Regular' },
-            { id: 'training', label: 'Training' },
-            { id: 'tournament', label: 'Tournament' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setPlayType(id)}
-              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
+                Goal Rush
+              </p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+            </div>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              Pitch ready
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🥅
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Match Setup</p>
+                  <p className="text-xs text-white/60">
+                    Configure your rush while the stadium loads in the background.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Quick kickoff</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} locked in</p>
+                  <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your lobby choices carry into the match intro.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-      {playType !== 'training' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Mode</h3>
-          <div className="flex gap-2">
-            {[
-              { id: 'ai', label: 'Vs AI' },
-              { id: 'online', label: '1v1 Online', disabled: true }
-            ].map(({ id, label, disabled }) => (
-              <div key={id} className="relative">
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Play</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex flex-wrap gap-2">
+              {[
+                { id: 'regular', label: 'Regular' },
+                { id: 'training', label: 'Training' },
+                { id: 'tournament', label: 'Tournament' }
+              ].map(({ id, label }) => (
                 <button
-                  onClick={() => !disabled && setMode(id)}
-                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                    disabled ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
-                  disabled={disabled}
+                  key={id}
+                  onClick={() => setPlayType(id)}
+                  className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
                 >
                   {label}
                 </button>
-                {disabled && (
-                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                    Under development
-                  </span>
-                )}
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </div>
-      )}
-      <div className="space-y-2">
-        <h3 className="font-semibold">Goals</h3>
-        <div className="flex gap-2">
-          {[3, 5, 10].map((g) => (
-            <button
-              key={g}
-              onClick={() => setGoal(g)}
-              className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
-            >
-              {g}
-            </button>
-          ))}
-        </div>
-      </div>
-      {playType === 'tournament' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Players</h3>
-          <div className="flex gap-2">
-            {[8, 16, 24].map((p) => (
-              <button
-                key={p}
-                onClick={() => setPlayers(p)}
-                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
-        </div>
-      )}
-      {playType !== 'training' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-        </div>
-      )}
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">Your Flag & Avatar</h3>
-        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
+        {playType !== 'training' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Mode</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+              <div className="flex flex-wrap gap-2">
+                {[
+                  { id: 'ai', label: 'Vs AI' },
+                  { id: 'online', label: '1v1 Online', disabled: true }
+                ].map(({ id, label, disabled }) => (
+                  <div key={id} className="relative">
+                    <button
+                      onClick={() => !disabled && setMode(id)}
+                      className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
+                        disabled ? 'opacity-50 cursor-not-allowed' : ''
+                      }`}
+                      disabled={disabled}
+                    >
+                      {label}
+                    </button>
+                    {disabled && (
+                      <span className="absolute inset-0 flex items-center justify-center text-xs bg-black/60 text-background">
+                        Under development
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Goals</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Target</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex flex-wrap gap-2">
+              {[3, 5, 10].map((g) => (
+                <button
+                  key={g}
+                  onClick={() => setGoal(g)}
+                  className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
+                >
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {playType === 'tournament' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Players</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bracket</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-2">
+              <div className="flex flex-wrap gap-2">
+                {[8, 16, 24].map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setPlayers(p)}
+                    className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
+            </div>
+          </div>
+        )}
+
+        {playType !== 'training' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Stake</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">TPC</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
+              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            {avatar && (
+              <div className="mt-3 flex items-center gap-3">
+                <img
+                  src={avatar}
+                  alt="Your avatar"
+                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
+                />
+                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+          <div className="flex items-start gap-3">
+            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                🤝
+              </div>
+            </div>
+            <div>
+              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+              <p className="text-xs text-white/60">
+                Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
+              </p>
+            </div>
+          </div>
           <button
             type="button"
-            onClick={() => setShowFlagPicker(true)}
-            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+            onClick={() => setShowAiFlagPicker(true)}
+            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
           >
-            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
-            <div className="flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedFlag || '🌐'}</span>
-              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
+            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+              <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
             </div>
           </button>
-          {avatar && (
-            <div className="flex items-center gap-3">
-              <img
-                src={avatar}
-                alt="Your avatar"
-                className="h-12 w-12 rounded-full border border-border object-cover"
-              />
-              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
-            </div>
-          )}
         </div>
-      </div>
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext">
-          Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
-        </p>
         <button
-          type="button"
-          onClick={() => setShowAiFlagPicker(true)}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover"
         >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-          </div>
+          START
         </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
       </div>
-      <button
-        onClick={startGame}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
-      >
-        START
-      </button>
-
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={1}
-        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setPlayerFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowFlagPicker(false)}
-      />
-
-      <FlagPickerModal
-        open={showAiFlagPicker}
-        count={1}
-        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setAiFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowAiFlagPicker(false)}
-      />
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Bring Goal Rush lobby visual and UX in line with the Chess Battle Royal modern lobby so players configure options while the game loads in the background. 
- Keep existing lobby options and buttons unchanged functionally while improving layout, contrast and mobile readiness. 
- Preload the Goal Rush game bundle to allow background preparation and faster transitions into the match. 

### Description
- Added a dynamic import `import('./GoalRush.jsx')` inside a `useEffect` to preload the Goal Rush game module on lobby mount. 
- Replaced the previous Goal Rush lobby JSX with a new modern, dark-gradient card layout that mirrors the Chess Battle Royal lobby and reorganizes controls into styled sections (header card, Type, Mode, Goals, Players, Stake, Profile, AI Flags). 
- Retained all existing state, logic and navigation (including `startGame`, flag storage, `FlagPickerModal` usage and RoomSelector), only updating presentation and CSS/Tailwind classes for the new look. 
- Updated action buttons and cards to use the same rounded, shadowed components and status labels used by other modern lobbies for consistent UX. 

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and the Vite dev server came up and served the app successfully. (succeeded) 
- Ran a Playwright script that opened `http://127.0.0.1:4173/games/goalrush/lobby` at a mobile viewport and captured a screenshot of the updated lobby (saved artifact `artifacts/goal-rush-lobby.png`). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697362e40e748329886411caecc9c3a5)