### PR TITLE
Scale PoolRoyale cue follow-through by topspin

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20743,13 +20743,14 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(startPos);
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
           const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const followThrough = Math.min(
-            CUE_FOLLOW_THROUGH_MAX,
-            Math.max(
-              CUE_FOLLOW_THROUGH_MIN,
-              visualPull * (0.22 + 0.28 * powerStrength)
-            )
-          );
+          const topspinFactor = THREE.MathUtils.clamp(appliedSpin?.y ?? 0, 0, 1);
+          const followThrough =
+            topspinFactor > 1e-4
+              ? Math.min(
+                  CUE_FOLLOW_THROUGH_MAX,
+                  BALL_R * 0.33 * topspinFactor * (0.35 + 0.65 * powerStrength)
+                )
+              : 0;
           const followThroughPos = buildCuePosition(-followThrough);
           const forwardDuration = isAiStroke
             ? AI_CUE_FORWARD_DURATION_MS


### PR DESCRIPTION
### Motivation
- Ensure the cue's forward follow-through no longer adds extra forward travel for normal shots and only contributes when topspin is applied, so pull and push distances match visually and mechanically.

### Description
- Replace the previous `followThrough` formula with a topspin-driven computation in `webapp/src/pages/Games/PoolRoyale.jsx`, where `followThrough` is `0` unless `appliedSpin.y` (topspin) > 0 and otherwise is clamped via `CUE_FOLLOW_THROUGH_MAX` and scaled by `BALL_R` and `powerStrength`.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev` and Vite served at `http://localhost:4173/`, and an automated Playwright screenshot attempt of `/games/poolroyale` timed out so no visual screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697458da16888329ba2c7738ed17db1e)