### PR TITLE
Align chess lobby identity and mode thumbnails with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -259,27 +259,7 @@ export default function ChessBattleRoyalLobby() {
               {onlineCount != null ? `${onlineCount} online` : 'Syncing…'}
             </div>
           </div>
-          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    ♟️
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Battle Queue</p>
-                  <p className="text-xs text-white/60">
-                    Prep your pieces while the arena loads in the background.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant start</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Mobile ready</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
-              </div>
-            </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-1">
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
               <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
               <div className="mt-3 flex items-center gap-3">
@@ -292,10 +272,32 @@ export default function ChessBattleRoyalLobby() {
                 </div>
                 <div className="text-sm text-white/80">
                   <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
-                  <p className="text-xs text-white/50">
-                    Flag: {selectedFlag || 'Auto'}
-                  </p>
+                  <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
                 </div>
+              </div>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedFlag || '🌐'}</span>
+                    <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowAiFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                    <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+                  </div>
+                </button>
               </div>
               <p className="mt-3 text-xs text-white/60">
                 Your lobby choices persist into the match start screen.
@@ -315,17 +317,19 @@ export default function ChessBattleRoyalLobby() {
                 key: 'ai',
                 label: 'Vs AI',
                 desc: 'Instant practice',
-                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
-                icon: '🤖'
+                accent: 'from-sky-400/30 via-indigo-500/10 to-transparent',
+                icon: '🤖',
+                iconKey: 'mode-ai'
               },
               {
                 key: 'online',
                 label: 'Online',
                 desc: 'Stake & match',
-                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
-                icon: '⚔️'
+                accent: 'from-sky-400/30 via-indigo-500/10 to-transparent',
+                icon: '⚔️',
+                iconKey: 'mode-online'
               }
-            ].map(({ key, label, desc, accent, icon }) => {
+            ].map(({ key, label, desc, accent, icon, iconKey }) => {
               const active = mode === key;
               return (
                 <button
@@ -339,7 +343,7 @@ export default function ChessBattleRoyalLobby() {
                   <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
                     <div className="lobby-option-thumb-inner">
                       <OptionIcon
-                        src={getLobbyIcon('chessbattleroyal', `mode-${key}`)}
+                        src={getLobbyIcon('poolroyale', iconKey)}
                         alt={label}
                         fallback={icon}
                         className="lobby-option-icon"
@@ -445,64 +449,7 @@ export default function ChessBattleRoyalLobby() {
           </div>
         )}
 
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Your Flag & Avatar</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Identity</span>
-          </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <button
-              type="button"
-              onClick={() => setShowFlagPicker(true)}
-              className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-            >
-              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">Flag</div>
-              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-                <span className="text-lg">{selectedFlag || '🌐'}</span>
-                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
-              </div>
-            </button>
-            {avatar && (
-              <div className="mt-3 flex items-center gap-3">
-                <img
-                  src={avatar}
-                  alt="Your avatar"
-                  className="h-12 w-12 rounded-full border border-white/20 object-cover"
-                />
-                <div className="text-sm text-white/60">Your avatar will appear in the match intro.</div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {mode === 'ai' && (
-          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <div className="flex items-start gap-3">
-              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
-                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                  🤝
-                </div>
-              </div>
-              <div>
-                <h3 className="font-semibold text-white">AI Avatar Flags</h3>
-                <p className="text-xs text-white/60">
-                  Pick the country flag for the AI rival so it matches the Snake &amp; Ladder experience.
-                </p>
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => setShowAiFlagPicker(true)}
-              className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-            >
-              <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flag</div>
-              <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
-                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick for opponent'}</span>
-              </div>
-            </button>
-          </div>
-        )}
+        
 
         {mode === 'online' && matching && (
           <div className="space-y-2 rounded-2xl border border-primary/40 bg-primary/5 p-4 shadow">


### PR DESCRIPTION
### Motivation
- Make the Chess Battle Royal lobby UI match the Pool Royale lobby layout and assets to provide a consistent identity and mode experience across games.
- Remove the separate "Battle Queue" card and reuse the Pool Royale–style player identity block so flag/avatar controls are in the same place users expect.

### Description
- Removed the standalone Battle Queue card from the Chess Battle Royal lobby header and replaced the header content with a single Player Profile card that matches the Pool Royale layout and behavior.
- Moved flag and AI-flag selection controls into the top Player Profile card so identity controls are identical to Pool Royale.
- Swapped the Chess lobby mode thumbnails to use the Pool Royale mode icons by changing `getLobbyIcon('chessbattleroyal', ...)` to `getLobbyIcon('poolroyale', ...)` and adding `iconKey` mapping for the mode cards.
- Cleaned up the duplicated Flag/AI UI blocks that were previously rendered lower in the document to avoid redundancy.

### Testing
- Launched the dev server with `npm run dev` (Vite) and confirmed the server started and served the app (Local: `http://localhost:4173/`). — succeeded.
- Ran a Playwright script that opened `/games/chessbattleroyal/lobby` at a mobile viewport and produced a screenshot (`artifacts/chess-lobby.png`) to verify the mobile layout visually. — succeeded.
- No unit tests were modified; no automated test failures observed during these UI checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d9a41988832994720a87ebf4190c)