### PR TITLE
Update Domino Royal lobby visuals and icons

### DIFF
--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -42,10 +42,13 @@ export const lobbyOptionIcons = {
     ],
     '/assets/icons/texas-holdem.svg'
   ),
-  'domino-royal': buildLobbyIconSet(
-    ['players-2', 'players-3', 'players-4', 'mode-local', 'mode-online'],
-    '/assets/icons/domino-royal.svg'
-  ),
+  'domino-royal': {
+    'players-2': '/assets/icons/profile.svg',
+    'players-3': '/assets/icons/profile.svg',
+    'players-4': '/assets/icons/profile.svg',
+    'mode-local': 'lobby/pool-royale/mode-ai.webp',
+    'mode-online': 'lobby/pool-royale/mode-online.webp'
+  },
   poolroyale: {
     'type-regular': 'lobby/pool-royale/type-regular.webp',
     'type-tournament': 'lobby/pool-royale/type-tournament.webp',

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -21,6 +21,7 @@ const CHESS_PLAYER_FLAG_KEY = 'chessBattleRoyalPlayerFlag';
 const CHESS_AI_FLAG_KEY = 'chessBattleRoyalAiFlag';
 
 const PLAYER_OPTIONS = [2, 3, 4];
+const HUMAN_ICON_FALLBACK = '🧑‍🤝‍🧑';
 
 export default function DominoRoyalLobby() {
   const navigate = useNavigate();
@@ -145,27 +146,7 @@ export default function DominoRoyalLobby() {
               Double-six set
             </div>
           </div>
-          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    🀄
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Arena Warmup</p>
-                  <p className="text-xs text-white/60">
-                    Set your domino table while the match scene loads in the background.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant lobby</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile first</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
-              </div>
-            </div>
+          <div className="mt-4">
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
               <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
               <div className="mt-3 flex items-center gap-3">
@@ -228,7 +209,7 @@ export default function DominoRoyalLobby() {
                     <OptionIcon
                       src={getLobbyIcon('domino-royal', `players-${value}`)}
                       alt={`${value} players`}
-                      fallback={`${value}`}
+                      fallback={HUMAN_ICON_FALLBACK}
                       className="lobby-option-icon"
                     />
                   </div>
@@ -305,7 +286,12 @@ export default function DominoRoyalLobby() {
           <div className="flex items-start gap-3">
             <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
               <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                🧑‍🤝‍🧑
+                <OptionIcon
+                  src={getLobbyIcon('domino-royal', 'players-2')}
+                  alt="AI avatars"
+                  fallback={HUMAN_ICON_FALLBACK}
+                  className="h-full w-full text-2xl"
+                />
               </div>
             </div>
             <div>


### PR DESCRIPTION
### Motivation

- Simplify the Domino Battle Royal lobby header by removing an unnecessary warmup frame to reduce visual clutter on mobile.
- Use a consistent human avatar for player thumbnails so local player/AI seats match other lobbies.
- Align Domino mode thumbnails with the Pool Royale lobby assets for visual consistency.

### Description

- Removed the extra "Arena Warmup" frame from the Domino lobby header and consolidated the header into a single player/profile block in `webapp/src/pages/Games/DominoRoyalLobby.jsx`.
- Replaced player-count thumbnails to use a shared human avatar fallback by adding `HUMAN_ICON_FALLBACK` and updating `OptionIcon` usage in `webapp/src/pages/Games/DominoRoyalLobby.jsx`.
- Updated lobby icon mappings in `webapp/src/config/gameAssets.js` to map `domino-royal` player entries to `/assets/icons/profile.svg` and to reuse Pool Royale mode thumbnails (`lobby/pool-royale/mode-ai.webp` and `lobby/pool-royale/mode-online.webp`) for `mode-local`/`mode-online`.
- Removed a transient untracked Gradle wrapper JAR that was created during a dev server run (`webapp/android/gradle/wrapper/gradle-wrapper.jar`).

### Testing

- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported `ready` indicating the site served successfully.
- Performed a UI smoke test by loading `/games/domino-royal/lobby` in an automated Playwright script and saved a mobile-portrait screenshot to `artifacts/domino-royal-lobby.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c5ba088483299673f411e1e28c8e)