### PR TITLE
Remove Magazine 3D section from profile page

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -760,29 +760,6 @@ export default function MyAccount() {
           </Link>
         </div>
       </div>
-      <div className="prism-box p-4 mt-4 space-y-3 mx-auto wide-card">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold">Magazine 3D</h3>
-          <span className="text-xs text-subtext">Showroom</span>
-        </div>
-        <p className="text-sm text-subtext">
-          Explore the dedicated Magazine page with Poly Haven tables, chairs, and decor arranged by category.
-        </p>
-        <div className="rounded-lg border border-dashed border-border bg-surface/60 p-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div className="space-y-1">
-            <p className="font-medium text-sm">Open Magazine</p>
-            <p className="text-xs text-subtext">
-              Full-screen gallery with numbered tickets and original textures applied.
-            </p>
-          </div>
-          <Link
-            to="/magazine"
-            className="inline-flex items-center justify-center px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold"
-          >
-            Open
-          </Link>
-        </div>
-      </div>
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
         <>


### PR DESCRIPTION
### Motivation
- The Magazine 3D showroom card is not required on the user profile and should be removed to simplify the account view.

### Description
- Deleted the Magazine 3D card and its link from the profile layout in `webapp/src/pages/MyAccount.jsx` (removed the JSX block that linked to `/magazine`).

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite served the site at `http://localhost:4173`; an attempted Playwright screenshot failed because Chromium crashed so no screenshot was produced, and no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750b1543dc832985b4c7eeb08aecab)