### PR TITLE
Adjust mining roulette layout and add prize reveal effects

### DIFF
--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -109,7 +109,7 @@ export default function RouletteMini() {
   const [remaining, setRemaining] = useState(0);
   const spinTimeoutRef = useRef(null);
   const spinSoundRef = useRef(null);
-  const targetRotationRef = useRef(0);
+  const targetIndexRef = useRef(0);
 
   const wheelBackground = useMemo(() => {
     const parts = ROULETTE_ORDER.map((num, idx) => {
@@ -180,13 +180,6 @@ export default function RouletteMini() {
     if (spinTimeoutRef.current) clearTimeout(spinTimeoutRef.current);
   }, []);
 
-  const resolveWinningIndex = (rotation) => {
-    const normalized = ((-rotation - SEGMENT_ANGLE / 2) % 360 + 360) % 360;
-    const index =
-      Math.round(normalized / SEGMENT_ANGLE) % ROULETTE_ORDER.length;
-    return index;
-  };
-
   const startSpin = () => {
     if (spinning) return;
     const index = Math.floor(Math.random() * ROULETTE_ORDER.length);
@@ -199,7 +192,7 @@ export default function RouletteMini() {
     setOutcome(null);
     setAdWatched(false);
     setSpinState({ totalSpins, rotation });
-    targetRotationRef.current = rotation;
+    targetIndexRef.current = index;
     if (spinSoundRef.current) {
       spinSoundRef.current.currentTime = 0;
       spinSoundRef.current.play().catch(() => {});
@@ -209,7 +202,7 @@ export default function RouletteMini() {
       setSpinning(false);
       spinSoundRef.current?.pause();
       if (spinSoundRef.current) spinSoundRef.current.currentTime = 0;
-      const resolvedIndex = resolveWinningIndex(targetRotationRef.current);
+      const resolvedIndex = targetIndexRef.current;
       const resolvedNumber = ROULETTE_ORDER[resolvedIndex];
       const resolvedPrize = PRIZE_MAP[resolvedNumber];
       setOutcome({ number: resolvedNumber, prize: resolvedPrize });
@@ -270,12 +263,12 @@ export default function RouletteMini() {
       />
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">
-        <div className="absolute left-1/2 -translate-x-1/2 -top-3 z-20 flex flex-col items-center">
-          <div className="w-0 h-0 border-l-[10px] border-r-[10px] border-b-[18px] border-l-transparent border-r-transparent border-b-yellow-400 drop-shadow" />
-          <div className="w-2 h-2 bg-white rounded-full mt-1 shadow ring-1 ring-gray-300" />
+        <div className="absolute left-1/2 -translate-x-1/2 -top-2 z-20 flex flex-col items-center">
+          <div className="w-0 h-0 border-l-[10px] border-r-[10px] border-t-[18px] border-l-transparent border-r-transparent border-t-yellow-400 drop-shadow" />
+          <div className="w-2 h-2 bg-white rounded-full -mt-1 shadow ring-1 ring-gray-300" />
         </div>
         <div
-          className="relative w-full h-full rounded-full border-[3px] border-yellow-400/80 shadow-inner flex items-center justify-center overflow-hidden [--roulette-label-radius:120px] sm:[--roulette-label-radius:136px] will-change-transform"
+          className="relative w-full h-full rounded-full border-[3px] border-yellow-400/80 shadow-inner flex items-center justify-center overflow-hidden [--roulette-label-radius:132px] sm:[--roulette-label-radius:150px] will-change-transform"
           style={{
             background: wheelBackground,
             transform: `translateZ(0) rotate(${spinState.rotation}deg)`,
@@ -312,13 +305,23 @@ export default function RouletteMini() {
               </div>
             );
           })}
-          <div className="absolute inset-[28%] rounded-full bg-surface/85 border border-yellow-400/80 flex flex-col items-center justify-center text-xs text-subtext space-y-1">
-            <span className="uppercase tracking-wide">TPC Rewards</span>
-            <span className="text-sm font-semibold text-white">
-              {outcome ? `+${formatPrize(outcome.prize)} TPC` : 'Spin to win'}
-            </span>
-          </div>
         </div>
+        <div className="absolute inset-[28%] rounded-full bg-surface/85 border border-yellow-400/80 flex flex-col items-center justify-center text-xs text-subtext space-y-1 pointer-events-none">
+          <span className="uppercase tracking-wide">TPC Rewards</span>
+          <span className="text-sm font-semibold text-white">
+            {outcome ? `+${formatPrize(outcome.prize)} TPC` : 'Spin to win'}
+          </span>
+        </div>
+        {outcome && !spinning && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="roulette-prize-beam" />
+            <div className="roulette-prize-pop">
+              <div className="roulette-prize-value">
+                +{formatPrize(outcome.prize)} TPC
+              </div>
+            </div>
+          </div>
+        )}
       </div>
       <div className="space-y-2">
         <button

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -198,6 +198,74 @@ input:focus {
   transition: transform 0.3s ease; /* ✅ scaling transition */
 }
 
+.roulette-prize-beam {
+  position: absolute;
+  width: 140px;
+  height: 140px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(250, 204, 21, 0.65) 0%,
+    rgba(250, 204, 21, 0.35) 35%,
+    rgba(250, 204, 21, 0) 70%
+  );
+  filter: blur(2px);
+  animation: rouletteBeamGrow 0.8s ease-out forwards;
+}
+
+.roulette-prize-pop {
+  position: relative;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #fff6bf 0%, #facc15 55%, #c08400 100%);
+  color: #1f2937;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+  box-shadow:
+    0 0 20px rgba(250, 204, 21, 0.8),
+    0 12px 20px rgba(0, 0, 0, 0.35);
+  transform: translateY(6px) scale(0.8);
+  animation: roulettePrizePop 0.6s ease-out forwards,
+    roulettePrizeFloat 2.4s ease-in-out infinite 0.6s;
+}
+
+.roulette-prize-value {
+  transform: translateZ(0);
+}
+
+@keyframes rouletteBeamGrow {
+  0% {
+    transform: scale(0.55);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+}
+
+@keyframes roulettePrizePop {
+  0% {
+    transform: translateY(10px) scale(0.7);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(-8px) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes roulettePrizeFloat {
+  0%,
+  100% {
+    transform: translateY(-8px) scale(1);
+  }
+  50% {
+    transform: translateY(-12px) scale(1.05);
+  }
+}
+
 /* Full-screen stage behind the Snake & Ladder board */
 .background-behind-board {
   position: absolute;


### PR DESCRIPTION
### Motivation
- Fix visual alignment of roulette numbers and pointer so labels sit between the red and yellow rings and the top triangle points correctly.
- Make the winning number resolution reliable so the declared winner matches where the ball/pointer stops.
- Improve UX by keeping the center text stationary during spins and adding a 3D glowing prize reveal when the ball stops.

### Description
- Use a `targetIndexRef` to store the chosen segment and resolve the winning number from that index instead of deriving it from the post-rotation value. 
- Update roulette markup/CSS to flip and nudge the top triangle pointer, push labels slightly outward via `--roulette-label-radius` changes, and keep the center text outside the rotating wheel so it does not spin. 
- Add prize reveal overlay markup that appears when `outcome` is set and `spinning` is false, and add corresponding animations/styles (`.roulette-prize-beam`, `.roulette-prize-pop`, keyframes) in `webapp/src/index.css`.
- Minor adjustments to label radius and small visual tweaks to the pointer dot for better alignment and visual balance.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a headless browser screenshot of `/mining` using a Playwright script, which completed successfully and produced `artifacts/mining-roulette.png`.
- No unit tests were run as part of this change; the UI verification was performed via the automated headless screenshot described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bb6a42e0832984631c6b112c713c)