### PR TITLE
Improve cushion physics, shift middle chrome plates outward, and enlarge lobby thumbnails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -413,7 +413,7 @@ export default function PoolRoyaleLobby() {
             <h3 className="font-semibold text-white">Choose Match Type</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-2 gap-3">
             {[
               {
                 id: 'regular',
@@ -442,13 +442,13 @@ export default function PoolRoyaleLobby() {
                       : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   }`}
                 >
-                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                  <div className={`h-16 w-16 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
                       <OptionIcon
                         src={getLobbyIcon('poolroyale', iconKey)}
                         alt={label}
                         fallback={id === 'regular' ? '🎯' : '🏆'}
-                        className="h-10 w-10"
+                        className="h-12 w-12"
                       />
                     </div>
                   </div>
@@ -467,7 +467,7 @@ export default function PoolRoyaleLobby() {
             <h3 className="font-semibold text-white">Play Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Opponents</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-2 gap-3">
             {[
               { id: 'ai', label: 'Vs AI', desc: 'Practice precision', iconKey: 'mode-ai' },
               {
@@ -491,13 +491,13 @@ export default function PoolRoyaleLobby() {
                       : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
                 >
-                  <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent p-[1px]">
+                  <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent p-[1px]">
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
                       <OptionIcon
                         src={getLobbyIcon('poolroyale', iconKey)}
                         alt={label}
                         fallback={id === 'ai' ? '🤖' : '🌐'}
-                        className="h-10 w-10"
+                        className="h-12 w-12"
                       />
                     </div>
                   </div>
@@ -518,7 +518,7 @@ export default function PoolRoyaleLobby() {
             <h3 className="font-semibold text-white">Game Variant</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Ruleset</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               { id: 'uk', label: '8 Pool UK' },
               { id: 'american', label: 'American' },
@@ -536,13 +536,13 @@ export default function PoolRoyaleLobby() {
                       : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                   }`}
                 >
-                  <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent p-[1px]">
+                  <div className="h-20 w-20 rounded-2xl bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent p-[1px]">
                     <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
                       <OptionIcon
                         src={getVariantThumbnail('poolroyale', id)}
                         alt={label}
                         fallback="🎱"
-                        className="h-12 w-12"
+                        className="h-14 w-14"
                       />
                     </div>
                   </div>
@@ -565,7 +565,7 @@ export default function PoolRoyaleLobby() {
             <p className="text-xs text-white/60">
               Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8 Pool UK rules.
             </p>
-            <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid grid-cols-2 gap-3">
               {[
                 { id: 'uk', label: 'Yellow & Red' },
                 { id: 'american', label: 'Solids & Stripes' }
@@ -582,13 +582,13 @@ export default function PoolRoyaleLobby() {
                         : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
                     }`}
                   >
-                    <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent p-[1px]">
+                    <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent p-[1px]">
                       <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
                         <OptionIcon
                           src={getLobbyIcon('poolroyale', `ball-${id}`)}
                           alt={label}
                           fallback={id === 'uk' ? '🟡' : '🔵'}
-                          className="h-10 w-10"
+                          className="h-12 w-12"
                         />
                       </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Make cushion/cut interactions feel more natural by tuning angled-cut rebound and friction so balls behave like real pool when hitting pocket angle cuts. 
- Nudge the chrome plates around the middle pockets slightly outward so the metal fascia sits away from the table center while preserving the rounded pocket cuts. 
- Improve lobby usability on mobile by enlarging option thumbnails and enforcing denser horizontal grids (up to 3 per row) to save vertical space.

### Description
- Add a configurable physics-side cut angle (`SIDE_POCKET_PHYSICS_CUT_ANGLE`) with clamped min/max and compute it from table spec in `applyTablePhysicsSpec`, and use it for side-pocket cut detection. 
- Reduce angled-cut restitution and add a friction multiplier for angled/cut impacts (`CUSHION_CUT_RESTITUTION_SCALE` -> 0.78 and `CUSHION_CUT_FRICTION_SCALE` -> 1.25) and apply a glancing-impact scale to blend rebound strength based on impact geometry. 
- Adjust rail impulse calculation to modulate restitution and friction on corner/cut impacts for less "punchy" bounces and more realistic grab. 
- Shift middle pocket chrome fascia outward by changing `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` to a negative value so side plates are pushed away from the table center while rounded pocket cuts are untouched. 
- Enlarge lobby thumbnails and switch option grids to fixed 2- or 3-column layouts (`grid-cols-2`, `grid-cols-3`) and increase the size of thumbnail containers and `OptionIcon` images to tighten horizontal layouts and save vertical space.

### Testing
- Started the web dev server (`npm --prefix webapp run dev`) and confirmed Vite reported the server ready. 
- Loaded the Lobby page with an automated Playwright script against `http://127.0.0.1:4173/games/poolroyale/lobby` and captured a screenshot to verify the updated thumbnail sizes and grid layout (screenshot artifact produced). 
- No unit tests were changed or executed as these are rendering and physics tweaks verified via runtime smoke checks; manual/playback verification recommended for in-engine physics behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748f60f2b08329be90b478c46d424c)