### PR TITLE
Add Snooker Royal voice commentary with selectable presets and mute

### DIFF
--- a/webapp/src/utils/snookerRoyalCommentary.js
+++ b/webapp/src/utils/snookerRoyalCommentary.js
@@ -1,0 +1,182 @@
+const DEFAULT_CONTEXT = Object.freeze({
+  player: 'Player A',
+  opponent: 'Player B',
+  arena: 'Snooker Royal arena',
+  table: 'main table',
+  color: 'the color',
+  points: 'four',
+  foulReason: 'foul',
+  breakTotal: '0',
+  scoreline: 'level',
+  frameNumber: 'this frame'
+});
+
+const EVENT_POOLS = Object.freeze({
+  intro: 'intro',
+  breakOff: 'breakOff',
+  redPot: 'redPot',
+  multiRed: 'multiRed',
+  colorPot: 'colorPot',
+  colorOrder: 'colorOrder',
+  respot: 'respot',
+  safety: 'safety',
+  snooker: 'snooker',
+  freeBall: 'freeBall',
+  foul: 'foul',
+  miss: 'miss',
+  breakBuild: 'breakBuild',
+  century: 'century',
+  colorsOrder: 'colorsOrder',
+  frameBall: 'frameBall',
+  frameWin: 'frameWin',
+  outro: 'outro',
+  turn: 'turn'
+});
+
+const TEMPLATES = Object.freeze({
+  intro: [
+    'Welcome to {arena}. {player} and {opponent} are set for {frameNumber}.',
+    'We are live at {arena}. {player} versus {opponent}, and the table is ready.',
+    'Good evening from {arena}. {player} and {opponent} prepare to open {frameNumber}.'
+  ],
+  breakOff: [
+    'Here comes the break-off from {player}. All about control and the baulk line.',
+    '{player} to break the pack. The cue ball needs to stay safe in baulk.',
+    '{player} steps in for the opener. Gentle break, heavy on precision.'
+  ],
+  redPot: [
+    'Red down for {player}. The break is alive.',
+    '{player} drops a red and stays in position.',
+    'That red is clean. {player} keeps the visit going.'
+  ],
+  multiRed: [
+    'Multiple reds fall and {player} opens the table.',
+    '{player} with a double red. That is a strong start.',
+    'Two reds drop and {player} has options.'
+  ],
+  colorPot: [
+    '{color} goes in for {player}. The cue ball is right in the lane.',
+    'Nice color from {player}. That should reset on the spot.',
+    '{player} lands the {color}. This break is building.'
+  ],
+  colorOrder: [
+    '{color} disappears in order. {player} clears through the colors.',
+    '{player} pots the {color} as the clearance continues.',
+    'That is the {color}, and the colors are now in sequence.'
+  ],
+  respot: [
+    '{color} drops and returns to its spot. {player} keeps the rhythm.',
+    'Color down and back on its mark. {player} stays on the attack.',
+    '{player} slots the {color}; it will be respotted for the next shot.'
+  ],
+  safety: [
+    'A patient safety from {player}. Tucking the cue ball tight.',
+    '{player} chooses the safety route. Pressure shifts to {opponent}.',
+    'Good containment. {player} leaves {opponent} long and awkward.'
+  ],
+  snooker: [
+    'That is a proper snooker. {opponent} can barely see the ball on.',
+    '{player} hides the cue ball. {opponent} is in trouble now.',
+    'Excellent snooker. {opponent} will need a clever escape.'
+  ],
+  freeBall: [
+    'Free ball on. {player} can turn this into a big visit.',
+    'Free ball opportunity for {player}. That changes the table.',
+    '{player} gets the free ball. Expect a tactical swing.'
+  ],
+  foul: [
+    'Foul from {player}. {points} points to {opponent}.',
+    '{player} commits a foul, giving {opponent} {points}.',
+    'That is a foul: {foulReason}. {opponent} collects {points}.'
+  ],
+  miss: [
+    'That one slides by. {player} misses the pot.',
+    'Just off line for {player}. Chance swings to {opponent}.',
+    '{player} cannot convert. A look now for {opponent}.'
+  ],
+  breakBuild: [
+    '{player} is building a break of {breakTotal}. Great cueing.',
+    'Break at {breakTotal} for {player}. This is real momentum.',
+    '{player} is in the groove with {breakTotal} on the run.'
+  ],
+  century: [
+    'That is a century! {player} hits {breakTotal}.',
+    '{player} reaches the hundred. A beautiful snooker break.',
+    'Century break for {player}. {arena} appreciates the class.'
+  ],
+  colorsOrder: [
+    'Reds are gone. Colors in order from here.',
+    'Now into the colors sequence. Every shot is vital.',
+    'Colors phase begins. Precision only from here.'
+  ],
+  frameBall: [
+    'This could be frame ball for {player}.',
+    'Frame ball moment for {player}. Big pressure shot.',
+    '{player} looking at the frame ball. One more clean strike.'
+  ],
+  frameWin: [
+    '{player} takes the frame. Scoreline {scoreline}.',
+    'Frame secured by {player}. A composed finish.',
+    '{player} closes it out. The frame is theirs.'
+  ],
+  outro: [
+    'That concludes {frameNumber} at {arena}. Thanks for watching.',
+    'From {arena}, that is the end of the frame. Great play.',
+    'Match coverage wraps here at {arena}. Appreciate you joining us.'
+  ],
+  turn: [
+    'Over to {player} now.',
+    '{player} steps in for the next visit.',
+    'Next shot belongs to {player}.'
+  ]
+});
+
+const pickRandom = (pool) => pool[Math.floor(Math.random() * pool.length)];
+
+const applyTemplate = (template, context) =>
+  template.replace(/\{(\w+)\}/g, (_, key) => String(context[key] ?? `{${key}}`));
+
+export const buildSnookerCommentaryLine = ({ event, speaker = 'Caster', context = {} }) => {
+  const mergedContext = {
+    ...DEFAULT_CONTEXT,
+    ...context,
+    speaker
+  };
+  const pool = TEMPLATES[EVENT_POOLS[event]] || TEMPLATES.redPot;
+  return applyTemplate(pickRandom(pool), mergedContext);
+};
+
+export const createSnookerMatchCommentaryScript = ({
+  players = { A: 'Player A', B: 'Player B' },
+  commentators = ['Caster'],
+  scoreline = 'level'
+} = {}) => {
+  const context = {
+    player: players.A,
+    opponent: players.B,
+    scoreline
+  };
+  const speaker = commentators[0] || 'Caster';
+  return [
+    {
+      speaker,
+      text: buildSnookerCommentaryLine({
+        event: EVENT_POOLS.intro,
+        speaker,
+        context
+      })
+    },
+    {
+      speaker,
+      text: buildSnookerCommentaryLine({
+        event: EVENT_POOLS.outro,
+        speaker,
+        context
+      })
+    }
+  ];
+};
+
+export const SNOOKER_ROYAL_COMMENTARY_EVENTS = Object.freeze({
+  ...EVENT_POOLS
+});


### PR DESCRIPTION
### Motivation
- Provide in-game voice commentary for Snooker Royal to improve feedback and broadcast feel, covering common snooker situations (breaks, pots, fouls, safeties, free ball, century, frame/match end).
- Allow players to choose between multiple voice personalities and mute commentary from the table setup menu.
- Use an open Web Speech (browser TTS) flow with queueing and rate-limiting so commentary does not overload audio channels or interfere with gameplay.

### Description
- Added a new commentary utility `webapp/src/utils/snookerRoyalCommentary.js` which contains event pools, templates and helper functions `buildSnookerCommentaryLine` and `createSnookerMatchCommentaryScript` to generate varied lines for many in-game events.
- Integrated commentary into the Snooker game (`webapp/src/pages/Games/SnookerRoyal.jsx`) by importing the new utilities and existing TTS helpers (`getSpeechSynthesis`, `speakCommentaryLines`).
- Implemented six selectable commentary presets (Atlas, Nova, Ivy, Onyx, Riley, Zara) with voice-hint metadata and speaker tuning, plus persistent storage keys `snookerRoyalCommentaryPreset` and `snookerRoyalCommentaryMute`.
- Added a commentary subsystem: queueing, minimum-interval throttling, greeting/start/end scripts, priority handling for fouls/free-ball/frame wins, and safe cancellation when game or webview is muted; the system is gated behind Web Speech support to avoid crashes on unsupported browsers.
- Wired commentary triggers into the shot resolution flow so relevant events (break-off, red/color pots, multi-red, safety, snooker, fouls, breaks milestones, frame wins) enqueue spoken lines.
- Exposed UI in the table setup panel to pick a commentary preset and toggle mute, with disabled state and a short help message when Web Speech is unavailable.

### Testing
- Dev server smoke run: started the webapp dev server (`npm --prefix webapp run dev`) and Vite reported ready and serving on the configured port, indicating the app builds and serves successfully (succeeded).
- Basic UI smoke attempt: attempted an automated browser smoke test to load the Snooker Royal page and capture a screenshot via Playwright, but the headless Chromium process crashed with a SIGSEGV during startup in this environment (Playwright run failed). No in-browser screenshot was captured.
- No unit tests or CI test suites were executed as part of this change; no automated test failures were produced by local static runs because unit/test steps were not invoked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975cf6793d083298ccb45aa5a211cea)