### PR TITLE
Move Texas Hold'em AI avatar selector into Player Profile card

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -127,6 +127,19 @@ export default function TexasHoldemLobby() {
               </p>
             </div>
           </div>
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={openAiFlagPicker}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">AI Avatars</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}</span>
+                <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
+              </div>
+            </button>
+          </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby settings carry over as soon as the poker arena finishes loading.
           </p>
@@ -241,33 +254,6 @@ export default function TexasHoldemLobby() {
               </div>
             ))}
           </div>
-        </div>
-
-        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#111827]/90 to-[#0f172a]/80 p-4 shadow-[0_20px_40px_rgba(0,0,0,0.35)]">
-          <div className="flex items-center gap-3">
-            <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-sky-400/40 to-indigo-500/40 p-[1px]">
-              <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-lg">
-                🏳️
-              </div>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-white">AI Avatar Flags</h3>
-              <p className="text-xs text-white/60">
-                Auto-filled with random worldwide flags—tap to customize or reshuffle before you start.
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={openAiFlagPicker}
-            className="mt-4 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-3 text-left text-sm text-white/80 transition hover:border-primary/70"
-          >
-            <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flags</div>
-            <div className="mt-1 flex items-center gap-2 text-base font-semibold text-white">
-              <span className="text-lg">{flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐'}</span>
-              <span>{flags.length ? 'Custom AI avatars' : 'Auto-pick from global flags'}</span>
-            </div>
-          </button>
         </div>
 
         <button


### PR DESCRIPTION
### Motivation
- Make the Texas Hold'em lobby match the Pool Royale layout by placing AI avatars inside the player profile frame so AI opponents visually share the same profile area as the human player.

### Description
- Moved the AI avatar selector UI into the existing Player Profile card in `webapp/src/pages/Games/TexasHoldemLobby.jsx` and removed the separate AI avatar flags card.
- Added a compact `AI Avatars` button inside the profile panel that reuses the existing `openAiFlagPicker` handler and `flags` state to show current AI avatar flags.
- Kept existing parameter wiring to `startGame` so `avatars=flags` and `flags` query params are still set for local mode.
- Only modified `TexasHoldemLobby.jsx` (UI change) and preserved existing flag picker modal integration.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server started successfully (Vite ready).
- Captured a portrait screenshot of `/games/texasholdem/lobby` using a Playwright script to validate the UI change and the screenshot artifact was produced successfully.
- No unit tests were modified or required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975aa2125788329a2912128234909f5)