### PR TITLE
Improve roulette visuals, hide lucky card faces until reveal, and add mining-page compositing hint

### DIFF
--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -170,32 +170,34 @@ export default function LuckyNumber() {
                 className="absolute inset-0 rounded-md flex items-center justify-center"
                 style={{ transform: 'rotateY(180deg)', backfaceVisibility: 'hidden' }}
               >
-                <div className="absolute inset-0 flex flex-col items-center justify-center text-xl font-bold">
-                  <span
-                    className={`${
-                      card.suit === 'hearts' || card.suit === 'diamonds'
-                        ? 'text-red-500'
-                        : 'text-black'
-                    }`}
-                  >
-                    {card.rank}
-                  </span>
-                  <span
-                    className={`text-2xl ${
-                      card.suit === 'hearts' || card.suit === 'diamonds'
-                        ? 'text-red-500'
-                        : 'text-black'
-                    }`}
-                  >
-                    {card.suit === 'hearts'
-                      ? '♥'
-                      : card.suit === 'spades'
-                      ? '♠'
-                      : card.suit === 'diamonds'
-                      ? '♦'
-                      : '♣'}
-                  </span>
-                </div>
+                {cardPrize && (
+                  <div className="absolute inset-0 flex flex-col items-center justify-center text-xl font-bold">
+                    <span
+                      className={`${
+                        card.suit === 'hearts' || card.suit === 'diamonds'
+                          ? 'text-red-500'
+                          : 'text-black'
+                      }`}
+                    >
+                      {card.rank}
+                    </span>
+                    <span
+                      className={`text-2xl ${
+                        card.suit === 'hearts' || card.suit === 'diamonds'
+                          ? 'text-red-500'
+                          : 'text-black'
+                      }`}
+                    >
+                      {card.suit === 'hearts'
+                        ? '♥'
+                        : card.suit === 'spades'
+                        ? '♠'
+                        : card.suit === 'diamonds'
+                        ? '♦'
+                        : '♣'}
+                    </span>
+                  </div>
+                )}
                 {selected === i && !cardPrize && (
                   <CardSpinner trigger={spinTrigger} onFinish={handleSpinFinish} />
                 )}

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -67,7 +67,7 @@ const RED_NUMBERS = new Set([
 ]);
 
 const SEGMENT_ANGLE = 360 / ROULETTE_ORDER.length;
-
+const LABEL_OFFSET_ANGLE = -90 + SEGMENT_ANGLE / 2;
 const PRIZE_MAP = ROULETTE_ORDER.reduce((acc, value) => {
   if (value === 0) acc[value] = 5000;
   else acc[value] = value * 100;
@@ -239,16 +239,16 @@ export default function RouletteMini() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
-      <div className="relative mx-auto w-64 h-64 sm:w-72 sm:h-72">
+      <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">
         <div className="absolute left-1/2 -translate-x-1/2 -top-3 z-20 flex flex-col items-center">
           <div className="w-0 h-0 border-l-[10px] border-r-[10px] border-b-[18px] border-l-transparent border-r-transparent border-b-yellow-400 drop-shadow" />
           <div className="w-2 h-2 bg-yellow-400 rounded-full mt-1" />
         </div>
         <div
-          className="relative w-full h-full rounded-full border-[6px] border-border shadow-inner flex items-center justify-center overflow-hidden"
+          className="relative w-full h-full rounded-full border-[3px] border-yellow-400/80 shadow-inner flex items-center justify-center overflow-hidden [--roulette-label-radius:120px] sm:[--roulette-label-radius:136px] will-change-transform"
           style={{
             background: wheelBackground,
-            transform: `rotate(${spinState.rotation}deg)`,
+            transform: `translateZ(0) rotate(${spinState.rotation}deg)`,
             transition: spinning
               ? 'transform 4.5s cubic-bezier(0.22, 1, 0.36, 1)'
               : 'transform 0s',
@@ -256,31 +256,33 @@ export default function RouletteMini() {
         >
           <div className="absolute inset-[6%] rounded-full border-2 border-red-500/80 pointer-events-none" />
           {ROULETTE_ORDER.map((num, idx) => {
-            const angle = idx * SEGMENT_ANGLE;
+            const angle = idx * SEGMENT_ANGLE + LABEL_OFFSET_ANGLE;
             const isWinning = outcome?.number === num;
             return (
               <div
                 key={num}
                 className="absolute top-1/2 left-1/2"
                 style={{
-                  transform: `rotate(${angle}deg) translateY(-48%)`,
+                  transform: `rotate(${angle}deg) translateY(calc(-1 * var(--roulette-label-radius)))`,
                   transformOrigin: '0 0',
                 }}
               >
                 <div
-                  className={`px-1 py-[1px] text-[11px] sm:text-xs font-bold rounded-full ${
+                  className={`px-1 py-[1px] text-[10px] sm:text-xs font-bold rounded-full ${
                     isWinning
                       ? 'bg-yellow-400 text-black shadow-lg'
                       : 'text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.85)]'
                   }`}
-                  style={{ transform: `rotate(${-angle}deg)` }}
+                  style={{
+                    transform: `translate(-50%, -50%) rotate(${-angle}deg)`,
+                  }}
                 >
                   {num}
                 </div>
               </div>
             );
           })}
-          <div className="absolute inset-[28%] rounded-full bg-surface/85 border border-border flex flex-col items-center justify-center text-xs text-subtext space-y-1">
+          <div className="absolute inset-[28%] rounded-full bg-surface/85 border border-yellow-400/80 flex flex-col items-center justify-center text-xs text-subtext space-y-1">
             <span className="uppercase tracking-wide">TPC Rewards</span>
             <span className="text-sm font-semibold text-white">
               {outcome ? `+${formatPrize(outcome.prize)} TPC` : 'Spin to win'}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -115,6 +115,12 @@ body.mining-page button {
   @apply text-white-shadow;
 }
 
+.mining-page-content {
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  will-change: transform;
+}
+
 input {
   border-color: #facc15;
   color: #facc15;

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -133,190 +133,199 @@ export default function Mining() {
 
   return (
     <>
-    <DailyCheckIn />
-    <SpinGame />
-    <LuckyNumber />
-    <RouletteMini />
-    <MiningCard />
-    <MiningTransactionsCard />
+      <div className="mining-page-content">
+        <DailyCheckIn />
+        <SpinGame />
+        <LuckyNumber />
+        <RouletteMini />
+        <MiningCard />
+        <MiningTransactionsCard />
 
-      <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
-      <img
-        src="/assets/icons/snakes_and_ladders.webp"
-        className="background-behind-board object-cover"
-        alt=""
-        onError={(e) => {
-          e.currentTarget.style.display = 'none';
-        }}
-      />
-        <h2 className="text-xl font-bold text-center text-white">Mining</h2>
+        <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
+          <img
+            src="/assets/icons/snakes_and_ladders.webp"
+            className="background-behind-board object-cover"
+            alt=""
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+          <h2 className="text-xl font-bold text-center text-white">Mining</h2>
 
-      {friendRequests.length > 0 && (
-        <section className="space-y-1">
-          <h3 className="text-lg font-semibold">Friend Requests</h3>
-          {friendRequests.map((fr) => (
-            <div key={fr._id} className="lobby-tile flex items-center justify-between">
-              <span>{fr.from}</span>
+          {friendRequests.length > 0 && (
+            <section className="space-y-1">
+              <h3 className="text-lg font-semibold">Friend Requests</h3>
+              {friendRequests.map((fr) => (
+                <div key={fr._id} className="lobby-tile flex items-center justify-between">
+                  <span>{fr.from}</span>
+                  <button
+                    onClick={async () => {
+                      await acceptFriendRequest(fr._id);
+                      listFriendRequests(telegramId).then(setFriendRequests);
+                    }}
+                    className="px-2 py-1 text-sm bg-primary hover:bg-primary-hover rounded"
+                  >
+                    Accept
+                  </button>
+                </div>
+              ))}
+            </section>
+          )}
+
+          <section className="space-y-1">
+            <h3 className="text-lg font-semibold">Referral</h3>
+            <p className="text-white text-outline-black">
+              Invited friends:{' '}
+              <span className="text-yellow-400 text-outline-black">
+                {referral.referralCount}
+              </span>
+            </p>
+            {totalBoost > 0 && (
+              <p className="text-white text-outline-black">
+                Mining boost:{' '}
+                <span className="text-yellow-400 text-outline-black">
+                  +{(totalBoost * 100).toFixed(0)}%
+                </span>
+              </p>
+            )}
+            {referral.storeMiningRate && referral.storeMiningExpiresAt && (
+              <p className="text-sm text-subtext">
+                Boost ends in {Math.max(
+                  0,
+                  Math.floor(
+                    (new Date(referral.storeMiningExpiresAt).getTime() - Date.now()) /
+                      86400000,
+                  ),
+                )}
+                d
+              </p>
+            )}
+          </section>
+
+          <section className="space-y-1">
+            <h3 className="text-lg font-semibold">Referral</h3>
+            <div className="flex items-center space-x-2">
+              <input
+                type="text"
+                readOnly
+                value={link}
+                onClick={(e) => e.target.select()}
+                className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+              />
               <button
-                onClick={async () => {
-                  await acceptFriendRequest(fr._id);
-                  listFriendRequests(telegramId).then(setFriendRequests);
-                }}
-                className="px-2 py-1 text-sm bg-primary hover:bg-primary-hover rounded"
+                onClick={() => navigator.clipboard.writeText(link)}
+                className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
               >
-                Accept
+                Copy
               </button>
             </div>
-          ))}
-        </section>
-      )}
+            <div className="flex items-center space-x-2 mt-2">
+              <input
+                type="text"
+                placeholder="Paste link or code"
+                value={claim}
+                onChange={(e) => setClaim(e.target.value)}
+                className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
+              />
+              <button
+                onClick={async () => {
+                  const c = claim.includes('start=') ? claim.split('start=')[1] : claim;
+                  try {
+                    const res = await claimReferral(telegramId, c.trim());
+                    if (!res.error) {
+                      setClaimMsg('Referral claimed!');
+                      getReferralInfo(telegramId).then(setReferral);
+                    } else {
+                      setClaimMsg(res.error || res.message || 'Failed');
+                    }
+                  } catch {
+                    setClaimMsg('Failed');
+                  }
+                }}
+                className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
+              >
+                Claim
+              </button>
+            </div>
+            {claimMsg && <p className="text-xs text-subtext">{claimMsg}</p>}
+          </section>
 
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold">Referral</h3>
-        <p className="text-white text-outline-black">
-          Invited friends:{' '}
-          <span className="text-yellow-400 text-outline-black">
-            {referral.referralCount}
-          </span>
-        </p>
-        {totalBoost > 0 && (
-          <p className="text-white text-outline-black">
-            Mining boost:{' '}
-            <span className="text-yellow-400 text-outline-black">
-              +{(totalBoost * 100).toFixed(0)}%
-            </span>
-          </p>
-        )}
-        {referral.storeMiningRate && referral.storeMiningExpiresAt && (
-          <p className="text-sm text-subtext">
-            Boost ends in {Math.max(0, Math.floor((new Date(referral.storeMiningExpiresAt).getTime() - Date.now()) / 86400000))}d
-          </p>
-        )}
-      </section>
-
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold">Referral</h3>
-        <div className="flex items-center space-x-2">
-          <input
-            type="text"
-            readOnly
-            value={link}
-            onClick={(e) => e.target.select()}
-            className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
-          />
-          <button
-            onClick={() => navigator.clipboard.writeText(link)}
-            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
-          >
-            Copy
-          </button>
+          <section className="space-y-1">
+            <h3 className="text-lg font-semibold text-center">Add Friends</h3>
+            <UserSearchBar />
+          </section>
         </div>
-        <div className="flex items-center space-x-2 mt-2">
-          <input
-            type="text"
-            placeholder="Paste link or code"
-            value={claim}
-            onChange={(e) => setClaim(e.target.value)}
-            className="flex-1 bg-surface border border-border rounded px-2 py-1 text-sm"
-          />
-          <button
-            onClick={async () => {
-              const c = claim.includes('start=') ? claim.split('start=')[1] : claim;
-              try {
-                const res = await claimReferral(telegramId, c.trim());
-                if (!res.error) {
-                  setClaimMsg('Referral claimed!');
-                  getReferralInfo(telegramId).then(setReferral);
+      </div>
+
+      <PlayerInvitePopup
+        open={!!inviteTarget}
+        player={inviteTarget}
+        stake={stake}
+        onStakeChange={setStake}
+        onInvite={() => {
+          if (inviteTarget) {
+            const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
+            socket.emit(
+              'invite1v1',
+              {
+                fromId: accountId,
+                fromName: myName,
+                toId: inviteTarget.accountId,
+                roomId,
+                token: stake.token,
+                amount: stake.amount,
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
                 } else {
-                  setClaimMsg(res.error || res.message || 'Failed');
+                  alert(res?.error || 'Failed to send invite');
                 }
-              } catch {
-                setClaimMsg('Failed');
-              }
-            }}
-            className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-sm text-white-shadow"
-          >
-            Claim
-          </button>
-        </div>
-        {claimMsg && <p className="text-xs text-subtext">{claimMsg}</p>}
-      </section>
-
-      <section className="space-y-1">
-        <h3 className="text-lg font-semibold text-center">Add Friends</h3>
-        <UserSearchBar />
-      </section>
-    </div>
-
-    <PlayerInvitePopup
-      open={!!inviteTarget}
-      player={inviteTarget}
-      stake={stake}
-      onStakeChange={setStake}
-      onInvite={() => {
-        if (inviteTarget) {
-          const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;
-          socket.emit(
-            'invite1v1',
-            {
-              fromId: accountId,
-              fromName: myName,
-              toId: inviteTarget.accountId,
-              roomId,
-              token: stake.token,
-              amount: stake.amount,
-            },
-            (res) => {
-              if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
-              } else {
-                alert(res?.error || 'Failed to send invite');
-              }
-            },
-          );
-        }
-        setInviteTarget(null);
-      }}
-      onClose={() => setInviteTarget(null)}
-    />
-    <InvitePopup
-      open={groupPopup}
-      name={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
-      stake={stake}
-      onStakeChange={setStake}
-      group
-      opponents={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
-      onAccept={() => {
-        if (selected.length > 0) {
-          const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
-          socket.emit(
-            'inviteGroup',
-            {
-              fromId: accountId,
-              fromName: myName,
-              toIds: selected.map((u) => u.accountId),
-              opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
-              roomId,
-              token: stake.token,
-              amount: stake.amount,
-            },
-            (res) => {
-              if (res && res.success) {
-                window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
-              } else {
-                alert(res?.error || 'Failed to send invite');
-              }
-            },
-          );
-        }
-        setGroupPopup(false);
-        setSelected([]);
-      }}
-      onReject={() => {
-        setGroupPopup(false);
-        setSelected([]);
-      }}
-    />
+              },
+            );
+          }
+          setInviteTarget(null);
+        }}
+        onClose={() => setInviteTarget(null)}
+      />
+      <InvitePopup
+        open={groupPopup}
+        name={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        stake={stake}
+        onStakeChange={setStake}
+        group
+        opponents={selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim())}
+        onAccept={() => {
+          if (selected.length > 0) {
+            const roomId = `invite-${accountId}-${Date.now()}-${selected.length + 1}`;
+            socket.emit(
+              'inviteGroup',
+              {
+                fromId: accountId,
+                fromName: myName,
+                toIds: selected.map((u) => u.accountId),
+                opponentNames: selected.map((u) => u.nickname || `${u.firstName || ''} ${u.lastName || ''}`.trim()),
+                roomId,
+                token: stake.token,
+                amount: stake.amount,
+              },
+              (res) => {
+                if (res && res.success) {
+                  window.location.href = `/games/snake?table=${roomId}&token=${stake.token}&amount=${stake.amount}`;
+                } else {
+                  alert(res?.error || 'Failed to send invite');
+                }
+              },
+            );
+          }
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+        onReject={() => {
+          setGroupPopup(false);
+          setSelected([]);
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the roulette wheel rings thinner and yellow and improve label placement so the wheel reads clearer and looks sharper at larger sizes. 
- Keep the lucky card face hidden until a prize is revealed so the card back (logo) is shown while spinning. 
- Add lightweight GPU/compositing hints for the Mining page to improve animation smoothness and help achieve stable 60fps on mobile.

### Description
- Updated `webapp/src/components/RouletteMini.jsx` to increase wheel size, use a thinner yellow outer border (`border-[3px] border-yellow-400/80`), add a yellow center ring, add `LABEL_OFFSET_ANGLE` and move labels slightly inward via `--roulette-label-radius`, switch label transforms to `translate(-50%, -50%) rotate(${-angle}deg)`, reduce label font, and add `translateZ(0)` + `will-change-transform` to the wheel container to encourage GPU compositing. 
- Changed `webapp/src/components/LuckyNumber.jsx` so card face content is gated by `cardPrize` and remains hidden until the prize is revealed, preserving the back/logo appearance during the spin. 
- Wrapped the mining page main content in a `.mining-page-content` container in `webapp/src/pages/Mining.jsx` to scope compositing hints and reflow, and kept existing UI sections intact with small layout cleanups. 
- Added `.mining-page-content { transform: translateZ(0); backface-visibility: hidden; will-change: transform; }` to `webapp/src/index.css` to hint the browser to promote the mining area to its own layer for smoother animations.

### Testing
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and it started successfully (Vite ready). — succeeded. 
- Captured mobile-viewport screenshots using Playwright after loading `/mining`, producing artifacts `artifacts/mining-roulette-yellow-rings.png` and `artifacts/mining-roulette-yellow-thin.png`; screenshots completed successfully. 
- No unit tests were run for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974fee0b29c8329a1ca9f83f5030127)