### PR TITLE
Move player-count selector into Local mode, simplify labels and add player flag picker

### DIFF
--- a/webapp/src/components/TableSelector.jsx
+++ b/webapp/src/components/TableSelector.jsx
@@ -5,7 +5,7 @@ export default function TableSelector({ tables, selected, onSelect }) {
     <div className="grid grid-cols-3 gap-3">
       {tables.map((t) => {
         const isSelected = selected?.id === t.id;
-        const subtitle = t.capacity
+        const subtitle = t.capacity && !t.hideSubtitle
           ? t.players
             ? `${t.players}/${t.capacity} players`
             : `${t.capacity} seats`

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5704,11 +5704,12 @@ export default function LudoBattleRoyal() {
     getTelegramFirstName() ||
     getTelegramUsername();
   const tableId = params.get('table') || 'royale';
+  const mode = params.get('mode') || (tableId === 'practice' ? 'local' : 'online');
   const capacityParam = parseInt(params.get('capacity') ?? '', 10);
   const aiParam = parseInt(params.get('ai') ?? '', 10);
   const parsedCapacity = clampPlayerCount(capacityParam);
   const requestedAiCount = clamp(Math.max(0, aiParam || 0), 0, DEFAULT_PLAYER_COUNT - 1);
-  const playerCount = tableId === 'practice'
+  const playerCount = mode === 'local'
     ? clampPlayerCount(1 + requestedAiCount)
     : parsedCapacity;
   const flagsParam = params.get('flags');
@@ -5727,7 +5728,7 @@ export default function LudoBattleRoyal() {
       username={username}
       aiFlagOverrides={aiFlagOverrides}
       playerCount={playerCount}
-      aiCount={tableId === 'practice' ? requestedAiCount : playerCount - 1}
+      aiCount={mode === 'local' ? requestedAiCount : playerCount - 1}
     />
   );
 }

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -12,7 +12,12 @@ import {
   getOnlineCount,
   pingOnline
 } from '../../utils/api.js';
-import { ensureAccountId, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import {
+  ensureAccountId,
+  getTelegramFirstName,
+  getTelegramId,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 
@@ -22,25 +27,28 @@ const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 
 const TABLES = [
   {
-    id: 'practice',
-    label: 'Practice (Solo)',
-    capacity: 1,
-    icon: getLobbyIcon('ludobattleroyal', 'table-1'),
-    iconFallback: '🎯'
-  },
-  {
-    id: 'duo',
-    label: 'Duo Battle',
+    id: 'players-2',
+    label: '2 Players',
     capacity: 2,
-    icon: getLobbyIcon('ludobattleroyal', 'table-2'),
-    iconFallback: '👥'
+    icon: getLobbyIcon('domino-royal', 'players-2'),
+    iconFallback: '👥',
+    hideSubtitle: true
   },
   {
-    id: 'royale',
-    label: 'Battle Royale (4 Players)',
+    id: 'players-3',
+    label: '3 Players',
+    capacity: 3,
+    icon: getLobbyIcon('domino-royal', 'players-3'),
+    iconFallback: '👥',
+    hideSubtitle: true
+  },
+  {
+    id: 'players-4',
+    label: '4 Players',
     capacity: 4,
-    icon: getLobbyIcon('ludobattleroyal', 'table-4'),
-    iconFallback: '👑'
+    icon: getLobbyIcon('domino-royal', 'players-4'),
+    iconFallback: '👥',
+    hideSubtitle: true
   }
 ];
 
@@ -51,10 +59,12 @@ export default function LudoBattleRoyalLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [table, setTable] = useState(TABLES[0]);
   const [avatar, setAvatar] = useState('');
-  const [aiCount, setAiCount] = useState(1);
-  const [aiType, setAiType] = useState('flags');
+  const [aiCount, setAiCount] = useState(Math.max(1, (TABLES[0]?.capacity || 2) - 1));
+  const [matchMode, setMatchMode] = useState('local');
   const [flags, setFlags] = useState([]);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [playerFlag, setPlayerFlag] = useState([]);
+  const [showPlayerFlagPicker, setShowPlayerFlagPicker] = useState(false);
   const [online, setOnline] = useState(null);
 
   useEffect(() => {
@@ -101,16 +111,20 @@ export default function LudoBattleRoyalLobby() {
     return () => window.removeEventListener('profilePhotoUpdated', updatePhoto);
   }, []);
 
-  const selectAiType = (type) => {
-    setAiType(type);
-    if (type === 'flags') setShowFlagPicker(true);
-    if (type !== 'flags') setFlags([]);
-  };
-
   const openAiFlagPicker = () => {
     if (!aiCount) setAiCount(1);
-    selectAiType('flags');
     setShowFlagPicker(true);
+  };
+
+  const openPlayerFlagPicker = () => {
+    setShowPlayerFlagPicker(true);
+  };
+
+  const handleTableSelect = (nextTable) => {
+    setTable(nextTable);
+    if (matchMode === 'local' && nextTable?.capacity) {
+      setAiCount(Math.max(1, Math.min(3, nextTable.capacity - 1)));
+    }
   };
 
   const buildAutoFlags = (count, selection = []) => {
@@ -128,6 +142,8 @@ export default function LudoBattleRoyalLobby() {
     }
     return chosen.slice(0, desired);
   };
+
+  const selectedPlayerFlag = playerFlag.length ? FLAG_EMOJIS[playerFlag[0]] : null;
 
   const startGame = async (flagOverride = flags) => {
     let tgId;
@@ -156,13 +172,13 @@ export default function LudoBattleRoyalLobby() {
     if (avatar) params.set('avatar', avatar);
     if (tgId) params.set('tgId', tgId);
     if (accountId) params.set('accountId', accountId);
+    if (matchMode) params.set('mode', matchMode);
 
-    if (table?.id === 'practice') {
+    if (matchMode === 'local') {
       const aiSlotCount = aiCount || 1;
       const aiFlagSelection = flagOverride && flagOverride.length ? flagOverride : flags;
       const resolvedFlags = buildAutoFlags(aiSlotCount, aiFlagSelection);
       params.set('ai', aiSlotCount);
-      params.set('avatars', aiType || 'flags');
       params.set('flags', resolvedFlags.join(','));
     }
 
@@ -178,9 +194,9 @@ export default function LudoBattleRoyalLobby() {
     !stake ||
     !stake.token ||
     !stake.amount ||
-    (table?.id === 'practice' && !aiType);
+    (matchMode === 'local' && !aiCount);
 
-  const flagPickerCount = table?.id === 'practice' ? aiCount || 1 : Math.max(aiCount || 1, 1);
+  const flagPickerCount = Math.max(aiCount || 1, 1);
 
   return (
     <div className="relative min-h-screen bg-[#070b16] text-text">
@@ -198,27 +214,7 @@ export default function LudoBattleRoyalLobby() {
               {online != null ? `${online} online` : 'Syncing…'}
             </div>
           </div>
-          <div className="mt-4 grid gap-3 sm:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#1f2937]/90 to-[#0f172a]/90 p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-14 w-14 rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-400/20 to-indigo-500/40 p-[1px]">
-                  <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-2xl">
-                    🎲
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Battle Queue</p>
-                  <p className="text-xs text-white/60">
-                    Configure your match while the arena loads in the background.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Instant lobby</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">Touch ready</span>
-                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1">HDR arena</span>
-              </div>
-            </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-1">
             <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
               <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
               <div className="mt-3 flex items-center gap-3">
@@ -230,11 +226,38 @@ export default function LudoBattleRoyalLobby() {
                   )}
                 </div>
                 <div className="text-sm text-white/80">
-                  <p className="font-semibold">Ready for battle</p>
+                  <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
                   <p className="text-xs text-white/50">
-                    AI flags: {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : 'Auto'}
+                    AI flags:{' '}
+                    {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : 'Auto'}
                   </p>
                 </div>
+              </div>
+              <div className="mt-3 grid gap-2">
+                <button
+                  type="button"
+                  onClick={openPlayerFlagPicker}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">{selectedPlayerFlag || '🌐'}</span>
+                    <span>{selectedPlayerFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={openAiFlagPicker}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flags</div>
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <span className="text-lg">
+                      {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
+                    </span>
+                    <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick opponents'}</span>
+                  </div>
+                </button>
               </div>
               <p className="mt-3 text-xs text-white/60">
                 Your lobby settings carry over as soon as the match loads.
@@ -245,13 +268,55 @@ export default function LudoBattleRoyalLobby() {
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Select Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Tables</span>
+            <h3 className="font-semibold text-white">Match Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-            <TableSelector tables={TABLES} selected={table} onSelect={setTable} />
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { id: 'local', label: 'Local vs AI', desc: 'Practice offline', iconKey: 'mode-ai' },
+              { id: 'online', label: 'Online Mode', desc: 'Live matchmaking', iconKey: 'mode-online' }
+            ].map(({ id, label, desc, iconKey }) => {
+              const active = matchMode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setMatchMode(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', iconKey)}
+                        alt={label}
+                        fallback={id === 'local' ? '🤖' : '🌐'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         </div>
+
+        {matchMode === 'local' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">VS How Many Players</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Players</span>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+              <TableSelector tables={TABLES} selected={table} onSelect={handleTableSelect} />
+            </div>
+          </div>
+        )}
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
@@ -265,88 +330,6 @@ export default function LudoBattleRoyalLobby() {
             </p>
           </div>
         </div>
-
-        <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-          <div className="flex items-start gap-3">
-            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
-              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                🧠
-              </div>
-            </div>
-            <div>
-              <h3 className="font-semibold text-white">AI Avatar Flags</h3>
-              <p className="text-xs text-white/60">
-                Match the Snake &amp; Ladder lobby by picking worldwide flags for AI opponents.
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={openAiFlagPicker}
-            className="mt-3 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-left text-sm text-white/80 transition hover:border-white/30"
-          >
-            <div className="text-[10px] uppercase tracking-[0.35em] text-white/60">AI Flags</div>
-            <div className="mt-2 flex items-center gap-2 text-base font-semibold">
-              <span className="text-lg">
-                {flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}
-              </span>
-              <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
-            </div>
-          </button>
-        </div>
-
-        {table?.id === 'practice' && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Practice Settings</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Solo</span>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow space-y-3">
-              <div>
-                <h4 className="font-semibold text-white text-sm">How many AI opponents?</h4>
-                <div className="mt-2 grid grid-cols-3 gap-3">
-                  {[1, 2, 3].map((n) => (
-                    <button
-                      key={n}
-                      onClick={() => setAiCount(n)}
-                      className={`lobby-option-card ${
-                        aiCount === n ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                      }`}
-                    >
-                      <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
-                        <div className="lobby-option-thumb-inner">
-                          <OptionIcon
-                            src={getLobbyIcon('ludobattleroyal', `ai-${n}`)}
-                            alt={`${n} AI`}
-                            fallback="🤖"
-                            className="lobby-option-icon"
-                          />
-                        </div>
-                      </div>
-                      <div className="text-center">
-                        <p className="lobby-option-label">{n} AI</p>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <h4 className="font-semibold text-white text-sm">AI Avatars</h4>
-                <div className="mt-2 flex gap-2">
-                  {['flags'].map((t) => (
-                    <button
-                      key={t}
-                      onClick={() => selectAiType(t)}
-                      className={`lobby-tile ${aiType === t ? 'lobby-selected' : ''}`}
-                    >
-                      Flags
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
 
         <button
           onClick={startGame}
@@ -363,6 +346,13 @@ export default function LudoBattleRoyalLobby() {
           onSave={setFlags}
           onClose={() => setShowFlagPicker(false)}
           onComplete={(sel) => startGame(sel)}
+        />
+        <FlagPickerModal
+          open={showPlayerFlagPicker}
+          count={1}
+          selected={playerFlag}
+          onSave={setPlayerFlag}
+          onClose={() => setShowPlayerFlagPicker(false)}
         />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Simplify the Local vs Online UX by surfacing a unified VS player-count selector only when `mode === 'local'` and removing the old AI-type flow. 
- Make table tiles clearer by using numeric player-count labels and supporting subtitle hiding for domino-style thumbnails. 
- Provide a small quality-of-life addition to save a local player flag and keep AI flag selection concise. 

### Description
- Replaced legacy `practice`/`duo`/`royale` table entries with `players-2`/`players-3`/`players-4` tiles, added `hideSubtitle` to `TABLES`, and simplified their `label` values in `webapp/src/pages/Games/LudoBattleRoyalLobby.jsx`. 
- Introduced `matchMode` state with Local/Online toggle UI and moved `TableSelector` into the Local panel; added `handleTableSelect` to sync `aiCount` when local. 
- Removed the old `aiType` flow, added a player flag picker (`playerFlag`) and `FlagPickerModal` hookup for saving a single player flag, and adjusted AI-flag behavior to use `buildAutoFlags`. 
- Propagated `mode` to the game route parameters and updated `LudoBattleRoyal.jsx` to compute `playerCount` and `aiCount` based on `mode === 'local'`. 
- Fixed `TableSelector.jsx` to respect `hideSubtitle` when rendering subtitles and trimmed imports to use `getTelegramFirstName()` for profile text. 

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported ready (succeeded). 
- Captured a headless screenshot of the lobby route using a Playwright script at viewport `430x932` and saved `artifacts/ludo-battle-royal-lobby.png` to validate the UI (succeeded). 
- Confirmed a local commit was created for the changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974db6a7dd48329ab21508c9b9afcb3)