### PR TITLE
Enable Pool Royale start commentary audio (Web Speech + integration)

### DIFF
--- a/webapp/src/commentary/commentaryManager.js
+++ b/webapp/src/commentary/commentaryManager.js
@@ -130,8 +130,6 @@ export class CommentaryManager {
   async processEntry(entry) {
     this.processing = true;
     const now = this.now();
-    this.lastSpokenAt = now;
-    this.categoryLastSpoken.set(entry.categoryKey, now);
 
     let result = null;
     try {
@@ -143,6 +141,11 @@ export class CommentaryManager {
       }
     } catch (error) {
       console.warn('Commentary TTS failed', error);
+    }
+
+    if (result) {
+      this.lastSpokenAt = now;
+      this.categoryLastSpoken.set(entry.categoryKey, now);
     }
 
     entry.resolve(result);

--- a/webapp/src/commentary/webSpeechTtsService.js
+++ b/webapp/src/commentary/webSpeechTtsService.js
@@ -1,0 +1,90 @@
+const DEFAULT_SETTINGS = {
+  rate: 1,
+  pitch: 1,
+  volume: 1,
+  locale: 'en-US'
+};
+
+const ensureVoices = (synth, timeoutMs = 1200) =>
+  new Promise((resolve) => {
+    const voices = synth.getVoices();
+    if (voices.length > 0) {
+      resolve(voices);
+      return;
+    }
+    let settled = false;
+    const handleVoices = () => {
+      if (settled) return;
+      settled = true;
+      synth.removeEventListener('voiceschanged', handleVoices);
+      resolve(synth.getVoices());
+    };
+    synth.addEventListener('voiceschanged', handleVoices);
+    window.setTimeout(handleVoices, timeoutMs);
+  });
+
+const pickVoice = (voices, { voiceId, locale }) => {
+  if (!Array.isArray(voices) || voices.length === 0) return null;
+  const normalized = voiceId ? String(voiceId).toLowerCase() : '';
+  if (normalized) {
+    const matched =
+      voices.find((voice) => voice.name.toLowerCase().includes(normalized)) ||
+      voices.find((voice) => voice.voiceURI?.toLowerCase().includes(normalized));
+    if (matched) return matched;
+  }
+  const localeLower = String(locale || '').toLowerCase();
+  const localeMatch = voices.find((voice) =>
+    voice.lang?.toLowerCase().startsWith(localeLower)
+  );
+  if (localeMatch) return localeMatch;
+  const english = voices.find((voice) => voice.lang?.toLowerCase().startsWith('en'));
+  return english || voices[0];
+};
+
+export class WebSpeechTtsService {
+  constructor({ getMuted, getVolume, settings } = {}) {
+    this.getMuted = typeof getMuted === 'function' ? getMuted : () => false;
+    this.getVolume = typeof getVolume === 'function' ? getVolume : () => 1;
+    this.settings = { ...DEFAULT_SETTINGS, ...settings };
+    this.pendingUtterances = new Set();
+  }
+
+  async speak(text, overrides = {}) {
+    if (this.getMuted?.()) return null;
+    if (typeof window === 'undefined' || !window.speechSynthesis) return null;
+    const merged = { ...this.settings, ...overrides };
+    const synth = window.speechSynthesis;
+    const voices = await ensureVoices(synth);
+    const utterance = new SpeechSynthesisUtterance(text);
+    const voice = pickVoice(voices, { voiceId: merged.voiceId, locale: merged.locale });
+    if (voice) utterance.voice = voice;
+    utterance.rate = Number.isFinite(merged.rate) ? merged.rate : DEFAULT_SETTINGS.rate;
+    utterance.pitch = Number.isFinite(merged.pitch) ? merged.pitch : DEFAULT_SETTINGS.pitch;
+    const resolvedVolume = Number.isFinite(merged.volume)
+      ? merged.volume
+      : this.getVolume?.() ?? DEFAULT_SETTINGS.volume;
+    utterance.volume = Math.max(0, Math.min(1, resolvedVolume));
+
+    return new Promise((resolve) => {
+      const cleanup = () => {
+        this.pendingUtterances.delete(utterance);
+      };
+      utterance.onend = () => {
+        cleanup();
+        resolve({ utterance, text });
+      };
+      utterance.onerror = () => {
+        cleanup();
+        resolve(null);
+      };
+      this.pendingUtterances.add(utterance);
+      synth.speak(utterance);
+    });
+  }
+
+  stop() {
+    if (typeof window === 'undefined' || !window.speechSynthesis) return;
+    window.speechSynthesis.cancel();
+    this.pendingUtterances.clear();
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix missing startup commentary so players hear commentary from the start of a match. 
- Use a browser-native fallback TTS when no remote engine is configured so commentary works reliably across platforms. 
- Avoid consuming commentary cooldowns when TTS fails so replay attempts remain available.

### Description
- Add a lightweight Web Speech wrapper `webapp/src/commentary/webSpeechTtsService.js` that uses `window.speechSynthesis`, selects a voice, respects mute/volume and exposes `speak` and `stop` APIs. 
- Update `commentaryManager` in `webapp/src/commentary/commentaryManager.js` to only update `lastSpokenAt` and `categoryLastSpoken` after TTS returned a result, preventing cooldowns from being locked on failed playback. 
- Wire the commentary system into Pool Royale: import `CommentaryManager` and `WebSpeechTtsService`, create refs for the manager/service in `webapp/src/pages/Games/PoolRoyale.jsx`, initialize them on mount, and clean them up on unmount. 
- Trigger an opening commentary event (`'break'`) at match start with player/opponent names as context, via `manager.onEvent(...)`, and ensure playback is attempted either on the first `pointerdown` or after a short timeout to work around browser autoplay restrictions. 
- Reset a per-match `commentaryStarted` flag on new frames so each match can replay its intro commentary.

### Testing
- Automated tests: none were run. 
- Basic runtime changes were compiled into the codebase and the integration code was added, but no automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69753522b2808329a74c55946c13eb6d)