### PR TITLE
Restore UK 8‑ball fouls to two‑shot behavior

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -210,7 +210,7 @@ export class UkPool {
       shotsNext = 2;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = scratched;
+      s.mustPlayFromBaulk = false;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10517,6 +10517,12 @@ function PoolRoyaleGame({
     () => resolvePoolVariant(variantKey, ballSetKey),
     [variantKey, ballSetKey]
   );
+  const infoText = useMemo(() => {
+    if (activeVariant?.id === 'uk') {
+      return 'Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent two shots.';
+    }
+    return 'Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent ball in hand.';
+  }, [activeVariant]);
   const isUkAmericanSet = useMemo(
     () => activeVariant?.id === 'uk' && activeVariant?.ballSet === 'american',
     [activeVariant]
@@ -26670,7 +26676,7 @@ const powerRef = useRef(hud.power);
           open={showInfo}
           onClose={() => setShowInfo(false)}
           title="Pool Royale"
-          info="Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent ball in hand."
+          info={infoText}
         />
       </div>
       <div className="pointer-events-auto">


### PR DESCRIPTION
### Motivation
- UK 8‑ball rules should award the incoming player two shots after a foul rather than forcing baulk/ball‑in‑hand, so gameplay matches the previous behavior and player expectation.

### Description
- In `lib/poolUk8Ball.js` stop setting `s.mustPlayFromBaulk` on a foul so the opponent receives two visits without forcing baulk placement. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` make the Info popup text dynamic and show "Fouls give your opponent two shots." when the active variant is `uk` while preserving the existing message for other variants. 
- Changes are limited to foul handling logic and the UI explanatory text; other game flows remain unchanged.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite served the app successfully (succeeded). 
- Attempted an automated Playwright script to open `/games/poolroyale?variant=uk` and capture the Info popup, but the Playwright run timed out (failed). 
- No unit test suite (`npm test`) was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b7ad7bc083299cafd7539f34a497)