### PR TITLE
Add commentary + Chatterbox TTS system; improve AI cue‑ball placement, cue stick visibility, and ball impact audio

### DIFF
--- a/docs/pool-royale-commentary-tts.md
+++ b/docs/pool-royale-commentary-tts.md
@@ -1,0 +1,169 @@
+# Pool Royale Commentary + TTS System (Chatterbox)
+
+## Plan (high level)
+1. **Define data-first commentary content** for all 4 modes in JSON with categories, cooldowns, priorities, and template lines.
+2. **Add a commentary manager** to select lines, fill placeholders, apply cooldown/suppression, and avoid repeats.
+3. **Wrap Chatterbox TTS** in a cache-first service with deterministic keys and an async queue.
+4. **Expose a lightweight API** (`onEvent`) for the game to request commentary output without blocking gameplay.
+5. **Document event schemas + examples** to make future localization (English → Albanian) straightforward.
+
+## Module structure
+```
+webapp/src/games/commentary/
+  commentaryDatabase.json
+  commentaryManager.js
+  chatterboxTtsService.js
+  commentarySchemas.js
+  index.js
+```
+
+## Commentary database format
+```json
+{
+  "meta": {
+    "locale": "en",
+    "version": 1,
+    "placeholders": ["{playerName}", "{ball}", "{points}"]
+  },
+  "modes": {
+    "9ball": {
+      "id": "9ball",
+      "voiceProfile": "energetic",
+      "categories": {
+        "break": {
+          "eventTypes": ["break.dry", "break.made", "break.scratch"],
+          "priority": 80,
+          "cooldownMs": 6000,
+          "suppresses": ["short"],
+          "suppressMs": 3000,
+          "lines": ["Dry break from {playerName}—nothing drops."]
+        }
+      }
+    }
+  }
+}
+```
+
+## Commentary manager behavior (implementation notes)
+- **Input**: `onEvent(gameMode, eventType, context)`.
+- **Selection**: map `eventType` to a category, prefer highest `priority` among pending events.
+- **Cooldowns**: enforce `globalCooldownMs` and per-category `cooldownMs`.
+- **Suppression**: allow high-priority categories to suppress low-priority categories for `suppressMs`.
+- **Non-repetition**: keep a `historySize` window to avoid repeating recent lines.
+- **Output**: resolves to `{ text, audio, category, mode }` or `null`.
+
+### Selection pseudocode
+```
+function onEvent(gameMode, eventType, context) -> Promise
+  enqueue event
+  processQueue()
+
+processQueue():
+  while pendingEvents:
+    best = pickBestEventByPriorityAndAge()
+    if suppressed or cooldown => skip
+    wait for global cooldown
+    template = pickLineWithoutRecentRepeats()
+    line = fillPlaceholders(template, context)
+    audio = ttsService.synthesize(line, voiceSettings)
+    resolve promise with audio
+```
+
+## Chatterbox TTS wrapper
+- **synthesize(text, options)**
+  - normalizes whitespace/punctuation
+  - clamps length to `maxTextLength`
+  - caches by `(voiceId + normalizedText + settings)`
+  - async queue to avoid blocking gameplay
+- **preload(lines)**
+  - warm-up at match start for common lines
+
+## Rules to avoid spam
+- **Global cooldown**: 2–4s (default 2.5s in manager)
+- **Category cooldown**: 3–8s (set per category in JSON)
+- **Suppression**: foul/pressure suppress short commentary lines
+- **Priority**: foul > match point/frame ball > big break > normal pot > short filler
+
+## Example commentary lines (sample)
+### 9-ball
+- “Dry break from {playerName}—nothing drops.”
+- “Open break, but no ball down for {playerName}.”
+- “Solid break—{playerName} pockets a ball and keeps the table.”
+- “Combination play—{ball} falls from the carom.”
+- “Two-ball combo and the {ball} drops.”
+- “Rattles in the jaws—{ball} stays up.”
+- “Overcut it, and the {ball} stays on the table.”
+- “Perfect leave—{playerName} is on the next ball.”
+- “The 9 is waiting—match ball pressure.”
+- “Clean finish—runout complete.”
+
+### 8-ball
+- “Open table after the break.”
+- “That break splits the pack nicely.”
+- “Clusters remain—work to do from here.”
+- “{playerName} takes solids.”
+- “Stripes are the choice for {playerName}.”
+- “Key ball cleared—{playerName} is on the 8.”
+- “One ball left before the money ball.”
+- “Pocket blocked—bank may be required.”
+- “Wrong side of the ball, tough route now.”
+- “On the 8-ball now—big moment.”
+
+### American billiards (points-based)
+- “Point on the board for {playerName}.”
+- “That adds {points} to the tally.”
+- “{streak} in a row—{playerName} is flowing.”
+- “Streak extends, {playerName} in full control.”
+- “Milestone hit—{points} points for {playerName}.”
+- “Race marker reached at {points}.”
+- “Textbook position there.”
+- “Two-rail route and perfect line.”
+- “Missed, and that could sell out points.”
+- “Lead grows to {lead} points.”
+
+### Snooker
+- “Break building now, {breakPoints} and counting.”
+- “That’s {breakPoints} in the break for {playerName}.”
+- “Switching to colors, blue to follow.”
+- “Pink is there—position looks perfect.”
+- “That’s a good snooker, {opponentName} is stuck.”
+- “Excellent escape, threaded through.”
+- “Frame ball on the table.”
+- “Needs snookers now to stay alive.”
+- “Long pot from distance—{difficulty} shot.”
+- “Rest shot coming up, steady hands.”
+
+## Example event payloads
+```json
+{
+  "gameMode": "9ball",
+  "eventType": "shot.pot",
+  "context": { "playerName": "Arben", "ball": "3", "positionQuality": "good", "runCount": 4 }
+}
+```
+```json
+{
+  "gameMode": "8ball",
+  "eventType": "pressure.on8",
+  "context": { "playerName": "Lina", "onEightBall": true, "pocketBlocked": false }
+}
+```
+```json
+{
+  "gameMode": "american",
+  "eventType": "score.point",
+  "context": { "playerName": "Mira", "currentPoints": 38, "streak": 7, "lead": 12 }
+}
+```
+```json
+{
+  "gameMode": "snooker",
+  "eventType": "break.build",
+  "context": { "playerName": "Noel", "breakPoints": 56, "remainingReds": 3, "needsSnookers": false }
+}
+```
+
+## Notes on localization
+- Keep templates in `commentaryDatabase.json` per locale key.
+- All placeholders are stable and language-agnostic.
+- Add a `meta.locale` and new language nodes for Albanian when ready.

--- a/webapp/src/games/commentary/chatterboxTtsService.js
+++ b/webapp/src/games/commentary/chatterboxTtsService.js
@@ -1,0 +1,74 @@
+const DEFAULT_SAMPLE_RATE = 24000;
+const DEFAULT_MAX_TEXT_LENGTH = 180;
+
+const normalizeText = (text) =>
+  String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .trim();
+
+export class ChatterboxTtsService {
+  constructor({
+    synthesizer,
+    cache = new Map(),
+    sampleRate = DEFAULT_SAMPLE_RATE,
+    maxTextLength = DEFAULT_MAX_TEXT_LENGTH,
+    format = 'wav'
+  } = {}) {
+    this.synthesizer = synthesizer;
+    this.cache = cache;
+    this.sampleRate = sampleRate;
+    this.maxTextLength = maxTextLength;
+    this.format = format;
+    this.queue = Promise.resolve();
+  }
+
+  buildCacheKey(text, options) {
+    const normalized = normalizeText(text).slice(0, this.maxTextLength);
+    const voiceId = options?.voiceId ?? 'default';
+    const speed = options?.speed ?? 1;
+    const pitch = options?.pitch ?? 1;
+    const style = options?.style ?? 'neutral';
+    const rate = options?.sampleRate ?? this.sampleRate;
+    const format = options?.format ?? this.format;
+    return [voiceId, speed, pitch, style, rate, format, normalized].join('::');
+  }
+
+  enqueue(task) {
+    this.queue = this.queue.then(task, task);
+    return this.queue;
+  }
+
+  async synthesize(text, options = {}) {
+    const normalized = normalizeText(text).slice(0, this.maxTextLength);
+    if (!normalized) return null;
+    const cacheKey = this.buildCacheKey(normalized, options);
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey);
+    }
+    if (!this.synthesizer) {
+      throw new Error('Chatterbox synthesizer is not configured.');
+    }
+    return this.enqueue(async () => {
+      if (this.cache.has(cacheKey)) {
+        return this.cache.get(cacheKey);
+      }
+      const result = await this.synthesizer({
+        text: normalized,
+        voiceId: options.voiceId,
+        speed: options.speed,
+        pitch: options.pitch,
+        style: options.style,
+        sampleRate: options.sampleRate ?? this.sampleRate,
+        format: options.format ?? this.format
+      });
+      this.cache.set(cacheKey, result);
+      return result;
+    });
+  }
+
+  preload(lines = [], options = {}) {
+    const tasks = lines.map((line) => this.synthesize(line, options));
+    return Promise.all(tasks);
+  }
+}

--- a/webapp/src/games/commentary/commentaryDatabase.json
+++ b/webapp/src/games/commentary/commentaryDatabase.json
@@ -1,0 +1,501 @@
+{
+  "meta": {
+    "locale": "en",
+    "version": 1,
+    "placeholders": [
+      "{playerName}",
+      "{opponentName}",
+      "{ball}",
+      "{points}",
+      "{remaining}",
+      "{frameScore}",
+      "{breakPoints}",
+      "{foulType}",
+      "{shotType}",
+      "{difficulty}",
+      "{streak}",
+      "{lead}"
+    ]
+  },
+  "modes": {
+    "9ball": {
+      "id": "9ball",
+      "voiceProfile": "energetic",
+      "categories": {
+        "break": {
+          "eventTypes": ["break.dry", "break.made", "break.scratch"],
+          "priority": 80,
+          "cooldownMs": 6000,
+          "suppresses": ["short"],
+          "suppressMs": 3000,
+          "lines": [
+            "Dry break from {playerName}—nothing drops.",
+            "Open break, but no ball down for {playerName}.",
+            "Solid break—{playerName} pockets a ball and keeps the table.",
+            "That break opens nicely, a ball down for {playerName}.",
+            "Scratch on the break—cue ball down off the snap.",
+            "A foul on the break, {playerName} gives up ball in hand."
+          ]
+        },
+        "pot": {
+          "eventTypes": ["shot.pot", "shot.legal"],
+          "priority": 40,
+          "cooldownMs": 3500,
+          "lines": [
+            "{playerName} pots the {ball} cleanly.",
+            "Nice {shotType} on the {ball}.",
+            "{ball} disappears—{playerName} stays at the table.",
+            "Smooth delivery, {ball} down.",
+            "Controlled stroke—{ball} is gone."
+          ]
+        },
+        "combo": {
+          "eventTypes": ["shot.combo", "shot.carom"],
+          "priority": 55,
+          "cooldownMs": 4500,
+          "lines": [
+            "Combination play—{ball} falls from the carom.",
+            "Two-ball combo and the {ball} drops.",
+            "{playerName} manufactures it—carom to sink the {ball}.",
+            "Clever combo there, {ball} is down.",
+            "Nice carom, that {ball} had no chance."
+          ]
+        },
+        "miss": {
+          "eventTypes": ["shot.miss", "shot.rattle", "shot.overcut", "shot.undercut"],
+          "priority": 30,
+          "cooldownMs": 3500,
+          "lines": [
+            "Rattles in the jaws—{ball} stays up.",
+            "Overcut it, and the {ball} stays on the table.",
+            "Undercut—missed by a fraction.",
+            "A miss there, and the {ball} is still in play.",
+            "Just off line, {playerName} can't convert."
+          ]
+        },
+        "position": {
+          "eventTypes": ["position.good", "position.bad", "position.hooked"],
+          "priority": 35,
+          "cooldownMs": 4000,
+          "lines": [
+            "Perfect leave—{playerName} is on the next ball.",
+            "Great position, the angle is right there.",
+            "Tough leave—cue ball drifted out of line.",
+            "Hooked behind traffic, that’s awkward.",
+            "Not the best leave; {playerName} has work to do."
+          ]
+        },
+        "safety": {
+          "eventTypes": ["safety.good", "safety.fail", "safety.jump"],
+          "priority": 45,
+          "cooldownMs": 4500,
+          "lines": [
+            "Smart safety—{opponentName} is snookered.",
+            "Locks it up nicely, good safety from {playerName}.",
+            "Safety attempt misses—shot opened up.",
+            "That safety leaks, and the table opens.",
+            "Jump shot on the menu—{playerName} goes airborne."
+          ]
+        },
+        "foul": {
+          "eventTypes": ["foul.scratch", "foul.pushout", "foul.illegal_contact"],
+          "priority": 90,
+          "cooldownMs": 6000,
+          "suppresses": ["short", "pot"],
+          "suppressMs": 3500,
+          "lines": [
+            "Scratch—ball in hand for {opponentName}.",
+            "Foul called: {foulType}.",
+            "Illegal contact—{opponentName} takes control.",
+            "Push out on the table; {opponentName} decides.",
+            "That’s a foul and it swings the rack."
+          ]
+        },
+        "pressure": {
+          "eventTypes": ["pressure.hill_hill", "pressure.match_ball", "pressure.comeback"],
+          "priority": 70,
+          "cooldownMs": 6000,
+          "lines": [
+            "Hill-hill now—every shot counts.",
+            "The 9 is waiting—match ball pressure.",
+            "Comeback brewing as {playerName} closes the gap.",
+            "Big moment with the 9 on the table.",
+            "Momentum shifts—this one’s tightening up."
+          ]
+        },
+        "runout": {
+          "eventTypes": ["runout.streak", "runout.near", "runout.clean"],
+          "priority": 75,
+          "cooldownMs": 6000,
+          "lines": [
+            "Three in a row—{playerName} is rolling.",
+            "Nearly perfect, that’s a tidy run.",
+            "Clean finish—runout complete.",
+            "Runout pace here, {playerName} in full control.",
+            "Stringing them together, {streak} straight pots."
+          ]
+        },
+        "short": {
+          "eventTypes": ["short.generic"],
+          "priority": 10,
+          "cooldownMs": 2500,
+          "lines": [
+            "Good touch.",
+            "Nice pace.",
+            "Smooth stroke.",
+            "Sharp hit.",
+            "Well judged."
+          ]
+        }
+      }
+    },
+    "8ball": {
+      "id": "8ball",
+      "voiceProfile": "classic",
+      "categories": {
+        "break": {
+          "eventTypes": ["break.open", "break.cluster", "break.early8"],
+          "priority": 80,
+          "cooldownMs": 6000,
+          "suppresses": ["short"],
+          "suppressMs": 3000,
+          "lines": [
+            "Open table after the break.",
+            "That break splits the pack nicely.",
+            "Clusters remain—work to do from here.",
+            "Early 8-ball threat, but it stays up.",
+            "Break shot sets the table, plenty of options."
+          ]
+        },
+        "groups": {
+          "eventTypes": ["groups.solids", "groups.stripes", "groups.open"],
+          "priority": 55,
+          "cooldownMs": 4500,
+          "lines": [
+            "{playerName} takes solids.",
+            "Stripes are the choice for {playerName}.",
+            "Table still open—decision time.",
+            "Groups decided, {playerName} is on {ball}.",
+            "That shot locks in {playerName}'s group."
+          ]
+        },
+        "clearance": {
+          "eventTypes": ["clearance.run", "clearance.key", "clearance.last"],
+          "priority": 65,
+          "cooldownMs": 5500,
+          "lines": [
+            "Key ball cleared—{playerName} is on the 8.",
+            "One ball left before the money ball.",
+            "Table is opening—clearance chance.",
+            "That’s the last of the set.",
+            "Clean path now, {playerName} in control."
+          ]
+        },
+        "defense": {
+          "eventTypes": ["defense.tie_up", "defense.break_cluster", "defense.lockup"],
+          "priority": 45,
+          "cooldownMs": 4500,
+          "lines": [
+            "Locks it down—tight safety from {playerName}.",
+            "Cluster broken with a smart touch.",
+            "Ties up the pocket, defensive move.",
+            "That’s a lock-up safety.",
+            "Defense first—{opponentName} has no clear look."
+          ]
+        },
+        "foul": {
+          "eventTypes": ["foul.scratch", "foul.illegal8", "foul.early8", "foul.no_rail"],
+          "priority": 90,
+          "cooldownMs": 6000,
+          "suppresses": ["short", "pot"],
+          "suppressMs": 3500,
+          "lines": [
+            "Scratch—ball in hand to {opponentName}.",
+            "Illegal 8-ball—foul called.",
+            "Early 8 down, and that’s a loss.",
+            "No rail after contact—foul on the shot.",
+            "That’s a foul, momentum swings."
+          ]
+        },
+        "pressure": {
+          "eventTypes": ["pressure.on8", "pressure.match_point"],
+          "priority": 75,
+          "cooldownMs": 6000,
+          "lines": [
+            "On the 8-ball now—big moment.",
+            "Match point pressure, {playerName} on the black.",
+            "This is for the rack—steady hands needed.",
+            "The 8 awaits, crowd goes quiet.",
+            "Pressure shot on the 8."
+          ]
+        },
+        "tactical": {
+          "eventTypes": ["tactical.wrong_side", "tactical.blocked_pocket", "tactical.bank_needed"],
+          "priority": 50,
+          "cooldownMs": 4500,
+          "lines": [
+            "Wrong side of the ball, tough route now.",
+            "Pocket blocked—bank may be required.",
+            "That lane is closed, creative shot needed.",
+            "Bank shot looks like the only play.",
+            "Angle’s awkward, {playerName} has to improvise."
+          ]
+        },
+        "miss": {
+          "eventTypes": ["shot.miss", "shot.rattle"],
+          "priority": 30,
+          "cooldownMs": 3500,
+          "lines": [
+            "Rattles out—{ball} stays up.",
+            "Missed that chance, table turns over.",
+            "Just clips the jaw and stays out.",
+            "A miss, and {opponentName} steps in.",
+            "Close, but no pot."
+          ]
+        },
+        "short": {
+          "eventTypes": ["short.generic"],
+          "priority": 10,
+          "cooldownMs": 2500,
+          "lines": [
+            "Nice touch.",
+            "Good angle.",
+            "Well played.",
+            "Steady stroke.",
+            "Clean hit."
+          ]
+        }
+      }
+    },
+    "american": {
+      "id": "american",
+      "voiceProfile": "analytical",
+      "categories": {
+        "scoring": {
+          "eventTypes": ["score.point", "score.combo"],
+          "priority": 55,
+          "cooldownMs": 3500,
+          "lines": [
+            "Point on the board for {playerName}.",
+            "That adds {points} to the tally.",
+            "Clean pot, score moves to {points}.",
+            "Points collected, {playerName} keeps the visit.",
+            "Good scoring touch, {playerName} builds."
+          ]
+        },
+        "streak": {
+          "eventTypes": ["streak.active", "streak.extend"],
+          "priority": 65,
+          "cooldownMs": 4500,
+          "lines": [
+            "{streak} in a row—{playerName} is flowing.",
+            "Streak extends, {playerName} in full control.",
+            "Consecutive points keep coming.",
+            "Stringing them together, {streak} straight scores.",
+            "The run continues, {playerName} stays in line."
+          ]
+        },
+        "milestone": {
+          "eventTypes": ["milestone.10", "milestone.25", "milestone.50"],
+          "priority": 75,
+          "cooldownMs": 6000,
+          "lines": [
+            "Milestone hit—{points} points for {playerName}.",
+            "That’s {points} on the board, strong visit.",
+            "Race marker reached at {points}.",
+            "Big number—{points} total now.",
+            "Checkpoint reached, {playerName} looks settled."
+          ]
+        },
+        "position": {
+          "eventTypes": ["position.textbook", "position.two_rail", "position.in_line"],
+          "priority": 45,
+          "cooldownMs": 4000,
+          "lines": [
+            "Textbook position there.",
+            "Two-rail route and perfect line.",
+            "Stays in line beautifully.",
+            "Great pattern play from {playerName}.",
+            "Routes mapped out, that’s smart position."
+          ]
+        },
+        "miss": {
+          "eventTypes": ["shot.miss", "shot.sellout"],
+          "priority": 35,
+          "cooldownMs": 3500,
+          "lines": [
+            "Missed, and that could sell out points.",
+            "That miss opens the table.",
+            "A rare error in the run.",
+            "Just off the line, score stays put.",
+            "Missed chance—momentum shifts."
+          ]
+        },
+        "safety": {
+          "eventTypes": ["safety.good", "safety.exchange"],
+          "priority": 40,
+          "cooldownMs": 4500,
+          "lines": [
+            "Safety exchange—{playerName} holds the edge.",
+            "Nice containment, forces a tougher reply.",
+            "Smart defense to protect the lead.",
+            "That safety could swing the next points.",
+            "Patience play, looking for an opening."
+          ]
+        },
+        "lead": {
+          "eventTypes": ["lead.change", "lead.extend"],
+          "priority": 60,
+          "cooldownMs": 5000,
+          "lines": [
+            "Lead changes hands—{playerName} moves ahead.",
+            "Lead grows to {lead} points.",
+            "Swing in the scoreline, big shift.",
+            "{playerName} edges in front with that point.",
+            "Score gap widens, {lead} now the margin."
+          ]
+        },
+        "clock": {
+          "eventTypes": ["clock.warning", "clock.expiring"],
+          "priority": 70,
+          "cooldownMs": 6000,
+          "lines": [
+            "Shot clock pressure now.",
+            "Time ticking, {playerName} has to move.",
+            "Clock is low—decisions must be quick.",
+            "Under the timer, that’s tense.",
+            "Late on the clock, tough call."
+          ]
+        },
+        "short": {
+          "eventTypes": ["short.generic"],
+          "priority": 10,
+          "cooldownMs": 2500,
+          "lines": [
+            "Good pace.",
+            "Nice line.",
+            "Clean pot.",
+            "Solid choice.",
+            "Right speed."
+          ]
+        }
+      }
+    },
+    "snooker": {
+      "id": "snooker",
+      "voiceProfile": "calm",
+      "categories": {
+        "break": {
+          "eventTypes": ["break.build", "break.10", "break.20", "break.30", "break.50", "break.100"],
+          "priority": 80,
+          "cooldownMs": 6000,
+          "lines": [
+            "Break building now, {breakPoints} and counting.",
+            "That’s {breakPoints} in the break for {playerName}.",
+            "Passes {breakPoints}, a quality visit.",
+            "The break grows—{playerName} is in rhythm.",
+            "Century watch as {breakPoints} mounts."
+          ]
+        },
+        "colors": {
+          "eventTypes": ["colors.black", "colors.blue", "colors.pink", "colors.clearance"],
+          "priority": 60,
+          "cooldownMs": 4500,
+          "lines": [
+            "Reds and blacks flow nicely.",
+            "Switching to colors, blue to follow.",
+            "Pink is there—position looks perfect.",
+            "Clearing the colors, frame in sight.",
+            "Clean on the colors, tidy work."
+          ]
+        },
+        "safety": {
+          "eventTypes": ["safety.snooker", "safety.escape", "safety.thin", "safety.double"],
+          "priority": 50,
+          "cooldownMs": 4500,
+          "lines": [
+            "That’s a good snooker, {opponentName} is stuck.",
+            "Excellent escape, threaded through.",
+            "Thin contact—safe play executed.",
+            "The double comes into play, brave shot.",
+            "Tactical exchange, both probing."
+          ]
+        },
+        "foul": {
+          "eventTypes": ["foul.miss", "foul.in_off", "foul.free_ball", "foul.touching"],
+          "priority": 90,
+          "cooldownMs": 6000,
+          "suppresses": ["short"],
+          "suppressMs": 3500,
+          "lines": [
+            "Foul—{foulType}, points to {opponentName}.",
+            "That’s a miss, and it’s called.",
+            "In-off—foul and points away.",
+            "Free ball situation now.",
+            "Touching ball—careful from here."
+          ]
+        },
+        "frame": {
+          "eventTypes": ["frame.ball", "frame.snookers_needed", "frame.clearance"],
+          "priority": 75,
+          "cooldownMs": 6000,
+          "lines": [
+            "Frame ball on the table.",
+            "Needs snookers now to stay alive.",
+            "Clearance chance to take the frame.",
+            "Pressure moment—frame within reach.",
+            "The table is open for the frame."
+          ]
+        },
+        "difficulty": {
+          "eventTypes": ["shot.long", "shot.rest", "shot.screw", "shot.stun", "shot.side"],
+          "priority": 55,
+          "cooldownMs": 4500,
+          "lines": [
+            "Long pot from distance—{difficulty} shot.",
+            "Rest shot coming up, steady hands.",
+            "Screw back nicely, cue ball returns.",
+            "Stun shot, holds the line.",
+            "Side spin applied, precise control."
+          ]
+        },
+        "audience": {
+          "eventTypes": ["audience.calm", "audience.ooh"],
+          "priority": 20,
+          "cooldownMs": 5000,
+          "lines": [
+            "Quiet focus in the arena.",
+            "The crowd appreciates that touch.",
+            "Measured applause for the visit.",
+            "Polite murmur as the safety lands.",
+            "Calm, composed snooker on display."
+          ]
+        },
+        "pressure": {
+          "eventTypes": ["pressure.close_frame", "pressure.comeback"],
+          "priority": 70,
+          "cooldownMs": 5500,
+          "lines": [
+            "Close frame now—every ball matters.",
+            "Comeback on the cards if {playerName} continues.",
+            "Pressure rising as the scores tighten.",
+            "Big moment with {remaining} remaining.",
+            "Nerves tested in this frame."
+          ]
+        },
+        "short": {
+          "eventTypes": ["short.generic"],
+          "priority": 10,
+          "cooldownMs": 2500,
+          "lines": [
+            "Nice cueing.",
+            "Good touch.",
+            "Clean pot.",
+            "Steady.",
+            "Well judged."
+          ]
+        }
+      }
+    }
+  }
+}

--- a/webapp/src/games/commentary/commentaryManager.js
+++ b/webapp/src/games/commentary/commentaryManager.js
@@ -1,0 +1,192 @@
+const DEFAULT_GLOBAL_COOLDOWN_MS = 2500;
+const DEFAULT_CATEGORY_COOLDOWN_MS = 4000;
+const DEFAULT_HISTORY_SIZE = 8;
+
+const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+const sleep = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, ms));
+  });
+
+const normalizeText = (text) =>
+  String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .trim();
+
+export class CommentaryManager {
+  constructor({
+    database,
+    ttsService,
+    locale = 'en',
+    globalCooldownMs = DEFAULT_GLOBAL_COOLDOWN_MS,
+    historySize = DEFAULT_HISTORY_SIZE
+  }) {
+    this.database = database;
+    this.ttsService = ttsService;
+    this.locale = locale;
+    this.globalCooldownMs = globalCooldownMs;
+    this.historySize = historySize;
+    this.pendingEvents = [];
+    this.processing = false;
+    this.lastSpokenAt = 0;
+    this.categoryCooldowns = new Map();
+    this.suppressedUntil = new Map();
+    this.recentLines = [];
+  }
+
+  onEvent(gameMode, eventType, context = {}) {
+    return new Promise((resolve) => {
+      const event = {
+        gameMode,
+        eventType,
+        context,
+        createdAt: nowMs(),
+        resolve
+      };
+      this.pendingEvents.push(event);
+      this.processQueue();
+    });
+  }
+
+  preload(gameMode, eventTypes = [], context = {}) {
+    const tasks = eventTypes.map((eventType) =>
+      this.onEvent(gameMode, eventType, context)
+    );
+    return Promise.all(tasks);
+  }
+
+  resolveMode(gameMode) {
+    const modes = this.database?.modes ?? {};
+    return modes[gameMode] ?? null;
+  }
+
+  resolveCategory(mode, eventType) {
+    if (!mode?.categories) return null;
+    const categories = Object.entries(mode.categories);
+    for (const [key, category] of categories) {
+      const eventTypes = category?.eventTypes ?? [];
+      if (eventTypes.includes(eventType) || key === eventType) {
+        return { key, category };
+      }
+    }
+    return null;
+  }
+
+  pickBestEvent() {
+    const now = nowMs();
+    let best = null;
+    let bestScore = -Infinity;
+    for (const event of this.pendingEvents) {
+      const mode = this.resolveMode(event.gameMode);
+      const resolved = this.resolveCategory(mode, event.eventType);
+      if (!resolved) continue;
+      const { key, category } = resolved;
+      const suppressedUntil = this.suppressedUntil.get(key) ?? 0;
+      if (suppressedUntil > now) continue;
+      const categoryCooldown = this.categoryCooldowns.get(key) ?? 0;
+      if (categoryCooldown > now) continue;
+      const priority = category?.priority ?? 0;
+      const age = Math.min((now - event.createdAt) / 1000, 5);
+      const score = priority + age;
+      if (score > bestScore) {
+        bestScore = score;
+        best = { event, key, category, mode };
+      }
+    }
+    return best;
+  }
+
+  buildTemplateLine(category) {
+    const lines = Array.isArray(category?.lines) ? category.lines : [];
+    if (!lines.length) return null;
+    const recent = new Set(this.recentLines);
+    const available = lines.filter((line) => !recent.has(line));
+    const pool = available.length ? available : lines;
+    const choice = pool[Math.floor(Math.random() * pool.length)];
+    if (!choice) return null;
+    this.recentLines.unshift(choice);
+    this.recentLines = this.recentLines.slice(0, this.historySize);
+    return choice;
+  }
+
+  fillTemplate(template, context) {
+    const defaults = {
+      playerName: context.playerName ?? 'Player',
+      opponentName: context.opponentName ?? 'Opponent',
+      ball: context.ball ?? 'ball',
+      points: context.points ?? context.score ?? '',
+      remaining: context.remaining ?? '',
+      frameScore: context.frameScore ?? '',
+      breakPoints: context.breakPoints ?? context.points ?? '',
+      foulType: context.foulType ?? 'foul',
+      shotType: context.shotType ?? 'shot',
+      difficulty: context.difficulty ?? 'tough',
+      streak: context.streak ?? '',
+      lead: context.lead ?? ''
+    };
+    return normalizeText(
+      String(template).replace(/\{(\w+)\}/g, (match, key) => {
+        const value = context[key] ?? defaults[key];
+        if (value == null) return '';
+        return String(value);
+      })
+    );
+  }
+
+  applySuppression(categoryKey, category) {
+    const suppresses = Array.isArray(category?.suppresses) ? category.suppresses : [];
+    const suppressMs = Number.isFinite(category?.suppressMs)
+      ? category.suppressMs
+      : 0;
+    if (!suppressMs) return;
+    const until = nowMs() + suppressMs;
+    suppresses.forEach((key) => {
+      this.suppressedUntil.set(key, until);
+    });
+  }
+
+  async processQueue() {
+    if (this.processing) return;
+    this.processing = true;
+    while (this.pendingEvents.length) {
+      const next = this.pickBestEvent();
+      if (!next) break;
+      const now = nowMs();
+      const waitMs = this.lastSpokenAt + this.globalCooldownMs - now;
+      if (waitMs > 0) {
+        await sleep(waitMs);
+      }
+      const { event, key, category, mode } = next;
+      const index = this.pendingEvents.indexOf(event);
+      if (index >= 0) this.pendingEvents.splice(index, 1);
+      const template = this.buildTemplateLine(category);
+      if (!template) {
+        event.resolve(null);
+        continue;
+      }
+      const line = this.fillTemplate(template, event.context ?? {});
+      if (!line) {
+        event.resolve(null);
+        continue;
+      }
+      const cooldownMs = Number.isFinite(category?.cooldownMs)
+        ? category.cooldownMs
+        : DEFAULT_CATEGORY_COOLDOWN_MS;
+      this.categoryCooldowns.set(key, nowMs() + cooldownMs);
+      this.applySuppression(key, category);
+      const voiceId = mode?.voiceProfile ?? 'default';
+      const ttsOptions = {
+        voiceId,
+        speed: event.context?.speed,
+        pitch: event.context?.pitch,
+        style: event.context?.style
+      };
+      const audio = await this.ttsService?.synthesize(line, ttsOptions);
+      this.lastSpokenAt = nowMs();
+      event.resolve({ text: line, audio, category: key, mode: mode?.id ?? event.gameMode });
+    }
+    this.processing = false;
+  }
+}

--- a/webapp/src/games/commentary/commentarySchemas.js
+++ b/webapp/src/games/commentary/commentarySchemas.js
@@ -1,0 +1,50 @@
+export const EVENT_SCHEMAS = {
+  common: {
+    playerName: 'string',
+    opponentName: 'string',
+    ball: 'string',
+    points: 'number',
+    remaining: 'number',
+    frameScore: 'string',
+    breakPoints: 'number',
+    foulType: 'string',
+    shotType: 'string',
+    difficulty: 'string',
+    streak: 'number',
+    lead: 'number'
+  },
+  events: {
+    'break.dry': { playerName: 'string' },
+    'break.made': { playerName: 'string', ball: 'string' },
+    'break.scratch': { playerName: 'string' },
+    'shot.pot': { playerName: 'string', ball: 'string', shotType: 'string' },
+    'shot.miss': { playerName: 'string', ball: 'string' },
+    'position.good': { playerName: 'string' },
+    'safety.good': { playerName: 'string', opponentName: 'string' },
+    'foul.scratch': { playerName: 'string', foulType: 'string' },
+    'pressure.match_point': { playerName: 'string' }
+  }
+};
+
+export const EXAMPLE_EVENT_PAYLOADS = {
+  '9ball.shot.pot': {
+    gameMode: '9ball',
+    eventType: 'shot.pot',
+    context: { playerName: 'Arben', ball: '3', positionQuality: 'good', runCount: 4 }
+  },
+  '8ball.pressure.on8': {
+    gameMode: '8ball',
+    eventType: 'pressure.on8',
+    context: { playerName: 'Lina', onEightBall: true, pocketBlocked: false }
+  },
+  'american.score.point': {
+    gameMode: 'american',
+    eventType: 'score.point',
+    context: { playerName: 'Mira', currentPoints: 38, streak: 7, lead: 12 }
+  },
+  'snooker.break.build': {
+    gameMode: 'snooker',
+    eventType: 'break.build',
+    context: { playerName: 'Noel', breakPoints: 56, remainingReds: 3, needsSnookers: false }
+  }
+};

--- a/webapp/src/games/commentary/index.js
+++ b/webapp/src/games/commentary/index.js
@@ -1,0 +1,4 @@
+export { CommentaryManager } from './commentaryManager.js';
+export { ChatterboxTtsService } from './chatterboxTtsService.js';
+export { EVENT_SCHEMAS, EXAMPLE_EVENT_PAYLOADS } from './commentarySchemas.js';
+export { default as commentaryDatabase } from './commentaryDatabase.json';

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12628,7 +12628,7 @@ const powerRef = useRef(hud.power);
     const ctx = audioContextRef.current;
     const buffer = audioBuffersRef.current.ball;
     if (!ctx || !buffer || muteRef.current) return;
-    const scaled = clamp(vol * volumeRef.current * 0.9, 0, 1);
+    const scaled = clamp(vol * volumeRef.current, 0, 1);
     if (scaled <= 0) return;
     ctx.resume().catch(() => {});
     const source = ctx.createBufferSource();
@@ -17276,13 +17276,14 @@ const powerRef = useRef(hud.power);
           const relative = Math.max(0, timestamp - start);
           const snapshot = captureBallSnapshot();
           const cameraSnapshot = captureReplayCameraSnapshot();
-          const cueSnapshot = cueStick
-            ? {
-                position: serializeVector3Snapshot(cueStick.position),
-                rotation: serializeQuaternionSnapshot(cueStick.quaternion),
-                visible: cueStick.visible
-              }
-            : null;
+          const cueSnapshot =
+            cueStick && cueStick.visible
+              ? {
+                  position: serializeVector3Snapshot(cueStick.position),
+                  rotation: serializeQuaternionSnapshot(cueStick.quaternion),
+                  visible: cueStick.visible
+                }
+              : null;
           shotRecording.frames.push({
             t: relative,
             balls: snapshot,
@@ -19865,18 +19866,115 @@ const powerRef = useRef(hud.power);
         cue.active = false;
         updateCuePlacement(clamped);
         inHandDrag.lastPos = clamped;
-      if (commit) {
-        cue.active = true;
-        inHandDrag.lastPos = null;
-        cueBallPlacedFromHandRef.current = true;
-        if (hudRef.current?.inHand) {
-          const nextHud = { ...hudRef.current, inHand: false };
-          hudRef.current = nextHud;
-          setHud(nextHud);
+        if (commit) {
+          cue.active = true;
+          inHandDrag.lastPos = null;
+          cueBallPlacedFromHandRef.current = true;
+          if (hudRef.current?.inHand) {
+            const nextHud = { ...hudRef.current, inHand: false };
+            hudRef.current = nextHud;
+            setHud(nextHud);
+          }
         }
-      }
-      return true;
-    };
+        return true;
+      };
+      const normalizeTargetId = (value) => {
+        const normalized = String(value ?? '').trim().toUpperCase();
+        return normalized.length ? normalized : null;
+      };
+      const parseBallNumber = (colorId) => {
+        const match = /^BALL_(\d+)/.exec(colorId ?? '');
+        return match ? parseInt(match[1], 10) : null;
+      };
+      const mapNumberToGroup = (colorId) => {
+        const num = parseBallNumber(colorId);
+        if (num == null) return null;
+        if (num === 8) return 'BLACK';
+        if (num >= 9) return 'STRIPE';
+        return 'SOLID';
+      };
+      const matchesInHandTarget = (ball, targetId) => {
+        if (!ball || !targetId) return false;
+        const normalizedTarget = normalizeTargetId(targetId);
+        if (!normalizedTarget) return false;
+        const colorId = toBallColorId(ball.id);
+        if (!colorId) return false;
+        const numericGroup = mapNumberToGroup(colorId);
+        if (normalizedTarget === 'BLACK') {
+          return colorId === 'BLACK' || numericGroup === 'BLACK';
+        }
+        if (normalizedTarget === 'SOLID' || normalizedTarget === 'SOLIDS') {
+          return colorId === 'SOLID' || numericGroup === 'SOLID';
+        }
+        if (normalizedTarget === 'STRIPE' || normalizedTarget === 'STRIPES') {
+          return colorId === 'STRIPE' || numericGroup === 'STRIPE';
+        }
+        if (normalizedTarget === 'YELLOW' || normalizedTarget === 'BLUE') {
+          return colorId === 'YELLOW' || colorId === 'BLUE';
+        }
+        if (normalizedTarget === 'BALL_8' || normalizedTarget === '8') {
+          return colorId === 'BLACK' || numericGroup === 'BLACK';
+        }
+        return colorId === normalizedTarget;
+      };
+      const resolveInHandTargets = () => {
+        const snapshot = frameRef.current ?? frameState;
+        const rawTargets = Array.isArray(snapshot?.ballOn) ? snapshot.ballOn : [];
+        const activeBalls = balls.filter((ball) => ball?.active && ball !== cue);
+        if (!rawTargets.length) return activeBalls;
+        const normalizedTargets = rawTargets
+          .map((entry) => normalizeTargetId(entry))
+          .filter(Boolean);
+        if (!normalizedTargets.length) return activeBalls;
+        const filtered = activeBalls.filter((ball) =>
+          normalizedTargets.some((target) => matchesInHandTarget(ball, target))
+        );
+        return filtered.length ? filtered : activeBalls;
+      };
+      const isLineClear = (start, end, ignoreIds = new Set()) => {
+        const delta = end.clone().sub(start);
+        const lenSq = delta.lengthSq();
+        if (lenSq < 1e-6) return true;
+        const len = Math.sqrt(lenSq);
+        const dir = delta.clone().divideScalar(len);
+        const clearanceSq = Math.pow(BALL_R * 2.05, 2);
+        for (const ball of balls) {
+          if (!ball?.active || ignoreIds.has(ball.id) || ball === cue) continue;
+          const rel = ball.pos.clone().sub(start);
+          const proj = THREE.MathUtils.clamp(rel.dot(dir), 0, len);
+          const closest = start.clone().add(dir.clone().multiplyScalar(proj));
+          const distSq = ball.pos.distanceToSquared(closest);
+          if (distSq < clearanceSq) return false;
+        }
+        return true;
+      };
+      const scoreAiInHandCandidate = (candidate, targetBalls) => {
+        if (!candidate) return -Infinity;
+        const maxDistance = Math.max(PLAY_W, PLAY_H);
+        let bestTargetScore = 0;
+        targetBalls.forEach((ball) => {
+          const dist = candidate.distanceTo(ball.pos);
+          const laneClear = isLineClear(candidate, ball.pos, new Set([ball.id]));
+          const distanceScore = 1 - clamp(dist / maxDistance, 0, 1);
+          const laneScore = laneClear ? 1 : 0.3;
+          bestTargetScore = Math.max(
+            bestTargetScore,
+            laneScore * (0.6 + 0.4 * distanceScore)
+          );
+        });
+        let minGap = Infinity;
+        for (const ball of balls) {
+          if (!ball?.active || ball === cue) continue;
+          const dist = candidate.distanceTo(ball.pos);
+          if (dist < minGap) minGap = dist;
+        }
+        const gapScore = Number.isFinite(minGap)
+          ? clamp(minGap / Math.max(BALL_R * 6, 1e-6), 0, 1)
+          : 0;
+        const centerBias =
+          1 - clamp(Math.abs(candidate.y) / Math.max(PLAY_H / 2, 1e-6), 0, 1);
+        return bestTargetScore + gapScore * 0.25 + centerBias * 0.15;
+      };
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
         const forwardBias = Math.max(baulkZ - BALL_R * 0.6, -PLAY_H / 2 + BALL_R);
@@ -19944,36 +20042,39 @@ const powerRef = useRef(hud.power);
           gridCandidates,
           jitterCandidates
         ];
+        const targetBalls = resolveInHandTargets();
         const clearanceLevels = [2.15, 2.1, 2.05, 2.02, 2.0];
         for (const clearance of clearanceLevels) {
+          let bestCandidate = null;
+          let bestScore = -Infinity;
           for (const group of candidateGroups) {
             for (const raw of group) {
               const clamped = clampInHandPosition(raw);
               if (!clamped) continue;
               if (!isSpotFree(clamped, clearance)) continue;
-              return clamped;
+              const score = scoreAiInHandCandidate(clamped, targetBalls);
+              if (score > bestScore) {
+                bestScore = score;
+                bestCandidate = clamped;
+              }
             }
           }
+          if (bestCandidate) return bestCandidate;
         }
         let best = null;
-        let bestGap = -Infinity;
+        let bestScore = -Infinity;
         const combined = candidateGroups.flat();
         for (const raw of combined) {
           const clamped = clampInHandPosition(raw);
           if (!clamped) continue;
-          let minDist = Infinity;
-          for (const ball of balls) {
-            if (!ball.active || ball === cue) continue;
-            const dist = clamped.distanceTo(ball.pos);
-            if (dist < minDist) minDist = dist;
-          }
-          if (minDist > bestGap) {
-            bestGap = minDist;
+          const score = scoreAiInHandCandidate(clamped, targetBalls);
+          if (score > bestScore) {
+            bestScore = score;
             best = clamped;
           }
         }
         if (best) {
-          if (bestGap < BALL_R * 2.02) {
+          if (!isSpotFree(best, 2.0)) {
             let nearest = null;
             let nearestDist = Infinity;
             for (const ball of balls) {
@@ -20023,6 +20124,17 @@ const powerRef = useRef(hud.power);
             }
           } else {
             return best;
+          }
+        }
+        const randomAttempts = 120;
+        for (let i = 0; i < randomAttempts; i += 1) {
+          const randX = (Math.random() * 2 - 1) * (PLAY_W / 2 - BALL_R);
+          const randY = allowFullTableInHand()
+            ? (Math.random() * 2 - 1) * (PLAY_H / 2 - BALL_R)
+            : baulkZ + (Math.random() * 2 - 1) * (D_RADIUS - BALL_R);
+          const candidate = clampInHandPosition(new THREE.Vector2(randX, randY));
+          if (candidate && isSpotFree(candidate, 2.0)) {
+            return candidate;
           }
         }
         const fallback = allowFullTableInHand()
@@ -23459,7 +23571,7 @@ const powerRef = useRef(hud.power);
         }
 
         sidePocketAimRef.current = false;
-        if (canShowCue && (isPlayerTurn || previewingAiShot)) {
+        if (canShowCue && (isPlayerTurn || previewingAiShot || aiCueViewActive)) {
           const baseAimDir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (baseAimDir.lengthSq() < 1e-8) baseAimDir.set(0, 0, 1);
           else baseAimDir.normalize();


### PR DESCRIPTION
### Motivation
- Provide broadcast-style commentary for 9-ball, 8-ball, American billiards, and snooker using an offline Chatterbox-compatible TTS pipeline and data-driven templates.
- Fix gameplay UX issues: make ball-impact sound full-volume, ensure the cue stick is visible for AI shots and replay playback, and avoid AI stalling when placing the cue ball in-hand. 
- Make AI ball-in-hand placement produce legal, playable placements favoring good views of targets and avoid placing the cue into blocked positions.

### Description
- Added a modular commentary system under `webapp/src/games/commentary/` including `commentaryDatabase.json`, `commentaryManager.js`, `chatterboxTtsService.js`, `commentarySchemas.js`, and `index.js`, plus documentation `docs/pool-royale-commentary-tts.md` with format, examples and payload schemas. 
- Implemented `CommentaryManager` with prioritized event selection, per-category and global cooldowns, suppression rules, placeholder filling, recent-history anti-repeat, and `onEvent(gameMode,eventType,context)` API that resolves with `{ text, audio, category, mode }`.
- Implemented `ChatterboxTtsService` wrapper that normalizes text, enqueues synth jobs, caches by deterministic key `(voiceId+text+settings)`, supports `preload`, and returns audio bytes/objects from an injected `synthesizer` function. 
- Refined Pool Royale gameplay code: raised ball-impact mix multiplier by removing an extra attenuation factor in `playBallHit` (`vol * volumeRef.current`), only capture cue snapshots when `cueStick.visible` for replays, and ensure cue stick remains visible during AI cue view and replay stroke playback (`canShowCue` and replay logic). 
- Substantially improved AI in-hand placement: added target-aware filtering `resolveInHandTargets`, candidate scoring `scoreAiInHandCandidate` (lane-clear checks, distance to useful targets, gap and center bias), smarter candidate search and fallback heuristics to favor legal placements that give the AI a clear view.

### Testing
- No automated tests were executed as part of this change; the PR includes new modules and behavior but automated test runs were not requested or performed.
- Manual review notes: code paths updated include `webapp/src/pages/Games/PoolRoyale.jsx` (cue/AI/replay/audio), new commentary modules under `webapp/src/games/commentary/`, and docs; recommend running the game and smoke-checking audio, AI in-hand placement, AI shot cue view, and replay cue visibility before shipping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752427bfcc83299b8b4660c3bad584)