### PR TITLE
Improve Pool Royale AI cue placement, audio & replay cue visibility; add modular Commentary + Chatterbox TTS system

### DIFF
--- a/webapp/src/commentary/chatterboxTtsService.js
+++ b/webapp/src/commentary/chatterboxTtsService.js
@@ -1,0 +1,118 @@
+const DEFAULT_SETTINGS = {
+  sampleRate: 24000,
+  speed: 1,
+  pitch: 1,
+  style: 'neutral',
+  maxTextLength: 140
+};
+
+const normalizeText = (text) =>
+  String(text || '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;!?])/g, '$1')
+    .trim();
+
+const buildCacheKey = (text, settings) => {
+  const payload = {
+    text,
+    voiceId: settings.voiceId,
+    speed: settings.speed,
+    pitch: settings.pitch,
+    style: settings.style,
+    sampleRate: settings.sampleRate
+  };
+  return JSON.stringify(payload);
+};
+
+class InMemoryAudioCache {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  get(key) {
+    return this.cache.get(key) || null;
+  }
+
+  set(key, value) {
+    this.cache.set(key, value);
+  }
+}
+
+export class ChatterboxTtsService {
+  constructor({ engine, cache, settings } = {}) {
+    this.engine = engine;
+    this.cache = cache || new InMemoryAudioCache();
+    this.settings = { ...DEFAULT_SETTINGS, ...settings };
+    this.queue = [];
+    this.processing = false;
+  }
+
+  async speak(text, overrides = {}) {
+    const normalized = normalizeText(text);
+    if (!normalized) return null;
+    const merged = { ...this.settings, ...overrides };
+    const trimmed = normalized.slice(0, merged.maxTextLength);
+    const key = buildCacheKey(trimmed, merged);
+
+    const cached = this.cache.get(key);
+    if (cached) {
+      return { ...cached, fromCache: true };
+    }
+
+    return this.enqueue(() => this.synthesize(trimmed, key, merged));
+  }
+
+  async enqueue(task) {
+    return new Promise((resolve) => {
+      this.queue.push({ task, resolve });
+      if (!this.processing) {
+        this.processing = true;
+        this.processQueue();
+      }
+    });
+  }
+
+  async processQueue() {
+    while (this.queue.length > 0) {
+      const { task, resolve } = this.queue.shift();
+      const result = await task();
+      resolve(result);
+    }
+    this.processing = false;
+  }
+
+  async synthesize(text, key, settings) {
+    if (!this.engine?.synthesize) {
+      console.warn('Chatterbox engine is not configured.');
+      return null;
+    }
+
+    const audioBuffer = await this.engine.synthesize({
+      text,
+      voiceId: settings.voiceId,
+      speed: settings.speed,
+      pitch: settings.pitch,
+      style: settings.style,
+      sampleRate: settings.sampleRate
+    });
+
+    if (!audioBuffer) return null;
+    const blob = new Blob([audioBuffer], { type: 'audio/wav' });
+    const url = URL.createObjectURL(blob);
+    const payload = {
+      url,
+      bytes: audioBuffer,
+      mimeType: 'audio/wav',
+      text
+    };
+    this.cache.set(key, payload);
+    return payload;
+  }
+
+  async preload(lines = [], overrides = {}) {
+    const unique = Array.from(new Set(lines));
+    for (const line of unique) {
+      await this.speak(line, overrides);
+    }
+  }
+}

--- a/webapp/src/commentary/commentaryDatabase.js
+++ b/webapp/src/commentary/commentaryDatabase.js
@@ -1,0 +1,421 @@
+export const COMMENTARY_DB = {
+  version: 1,
+  localeFallback: 'en',
+  globalRules: {
+    globalCooldownMs: 2800,
+    historyWindow: 10,
+    maxTextLength: 140
+  },
+  locales: {
+    en: {
+      modes: {
+        nineBall: {
+          voiceId: '9ball-energetic',
+          categories: {
+            break: {
+              priority: 85,
+              cooldownMs: 7000,
+              lines: [
+                'Big break from {playerName} and the cue ball holds up.',
+                'Dry break this time; the table stays open.',
+                '{playerName} scatters them well and has a look.',
+                'Scratch on the break; ball in hand for {opponentName}.',
+                'Made a ball on the break, and the one is in view.'
+              ]
+            },
+            pot: {
+              priority: 55,
+              cooldownMs: 4200,
+              lines: [
+                '{playerName} buries the {ball} and stays on the line.',
+                'Clean pot on the {ball}; cue ball stays obedient.',
+                '{playerName} takes the {ball} and keeps the run going.',
+                'Nice contact on the {ball}; that opens the table.',
+                'The {ball} drops and {playerName} has a chance to run.'
+              ]
+            },
+            miss: {
+              priority: 52,
+              cooldownMs: 4500,
+              lines: [
+                'Rattled the pocket on the {ball}; that was close.',
+                'Overcut on the {ball}; chance for {opponentName}.',
+                'Undercut there, and the {ball} stays up.',
+                'Tough miss on the {ball}; speed looked perfect.',
+                '{playerName} misses the {ball} and leaves the table open.'
+              ]
+            },
+            position: {
+              priority: 50,
+              cooldownMs: 4200,
+              lines: [
+                'Lovely leave on the next ball; that is textbook.',
+                'Great angle now; {playerName} can stay in rhythm.',
+                'The cue ball lands perfect; {shotType} is on.',
+                'Bit of a stretch here; cue ball not ideal.',
+                'Hooked behind the {ball}; that is awkward.'
+              ]
+            },
+            safety: {
+              priority: 60,
+              cooldownMs: 5200,
+              lines: [
+                'Smart safety from {playerName}; the {ball} is tied up.',
+                'A good trap; {opponentName} might have to jump.',
+                'Safety battle now, and that is a strong move.',
+                'Safety attempt leaks out; there is a shot.',
+                'Nice touch on the safety; cue ball hides well.'
+              ]
+            },
+            foul: {
+              priority: 95,
+              cooldownMs: 6500,
+              lines: [
+                'Foul: {foulType}. Ball in hand to {opponentName}.',
+                'Cue ball scratch; {opponentName} will like this look.',
+                'Illegal contact there; that is ball in hand.',
+                'Push out called; table is open for {opponentName}.',
+                'A costly error; foul gives control away.'
+              ]
+            },
+            pressure: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'Hill-hill pressure; every shot matters now.',
+                'Match ball on the nine; {playerName} feels it.',
+                'Comeback brewing; {playerName} is back within {lead}.',
+                'Big moment here with the {ball} on the table.',
+                '{playerName} needs this one to stay alive.'
+              ]
+            },
+            runout: {
+              priority: 78,
+              cooldownMs: 6200,
+              lines: [
+                'That is three in a row; this run is building.',
+                'Nearly perfect so far; {streak} balls without error.',
+                'Clean finish lines up if {playerName} keeps shape.',
+                'Two balls left; a clear path to the nine.',
+                '{playerName} is in full control of this rack.'
+              ]
+            },
+            short: {
+              priority: 40,
+              cooldownMs: 3000,
+              lines: [
+                'Nice shot.',
+                'Good pace.',
+                'Solid cueing.',
+                'Well judged.',
+                'Clean hit.'
+              ]
+            }
+          }
+        },
+        eightBall: {
+          voiceId: '8ball-energetic',
+          categories: {
+            break: {
+              priority: 82,
+              cooldownMs: 7000,
+              lines: [
+                'Open table after the break; choices everywhere.',
+                'Clusters stay tight; pattern play will be key.',
+                'Early 8-ball danger on the break; watch this.',
+                '{playerName} makes a ball and gets the first look.',
+                'Scratch on the break; {opponentName} has ball in hand.'
+              ]
+            },
+            groups: {
+              priority: 70,
+              cooldownMs: 6000,
+              lines: [
+                '{playerName} takes solids; the path looks clear.',
+                'Stripes claimed; now it is all about the key ball.',
+                'Decision made: {playerName} goes with {shotType}.',
+                '{playerName} chooses the set with the cleaner lanes.',
+                'Groups are set; pattern time.'
+              ]
+            },
+            pot: {
+              priority: 55,
+              cooldownMs: 4200,
+              lines: [
+                '{playerName} pockets the {ball} and stays in control.',
+                'That is a key ball; table opens up nicely.',
+                'Great shot on the {ball}; pattern still intact.',
+                '{playerName} clears another; two left in the set.',
+                'Nice pocket choice; {playerName} keeps the angle.'
+              ]
+            },
+            miss: {
+              priority: 52,
+              cooldownMs: 4500,
+              lines: [
+                'Wrong side of the ball; that miss costs position.',
+                'Blocked pocket; {playerName} will regret that.',
+                'Bank needed and it stays out; chance swings.',
+                'Overcut on the {ball}; that opens the table.',
+                'Rattled the {ball}; now the set is exposed.'
+              ]
+            },
+            defense: {
+              priority: 62,
+              cooldownMs: 5200,
+              lines: [
+                'Lock-up safety; {opponentName} may be trapped.',
+                'Great tie-up; that cluster just got worse.',
+                'Smart choice to break the cluster now.',
+                'Safety attempt sells out a shot.',
+                'Nice containment; {playerName} keeps control.'
+              ]
+            },
+            foul: {
+              priority: 95,
+              cooldownMs: 6500,
+              lines: [
+                'Scratch; ball in hand for {opponentName}.',
+                'Illegal 8-ball; that is game over.',
+                'Early 8-ball drops; that is a loss by rule.',
+                'No rail after contact; foul called.',
+                'Foul on the {ball}; {opponentName} gets the advantage.'
+              ]
+            },
+            pressure: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'On the 8-ball now; this is the moment.',
+                '{playerName} at match point on the 8.',
+                'Pressure shot with the 8-ball looming.',
+                '{opponentName} needs a miss to stay alive.',
+                'All eyes on this 8-ball attempt.'
+              ]
+            },
+            short: {
+              priority: 40,
+              cooldownMs: 3000,
+              lines: [
+                'Great touch.',
+                'Nice angle.',
+                'Clean pocket.',
+                'Good choice.',
+                'Well played.'
+              ]
+            }
+          }
+        },
+        americanPoints: {
+          voiceId: 'american-analyst',
+          categories: {
+            scoring: {
+              priority: 65,
+              cooldownMs: 4500,
+              lines: [
+                '{playerName} adds {points}; the run reaches {streak}.',
+                'Another point; {playerName} is staying in line.',
+                'That brings the total to {points}; steady progress.',
+                '{playerName} hits the {points} mark; strong control.',
+                'Milestone reached at {points}; nice pace.'
+              ]
+            },
+            position: {
+              priority: 55,
+              cooldownMs: 4200,
+              lines: [
+                'Textbook position; {playerName} stays on pattern.',
+                'Two-rail route executed perfectly.',
+                'Staying in line here keeps the run simple.',
+                'That leave makes the next shot awkward.',
+                'Great speed; the cue ball is right in the window.'
+              ]
+            },
+            miss: {
+              priority: 52,
+              cooldownMs: 4500,
+              lines: [
+                'That miss sells out big points.',
+                'Tough miss; {opponentName} has a chance to run.',
+                'The pattern breaks down with that error.',
+                'Overhit the position; that ends the streak.',
+                'Missed the {shotType}; opening for the other side.'
+              ]
+            },
+            safety: {
+              priority: 60,
+              cooldownMs: 5200,
+              lines: [
+                'Smart safety exchange; pressure builds.',
+                'Locked up nicely; forcing a thin hit.',
+                'Safety wins the table; {playerName} stays ahead.',
+                'Risky safety; it leaks a shot.',
+                'Good containment; {opponentName} is squeezed.'
+              ]
+            },
+            leadChange: {
+              priority: 80,
+              cooldownMs: 6500,
+              lines: [
+                'Lead changes hands; {playerName} now at {lead}.',
+                'That run swings the race; advantage {playerName}.',
+                'The gap closes to {lead}; momentum shifts.',
+                '{playerName} stretches the lead to {lead}.',
+                'Score pressure now; {opponentName} must respond.'
+              ]
+            },
+            clock: {
+              priority: 75,
+              cooldownMs: 6000,
+              lines: [
+                'Shot-clock pressure; quick decision needed.',
+                'Running out of time; {playerName} must commit.',
+                'That was late on the clock but well played.',
+                'Clock ticking; the pace speeds up.',
+                'Under the gun and still finds the line.'
+              ]
+            },
+            short: {
+              priority: 40,
+              cooldownMs: 3000,
+              lines: [
+                'Sharp.',
+                'Smooth.',
+                'Good speed.',
+                'Right line.',
+                'Steady.'
+              ]
+            }
+          }
+        },
+        snooker: {
+          voiceId: 'snooker-calm',
+          categories: {
+            breakBuilding: {
+              priority: 70,
+              cooldownMs: 5200,
+              lines: [
+                '{playerName} moves to {breakPoints} and counting.',
+                'Break reaches {breakPoints}; nice control.',
+                'That takes the break past {breakPoints}.',
+                '{playerName} is building a serious visit.',
+                'Clean cueing keeps the break alive.'
+              ]
+            },
+            colors: {
+              priority: 60,
+              cooldownMs: 4800,
+              lines: [
+                'Reds and blacks again; this is the rhythm.',
+                'Switching colors now with {remaining} reds left.',
+                'Blue is on; key moment in the break.',
+                'Pink available; a chance to extend the lead.',
+                'Clearing the colors; pressure rising.'
+              ]
+            },
+            safety: {
+              priority: 65,
+              cooldownMs: 5200,
+              lines: [
+                'Excellent safety; {opponentName} is snookered.',
+                'Thin hit escape; that was very tight.',
+                'Great snooker laid; {playerName} asks the question.',
+                'Safety battle now; tactical chess on the baize.',
+                'Escape missed; foul points on offer.'
+              ]
+            },
+            foul: {
+              priority: 95,
+              cooldownMs: 6500,
+              lines: [
+                'Foul: {foulType}; {points} points to {opponentName}.',
+                'In-off there; costly mistake.',
+                'Miss called; {opponentName} may ask again.',
+                'Free ball situation; advantage swings.',
+                'Touching ball declared; needs precision.'
+              ]
+            },
+            difficulty: {
+              priority: 58,
+              cooldownMs: 4800,
+              lines: [
+                'Long pot from {difficulty} distance; very brave.',
+                'Rest shot played beautifully.',
+                'Screw shot with side; great cue action.',
+                'Stun run-through executed with control.',
+                'Thin cut on the {ball}; excellent touch.'
+              ]
+            },
+            pressure: {
+              priority: 88,
+              cooldownMs: 7000,
+              lines: [
+                'Frame ball here; {playerName} can seal it.',
+                'Needs snookers now; still a chance.',
+                'Match pressure with {frameScore} on the board.',
+                'Big moment; every point counts.',
+                'One chance table; no easy returns.'
+              ]
+            },
+            short: {
+              priority: 40,
+              cooldownMs: 3000,
+              lines: [
+                'Lovely.',
+                'Classy.',
+                'Pure cueing.',
+                'Well judged.',
+                'Nice touch.'
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const COMMENTARY_EVENT_CATEGORY_MAP = {
+  nineBall: {
+    break: 'break',
+    pot: 'pot',
+    combo: 'pot',
+    carom: 'pot',
+    miss: 'miss',
+    position: 'position',
+    safety: 'safety',
+    foul: 'foul',
+    pressure: 'pressure',
+    runout: 'runout',
+    short: 'short'
+  },
+  eightBall: {
+    break: 'break',
+    groupsChosen: 'groups',
+    pot: 'pot',
+    miss: 'miss',
+    defense: 'defense',
+    foul: 'foul',
+    pressure: 'pressure',
+    tactical: 'miss',
+    short: 'short'
+  },
+  americanPoints: {
+    scoring: 'scoring',
+    position: 'position',
+    miss: 'miss',
+    safety: 'safety',
+    leadChange: 'leadChange',
+    clock: 'clock',
+    short: 'short'
+  },
+  snooker: {
+    breakBuilding: 'breakBuilding',
+    colors: 'colors',
+    safety: 'safety',
+    foul: 'foul',
+    difficulty: 'difficulty',
+    pressure: 'pressure',
+    short: 'short'
+  }
+};

--- a/webapp/src/commentary/commentaryManager.js
+++ b/webapp/src/commentary/commentaryManager.js
@@ -1,0 +1,159 @@
+import { COMMENTARY_DB, COMMENTARY_EVENT_CATEGORY_MAP } from './commentaryDatabase.js';
+
+const DEFAULT_PLACEHOLDERS = {
+  playerName: 'The player',
+  opponentName: 'the opponent',
+  ball: 'ball',
+  points: 'points',
+  remaining: 'remaining',
+  frameScore: 'the frame score',
+  breakPoints: 'the break',
+  foulType: 'foul',
+  shotType: 'shot',
+  difficulty: 'long range',
+  streak: 'a streak',
+  lead: 'the lead'
+};
+
+const normalizeGameMode = (mode) => {
+  if (!mode) return 'nineBall';
+  const normalized = String(mode).toLowerCase();
+  if (normalized.includes('9')) return 'nineBall';
+  if (normalized.includes('8')) return 'eightBall';
+  if (normalized.includes('snooker')) return 'snooker';
+  if (normalized.includes('american')) return 'americanPoints';
+  return 'nineBall';
+};
+
+const normalizeText = (text) =>
+  String(text || '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;!?])/g, '$1')
+    .trim();
+
+export class CommentaryManager {
+  constructor({ database = COMMENTARY_DB, ttsService, locale = 'en', now } = {}) {
+    this.database = database;
+    this.ttsService = ttsService;
+    this.locale = locale;
+    this.now = now || (() => performance.now());
+    this.history = [];
+    this.categoryLastSpoken = new Map();
+    this.lastSpokenAt = 0;
+    this.pending = null;
+    this.processing = false;
+  }
+
+  onEvent(gameMode, eventType, context = {}) {
+    const entry = this.buildEntry(gameMode, eventType, context);
+    if (!entry) return Promise.resolve(null);
+    if (this.processing) {
+      if (!this.pending || entry.priority > this.pending.priority) {
+        this.pending = entry;
+      }
+      return entry.promise;
+    }
+    return this.processEntry(entry);
+  }
+
+  buildEntry(gameMode, eventType, context) {
+    const modeKey = normalizeGameMode(gameMode);
+    const localeBundle = this.database.locales?.[this.locale]
+      ?? this.database.locales?.[this.database.localeFallback]
+      ?? null;
+    const mode = localeBundle?.modes?.[modeKey];
+    if (!mode) return null;
+    const categoryKey =
+      COMMENTARY_EVENT_CATEGORY_MAP?.[modeKey]?.[eventType] || eventType;
+    const category = mode.categories?.[categoryKey];
+    if (!category) return null;
+    const now = this.now();
+    const globalCooldown = this.database.globalRules?.globalCooldownMs ?? 2500;
+    if (now - this.lastSpokenAt < globalCooldown) return null;
+    const categoryCooldown = category.cooldownMs ?? 4000;
+    const lastCategoryAt = this.categoryLastSpoken.get(categoryKey) ?? 0;
+    if (now - lastCategoryAt < categoryCooldown) return null;
+
+    const text = this.pickTemplate(category.lines || [], modeKey, categoryKey);
+    if (!text) return null;
+    const resolved = this.fillTemplate(text, context);
+    const normalized = normalizeText(resolved);
+    if (!normalized) return null;
+
+    const priority = Number.isFinite(category.priority)
+      ? category.priority
+      : 50;
+    let resolvePromise;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    return {
+      gameMode: modeKey,
+      categoryKey,
+      text: normalized,
+      voiceId: mode.voiceId,
+      priority,
+      context,
+      resolve: resolvePromise,
+      promise
+    };
+  }
+
+  pickTemplate(lines, modeKey, categoryKey) {
+    if (!Array.isArray(lines) || lines.length === 0) return null;
+    const historyWindow = this.database.globalRules?.historyWindow ?? 8;
+    const recent = new Set(
+      this.history.slice(-historyWindow).map((entry) => entry.template)
+    );
+    const available = lines.filter((line) => !recent.has(line));
+    const pool = available.length > 0 ? available : lines;
+    const index = Math.floor(Math.random() * pool.length);
+    const template = pool[index];
+    this.history.push({
+      template,
+      modeKey,
+      categoryKey,
+      at: this.now()
+    });
+    return template;
+  }
+
+  fillTemplate(template, context = {}) {
+    return template.replace(/\{(\w+)\}/g, (_match, key) => {
+      if (context[key] != null && context[key] !== '') return String(context[key]);
+      if (DEFAULT_PLACEHOLDERS[key]) return DEFAULT_PLACEHOLDERS[key];
+      return '';
+    });
+  }
+
+  async processEntry(entry) {
+    this.processing = true;
+    const now = this.now();
+    this.lastSpokenAt = now;
+    this.categoryLastSpoken.set(entry.categoryKey, now);
+
+    let result = null;
+    try {
+      if (this.ttsService?.speak) {
+        result = await this.ttsService.speak(entry.text, {
+          voiceId: entry.voiceId,
+          gameMode: entry.gameMode
+        });
+      }
+    } catch (error) {
+      console.warn('Commentary TTS failed', error);
+    }
+
+    entry.resolve(result);
+    this.processing = false;
+
+    if (this.pending) {
+      const next = this.pending;
+      this.pending = null;
+      return this.processEntry(next);
+    }
+
+    return result;
+  }
+}

--- a/webapp/src/commentary/eventSchemas.js
+++ b/webapp/src/commentary/eventSchemas.js
@@ -1,0 +1,72 @@
+export const EVENT_PAYLOAD_SCHEMAS = {
+  nineBall: {
+    break: {
+      eventType: 'break',
+      playerName: 'Player 1',
+      result: 'made-ball|dry|scratch',
+      ball: '1'
+    },
+    pot: {
+      eventType: 'pot',
+      playerName: 'Player 1',
+      ball: '3',
+      positionQuality: 'good',
+      runCount: 4,
+      difficulty: 'medium'
+    },
+    foul: {
+      eventType: 'foul',
+      playerName: 'Player 2',
+      opponentName: 'Player 1',
+      foulType: 'scratch'
+    }
+  },
+  eightBall: {
+    groupsChosen: {
+      eventType: 'groupsChosen',
+      playerName: 'Player 1',
+      shotType: 'solids'
+    },
+    pressure: {
+      eventType: 'pressure',
+      playerName: 'Player 1',
+      onEightBall: true,
+      pocketBlocked: false
+    }
+  },
+  americanPoints: {
+    scoring: {
+      eventType: 'scoring',
+      playerName: 'Player 1',
+      points: 38,
+      streak: 7,
+      lead: '+12'
+    },
+    clock: {
+      eventType: 'clock',
+      playerName: 'Player 2',
+      timeRemaining: 3
+    }
+  },
+  snooker: {
+    breakBuilding: {
+      eventType: 'breakBuilding',
+      playerName: 'Player 1',
+      breakPoints: 56,
+      remaining: 3
+    },
+    pressure: {
+      eventType: 'pressure',
+      playerName: 'Player 2',
+      frameScore: '45-52',
+      needsSnookers: false
+    },
+    foul: {
+      eventType: 'foul',
+      playerName: 'Player 1',
+      opponentName: 'Player 2',
+      foulType: 'in-off',
+      points: 4
+    }
+  }
+};

--- a/webapp/src/commentary/index.js
+++ b/webapp/src/commentary/index.js
@@ -1,0 +1,4 @@
+export { COMMENTARY_DB, COMMENTARY_EVENT_CATEGORY_MAP } from './commentaryDatabase.js';
+export { CommentaryManager } from './commentaryManager.js';
+export { ChatterboxTtsService } from './chatterboxTtsService.js';
+export { EVENT_PAYLOAD_SCHEMAS } from './eventSchemas.js';


### PR DESCRIPTION
### Motivation
- Make AI turns clearer and less likely to stall by improving automatic cue-ball placement when the AI has ball-in-hand. 
- Improve audio feedback for ball impacts so hits are audible and satisfying. 
- Ensure the cue stick is visible during AI shots and in replays so players can follow AI actions. 
- Provide an offline, template-driven commentary system (with caching) for 9-ball, 8-ball, American points and snooker to deliver quick broadcast-style lines via Chatterbox TTS.

### Description
- Pool/Aiming/audio changes in `webapp/src/pages/Games/PoolRoyale.jsx`: adjusted `playBallHit` gain calculation to use full scaled volume (`clamp(vol * volumeRef.current, 0, 1)`), extended replay cue-stick visibility by computing `holdMs` instead of a fixed threshold, and allowed the cue to show during AI activity by adding `aiTakingShot` to the `canShowCue` check. 
- AI ball-in-hand placement: added helper functions `getLegalTargetBalls`, `distanceToSegment`, and `scoreInHandCandidate`, and refactored `findAiInHandPlacement` to score candidate placements by open-lane clearance, distance penalty and rail clearance; added a spiral fallback search to avoid stalls (all in `PoolRoyale.jsx`). 
- Replay cue stick: show-logic updated to use `holdMs = Math.max(REPLAY_CUE_STICK_HOLD_MS, Math.min(playback?.duration ?? REPLAY_CUE_STICK_HOLD_MS, 2000))` so the cue is visible for longer/for the recorded playback length. 
- Commentary system added under `webapp/src/commentary/`: 
  - `commentaryDatabase.js` — structured template database for `nineBall`, `eightBall`, `americanPoints`, and `snooker` with categories, priorities, cooldowns and many example lines. 
  - `commentaryManager.js` — selection logic that maps events -> categories, enforces global/category cooldowns, history suppression, fills placeholders, and manages queueing/priority. 
  - `chatterboxTtsService.js` — local/offline TTS wrapper with deterministic cache keying, async queueing, `speak` API and `preload` support (engine-agnostic; expects an `engine.synthesize` implementation). 
  - `eventSchemas.js` — example payload schemas for events per mode to guide callers. 
  - `index.js` — export surface for the commentary module. 
- Small housekeeping: staged and committed the changes as a single change-set (see commit message). 

### Testing
- Automated tests: none were executed as part of this change; no CI/test runs were performed. 
- Notes: changes were implemented and committed; recommend running the game locally and exercising AI turns, ball-in-hand placement, AI-shot replay playback, and commentary `onEvent` calls with a local Chatterbox-compatible `engine.synthesize` to validate audio output, caching and cooldown behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752427bfcc83299b8b4660c3bad584)