### PR TITLE
Align lobby layouts to Pool Royale: 3-up option grid, thumbnails, and default icons

### DIFF
--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -1,45 +1,47 @@
-import React from 'react';
 import OptionIcon from './OptionIcon.jsx';
 
 export default function TableSelector({ tables, selected, onSelect }) {
   return (
-    <div className="space-y-2">
-      {tables.map((t, idx) => (
-        <React.Fragment key={t.id}>
-          {idx === 1 && tables[0]?.id === 'single' && <div className="h-4" />}
-          <div className="relative">
-          <button
-            onClick={() => !t.disabled && onSelect(t)}
-            disabled={t.disabled}
-            className={`lobby-tile w-full flex justify-between ${
-              selected?.id === t.id ? 'lobby-selected' : ''
-            } ${t.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-          >
-            <span className="flex items-center gap-2">
-              {(t.icon || t.iconFallback) && (
-                <OptionIcon
-                  src={t.icon}
-                  alt={t.iconAlt || t.label || 'Table'}
-                  fallback={t.iconFallback || '🎲'}
-                  className="h-5 w-5"
-                />
-              )}
-              {t.label || `Table ${t.capacity}p`}
-            </span>
-            {t.capacity && (
-              <span>
-                {t.players}/{t.capacity}
+    <div className="grid grid-cols-3 gap-3">
+      {tables.map((t) => {
+        const isSelected = selected?.id === t.id;
+        const subtitle = t.capacity
+          ? t.players
+            ? `${t.players}/${t.capacity} players`
+            : `${t.capacity} seats`
+          : null;
+        return (
+          <div key={t.id} className="relative">
+            <button
+              onClick={() => !t.disabled && onSelect(t)}
+              disabled={t.disabled}
+              className={`lobby-option-card ${
+                isSelected ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+              } ${t.disabled ? 'lobby-option-card-disabled' : ''}`}
+            >
+              <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
+                <div className="lobby-option-thumb-inner">
+                  <OptionIcon
+                    src={t.icon}
+                    alt={t.iconAlt || t.label || 'Table'}
+                    fallback={t.iconFallback || '🎲'}
+                    className="lobby-option-icon"
+                  />
+                </div>
+              </div>
+              <div className="text-center">
+                <p className="lobby-option-label">{t.label || `Table ${t.capacity || ''}`}</p>
+                {subtitle && <p className="lobby-option-subtitle">{subtitle}</p>}
+              </div>
+            </button>
+            {t.disabled && (
+              <span className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/60 text-xs text-background">
+                Under development
               </span>
             )}
-          </button>
-          {t.disabled && (
-            <span className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-50 text-background">
-              Under development
-            </span>
-          )}
           </div>
-        </React.Fragment>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -23,23 +23,29 @@ export const gameThumbnails = {
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png'
 };
 
+const buildLobbyIconSet = (keys, icon) =>
+  keys.reduce((acc, key) => {
+    acc[key] = icon;
+    return acc;
+  }, {});
+
 export const lobbyOptionIcons = {
-  texasholdem: {
-    'mode-local': 'lobby/texas-holdem/mode-local.webp',
-    'mode-online': 'lobby/texas-holdem/mode-online.webp',
-    'opponents-1': 'lobby/texas-holdem/opponents-1.webp',
-    'opponents-2': 'lobby/texas-holdem/opponents-2.webp',
-    'opponents-3': 'lobby/texas-holdem/opponents-3.webp',
-    'opponents-4': 'lobby/texas-holdem/opponents-4.webp',
-    'opponents-5': 'lobby/texas-holdem/opponents-5.webp'
-  },
-  'domino-royal': {
-    'players-2': 'lobby/domino-royal/players-2.webp',
-    'players-3': 'lobby/domino-royal/players-3.webp',
-    'players-4': 'lobby/domino-royal/players-4.webp',
-    'mode-local': 'lobby/domino-royal/mode-local.webp',
-    'mode-online': 'lobby/domino-royal/mode-online.webp'
-  },
+  texasholdem: buildLobbyIconSet(
+    [
+      'mode-local',
+      'mode-online',
+      'opponents-1',
+      'opponents-2',
+      'opponents-3',
+      'opponents-4',
+      'opponents-5'
+    ],
+    '/assets/icons/texas-holdem.svg'
+  ),
+  'domino-royal': buildLobbyIconSet(
+    ['players-2', 'players-3', 'players-4', 'mode-local', 'mode-online'],
+    '/assets/icons/domino-royal.svg'
+  ),
   poolroyale: {
     'type-regular': 'lobby/pool-royale/type-regular.webp',
     'type-tournament': 'lobby/pool-royale/type-tournament.webp',
@@ -51,74 +57,89 @@ export const lobbyOptionIcons = {
     'ball-uk': '/assets/icons/8ballrack.png',
     'ball-american': '/assets/icons/American%20Billiards%20.png'
   },
-  snookerroyale: {
-    'type-regular': 'lobby/snooker-royale/type-regular.webp',
-    'type-tournament': 'lobby/snooker-royale/type-tournament.webp',
-    'mode-ai': 'lobby/snooker-royale/mode-ai.webp',
-    'mode-online': 'lobby/snooker-royale/mode-online.webp',
-    'table-championship': 'lobby/snooker-royale/table-championship.webp',
-    'table-club': 'lobby/snooker-royale/table-club.webp',
-    'table-practice': 'lobby/snooker-royale/table-practice.webp'
-  },
-  goalrush: {
-    'type-regular': 'lobby/goal-rush/type-regular.webp',
-    'type-training': 'lobby/goal-rush/type-training.webp',
-    'type-tournament': 'lobby/goal-rush/type-tournament.webp',
-    'mode-ai': 'lobby/goal-rush/mode-ai.webp',
-    'mode-online': 'lobby/goal-rush/mode-online.webp',
-    'target-3': 'lobby/goal-rush/target-3.webp',
-    'target-5': 'lobby/goal-rush/target-5.webp',
-    'target-10': 'lobby/goal-rush/target-10.webp'
-  },
-  airhockey: {
-    'type-regular': 'lobby/air-hockey/type-regular.webp',
-    'type-training': 'lobby/air-hockey/type-training.webp',
-    'type-tournament': 'lobby/air-hockey/type-tournament.webp',
-    'mode-ai': 'lobby/air-hockey/mode-ai.webp',
-    'mode-online': 'lobby/air-hockey/mode-online.webp',
-    'target-11': 'lobby/air-hockey/target-11.webp',
-    'target-21': 'lobby/air-hockey/target-21.webp',
-    'target-31': 'lobby/air-hockey/target-31.webp'
-  },
-  snake: {
-    'board-quick': 'lobby/snake/board-quick.webp',
-    'board-mobile': 'lobby/snake/board-mobile.webp',
-    'board-3d': 'lobby/snake/board-3d.webp',
-    'table-single': 'lobby/snake/table-single.webp',
-    'table-2': 'lobby/snake/table-2.webp',
-    'table-3': 'lobby/snake/table-3.webp',
-    'table-4': 'lobby/snake/table-4.webp',
-    'ai-1': 'lobby/snake/ai-1.webp',
-    'ai-2': 'lobby/snake/ai-2.webp',
-    'ai-3': 'lobby/snake/ai-3.webp'
-  },
-  murlanroyale: {
-    'mode-local': 'lobby/murlan-royale/mode-local.webp',
-    'mode-online': 'lobby/murlan-royale/mode-online.webp',
-    'type-single': 'lobby/murlan-royale/type-single.webp',
-    'type-points': 'lobby/murlan-royale/type-points.webp',
-    'points-11': 'lobby/murlan-royale/points-11.webp',
-    'points-21': 'lobby/murlan-royale/points-21.webp',
-    'points-31': 'lobby/murlan-royale/points-31.webp'
-  },
-  chessbattleroyal: {
-    'mode-ai': 'lobby/chess-battle-royal/mode-ai.webp',
-    'mode-online': 'lobby/chess-battle-royal/mode-online.webp',
-    'queue-instant': 'lobby/chess-battle-royal/queue-instant.webp',
-    'queue-mobile': 'lobby/chess-battle-royal/queue-mobile.webp',
-    'queue-hdr': 'lobby/chess-battle-royal/queue-hdr.webp'
-  },
-  ludobattleroyal: {
-    'queue-instant': 'lobby/ludo-battle-royal/queue-instant.webp',
-    'queue-touch': 'lobby/ludo-battle-royal/queue-touch.webp',
-    'queue-hdr': 'lobby/ludo-battle-royal/queue-hdr.webp',
-    'table-1': 'lobby/ludo-battle-royal/table-1.webp',
-    'table-2': 'lobby/ludo-battle-royal/table-2.webp',
-    'table-4': 'lobby/ludo-battle-royal/table-4.webp',
-    'ai-1': 'lobby/ludo-battle-royal/ai-1.webp',
-    'ai-2': 'lobby/ludo-battle-royal/ai-2.webp',
-    'ai-3': 'lobby/ludo-battle-royal/ai-3.webp'
-  }
+  snookerroyale: buildLobbyIconSet(
+    [
+      'type-regular',
+      'type-tournament',
+      'mode-ai',
+      'mode-online',
+      'table-championship',
+      'table-club',
+      'table-practice'
+    ],
+    '/assets/icons/snooker-royale.svg'
+  ),
+  goalrush: buildLobbyIconSet(
+    [
+      'type-regular',
+      'type-training',
+      'type-tournament',
+      'mode-ai',
+      'mode-online',
+      'target-3',
+      'target-5',
+      'target-10'
+    ],
+    '/assets/icons/goal_rush_card_1200x675.webp'
+  ),
+  airhockey: buildLobbyIconSet(
+    [
+      'type-regular',
+      'type-training',
+      'type-tournament',
+      'mode-ai',
+      'mode-online',
+      'target-11',
+      'target-21',
+      'target-31'
+    ],
+    '/assets/icons/air-hockey.svg'
+  ),
+  snake: buildLobbyIconSet(
+    [
+      'board-quick',
+      'board-mobile',
+      'board-3d',
+      'table-single',
+      'table-2',
+      'table-3',
+      'table-4',
+      'ai-1',
+      'ai-2',
+      'ai-3'
+    ],
+    '/assets/icons/snake_vector_no_bg.webp'
+  ),
+  murlanroyale: buildLobbyIconSet(
+    [
+      'mode-local',
+      'mode-online',
+      'type-single',
+      'type-points',
+      'points-11',
+      'points-21',
+      'points-31'
+    ],
+    '/assets/icons/murlan-royale.svg'
+  ),
+  chessbattleroyal: buildLobbyIconSet(
+    ['mode-ai', 'mode-online', 'queue-instant', 'queue-mobile', 'queue-hdr'],
+    '/assets/icons/chess-royale.svg'
+  ),
+  ludobattleroyal: buildLobbyIconSet(
+    [
+      'queue-instant',
+      'queue-touch',
+      'queue-hdr',
+      'table-1',
+      'table-2',
+      'table-4',
+      'ai-1',
+      'ai-2',
+      'ai-3'
+    ],
+    '/assets/icons/ludo-royale.svg'
+  )
 };
 
 export const variantThumbnails = {

--- a/webapp/src/pages/Games/AirHockeyLobby.jsx
+++ b/webapp/src/pages/Games/AirHockeyLobby.jsx
@@ -124,7 +124,7 @@ export default function AirHockeyLobby() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Air Hockey</p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Air Hockey Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               Fast load
@@ -178,7 +178,7 @@ export default function AirHockeyLobby() {
             <h3 className="font-semibold text-white">Game Type</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Mode</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               { id: 'regular', label: 'Regular', desc: 'Classic rink', icon: '🏒' },
               { id: 'training', label: 'Training', desc: 'Practice hits', icon: '🎯' },
@@ -220,7 +220,7 @@ export default function AirHockeyLobby() {
               <h3 className="font-semibold text-white">Match Mode</h3>
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid grid-cols-3 gap-3">
                 {[
                   { id: 'ai', label: 'Vs AI', desc: 'Instant practice', icon: '🤖' },
                   { id: 'online', label: '1v1 Online', desc: 'Coming soon', icon: '⚔️', disabled: true }
@@ -263,7 +263,7 @@ export default function AirHockeyLobby() {
             <h3 className="font-semibold text-white">Goal Target</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Score</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-3">
             {[11, 21, 31].map((g) => {
               const active = goal === g;
               return (
@@ -307,7 +307,7 @@ export default function AirHockeyLobby() {
                 <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
               </div>
             </div>
-            <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="mt-3 grid grid-cols-3 gap-3">
               {[8, 16, 24].map((p) => {
                 const active = players === p;
                 return (

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -253,7 +253,7 @@ export default function ChessBattleRoyalLobby() {
               <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">
                 Chess Battle Royal
               </p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Chess Battle Royal Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               {onlineCount != null ? `${onlineCount} online` : 'Syncing…'}
@@ -309,7 +309,7 @@ export default function ChessBattleRoyalLobby() {
             <h3 className="font-semibold text-white">Choose Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 key: 'ai',
@@ -387,7 +387,7 @@ export default function ChessBattleRoyalLobby() {
               <h3 className="font-semibold text-white">Pick Your Pieces</h3>
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Sides</span>
             </div>
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="grid grid-cols-3 gap-3">
               {[
                 {
                   key: 'auto',

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -139,7 +139,7 @@ export default function DominoRoyalLobby() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Domino Battle Royal</p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Domino Battle Royal Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               Double-six set
@@ -213,7 +213,7 @@ export default function DominoRoyalLobby() {
             <h3 className="font-semibold text-white">Players</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Seats</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-3">
             {PLAYER_OPTIONS.map((value) => (
               <button
                 key={value}
@@ -247,7 +247,7 @@ export default function DominoRoyalLobby() {
             <h3 className="font-semibold text-white">Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'local',

--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -130,7 +130,7 @@ export default function GoalRushLobby() {
               <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
                 Goal Rush
               </p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Goal Rush Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               Pitch ready
@@ -224,7 +224,7 @@ export default function GoalRushLobby() {
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               {[
                 { id: 'ai', label: 'Vs AI' },
                 { id: 'online', label: '1v1 Online', disabled: true }

--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -397,7 +397,7 @@ export default function Lobby() {
                 <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
                   Snake &amp; Ladder
                 </p>
-                <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+                <h2 className="text-2xl font-bold text-white">Snake &amp; Ladder Lobby</h2>
               </div>
               <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
                 {online != null ? `${online} online` : 'Syncing…'}

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -192,7 +192,7 @@ export default function LudoBattleRoyalLobby() {
               <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
                 Ludo Battle Royal
               </p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Ludo Battle Royal Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               {online != null ? `${online} online` : 'Syncing…'}

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -111,7 +111,7 @@ export default function MurlanRoyaleLobby() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">Murlan Royale</p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Murlan Royale Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               AI ready
@@ -167,7 +167,7 @@ export default function MurlanRoyaleLobby() {
             <h3 className="font-semibold text-white">Choose Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'local',
@@ -258,7 +258,7 @@ export default function MurlanRoyaleLobby() {
             <h3 className="font-semibold text-white">Game Type</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Rules</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'single',
@@ -304,7 +304,7 @@ export default function MurlanRoyaleLobby() {
             })}
           </div>
           {gameType === 'points' && (
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="grid grid-cols-3 gap-3">
               {[11, 21, 31].map((pts) => (
                 <button
                   key={pts}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -392,7 +392,7 @@ export default function PoolRoyaleLobby() {
             <h3 className="font-semibold text-white">Choose Match Type</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'regular',
@@ -444,7 +444,7 @@ export default function PoolRoyaleLobby() {
             <h3 className="font-semibold text-white">Play Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Opponents</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               { id: 'ai', label: 'Vs AI', desc: 'Practice precision', iconKey: 'mode-ai' },
               {
@@ -537,7 +537,7 @@ export default function PoolRoyaleLobby() {
             <p className="text-xs text-white/60">
               Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8 Pool UK rules.
             </p>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               {[
                 { id: 'uk', label: 'Yellow & Red' },
                 { id: 'american', label: 'Solids & Stripes' }

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -332,7 +332,7 @@ export default function SnookerRoyalLobby() {
               <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">
                 Snooker Royal
               </p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Snooker Royal Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               {onlinePlayers.length} online
@@ -386,7 +386,7 @@ export default function SnookerRoyalLobby() {
             <h3 className="font-semibold text-white">Choose Match Type</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'regular',
@@ -441,7 +441,7 @@ export default function SnookerRoyalLobby() {
             <h3 className="font-semibold text-white">Choose Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid grid-cols-3 gap-3">
             {[
               {
                 id: 'ai',
@@ -501,7 +501,7 @@ export default function SnookerRoyalLobby() {
             <h3 className="font-semibold text-white">Table Setup</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Options</span>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               { id: 'uk', label: 'Championship 12 ft', desc: 'Official layout', icon: '🏟️' },
               { id: 'american', label: 'Club 10 ft', desc: 'Local tables', icon: '🎲' },
@@ -553,7 +553,7 @@ export default function SnookerRoyalLobby() {
                 <p className="text-xs text-white/60">Choose the bracket size before launching.</p>
               </div>
             </div>
-            <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="mt-3 grid grid-cols-3 gap-3">
               {[8, 16, 24].map((p) => {
                 const active = players === p;
                 return (

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -113,7 +113,7 @@ export default function TexasHoldemLobby() {
               <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
                 Texas Hold&apos;em
               </p>
-              <h2 className="text-2xl font-bold text-white">Modern Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">Texas Hold&apos;em Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               Poker table ready
@@ -242,7 +242,7 @@ export default function TexasHoldemLobby() {
               <p className="text-xs text-white/60">Local AI is ready, online tables are coming soon.</p>
             </div>
           </div>
-          <div className="mt-4 grid grid-cols-2 gap-3">
+          <div className="mt-4 grid grid-cols-3 gap-3">
             {[
               { id: 'local', label: 'Local (AI)' },
               { id: 'online', label: 'Online', disabled: true }


### PR DESCRIPTION
### Motivation
- Standardize all game lobby UIs to match the Pool Royale lobby visual pattern: 3-up option thumbnails per row and consistent card layout.
- Replace the generic header text `Modern Lobby` with a game-specific header so each lobby clearly shows the game name.
- Ensure every lobby option and table selector uses thumbnails (or fallbacks) so missing images don't produce inconsistent layouts.
- Provide default thumbnail/icon mappings for non-pool games so option cards render consistent artwork across lobbies.

### Description
- Updated multiple lobby pages to use three-column option grids and game-specific headers by changing grid classes and titles in `webapp/src/pages/Games/*Lobby.jsx` (AirHockey, GoalRush, PoolRoyale, SnookerRoyal, TexasHoldem, Snake & Ladder, ChessBattleRoyal, DominoRoyal, LudoBattleRoyal, MurlanRoyale, etc.).
- Reworked table selector into thumbnail card tiles by replacing the old list style with a 3-column `TableSelector` card grid in `webapp/src/components/TableSelector.jsx` and rendering table thumbnails via `OptionIcon`.
- Added `buildLobbyIconSet` and new default lobby icon mappings in `webapp/src/config/gameAssets.js` to point many lobby option keys to `/assets/icons/*` fallbacks for games that previously lacked pool-style thumbnails.
- Small repository cleanup to remove an untracked gradle wrapper artifact (`webapp/android/gradle/wrapper/gradle-wrapper.jar`) so it doesn't interfere with the tree.

### Testing
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app started successfully (Vite output shown). 
- Captured a Playwright screenshot of the Air Hockey lobby at `http://127.0.0.1:4173/games/airhockey/lobby` which loaded and produced the artifact `artifacts/air-hockey-lobby.png`, confirming the new 3-up layout and thumbnails render in the browser.
- No unit tests were modified or executed (UI/layout changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974bb1274908329a75af96291b97ce3)