### PR TITLE
Improve Pool Royale commentary: distinct voices, variant scripts, and live score context

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -919,23 +919,23 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'arena-duo',
     label: 'Arena duo',
-    description: 'UK lead with US analyst',
+    description: 'UK female lead with US male analyst',
     voiceHints: {
-      Steven: ['Google UK English Male', 'en-GB', 'English', 'UK'],
-      John: ['Google US English', 'en-US', 'English', 'US']
+      Steven: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia'],
+      John: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
     },
     speakerSettings: {
-      Steven: { rate: 1, pitch: 0.94, volume: 1 },
-      John: { rate: 1.03, pitch: 1.04, volume: 1 }
+      Steven: { rate: 1, pitch: 1.02, volume: 1 },
+      John: { rate: 1.03, pitch: 0.98, volume: 1 }
     }
   },
   {
     id: 'atlantic',
     label: 'Atlantic booth',
-    description: 'US lead with UK analyst',
+    description: 'US female lead with UK male analyst',
     voiceHints: {
-      Steven: ['Google US English', 'en-US', 'English', 'US'],
-      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+      Steven: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira'],
+      John: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
     },
     speakerSettings: {
       Steven: { rate: 1.02, pitch: 0.98, volume: 1 },
@@ -945,23 +945,23 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'pacific',
     label: 'Pacific desk',
-    description: 'Australian & US cadence',
+    description: 'Australian male with US female analyst',
     voiceHints: {
-      Steven: ['Google Australian English', 'en-AU', 'English', 'Australia'],
-      John: ['Google US English', 'en-US', 'English', 'US']
+      Steven: ['Google Australian English', 'en-AU', 'English', 'male', 'Australia', 'Lee', 'William'],
+      John: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira']
     },
     speakerSettings: {
       Steven: { rate: 1.01, pitch: 0.96, volume: 1 },
-      John: { rate: 1.04, pitch: 1.02, volume: 1 }
+      John: { rate: 1.04, pitch: 1.06, volume: 1 }
     }
   },
   {
     id: 'emerald',
     label: 'Emerald studio',
-    description: 'Irish with UK tone',
+    description: 'Irish female with UK male analyst',
     voiceHints: {
-      Steven: ['Google Irish English', 'en-IE', 'English', 'Ireland'],
-      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+      Steven: ['Google Irish English Female', 'en-IE', 'English', 'female', 'Ireland', 'Moira'],
+      John: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
     },
     speakerSettings: {
       Steven: { rate: 0.98, pitch: 0.9, volume: 1 },
@@ -971,10 +971,10 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'global',
     label: 'Global mix',
-    description: 'Indian lead with US analyst',
+    description: 'Indian female with US male analyst',
     voiceHints: {
-      Steven: ['Google Indian English', 'en-IN', 'English', 'India'],
-      John: ['Google US English', 'en-US', 'English', 'US']
+      Steven: ['Google Indian English Female', 'en-IN', 'English', 'female', 'India', 'Asha', 'Raveena'],
+      John: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
     },
     speakerSettings: {
       Steven: { rate: 1.02, pitch: 1.06, volume: 1 },
@@ -984,10 +984,10 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'northern',
     label: 'Northern call',
-    description: 'Canadian with UK analyst',
+    description: 'Canadian male with UK female analyst',
     voiceHints: {
-      Steven: ['Google Canadian English', 'en-CA', 'English', 'Canada'],
-      John: ['Google UK English Male', 'en-GB', 'English', 'UK']
+      Steven: ['Google Canadian English', 'en-CA', 'English', 'male', 'Canada', 'Liam'],
+      John: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia', 'Hazel']
     },
     speakerSettings: {
       Steven: { rate: 0.99, pitch: 0.97, volume: 1 },
@@ -12882,17 +12882,32 @@ const powerRef = useRef(hud.power);
     () => {
       const playerName = player.name || 'Player A';
       const opponentName = opponentLabel || 'Player B';
+      const scoreA = frameState?.players?.A?.score ?? 0;
+      const scoreB = frameState?.players?.B?.score ?? 0;
+      const scoreline =
+        scoreA === scoreB
+          ? `level at ${scoreA}-${scoreB}`
+          : scoreA > scoreB
+            ? `${framePlayerAName || playerName} leads ${scoreA}-${scoreB}`
+            : `${framePlayerBName || opponentName} leads ${scoreB}-${scoreA}`;
+      const commentaryVariant = activeVariant?.id ?? variantKey ?? '9ball';
       return [
         {
           speaker: 'Steven',
           text: buildCommentaryLine({
             event: 'intro',
-            variant: '9ball',
+            variant: commentaryVariant,
             speaker: 'Steven',
             context: {
               player: playerName,
               opponent: opponentName,
-              arena: 'Pool Royale arena'
+              arena: 'Pool Royale arena',
+              playerScore: scoreA,
+              opponentScore: scoreB,
+              playerPoints: scoreA,
+              opponentPoints: scoreB,
+              scoreline,
+              ballSet: activeVariant?.ballSet
             }
           })
         },
@@ -12900,29 +12915,71 @@ const powerRef = useRef(hud.power);
           speaker: 'John',
           text: buildCommentaryLine({
             event: 'introReply',
-            variant: '9ball',
+            variant: commentaryVariant,
             speaker: 'John',
             context: {
               player: playerName,
               opponent: opponentName,
-              arena: 'Pool Royale arena'
+              arena: 'Pool Royale arena',
+              playerScore: scoreA,
+              opponentScore: scoreB,
+              playerPoints: scoreA,
+              opponentPoints: scoreB,
+              scoreline,
+              ballSet: activeVariant?.ballSet
             }
           })
         }
       ];
     },
-    [opponentLabel, player.name]
+    [
+      activeVariant?.ballSet,
+      activeVariant?.id,
+      framePlayerAName,
+      framePlayerBName,
+      frameState?.players,
+      opponentLabel,
+      player.name,
+      variantKey
+    ]
   );
   const buildMatchCommentaryScript = useCallback(
     () =>
       createMatchCommentaryScript({
-        variant: '9ball',
+        variant: activeVariant?.id ?? variantKey ?? '9ball',
+        ballSet: activeVariant?.ballSet ?? 'uk',
         players: {
           A: framePlayerAName || 'Player A',
           B: framePlayerBName || 'Player B'
-        }
+        },
+        scores: {
+          A: frameState?.players?.A?.score ?? 0,
+          B: frameState?.players?.B?.score ?? 0
+        },
+        points: {
+          A: frameState?.players?.A?.score ?? 0,
+          B: frameState?.players?.B?.score ?? 0
+        },
+        pots: {
+          A: pottedBySeat?.A?.length ?? 0,
+          B: pottedBySeat?.B?.length ?? 0
+        },
+        scoreline:
+          (frameState?.players?.A?.score ?? 0) === (frameState?.players?.B?.score ?? 0)
+            ? `level at ${frameState?.players?.A?.score ?? 0}-${frameState?.players?.B?.score ?? 0}`
+            : (frameState?.players?.A?.score ?? 0) > (frameState?.players?.B?.score ?? 0)
+              ? `${framePlayerAName || 'Player A'} leads ${frameState?.players?.A?.score ?? 0}-${frameState?.players?.B?.score ?? 0}`
+              : `${framePlayerBName || 'Player B'} leads ${frameState?.players?.B?.score ?? 0}-${frameState?.players?.A?.score ?? 0}`
       }),
-    [framePlayerAName, framePlayerBName]
+    [
+      activeVariant?.ballSet,
+      activeVariant?.id,
+      framePlayerAName,
+      framePlayerBName,
+      frameState?.players,
+      pottedBySeat,
+      variantKey
+    ]
   );
 
   const speakPoolCommentary = useCallback(
@@ -13006,12 +13063,23 @@ const powerRef = useRef(hud.power);
             speaker: 'Steven',
             text: buildCommentaryLine({
               event: 'intro',
-              variant: '9ball',
+              variant: activeVariant?.id ?? variantKey ?? '9ball',
               speaker: 'Steven',
               context: {
                 player: player.name || 'Player A',
                 opponent: opponentLabel || 'Player B',
-                arena: 'Pool Royale arena'
+                arena: 'Pool Royale arena',
+                playerScore: frameState?.players?.A?.score ?? 0,
+                opponentScore: frameState?.players?.B?.score ?? 0,
+                playerPoints: frameState?.players?.A?.score ?? 0,
+                opponentPoints: frameState?.players?.B?.score ?? 0,
+                scoreline:
+                  (frameState?.players?.A?.score ?? 0) === (frameState?.players?.B?.score ?? 0)
+                    ? `level at ${frameState?.players?.A?.score ?? 0}-${frameState?.players?.B?.score ?? 0}`
+                    : (frameState?.players?.A?.score ?? 0) > (frameState?.players?.B?.score ?? 0)
+                      ? `${framePlayerAName || 'Player A'} leads ${frameState?.players?.A?.score ?? 0}-${frameState?.players?.B?.score ?? 0}`
+                      : `${framePlayerBName || 'Player B'} leads ${frameState?.players?.B?.score ?? 0}-${frameState?.players?.A?.score ?? 0}`,
+                ballSet: activeVariant?.ballSet
               }
             })
           }
@@ -13019,7 +13087,17 @@ const powerRef = useRef(hud.power);
         preset
       );
     },
-    [opponentLabel, player.name, speakPoolCommentary]
+    [
+      activeVariant?.ballSet,
+      activeVariant?.id,
+      framePlayerAName,
+      framePlayerBName,
+      frameState?.players,
+      opponentLabel,
+      player.name,
+      speakPoolCommentary,
+      variantKey
+    ]
   );
   useEffect(() => {
     document.title = 'Pool Royale 3D';

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -14,66 +14,75 @@ const SPEAKER_PROFILES = Object.freeze({
 const DEFAULT_CONTEXT = Object.freeze({
   player: 'Player A',
   opponent: 'Player B',
+  playerScore: 0,
+  opponentScore: 0,
+  playerPoints: 0,
+  opponentPoints: 0,
+  playerPots: 0,
+  opponentPots: 0,
   targetBall: 'the object ball',
   pocket: 'the corner pocket',
   table: 'the main table',
   arena: 'Pool Royale arena',
   breakType: 'thunder break',
-  scoreline: 'level',
+  scoreline: 'level at 0-0',
+  groupPrimary: 'reds',
+  groupSecondary: 'yellows',
+  ballSet: 'uk',
   rackNumber: 'this rack'
 });
 
 const TEMPLATES = Object.freeze({
   common: {
     intro: [
-      'Welcome to {arena}! I am {speaker}, alongside {partner} for {rackNumber}.',
-      'It is match time at {arena}. {speaker} here with {partner}, and we are set for {variantName}.',
-      'Good evening from {arena}. {speaker} with {partner}, and the balls are ready for {variantName}.'
+      'Welcome to {arena}. {speaker} with {partner}. {player} faces {opponent} with the score {playerScore}-{opponentScore} in {variantName}.',
+      'It is match time at {arena}. {speaker} alongside {partner}. {player} versus {opponent}, {scoreline} in {variantName}.',
+      'Good evening from {arena}. {speaker} with {partner}. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
     ],
     introReply: [
-      'Thanks {speaker}. The table is tight and the pressure is real in {variantName}.',
-      'Great to be here, {speaker}. Expect a tactical battle in {variantName}.',
-      'Absolutely, {speaker}. This is the kind of arena where every inch of position matters.'
+      'Thanks {speaker}. Points are precious tonight—every pot will matter for {player} and {opponent}.',
+      'Great to be here, {speaker}. The scoreboard reads {playerScore}-{opponentScore}, and the margins are razor thin.',
+      'Absolutely, {speaker}. {player} and {opponent} both need clean pots to turn points into control.'
     ],
     breakShot: [
-      '{player} steps in for the break—eyes on the head ball and the wing balls.',
-      '{player} leaning in. A clean break could open {table} wide.',
-      'Here comes the break from {player}. Watch the cue ball for control.'
+      '{player} steps in for the break; a sharp split sets up early pots.',
+      '{player} leans in. A controlled break can define the scoring chances.',
+      'Here comes the break from {player}. Cue ball control will be everything.'
     ],
     breakResult: [
-      'Nice spread off the break; the rack is open now.',
-      'That break has cracked the pack—plenty of lanes available.',
-      'Solid pop on the break. Control on the cue ball is the key.'
+      'Nice spread off the break, {speaker}. The rack is open now.',
+      'That break has cracked the pack—clean lanes for scoring chances, {speaker}.',
+      'Solid pop on the break. Control on the cue ball is the key from here.'
     ],
     openTable: [
-      'Early pattern here—{player} wants to take the natural angles.',
-      'Plenty of options with the open table; cue ball path is everything.',
-      '{player} is reading the table, looking for a simple route.'
+      'Early pattern here—{player} wants natural angles and quick pots.',
+      'Plenty of options with the open table; cue ball paths decide the points.',
+      '{player} is reading the table, looking for a simple route to the next pot.'
     ],
     safety: [
-      'A smart safety. {player} tucks the cue ball behind a blocker.',
+      'A smart safety, {partner}. {player} tucks the cue ball behind a blocker.',
       'That is a measured safety, leaving {opponent} long and awkward.',
-      '{player} turns down the pot and plays the safety battle.'
+      '{player} turns down the pot and plays the safety battle to protect the score.'
     ],
     pressure: [
-      'Big moment. {player} needs this pot to keep the run alive.',
-      'Pressure shot here for {player}; it is all about a soft touch.',
-      'This is where nerves show—{player} has to deliver.'
+      'Big moment. {player} needs this pot to keep the scoring run alive.',
+      'Pressure shot here for {player}; it is all about soft touch and points.',
+      'This is where nerves show—{player} has to deliver for the scoreboard.'
     ],
     pot: [
-      'Beautiful pot. {player} stays right on line for the next ball.',
-      'Clean strike from {player}. That is textbook cueing.',
-      '{player} drops it in and holds the cue ball in the lane.'
+      'Beautiful pot. {player} moves to {playerPots} pots and {playerPoints} points.',
+      'Clean strike from {player}. That pot bumps the score to {playerScore}-{opponentScore}.',
+      '{player} drops it in and holds the cue ball in the lane for more points.'
     ],
     combo: [
-      'That is a clever combination—using the {targetBall} to open the {pocket}.',
-      'What a combo! {player} turns a tough angle into a makeable shot.',
-      'Great combination play. {player} sees the carom and takes it.'
+      'That is a clever combination—{player} uses {targetBall} to open the {pocket}.',
+      'What a combo! {player} turns a tough angle into a makeable pot.',
+      'Great combination play. {player} sees the carom and takes the points.'
     ],
     bank: [
       '{player} goes to the cushion—bank shot, perfectly judged.',
       'Bold bank from {player}, and it lands in the heart of the {pocket}.',
-      'Bank shot called and made. That is confidence.'
+      'Bank shot called and made. That is confidence and points.'
     ],
     kick: [
       'Kick shot required—{player} goes one rail to find it.',
@@ -88,7 +97,7 @@ const TEMPLATES = Object.freeze({
     miss: [
       'Oh, that one drifts offline. {player} misses the pocket.',
       'It slides past. {player} will be disappointed with that miss.',
-      'A rare miss from {player}, and now {opponent} has a look.'
+      'A rare miss from {player}, and now {opponent} has a look at points.'
     ],
     foul: [
       'Foul called. That gives {opponent} a major opportunity.',
@@ -111,19 +120,19 @@ const TEMPLATES = Object.freeze({
       'Final rack nerves—every shot feels heavier now.'
     ],
     frameWin: [
-      '{player} closes the rack. That is clinical pool.',
-      'Rack won by {player}. Clean finish.',
-      '{player} finishes it in style and takes the rack.'
+      '{player} closes the rack. That is clinical pool and {playerPoints} points.',
+      'Rack won by {player}. Score now {playerScore}-{opponentScore}.',
+      '{player} finishes it in style and takes the rack with a points swing.'
     ],
     matchWin: [
-      '{player} seals the match—what a performance.',
-      'That is the match. {player} comes through under pressure.',
+      '{player} seals the match—what a performance and a final tally of {playerScore}-{opponentScore}.',
+      'That is the match. {player} comes through under pressure on points.',
       '{player} wins it, and {arena} appreciates a professional display.'
     ],
     outro: [
-      'That wraps it up from {arena}. Thanks for joining us.',
-      'From {arena}, that is full time. Great match tonight.',
-      'A fantastic finish in {variantName}. Thanks for watching.'
+      'That wraps it up from {arena}. Thanks for joining us, {partner}.',
+      'From {arena}, that is full time. Great match tonight, {partner}.',
+      'A fantastic finish in {variantName}. Thanks for watching with us.'
     ]
   },
   nineBall: {
@@ -149,12 +158,30 @@ const TEMPLATES = Object.freeze({
       'Push-out played—now {opponent} must decide to shoot or pass.'
     ]
   },
+  eightBallUs: {
+    variantName: '8-ball American pool',
+    groupCall: [
+      'Open table between {groupPrimary} and {groupSecondary}; {player} is looking to claim one.',
+      '{player} can choose {groupPrimary} or {groupSecondary}—the first clean pot decides the pattern.',
+      'Plenty of options here, {partner}. {groupPrimary} and {groupSecondary} are both available.'
+    ],
+    inHand: [
+      'Foul gives {opponent} ball in hand—prime time for an 8-ball run.',
+      '{opponent} has ball in hand, and that is a big swing in American 8-ball.',
+      'Ball in hand now for {opponent}; expect a composed clearance attempt.'
+    ],
+    eightBall: [
+      'The 8-ball is in play now. Position is everything.',
+      'Everything moves through the 8-ball from here.',
+      'Eight-ball on the table—one mistake decides it.'
+    ]
+  },
   eightBallUk: {
     variantName: '8-ball UK',
     groupCall: [
-      '{player} is on {group}, and that changes the pattern immediately.',
-      '{player} is taking {group}; the layout opens for a run.',
-      '{player} chooses {group}, so the route is clear to the black.'
+      'Open table between {groupPrimary} and {groupSecondary}; {player} will claim a set soon.',
+      '{groupPrimary} versus {groupSecondary} in UK rules; the first clean pot sets the route.',
+      'UK rules in play, {partner}. {groupPrimary} and {groupSecondary} are both available.'
     ],
     freeBall: [
       'Foul gives {player} a free ball—huge advantage in UK rules.',
@@ -205,7 +232,8 @@ const applyTemplate = (template, context) =>
   template.replace(/\{(\w+)\}/g, (_, key) => String(context[key] ?? `{${key}}`));
 
 const resolveVariantData = (variantId) => {
-  if (variantId === '8ball-uk') return TEMPLATES.eightBallUk;
+  if (variantId === 'uk' || variantId === '8ball-uk') return TEMPLATES.eightBallUk;
+  if (variantId === 'american' || variantId === '8ball-us') return TEMPLATES.eightBallUs;
   return TEMPLATES.nineBall;
 };
 
@@ -227,15 +255,26 @@ export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Steve
 
 export const createMatchCommentaryScript = ({
   variant = '9ball',
+  ballSet = 'uk',
   players = { A: 'Player A', B: 'Player B' },
   commentators = ['Steven', 'John'],
-  scoreline = 'level'
+  scoreline = 'level at 0-0',
+  scores = { A: 0, B: 0 },
+  pots = { A: 0, B: 0 },
+  points = { A: 0, B: 0 }
 } = {}) => {
   const [lead, analyst] = commentators;
   const context = {
     player: players.A,
     opponent: players.B,
-    scoreline
+    scoreline,
+    playerScore: scores.A ?? 0,
+    opponentScore: scores.B ?? 0,
+    playerPoints: points.A ?? scores.A ?? 0,
+    opponentPoints: points.B ?? scores.B ?? 0,
+    playerPots: pots.A ?? 0,
+    opponentPots: pots.B ?? 0,
+    ballSet
   };
 
   const script = [
@@ -253,18 +292,39 @@ export const createMatchCommentaryScript = ({
     { speaker: analyst, event: EVENT_POOLS.outro }
   ];
 
+  const groupLabels =
+    variant === 'uk'
+      ? ballSet === 'american'
+        ? { primary: 'solids', secondary: 'stripes' }
+        : { primary: 'reds', secondary: 'yellows' }
+      : { primary: 'solids', secondary: 'stripes' };
+
   const variantScriptExtras =
-    variant === '8ball-uk'
+    variant === 'uk'
       ? [
-          { speaker: lead, event: EVENT_POOLS.groupCall, context: { group: 'reds' } },
+          {
+            speaker: lead,
+            event: EVENT_POOLS.groupCall,
+            context: { groupPrimary: groupLabels.primary, groupSecondary: groupLabels.secondary }
+          },
           { speaker: analyst, event: EVENT_POOLS.freeBall },
           { speaker: lead, event: EVENT_POOLS.blackBall }
         ]
-      : [
-          { speaker: lead, event: EVENT_POOLS.rotation },
-          { speaker: analyst, event: EVENT_POOLS.goldenBreak },
-          { speaker: lead, event: EVENT_POOLS.comboNine }
-        ];
+      : variant === 'american'
+        ? [
+            {
+              speaker: lead,
+              event: EVENT_POOLS.groupCall,
+              context: { groupPrimary: groupLabels.primary, groupSecondary: groupLabels.secondary }
+            },
+            { speaker: analyst, event: EVENT_POOLS.inHand },
+            { speaker: lead, event: EVENT_POOLS.blackBall }
+          ]
+        : [
+            { speaker: lead, event: EVENT_POOLS.rotation },
+            { speaker: analyst, event: EVENT_POOLS.goldenBreak },
+            { speaker: lead, event: EVENT_POOLS.comboNine }
+          ];
 
   const combined = [script[0], script[1], ...variantScriptExtras, ...script.slice(2)];
 


### PR DESCRIPTION
### Motivation
- Provide a professional, player-focused two-voice commentary system with six selectable voice presets so commentators do not sound the same.
- Make commentary scripts variant-aware (9-ball, UK 8-ball, US 8-ball) and avoid repeating rules by introducing players and commenting scores, pots, points and ball-in-hand state.
- Ensure commentary lines reference players by username and have commentators call each other by name to improve broadcast realism.

### Description
- Add score, points, pots and ball-set context to `DEFAULT_CONTEXT` and extend templates so lines can include `{playerScore}`, `{opponentScore}`, `{playerPoints}`, `{playerPots}` and group labels; updated files: `webapp/src/utils/poolRoyaleCommentary.js` and `webapp/src/pages/Games/PoolRoyale.jsx`.
- Make `createMatchCommentaryScript` accept `scores`, `points`, `pots`, and `ballSet` and inject live frame context into generated scripts and greetings via the existing `buildCommentaryLine` helper.
- Add an `eightBallUs` template set and extend `resolveVariantData` and the variant-specific script assembly so UK, US and 9-ball variants produce appropriate, separate commentary segments with `groupPrimary`/`groupSecondary` support.
- Refresh `POOL_ROYALE_COMMENTARY_PRESETS` with six mixed male/female booth presets and update `speakCommentaryLines` in `webapp/src/utils/textToSpeech.js` to prefer distinct voices per speaker by adding `findDistinctVoice` and allocating `speakerVoices` so lead and analyst do not use the same TTS voice when possible.

### Testing
- No automated tests were run for these changes (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d263bea88329b263ab1beaf08286)