### PR TITLE
Redesign games lobby grid

### DIFF
--- a/webapp/public/assets/icons/air-hockey.svg
+++ b/webapp/public/assets/icons/air-hockey.svg
@@ -1,0 +1,18 @@
+<svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="airHockeyBg" x1="0" y1="0" x2="300" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="airHockeyTable" x1="38" y1="40" x2="262" y2="160" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1F2937"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" rx="28" fill="url(#airHockeyBg)"/>
+  <rect x="38" y="40" width="224" height="120" rx="20" fill="url(#airHockeyTable)" stroke="#38BDF8" stroke-width="4"/>
+  <line x1="150" y1="48" x2="150" y2="152" stroke="#38BDF8" stroke-width="2" stroke-dasharray="6 6"/>
+  <circle cx="110" cy="110" r="14" fill="#E2E8F0" stroke="#38BDF8" stroke-width="3"/>
+  <circle cx="198" cy="88" r="20" fill="#22D3EE" stroke="#0EA5E9" stroke-width="4"/>
+  <circle cx="198" cy="88" r="7" fill="#0F172A"/>
+</svg>

--- a/webapp/public/assets/icons/chess-royale.svg
+++ b/webapp/public/assets/icons/chess-royale.svg
@@ -1,0 +1,21 @@
+<svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="chessBg" x1="0" y1="0" x2="300" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#111827"/>
+      <stop offset="1" stop-color="#6D28D9"/>
+    </linearGradient>
+    <linearGradient id="chessGlow" x1="70" y1="40" x2="230" y2="170" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE047"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" rx="28" fill="url(#chessBg)"/>
+  <path
+    d="M188 56C188 42.7 176.3 32 162 32C149.4 32 139 40.7 136.7 52.1C126.1 55.3 118.5 65.1 118.5 76.7C118.5 81.8 120.1 86.5 122.8 90.4L110 110H191.5L179.6 93.9C185.5 88.1 189 80.3 189 71.6C189 66.2 187.7 60.9 185.1 56.2L188 56Z"
+    fill="url(#chessGlow)"
+  />
+  <rect x="106" y="110" width="92" height="18" rx="9" fill="#FDE68A"/>
+  <rect x="94" y="128" width="116" height="22" rx="11" fill="#F97316"/>
+  <rect x="84" y="150" width="136" height="18" rx="9" fill="#111827" stroke="#F97316" stroke-width="3"/>
+  <circle cx="220" cy="60" r="18" fill="#FACC15" opacity="0.8"/>
+</svg>

--- a/webapp/public/assets/icons/ludo-royale.svg
+++ b/webapp/public/assets/icons/ludo-royale.svg
@@ -1,0 +1,16 @@
+<svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ludoBg" x1="0" y1="0" x2="300" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1E293B"/>
+      <stop offset="1" stop-color="#0F766E"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" rx="28" fill="url(#ludoBg)"/>
+  <rect x="50" y="40" width="200" height="120" rx="24" fill="#0F172A" stroke="#38BDF8" stroke-width="4"/>
+  <rect x="108" y="88" width="84" height="24" rx="12" fill="#E2E8F0"/>
+  <circle cx="95" cy="75" r="22" fill="#22C55E"/>
+  <circle cx="205" cy="75" r="22" fill="#F97316"/>
+  <circle cx="95" cy="125" r="22" fill="#60A5FA"/>
+  <circle cx="205" cy="125" r="22" fill="#FACC15"/>
+  <circle cx="150" cy="100" r="10" fill="#F8FAFC"/>
+</svg>

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,14 +1,64 @@
 const gamesCatalog = [
-  { name: "Texas Hold'em", route: '/games/texasholdem/lobby' },
-  { name: 'Domino Royal 3D', route: '/games/domino-royal/lobby' },
-  { name: 'Pool Royale', route: '/games/poolroyale/lobby' },
-  { name: 'Snooker Royal', route: '/games/snookerroyale/lobby' },
-  { name: 'Goal Rush', route: '/games/goalrush/lobby' },
-  { name: 'Air Hockey', route: '/games/airhockey/lobby' },
-  { name: 'Snake & Ladder', route: '/games/snake/lobby' },
-  { name: 'Murlan Royale', route: '/games/murlanroyale/lobby' },
-  { name: 'Chess Battle Royal', route: '/games/chessbattleroyal/lobby' },
-  { name: 'Ludo Battle Royal', route: '/games/ludobattleroyal/lobby' }
+  {
+    name: "Texas Hold'em",
+    route: '/games/texasholdem/lobby',
+    image: '/assets/icons/texas-holdem.svg',
+    description: 'High-stakes poker tables with quick matchmaking.'
+  },
+  {
+    name: 'Domino Royal 3D',
+    route: '/games/domino-royal/lobby',
+    image: '/assets/icons/domino-royal.svg',
+    description: 'Classic domino strategy with modern 3D flair.'
+  },
+  {
+    name: 'Pool Royale',
+    route: '/games/poolroyale/lobby',
+    image: '/assets/icons/pool-royale.svg',
+    description: 'Rack up and run the table in stylish arenas.'
+  },
+  {
+    name: 'Snooker Royal',
+    route: '/games/snookerroyale/lobby',
+    image: '/assets/icons/snooker-royale.svg',
+    description: 'Precision snooker battles with competitive stakes.'
+  },
+  {
+    name: 'Goal Rush',
+    route: '/games/goalrush/lobby',
+    image: '/assets/icons/goal_rush_card_1200x675.webp',
+    description: 'Score fast goals and climb the rankings.'
+  },
+  {
+    name: 'Air Hockey',
+    route: '/games/airhockey/lobby',
+    image: '/assets/icons/air-hockey.svg',
+    description: 'Lightning puck duels with neon energy.'
+  },
+  {
+    name: 'Snake & Ladder',
+    route: '/games/snake/lobby',
+    image: '/assets/icons/snakes_and_ladders.webp',
+    description: 'Race to the top with quick dice rolls.'
+  },
+  {
+    name: 'Murlan Royale',
+    route: '/games/murlanroyale/lobby',
+    image: '/assets/icons/murlan-royale.svg',
+    description: 'Card-based tactics with a competitive twist.'
+  },
+  {
+    name: 'Chess Battle Royal',
+    route: '/games/chessbattleroyal/lobby',
+    image: '/assets/icons/chess-royale.svg',
+    description: 'Strategic chess showdowns with royal flair.'
+  },
+  {
+    name: 'Ludo Battle Royal',
+    route: '/games/ludobattleroyal/lobby',
+    image: '/assets/icons/ludo-royale.svg',
+    description: 'Classic ludo chaos in a battle royale lobby.'
+  }
 ];
 
 export default gamesCatalog;

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,47 +1,48 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
-import GamesHallway from '../components/GamesHallway.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
-import { refreshGltfAssets } from '../pwa/preloadGames.js';
 
 export default function Games() {
   useTelegramBackButton();
-  const [showHallway, setShowHallway] = useState(false);
-  const baseUrl = useMemo(() => import.meta.env.BASE_URL || '/', []);
-
-  useEffect(() => {
-    const isTelegram = Boolean(window.Telegram?.WebApp);
-    if (!isTelegram) return;
-
-    refreshGltfAssets({ baseUrl, forceReload: true });
-  }, [baseUrl]);
 
   return (
     <div className="relative space-y-4 text-text">
-      <h2 className="text-2xl font-bold text-center mt-4">Games</h2>
-      <p className="text-center text-sm text-subtext">Online games are under construction and will be available soon.</p>
-      <div className="space-y-4">
-        <div className="relative bg-surface border border-border rounded-xl p-6 shadow-lg overflow-hidden wide-card space-y-4 text-center">
-          <div className="space-y-2">
-            <h3 className="text-lg font-semibold">3D Hallway Experience</h3>
-            <p className="text-sm text-subtext">
-              Explore the luxury hallway and pick your favorite game by stepping through its golden door or tapping the illuminated sign.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setShowHallway(true)}
-            className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-base font-semibold text-black shadow-lg shadow-primary/40"
+      <h2 className="text-2xl font-bold text-center mt-4">Games Lobby</h2>
+      <p className="text-center text-sm text-subtext">
+        Jump straight into a lobby. Tap any game to start your next match.
+      </p>
+      <div className="grid grid-cols-3 gap-3">
+        {gamesCatalog.map((game) => (
+          <Link
+            key={game.name}
+            to={game.route}
+            className="group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-surface/90 shadow-lg transition hover:-translate-y-0.5 hover:border-primary/60"
           >
-            Enter Games
-          </button>
-        </div>
+            <div className="relative h-24 overflow-hidden">
+              <img
+                src={game.image}
+                alt={game.name}
+                loading="lazy"
+                className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+              <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
+                {game.name}
+              </span>
+            </div>
+            <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
+              <p className="text-[10px] text-subtext line-clamp-2">{game.description}</p>
+              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                Enter Lobby
+              </span>
+            </div>
+          </Link>
+        ))}
       </div>
       <GameTransactionsCard />
       <LeaderboardCard />
-      {showHallway && <GamesHallway games={gamesCatalog} onClose={() => setShowHallway(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the 3D hallway entry flow with a modern, mobile-first games lobby that gives quicker access to each game's lobby and displays thumbnails in a 3-across layout.

### Description
- Replaced the hallway entry card with a three-column grid in `webapp/src/pages/Games.jsx` that renders clickable game tiles linking directly to each lobby.
- Enhanced `webapp/src/config/gamesCatalog.js` to include `image` and `description` metadata for each game so tiles can show thumbnails and short copy.
- Added new SVG thumbnails `webapp/public/assets/icons/air-hockey.svg`, `webapp/public/assets/icons/chess-royale.svg`, and `webapp/public/assets/icons/ludo-royale.svg` for missing thumbnails.
- Removed the hallway-specific UI state and unused imports from the `Games` page to simplify load and navigation.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app (success).
- Loaded `/games` in a headless browser and captured a mobile viewport screenshot (430x932) using Playwright; the screenshot artifact `artifacts/games-page.png` was produced (success).
- No unit tests were modified; layout/UI change was validated via the screenshot capture (visual check successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736b248c1c83299325be88bb1efd52)