### PR TITLE
Align Snake lobby player-count options for local AI and online modes

### DIFF
--- a/webapp/src/pages/Games/Lobby.jsx
+++ b/webapp/src/pages/Games/Lobby.jsx
@@ -66,6 +66,7 @@ export default function Lobby() {
   const matchTimeoutRef = useRef(null);
   const seatTimeoutRef = useRef(null);
   const isOnlineMatch = table?.id && table.id !== 'single';
+  const isLocalMatch = table?.id === 'single';
 
   useEffect(() => {
     cleanupRef.current?.({ keepError: true });
@@ -113,6 +114,34 @@ export default function Lobby() {
     }
     const onlineTable = tables.find((entry) => entry.id !== 'single');
     if (onlineTable) setTable(onlineTable);
+  };
+
+  const multiplayerTables = tables.filter((entry) => entry.id !== 'single');
+  const fallbackCapacities = [
+    { id: 'snake-2', capacity: 2 },
+    { id: 'snake-3', capacity: 3 },
+    { id: 'snake-4', capacity: 4 }
+  ];
+  const capacityOptions = multiplayerTables.length ? multiplayerTables : fallbackCapacities;
+  const localTableOptions = capacityOptions.map((entry) => ({
+    ...entry,
+    id: `local-${entry.capacity}`,
+    label: `${entry.capacity} Players`,
+    subtitle: 'AI opponents'
+  }));
+  const displayedTables = isLocalMatch ? localTableOptions : multiplayerTables;
+  const selectedTable = isLocalMatch
+    ? localTableOptions.find((entry) => entry.capacity === aiCount + 1) || localTableOptions[0]
+    : table;
+
+  const handleTableSelect = (selectedOption) => {
+    if (isLocalMatch || selectedOption.id.startsWith('local-')) {
+      const singleTable = tables.find((entry) => entry.id === 'single');
+      if (singleTable) setTable(singleTable);
+      setAiCount(Math.max((selectedOption.capacity || 2) - 1, 1));
+      return;
+    }
+    setTable(selectedOption);
   };
 
   useEffect(() => {
@@ -511,7 +540,11 @@ export default function Lobby() {
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-              <TableSelector tables={tables} selected={table} onSelect={setTable} />
+              <TableSelector
+                tables={displayedTables}
+                selected={selectedTable}
+                onSelect={handleTableSelect}
+              />
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation

- Make local "Local vs AI" match setup offer the same 2–4 player capacity choices as the online lobby so players can pick up to 3 opponents in the same way as online. 
- Keep the existing single-table flow used for AI matches while mapping capacity selections to the `aiCount` used by the single-player game entry.

### Description

- Added an `isLocalMatch` flag and built `localTableOptions` that mirror multiplayer capacities (2–4) with a fallback when server lobbies aren't available. 
- Replaced the previous `TableSelector` input with a computed `displayedTables` and `selectedTable` so the selector shows AI-capacity options in local mode and multiplayer tables in online mode. 
- Implemented `handleTableSelect` which maps local selections to the single-table flow by setting the single `table` and updating `aiCount`, and leaves online picks to set the multiplayer `table` directly.

### Testing

- Launched the webdev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app successfully. 
- Ran a Playwright capture that loaded `/games/snake/lobby` and saved a screenshot to `artifacts/snake-lobby.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b57258188329a3db4ac399fe83e5)