### PR TITLE
Add configurable game-art manifest and lobby option icons (no binaries in PR)

### DIFF
--- a/webapp/public/assets/game-art/.gitignore
+++ b/webapp/public/assets/game-art/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/webapp/public/assets/game-art/README.md
+++ b/webapp/public/assets/game-art/README.md
@@ -1,0 +1,36 @@
+# Game art drop-in folder (not tracked)
+
+This directory is intentionally ignored by Git so high-resolution game art can be dropped in without
+appearing in PRs. Add the production-ready assets here or host them on a CDN and set
+`VITE_GAME_ASSET_BASE_URL` to the CDN root.
+
+Expected structure:
+
+```
+games/
+  texas-holdem.webp
+  domino-royal.webp
+  pool-royale.webp
+  snooker-royale.webp
+  goal-rush.webp
+  air-hockey.webp
+  snake-ladder.webp
+  murlan-royale.webp
+  chess-battle-royal.webp
+  ludo-battle-royal.webp
+lobby/
+  texas-holdem/
+  domino-royal/
+  pool-royale/
+  snooker-royale/
+  goal-rush/
+  air-hockey/
+  snake/
+  murlan-royale/
+  chess-battle-royal/
+  ludo-battle-royal/
+variants/
+  pool-royale/
+```
+
+Use the filenames defined in `webapp/src/config/gameAssets.js` so the UI loads the right art.

--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router-dom';
+import { getGameThumbnail } from '../config/gameAssets.js';
 
 export default function HomeGamesCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src="/assets/icons/snakes_and_ladders.webp"
+        src={getGameThumbnail('snake') || '/assets/icons/snakes_and_ladders.webp'}
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {
@@ -18,9 +19,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/texas-holdem.svg"
+            src={getGameThumbnail('texasholdem') || '/assets/icons/texas-holdem.svg'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/texas-holdem.svg';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Texas Hold'em
@@ -31,9 +35,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/domino-royal.svg"
+            src={getGameThumbnail('domino-royal') || '/assets/icons/domino-royal.svg'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/domino-royal.svg';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Domino Royal 3D
@@ -44,9 +51,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/pool-royale.svg"
+            src={getGameThumbnail('poolroyale') || '/assets/icons/pool-royale.svg'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/pool-royale.svg';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Pool Royale
@@ -57,9 +67,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/snooker-royale.svg"
+            src={getGameThumbnail('snookerroyale') || '/assets/icons/snooker-royale.svg'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/snooker-royale.svg';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Snooker Royal
@@ -70,9 +83,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/goal_rush_card_1200x675.webp"
+            src={getGameThumbnail('goalrush') || '/assets/icons/goal_rush_card_1200x675.webp'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/goal_rush_card_1200x675.webp';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Goal Rush
@@ -83,9 +99,12 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src="/assets/icons/snakes_and_ladders.webp"
+            src={getGameThumbnail('snake') || '/assets/icons/snakes_and_ladders.webp'}
             alt=""
             className="h-20 w-20"
+            onError={(event) => {
+              event.currentTarget.src = '/assets/icons/snakes_and_ladders.webp';
+            }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
             Snake &amp; Ladder

--- a/webapp/src/components/OptionIcon.jsx
+++ b/webapp/src/components/OptionIcon.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export default function OptionIcon({ src, alt, fallback, className = '' }) {
+  const [failed, setFailed] = useState(false);
+  const showFallback = failed || !src;
+
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      {!showFallback ? (
+        <img
+          src={src}
+          alt={alt}
+          className="h-full w-full object-contain"
+          onError={() => setFailed(true)}
+          loading="lazy"
+        />
+      ) : (
+        <span className="text-lg">{fallback}</span>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import OptionIcon from './OptionIcon.jsx';
 
 export default function TableSelector({ tables, selected, onSelect }) {
   return (
@@ -14,7 +15,17 @@ export default function TableSelector({ tables, selected, onSelect }) {
               selected?.id === t.id ? 'lobby-selected' : ''
             } ${t.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
-            <span>{t.label || `Table ${t.capacity}p`}</span>
+            <span className="flex items-center gap-2">
+              {(t.icon || t.iconFallback) && (
+                <OptionIcon
+                  src={t.icon}
+                  alt={t.iconAlt || t.label || 'Table'}
+                  fallback={t.iconFallback || '🎲'}
+                  className="h-5 w-5"
+                />
+              )}
+              {t.label || `Table ${t.capacity}p`}
+            </span>
             {t.capacity && (
               <span>
                 {t.players}/{t.capacity}

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -1,0 +1,140 @@
+const GAME_ASSET_BASE_URL =
+  (import.meta.env && import.meta.env.VITE_GAME_ASSET_BASE_URL) || '/assets/game-art';
+
+const normalizeBase = (base) => base.replace(/\/+$/, '');
+
+const withBase = (path) => `${normalizeBase(GAME_ASSET_BASE_URL)}/${path.replace(/^\/+/, '')}`;
+
+export const gameThumbnails = {
+  texasholdem: 'games/texas-holdem.webp',
+  'domino-royal': 'games/domino-royal.webp',
+  poolroyale: 'games/pool-royale.webp',
+  snookerroyale: 'games/snooker-royale.webp',
+  goalrush: 'games/goal-rush.webp',
+  airhockey: 'games/air-hockey.webp',
+  snake: 'games/snake-ladder.webp',
+  murlanroyale: 'games/murlan-royale.webp',
+  chessbattleroyal: 'games/chess-battle-royal.webp',
+  ludobattleroyal: 'games/ludo-battle-royal.webp'
+};
+
+export const lobbyOptionIcons = {
+  texasholdem: {
+    'mode-local': 'lobby/texas-holdem/mode-local.webp',
+    'mode-online': 'lobby/texas-holdem/mode-online.webp',
+    'opponents-1': 'lobby/texas-holdem/opponents-1.webp',
+    'opponents-2': 'lobby/texas-holdem/opponents-2.webp',
+    'opponents-3': 'lobby/texas-holdem/opponents-3.webp',
+    'opponents-4': 'lobby/texas-holdem/opponents-4.webp',
+    'opponents-5': 'lobby/texas-holdem/opponents-5.webp'
+  },
+  'domino-royal': {
+    'players-2': 'lobby/domino-royal/players-2.webp',
+    'players-3': 'lobby/domino-royal/players-3.webp',
+    'players-4': 'lobby/domino-royal/players-4.webp',
+    'mode-local': 'lobby/domino-royal/mode-local.webp',
+    'mode-online': 'lobby/domino-royal/mode-online.webp'
+  },
+  poolroyale: {
+    'type-regular': 'lobby/pool-royale/type-regular.webp',
+    'type-tournament': 'lobby/pool-royale/type-tournament.webp',
+    'mode-ai': 'lobby/pool-royale/mode-ai.webp',
+    'mode-online': 'lobby/pool-royale/mode-online.webp',
+    'variant-uk': 'lobby/pool-royale/variant-uk.webp',
+    'variant-american': 'lobby/pool-royale/variant-american.webp',
+    'variant-9ball': 'lobby/pool-royale/variant-9ball.webp',
+    'ball-uk': 'lobby/pool-royale/ball-uk.webp',
+    'ball-american': 'lobby/pool-royale/ball-american.webp'
+  },
+  snookerroyale: {
+    'type-regular': 'lobby/snooker-royale/type-regular.webp',
+    'type-tournament': 'lobby/snooker-royale/type-tournament.webp',
+    'mode-ai': 'lobby/snooker-royale/mode-ai.webp',
+    'mode-online': 'lobby/snooker-royale/mode-online.webp',
+    'table-championship': 'lobby/snooker-royale/table-championship.webp',
+    'table-club': 'lobby/snooker-royale/table-club.webp',
+    'table-practice': 'lobby/snooker-royale/table-practice.webp'
+  },
+  goalrush: {
+    'type-regular': 'lobby/goal-rush/type-regular.webp',
+    'type-training': 'lobby/goal-rush/type-training.webp',
+    'type-tournament': 'lobby/goal-rush/type-tournament.webp',
+    'mode-ai': 'lobby/goal-rush/mode-ai.webp',
+    'mode-online': 'lobby/goal-rush/mode-online.webp',
+    'target-3': 'lobby/goal-rush/target-3.webp',
+    'target-5': 'lobby/goal-rush/target-5.webp',
+    'target-10': 'lobby/goal-rush/target-10.webp'
+  },
+  airhockey: {
+    'type-regular': 'lobby/air-hockey/type-regular.webp',
+    'type-training': 'lobby/air-hockey/type-training.webp',
+    'type-tournament': 'lobby/air-hockey/type-tournament.webp',
+    'mode-ai': 'lobby/air-hockey/mode-ai.webp',
+    'mode-online': 'lobby/air-hockey/mode-online.webp',
+    'target-11': 'lobby/air-hockey/target-11.webp',
+    'target-21': 'lobby/air-hockey/target-21.webp',
+    'target-31': 'lobby/air-hockey/target-31.webp'
+  },
+  snake: {
+    'board-quick': 'lobby/snake/board-quick.webp',
+    'board-mobile': 'lobby/snake/board-mobile.webp',
+    'board-3d': 'lobby/snake/board-3d.webp',
+    'table-single': 'lobby/snake/table-single.webp',
+    'table-2': 'lobby/snake/table-2.webp',
+    'table-3': 'lobby/snake/table-3.webp',
+    'table-4': 'lobby/snake/table-4.webp',
+    'ai-1': 'lobby/snake/ai-1.webp',
+    'ai-2': 'lobby/snake/ai-2.webp',
+    'ai-3': 'lobby/snake/ai-3.webp'
+  },
+  murlanroyale: {
+    'mode-local': 'lobby/murlan-royale/mode-local.webp',
+    'mode-online': 'lobby/murlan-royale/mode-online.webp',
+    'type-single': 'lobby/murlan-royale/type-single.webp',
+    'type-points': 'lobby/murlan-royale/type-points.webp',
+    'points-11': 'lobby/murlan-royale/points-11.webp',
+    'points-21': 'lobby/murlan-royale/points-21.webp',
+    'points-31': 'lobby/murlan-royale/points-31.webp'
+  },
+  chessbattleroyal: {
+    'mode-ai': 'lobby/chess-battle-royal/mode-ai.webp',
+    'mode-online': 'lobby/chess-battle-royal/mode-online.webp',
+    'queue-instant': 'lobby/chess-battle-royal/queue-instant.webp',
+    'queue-mobile': 'lobby/chess-battle-royal/queue-mobile.webp',
+    'queue-hdr': 'lobby/chess-battle-royal/queue-hdr.webp'
+  },
+  ludobattleroyal: {
+    'queue-instant': 'lobby/ludo-battle-royal/queue-instant.webp',
+    'queue-touch': 'lobby/ludo-battle-royal/queue-touch.webp',
+    'queue-hdr': 'lobby/ludo-battle-royal/queue-hdr.webp',
+    'table-1': 'lobby/ludo-battle-royal/table-1.webp',
+    'table-2': 'lobby/ludo-battle-royal/table-2.webp',
+    'table-4': 'lobby/ludo-battle-royal/table-4.webp',
+    'ai-1': 'lobby/ludo-battle-royal/ai-1.webp',
+    'ai-2': 'lobby/ludo-battle-royal/ai-2.webp',
+    'ai-3': 'lobby/ludo-battle-royal/ai-3.webp'
+  }
+};
+
+export const variantThumbnails = {
+  poolroyale: {
+    uk: 'variants/pool-royale/8-pool-uk.webp',
+    american: 'variants/pool-royale/8-ball-american.webp',
+    '9ball': 'variants/pool-royale/9-ball.webp'
+  }
+};
+
+export const getGameThumbnail = (key) =>
+  (key && gameThumbnails[key] ? withBase(gameThumbnails[key]) : '');
+
+export const getLobbyIcon = (gameKey, iconKey) =>
+  (gameKey && iconKey && lobbyOptionIcons[gameKey]?.[iconKey]
+    ? withBase(lobbyOptionIcons[gameKey][iconKey])
+    : '');
+
+export const getVariantThumbnail = (gameKey, variantKey) =>
+  (gameKey && variantKey && variantThumbnails[gameKey]?.[variantKey]
+    ? withBase(variantThumbnails[gameKey][variantKey])
+    : '');
+
+export const gameAssetBase = GAME_ASSET_BASE_URL;

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -2,60 +2,70 @@ const gamesCatalog = [
   {
     name: "Texas Hold'em",
     route: '/games/texasholdem/lobby',
+    slug: 'texasholdem',
     image: '/assets/icons/texas-holdem.svg',
     description: 'High-stakes poker tables with quick matchmaking.'
   },
   {
     name: 'Domino Royal 3D',
     route: '/games/domino-royal/lobby',
+    slug: 'domino-royal',
     image: '/assets/icons/domino-royal.svg',
     description: 'Classic domino strategy with modern 3D flair.'
   },
   {
     name: 'Pool Royale',
     route: '/games/poolroyale/lobby',
+    slug: 'poolroyale',
     image: '/assets/icons/pool-royale.svg',
     description: 'Rack up and run the table in stylish arenas.'
   },
   {
     name: 'Snooker Royal',
     route: '/games/snookerroyale/lobby',
+    slug: 'snookerroyale',
     image: '/assets/icons/snooker-royale.svg',
     description: 'Precision snooker battles with competitive stakes.'
   },
   {
     name: 'Goal Rush',
     route: '/games/goalrush/lobby',
+    slug: 'goalrush',
     image: '/assets/icons/goal_rush_card_1200x675.webp',
     description: 'Score fast goals and climb the rankings.'
   },
   {
     name: 'Air Hockey',
     route: '/games/airhockey/lobby',
+    slug: 'airhockey',
     image: '/assets/icons/air-hockey.svg',
     description: 'Lightning puck duels with neon energy.'
   },
   {
     name: 'Snake & Ladder',
     route: '/games/snake/lobby',
+    slug: 'snake',
     image: '/assets/icons/snakes_and_ladders.webp',
     description: 'Race to the top with quick dice rolls.'
   },
   {
     name: 'Murlan Royale',
     route: '/games/murlanroyale/lobby',
+    slug: 'murlanroyale',
     image: '/assets/icons/murlan-royale.svg',
     description: 'Card-based tactics with a competitive twist.'
   },
   {
     name: 'Chess Battle Royal',
     route: '/games/chessbattleroyal/lobby',
+    slug: 'chessbattleroyal',
     image: '/assets/icons/chess-royale.svg',
     description: 'Strategic chess showdowns with royal flair.'
   },
   {
     name: 'Ludo Battle Royal',
     route: '/games/ludobattleroyal/lobby',
+    slug: 'ludobattleroyal',
     image: '/assets/icons/ludo-royale.svg',
     description: 'Classic ludo chaos in a battle royale lobby.'
   }
@@ -64,6 +74,7 @@ const gamesCatalog = [
 export default gamesCatalog;
 
 export const catalogWithSlugs = gamesCatalog.map((game) => {
+  if (game.slug) return game;
   const [, , slug] = game.route.split('/');
   return { ...game, slug };
 });

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -3,6 +3,7 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
+import { getGameThumbnail } from '../config/gameAssets.js';
 
 export default function Games() {
   useTelegramBackButton();
@@ -14,19 +15,24 @@ export default function Games() {
         Jump straight into a lobby. Tap any game to start your next match.
       </p>
       <div className="grid grid-cols-3 gap-3">
-        {gamesCatalog.map((game) => (
-          <Link
-            key={game.name}
-            to={game.route}
-            className="group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-surface/90 shadow-lg transition hover:-translate-y-0.5 hover:border-primary/60"
-          >
-            <div className="relative h-24 overflow-hidden">
-              <img
-                src={game.image}
-                alt={game.name}
-                loading="lazy"
-                className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-              />
+        {gamesCatalog.map((game) => {
+          const thumbnail = getGameThumbnail(game.slug);
+          return (
+            <Link
+              key={game.name}
+              to={game.route}
+              className="group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-surface/90 shadow-lg transition hover:-translate-y-0.5 hover:border-primary/60"
+            >
+              <div className="relative h-24 overflow-hidden">
+                <img
+                  src={thumbnail || game.image}
+                  alt={game.name}
+                  loading="lazy"
+                  className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                  onError={(event) => {
+                    event.currentTarget.src = game.image;
+                  }}
+                />
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
               <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
                 {game.name}
@@ -38,8 +44,9 @@ export default function Games() {
                 Enter Lobby
               </span>
             </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
       <GameTransactionsCard />
       <LeaderboardCard />

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -12,6 +12,8 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const AI_FLAG_STORAGE_KEY = 'airHockeyAiFlag';
 const PLAYER_FLAG_STORAGE_KEY = 'airHockeyPlayerFlag';
@@ -196,7 +198,12 @@ export default function AirHockeyLobby() {
                 >
                   <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-400/20 to-transparent p-[1px]">
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon('airhockey', `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-7 w-7"
+                      />
                     </div>
                   </div>
                   <div>
@@ -219,10 +226,10 @@ export default function AirHockeyLobby() {
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
-              {[
-                { id: 'ai', label: 'Vs AI', desc: 'Instant practice', icon: '🤖' },
-                { id: 'online', label: '1v1 Online', desc: 'Coming soon', icon: '⚔️', disabled: true }
-              ].map(({ id, label, desc, icon, disabled }) => {
+                {[
+                  { id: 'ai', label: 'Vs AI', desc: 'Instant practice', icon: '🤖' },
+                  { id: 'online', label: '1v1 Online', desc: 'Coming soon', icon: '⚔️', disabled: true }
+                ].map(({ id, label, desc, icon, disabled }) => {
                 const active = mode === id;
                 return (
                   <div key={id} className="relative">
@@ -238,7 +245,12 @@ export default function AirHockeyLobby() {
                     >
                       <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-emerald-400/30 via-sky-400/20 to-transparent p-[1px]">
                         <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                          {icon}
+                          <OptionIcon
+                            src={getLobbyIcon('airhockey', `mode-${id}`)}
+                            alt={label}
+                            fallback={icon}
+                            className="h-7 w-7"
+                          />
                         </div>
                       </div>
                       <div className="flex-1">
@@ -280,7 +292,15 @@ export default function AirHockeyLobby() {
                       : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   }`}
                 >
-                  First to {g}
+                  <div className="flex items-center justify-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('airhockey', `target-${g}`)}
+                      alt={`First to ${g}`}
+                      fallback="🏁"
+                      className="h-5 w-5"
+                    />
+                    First to {g}
+                  </div>
                 </button>
               );
             })}

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -14,6 +14,8 @@ import { getAccountBalance, addTransaction, getOnlineCount } from '../../utils/a
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { socket } from '../../utils/socket.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -338,7 +340,12 @@ export default function ChessBattleRoyalLobby() {
                 >
                   <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon('chessbattleroyal', `mode-${key}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-8 w-8"
+                      />
                     </div>
                   </div>
                   <div className="flex-1">

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -8,6 +8,8 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -225,7 +227,12 @@ export default function DominoRoyalLobby() {
               >
                 <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent p-[1px]">
                   <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                    {value}
+                    <OptionIcon
+                      src={getLobbyIcon('domino-royal', `players-${value}`)}
+                      alt={`${value} players`}
+                      fallback={`${value}`}
+                      className="h-7 w-7"
+                    />
                   </div>
                 </div>
                 <div>
@@ -267,21 +274,26 @@ export default function DominoRoyalLobby() {
               const active = mode === id;
               return (
                 <div key={id} className="relative">
-                  <button
-                    type="button"
-                    onClick={() => !disabled && setMode(id)}
-                    className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                    } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
-                    disabled={disabled}
-                  >
-                    <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                        {icon}
-                      </div>
+                <button
+                  type="button"
+                  onClick={() => !disabled && setMode(id)}
+                  className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                  disabled={disabled}
+                >
+                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                      <OptionIcon
+                        src={getLobbyIcon('domino-royal', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-8 w-8"
+                      />
                     </div>
+                  </div>
                     <div className="flex-1">
                       <div className="flex items-center justify-between">
                         <span className="text-base font-semibold">{label}</span>

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -12,6 +12,8 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const AI_FLAG_STORAGE_KEY = 'goalRushAiFlag';
 const PLAYER_FLAG_STORAGE_KEY = 'goalRushPlayerFlag';
@@ -194,7 +196,15 @@ export default function GoalRushLobby() {
                   onClick={() => setPlayType(id)}
                   className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
                 >
-                  {label}
+                  <span className="flex items-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('goalrush', `type-${id}`)}
+                      alt={label}
+                      fallback={id === 'regular' ? '🎯' : id === 'training' ? '🛠️' : '🏆'}
+                      className="h-5 w-5"
+                    />
+                    {label}
+                  </span>
                 </button>
               ))}
             </div>
@@ -221,7 +231,15 @@ export default function GoalRushLobby() {
                       }`}
                       disabled={disabled}
                     >
-                      {label}
+                      <span className="flex items-center gap-2">
+                        <OptionIcon
+                          src={getLobbyIcon('goalrush', `mode-${id}`)}
+                          alt={label}
+                          fallback={id === 'ai' ? '🤖' : '🌐'}
+                          className="h-5 w-5"
+                        />
+                        {label}
+                      </span>
                     </button>
                     {disabled && (
                       <span className="absolute inset-0 flex items-center justify-center text-xs bg-black/60 text-background">
@@ -248,7 +266,15 @@ export default function GoalRushLobby() {
                   onClick={() => setGoal(g)}
                   className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
                 >
-                  {g}
+                  <span className="flex items-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('goalrush', `target-${g}`)}
+                      alt={`${g} goals`}
+                      fallback="🥅"
+                      className="h-5 w-5"
+                    />
+                    {g}
+                  </span>
                 </button>
               ))}
             </div>

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -24,6 +24,8 @@ import {
 import { canStartGame } from '../../utils/lobby.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { runSnakeOnlineFlow } from './snakeOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 export default function Lobby() {
   const { game } = useParams();
@@ -121,7 +123,13 @@ export default function Lobby() {
   useEffect(() => {
     if (game !== 'snake') return undefined;
     let cancelled = false;
-    const singleTable = { id: 'single', label: 'Single Player vs AI', capacity: 1 };
+    const singleTable = {
+      id: 'single',
+      label: 'Single Player vs AI',
+      capacity: 1,
+      icon: getLobbyIcon('snake', 'table-single'),
+      iconFallback: '🎯'
+    };
 
     const applyTables = (lobbies = []) => {
       if (cancelled) return;
@@ -130,7 +138,9 @@ export default function Lobby() {
           id: entry.id,
           label: `Table ${entry.capacity} Players`,
           capacity: entry.capacity,
-          players: entry.players || 0
+          players: entry.players || 0,
+          icon: getLobbyIcon('snake', `table-${entry.capacity}`),
+          iconFallback: '🎲'
         }))
         .sort((a, b) => a.capacity - b.capacity);
       const nextTables = [singleTable, ...multiplayer];
@@ -511,7 +521,15 @@ export default function Lobby() {
                         : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                     }`}
                   >
-                    {n} AI
+                    <span className="flex items-center justify-center gap-2">
+                      <OptionIcon
+                        src={getLobbyIcon('snake', `ai-${n}`)}
+                        alt={`${n} AI`}
+                        fallback="🤖"
+                        className="h-5 w-5"
+                      />
+                      {n} AI
+                    </span>
                   </button>
                 ))}
               </div>

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -13,15 +13,35 @@ import {
   pingOnline
 } from '../../utils/api.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 const TABLES = [
-  { id: 'practice', label: 'Practice (Solo)', capacity: 1 },
-  { id: 'duo', label: 'Duo Battle', capacity: 2 },
-  { id: 'royale', label: 'Battle Royale (4 Players)', capacity: 4 }
+  {
+    id: 'practice',
+    label: 'Practice (Solo)',
+    capacity: 1,
+    icon: getLobbyIcon('ludobattleroyal', 'table-1'),
+    iconFallback: '🎯'
+  },
+  {
+    id: 'duo',
+    label: 'Duo Battle',
+    capacity: 2,
+    icon: getLobbyIcon('ludobattleroyal', 'table-2'),
+    iconFallback: '👥'
+  },
+  {
+    id: 'royale',
+    label: 'Battle Royale (4 Players)',
+    capacity: 4,
+    icon: getLobbyIcon('ludobattleroyal', 'table-4'),
+    iconFallback: '👑'
+  }
 ];
 
 export default function LudoBattleRoyalLobby() {
@@ -291,7 +311,15 @@ export default function LudoBattleRoyalLobby() {
                       onClick={() => setAiCount(n)}
                       className={`lobby-tile ${aiCount === n ? 'lobby-selected' : ''}`}
                     >
-                      {n}
+                      <span className="flex items-center gap-2">
+                        <OptionIcon
+                          src={getLobbyIcon('ludobattleroyal', `ai-${n}`)}
+                          alt={`${n} AI`}
+                          fallback="🤖"
+                          className="h-5 w-5"
+                        />
+                        {n}
+                      </span>
                     </button>
                   ))}
                 </div>

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -7,6 +7,8 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -198,7 +200,12 @@ export default function MurlanRoyaleLobby() {
                   >
                     <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                       <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                        {icon}
+                        <OptionIcon
+                          src={getLobbyIcon('murlanroyale', `mode-${id}`)}
+                          alt={label}
+                          fallback={icon}
+                          className="h-8 w-8"
+                        />
                       </div>
                     </div>
                     <div className="flex-1">
@@ -292,7 +299,12 @@ export default function MurlanRoyaleLobby() {
                 >
                   <div className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon('murlanroyale', `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-7 w-7"
+                      />
                     </div>
                   </div>
                   <div>
@@ -318,7 +330,15 @@ export default function MurlanRoyaleLobby() {
                       : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   }`}
                 >
-                  {pts} pts
+                  <div className="flex items-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('murlanroyale', `points-${pts}`)}
+                      alt={`${pts} points`}
+                      fallback="🏁"
+                      className="h-5 w-5"
+                    />
+                    {pts} pts
+                  </div>
                 </button>
               ))}
             </div>

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -11,6 +11,8 @@ import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon, getVariantThumbnail } from '../../config/gameAssets.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
@@ -342,7 +344,15 @@ export default function PoolRoyaleLobby() {
               onClick={() => setPlayType(id)}
               className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
             >
-              {label}
+              <span className="flex items-center gap-2">
+                <OptionIcon
+                  src={getLobbyIcon('poolroyale', `type-${id}`)}
+                  alt={label}
+                  fallback={id === 'regular' ? '🎯' : '🏆'}
+                  className="h-5 w-5"
+                />
+                {label}
+              </span>
             </button>
           ))}
         </div>
@@ -362,7 +372,15 @@ export default function PoolRoyaleLobby() {
                 }`}
                 disabled={disabled}
               >
-                {label}
+                <span className="flex items-center gap-2">
+                  <OptionIcon
+                    src={getLobbyIcon('poolroyale', `mode-${id}`)}
+                    alt={label}
+                    fallback={id === 'ai' ? '🤖' : '🌐'}
+                    className="h-5 w-5"
+                  />
+                  {label}
+                </span>
               </button>
               {disabled && (
                 <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
@@ -386,7 +404,15 @@ export default function PoolRoyaleLobby() {
               onClick={() => setVariant(id)}
               className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
             >
-              {label}
+              <span className="flex items-center gap-2">
+                <OptionIcon
+                  src={getVariantThumbnail('poolroyale', id)}
+                  alt={label}
+                  fallback="🎱"
+                  className="h-5 w-5"
+                />
+                {label}
+              </span>
             </button>
           ))}
         </div>
@@ -405,7 +431,15 @@ export default function PoolRoyaleLobby() {
                   onClick={() => setUkBallSet(id)}
                   className={`lobby-tile ${ukBallSet === id ? 'lobby-selected' : ''}`}
                 >
-                  {label}
+                  <span className="flex items-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('poolroyale', `ball-${id}`)}
+                      alt={label}
+                      fallback={id === 'uk' ? '🟡' : '🔵'}
+                      className="h-5 w-5"
+                    />
+                    {label}
+                  </span>
                 </button>
               )
             )}

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -11,6 +11,8 @@ import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { runSnookerRoyalOnlineFlow } from './snookerRoyalOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'snookerRoyalPlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'snookerRoyalAiFlag';
@@ -415,7 +417,12 @@ export default function SnookerRoyalLobby() {
                 >
                   <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon('snookerroyale', `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-8 w-8"
+                      />
                     </div>
                   </div>
                   <div className="flex-1">
@@ -473,7 +480,12 @@ export default function SnookerRoyalLobby() {
                 >
                   <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon('snookerroyale', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="h-8 w-8"
+                      />
                     </div>
                   </div>
                   <div className="flex-1">
@@ -519,7 +531,15 @@ export default function SnookerRoyalLobby() {
                 >
                   <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent p-[1px]">
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                      {icon}
+                      <OptionIcon
+                        src={getLobbyIcon(
+                          'snookerroyale',
+                          `table-${id === 'uk' ? 'championship' : id === 'american' ? 'club' : 'practice'}`
+                        )}
+                        alt={label}
+                        fallback={icon}
+                        className="h-7 w-7"
+                      />
                     </div>
                   </div>
                   <div>

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -7,6 +7,8 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { ensureAccountId, getTelegramId, getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -202,7 +204,15 @@ export default function TexasHoldemLobby() {
                   onClick={() => setOpponents(count)}
                   className={`lobby-tile ${isSelected ? 'lobby-selected' : ''}`}
                 >
-                  VS {count}
+                  <div className="flex flex-col items-center gap-1">
+                    <OptionIcon
+                      src={getLobbyIcon('texasholdem', `opponents-${count}`)}
+                      alt={`${count} opponents`}
+                      fallback="🂡"
+                      className="h-6 w-6"
+                    />
+                    <span>VS {count}</span>
+                  </div>
                 </button>
               );
             })}
@@ -213,7 +223,12 @@ export default function TexasHoldemLobby() {
           <div className="flex items-center gap-3">
             <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
               <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-lg">
-                ⚙️
+                <OptionIcon
+                  src={getLobbyIcon('texasholdem', 'mode-local')}
+                  alt="Match mode"
+                  fallback="⚙️"
+                  className="h-6 w-6"
+                />
               </div>
             </div>
             <div>
@@ -234,7 +249,15 @@ export default function TexasHoldemLobby() {
                   }`}
                   disabled={disabled}
                 >
-                  {label}
+                  <div className="flex items-center gap-2">
+                    <OptionIcon
+                      src={getLobbyIcon('texasholdem', `mode-${id}`)}
+                      alt={label}
+                      fallback={id === 'local' ? '🤖' : '🌐'}
+                      className="h-5 w-5"
+                    />
+                    <span>{label}</span>
+                  </div>
                 </button>
                 {disabled && (
                   <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">


### PR DESCRIPTION
### Motivation
- Provide high-quality game thumbnails and lobby option icons while keeping binary art out of the PR by allowing a separate drop-in folder or CDN root.
- Make lobby UI more expressive and future-proof by referencing named icon slots instead of hard-coded emoji or small SVGs.
- Keep run-time fallback behavior so the app works even when production art is not present locally.

### Description
- Added a configurable asset manifest and helpers in `webapp/src/config/gameAssets.js` with `getGameThumbnail`, `getLobbyIcon`, `getVariantThumbnail`, and an environment override via `VITE_GAME_ASSET_BASE_URL`.
- Introduced a non-tracked drop-in folder with guidance at `webapp/public/assets/game-art/README.md` and an ignore rule at `webapp/public/assets/game-art/.gitignore` so production binaries can be dropped locally or hosted on a CDN without appearing in PRs.
- Added a reusable `OptionIcon` component at `webapp/src/components/OptionIcon.jsx` and wired lobby pages and selectors to use `getLobbyIcon` with safe fallbacks; updated `TableSelector`, `Games` listing, `HomeGamesCard`, and lobby pages (Pool, Snooker, Texas Hold'em, Domino, Goal Rush, Air Hockey, Murlan, Chess, Ludo, Snake) to use the new API and icons.
- Extended `webapp/src/config/gamesCatalog.js` with optional `slug` fields and changed UI to prefer manifest thumbnails while falling back to existing icon assets when necessary.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported `ready` and served the site (local network URL printed), which succeeded.
- Ran a headless Playwright script that opened `http://127.0.0.1:4173/games` at mobile viewport and saved a screenshot to `artifacts/games-page.png`, which completed successfully and demonstrates the new thumbnail/fallback behavior.
- No automated unit tests were modified or run; there are no failing build/runtime errors observed during the local dev server run or the Playwright verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697461fc17348329b12354ec2091f5d5)