### PR TITLE
Unify lobby option card layouts across lobbies

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1332,6 +1332,42 @@ input:focus {
   color: #facc15;
 }
 
+.lobby-option-card {
+  @apply flex flex-col items-center gap-3 rounded-2xl border px-4 py-4 text-center shadow transition;
+}
+
+.lobby-option-card-active {
+  @apply border-primary bg-primary/10 text-primary;
+}
+
+.lobby-option-card-inactive {
+  @apply border-white/10 bg-black/30 text-white/80 hover:border-white/30;
+}
+
+.lobby-option-card-disabled {
+  @apply cursor-not-allowed opacity-50;
+}
+
+.lobby-option-thumb {
+  @apply h-24 w-24 rounded-2xl p-[1px];
+}
+
+.lobby-option-thumb-inner {
+  @apply flex h-full w-full items-center justify-center overflow-hidden rounded-[18px] bg-[#0b1220];
+}
+
+.lobby-option-icon {
+  @apply h-20 w-20;
+}
+
+.lobby-option-label {
+  @apply text-sm font-semibold;
+}
+
+.lobby-option-subtitle {
+  @apply text-xs text-white/50;
+}
+
 .board-style {
   background-color: #0e3b45;
   color: #ffffff;

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -190,28 +190,23 @@ export default function AirHockeyLobby() {
                   key={id}
                   type="button"
                   onClick={() => setPlayType(id)}
-                  className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-400/20 to-transparent p-[1px]">
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-400/20 to-transparent">
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('airhockey', `type-${id}`)}
                         alt={label}
                         fallback={icon}
-                        className="h-7 w-7"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">{desc}</div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
@@ -236,36 +231,26 @@ export default function AirHockeyLobby() {
                     <button
                       type="button"
                       onClick={() => !disabled && setMode(id)}
-                      className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                        active
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                      } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                      className={`lobby-option-card ${
+                        active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                      } ${disabled ? 'lobby-option-card-disabled' : ''}`}
                       disabled={disabled}
                     >
-                      <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-emerald-400/30 via-sky-400/20 to-transparent p-[1px]">
-                        <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                      <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-400/20 to-transparent">
+                        <div className="lobby-option-thumb-inner">
                           <OptionIcon
                             src={getLobbyIcon('airhockey', `mode-${id}`)}
                             alt={label}
                             fallback={icon}
-                            className="h-7 w-7"
+                            className="lobby-option-icon"
                           />
                         </div>
                       </div>
-                      <div className="flex-1">
-                        <div className="flex items-center justify-between">
-                          <span className="text-base font-semibold">{label}</span>
-                          {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                        </div>
-                        <div className="text-xs text-white/60">{desc}</div>
+                      <div className="text-center">
+                        <p className="lobby-option-label">{label}</p>
+                        <p className="lobby-option-subtitle">{disabled ? 'Under development' : desc}</p>
                       </div>
                     </button>
-                    {disabled && (
-                      <span className="absolute inset-0 flex items-center justify-center rounded-2xl text-xs text-white/70">
-                        Under development
-                      </span>
-                    )}
                   </div>
                 );
               })}
@@ -286,20 +271,22 @@ export default function AirHockeyLobby() {
                   key={g}
                   type="button"
                   onClick={() => setGoal(g)}
-                  className={`rounded-2xl border px-4 py-3 text-center font-semibold shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className="flex items-center justify-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('airhockey', `target-${g}`)}
-                      alt={`First to ${g}`}
-                      fallback="🏁"
-                      className="h-5 w-5"
-                    />
-                    First to {g}
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('airhockey', `target-${g}`)}
+                        alt={`First to ${g}`}
+                        fallback="🏁"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">First to {g}</p>
                   </div>
                 </button>
               );
@@ -328,13 +315,18 @@ export default function AirHockeyLobby() {
                     key={p}
                     type="button"
                     onClick={() => setPlayers(p)}
-                    className={`rounded-2xl border px-4 py-3 text-center font-semibold shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                     }`}
                   >
-                    {p} Players
+                    <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl font-semibold">{p}</span>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{p} Players</p>
+                    </div>
                   </button>
                 );
               })}

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -332,28 +332,23 @@ export default function ChessBattleRoyalLobby() {
                   key={key}
                   type="button"
                   onClick={() => setMode(key)}
-                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('chessbattleroyal', `mode-${key}`)}
                         alt={label}
                         fallback={icon}
-                        className="h-8 w-8"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-base font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">{desc}</div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -219,28 +219,23 @@ export default function DominoRoyalLobby() {
                 key={value}
                 type="button"
                 onClick={() => setPlayerCount(value)}
-                className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                  playerCount === value
-                    ? 'border-primary bg-primary/10 text-primary'
-                    : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                className={`lobby-option-card ${
+                  playerCount === value ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                 }`}
               >
-                <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
+                  <div className="lobby-option-thumb-inner">
                     <OptionIcon
                       src={getLobbyIcon('domino-royal', `players-${value}`)}
                       alt={`${value} players`}
                       fallback={`${value}`}
-                      className="h-7 w-7"
+                      className="lobby-option-icon"
                     />
                   </div>
                 </div>
-                <div>
-                  <div className="flex items-center justify-between">
-                    <span className="font-semibold">{value} Players</span>
-                    {playerCount === value && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                  </div>
-                  <div className="text-xs text-white/60">Local table seats</div>
+                <div className="text-center">
+                  <p className="lobby-option-label">{value} Players</p>
+                  <p className="lobby-option-subtitle">Local table seats</p>
                 </div>
               </button>
             ))}
@@ -274,39 +269,29 @@ export default function DominoRoyalLobby() {
               const active = mode === id;
               return (
                 <div key={id} className="relative">
-                <button
-                  type="button"
-                  onClick={() => !disabled && setMode(id)}
-                  className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                  } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
-                  disabled={disabled}
-                >
-                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                      <OptionIcon
-                        src={getLobbyIcon('domino-royal', `mode-${id}`)}
-                        alt={label}
-                        fallback={icon}
-                        className="h-8 w-8"
-                      />
-                    </div>
-                  </div>
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between">
-                        <span className="text-base font-semibold">{label}</span>
-                        {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                  <button
+                    type="button"
+                    onClick={() => !disabled && setMode(id)}
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                    disabled={disabled}
+                  >
+                    <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                      <div className="lobby-option-thumb-inner">
+                        <OptionIcon
+                          src={getLobbyIcon('domino-royal', `mode-${id}`)}
+                          alt={label}
+                          fallback={icon}
+                          className="lobby-option-icon"
+                        />
                       </div>
-                      <div className="text-xs text-white/60">{desc}</div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{label}</p>
+                      <p className="lobby-option-subtitle">{disabled ? 'Under development' : desc}</p>
                     </div>
                   </button>
-                  {disabled && (
-                    <span className="absolute inset-0 flex items-center justify-center text-xs text-white/80">
-                      Under development
-                    </span>
-                  )}
                 </div>
               );
             })}

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -185,7 +185,7 @@ export default function GoalRushLobby() {
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Play</span>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-3 gap-3">
               {[
                 { id: 'regular', label: 'Regular' },
                 { id: 'training', label: 'Training' },
@@ -194,17 +194,23 @@ export default function GoalRushLobby() {
                 <button
                   key={id}
                   onClick={() => setPlayType(id)}
-                  className={`lobby-tile ${playType === id ? 'lobby-selected' : ''}`}
+                  className={`lobby-option-card ${
+                    playType === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
                 >
-                  <span className="flex items-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('goalrush', `type-${id}`)}
-                      alt={label}
-                      fallback={id === 'regular' ? '🎯' : id === 'training' ? '🛠️' : '🏆'}
-                      className="h-5 w-5"
-                    />
-                    {label}
-                  </span>
+                  <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-emerald-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('goalrush', `type-${id}`)}
+                        alt={label}
+                        fallback={id === 'regular' ? '🎯' : id === 'training' ? '🛠️' : '🏆'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                  </div>
                 </button>
               ))}
             </div>
@@ -213,44 +219,44 @@ export default function GoalRushLobby() {
 
         {playType !== 'training' && (
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Mode</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-              <div className="flex flex-wrap gap-2">
-                {[
-                  { id: 'ai', label: 'Vs AI' },
-                  { id: 'online', label: '1v1 Online', disabled: true }
-                ].map(({ id, label, disabled }) => (
-                  <div key={id} className="relative">
-                    <button
-                      onClick={() => !disabled && setMode(id)}
-                      className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                        disabled ? 'opacity-50 cursor-not-allowed' : ''
-                      }`}
-                      disabled={disabled}
-                    >
-                      <span className="flex items-center gap-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { id: 'ai', label: 'Vs AI' },
+                { id: 'online', label: '1v1 Online', disabled: true }
+              ].map(({ id, label, disabled }) => (
+                <div key={id} className="relative">
+                  <button
+                    onClick={() => !disabled && setMode(id)}
+                    className={`lobby-option-card ${
+                      mode === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                    disabled={disabled}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
                         <OptionIcon
                           src={getLobbyIcon('goalrush', `mode-${id}`)}
                           alt={label}
                           fallback={id === 'ai' ? '🤖' : '🌐'}
-                          className="h-5 w-5"
+                          className="lobby-option-icon"
                         />
-                        {label}
-                      </span>
-                    </button>
-                    {disabled && (
-                      <span className="absolute inset-0 flex items-center justify-center text-xs bg-black/60 text-background">
-                        Under development
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{label}</p>
+                      {disabled && <p className="lobby-option-subtitle">Under development</p>}
+                    </div>
+                  </button>
+                </div>
+              ))}
             </div>
           </div>
+        </div>
         )}
 
         <div className="space-y-3">
@@ -259,22 +265,28 @@ export default function GoalRushLobby() {
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Target</span>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-3 gap-3">
               {[3, 5, 10].map((g) => (
                 <button
                   key={g}
                   onClick={() => setGoal(g)}
-                  className={`lobby-tile ${goal === g ? 'lobby-selected' : ''}`}
+                  className={`lobby-option-card ${
+                    goal === g ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
                 >
-                  <span className="flex items-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('goalrush', `target-${g}`)}
-                      alt={`${g} goals`}
-                      fallback="🥅"
-                      className="h-5 w-5"
-                    />
-                    {g}
-                  </span>
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('goalrush', `target-${g}`)}
+                        alt={`${g} goals`}
+                        fallback="🥅"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{g} Goals</p>
+                  </div>
                 </button>
               ))}
             </div>
@@ -283,24 +295,33 @@ export default function GoalRushLobby() {
 
         {playType === 'tournament' && (
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Players</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bracket</span>
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Players</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bracket</span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-2">
+            <div className="grid grid-cols-3 gap-3">
+              {[8, 16, 24].map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPlayers(p)}
+                  className={`lobby-option-card ${
+                    players === p ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <span className="text-2xl font-semibold">{p}</span>
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{p} Players</p>
+                  </div>
+                </button>
+              ))}
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-2">
-              <div className="flex flex-wrap gap-2">
-                {[8, 16, 24].map((p) => (
-                  <button
-                    key={p}
-                    onClick={() => setPlayers(p)}
-                    className={`lobby-tile ${players === p ? 'lobby-selected' : ''}`}
-                  >
-                    {p}
-                  </button>
-                ))}
-              </div>
-              <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
-            </div>
+            <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
+          </div>
           </div>
         )}
 

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -510,26 +510,28 @@ export default function Lobby() {
                 <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Solo</span>
               </div>
               <p className="text-xs text-white/60">Choose how many AI rivals join your board.</p>
-              <div className="mt-3 flex gap-2">
+              <div className="mt-3 grid grid-cols-3 gap-3">
                 {[1, 2, 3].map((n) => (
                   <button
                     key={n}
                     onClick={() => setAiCount(n)}
-                    className={`flex-1 rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
-                      aiCount === n
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    className={`lobby-option-card ${
+                      aiCount === n ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                     }`}
                   >
-                    <span className="flex items-center justify-center gap-2">
-                      <OptionIcon
-                        src={getLobbyIcon('snake', `ai-${n}`)}
-                        alt={`${n} AI`}
-                        fallback="🤖"
-                        className="h-5 w-5"
-                      />
-                      {n} AI
-                    </span>
+                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <OptionIcon
+                          src={getLobbyIcon('snake', `ai-${n}`)}
+                          alt={`${n} AI`}
+                          fallback="🤖"
+                          className="lobby-option-icon"
+                        />
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{n} AI</p>
+                    </div>
                   </button>
                 ))}
               </div>

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -304,22 +304,28 @@ export default function LudoBattleRoyalLobby() {
             <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-3">
               <div>
                 <h4 className="font-semibold text-white text-sm">How many AI opponents?</h4>
-                <div className="mt-2 flex gap-2">
+                <div className="mt-2 grid grid-cols-3 gap-3">
                   {[1, 2, 3].map((n) => (
                     <button
                       key={n}
                       onClick={() => setAiCount(n)}
-                      className={`lobby-tile ${aiCount === n ? 'lobby-selected' : ''}`}
+                      className={`lobby-option-card ${
+                        aiCount === n ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                      }`}
                     >
-                      <span className="flex items-center gap-2">
-                        <OptionIcon
-                          src={getLobbyIcon('ludobattleroyal', `ai-${n}`)}
-                          alt={`${n} AI`}
-                          fallback="🤖"
-                          className="h-5 w-5"
-                        />
-                        {n}
-                      </span>
+                      <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
+                        <div className="lobby-option-thumb-inner">
+                          <OptionIcon
+                            src={getLobbyIcon('ludobattleroyal', `ai-${n}`)}
+                            alt={`${n} AI`}
+                            fallback="🤖"
+                            className="lobby-option-icon"
+                          />
+                        </div>
+                      </div>
+                      <div className="text-center">
+                        <p className="lobby-option-label">{n} AI</p>
+                      </div>
                     </button>
                   ))}
                 </div>

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -191,36 +191,26 @@ export default function MurlanRoyaleLobby() {
                   <button
                     type="button"
                     onClick={() => !disabled && setMode(id)}
-                    className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                    } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    } ${disabled ? 'lobby-option-card-disabled' : ''}`}
                     disabled={disabled}
                   >
-                    <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                    <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                      <div className="lobby-option-thumb-inner">
                         <OptionIcon
                           src={getLobbyIcon('murlanroyale', `mode-${id}`)}
                           alt={label}
                           fallback={icon}
-                          className="h-8 w-8"
+                          className="lobby-option-icon"
                         />
                       </div>
                     </div>
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between">
-                        <span className="text-base font-semibold">{label}</span>
-                        {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                      </div>
-                      <div className="text-xs text-white/60">{desc}</div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{label}</p>
+                      <p className="lobby-option-subtitle">{disabled ? 'Under development' : desc}</p>
                     </div>
                   </button>
-                  {disabled && (
-                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[11px] uppercase tracking-[0.2em] text-white/60">
-                      Under development
-                    </span>
-                  )}
                 </div>
               );
             })}
@@ -291,28 +281,23 @@ export default function MurlanRoyaleLobby() {
                   key={id}
                   type="button"
                   onClick={() => setGameType(id)}
-                  className={`flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('murlanroyale', `type-${id}`)}
                         alt={label}
                         fallback={icon}
-                        className="h-7 w-7"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">{desc}</div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
@@ -324,20 +309,22 @@ export default function MurlanRoyaleLobby() {
                 <button
                   key={pts}
                   onClick={() => setTargetPoints(pts)}
-                  className={`rounded-2xl border px-4 py-3 text-left text-sm font-semibold shadow transition ${
-                    targetPoints === pts
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    targetPoints === pts ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className="flex items-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('murlanroyale', `points-${pts}`)}
-                      alt={`${pts} points`}
-                      fallback="🏁"
-                      className="h-5 w-5"
-                    />
-                    {pts} pts
+                  <div className="lobby-option-thumb bg-gradient-to-br from-pink-400/30 via-fuchsia-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('murlanroyale', `points-${pts}`)}
+                        alt={`${pts} points`}
+                        fallback="🏁"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{pts} pts</p>
                   </div>
                 </button>
               ))}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -415,27 +415,23 @@ export default function PoolRoyaleLobby() {
                   key={id}
                   type="button"
                   onClick={() => setPlayType(id)}
-                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className={`h-16 w-16 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('poolroyale', iconKey)}
                         alt={label}
                         fallback={id === 'regular' ? '🎯' : '🏆'}
-                        className="h-12 w-12"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <p className={`font-semibold ${label === 'Tournament' ? 'text-sm' : 'text-base'}`}>
-                      {label}
-                    </p>
-                    <p className="text-xs text-white/50">{desc}</p>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
@@ -466,25 +462,23 @@ export default function PoolRoyaleLobby() {
                   type="button"
                   onClick={() => !disabled && setMode(id)}
                   disabled={disabled}
-                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                  } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
                 >
-                  <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent p-[1px]">
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('poolroyale', iconKey)}
                         alt={label}
                         fallback={id === 'ai' ? '🤖' : '🌐'}
-                        className="h-12 w-12"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <p className="text-base font-semibold">{label}</p>
-                    <p className="text-xs text-white/50">
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">
                       {disabled ? 'Tournament bracket only' : desc}
                     </p>
                   </div>
@@ -511,24 +505,22 @@ export default function PoolRoyaleLobby() {
                   key={id}
                   type="button"
                   onClick={() => setVariant(id)}
-                  className={`group flex flex-col items-start gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className="h-24 w-24 rounded-2xl bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent p-[1px]">
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getVariantThumbnail('poolroyale', id)}
                         alt={label}
                         fallback="🎱"
-                        className="h-16 w-16"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <p className="text-base font-semibold">{label}</p>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
                   </div>
                 </button>
               );
@@ -552,34 +544,32 @@ export default function PoolRoyaleLobby() {
               ].map(({ id, label }) => {
                 const active = ukBallSet === id;
                 return (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => setUkBallSet(id)}
-                    className={`group flex flex-col items-start gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                    }`}
-                  >
-                    <div className="h-24 w-24 rounded-2xl bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent p-[1px]">
-                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220]">
-                        <OptionIcon
-                          src={getLobbyIcon('poolroyale', `ball-${id}`)}
-                          alt={label}
-                          fallback={id === 'uk' ? '🟡' : '🔵'}
-                          className="h-16 w-16"
-                        />
-                      </div>
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setUkBallSet(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', `ball-${id}`)}
+                        alt={label}
+                        fallback={id === 'uk' ? '🟡' : '🔵'}
+                        className="lobby-option-icon"
+                      />
                     </div>
-                    <div>
-                      <p className="text-base font-semibold">{label}</p>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                  </div>
+                </button>
+              );
+            })}
           </div>
+        </div>
         )}
 
         {playType === 'tournament' && (

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -409,28 +409,23 @@ export default function SnookerRoyalLobby() {
                   key={id}
                   type="button"
                   onClick={() => setPlayType(id)}
-                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('snookerroyale', `type-${id}`)}
                         alt={label}
                         fallback={icon}
-                        className="h-8 w-8"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-base font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">{desc}</div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
@@ -472,30 +467,25 @@ export default function SnookerRoyalLobby() {
                   type="button"
                   onClick={() => !disabled && setMode(id)}
                   disabled={disabled}
-                  className={`group flex items-center gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                  } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
                 >
-                  <div className={`h-14 w-14 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon('snookerroyale', `mode-${id}`)}
                         alt={label}
                         fallback={icon}
-                        className="h-8 w-8"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-base font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">
                       {disabled ? 'Tournament bracket only' : desc}
-                    </div>
+                    </p>
                   </div>
                 </button>
               );
@@ -523,14 +513,12 @@ export default function SnookerRoyalLobby() {
                   key={id}
                   type="button"
                   onClick={() => setVariant(id)}
-                  className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                    active
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                   }`}
                 >
-                  <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent p-[1px]">
-                    <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
                       <OptionIcon
                         src={getLobbyIcon(
                           'snookerroyale',
@@ -538,16 +526,13 @@ export default function SnookerRoyalLobby() {
                         )}
                         alt={label}
                         fallback={icon}
-                        className="h-7 w-7"
+                        className="lobby-option-icon"
                       />
                     </div>
                   </div>
-                  <div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">{label}</span>
-                      {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
-                    </div>
-                    <div className="text-xs text-white/60">{desc}</div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
@@ -576,13 +561,18 @@ export default function SnookerRoyalLobby() {
                     key={p}
                     type="button"
                     onClick={() => setPlayers(p)}
-                    className={`rounded-2xl border px-4 py-3 text-left text-sm font-semibold shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
                     }`}
                   >
-                    {p} players
+                    <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl font-semibold">{p}</span>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{p} Players</p>
+                    </div>
                   </button>
                 );
               })}

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -202,16 +202,22 @@ export default function TexasHoldemLobby() {
                   key={count}
                   type="button"
                   onClick={() => setOpponents(count)}
-                  className={`lobby-tile ${isSelected ? 'lobby-selected' : ''}`}
+                  className={`lobby-option-card ${
+                    isSelected ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
                 >
-                  <div className="flex flex-col items-center gap-1">
-                    <OptionIcon
-                      src={getLobbyIcon('texasholdem', `opponents-${count}`)}
-                      alt={`${count} opponents`}
-                      fallback="🂡"
-                      className="h-6 w-6"
-                    />
-                    <span>VS {count}</span>
+                  <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('texasholdem', `opponents-${count}`)}
+                        alt={`${count} opponents`}
+                        fallback="🂡"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">VS {count}</p>
                   </div>
                 </button>
               );
@@ -236,7 +242,7 @@ export default function TexasHoldemLobby() {
               <p className="text-xs text-white/60">Local AI is ready, online tables are coming soon.</p>
             </div>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
+          <div className="mt-4 grid grid-cols-2 gap-3">
             {[
               { id: 'local', label: 'Local (AI)' },
               { id: 'online', label: 'Online', disabled: true }
@@ -244,26 +250,26 @@ export default function TexasHoldemLobby() {
               <div key={id} className="relative">
                 <button
                   onClick={() => !disabled && setMode(id)}
-                  className={`lobby-tile ${mode === id ? 'lobby-selected' : ''} ${
-                    disabled ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
+                  className={`lobby-option-card ${
+                    mode === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
                   disabled={disabled}
                 >
-                  <div className="flex items-center gap-2">
-                    <OptionIcon
-                      src={getLobbyIcon('texasholdem', `mode-${id}`)}
-                      alt={label}
-                      fallback={id === 'local' ? '🤖' : '🌐'}
-                      className="h-5 w-5"
-                    />
-                    <span>{label}</span>
+                  <div className="lobby-option-thumb bg-gradient-to-br from-yellow-400/30 via-orange-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('texasholdem', `mode-${id}`)}
+                        alt={label}
+                        fallback={id === 'local' ? '🤖' : '🌐'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    {disabled && <p className="lobby-option-subtitle">Under development</p>}
                   </div>
                 </button>
-                {disabled && (
-                  <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-                    Under development
-                  </span>
-                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Standardize the visual layout for match type, play mode, and variant thumbnails so images stay inside their frames and all thumbnails share the same size and spacing. 
- Match other lobby pages to the successful Pool Royale vertical thumbnail+label card style for consistent UX across portrait/mobile screens. 

### Description
- Add a reusable set of CSS utilities (`.lobby-option-card`, `.lobby-option-thumb`, `.lobby-option-icon`, `.lobby-option-label`, etc.) in `webapp/src/index.css` to enforce consistent sizing, framing and spacing for lobby option cards. 
- Replace a number of inline option layouts with the new vertical card structure and in-frame larger thumbnails in Pool Royale (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) so match type, play mode, variants, and ball color selectors render uniformly. 
- Apply the same card layout and thumbnail sizing to other lobby pages to align style and behavior, including Goal Rush, Air Hockey, Snooker, Domino Royal, Texas Hold'em, Murlan Royale, Ludo Battle Royal, Chess Battle Royal, and the generic Lobby (`webapp/src/pages/Games/*Lobby.jsx`). 
- Adjust `OptionIcon` usages to use the new thumbnail sizing class and ensure images use `object-contain`/overflow rules so thumbnails stay within frames. 

### Testing
- Started the local dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the Vite server booted successfully. 
- Rendered the Pool Royale lobby in a headless browser with a Playwright script (mobile viewport 390x844) and captured a screenshot to validate the new thumbnail framing and card layout; the screenshot was produced successfully. 
- Fixed a PostCSS/Tailwind `@apply` usage (removed `group` from the `@apply`) during validation so the CSS now compiles without the earlier build error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974984ef94483299eefe4a92b20d31b)