### PR TITLE
Update game thumbnails to use new logo assets

### DIFF
--- a/webapp/src/components/HomeGamesCard.jsx
+++ b/webapp/src/components/HomeGamesCard.jsx
@@ -5,7 +5,7 @@ export default function HomeGamesCard() {
   return (
     <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
       <img
-        src={getGameThumbnail('snake') || '/assets/icons/snakes_and_ladders.webp'}
+        src={getGameThumbnail('snake') || '/assets/icons/Snake%20and%20ladder%20game%20logo.png'}
         className="background-behind-board object-cover"
         alt=""
         onError={(e) => {
@@ -19,11 +19,14 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src={getGameThumbnail('texasholdem') || '/assets/icons/texas-holdem.svg'}
+            src={
+              getGameThumbnail('texasholdem') ||
+              '/assets/icons/Texas%20holdem%20poker%20game%20logo.png'
+            }
             alt=""
             className="h-20 w-20"
             onError={(event) => {
-              event.currentTarget.src = '/assets/icons/texas-holdem.svg';
+              event.currentTarget.src = '/assets/icons/Texas%20holdem%20poker%20game%20logo.png';
             }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
@@ -35,11 +38,14 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src={getGameThumbnail('domino-royal') || '/assets/icons/domino-royal.svg'}
+            src={
+              getGameThumbnail('domino-royal') ||
+              '/assets/icons/Domino%20battle%20Royal%20logo.png'
+            }
             alt=""
             className="h-20 w-20"
             onError={(event) => {
-              event.currentTarget.src = '/assets/icons/domino-royal.svg';
+              event.currentTarget.src = '/assets/icons/Domino%20battle%20Royal%20logo.png';
             }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
@@ -51,11 +57,11 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src={getGameThumbnail('poolroyale') || '/assets/icons/pool-royale.svg'}
+            src={getGameThumbnail('poolroyale') || '/assets/icons/Pool%20Royal%20game%20logo.png'}
             alt=""
             className="h-20 w-20"
             onError={(event) => {
-              event.currentTarget.src = '/assets/icons/pool-royale.svg';
+              event.currentTarget.src = '/assets/icons/Pool%20Royal%20game%20logo.png';
             }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
@@ -87,11 +93,11 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src={getGameThumbnail('goalrush') || '/assets/icons/goal_rush_card_1200x675.webp'}
+            src={getGameThumbnail('goalrush') || '/assets/icons/Goal%20rush%20logo.png'}
             alt=""
             className="h-20 w-20"
             onError={(event) => {
-              event.currentTarget.src = '/assets/icons/goal_rush_card_1200x675.webp';
+              event.currentTarget.src = '/assets/icons/Goal%20rush%20logo.png';
             }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">
@@ -103,11 +109,11 @@ export default function HomeGamesCard() {
           className="flex flex-col items-center space-y-1 border border-border rounded-lg p-2 flex-shrink-0 tetris-grid-bg"
         >
           <img
-            src={getGameThumbnail('snake') || '/assets/icons/snakes_and_ladders.webp'}
+            src={getGameThumbnail('snake') || '/assets/icons/Snake%20and%20ladder%20game%20logo.png'}
             alt=""
             className="h-20 w-20"
             onError={(event) => {
-              event.currentTarget.src = '/assets/icons/snakes_and_ladders.webp';
+              event.currentTarget.src = '/assets/icons/Snake%20and%20ladder%20game%20logo.png';
             }}
           />
           <h3 className="text-sm font-semibold text-center text-yellow-400">

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -11,16 +11,16 @@ const withBase = (path) => {
 };
 
 export const gameThumbnails = {
-  texasholdem: 'games/texas-holdem.webp',
-  'domino-royal': 'games/domino-royal.webp',
+  texasholdem: '/assets/icons/Texas%20holdem%20poker%20game%20logo.png',
+  'domino-royal': '/assets/icons/Domino%20battle%20Royal%20logo.png',
   poolroyale: '/assets/icons/Pool%20Royal%20game%20logo.png',
   snookerroyale: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
-  goalrush: 'games/goal-rush.webp',
-  airhockey: 'games/air-hockey.webp',
-  snake: 'games/snake-ladder.webp',
-  murlanroyale: 'games/murlan-royale.webp',
-  chessbattleroyal: 'games/chess-battle-royal.webp',
-  ludobattleroyal: 'games/ludo-battle-royal.webp'
+  goalrush: '/assets/icons/Goal%20rush%20logo.png',
+  airhockey: '/assets/icons/Air%20hockey%20game%20logo.png',
+  snake: '/assets/icons/Snake%20and%20ladder%20game%20logo.png',
+  murlanroyale: '/assets/icons/Murlan%20Royal%20logo.png',
+  chessbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+  ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png'
 };
 
 export const lobbyOptionIcons = {

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -3,14 +3,14 @@ const gamesCatalog = [
     name: "Texas Hold'em",
     route: '/games/texasholdem/lobby',
     slug: 'texasholdem',
-    image: '/assets/icons/texas-holdem.svg',
+    image: '/assets/icons/Texas%20holdem%20poker%20game%20logo.png',
     description: 'High-stakes poker tables with quick matchmaking.'
   },
   {
     name: 'Domino Royal 3D',
     route: '/games/domino-royal/lobby',
     slug: 'domino-royal',
-    image: '/assets/icons/domino-royal.svg',
+    image: '/assets/icons/Domino%20battle%20Royal%20logo.png',
     description: 'Classic domino strategy with modern 3D flair.'
   },
   {
@@ -31,42 +31,42 @@ const gamesCatalog = [
     name: 'Goal Rush',
     route: '/games/goalrush/lobby',
     slug: 'goalrush',
-    image: '/assets/icons/goal_rush_card_1200x675.webp',
+    image: '/assets/icons/Goal%20rush%20logo.png',
     description: 'Score fast goals and climb the rankings.'
   },
   {
     name: 'Air Hockey',
     route: '/games/airhockey/lobby',
     slug: 'airhockey',
-    image: '/assets/icons/air-hockey.svg',
+    image: '/assets/icons/Air%20hockey%20game%20logo.png',
     description: 'Lightning puck duels with neon energy.'
   },
   {
     name: 'Snake & Ladder',
     route: '/games/snake/lobby',
     slug: 'snake',
-    image: '/assets/icons/snakes_and_ladders.webp',
+    image: '/assets/icons/Snake%20and%20ladder%20game%20logo.png',
     description: 'Race to the top with quick dice rolls.'
   },
   {
     name: 'Murlan Royale',
     route: '/games/murlanroyale/lobby',
     slug: 'murlanroyale',
-    image: '/assets/icons/murlan-royale.svg',
+    image: '/assets/icons/Murlan%20Royal%20logo.png',
     description: 'Card-based tactics with a competitive twist.'
   },
   {
     name: 'Chess Battle Royal',
     route: '/games/chessbattleroyal/lobby',
     slug: 'chessbattleroyal',
-    image: '/assets/icons/chess-royale.svg',
+    image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
     description: 'Strategic chess showdowns with royal flair.'
   },
   {
     name: 'Ludo Battle Royal',
     route: '/games/ludobattleroyal/lobby',
     slug: 'ludobattleroyal',
-    image: '/assets/icons/ludo-royale.svg',
+    image: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
     description: 'Classic ludo chaos in a battle royale lobby.'
   }
 ];


### PR DESCRIPTION
### Motivation
- Replace older generic thumbnails with the provided logo images from `webapp/public/assets/icons` so Games and Home pages show the intended branded thumbnails. 
- Ensure fallback images used across catalog and home card components are consistent with the new logos.

### Description
- Updated the `gameThumbnails` mapping in `webapp/src/config/gameAssets.js` to point thumbnail keys to the new `/assets/icons/...` logo files. 
- Aligned the `image` fallbacks in `webapp/src/config/gamesCatalog.js` to reference the same logo files so the Games page uses the new thumbnails. 
- Updated `webapp/src/components/HomeGamesCard.jsx` to use the new logo file paths as fallbacks and updated `onError` handlers to keep behavior consistent. 
- No binary assets were added to the PR; only references to existing icon files in `webapp/public/assets/icons` were changed.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server started successfully. 
- Automated visual verification was done using a Playwright script that loaded `http://127.0.0.1:4173/` and `http://127.0.0.1:4173/games` and produced screenshots at `artifacts/home-games.png` and `artifacts/games-page.png`, which completed successfully. 
- No unit tests were changed or required for this visual asset update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a721e0a4832980ae02b33f4436a3)