### PR TITLE
Pool Royale: lobby redesign, rack thumbnails, and table/cue physics tuning

### DIFF
--- a/webapp/public/assets/game-art/.gitignore
+++ b/webapp/public/assets/game-art/.gitignore
@@ -1,3 +1,9 @@
 *
 !.gitignore
 !README.md
+!lobby/
+!lobby/pool-royale/
+!lobby/pool-royale/*.svg
+!variants/
+!variants/pool-royale/
+!variants/pool-royale/*.svg

--- a/webapp/public/assets/game-art/lobby/pool-royale/ball-american-rack.svg
+++ b/webapp/public/assets/game-art/lobby/pool-royale/ball-american-rack.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 140">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="140" rx="16" fill="url(#bg)"/>
+  <g stroke="#111827" stroke-width="2">
+    <circle cx="100" cy="22" r="10" fill="#fbbf24"/>
+
+    <circle cx="88" cy="44" r="10" fill="#1d4ed8"/>
+    <circle cx="112" cy="44" r="10" fill="#ffffff" stroke="#ef4444" stroke-width="5"/>
+
+    <circle cx="76" cy="66" r="10" fill="#ffffff" stroke="#22c55e" stroke-width="5"/>
+    <circle cx="100" cy="66" r="10" fill="#111111"/>
+    <circle cx="124" cy="66" r="10" fill="#ffffff" stroke="#a855f7" stroke-width="5"/>
+
+    <circle cx="64" cy="88" r="10" fill="#f97316"/>
+    <circle cx="88" cy="88" r="10" fill="#ffffff" stroke="#1d4ed8" stroke-width="5"/>
+    <circle cx="112" cy="88" r="10" fill="#22c55e"/>
+    <circle cx="136" cy="88" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="5"/>
+
+    <circle cx="52" cy="110" r="10" fill="#ef4444"/>
+    <circle cx="76" cy="110" r="10" fill="#ffffff" stroke="#f97316" stroke-width="5"/>
+    <circle cx="100" cy="110" r="10" fill="#a855f7"/>
+    <circle cx="124" cy="110" r="10" fill="#ffffff" stroke="#22c55e" stroke-width="5"/>
+    <circle cx="148" cy="110" r="10" fill="#7f1d1d"/>
+  </g>
+</svg>

--- a/webapp/public/assets/game-art/lobby/pool-royale/ball-uk-rack.svg
+++ b/webapp/public/assets/game-art/lobby/pool-royale/ball-uk-rack.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 140">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="140" rx="16" fill="url(#bg)"/>
+  <g stroke="#111827" stroke-width="2">
+    <circle cx="100" cy="22" r="10" fill="#ffd200"/>
+
+    <circle cx="88" cy="44" r="10" fill="#d12c2c"/>
+    <circle cx="112" cy="44" r="10" fill="#ffd200"/>
+
+    <circle cx="76" cy="66" r="10" fill="#ffd200"/>
+    <circle cx="100" cy="66" r="10" fill="#111111"/>
+    <circle cx="124" cy="66" r="10" fill="#d12c2c"/>
+
+    <circle cx="64" cy="88" r="10" fill="#d12c2c"/>
+    <circle cx="88" cy="88" r="10" fill="#ffd200"/>
+    <circle cx="112" cy="88" r="10" fill="#d12c2c"/>
+    <circle cx="136" cy="88" r="10" fill="#ffd200"/>
+
+    <circle cx="52" cy="110" r="10" fill="#ffd200"/>
+    <circle cx="76" cy="110" r="10" fill="#d12c2c"/>
+    <circle cx="100" cy="110" r="10" fill="#ffd200"/>
+    <circle cx="124" cy="110" r="10" fill="#d12c2c"/>
+    <circle cx="148" cy="110" r="10" fill="#ffd200"/>
+  </g>
+</svg>

--- a/webapp/public/assets/game-art/variants/pool-royale/8-ball-american-rack.svg
+++ b/webapp/public/assets/game-art/variants/pool-royale/8-ball-american-rack.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="160" rx="18" fill="url(#bg)"/>
+  <g stroke="#111827" stroke-width="2">
+    <circle cx="120" cy="24" r="12" fill="#fbbf24"/>
+
+    <circle cx="105" cy="48" r="12" fill="#1d4ed8"/>
+    <circle cx="135" cy="48" r="12" fill="#ffffff" stroke="#ef4444" stroke-width="6"/>
+
+    <circle cx="90" cy="72" r="12" fill="#ffffff" stroke="#22c55e" stroke-width="6"/>
+    <circle cx="120" cy="72" r="12" fill="#111111"/>
+    <circle cx="150" cy="72" r="12" fill="#ffffff" stroke="#a855f7" stroke-width="6"/>
+
+    <circle cx="75" cy="96" r="12" fill="#f97316"/>
+    <circle cx="105" cy="96" r="12" fill="#ffffff" stroke="#1d4ed8" stroke-width="6"/>
+    <circle cx="135" cy="96" r="12" fill="#22c55e"/>
+    <circle cx="165" cy="96" r="12" fill="#ffffff" stroke="#fbbf24" stroke-width="6"/>
+
+    <circle cx="60" cy="120" r="12" fill="#ef4444"/>
+    <circle cx="90" cy="120" r="12" fill="#ffffff" stroke="#f97316" stroke-width="6"/>
+    <circle cx="120" cy="120" r="12" fill="#a855f7"/>
+    <circle cx="150" cy="120" r="12" fill="#ffffff" stroke="#22c55e" stroke-width="6"/>
+    <circle cx="180" cy="120" r="12" fill="#7f1d1d"/>
+  </g>
+  <text x="120" y="152" font-family="'Inter', Arial, sans-serif" font-size="14" fill="#cbd5f5" text-anchor="middle">American 8-Ball</text>
+</svg>

--- a/webapp/public/assets/game-art/variants/pool-royale/8-pool-uk-rack.svg
+++ b/webapp/public/assets/game-art/variants/pool-royale/8-pool-uk-rack.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="160" rx="18" fill="url(#bg)"/>
+  <g stroke="#111827" stroke-width="2">
+    <circle cx="120" cy="24" r="12" fill="#ffd200"/>
+
+    <circle cx="105" cy="48" r="12" fill="#d12c2c"/>
+    <circle cx="135" cy="48" r="12" fill="#ffd200"/>
+
+    <circle cx="90" cy="72" r="12" fill="#ffd200"/>
+    <circle cx="120" cy="72" r="12" fill="#111111"/>
+    <circle cx="150" cy="72" r="12" fill="#d12c2c"/>
+
+    <circle cx="75" cy="96" r="12" fill="#d12c2c"/>
+    <circle cx="105" cy="96" r="12" fill="#ffd200"/>
+    <circle cx="135" cy="96" r="12" fill="#d12c2c"/>
+    <circle cx="165" cy="96" r="12" fill="#ffd200"/>
+
+    <circle cx="60" cy="120" r="12" fill="#ffd200"/>
+    <circle cx="90" cy="120" r="12" fill="#d12c2c"/>
+    <circle cx="120" cy="120" r="12" fill="#ffd200"/>
+    <circle cx="150" cy="120" r="12" fill="#d12c2c"/>
+    <circle cx="180" cy="120" r="12" fill="#ffd200"/>
+  </g>
+  <text x="120" y="152" font-family="'Inter', Arial, sans-serif" font-size="14" fill="#cbd5f5" text-anchor="middle">8 Pool UK</text>
+</svg>

--- a/webapp/public/assets/game-art/variants/pool-royale/9-ball-rack.svg
+++ b/webapp/public/assets/game-art/variants/pool-royale/9-ball-rack.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="160" rx="18" fill="url(#bg)"/>
+  <g stroke="#111827" stroke-width="2" font-family="'Inter', Arial, sans-serif" font-size="10" text-anchor="middle" fill="#0f172a">
+    <circle cx="120" cy="32" r="12" fill="#fbbf24"/>
+    <text x="120" y="36" fill="#0f172a">1</text>
+
+    <circle cx="105" cy="56" r="12" fill="#1d4ed8"/>
+    <text x="105" y="60" fill="#e2e8f0">2</text>
+    <circle cx="135" cy="56" r="12" fill="#ef4444"/>
+    <text x="135" y="60" fill="#e2e8f0">3</text>
+
+    <circle cx="90" cy="80" r="12" fill="#a855f7"/>
+    <text x="90" y="84" fill="#e2e8f0">4</text>
+    <circle cx="120" cy="80" r="12" fill="#fbbf24"/>
+    <text x="120" y="84" fill="#0f172a">9</text>
+    <circle cx="150" cy="80" r="12" fill="#22c55e"/>
+    <text x="150" y="84" fill="#0f172a">6</text>
+
+    <circle cx="105" cy="104" r="12" fill="#f97316"/>
+    <text x="105" y="108" fill="#0f172a">5</text>
+    <circle cx="135" cy="104" r="12" fill="#7f1d1d"/>
+    <text x="135" y="108" fill="#e2e8f0">7</text>
+
+    <circle cx="120" cy="128" r="12" fill="#111111"/>
+    <text x="120" y="132" fill="#e2e8f0">8</text>
+  </g>
+  <text x="120" y="152" font-family="'Inter', Arial, sans-serif" font-size="14" fill="#cbd5f5" text-anchor="middle">9-Ball Rack</text>
+</svg>

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -43,8 +43,8 @@ export const lobbyOptionIcons = {
     'variant-uk': 'lobby/pool-royale/variant-uk.webp',
     'variant-american': 'lobby/pool-royale/variant-american.webp',
     'variant-9ball': 'lobby/pool-royale/variant-9ball.webp',
-    'ball-uk': 'lobby/pool-royale/ball-uk.webp',
-    'ball-american': 'lobby/pool-royale/ball-american.webp'
+    'ball-uk': 'lobby/pool-royale/ball-uk-rack.svg',
+    'ball-american': 'lobby/pool-royale/ball-american-rack.svg'
   },
   snookerroyale: {
     'type-regular': 'lobby/snooker-royale/type-regular.webp',
@@ -118,9 +118,9 @@ export const lobbyOptionIcons = {
 
 export const variantThumbnails = {
   poolroyale: {
-    uk: 'variants/pool-royale/8-pool-uk.webp',
-    american: 'variants/pool-royale/8-ball-american.webp',
-    '9ball': 'variants/pool-royale/9-ball.webp'
+    uk: 'variants/pool-royale/8-pool-uk-rack.svg',
+    american: 'variants/pool-royale/8-ball-american-rack.svg',
+    '9ball': 'variants/pool-royale/9-ball-rack.svg'
   }
 };
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -325,289 +325,414 @@ export default function PoolRoyaleLobby() {
   const winnerParam = searchParams.get('winner');
 
   return (
-    <div className="relative p-4 space-y-4 text-text min-h-screen tetris-grid-bg">
-      {winnerParam && (
-        <div className="text-center font-semibold">
-          {winnerParam === '1' ? 'You won!' : 'CPU won!'}
-        </div>
-      )}
-      <h2 className="text-xl font-bold text-center">Pool Royale Lobby</h2>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Type</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'regular', label: 'Regular' },
-            { id: 'tournament', label: 'Tournament' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setPlayType(id)}
-              className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
-            >
-              <span className="flex items-center gap-2">
-                <OptionIcon
-                  src={getLobbyIcon('poolroyale', `type-${id}`)}
-                  alt={label}
-                  fallback={id === 'regular' ? '🎯' : '🏆'}
-                  className="h-5 w-5"
-                />
-                {label}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Mode</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'ai', label: 'Vs AI' },
-            { id: 'online', label: '1v1 Online', disabled: playType === 'tournament' }
-          ].map(({ id, label, disabled }) => (
-            <div key={id} className="relative">
-              <button
-                onClick={() => !disabled && setMode(id)}
-                className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                  disabled ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-                disabled={disabled}
-              >
-                <span className="flex items-center gap-2">
-                  <OptionIcon
-                    src={getLobbyIcon('poolroyale', `mode-${id}`)}
-                    alt={label}
-                    fallback={id === 'ai' ? '🤖' : '🌐'}
-                    className="h-5 w-5"
-                  />
-                  {label}
-                </span>
-              </button>
-              {disabled && (
-                <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                  Tournament bracket only
-                </span>
-              )}
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-6 p-4 pb-8">
+        {winnerParam && (
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-center text-sm font-semibold text-emerald-200">
+            {winnerParam === '1' ? 'You won!' : 'CPU won!'}
+          </div>
+        )}
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Pool Royale</p>
+              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
             </div>
-          ))}
+            <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
+              {onlinePlayers.length} online
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-[1.2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
+              <div className="flex items-center gap-3">
+                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
+                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    🎱
+                  </div>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Cue Table Ready</p>
+                  <p className="text-xs text-white/60">
+                    Match setup stays snappy while the arena finishes loading in the background.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Precision cushions</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Tournament ready</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+                  {avatar ? (
+                    <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+                  )}
+                </div>
+                <div className="text-sm text-white/80">
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+                  <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+                </div>
+              </div>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedFlag || '🌐'}</span>
+                    <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowAiFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                    <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+                  </div>
+                </button>
+              </div>
+              <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="space-y-2">
-        <h3 className="font-semibold">Variant</h3>
-        <div className="flex gap-2">
-          {[
-            { id: 'uk', label: '8 Pool UK' },
-            { id: 'american', label: 'American' },
-            { id: '9ball', label: '9-Ball' }
-          ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setVariant(id)}
-              className={`lobby-tile ${variant === id ? 'lobby-selected' : ''}`}
-            >
-              <span className="flex items-center gap-2">
-                <OptionIcon
-                  src={getVariantThumbnail('poolroyale', id)}
-                  alt={label}
-                  fallback="🎱"
-                  className="h-5 w-5"
-                />
-                {label}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-      {variant === 'uk' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Ball Colors</h3>
-          <p className="text-xs text-subtext">
-            Keep UK yellow/red sets or switch to Solids &amp; Stripes visuals while retaining 8 Pool UK rules.
-          </p>
-          <div className="flex gap-2">
-            {[{ id: 'uk', label: 'Yellow & Red' }, { id: 'american', label: 'Solids & Stripes' }].map(
-              ({ id, label }) => (
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Match Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                id: 'regular',
+                label: 'Regular',
+                desc: 'Quick single match',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                iconKey: 'type-regular'
+              },
+              {
+                id: 'tournament',
+                label: 'Tournament',
+                desc: 'Bracket challenge',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                iconKey: 'type-tournament'
+              }
+            ].map(({ id, label, desc, accent, iconKey }) => {
+              const active = playType === id;
+              return (
                 <button
                   key={id}
-                  onClick={() => setUkBallSet(id)}
-                  className={`lobby-tile ${ukBallSet === id ? 'lobby-selected' : ''}`}
+                  type="button"
+                  onClick={() => setPlayType(id)}
+                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
                 >
-                  <span className="flex items-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('poolroyale', `ball-${id}`)}
-                      alt={label}
-                      fallback={id === 'uk' ? '🟡' : '🔵'}
-                      className="h-5 w-5"
-                    />
-                    {label}
-                  </span>
+                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', iconKey)}
+                        alt={label}
+                        fallback={id === 'regular' ? '🎯' : '🏆'}
+                        className="h-10 w-10"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-base font-semibold">{label}</p>
+                    <p className="text-xs text-white/50">{desc}</p>
+                  </div>
                 </button>
-              )
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Play Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Opponents</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              { id: 'ai', label: 'Vs AI', desc: 'Practice precision', iconKey: 'mode-ai' },
+              {
+                id: 'online',
+                label: '1v1 Online',
+                desc: 'Live matchmaking',
+                iconKey: 'mode-online',
+                disabled: playType === 'tournament'
+              }
+            ].map(({ id, label, desc, iconKey, disabled }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => !disabled && setMode(id)}
+                  disabled={disabled}
+                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                >
+                  <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent p-[1px]">
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', iconKey)}
+                        alt={label}
+                        fallback={id === 'ai' ? '🤖' : '🌐'}
+                        className="h-10 w-10"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-base font-semibold">{label}</p>
+                    <p className="text-xs text-white/50">
+                      {disabled ? 'Tournament bracket only' : desc}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Variant</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Ruleset</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { id: 'uk', label: '8 Pool UK' },
+              { id: 'american', label: 'American' },
+              { id: '9ball', label: '9-Ball' }
+            ].map(({ id, label }) => {
+              const active = variant === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setVariant(id)}
+                  className={`group flex flex-col items-start gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  }`}
+                >
+                  <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent p-[1px]">
+                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
+                      <OptionIcon
+                        src={getVariantThumbnail('poolroyale', id)}
+                        alt={label}
+                        fallback="🎱"
+                        className="h-12 w-12"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-base font-semibold">{label}</p>
+                    <p className="text-xs text-white/50">Official rack layout</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {variant === 'uk' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Ball Colors</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Visuals</span>
+            </div>
+            <p className="text-xs text-white/60">
+              Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8 Pool UK rules.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                { id: 'uk', label: 'Yellow & Red' },
+                { id: 'american', label: 'Solids & Stripes' }
+              ].map(({ id, label }) => {
+                const active = ukBallSet === id;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setUkBallSet(id)}
+                    className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    }`}
+                  >
+                    <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent p-[1px]">
+                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
+                        <OptionIcon
+                          src={getLobbyIcon('poolroyale', `ball-${id}`)}
+                          alt={label}
+                          fallback={id === 'uk' ? '🟡' : '🔵'}
+                          className="h-10 w-10"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-base font-semibold">{label}</p>
+                      <p className="text-xs text-white/50">Official rack</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {playType === 'tournament' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <h3 className="font-semibold text-white">Tournament Players</h3>
+            <div className="flex flex-wrap gap-2">
+              {[8, 16, 24].map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setPlayers(p)}
+                  className={`rounded-xl border px-4 py-2 text-sm font-semibold transition ${
+                    players === p
+                      ? 'border-primary bg-primary/15 text-primary'
+                      : 'border-white/10 bg-white/5 text-white/70 hover:border-white/30'
+                  }`}
+                >
+                  {p} Players
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-white/50">Winner takes pot minus 10% developer fee.</p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Stake</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">TPC</span>
+            </div>
+            <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            <p className="text-center text-xs text-white/50">
+              Online games use your TPC stake as escrow, while AI matches stay free.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-white">Online Arena</h3>
+                <p className="text-sm text-white/60">
+                  We match players by TPC account number, stake ({stake.amount} {stake.token}), and Pool Royale game type.
+                </p>
+              </div>
+              <div className="text-xs text-white/50">{onlinePlayers.length} online</div>
+            </div>
+            {matchingError && <div className="text-sm text-red-400">{matchingError}</div>}
+            {matching && (
+              <div className="space-y-2">
+                {matchStatus && <div className="text-xs text-white/50">{matchStatus}</div>}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Spinning wheel</span>
+                  <span className="text-xs text-white/50">Searching for stake match…</span>
+                </div>
+                <div className="lobby-tile w-full flex items-center justify-between">
+                  <span>🎯 {spinningPlayer || 'Searching…'}</span>
+                  <span className="text-xs text-white/60">Stake {stake.amount} {stake.token}</span>
+                </div>
+                <div className="space-y-1">
+                  {matchPlayers.map((p) => (
+                    <div
+                      key={p.id}
+                      className="lobby-tile w-full flex items-center justify-between"
+                    >
+                      <div>
+                        <p className="text-sm font-semibold">{p.name || `TPC ${p.id}`}</p>
+                        <p className="text-xs text-white/50">Account #{p.id}</p>
+                      </div>
+                      <span
+                        className={`text-xs font-semibold ${
+                          readyIds.has(String(p.id)) ? 'text-emerald-400' : 'text-white/50'
+                        }`}
+                      >
+                        {readyIds.has(String(p.id)) ? 'Ready' : 'Waiting'}
+                      </span>
+                    </div>
+                  ))}
+                  {matchPlayers.length === 0 && (
+                    <div className="lobby-tile w-full text-sm text-white/50">
+                      Waiting for another player in this pool arena…
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {!matching && (
+              <div className="text-sm text-white/50">
+                Start to join a 1v1 pool arena. We keep you at the same table until the match begins.
+              </div>
             )}
           </div>
-        </div>
-      )}
-      {playType === 'tournament' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Players</h3>
-          <div className="flex gap-2">
-            {[8, 16, 24].map((p) => (
-              <button
-                key={p}
-                onClick={() => setPlayers(p)}
-                className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs">Winner takes pot minus 10% developer fee.</p>
-        </div>
-      )}
-      {mode === 'online' && playType === 'regular' && (
-        <div className="space-y-2">
-          <h3 className="font-semibold">Stake</h3>
-          <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
-          <p className="text-center text-xs text-subtext">
-            Online games use your TPC stake as escrow, while AI matches stay free.
-          </p>
-        </div>
-      )}
-      <div className="space-y-2">
-        <h3 className="font-semibold">Your Flag & Avatar</h3>
-        <div className="rounded-xl border border-border bg-surface/60 p-3 space-y-2 shadow">
-          <button
-            type="button"
-            onClick={() => setShowFlagPicker(true)}
-            className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
-          >
-            <div className="text-[11px] uppercase tracking-wide text-subtext">Flag</div>
-            <div className="flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedFlag || '🌐'}</span>
-              <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
-            </div>
-          </button>
-          {avatar && (
-            <div className="flex items-center gap-3">
-              <img
-                src={avatar}
-                alt="Your avatar"
-                className="h-12 w-12 rounded-full border border-border object-cover"
-              />
-              <div className="text-sm text-subtext">Your avatar will appear in the match intro.</div>
-            </div>
-          )}
-        </div>
-      </div>
+        )}
 
-      <div className="space-y-2">
-        <h3 className="font-semibold">AI Avatar Flags</h3>
         <button
-          type="button"
-          onClick={() => setShowAiFlagPicker(true)}
-          className="w-full px-3 py-2 rounded-lg border border-border bg-background/60 hover:border-primary text-sm text-left"
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"
+          disabled={mode === 'online' && (isSearching || matching)}
         >
-          <div className="text-[11px] uppercase tracking-wide text-subtext">AI Flag</div>
-          <div className="flex items-center gap-2 text-base font-semibold">
-            <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-            <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-          </div>
+          {mode === 'online' ? (matching ? 'Waiting for opponent…' : 'START ONLINE') : 'START'}
         </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
       </div>
-      {mode === 'online' && playType === 'regular' && (
-        <div className="space-y-3 p-3 rounded-lg border border-border bg-surface/60">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="font-semibold">Online Arena</h3>
-              <p className="text-sm text-subtext">
-                We match players by TPC account number, stake ({stake.amount} {stake.token}),
-                and Pool Royale game type.
-              </p>
-            </div>
-            <div className="text-xs text-subtext">{onlinePlayers.length} online</div>
-          </div>
-          {matchingError && (
-            <div className="text-sm text-red-400">{matchingError}</div>
-          )}
-          {matching && (
-            <div className="space-y-2">
-              {matchStatus && <div className="text-xs text-subtext">{matchStatus}</div>}
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-semibold">Spinning wheel</span>
-                <span className="text-xs text-subtext">Searching for stake match…</span>
-              </div>
-              <div className="lobby-tile w-full flex items-center justify-between">
-                <span>🎯 {spinningPlayer || 'Searching…'}</span>
-                <span className="text-xs text-subtext">Stake {stake.amount} {stake.token}</span>
-              </div>
-              <div className="space-y-1">
-                {matchPlayers.map((p) => (
-                  <div
-                    key={p.id}
-                    className="lobby-tile w-full flex items-center justify-between"
-                  >
-                    <div>
-                      <p className="text-sm font-semibold">{p.name || `TPC ${p.id}`}</p>
-                      <p className="text-xs text-subtext">Account #{p.id}</p>
-                    </div>
-                    <span
-                      className={`text-xs font-semibold ${
-                        readyIds.has(String(p.id)) ? 'text-emerald-400' : 'text-subtext'
-                      }`}
-                    >
-                      {readyIds.has(String(p.id)) ? 'Ready' : 'Waiting'}
-                    </span>
-                  </div>
-                ))}
-                {matchPlayers.length === 0 && (
-                  <div className="lobby-tile w-full text-sm text-subtext">
-                    Waiting for another player in this pool arena…
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-          {!matching && (
-            <div className="text-sm text-subtext">
-              Start to join a 1v1 pool arena. We keep you at the same table until the match begins.
-            </div>
-          )}
-        </div>
-      )}
-      <button
-        onClick={startGame}
-        className="px-4 py-2 w-full bg-primary hover:bg-primary-hover text-background rounded"
-        disabled={mode === 'online' && (isSearching || matching)}
-      >
-        {mode === 'online' ? (matching ? 'Waiting for opponent…' : 'START ONLINE') : 'START'}
-      </button>
-
-      <FlagPickerModal
-        open={showFlagPicker}
-        count={1}
-        selected={playerFlagIndex != null ? [playerFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setPlayerFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowFlagPicker(false)}
-      />
-
-      <FlagPickerModal
-        open={showAiFlagPicker}
-        count={1}
-        selected={aiFlagIndex != null ? [aiFlagIndex] : []}
-        onSave={(indices) => {
-          const idx = indices?.[0] ?? null;
-          setAiFlagIndex(idx);
-          try {
-            if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
-          } catch {}
-        }}
-        onClose={() => setShowAiFlagPicker(false)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the Pool Royale lobby UX to match the modern lobby style and provide clearer, larger variant thumbnails for players. 
- Reduce visual/physics mismatches around middle pockets and cue animations that can cause unnatural bounces or brief stutters. 
- Provide explicit rack thumbnails for UK/American/9-ball so thumbnails reflect official rack visuals.

### Description
- Reworked the Pool Royale lobby UI to a modern card layout with larger option tiles and reorganized sections (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`).
- Added SVG rack thumbnails for variants and ball-color options and wired them into the asset config (`webapp/src/config/gameAssets.js`) while updating the game-art ignore rules to include the new assets (`webapp/public/assets/game-art/.gitignore` and new SVG files under `webapp/public/assets/game-art/variants/pool-royale` and `webapp/public/assets/game-art/lobby/pool-royale`).
- Enabled cue stroke animation and improved visual follow-through calculation to make strokes more readable and less likely to produce camera/animation discontinuities (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tuned table/chrome/pocket geometry and pocket guarding: reduced the side chrome plate outward shift (`CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`), tightened `SIDE_POCKET_GUARD_CLEARANCE`, aligned `SIDE_POCKET_DEPTH_LIMIT` to side-pocket radius, and updated side pocket span resolution to better match visible cushions (all changes in `PoolRoyale.jsx`).

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and verified the lobby page loads without syntax errors (Vite dev server ready). (succeeded)
- Captured a portrait screenshot of the updated Pool Royale lobby using a Playwright script that opened `http://127.0.0.1:5173/games/poolroyale/lobby` at 430×932 and saved `artifacts/pool-royale-lobby.png` to validate layout and thumbnails (succeeded).
- No automated unit tests were modified or executed for the physics changes; visual/manual smoke checks were used to validate layout and that the scene boots cleanly (successful load and screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974688829a483298ba79b8d09b646ea)