### PR TITLE
Update Snooker Royal lobby layout and icons

### DIFF
--- a/webapp/public/assets/icons/snooker-regular.svg
+++ b/webapp/public/assets/icons/snooker-regular.svg
@@ -1,0 +1,20 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="24" fill="#0b1220" />
+  <g fill="#e11d48">
+    <circle cx="60" cy="24" r="7" />
+    <circle cx="52" cy="38" r="7" />
+    <circle cx="68" cy="38" r="7" />
+    <circle cx="44" cy="52" r="7" />
+    <circle cx="60" cy="52" r="7" />
+    <circle cx="76" cy="52" r="7" />
+    <circle cx="36" cy="66" r="7" />
+    <circle cx="52" cy="66" r="7" />
+    <circle cx="68" cy="66" r="7" />
+    <circle cx="84" cy="66" r="7" />
+    <circle cx="28" cy="80" r="7" />
+    <circle cx="44" cy="80" r="7" />
+    <circle cx="60" cy="80" r="7" />
+    <circle cx="76" cy="80" r="7" />
+    <circle cx="92" cy="80" r="7" />
+  </g>
+</svg>

--- a/webapp/public/assets/icons/snooker-tournament.svg
+++ b/webapp/public/assets/icons/snooker-tournament.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="24" fill="#0b1220" />
+  <text x="60" y="78" font-size="64" text-anchor="middle">🏆</text>
+</svg>

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -57,18 +57,15 @@ export const lobbyOptionIcons = {
     'ball-uk': '/assets/icons/8ballrack.png',
     'ball-american': '/assets/icons/American%20Billiards%20.png'
   },
-  snookerroyale: buildLobbyIconSet(
-    [
-      'type-regular',
-      'type-tournament',
-      'mode-ai',
-      'mode-online',
-      'table-championship',
-      'table-club',
-      'table-practice'
-    ],
-    '/assets/icons/snooker-royale.svg'
-  ),
+  snookerroyale: {
+    'type-regular': '/assets/icons/snooker-regular.svg',
+    'type-tournament': '/assets/icons/snooker-tournament.svg',
+    'mode-ai': '/assets/icons/snooker-royale.svg',
+    'mode-online': '/assets/icons/snooker-royale.svg',
+    'table-championship': '/assets/icons/snooker-royale.svg',
+    'table-club': '/assets/icons/snooker-royale.svg',
+    'table-practice': '/assets/icons/snooker-royale.svg'
+  },
   goalrush: buildLobbyIconSet(
     [
       'type-regular',

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -35,7 +35,6 @@ export default function SnookerRoyalLobby() {
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
-  const [variant, setVariant] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -320,7 +319,7 @@ export default function SnookerRoyalLobby() {
   return (
     <div className="relative min-h-screen bg-[#070b16] text-text">
       <div className="absolute inset-0 tetris-grid-bg opacity-60" />
-      <div className="relative z-10 space-y-4 p-4 pb-8">
+      <div className="relative z-10 space-y-6 p-4 pb-8">
         {winnerParam && (
           <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-center text-sm font-semibold text-emerald-200">
             {winnerParam === '1' ? 'You won!' : 'CPU won!'}
@@ -329,36 +328,13 @@ export default function SnookerRoyalLobby() {
         <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">
-                Snooker Royal
-              </p>
               <h2 className="text-2xl font-bold text-white">Snooker Royal Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               {onlinePlayers.length} online
             </div>
           </div>
-          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    🎱
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Cue Table Ready</p>
-                  <p className="text-xs text-white/60">
-                    Load the snooker arena in the background while you configure your match.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Fast load</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Tournament ready</span>
-              </div>
-            </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-1">
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
               <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
               <div className="mt-3 flex items-center gap-3">
@@ -374,9 +350,31 @@ export default function SnookerRoyalLobby() {
                   <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
                 </div>
               </div>
-              <p className="mt-3 text-xs text-white/60">
-                Your lobby choices persist into the match intro.
-              </p>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedFlag || '🌐'}</span>
+                    <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowAiFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                    <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+                  </div>
+                </button>
+              </div>
+              <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
             </div>
           </div>
         </div>
@@ -393,7 +391,7 @@ export default function SnookerRoyalLobby() {
                 label: 'Regular',
                 desc: 'Quick single match',
                 accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
-                icon: '🎯'
+                icon: '🔴'
               },
               {
                 id: 'tournament',
@@ -474,7 +472,7 @@ export default function SnookerRoyalLobby() {
                   <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
                     <div className="lobby-option-thumb-inner">
                       <OptionIcon
-                        src={getLobbyIcon('snookerroyale', `mode-${id}`)}
+                        src={getLobbyIcon('poolroyale', `mode-${id}`)}
                         alt={label}
                         fallback={icon}
                         className="lobby-option-icon"
@@ -494,50 +492,6 @@ export default function SnookerRoyalLobby() {
           <p className="text-xs text-white/60 text-center">
             AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
           </p>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Table Setup</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Options</span>
-          </div>
-          <div className="grid grid-cols-3 gap-3">
-            {[
-              { id: 'uk', label: 'Championship 12 ft', desc: 'Official layout', icon: '🏟️' },
-              { id: 'american', label: 'Club 10 ft', desc: 'Local tables', icon: '🎲' },
-              { id: '9ball', label: 'Practice Session', desc: 'Warm-up mode', icon: '🎱' }
-            ].map(({ id, label, desc, icon }) => {
-              const active = variant === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setVariant(id)}
-                  className={`lobby-option-card ${
-                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
-                    <div className="lobby-option-thumb-inner">
-                      <OptionIcon
-                        src={getLobbyIcon(
-                          'snookerroyale',
-                          `table-${id === 'uk' ? 'championship' : id === 'american' ? 'club' : 'practice'}`
-                        )}
-                        alt={label}
-                        fallback={icon}
-                        className="lobby-option-icon"
-                      />
-                    </div>
-                  </div>
-                  <div className="text-center">
-                    <p className="lobby-option-label">{label}</p>
-                    <p className="lobby-option-subtitle">{desc}</p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
         </div>
 
         {playType === 'tournament' && (
@@ -602,65 +556,6 @@ export default function SnookerRoyalLobby() {
             <p className="text-center text-white/60 text-xs">
               Online games use your TPC stake as escrow, while AI matches stay free.
             </p>
-          </div>
-        )}
-
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <button
-              type="button"
-              onClick={() => setShowFlagPicker(true)}
-              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-            >
-              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
-              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-                <span className="text-lg">{selectedFlag || '🌐'}</span>
-                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
-              </div>
-            </button>
-            {avatar && (
-              <div className="mt-3 flex items-center gap-3">
-                <img
-                  src={avatar}
-                  alt="Your avatar"
-                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
-                />
-                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {mode === 'ai' && (
-          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="flex items-start gap-3">
-              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
-                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                  🤝
-                </div>
-              </div>
-              <div>
-                <h3 className="font-semibold text-white">AI Avatar Flags</h3>
-                <p className="text-xs text-white/60">
-                  Pick the country flag for the AI rival so the intro stays consistent.
-                </p>
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => setShowAiFlagPicker(true)}
-              className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-            >
-              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
-              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-              </div>
-            </button>
           </div>
         )}
 


### PR DESCRIPTION
### Motivation
- Simplify the Snooker Royal lobby UI by removing redundant table setup controls and make identity/flags match the Pool Royal lobby layout for a consistent UX on mobile portrait screens.
- Use the same mode thumbnails as Pool Royal and provide snooker-specific match-type thumbnails to make options visually consistent and clearer for players.

### Description
- Removed the initial "Cue Table Ready" card and the separate Table Setup options, and stopped exposing the `variant` selector so the current table is used as the default (`forcedVariant = 'snooker'`).
- Moved and restyled the identity/profile area to match the Pool Royal lobby pattern and merged flag/AI-flag controls into the top profile card.
- Updated mode thumbnails to reuse Pool Royale icons by changing the `OptionIcon` source to `getLobbyIcon('poolroyale', 'mode-...')` for mode buttons.
- Added snooker-specific thumbnails and wired them into the lobby asset map by updating `webapp/src/config/gameAssets.js` and adding two SVG assets: `webapp/public/assets/icons/snooker-regular.svg` (15 red balls in a triangle) and `webapp/public/assets/icons/snooker-tournament.svg` (trophy). Also updated the regular match fallback icon to `🔴`.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev` and verified Vite served the site successfully.
- Rendered the lobby at `/games/snookerroyale/lobby` and captured a screenshot using a Playwright script to visually validate the layout and new icons (succeeded and produced an artifact).
- No unit tests or automated CI tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c85a55b0832999370293edc33390)