### PR TITLE
Update Goal Rush lobby visuals and icons

### DIFF
--- a/webapp/src/pages/Games/GoalRushLobby.jsx
+++ b/webapp/src/pages/Games/GoalRushLobby.jsx
@@ -127,36 +127,13 @@ export default function GoalRushLobby() {
         <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 via-[#0f172a]/80 to-[#0b1324]/90 p-4 shadow-[0_20px_50px_rgba(0,0,0,0.45)]">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[11px] uppercase tracking-[0.35em] text-emerald-200/70">
-                Goal Rush
-              </p>
-              <h2 className="text-2xl font-bold text-white">Goal Rush Lobby</h2>
+              <h2 className="text-2xl font-bold text-white">🥅 Goal Rush Lobby</h2>
             </div>
             <div className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/80">
               Pitch ready
             </div>
           </div>
-          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    🥅
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Match Setup</p>
-                  <p className="text-xs text-white/60">
-                    Configure your rush while the stadium loads in the background.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Quick kickoff</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
-              </div>
-            </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-1">
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
               <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
               <div className="mt-3 flex items-center gap-3">
@@ -168,13 +145,35 @@ export default function GoalRushLobby() {
                   )}
                 </div>
                 <div className="text-sm text-white/80">
-                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} locked in</p>
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
                   <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
                 </div>
               </div>
-              <p className="mt-3 text-xs text-white/60">
-                Your lobby choices carry into the match intro.
-              </p>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedFlag || '🌐'}</span>
+                    <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowAiFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                    <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+                  </div>
+                </button>
+              </div>
+              <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
             </div>
           </div>
         </div>
@@ -187,10 +186,10 @@ export default function GoalRushLobby() {
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
             <div className="grid grid-cols-3 gap-3">
               {[
-                { id: 'regular', label: 'Regular' },
-                { id: 'training', label: 'Training' },
-                { id: 'tournament', label: 'Tournament' }
-              ].map(({ id, label }) => (
+                { id: 'regular', label: 'Regular', icon: '🥅' },
+                { id: 'training', label: 'Training', icon: '🏟' },
+                { id: 'tournament', label: 'Tournament', icon: '🏆' }
+              ].map(({ id, label, icon }) => (
                 <button
                   key={id}
                   onClick={() => setPlayType(id)}
@@ -201,9 +200,9 @@ export default function GoalRushLobby() {
                   <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-emerald-500/10 to-transparent">
                     <div className="lobby-option-thumb-inner">
                       <OptionIcon
-                        src={getLobbyIcon('goalrush', `type-${id}`)}
+                        src={null}
                         alt={label}
-                        fallback={id === 'regular' ? '🎯' : id === 'training' ? '🛠️' : '🏆'}
+                        fallback={icon}
                         className="lobby-option-icon"
                       />
                     </div>
@@ -219,44 +218,44 @@ export default function GoalRushLobby() {
 
         {playType !== 'training' && (
           <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Mode</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="grid grid-cols-3 gap-3">
-              {[
-                { id: 'ai', label: 'Vs AI' },
-                { id: 'online', label: '1v1 Online', disabled: true }
-              ].map(({ id, label, disabled }) => (
-                <div key={id} className="relative">
-                  <button
-                    onClick={() => !disabled && setMode(id)}
-                    className={`lobby-option-card ${
-                      mode === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                    } ${disabled ? 'lobby-option-card-disabled' : ''}`}
-                    disabled={disabled}
-                  >
-                    <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
-                      <div className="lobby-option-thumb-inner">
-                        <OptionIcon
-                          src={getLobbyIcon('goalrush', `mode-${id}`)}
-                          alt={label}
-                          fallback={id === 'ai' ? '🤖' : '🌐'}
-                          className="lobby-option-icon"
-                        />
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Mode</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+              <div className="grid grid-cols-3 gap-3">
+                {[
+                  { id: 'ai', label: 'Vs AI' },
+                  { id: 'online', label: '1v1 Online', disabled: true }
+                ].map(({ id, label, disabled }) => (
+                  <div key={id} className="relative">
+                    <button
+                      onClick={() => !disabled && setMode(id)}
+                      className={`lobby-option-card ${
+                        mode === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                      } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                      disabled={disabled}
+                    >
+                      <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                        <div className="lobby-option-thumb-inner">
+                          <OptionIcon
+                            src={getLobbyIcon('poolroyale', `mode-${id}`)}
+                            alt={label}
+                            fallback={id === 'ai' ? '🤖' : '🌐'}
+                            className="lobby-option-icon"
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div className="text-center">
-                      <p className="lobby-option-label">{label}</p>
-                      {disabled && <p className="lobby-option-subtitle">Under development</p>}
-                    </div>
-                  </button>
-                </div>
-              ))}
+                      <div className="text-center">
+                        <p className="lobby-option-label">{label}</p>
+                        {disabled && <p className="lobby-option-subtitle">Under development</p>}
+                      </div>
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
         )}
 
         <div className="space-y-3">
@@ -277,7 +276,7 @@ export default function GoalRushLobby() {
                   <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
                     <div className="lobby-option-thumb-inner">
                       <OptionIcon
-                        src={getLobbyIcon('goalrush', `target-${g}`)}
+                        src={null}
                         alt={`${g} goals`}
                         fallback="🥅"
                         className="lobby-option-icon"
@@ -295,33 +294,33 @@ export default function GoalRushLobby() {
 
         {playType === 'tournament' && (
           <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Players</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bracket</span>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-2">
-            <div className="grid grid-cols-3 gap-3">
-              {[8, 16, 24].map((p) => (
-                <button
-                  key={p}
-                  onClick={() => setPlayers(p)}
-                  className={`lobby-option-card ${
-                    players === p ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
-                    <div className="lobby-option-thumb-inner">
-                      <span className="text-2xl font-semibold">{p}</span>
-                    </div>
-                  </div>
-                  <div className="text-center">
-                    <p className="lobby-option-label">{p} Players</p>
-                  </div>
-                </button>
-              ))}
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Players</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Bracket</span>
             </div>
-            <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
-          </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-2">
+              <div className="grid grid-cols-3 gap-3">
+                {[8, 16, 24].map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setPlayers(p)}
+                    className={`lobby-option-card ${
+                      players === p ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl font-semibold">{p}</span>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{p} Players</p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-white/60">Winner takes pot minus 10% developer fee.</p>
+            </div>
           </div>
         )}
 
@@ -336,63 +335,6 @@ export default function GoalRushLobby() {
             </div>
           </div>
         )}
-
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <button
-              type="button"
-              onClick={() => setShowFlagPicker(true)}
-              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-            >
-              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
-              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-                <span className="text-lg">{selectedFlag || '🌐'}</span>
-                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
-              </div>
-            </button>
-            {avatar && (
-              <div className="mt-3 flex items-center gap-3">
-                <img
-                  src={avatar}
-                  alt="Your avatar"
-                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
-                />
-                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-          <div className="flex items-start gap-3">
-            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
-              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                🤝
-              </div>
-            </div>
-            <div>
-              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
-              <p className="text-xs text-white/60">
-                Pick the country flag for the AI rival so it matches the Chess Battle Royal lobby experience.
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => setShowAiFlagPicker(true)}
-            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-          >
-            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
-            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-              <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-            </div>
-          </button>
-        </div>
 
         <button
           onClick={startGame}


### PR DESCRIPTION
### Motivation
- Align Goal Rush lobby visuals and identity handling with the established Pool Royale lobby styling and remove duplicated identity blocks.
- Ensure the option thumbnails (type/mode/target) match the requested icons: use the existing Pool Royale mode thumbnails and emoji thumbnails for types/targets.

### Description
- Updated the Goal Rush header to include the goal icon in the title (`🥅 Goal Rush Lobby`) and consolidated the profile card to match Pool Royale's layout in `webapp/src/pages/Games/GoalRushLobby.jsx`.
- Replaced the previous match-setup block and duplicate identity sections with a single player profile card that exposes `Flag` and `AI Flag` pickers inline.
- Switched Type option thumbnails to emoji fallbacks (`🥅`, `🏟`, `🏆`) by passing `src={null}` and `fallback` icons, and changed Mode thumbnails to reuse Pool Royale assets via `getLobbyIcon('poolroyale', \\`mode-${id}\\`)`.
- Updated Goals (target) thumbnails to use the goal emoji fallback and cleaned up layout adjustments for tournament/player blocks.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched Vite successfully.
- Loaded `/games/goalrush/lobby` using a Playwright script (viewport `430x932`) and captured a screenshot saved to `artifacts/goalrush-lobby.png`, confirming the UI changes rendered as expected.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974caaccba08329b84abb29f76b4ac5)