### PR TITLE
Update Ludo Battle Royal lobby: identity frame, match mode, and player-count thumbnails

### DIFF
--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -5,7 +5,9 @@ export default function TableSelector({ tables, selected, onSelect }) {
     <div className="grid grid-cols-3 gap-3">
       {tables.map((t) => {
         const isSelected = selected?.id === t.id;
-        const subtitle = t.capacity
+        const subtitle = t.hideSubtitle
+          ? null
+          : t.capacity
           ? t.players
             ? `${t.players}/${t.capacity} players`
             : `${t.capacity} seats`

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -12,7 +12,12 @@ import {
   getOnlineCount,
   pingOnline
 } from '../../utils/api.js';
-import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import {
+  ensureAccountId,
+  getTelegramFirstName,
+  getTelegramId,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 
@@ -22,25 +27,28 @@ const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 const TABLES = [
   {
-    id: 'practice',
-    label: 'Practice (Solo)',
-    capacity: 1,
-    icon: getLobbyIcon('ludobattleroyal', 'table-1'),
-    iconFallback: '🎯'
-  },
-  {
-    id: 'duo',
-    label: 'Duo Battle',
+    id: 'players-2',
+    label: '2 Players',
     capacity: 2,
-    icon: getLobbyIcon('ludobattleroyal', 'table-2'),
-    iconFallback: '👥'
+    icon: getLobbyIcon('domino-royal', 'players-2'),
+    iconFallback: '👤',
+    hideSubtitle: true
   },
   {
-    id: 'royale',
-    label: 'Battle Royale (4 Players)',
+    id: 'players-3',
+    label: '3 Players',
+    capacity: 3,
+    icon: getLobbyIcon('domino-royal', 'players-3'),
+    iconFallback: '👥',
+    hideSubtitle: true
+  },
+  {
+    id: 'players-4',
+    label: '4 Players',
     capacity: 4,
-    icon: getLobbyIcon('ludobattleroyal', 'table-4'),
-    iconFallback: '👑'
+    icon: getLobbyIcon('domino-royal', 'players-4'),
+    iconFallback: '👥',
+    hideSubtitle: true
   }
 ];
 
@@ -51,10 +59,12 @@ export default function LudoBattleRoyalLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [table, setTable] = useState(TABLES[0]);
   const [avatar, setAvatar] = useState('');
+  const [mode, setMode] = useState('ai');
   const [aiCount, setAiCount] = useState(1);
-  const [aiType, setAiType] = useState('flags');
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [flags, setFlags] = useState([]);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [online, setOnline] = useState(null);
 
   useEffect(() => {
@@ -101,16 +111,9 @@ export default function LudoBattleRoyalLobby() {
     return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
   }, []);
 
-  const selectAiType = (type) => {
-    setAiType(type);
-    if (type === 'flags') setShowFlagPicker(true);
-    if (type !== 'flags') setFlags([]);
-  };
-
   const openAiFlagPicker = () => {
     if (!aiCount) setAiCount(1);
-    selectAiType('flags');
-    setShowFlagPicker(true);
+    setShowAiFlagPicker(true);
   };
 
   const buildAutoFlags = (count, selection = []) => {
@@ -149,7 +152,8 @@ export default function LudoBattleRoyalLobby() {
 
     const params = new URLSearchParams();
     const initData = window.Telegram?.WebApp?.initData;
-    if (table?.id) params.set('table', table.id);
+    if (mode) params.set('mode', mode);
+    if (table?.id) params.set('table', mode === 'ai' ? 'practice' : table.id);
     if (table?.capacity) params.set('capacity', String(table.capacity));
     if (stake.token) params.set('token', stake.token);
     if (stake.amount) params.set('amount', stake.amount);
@@ -157,12 +161,12 @@ export default function LudoBattleRoyalLobby() {
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
 
-    if (table?.id === 'practice') {
-      const aiSlotCount = aiCount || 1;
+    if (mode === 'ai') {
+      const aiSlotCount = aiCount || Math.max(1, (table?.capacity || 2) - 1);
       const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;
       const resolvedFlags = buildAutoFlags(aiSlotCount, aiFlagSelection);
       params.set('ai', aiSlotCount);
-      params.set('avatars', aiType || 'flags');
+      params.set('avatars', 'flags');
       params.set('flags', resolvedFlags.join(','));
     }
 
@@ -174,13 +178,25 @@ export default function LudoBattleRoyalLobby() {
     navigate(`/games/ludobattleroyal?${params.toString()}`);
   };
 
-  const disabled =
-    !stake ||
-    !stake.token ||
-    !stake.amount ||
-    (table?.id === 'practice' && !aiType);
+  const disabled = !stake || !stake.token || !stake.amount;
 
-  const flagPickerCount = table?.id === 'practice' ? aiCount || 1 : Math.max(aiCount || 1, 1);
+  const flagPickerCount = Math.max(aiCount || 1, 1);
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+
+  useEffect(() => {
+    if (mode !== 'ai') return;
+    const desired = Math.max(1, (table?.capacity || 2) - 1);
+    if (aiCount !== desired) setAiCount(desired);
+  }, [aiCount, mode, table]);
+
+  useEffect(() => {
+    if (mode !== 'ai') return;
+    const desiredCapacity = aiCount + 1;
+    const match = TABLES.find((entry) => entry.capacity === desiredCapacity);
+    if (match && match.id !== table?.id) {
+      setTable(match);
+    }
+  }, [aiCount, mode, table]);
 
   return (
     <div className="relative min-h-screen bg-[#070b16] text-text">
@@ -199,28 +215,8 @@ export default function LudoBattleRoyalLobby() {
             </div>
           </div>
           <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    🎲
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Battle Queue</p>
-                  <p className="text-xs text-white/60">
-                    Configure your match while the arena loads in the background.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant lobby</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Touch ready</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
-              </div>
-            </div>
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
-              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+              <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Identity</p>
               <div className="mt-3 flex items-center gap-3">
                 <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
                   {avatar ? (
@@ -230,26 +226,88 @@ export default function LudoBattleRoyalLobby() {
                   )}
                 </div>
                 <div className="text-sm text-white/80">
-                  <p className="font-semibold">Ready for battle</p>
-                  <p className="text-xs text-white/50">
-                    AI flags: {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : 'Auto'}
-                  </p>
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+                  <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
                 </div>
               </div>
-              <p className="mt-3 text-xs text-white/60">
-                Your lobby settings carry over as soon as the match loads.
-              </p>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFlagPicker(true)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedFlag || '🌐'}</span>
+                    <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={openAiFlagPicker}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flags</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">
+                      {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
+                    </span>
+                    <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick opponents'}</span>
+                  </div>
+                </button>
+              </div>
+              <p className="mt-3 text-xs text-white/60">Your lobby settings carry into the match.</p>
             </div>
           </div>
         </div>
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Select Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Tables</span>
+            <h3 className="font-semibold text-white">VS How Many Players</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Players</span>
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
             <TableSelector tables={TABLES} selected={table} onSelect={setTable} />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Match Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Opponents</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { id: 'ai', label: 'Local vs AI', desc: 'Practice locally', iconKey: 'mode-ai' },
+              { id: 'online', label: 'Online Mode', desc: 'Live matchmaking', iconKey: 'mode-online' }
+            ].map(({ id, label, desc, iconKey }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setMode(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', iconKey)}
+                        alt={label}
+                        fallback={id === 'ai' ? '🤖' : '🌐'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         </div>
 
@@ -266,40 +324,11 @@ export default function LudoBattleRoyalLobby() {
           </div>
         </div>
 
-        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-          <div className="flex items-start gap-3">
-            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
-              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                🧠
-              </div>
-            </div>
-            <div>
-              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
-              <p className="text-xs text-white/60">
-                Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents.
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={openAiFlagPicker}
-            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-          >
-            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flags</div>
-            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">
-                {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
-              </span>
-              <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
-            </div>
-          </button>
-        </div>
-
-        {table?.id === 'practice' && (
+        {mode === 'ai' && (
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Practice Settings</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Solo</span>
+              <h3 className="font-semibold text-white">Local vs AI Settings</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Local</span>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-3">
               <div>
@@ -330,20 +359,6 @@ export default function LudoBattleRoyalLobby() {
                   ))}
                 </div>
               </div>
-              <div>
-                <h4 className="font-semibold text-white text-sm">AI Avatars</h4>
-                <div className="mt-2 flex gap-2">
-                  {['flags'].map((t) => (
-                    <button
-                      key={t}
-                      onClick={() => selectAiType(t)}
-                      className={`lobby-tile ${aiType === t ? 'lobby-selected' : ''}`}
-                    >
-                      Flags
-                    </button>
-                  ))}
-                </div>
-              </div>
             </div>
           </div>
         )}
@@ -358,10 +373,21 @@ export default function LudoBattleRoyalLobby() {
 
         <FlagPickerModal
           open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(selection) => {
+            const [idx] = selection;
+            setPlayerFlagIndex(Number.isFinite(idx) ? idx : null);
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
           count={flagPickerCount}
           selected={flags}
           onSave={setFlags}
-          onClose={() => setShowFlagPicker(false)}
+          onClose={() => setShowAiFlagPicker(false)}
           onComplete={(sel) => startGame(sel)}
         />
       </div>


### PR DESCRIPTION
### Motivation
- Simplify and align the Ludo Battle Royal lobby UI with other royales by removing the extra "Battle Queue" banner and reusing the Pool Royale-style identity frame.
- Replace the existing table selection and AI avatar/flag handling with a clearer player-count flow and consolidated flag pickers to reduce duplicated controls.
- Add an explicit match mode selector (Local vs AI / Online) so players choose local practice or live matchmaking from the same lobby.

### Description
- Reworked `webapp/src/pages/Games/LudoBattleRoyalLobby.jsx` to remove the top "Battle Queue" card and replace the `Player Profile` block with an `Identity` frame that matches the Pool Royale layout and exposes a player flag picker via `FlagPickerModal` (added `playerFlagIndex` state and `getTelegramFirstName()` usage).
- Added a `Match Mode` section and `mode` state with two options `ai` (Local vs AI) and `online` (Online Mode), and updated `startGame` to include `mode` in the generated params and to map local AI matches to `table=practice` and include AI flags/avatars parameters.
- Replaced the old `TABLES` entries (`practice`, `duo`, `royale`) with Domino-style player-count entries (`players-2`, `players-3`, `players-4`) that use `getLobbyIcon('domino-royal', ...)`, changed the header to "VS How Many Players", and set `hideSubtitle` on these thumbnails to simplify their appearance.
- Moved practice settings under the `mode === 'ai'` block as `Local vs AI Settings`, made AI count selection drive the chosen table capacity, replaced the previous `aiType` flow with two separate flag pickers (one for the player and one for AI opponents), and updated `FlagPickerModal` props accordingly.
- Updated `webapp/src/components/TableSelector.jsx` to respect a new `hideSubtitle` property so certain table thumbnails can omit the subtitle text.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the site at the expected URL (success).
- Ran a Playwright screenshot script that navigated to `/games/ludobattleroyal/lobby` and produced a screenshot artifact, confirming the updated layout rendered (screenshot saved to the build artifacts, success).
- No unit or integration tests were run for these UI-only changes (`npm test` / Jest not executed during this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974db6a7dd48329ab21508c9b9afcb3)