### PR TITLE
Fix commentary playback gating and UK scratch behavior

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -210,7 +210,7 @@ export class UkPool {
       shotsNext = 2;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = false;
+      s.mustPlayFromBaulk = scratched;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -34,6 +34,8 @@ import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/soundData.js';
+import { buildCommentaryLine } from '../../utils/poolRoyaleCommentary.js';
+import { getSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -911,6 +913,89 @@ const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
+const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
+const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
+const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
+  {
+    id: 'arena-duo',
+    label: 'Arena duo',
+    description: 'UK lead with US analyst',
+    voiceHints: {
+      Steven: ['Google UK English Male', 'en-GB', 'English', 'UK'],
+      John: ['Google US English', 'en-US', 'English', 'US']
+    },
+    speakerSettings: {
+      Steven: { rate: 1, pitch: 0.94, volume: 1 },
+      John: { rate: 1.03, pitch: 1.04, volume: 1 }
+    }
+  },
+  {
+    id: 'atlantic',
+    label: 'Atlantic booth',
+    description: 'US lead with UK analyst',
+    voiceHints: {
+      Steven: ['Google US English', 'en-US', 'English', 'US'],
+      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+    },
+    speakerSettings: {
+      Steven: { rate: 1.02, pitch: 0.98, volume: 1 },
+      John: { rate: 1, pitch: 0.92, volume: 1 }
+    }
+  },
+  {
+    id: 'pacific',
+    label: 'Pacific desk',
+    description: 'Australian & US cadence',
+    voiceHints: {
+      Steven: ['Google Australian English', 'en-AU', 'English', 'Australia'],
+      John: ['Google US English', 'en-US', 'English', 'US']
+    },
+    speakerSettings: {
+      Steven: { rate: 1.01, pitch: 0.96, volume: 1 },
+      John: { rate: 1.04, pitch: 1.02, volume: 1 }
+    }
+  },
+  {
+    id: 'emerald',
+    label: 'Emerald studio',
+    description: 'Irish with UK tone',
+    voiceHints: {
+      Steven: ['Google Irish English', 'en-IE', 'English', 'Ireland'],
+      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+    },
+    speakerSettings: {
+      Steven: { rate: 0.98, pitch: 0.9, volume: 1 },
+      John: { rate: 1.01, pitch: 1, volume: 1 }
+    }
+  },
+  {
+    id: 'global',
+    label: 'Global mix',
+    description: 'Indian lead with US analyst',
+    voiceHints: {
+      Steven: ['Google Indian English', 'en-IN', 'English', 'India'],
+      John: ['Google US English', 'en-US', 'English', 'US']
+    },
+    speakerSettings: {
+      Steven: { rate: 1.02, pitch: 1.06, volume: 1 },
+      John: { rate: 1, pitch: 1.01, volume: 1 }
+    }
+  },
+  {
+    id: 'northern',
+    label: 'Northern call',
+    description: 'Canadian with UK analyst',
+    voiceHints: {
+      Steven: ['Google Canadian English', 'en-CA', 'English', 'Canada'],
+      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+    },
+    speakerSettings: {
+      Steven: { rate: 0.99, pitch: 0.97, volume: 1 },
+      John: { rate: 1.01, pitch: 1.03, volume: 1 }
+    }
+  }
+]);
+const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'arena-duo';
 const DEFAULT_TABLE_BASE_ID = POOL_ROYALE_BASE_VARIANTS[0]?.id || 'classicCylinders';
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
@@ -10724,8 +10809,29 @@ function PoolRoyaleGame({
     }
     return false;
   });
+  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
+      if (stored && POOL_ROYALE_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
+        return stored;
+      }
+    }
+    return DEFAULT_COMMENTARY_PRESET_ID;
+  });
+  const [commentaryMuted, setCommentaryMuted] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(COMMENTARY_MUTE_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return false;
+  });
   const skipReplayRef = useRef(() => {});
   const skipAllReplaysRef = useRef(skipAllReplays);
+  const commentaryMutedRef = useRef(commentaryMuted);
+  const commentaryGreetingPlayedRef = useRef(false);
+  const commentaryReadyRef = useRef(false);
+  const pendingCommentaryLinesRef = useRef(null);
   useEffect(() => {
     skipAllReplaysRef.current = skipAllReplays;
   }, [skipAllReplays]);
@@ -10734,6 +10840,24 @@ function PoolRoyaleGame({
       skipReplayRef.current?.();
     }
   }, [skipAllReplays]);
+  useEffect(() => {
+    commentaryMutedRef.current = commentaryMuted;
+    if (commentaryMuted) {
+      const synth = getSpeechSynthesis();
+      synth?.cancel();
+      pendingCommentaryLinesRef.current = null;
+    }
+  }, [commentaryMuted]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(COMMENTARY_PRESET_STORAGE_KEY, commentaryPresetId);
+    }
+  }, [commentaryPresetId]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(COMMENTARY_MUTE_STORAGE_KEY, commentaryMuted ? '1' : '0');
+    }
+  }, [commentaryMuted]);
   const [pocketLinerId, setPocketLinerId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(POCKET_LINER_STORAGE_KEY);
@@ -10847,6 +10971,12 @@ function PoolRoyaleGame({
   const activeBroadcastSystem = useMemo(
     () => resolveBroadcastSystem(broadcastSystemId),
     [broadcastSystemId]
+  );
+  const activeCommentaryPreset = useMemo(
+    () =>
+      POOL_ROYALE_COMMENTARY_PRESETS.find((preset) => preset.id === commentaryPresetId) ??
+      POOL_ROYALE_COMMENTARY_PRESETS[0],
+    [commentaryPresetId]
   );
   const availableTableFinishes = useMemo(
     () =>
@@ -12744,9 +12874,125 @@ const powerRef = useRef(hud.power);
     },
     [stopActiveCrowdSound]
   );
+
+  const buildCommentaryGreetingLines = useCallback(
+    () => {
+      const playerName = player.name || 'Player A';
+      const opponentName = opponentLabel || 'Player B';
+      return [
+        {
+          speaker: 'Steven',
+          text: buildCommentaryLine({
+            event: 'intro',
+            variant: '9ball',
+            speaker: 'Steven',
+            context: {
+              player: playerName,
+              opponent: opponentName,
+              arena: 'Pool Royale arena'
+            }
+          })
+        },
+        {
+          speaker: 'John',
+          text: buildCommentaryLine({
+            event: 'introReply',
+            variant: '9ball',
+            speaker: 'John',
+            context: {
+              player: playerName,
+              opponent: opponentName,
+              arena: 'Pool Royale arena'
+            }
+          })
+        }
+      ];
+    },
+    [opponentLabel, player.name]
+  );
+
+  const speakPoolCommentary = useCallback(
+    async (lines, preset = activeCommentaryPreset) => {
+      if (!Array.isArray(lines) || lines.length === 0) return;
+      if (commentaryMutedRef.current || isGameMuted()) return;
+      if (!commentaryReadyRef.current) {
+        pendingCommentaryLinesRef.current = lines;
+        return;
+      }
+      const synth = getSpeechSynthesis();
+      if (!synth) return;
+      try {
+        synth.cancel();
+      } catch {}
+      await speakCommentaryLines(lines, {
+        speakerSettings: preset?.speakerSettings,
+        voiceHints: preset?.voiceHints
+      });
+    },
+    [activeCommentaryPreset]
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const unlockCommentary = () => {
+      if (commentaryReadyRef.current) return;
+      commentaryReadyRef.current = true;
+      const pending = pendingCommentaryLinesRef.current;
+      if (pending) {
+        pendingCommentaryLinesRef.current = null;
+        speakPoolCommentary(pending);
+      }
+    };
+    window.addEventListener('pointerdown', unlockCommentary);
+    window.addEventListener('keydown', unlockCommentary);
+    return () => {
+      window.removeEventListener('pointerdown', unlockCommentary);
+      window.removeEventListener('keydown', unlockCommentary);
+    };
+  }, [speakPoolCommentary]);
+
+  const handleCommentaryPresetSelect = useCallback(
+    (preset) => {
+      if (!preset?.id) return;
+      setCommentaryPresetId(preset.id);
+      if (commentaryMutedRef.current || isGameMuted()) return;
+      speakPoolCommentary(
+        [
+          {
+            speaker: 'Steven',
+            text: buildCommentaryLine({
+              event: 'intro',
+              variant: '9ball',
+              speaker: 'Steven',
+              context: {
+                player: player.name || 'Player A',
+                opponent: opponentLabel || 'Player B',
+                arena: 'Pool Royale arena'
+              }
+            })
+          }
+        ],
+        preset
+      );
+    },
+    [opponentLabel, player.name, speakPoolCommentary]
+  );
   useEffect(() => {
     document.title = 'Pool Royale 3D';
   }, []);
+  useEffect(() => {
+    if (commentaryGreetingPlayedRef.current) return undefined;
+    if (commentaryMutedRef.current || isGameMuted()) return undefined;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      if (cancelled || commentaryGreetingPlayedRef.current) return;
+      commentaryGreetingPlayedRef.current = true;
+      speakPoolCommentary(buildCommentaryGreetingLines());
+    }, 1200);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [buildCommentaryGreetingLines, commentaryMuted, speakPoolCommentary]);
   useEffect(() => {
     const nextName = playerName || getTelegramUsername() || 'Player';
     const nextAvatar = playerAvatar || getTelegramPhotoUrl();
@@ -12836,7 +13082,12 @@ const powerRef = useRef(hud.power);
     volumeRef.current = getGameVolume();
     const handleMute = () => {
       muteRef.current = isGameMuted();
-      if (muteRef.current) stopActiveCrowdSound();
+      if (muteRef.current) {
+        stopActiveCrowdSound();
+        const synth = getSpeechSynthesis();
+        synth?.cancel();
+        pendingCommentaryLinesRef.current = null;
+      }
     };
     const handleVolume = () => {
       volumeRef.current = getGameVolume();
@@ -25919,6 +26170,55 @@ const powerRef = useRef(hud.power);
                     }`}
                   >
                     {skipAllReplays ? 'On' : 'Off'}
+                  </span>
+                </button>
+              </div>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Commentary
+                </h3>
+                <div className="mt-2 grid grid-cols-1 gap-2">
+                  {POOL_ROYALE_COMMENTARY_PRESETS.map((preset) => {
+                    const active = preset.id === commentaryPresetId;
+                    return (
+                      <button
+                        key={preset.id}
+                        type="button"
+                        onClick={() => handleCommentaryPresetSelect(preset)}
+                        aria-pressed={active}
+                        className={`rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_18px_rgba(16,185,129,0.55)]'
+                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                      >
+                        <span className="block">{preset.label}</span>
+                        <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
+                          {preset.description}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setCommentaryMuted((prev) => !prev)}
+                  aria-pressed={commentaryMuted}
+                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    commentaryMuted
+                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
+                      : 'bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span>Mute commentary</span>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                      commentaryMuted
+                        ? 'border-black/30 text-black/70'
+                        : 'border-white/30 text-white/70'
+                    }`}
+                  >
+                    {commentaryMuted ? 'On' : 'Off'}
                   </span>
                 </button>
               </div>


### PR DESCRIPTION
### Motivation
- Prevent speech from attempting to play before a user gesture unlocks audio and avoid stale queued commentary after mute or global mute changes. 
- Allow commentary preset previews to use the same queued playback flow so they behave consistently on mobile/locked audio contexts. 
- Make UK rules reflect that a scratch should require play-from-baulk so rule serialization tests match expectations.

### Description
- Queue commentary lines when the page audio is locked by the browser by adding `commentaryReadyRef` and `pendingCommentaryLinesRef` and gating playback in `speakPoolCommentary` inside `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Add user-gesture unlock listeners (`pointerdown`/`keydown`) that flush the queued lines and ensure preset preview playback uses the queued flow via `handleCommentaryPresetSelect`, and persist preset/mute choices to `localStorage`. 
- Clear queued commentary when commentary is muted or when the global game mute fires to avoid stale playback attempts, and cancel the speech synthesis via `getSpeechSynthesis().cancel()`. 
- Add commentary presets, storage keys and UI controls (preset buttons + mute toggle) to the Table Setup panel in `PoolRoyale.jsx` and import `buildCommentaryLine`, `getSpeechSynthesis` and `speakCommentaryLines`. 
- Fix UK rules in `lib/poolUk8Ball.js` to set `mustPlayFromBaulk` when a foul is a scratch (`s.mustPlayFromBaulk = scratched`) so the engine enforces baulk play after scratches.

### Testing
- Ran `npm test -- poolRoyaleRules.test.ts` which executed the `PoolRoyaleRules` suite and all tests passed (3 tests, 3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b7e6f7ac8329bfdb64bf4a98dfff)