### PR TITLE
Add achievements checklist and 4-up game thumbnails to Achievements card

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -1,16 +1,12 @@
+import gamesCatalog from '../config/gamesCatalog.js';
+import { getGameThumbnail } from '../config/gameAssets.js';
+
 export default function ProjectAchievementsCard() {
   const achievements = [
     '🧾 Wallet transaction history works',
     '💬 In-chat TPC transfers enabled',
-    '🎲 Snake & Ladder multiplayer game',
     '🧑‍🤝‍🤝 Friends and inbox chat',
     '🕹️ Telegram bot and web app integration',
-    '🥅 Goal Rush multiplayer',
-    '🎱 Pool Royale',
-    "🃏 Texas Hold'em",
-    '🁣 Domino Royal 3D',
-    '⚽ Free Kick',
-    '🂠 Murlan Royale',
     '🔄 Daily Check-In rewards',
     '⛏️ Mining system active',
     '📺 Ad watch rewards',
@@ -23,20 +19,129 @@ export default function ProjectAchievementsCard() {
     '⛏️ Mining transactions are public',
   ];
 
+  const roadmap = [
+    {
+      title: 'Mobile Launch',
+      description:
+        'Release the Playgram app on Android and iOS with the current 3D game lineup.',
+    },
+    {
+      title: 'Growth & Community',
+      description:
+        'Start the marketing campaign and launch an airdrop program for early users.',
+    },
+    {
+      title: 'TPC Tokenization',
+      description:
+        'Mint the official TPC token and finalize token utility across the ecosystem.',
+    },
+    {
+      title: 'Exchange Readiness',
+      description:
+        'Begin CEX outreach and prepare DEX liquidity provisioning.',
+    },
+    {
+      title: 'CEX + DEX Listings',
+      description:
+        'List on decentralized exchanges and finalize listings on major CEX partners.',
+    },
+    {
+      title: 'Next Phases',
+      description:
+        'Post-listing initiatives are in progress and will be announced after CEX/DEX milestones.',
+    },
+  ];
+
   return (
-    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-2 overflow-hidden wide-card">
+    <div className="relative rounded-2xl border border-border/70 bg-gradient-to-br from-surface/95 via-surface/90 to-surface/80 p-5 shadow-xl shadow-black/5 space-y-6 overflow-hidden wide-card">
       <img
         src="/assets/icons/snakes_and_ladders.webp"
-        className="background-behind-board object-cover"
+        className="background-behind-board object-cover opacity-30"
         alt=""
         onError={(e) => { e.currentTarget.style.display = 'none'; }}
       />
-      <h3 className="text-lg font-bold text-center">Playgram Achievements</h3>
-      <ul className="list-disc pl-6 text-sm space-y-1">
-        {achievements.map((a) => (
-          <li key={a}>{a}</li>
-        ))}
-      </ul>
+      <div className="space-y-2 text-center">
+        <p className="text-[10px] uppercase tracking-[0.4em] text-muted">Playgram</p>
+        <h3 className="text-xl font-semibold">Achievements & Roadmap</h3>
+        <p className="text-xs text-muted max-w-[28rem] mx-auto">
+          Progress highlights, core game lineup, and the next delivery milestones.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-border/60 bg-surface/80 p-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold">Delivered Achievements</h4>
+          <span className="text-[10px] uppercase tracking-[0.2em] text-muted/70">
+            live now
+          </span>
+        </div>
+        <ul className="mt-3 grid gap-2 text-xs text-muted sm:grid-cols-2">
+          {achievements.map((item) => (
+            <li key={item} className="rounded-lg border border-border/40 bg-surface/90 px-3 py-2">
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="rounded-xl border border-border/60 bg-surface/80 p-4 shadow-sm space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold">Live Game Lineup</h4>
+          <span className="text-[10px] uppercase tracking-[0.2em] text-muted/70">
+            full 3D focus
+          </span>
+        </div>
+        <p className="text-xs text-muted">
+          Pool Royale includes UK 8 Ball, 9 Ball, and American Billiards.
+        </p>
+        <div className="grid grid-cols-4 gap-2">
+          {gamesCatalog.map((game) => {
+            const thumbnail = getGameThumbnail(game.slug);
+            return (
+              <div
+                key={game.name}
+                className="flex flex-col items-center gap-1 rounded-lg border border-border/50 bg-surface/90 p-2 text-center"
+              >
+                <img
+                  src={thumbnail || game.image}
+                  alt={game.name}
+                  className="h-10 w-10 rounded-md object-cover"
+                  loading="lazy"
+                  onError={(event) => {
+                    event.currentTarget.src = game.image;
+                  }}
+                />
+                <span className="text-[9px] font-semibold text-muted">{game.name}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold">Roadmap (Next)</h4>
+          <span className="text-[10px] uppercase tracking-[0.2em] text-muted/70">
+            in progress
+          </span>
+        </div>
+        <ol className="space-y-3 text-xs text-muted">
+          {roadmap.map((step, index) => (
+            <li key={step.title} className="rounded-xl border border-border/70 bg-surface/70 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[10px] font-semibold text-muted/80">
+                  Phase {index + 1}
+                </span>
+                <span className="text-[10px] uppercase tracking-[0.2em] text-muted/60">
+                  upcoming
+                </span>
+              </div>
+              <p className="mt-1 text-sm font-semibold text-foreground">{step.title}</p>
+              <p className="text-xs text-muted">{step.description}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Restore the requested, explicit achievements checklist so the card matches current live features and stakeholder expectations. 
- Show the full game lineup using the same small thumbnails used elsewhere so the Games list is visually consistent and fits four items per row. 
- Call out Pool Royale variants (UK 8 Ball, 9 Ball, American Billiards) and keep the roadmap visible for delivery context. 

### Description
- Added imports for `gamesCatalog` and `getGameThumbnail` from `../config` and switched the card to render a flat `achievements` checklist using the exact items provided. 
- Replaced the previous grouped sections with a `Delivered Achievements` tile and a `Live Game Lineup` tile that renders a four-column grid of game thumbnails using `getGameThumbnail(game.slug)` with a fallback to `game.image` and an `onError` handler. 
- Introduced a `roadmap` array and a compact `Roadmap (Next)` section to preserve phase-based milestones. 
- Adjusted container/tailwind classes (spacing, rounded corners, gradient background, faded background image opacity) to produce a cleaner, modern presentation and ensure thumbnails render at `h-10 w-10` in a horizontal row of four. 

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (success). 
- Captured a mobile-viewport screenshot with Playwright at `430x932`, producing `artifacts/playgram-achievements.png` to validate layout and thumbnails (success). 
- No unit tests or lint runs were executed (`npm test` / `npm run lint` not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974edfc9f608329a12e467ebb110d46)