### PR TITLE
Update snake lobby identity panel and player selectors

### DIFF
--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -5,11 +5,14 @@ export default function TableSelector({ tables, selected, onSelect }) {
     <div className="grid grid-cols-3 gap-3">
       {tables.map((t) => {
         const isSelected = selected?.id === t.id;
-        const subtitle = t.capacity
-          ? t.players
-            ? `${t.players}/${t.capacity} players`
-            : `${t.capacity} seats`
-          : null;
+        const hasSubtitle = Object.prototype.hasOwnProperty.call(t, 'subtitle');
+        const subtitle = hasSubtitle
+          ? t.subtitle
+          : t.capacity
+            ? t.players
+              ? `${t.players}/${t.capacity} players`
+              : `${t.capacity} seats`
+            : null;
         return (
           <div key={t.id} className="relative">
             <button

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -43,6 +43,7 @@ export const lobbyOptionIcons = {
     '/assets/icons/texas-holdem.svg'
   ),
   'domino-royal': {
+    'players-1': '/assets/icons/profile.svg',
     'players-2': '/assets/icons/profile.svg',
     'players-3': '/assets/icons/profile.svg',
     'players-4': '/assets/icons/profile.svg',


### PR DESCRIPTION
### Motivation
- Simplify the Snake & Ladder lobby by removing the initial promotional frame and surface an identity-focused panel similar to Pool/Domino Royal for clarity. 
- Let players pick a single identity flag and provide AI-flag auto-pick per match while keeping user control to change flags. 
- Replace ambiguous “Select Table / seats” wording and icons with a clear "Vs how many players" selector and reuse Domino Royal player thumbnails for visual consistency.

### Description
- Replaced the lobby header promotional block with an Identity panel showing player avatar, player flag, and AI flag controls in `Lobby.jsx`. 
- Added `playerFlag` and `flagPickerMode` state and new `openPlayerFlagPicker`/`openAiFlagPicker` flows to let the flag picker save player or AI flags, and wired `FlagPickerModal` to respect the picker mode. 
- Changed single/multiplayer table labels (single -> `1 Player`, multiplayer -> `N Players`) and swapped snake table icons to use `domino-royal` player thumbnails, and updated AI opponent thumbnails to use domino-style icons in `Lobby.jsx`. 
- Removed the `aiType`/avatars toggle and simplified start-game flag handling to pass `flags`/`aiFlags` as needed; adjusted disabled logic for single-player AI to require an AI count. 
- Made `TableSelector` honor an explicit `subtitle` field so table items can hide the old "seats" copy when needed in `webapp/src/components/TableSelector.jsx`. 
- Added a `players-1` icon entry to `lobbyOptionIcons['domino-royal']` in `webapp/src/config/gameAssets.js` for the new single-player thumbnail.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported the server ready (local URL printed). — succeeded. 
- Ran a Playwright script to open `/games/snake/lobby` (mobile viewport) and captured `artifacts/snake-lobby.png` to verify the UI layout changes visually — succeeded. 
- No unit or integration test suite (`npm test`) was executed as these are UI layout changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d78c0e9c8329a0611cac7a463e84)