### PR TITLE
Add commentary + Chatterbox TTS system; improve Pool Royale AI placement, audio, and replay cue visibility

### DIFF
--- a/docs/commentary-tts-system.md
+++ b/docs/commentary-tts-system.md
@@ -1,0 +1,192 @@
+# Commentary + TTS System (Pool Royale / Snooker Royale)
+
+## Plan
+1. **Data-driven commentary**: store all lines as templates with placeholders per game mode.
+2. **Selection manager**: choose lines by event priority, cooldowns, and recent history.
+3. **Chatterbox TTS wrapper**: offline synthesis with caching + async queue.
+4. **Engine-agnostic API**: one `onEvent` call for gameplay; optional queueing.
+5. **Mobile optimization**: warm up common lines during idle/turn transitions.
+
+## Module structure
+```
+webapp/src/services/commentary/
+  commentaryDatabase.js     # Templates, priorities, cooldowns, event map
+  CommentaryManager.js      # Event -> line selection, spam controls, queueing
+  ChatterboxTtsService.js   # Chatterbox adapter wrapper + cache + async queue
+```
+
+## Commentary database format
+- `COMMENTARY_DATABASE.locales[locale].modes[modeId]` contains:
+  - `categories`: map of category id -> { priority, cooldownMs, lines[] }
+  - `eventMap`: eventType -> category id
+  - `defaultVoiceId`
+
+Example (shortened):
+```js
+{
+  schemaVersion: 1,
+  rules: { globalCooldownMs: [2000, 4000], historySize: 8 },
+  locales: {
+    en: {
+      modes: {
+        nineBall: {
+          defaultVoiceId: '9ball-energetic',
+          categories: {
+            breakDry: {
+              priority: 70,
+              cooldownMs: 6000,
+              lines: ['Dry break for {playerName}.']
+            }
+          },
+          eventMap: { 'break.dry': 'breakDry' }
+        }
+      }
+    }
+  }
+}
+```
+
+## Commentary selection logic
+- **Priority**: each category sets a priority (foul > match point > runout > pot).
+- **Cooldowns**:
+  - global cooldown range (2–4s), randomized per line
+  - per-category cooldown (3–8s typical)
+- **History suppression**: avoid repeating recent lines (default window: 8).
+- **Queueing**: multiple events can be queued; manager drains highest-priority event.
+- **Suppression flags**: `context.suppressCommentary`, `context.isReplay`, `context.isQuietPeriod`.
+
+### Pseudocode
+```pseudo
+function onEvent(mode, eventType, context):
+  category = lookupCategory(mode, eventType)
+  if cooldowns active or suppress flags -> return null
+  template = randomLineExcludingHistory(category)
+  text = fillPlaceholders(template, context)
+  if ttsService -> synthesize(text)
+  store history + timestamps
+  return selection
+```
+
+## Chatterbox TTS wrapper
+- **Inputs**: text + voiceId + speed/pitch/style + sampleRate.
+- **Outputs**: ArrayBuffer WAV (OGG optional).
+- **Caching**: key = hash(voiceId + normalizedText + settings).
+- **Async queue**: avoids blocking the render loop.
+- **Warm-up**: pre-generate common lines at match start or between turns.
+
+### Adapter contract
+```js
+adapter.synthesize({ text, voiceId, speed, pitch, style, sampleRate, format })
+  -> Promise<ArrayBuffer>
+```
+
+## Engine-agnostic API
+```ts
+onEvent(gameMode, eventType, context) -> {
+  text,
+  audio, // ArrayBuffer
+  categoryId,
+  priority
+}
+```
+
+## Event payload schemas (examples)
+- **9-ball pot**
+```json
+{
+  "eventType": "pot.legal",
+  "context": {
+    "playerName": "Ardi",
+    "ball": "3",
+    "positionQuality": "good",
+    "runCount": 4
+  }
+}
+```
+
+- **8-ball on the 8**
+```json
+{
+  "eventType": "eight.on",
+  "context": {
+    "playerName": "Lina",
+    "onEightBall": true,
+    "pocketBlocked": false
+  }
+}
+```
+
+- **American points**
+```json
+{
+  "eventType": "streak",
+  "context": {
+    "playerName": "Milo",
+    "currentPoints": 38,
+    "streak": 7,
+    "lead": "+12"
+  }
+}
+```
+
+- **Snooker break**
+```json
+{
+  "eventType": "break",
+  "context": {
+    "playerName": "Dana",
+    "breakPoints": 56,
+    "remainingReds": 3,
+    "needsSnookers": false
+  }
+}
+```
+
+## Example lines (tone + variety)
+### 9-ball (samples)
+- "Dry break for {playerName}. That opens the door."
+- "Ball down on the break. Nice start for {playerName}."
+- "Combination play—{playerName} threads the {ball} in."
+- "Cue ball scratch! A gift for {opponentName}."
+- "Hill-hill tension—every shot matters now."
+- "{playerName} strings {streak} in a row. Runout threat."
+- "Lovely leave. {playerName} has a clear view."
+- "A miss on the {ball}; the table opens."
+- "Strong safety. {opponentName} can barely see it."
+- "Nice shot."
+
+### 8-ball (samples)
+- "Open table after the break—choices everywhere."
+- "Groups assigned. {playerName} is on {ball}."
+- "That was the key ball. The 8 is now in sight."
+- "On the 8-ball now. Big moment for {playerName}."
+- "Lock-up safety. {opponentName} is tied up."
+- "No rail—foul called. {opponentName} gets ball in hand."
+- "Pocket blocked. {playerName} may need a bank."
+- "Missed opportunity—{opponentName} has a chance."
+- "Smooth stroke."
+- "Tough angle."
+
+### American billiards (samples)
+- "{playerName} adds {points} points to the tally."
+- "{playerName} is on a {streak}-ball run."
+- "Milestone hit: {points} on the card for {playerName}."
+- "Textbook position from {playerName}."
+- "That miss sells out big points."
+- "Safety exchange continues. {playerName} keeps it tight."
+- "Lead change—{playerName} now ahead by {lead}."
+- "Clock pressure—{playerName} needs a quick decision."
+- "Well played."
+- "Steady pace."
+
+### Snooker (samples)
+- "{playerName} moves to {breakPoints} in the break."
+- "Century watch—{breakPoints} on the scoreboard."
+- "Reds and blacks flowing for {playerName}."
+- "Excellent safety—{opponentName} needs an escape."
+- "Foul: {foulType}. {points} points to {opponentName}."
+- "Frame ball now. {playerName} can close it out."
+- "Long pot attempt—{difficulty} difficulty."
+- "That one stays out. Chance for {opponentName}."
+- "Lovely cueing."
+- "Tactical moment."

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12628,7 +12628,7 @@ const powerRef = useRef(hud.power);
     const ctx = audioContextRef.current;
     const buffer = audioBuffersRef.current.ball;
     if (!ctx || !buffer || muteRef.current) return;
-    const scaled = clamp(vol * volumeRef.current * 0.9, 0, 1);
+    const scaled = clamp(vol * volumeRef.current, 0, 1);
     if (scaled <= 0) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
@@ -19813,6 +19813,53 @@ const powerRef = useRef(hud.power);
         }
         return true;
       };
+      const inHandTemp = {
+        seg: new THREE.Vector2(),
+        toPoint: new THREE.Vector2(),
+        closest: new THREE.Vector2()
+      };
+      const distanceToSegment = (point, start, end) => {
+        if (!point || !start || !end) return Infinity;
+        inHandTemp.seg.copy(end).sub(start);
+        const segLenSq = inHandTemp.seg.lengthSq();
+        if (segLenSq < 1e-8) return point.distanceTo(start);
+        inHandTemp.toPoint.copy(point).sub(start);
+        const t = THREE.MathUtils.clamp(
+          inHandTemp.toPoint.dot(inHandTemp.seg) / segLenSq,
+          0,
+          1
+        );
+        inHandTemp.closest.copy(start).add(inHandTemp.seg.multiplyScalar(t));
+        return point.distanceTo(inHandTemp.closest);
+      };
+      const hasClearLineOfSight = (from, to, targetBall, clearanceMultiplier = 2.05) => {
+        const clearance = BALL_R * clearanceMultiplier;
+        for (const ball of balls) {
+          if (!ball.active || ball === cue || ball === targetBall) continue;
+          const distance = distanceToSegment(ball.pos, from, to);
+          if (distance <= clearance) return false;
+        }
+        return true;
+      };
+      const scoreAiInHandPlacement = (candidate, clearanceMultiplier = 2.05) => {
+        let clearCount = 0;
+        let bestShotScore = -Infinity;
+        let nearest = Infinity;
+        for (const ball of balls) {
+          if (!ball.active || ball === cue) continue;
+          const dist = candidate.distanceTo(ball.pos);
+          if (dist < nearest) nearest = dist;
+          if (dist <= BALL_R * 2.05) continue;
+          if (!hasClearLineOfSight(candidate, ball.pos, ball, clearanceMultiplier)) continue;
+          clearCount += 1;
+          const shotScore = 1 / Math.max(dist, 1e-3);
+          if (shotScore > bestShotScore) bestShotScore = shotScore;
+        }
+        const spacingScore = Number.isFinite(nearest) ? nearest / (BALL_R * 2) : 0;
+        const totalScore =
+          clearCount * 12 + (bestShotScore > -Infinity ? bestShotScore * 6 : 0) + spacingScore;
+        return { totalScore, clearCount, spacingScore };
+      };
       const clampInHandPosition = (point) => {
         if (!point) return null;
         const clamped = point.clone();
@@ -19876,7 +19923,7 @@ const powerRef = useRef(hud.power);
         }
       }
       return true;
-    };
+      };
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
         const forwardBias = Math.max(baulkZ - BALL_R * 0.6, -PLAY_H / 2 + BALL_R);
@@ -19944,87 +19991,34 @@ const powerRef = useRef(hud.power);
           gridCandidates,
           jitterCandidates
         ];
-        const clearanceLevels = [2.15, 2.1, 2.05, 2.02, 2.0];
-        for (const clearance of clearanceLevels) {
-          for (const group of candidateGroups) {
-            for (const raw of group) {
-              const clamped = clampInHandPosition(raw);
-              if (!clamped) continue;
-              if (!isSpotFree(clamped, clearance)) continue;
-              return clamped;
-            }
-          }
-        }
-        let best = null;
-        let bestGap = -Infinity;
+        const clearanceLevels = [2.15, 2.1, 2.05, 2.02, 2.0, 1.95, 1.9];
         const combined = candidateGroups.flat();
-        for (const raw of combined) {
-          const clamped = clampInHandPosition(raw);
-          if (!clamped) continue;
-          let minDist = Infinity;
-          for (const ball of balls) {
-            if (!ball.active || ball === cue) continue;
-            const dist = clamped.distanceTo(ball.pos);
-            if (dist < minDist) minDist = dist;
+        let best = null;
+        let bestScore = -Infinity;
+        let bestClearCount = -1;
+        for (const clearance of clearanceLevels) {
+          for (const raw of combined) {
+            const clamped = clampInHandPosition(raw);
+            if (!clamped) continue;
+            if (!isSpotFree(clamped, clearance)) continue;
+            const { totalScore, clearCount } = scoreAiInHandPlacement(
+              clamped,
+              clearance
+            );
+            if (
+              clearCount > bestClearCount ||
+              (clearCount === bestClearCount && totalScore > bestScore)
+            ) {
+              best = clamped;
+              bestScore = totalScore;
+              bestClearCount = clearCount;
+            }
           }
-          if (minDist > bestGap) {
-            bestGap = minDist;
-            best = clamped;
-          }
-        }
-        if (best) {
-          if (bestGap < BALL_R * 2.02) {
-            let nearest = null;
-            let nearestDist = Infinity;
-            for (const ball of balls) {
-              if (!ball.active || ball === cue) continue;
-              const dist = best.distanceTo(ball.pos);
-              if (dist < nearestDist) {
-                nearestDist = dist;
-                nearest = ball;
-              }
-            }
-            if (nearest) {
-              const offset = best.clone().sub(nearest.pos);
-              if (offset.lengthSq() < 1e-6) {
-                offset.set(1, 0);
-              }
-              offset.setLength(BALL_R * 2.05);
-              const nudged = clampInHandPosition(
-                nearest.pos.clone().add(offset)
-              );
-              if (nudged && isSpotFree(nudged, 2.02)) {
-                return nudged;
-              }
-            }
-            const searchDirs = [
-              [1, 0],
-              [-1, 0],
-              [0, 1],
-              [0, -1],
-              [Math.SQRT1_2, Math.SQRT1_2],
-              [Math.SQRT1_2, -Math.SQRT1_2],
-              [-Math.SQRT1_2, Math.SQRT1_2],
-              [-Math.SQRT1_2, -Math.SQRT1_2]
-            ];
-            const stepSize = BALL_R * 0.45;
-            const maxSteps = 10;
-            for (const [dx, dz] of searchDirs) {
-              for (let stepIdx = 1; stepIdx <= maxSteps; stepIdx++) {
-                TMP_VEC2_A.copy(best);
-                TMP_VEC2_A.x += dx * stepSize * stepIdx;
-                TMP_VEC2_A.y += dz * stepSize * stepIdx;
-                const candidate = clampInHandPosition(TMP_VEC2_A);
-                if (!candidate) continue;
-                if (isSpotFree(candidate, 2.02)) {
-                  return candidate;
-                }
-              }
-            }
-          } else {
+          if (best && bestClearCount > 0) {
             return best;
           }
         }
+        if (best) return best;
         const fallback = allowFullTableInHand()
           ? defaultInHandPosition()
           : clampInHandPosition(new THREE.Vector2(0, forwardBias));
@@ -23187,7 +23181,9 @@ const powerRef = useRef(hud.power);
               ? THREE.MathUtils.clamp((targetTime - frameA.t) / span, 0, 1)
               : 0;
             const hasCueSnapshot = applyReplayFrame(frameA, frameB, alpha);
-            if (!hasCueSnapshot) {
+            if (playback.cueStroke) {
+              applyReplayCueStroke(playback, targetTime);
+            } else if (!hasCueSnapshot) {
               applyReplayCueStroke(playback, targetTime);
             }
             updateReplayTrail(playback.cuePath, targetTime);

--- a/webapp/src/services/commentary/ChatterboxTtsService.js
+++ b/webapp/src/services/commentary/ChatterboxTtsService.js
@@ -1,0 +1,149 @@
+const DEFAULT_SAMPLE_RATE = 24000;
+const DEFAULT_FORMAT = 'wav';
+const DEFAULT_MAX_LENGTH = 140;
+
+const normalizeText = (text, maxLength = DEFAULT_MAX_LENGTH) => {
+  if (!text) return '';
+  const compact = text
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .trim();
+  if (compact.length <= maxLength) return compact;
+  return compact.slice(0, Math.max(0, maxLength - 1)).trimEnd() + '…';
+};
+
+const fnv1a = (value) => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = (hash + (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)) >>> 0;
+  }
+  return hash.toString(16);
+};
+
+export class MemoryAudioCache {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  get(key) {
+    return this.cache.get(key) ?? null;
+  }
+
+  set(key, value) {
+    this.cache.set(key, value);
+  }
+}
+
+export class ChatterboxTtsService {
+  constructor({
+    adapter,
+    cache = new MemoryAudioCache(),
+    sampleRate = DEFAULT_SAMPLE_RATE,
+    format = DEFAULT_FORMAT,
+    maxTextLength = DEFAULT_MAX_LENGTH,
+    concurrency = 1
+  } = {}) {
+    this.adapter = adapter;
+    this.cache = cache;
+    this.sampleRate = sampleRate;
+    this.format = format;
+    this.maxTextLength = maxTextLength;
+    this.concurrency = Math.max(1, concurrency);
+    this.activeCount = 0;
+    this.queue = [];
+  }
+
+  buildCacheKey({ voiceId, text, speed, pitch, style, sampleRate, format }) {
+    const payload = JSON.stringify({
+      voiceId: voiceId ?? 'default',
+      text,
+      speed: Number.isFinite(speed) ? speed : 1,
+      pitch: Number.isFinite(pitch) ? pitch : 0,
+      style: style ?? 'neutral',
+      sampleRate: sampleRate ?? this.sampleRate,
+      format: format ?? this.format
+    });
+    return fnv1a(payload);
+  }
+
+  enqueue(task) {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ task, resolve, reject });
+      this.processQueue();
+    });
+  }
+
+  processQueue() {
+    if (this.activeCount >= this.concurrency) return;
+    const next = this.queue.shift();
+    if (!next) return;
+    this.activeCount += 1;
+    Promise.resolve()
+      .then(next.task)
+      .then((result) => next.resolve(result))
+      .catch((error) => next.reject(error))
+      .finally(() => {
+        this.activeCount -= 1;
+        this.processQueue();
+      });
+  }
+
+  async synthesize({
+    text,
+    voiceId,
+    speed = 1,
+    pitch = 0,
+    style = 'neutral',
+    sampleRate = this.sampleRate,
+    format = this.format
+  }) {
+    if (!this.adapter?.synthesize) {
+      throw new Error('Chatterbox adapter missing. Provide an adapter with synthesize().');
+    }
+    const normalizedText = normalizeText(text, this.maxTextLength);
+    const cacheKey = this.buildCacheKey({
+      voiceId,
+      text: normalizedText,
+      speed,
+      pitch,
+      style,
+      sampleRate,
+      format
+    });
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return { ...cached, cacheKey, fromCache: true };
+    }
+    const task = async () => {
+      const audio = await this.adapter.synthesize({
+        text: normalizedText,
+        voiceId,
+        speed,
+        pitch,
+        style,
+        sampleRate,
+        format
+      });
+      const payload = { audio, format, sampleRate };
+      this.cache.set(cacheKey, payload);
+      return { ...payload, cacheKey, fromCache: false };
+    };
+    return this.enqueue(task);
+  }
+
+  async warmUp(lines = [], options = {}) {
+    const jobs = lines.map((text) =>
+      this.synthesize({
+        text,
+        voiceId: options.voiceId,
+        speed: options.speed,
+        pitch: options.pitch,
+        style: options.style,
+        sampleRate: options.sampleRate,
+        format: options.format
+      })
+    );
+    return Promise.allSettled(jobs);
+  }
+}

--- a/webapp/src/services/commentary/CommentaryManager.js
+++ b/webapp/src/services/commentary/CommentaryManager.js
@@ -1,0 +1,165 @@
+import { COMMENTARY_DATABASE, COMMENTARY_DEFAULT_VOICES } from './commentaryDatabase.js';
+
+const DEFAULT_HISTORY_SIZE = COMMENTARY_DATABASE.rules.historySize ?? 8;
+const DEFAULT_GLOBAL_COOLDOWN = COMMENTARY_DATABASE.rules.globalCooldownMs ?? [2000, 4000];
+const DEFAULT_MAX_TEXT = COMMENTARY_DATABASE.rules.maxTextLength ?? 140;
+
+const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+const randomBetween = (minMs, maxMs) => {
+  const min = Number.isFinite(minMs) ? minMs : 0;
+  const max = Number.isFinite(maxMs) ? maxMs : min;
+  if (max <= min) return min;
+  return Math.floor(min + Math.random() * (max - min));
+};
+
+const resolvePlaceholders = (template, context) => {
+  if (!template) return '';
+  const fallback = context?.fallback ?? '—';
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = context?.[key];
+    if (value == null || value === '') return fallback;
+    return String(value);
+  });
+};
+
+const normalizeText = (text, maxLength = DEFAULT_MAX_TEXT) => {
+  if (!text) return '';
+  const compact = text
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .trim();
+  if (compact.length <= maxLength) return compact;
+  return compact.slice(0, Math.max(0, maxLength - 1)).trimEnd() + '…';
+};
+
+export class CommentaryManager {
+  constructor({
+    locale = 'en',
+    database = COMMENTARY_DATABASE,
+    ttsService = null,
+    historySize = DEFAULT_HISTORY_SIZE,
+    globalCooldownMs = DEFAULT_GLOBAL_COOLDOWN
+  } = {}) {
+    this.locale = locale;
+    this.database = database;
+    this.ttsService = ttsService;
+    this.historySize = historySize;
+    this.globalCooldownMs = globalCooldownMs;
+    this.history = [];
+    this.categoryCooldowns = new Map();
+    this.lastGlobalTime = 0;
+    this.queue = [];
+  }
+
+  queueEvent(gameMode, eventType, context = {}) {
+    this.queue.push({ gameMode, eventType, context, queuedAt: nowMs() });
+  }
+
+  drainQueue() {
+    if (this.queue.length === 0) return null;
+    const queued = [...this.queue];
+    this.queue = [];
+    let best = null;
+    let bestPriority = -Infinity;
+    for (const entry of queued) {
+      const { category } = this.resolveCategory(entry.gameMode, entry.eventType) ?? {};
+      const priority = category?.priority ?? 0;
+      if (priority > bestPriority) {
+        bestPriority = priority;
+        best = entry;
+      }
+    }
+    return best;
+  }
+
+  resolveCategory(gameMode, eventType) {
+    const localeData = this.database.locales?.[this.locale];
+    const modeData = localeData?.modes?.[gameMode];
+    if (!modeData) return null;
+    const categoryId = modeData.eventMap?.[eventType] ?? eventType;
+    const category = modeData.categories?.[categoryId];
+    if (!category) return null;
+    return { category, categoryId, modeData };
+  }
+
+  shouldSuppress(categoryId, category, context) {
+    if (context?.suppressCommentary) return true;
+    if (context?.isReplay) return true;
+    if (context?.isQuietPeriod) return true;
+    const now = nowMs();
+    const lastGlobal = this.lastGlobalTime ?? 0;
+    const [minGlobal, maxGlobal] = this.globalCooldownMs;
+    const globalCooldown = randomBetween(minGlobal, maxGlobal);
+    if (now - lastGlobal < globalCooldown) return true;
+    const lastCategory = this.categoryCooldowns.get(categoryId) ?? 0;
+    const categoryCooldown =
+      category?.cooldownMs ?? this.database.rules?.defaultCategoryCooldownMs ?? 0;
+    if (now - lastCategory < categoryCooldown) return true;
+    return false;
+  }
+
+  pickTemplate(categoryId, category, context) {
+    const lines = Array.isArray(category?.lines) ? category.lines : [];
+    if (lines.length === 0) return null;
+    const historySet = new Set(this.history.map((entry) => entry.lineId));
+    const available = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ index }) => !historySet.has(`${categoryId}:${index}`));
+    const pool = available.length > 0 ? available : lines.map((line, index) => ({ line, index }));
+    const choice = pool[Math.floor(Math.random() * pool.length)];
+    return choice ? { line: choice.line, index: choice.index } : null;
+  }
+
+  recordHistory(categoryId, index, text) {
+    this.history.unshift({ lineId: `${categoryId}:${index}`, text, at: nowMs() });
+    if (this.history.length > this.historySize) {
+      this.history.length = this.historySize;
+    }
+  }
+
+  selectLine(gameMode, eventType, context = {}) {
+    const resolved = this.resolveCategory(gameMode, eventType);
+    if (!resolved) return null;
+    const { category, categoryId, modeData } = resolved;
+    if (this.shouldSuppress(categoryId, category, context)) return null;
+    const template = this.pickTemplate(categoryId, category, context);
+    if (!template) return null;
+    const filled = resolvePlaceholders(template.line, context);
+    const text = normalizeText(filled, this.database.rules?.maxTextLength ?? DEFAULT_MAX_TEXT);
+    const now = nowMs();
+    this.lastGlobalTime = now;
+    this.categoryCooldowns.set(categoryId, now);
+    this.recordHistory(categoryId, template.index, text);
+    return {
+      text,
+      categoryId,
+      mode: modeData?.label ?? gameMode,
+      priority: category?.priority ?? 0
+    };
+  }
+
+  async onEvent(gameMode, eventType, context = {}) {
+    const selection = this.selectLine(gameMode, eventType, context);
+    if (!selection) return null;
+    if (!this.ttsService) return selection;
+    const voiceId =
+      context.voiceId || COMMENTARY_DEFAULT_VOICES[gameMode] || selection.voiceId || 'default';
+    const audio = await this.ttsService.synthesize({
+      text: selection.text,
+      voiceId,
+      speed: context.speed,
+      pitch: context.pitch,
+      style: context.style
+    });
+    return { ...selection, audio };
+  }
+
+  async handleQueuedEvents() {
+    const event = this.drainQueue();
+    if (!event) return null;
+    return this.onEvent(event.gameMode, event.eventType, event.context);
+  }
+}
+
+export const createCommentaryManager = (options = {}) => new CommentaryManager(options);

--- a/webapp/src/services/commentary/commentaryDatabase.js
+++ b/webapp/src/services/commentary/commentaryDatabase.js
@@ -1,0 +1,543 @@
+export const COMMENTARY_DATABASE = {
+  schemaVersion: 1,
+  rules: {
+    globalCooldownMs: [2000, 4000],
+    historySize: 8,
+    maxTextLength: 140,
+    defaultCategoryCooldownMs: 4500
+  },
+  locales: {
+    en: {
+      modes: {
+        nineBall: {
+          label: '9-Ball',
+          defaultVoiceId: '9ball-energetic',
+          categories: {
+            breakDry: {
+              priority: 70,
+              cooldownMs: 6000,
+              lines: [
+                'Dry break for {playerName}. That opens the door.',
+                '{playerName} comes up empty on the break.',
+                'No balls down on the break. {opponentName} will fancy this.',
+                'A quiet break—nothing drops for {playerName}.'
+              ]
+            },
+            breakMade: {
+              priority: 72,
+              cooldownMs: 6000,
+              lines: [
+                '{playerName} pockets a ball on the break.',
+                'A productive break—{playerName} stays at the table.',
+                'Ball down on the break. Nice start for {playerName}.',
+                '{playerName} gets one to go and keeps control.'
+              ]
+            },
+            breakScratch: {
+              priority: 85,
+              cooldownMs: 7000,
+              lines: [
+                'Scratch on the break. Ball in hand for {opponentName}.',
+                '{playerName} loses the cue ball on the break—costly.',
+                'Break scratch! Big swing to {opponentName}.'
+              ]
+            },
+            legalPot: {
+              priority: 60,
+              cooldownMs: 3200,
+              lines: [
+                '{playerName} buries the {ball} with authority.',
+                'Clean pot on the {ball} by {playerName}.',
+                '{playerName} makes the {ball}—textbook.',
+                'That {ball} drops and the run continues.',
+                'Solid pot from {playerName}; cue ball stays in play.',
+                '{playerName} knocks in the {ball} on a {shotType}.'
+              ]
+            },
+            comboCarom: {
+              priority: 65,
+              cooldownMs: 4200,
+              lines: [
+                'Combination play—{playerName} threads the {ball} in.',
+                'Nice carom! {playerName} nudges the {ball} home.',
+                'A clever combo sends the {ball} down.',
+                '{playerName} manufactures it with a combo on the {ball}.'
+              ]
+            },
+            miss: {
+              priority: 40,
+              cooldownMs: 2800,
+              lines: [
+                'That one rattles out. {opponentName} gets a look.',
+                '{playerName} overcuts the {ball} and leaves a chance.',
+                'Undercut there—no pot for {playerName}.',
+                'A miss on the {ball}; the table opens.',
+                'Just misses the {ball}. Pressure flips.'
+              ]
+            },
+            positionGood: {
+              priority: 52,
+              cooldownMs: 3200,
+              lines: [
+                'Lovely leave. {playerName} has a clear view.',
+                'Perfect position—{playerName} lines up the next {ball}.',
+                'Great control from {playerName}; cue ball exactly where needed.'
+              ]
+            },
+            positionBad: {
+              priority: 45,
+              cooldownMs: 3200,
+              lines: [
+                'Not the best leave. {playerName} is awkward now.',
+                'Cue ball drifts into trouble for {playerName}.',
+                'That position is tough—{playerName} may need a rescue.'
+              ]
+            },
+            positionHooked: {
+              priority: 55,
+              cooldownMs: 4200,
+              lines: [
+                'Hooked behind a ball—{playerName} is snookered.',
+                '{playerName} loses the angle and sits hooked.',
+                'Cue ball buried. {playerName} faces a jump or safety.'
+              ]
+            },
+            safetyGood: {
+              priority: 58,
+              cooldownMs: 4200,
+              lines: [
+                'Strong safety. {opponentName} can barely see it.',
+                '{playerName} locks it up and forces a difficult reply.',
+                'Excellent safety—{opponentName} is in a bind.'
+              ]
+            },
+            safetyFailed: {
+              priority: 46,
+              cooldownMs: 3800,
+              lines: [
+                'Safety fails—{opponentName} gets a clean look.',
+                '{playerName} leaves an opening on the {ball}.',
+                'Not enough cover. {opponentName} has a shot.'
+              ]
+            },
+            foul: {
+              priority: 90,
+              cooldownMs: 6500,
+              lines: [
+                'Foul called: {foulType}. Ball in hand to {opponentName}.',
+                'Illegal contact—{opponentName} will take ball in hand.',
+                'Cue ball scratch! A gift for {opponentName}.',
+                'Push out or foul? That is ruled a {foulType}.'
+              ]
+            },
+            pressure: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'Hill-hill tension—every shot matters now.',
+                'Match ball on the table. {playerName} must hold nerve.',
+                '{playerName} is chasing a comeback at {lead} down.'
+              ]
+            },
+            runout: {
+              priority: 80,
+              cooldownMs: 6500,
+              lines: [
+                '{playerName} strings {streak} in a row. Runout threat.',
+                'Nearly perfect control from {playerName}.',
+                'Clean finish loading—{playerName} sees the 9.'
+              ]
+            },
+            short: {
+              priority: 20,
+              cooldownMs: 2400,
+              lines: [
+                'Nice shot.',
+                'Good pace.',
+                'Great control.',
+                'Pressure moment.'
+              ]
+            }
+          },
+          eventMap: {
+            'break.dry': 'breakDry',
+            'break.made': 'breakMade',
+            'break.scratch': 'breakScratch',
+            'pot.legal': 'legalPot',
+            'pot.combo': 'comboCarom',
+            'pot.carom': 'comboCarom',
+            'miss.rattle': 'miss',
+            'miss.overcut': 'miss',
+            'miss.undercut': 'miss',
+            'position.good': 'positionGood',
+            'position.bad': 'positionBad',
+            'position.hooked': 'positionHooked',
+            'safety.good': 'safetyGood',
+            'safety.failed': 'safetyFailed',
+            'foul': 'foul',
+            'pressure.hill': 'pressure',
+            'pressure.match': 'pressure',
+            'comeback': 'pressure',
+            'runout.streak': 'runout',
+            'runout.clean': 'runout',
+            'short': 'short'
+          }
+        },
+        eightBall: {
+          label: '8-Ball',
+          defaultVoiceId: '8ball-classic',
+          categories: {
+            breakOpen: {
+              priority: 68,
+              cooldownMs: 6000,
+              lines: [
+                'Open table after the break—choices everywhere.',
+                'Break opens the table. {playerName} can choose a group.',
+                'Clusters loosen up—this table is wide open.',
+                '{playerName} spreads them nicely on the break.'
+              ]
+            },
+            breakThreat: {
+              priority: 75,
+              cooldownMs: 6500,
+              lines: [
+                'Early 8-ball drama—{playerName} has a look but must be careful.',
+                'The 8 sits near a pocket already. Danger signs.',
+                'Break leaves the 8-ball temptingly close to a pocket.'
+              ]
+            },
+            groupChosen: {
+              priority: 70,
+              cooldownMs: 5200,
+              lines: [
+                '{playerName} takes {shotType} and claims {ball}.',
+                '{playerName} settles on {shotType}—that is the group.',
+                'Groups assigned. {playerName} is on {ball}.'
+              ]
+            },
+            clearSet: {
+              priority: 65,
+              cooldownMs: 5200,
+              lines: [
+                '{playerName} is clearing the set nicely.',
+                'That is another in the set for {playerName}.',
+                'The set is thinning—{playerName} is in rhythm.'
+              ]
+            },
+            keyBall: {
+              priority: 72,
+              cooldownMs: 6000,
+              lines: [
+                'Key ball down—{playerName} is lining up the 8.',
+                'That was the key ball. The 8 is now in sight.',
+                '{playerName} solves the key ball problem.'
+              ]
+            },
+            onEight: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'On the 8-ball now. Big moment for {playerName}.',
+                '{playerName} lines up the 8—match point pressure.',
+                'Everything rides on the 8 here.'
+              ]
+            },
+            defenseGood: {
+              priority: 58,
+              cooldownMs: 4200,
+              lines: [
+                'Lock-up safety. {opponentName} is tied up.',
+                '{playerName} plays the lock and freezes the table.',
+                'A tidy safety—{opponentName} has no clear pocket.'
+              ]
+            },
+            defenseCluster: {
+              priority: 60,
+              cooldownMs: 4500,
+              lines: [
+                '{playerName} nudges the cluster open—smart timing.',
+                'Great cluster break. That opens the run.',
+                'The cluster is gone. {playerName} can run now.'
+              ]
+            },
+            foul: {
+              priority: 90,
+              cooldownMs: 6500,
+              lines: [
+                'Foul on {playerName}: {foulType}. Ball in hand.',
+                'Scratch! {opponentName} takes control.',
+                'Illegal 8-ball contact—big mistake.',
+                'No rail—foul called. {opponentName} gets ball in hand.'
+              ]
+            },
+            tactical: {
+              priority: 55,
+              cooldownMs: 3800,
+              lines: [
+                'Wrong side of the ball—this is tricky now.',
+                'Pocket blocked. {playerName} may need a bank.',
+                '{playerName} is forced to go two rails here.'
+              ]
+            },
+            miss: {
+              priority: 42,
+              cooldownMs: 2800,
+              lines: [
+                'That one hangs in the jaws.',
+                'Missed opportunity—{opponentName} has a chance.',
+                '{playerName} overcuts it and leaves the table open.',
+                'A miss at the worst time for {playerName}.',
+                'Rattled in the pocket. It stays up.'
+              ]
+            },
+            short: {
+              priority: 20,
+              cooldownMs: 2400,
+              lines: [
+                'Nice touch.',
+                'Good call.',
+                'Smooth stroke.',
+                'Tough angle.'
+              ]
+            }
+          },
+          eventMap: {
+            'break.open': 'breakOpen',
+            'break.threat': 'breakThreat',
+            'group.chosen': 'groupChosen',
+            'set.clear': 'clearSet',
+            'key.ball': 'keyBall',
+            'eight.on': 'onEight',
+            'pressure.match': 'onEight',
+            'defense.lock': 'defenseGood',
+            'defense.cluster': 'defenseCluster',
+            'foul': 'foul',
+            'tactical.blocked': 'tactical',
+            'tactical.wrongside': 'tactical',
+            'miss': 'miss',
+            'short': 'short'
+          }
+        },
+        american: {
+          label: 'American Billiards',
+          defaultVoiceId: 'american-analyst',
+          categories: {
+            score: {
+              priority: 70,
+              cooldownMs: 4200,
+              lines: [
+                '{playerName} adds {points} points to the tally.',
+                'That brings {playerName} to {points} for the run.',
+                '{playerName} pockets another and builds the count.',
+                'Nice scoring touch—{points} more on the board.',
+                '{playerName} keeps the points flowing.'
+              ]
+            },
+            streak: {
+              priority: 78,
+              cooldownMs: 5200,
+              lines: [
+                '{playerName} is on a {streak}-ball run.',
+                'Streak at {streak} and climbing for {playerName}.',
+                'That is {streak} in a row—real rhythm.',
+                '{playerName} strings them together with ease.'
+              ]
+            },
+            milestone: {
+              priority: 82,
+              cooldownMs: 6200,
+              lines: [
+                '{playerName} reaches {points} points—big milestone.',
+                'There is {points} for {playerName}. A strong mark.',
+                'Milestone hit: {points} on the card for {playerName}.'
+              ]
+            },
+            position: {
+              priority: 60,
+              cooldownMs: 3600,
+              lines: [
+                'Textbook position from {playerName}.',
+                'Two-rail route executed perfectly.',
+                '{playerName} stays in line with the pattern.',
+                'Clean pattern play keeps the run alive.'
+              ]
+            },
+            miss: {
+              priority: 45,
+              cooldownMs: 3000,
+              lines: [
+                'That miss sells out big points.',
+                '{playerName} comes up short and leaves a chance.',
+                'A costly miss at {points} on the run.',
+                'That one leaks out—opportunity swings.'
+              ]
+            },
+            safety: {
+              priority: 55,
+              cooldownMs: 4200,
+              lines: [
+                'Safety exchange continues. {playerName} keeps it tight.',
+                'Smart containing safety from {playerName}.',
+                '{playerName} forces the error with a measured safety.'
+              ]
+            },
+            leadChange: {
+              priority: 80,
+              cooldownMs: 6400,
+              lines: [
+                'Lead change—{playerName} now ahead by {lead}.',
+                '{playerName} flips the lead. That is a swing.',
+                'The race tightens—{lead} separates them now.'
+              ]
+            },
+            shotClock: {
+              priority: 65,
+              cooldownMs: 5200,
+              lines: [
+                'Clock pressure—{playerName} needs a quick decision.',
+                'Shot clock ticking. {playerName} has to commit.',
+                'Time pressure rising. {playerName} stays composed.'
+              ]
+            },
+            short: {
+              priority: 20,
+              cooldownMs: 2400,
+              lines: [
+                'Well played.',
+                'Good pattern.',
+                'Nice touch.',
+                'Steady pace.'
+              ]
+            }
+          },
+          eventMap: {
+            'score': 'score',
+            'streak': 'streak',
+            'milestone': 'milestone',
+            'position.good': 'position',
+            'miss': 'miss',
+            'safety': 'safety',
+            'lead.change': 'leadChange',
+            'shotclock': 'shotClock',
+            'short': 'short'
+          }
+        },
+        snooker: {
+          label: 'Snooker',
+          defaultVoiceId: 'snooker-calm',
+          categories: {
+            breakBuild: {
+              priority: 78,
+              cooldownMs: 5200,
+              lines: [
+                '{playerName} moves to {breakPoints} in the break.',
+                'Break at {breakPoints} and counting.',
+                '{playerName} is building nicely, now {breakPoints}.',
+                'That takes the break to {breakPoints}.',
+                'A smooth visit—{playerName} grows the break.'
+              ]
+            },
+            milestone: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'That is {breakPoints}—a landmark break.',
+                'Fifty up for {playerName}.',
+                'Century watch—{breakPoints} on the scoreboard.',
+                '{playerName} reaches {breakPoints} with ease.'
+              ]
+            },
+            colorSequence: {
+              priority: 70,
+              cooldownMs: 4600,
+              lines: [
+                'Reds and blacks flowing for {playerName}.',
+                'Beautiful sequence—reds with a black to follow.',
+                '{playerName} takes blue and stays perfect.',
+                'Now onto the colors—precision required.'
+              ]
+            },
+            safety: {
+              priority: 65,
+              cooldownMs: 4200,
+              lines: [
+                'Safety duel underway. {playerName} lays a snooker.',
+                'Excellent safety—{opponentName} needs an escape.',
+                'A thin hit escape keeps {playerName} safe.',
+                'Smart containment from {playerName}.'
+              ]
+            },
+            foul: {
+              priority: 92,
+              cooldownMs: 7000,
+              lines: [
+                'Foul: {foulType}. {points} points to {opponentName}.',
+                'In-off! That costs {points}.',
+                'Miss called—{opponentName} will have it again.',
+                'Free ball situation after the foul.'
+              ]
+            },
+            frameContext: {
+              priority: 90,
+              cooldownMs: 7200,
+              lines: [
+                'Frame ball now. {playerName} can close it out.',
+                'Needs snookers: {remaining} required.',
+                'Clearing the colors could decide the frame.',
+                '{playerName} is chasing with {remaining} reds left.'
+              ]
+            },
+            difficulty: {
+              priority: 72,
+              cooldownMs: 4600,
+              lines: [
+                'Long pot attempt—{difficulty} difficulty.',
+                'Rest shot coming up. Tricky mechanics.',
+                'Screw shot needed here. Plenty of touch.',
+                'Stun and hold—delicate cue ball control.'
+              ]
+            },
+            miss: {
+              priority: 45,
+              cooldownMs: 3200,
+              lines: [
+                'That one stays out. Chance for {opponentName}.',
+                'Missed the long pot—table opens.',
+                '{playerName} rattles it and loses the chance.',
+                'That was close, but it does not drop.'
+              ]
+            },
+            short: {
+              priority: 20,
+              cooldownMs: 2400,
+              lines: [
+                'Lovely cueing.',
+                'Excellent touch.',
+                'Very composed.',
+                'Tactical moment.'
+              ]
+            }
+          },
+          eventMap: {
+            'break': 'breakBuild',
+            'break.milestone': 'milestone',
+            'color.sequence': 'colorSequence',
+            'safety': 'safety',
+            'foul': 'foul',
+            'frame.context': 'frameContext',
+            'difficulty': 'difficulty',
+            'miss': 'miss',
+            'short': 'short'
+          }
+        }
+      }
+    }
+  }
+};
+
+export const COMMENTARY_DEFAULT_VOICES = {
+  nineBall: '9ball-energetic',
+  eightBall: '8ball-classic',
+  american: 'american-analyst',
+  snooker: 'snooker-calm'
+};


### PR DESCRIPTION
### Motivation
- Provide a modular, offline commentary system (template-based, broadcast-safe) for 9‑ball, 8‑ball, American points and snooker with fast cached TTS output. 
- Fix gameplay issues: make ball-impact audio reliably audible, stop AI from stalling when it has ball‑in‑hand, and ensure the cue‑stick is visible during replays.

### Description
- Added a commentary data pipeline and manager: `webapp/src/services/commentary/commentaryDatabase.js` (templates, categories, event→category map), `CommentaryManager.js` (selection, cooldowns, history, queueing, placeholder filling) and `ChatterboxTtsService.js` (adapter wrapper, in‑memory cache, async job queue, deterministic cache key).  The DB covers the four modes with priority/cooldown rules and example lines. 
- Documented architecture, event schemas, example lines and usage guidance in `docs/commentary-tts-system.md` and exported default voice mapping via `COMMENTARY_DEFAULT_VOICES`. 
- Improved AI ball‑in‑hand placement logic in `webapp/src/pages/Games/PoolRoyale.jsx` by adding line‑of‑sight checks, distance‑to‑segment helper, a scoring function for candidate placements, expanded clearance levels and candidate evaluation to pick placements that give the AI better shooting angles. 
- Audio and replay fixes in `PoolRoyale.jsx`: increased ball collision playback volume scaling (`playBallHit`) for clearer impact sound, and adjusted replay cue application so cue‑stroke animation/position is applied when available (ensures cue stick shows during replays). 

### Testing
- No automated test suite was run as part of this change; changes were implemented and staged for review (`git commit` performed).
- Manual validation recommended before release: 1) verify commentary manager selects and fills templates and that `ChatterboxTtsService` accepts an adapter and returns cached audio, 2) run a local match to confirm audible ball hits and that AI auto‑places the cue ball quickly and chooses candidates with clear sightlines, and 3) play recorded replays to confirm cue‑stick is visible for replayed strokes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752427bfcc83299b8b4660c3bad584)