### PR TITLE
Refresh Murlan Royale lobby styling and preload game

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -41,6 +41,10 @@ export default function MurlanRoyaleLobby() {
   };
 
   useEffect(() => {
+    import('./MurlanRoyale.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
     try {
       const saved = loadAvatar();
       setAvatar(saved || getTelegramPhotoUrl());
@@ -98,108 +102,271 @@ export default function MurlanRoyaleLobby() {
   };
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      <h2 className="text-xl font-bold text-center">Murlan Royale Lobby</h2>
-      {mode === 'local' ? (
-        <div className="space-y-2 rounded-lg border border-border bg-background/60 p-3 text-sm text-subtext">
-          <h3 className="font-semibold text-text">Stake</h3>
-          <p className="text-sm text-subtext">Playing against AI is free — no stake required.</p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-        </div>
-      )}
-      <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'local', label: 'Local (AI)' },
-            { id: 'online', label: 'Online', disabled: true }
-          ].map(({ id, label, disabled }) => (
-            <div key={id} className="relative">
-              <button
-                onClick={() => !disabled && setMode(id)}
-                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                  disabled ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-                disabled={disabled}
-              >
-                {label}
-              </button>
-              {disabled && (
-                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Under development
-                </span>
-              )}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Murlan Royale</p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
             </div>
-          ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
-        <p className="text-sm text-subtext text-center">
-          Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents and your seat.
-        </p>
-        <button
-          type="button"
-          onClick={openAiFlagPicker}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-        >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flags</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}</span>
-            <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              AI ready
+            </div>
           </div>
-        </button>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Game Type</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'single', label: 'Single Game' },
-            { id: 'points', label: 'Points' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setGameType(id)}
-              className={`lobby-tile ${gameType === id ? 'lobby-selected' : ''}`}
-            >
-              {label}
-            </button>
-          ))}
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🂠
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Royal Table</p>
+                  <p className="text-xs text-white/60">
+                    Keep the arena loading while you choose your Murlan settings.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant start</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Flag avatars</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">3D arena</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">Seat ready</p>
+                  <p className="text-xs text-white/50">
+                    Flags: {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : 'Auto'}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-white/60">
+                Your choices load into the Murlan Royale match instantly.
+              </p>
+            </div>
+          </div>
         </div>
-        {gameType === 'points' && (
-          <div className="flex gap-2">
-            {[11, 21, 31].map((pts) => (
-              <button
-                key={pts}
-                onClick={() => setTargetPoints(pts)}
-                className={`lobby-tile ${targetPoints === pts ? 'lobby-selected' : ''}`}
-              >
-                {pts} pts
-              </button>
-            ))}
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                id: 'local',
+                label: 'Local (AI)',
+                desc: 'Instant practice',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🤖'
+              },
+              {
+                id: 'online',
+                label: 'Online',
+                desc: 'Stake & match',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '⚔️',
+                disabled: true
+              }
+            ].map(({ id, label, desc, accent, icon, disabled }) => {
+              const active = mode === id;
+              return (
+                <div key={id} className="relative">
+                  <button
+                    type="button"
+                    onClick={() => !disabled && setMode(id)}
+                    className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                    disabled={disabled}
+                  >
+                    <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                        {icon}
+                      </div>
+                    </div>
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-base font-semibold">{label}</span>
+                        {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                      </div>
+                      <div className="text-xs text-white/60">{desc}</div>
+                    </div>
+                  </button>
+                  {disabled && (
+                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[11px] uppercase tracking-[0.2em] text-white/60">
+                      Under development
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline while the arena preloads. Online mode launches when staking is ready.
+          </p>
+        </div>
+
+        {mode === 'local' ? (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-emerald-400/40 to-sky-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🎯
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Stake</h3>
+                <p className="text-xs text-white/60">Playing against AI is free — no stake required.</p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
           </div>
         )}
-      </div>
-      <button
-        onClick={startGame}
-        disabled={mode === 'local' && flags.length !== flagPickerCount}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded disabled:opacity-50"
-      >
-        START
-      </button>
 
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={flagPickerCount}
-        selected={flags}
-        onSave={setFlags}
-        onClose={() => setShowFlagPicker(false)}
-        onComplete={(sel) => startGame(sel)}
-      />
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Rules</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                id: 'single',
+                label: 'Single Game',
+                desc: 'Standard match',
+                accent: 'from-purple-400/30 via-indigo-500/10 to-transparent',
+                icon: '🎴'
+              },
+              {
+                id: 'points',
+                label: 'Points',
+                desc: 'Race to target',
+                accent: 'from-pink-400/30 via-fuchsia-500/10 to-transparent',
+                icon: '🏁'
+              }
+            ].map(({ id, label, desc, accent, icon }) => {
+              const active = gameType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setGameType(id)}
+                  className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  <div className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                      {icon}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{label}</span>
+                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                    </div>
+                    <div className="text-xs text-white/60">{desc}</div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {gameType === 'points' && (
+            <div className="grid gap-3 sm:grid-cols-3">
+              {[11, 21, 31].map((pts) => (
+                <button
+                  key={pts}
+                  onClick={() => setTargetPoints(pts)}
+                  className={`rounded-2xl border px-4 py-3 text-left text-sm font-semibold shadow transition ${
+                    targetPoints === pts
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  {pts} pts
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">AI Avatar Flags</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <p className="text-xs text-white/60">
+              Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents and your seat.
+            </p>
+            <button
+              type="button"
+              onClick={openAiFlagPicker}
+              className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flags</div>
+              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">
+                  {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
+                </span>
+                <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <button
+          onClick={startGame}
+          disabled={mode === 'local' && flags.length !== flagPickerCount}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Start Murlan Match
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={flagPickerCount}
+          selected={flags}
+          onSave={setFlags}
+          onClose={() => setShowFlagPicker(false)}
+          onComplete={(sel) => startGame(sel)}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Modernize the Murlan Royale lobby to match the visual style and UX of the Chess Battle Royal lobby so players get a consistent, mobile-friendly entry experience.
- Ensure the Murlan game begins preloading while the lobby is open so the match can start faster when the player presses Start.

### Description
- Restyled and reorganized the Murlan lobby UI into modern card sections, updating layout, colors, and copy to match the Chess Battle Royal lobby (file changed: `webapp/src/pages/Games/MurlanRoyaleLobby.jsx`).
- Added a background dynamic import (`import('./MurlanRoyale.jsx')`) inside a `useEffect` so the Murlan game bundle preloads when the lobby mounts.
- Preserved existing lobby controls and behavior (stake selection, mode, game type, AI flag picker and start flow) while moving them into the new card-based layout and updating button labels.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which reported Vite ready and served the app successfully.
- Captured a mobile-size screenshot of the updated lobby using a Playwright script (viewport 390x844) which completed and produced `artifacts/murlan-royale-lobby.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736469cdfc8329bc145f8e9dac63c9)