### PR TITLE
Pool Royale: fix UK 8‑ball turn rules, aiming, pocket holders, chrome plates and replay

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -238,7 +238,9 @@ export class UkPool {
         };
       }
 
-      const potOwn = groupAfter && shot.potted.includes(groupAfter);
+      const hasOpenTablePot =
+        s.isOpenTable && shot.potted.some(col => col === 'blue' || col === 'red');
+      const potOwn = (groupAfter && shot.potted.includes(groupAfter)) || hasOpenTablePot;
       if (!potOwn) {
         shotsNext = s.shotsRemaining - 1;
       }


### PR DESCRIPTION
### Motivation
- Resolve several gameplay and visual regressions for Pool Royale: keep the shooter’s turn on UK open-table pots, show potted balls riding the chrome pocket holders exactly like Snooker Royal, match the aiming-line behavior to the Snooker Royal implementation scaled for the pool table, and tweak chrome plate placement and corner cuts for improved visuals while restoring replay triggering for pot-centric shots.

### Description
- Treat an open-table pot in UK 8‑ball as a valid "pot own" so the shooter retains their turn by updating `UkPool.shotTaken` logic in `lib/poolUk8Ball.js` (detect `s.isOpenTable` potted colours). 
- Align Pool Royale pocket/drop and holder behaviour with the Snooker Royal implementation by removing proxy/glow/proxy-mesh proxies and animating the real ball mesh along the holder path so potted balls rest visibly on the chrome holders in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Update aiming/rail clipping logic to follow the Snooker Royal approach for more faithful aim-line visuals (clean up the pocket guard/corner clipping region used by `calcTarget`) so the aiming line matches Snooker Royal semantics scaled to the pool table.
- Tweak chrome geometry constants to push middle chrome plates outward and slightly increase corner cut size by changing `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` and `CHROME_CORNER_POCKET_CUT_SCALE` and remove unused proxy cleanup paths to keep pocket-holder meshes consistent.
- Restore replay eligibility for pot-only shots by removing the early filter that rejected pot-only `replay` decisions so the replay slate/banner/auto-start logic will fire for notable potted shots.

### Testing
- Started a local dev server with `npm --prefix webapp run dev` to perform a visual smoke check and observed the dev server (Vite) become ready.
- Attempted an automated visual smoke capture of `/games/poolroyale` with Playwright to validate the aiming/pocket changes, but the screenshot run timed out in this environment.
- No additional automated unit or integration tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bf4f0b048329a492dcb4b7e2dc7f)