### PR TITLE
Snooker Royal: dual commentators, varied commentary and TTS priming

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -962,17 +962,27 @@ const COMMENTARY_PRESET_STORAGE_KEY = 'snookerRoyalCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snookerRoyalCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
-const COMMENTARY_SPEAKER_ID = 'Caster';
+const COMMENTARY_SPEAKER_LEAD = 'Caster';
+const COMMENTARY_SPEAKER_ANALYST = 'Analyst';
 const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'atlas',
     label: 'Atlas',
     description: 'Classic arena broadcaster with measured pace.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-GB', 'english', 'male', 'daniel', 'george', 'google uk english']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-GB', 'english', 'male', 'daniel', 'george', 'google uk english'],
+      [COMMENTARY_SPEAKER_ANALYST]: [
+        'en-GB',
+        'english',
+        'female',
+        'kate',
+        'serena',
+        'google uk english female'
+      ]
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 0.98, pitch: 0.92, volume: 1 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 0.98, pitch: 0.92, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 1.08, volume: 0.98 }
     }
   },
   {
@@ -980,10 +990,12 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
     label: 'Nova',
     description: 'High-energy commentary with a crisp edge.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-US', 'female', 'samantha', 'victoria', 'zira', 'google us']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-US', 'female', 'samantha', 'victoria', 'zira', 'google us'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['en-US', 'male', 'alex', 'david', 'guy', 'google us english male']
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 1.04, pitch: 1.08, volume: 1 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 1.04, pitch: 1.08, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 0.98, pitch: 0.92, volume: 1 }
     }
   },
   {
@@ -991,10 +1003,12 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
     label: 'Ivy',
     description: 'Smooth tactical analysis and calm delivery.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-GB', 'female', 'kate', 'serena', 'google uk english female']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-GB', 'female', 'kate', 'serena', 'google uk english female'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['en-GB', 'male', 'daniel', 'george', 'google uk english']
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 0.96, pitch: 1.1, volume: 0.98 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 0.96, pitch: 1.1, volume: 0.98 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 0.98, pitch: 0.9, volume: 1 }
     }
   },
   {
@@ -1002,10 +1016,12 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
     label: 'Onyx',
     description: 'Deep tone with a steady play-by-play focus.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-US', 'male', 'alex', 'david', 'guy', 'google us english male']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-US', 'male', 'alex', 'david', 'guy', 'google us english male'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['en-US', 'female', 'samantha', 'victoria', 'zira', 'google us']
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 0.94, pitch: 0.85, volume: 1 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 0.94, pitch: 0.85, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.04, pitch: 1.06, volume: 0.98 }
     }
   },
   {
@@ -1013,10 +1029,12 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
     label: 'Riley',
     description: 'Bright, upbeat narration for fast frames.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-AU', 'en-US', 'karen', 'oliver', 'google']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-AU', 'en-US', 'female', 'karen', 'google'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['en-AU', 'en-US', 'male', 'oliver', 'google']
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 1.06, pitch: 1.15, volume: 1 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 1.06, pitch: 1.15, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 0.96, pitch: 0.9, volume: 1 }
     }
   },
   {
@@ -1024,10 +1042,12 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
     label: 'Zara',
     description: 'Analytical calls with a balanced cadence.',
     voiceHints: {
-      [COMMENTARY_SPEAKER_ID]: ['en-IN', 'en-US', 'female', 'neural', 'google']
+      [COMMENTARY_SPEAKER_LEAD]: ['en-IN', 'en-US', 'female', 'neural', 'google'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['en-IN', 'en-GB', 'male', 'google']
     },
     speakerSettings: {
-      [COMMENTARY_SPEAKER_ID]: { rate: 1.02, pitch: 1.02, volume: 1 }
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 1.02, pitch: 1.02, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 0.98, pitch: 0.9, volume: 1 }
     }
   }
 ]);
@@ -11983,6 +12003,65 @@ function SnookerRoyalGame({
     },
     [frameState?.players, localSeat, opponentLabel, playerLabel]
   );
+  const commentarySpeakers = useMemo(
+    () => [COMMENTARY_SPEAKER_LEAD, COMMENTARY_SPEAKER_ANALYST],
+    []
+  );
+  const lastCommentarySpeakerRef = useRef(COMMENTARY_SPEAKER_LEAD);
+  const getAlternateCommentarySpeaker = useCallback(
+    (speaker) =>
+      speaker === COMMENTARY_SPEAKER_LEAD ? COMMENTARY_SPEAKER_ANALYST : COMMENTARY_SPEAKER_LEAD,
+    []
+  );
+  const pickCommentarySpeaker = useCallback(
+    (event, preferred) => {
+      if (preferred) {
+        lastCommentarySpeakerRef.current = preferred;
+        return preferred;
+      }
+      if (
+        event === 'intro' ||
+        event === 'breakOff' ||
+        event === 'century' ||
+        event === 'frameBall' ||
+        event === 'frameWin' ||
+        event === 'outro'
+      ) {
+        lastCommentarySpeakerRef.current = COMMENTARY_SPEAKER_LEAD;
+        return COMMENTARY_SPEAKER_LEAD;
+      }
+      if (
+        event === 'safety' ||
+        event === 'snooker' ||
+        event === 'foul' ||
+        event === 'miss' ||
+        event === 'freeBall'
+      ) {
+        lastCommentarySpeakerRef.current = COMMENTARY_SPEAKER_ANALYST;
+        return COMMENTARY_SPEAKER_ANALYST;
+      }
+      const nextSpeaker = getAlternateCommentarySpeaker(lastCommentarySpeakerRef.current);
+      lastCommentarySpeakerRef.current = nextSpeaker;
+      return nextSpeaker;
+    },
+    [getAlternateCommentarySpeaker]
+  );
+  const buildCommentaryLine = useCallback(
+    (event, context = {}, options = {}) => {
+      const speaker = pickCommentarySpeaker(event, options.speaker);
+      const text = buildSnookerCommentaryLine({
+        event,
+        speaker,
+        context: {
+          arena: 'Snooker Royal arena',
+          ...context
+        }
+      });
+      if (!text) return null;
+      return { speaker, text };
+    },
+    [pickCommentarySpeaker]
+  );
   const playNextCommentary = useCallback(async () => {
     if (commentarySpeakingRef.current) return;
     const next = commentaryQueueRef.current.shift();
@@ -12023,26 +12102,11 @@ function SnookerRoyalGame({
   );
   const enqueueSnookerCommentaryEvent = useCallback(
     (event, context = {}, options = {}) => {
-      const text = buildSnookerCommentaryLine({
-        event,
-        speaker: COMMENTARY_SPEAKER_ID,
-        context: {
-          arena: 'Snooker Royal arena',
-          ...context
-        }
-      });
-      if (!text) return;
-      enqueueCommentaryLines(
-        [
-          {
-            speaker: COMMENTARY_SPEAKER_ID,
-            text
-          }
-        ],
-        options
-      );
+      const line = buildCommentaryLine(event, context, { speaker: options.speaker });
+      if (!line) return;
+      enqueueCommentaryLines([line], options);
     },
-    [enqueueCommentaryLines]
+    [buildCommentaryLine, enqueueCommentaryLines]
   );
   const maybeSpeakShotCommentary = useCallback(
     ({ currentState, nextState, potted, shotContext, shooterSeat }) => {
@@ -12109,11 +12173,36 @@ function SnookerRoyalGame({
 
       if (event) {
         const priority = event === 'foul' || event === 'freeBall';
-        enqueueSnookerCommentaryEvent(event, context, { priority });
+        const lines = [];
+        const primaryLine = buildCommentaryLine(event, context);
+        if (primaryLine) lines.push(primaryLine);
+        const nextActiveSeat = nextState.activePlayer;
+        if (
+          primaryLine &&
+          nextActiveSeat &&
+          nextActiveSeat !== shooterSeat &&
+          ['miss', 'safety', 'foul'].includes(event)
+        ) {
+          const turnLine = buildCommentaryLine(
+            'turn',
+            { player: resolveSeatLabel(nextActiveSeat) },
+            { speaker: getAlternateCommentarySpeaker(primaryLine.speaker) }
+          );
+          if (turnLine) lines.push(turnLine);
+        }
+        if (lines.length) {
+          enqueueCommentaryLines(lines, { priority });
+        }
       }
       shotCountRef.current += 1;
     },
-    [enqueueSnookerCommentaryEvent, formatSnookerColorLabel, resolveSeatLabel]
+    [
+      buildCommentaryLine,
+      enqueueCommentaryLines,
+      formatSnookerColorLabel,
+      getAlternateCommentarySpeaker,
+      resolveSeatLabel
+    ]
   );
   const handleCommentaryPresetSelect = useCallback(
     (preset) => {
@@ -12136,11 +12225,22 @@ function SnookerRoyalGame({
       players: {
         A: framePlayerAName || 'Player A',
         B: framePlayerBName || 'Player B'
-      }
+      },
+      commentators: commentarySpeakers
     });
+    const startLines = Array.isArray(script?.start)
+      ? script.start
+      : Array.isArray(script)
+        ? script.slice(0, 1)
+        : [];
+    const endLines = Array.isArray(script?.end)
+      ? script.end
+      : Array.isArray(script)
+        ? script.slice(1)
+        : [];
     commentaryScriptRef.current = {
-      start: script.slice(0, 1),
-      end: script.slice(1)
+      start: startLines,
+      end: endLines
     };
     commentaryScriptPlayedRef.current = false;
     commentaryOutroPlayedRef.current = false;
@@ -12150,12 +12250,22 @@ function SnookerRoyalGame({
     shotCountRef.current = 0;
     breakMilestoneRef.current = 0;
     freeBallAnnouncedRef.current = false;
-  }, [framePlayerAName, framePlayerBName, initialFrame]);
+    lastCommentarySpeakerRef.current = COMMENTARY_SPEAKER_LEAD;
+  }, [commentarySpeakers, framePlayerAName, framePlayerBName, initialFrame]);
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const unlockCommentary = () => {
       if (commentaryReadyRef.current) return;
       commentaryReadyRef.current = true;
+      const synth = getSpeechSynthesis();
+      if (synth) {
+        try {
+          synth.resume?.();
+        } catch {}
+        try {
+          synth.getVoices();
+        } catch {}
+      }
       const pending = pendingCommentaryLinesRef.current;
       if (pending) {
         pendingCommentaryLinesRef.current = null;
@@ -12164,9 +12274,13 @@ function SnookerRoyalGame({
     };
     window.addEventListener('pointerdown', unlockCommentary);
     window.addEventListener('keydown', unlockCommentary);
+    window.addEventListener('touchstart', unlockCommentary);
+    window.addEventListener('click', unlockCommentary);
     return () => {
       window.removeEventListener('pointerdown', unlockCommentary);
       window.removeEventListener('keydown', unlockCommentary);
+      window.removeEventListener('touchstart', unlockCommentary);
+      window.removeEventListener('click', unlockCommentary);
     };
   }, [enqueueCommentaryLines]);
   useEffect(() => {

--- a/webapp/src/utils/snookerRoyalCommentary.js
+++ b/webapp/src/utils/snookerRoyalCommentary.js
@@ -13,6 +13,7 @@ const DEFAULT_CONTEXT = Object.freeze({
 
 const EVENT_POOLS = Object.freeze({
   intro: 'intro',
+  introReply: 'introReply',
   breakOff: 'breakOff',
   redPot: 'redPot',
   multiRed: 'multiRed',
@@ -30,6 +31,7 @@ const EVENT_POOLS = Object.freeze({
   frameBall: 'frameBall',
   frameWin: 'frameWin',
   outro: 'outro',
+  outroReply: 'outroReply',
   turn: 'turn'
 });
 
@@ -37,97 +39,147 @@ const TEMPLATES = Object.freeze({
   intro: [
     'Welcome to {arena}. {player} and {opponent} are set for {frameNumber}.',
     'We are live at {arena}. {player} versus {opponent}, and the table is ready.',
-    'Good evening from {arena}. {player} and {opponent} prepare to open {frameNumber}.'
+    'Good evening from {arena}. {player} and {opponent} prepare to open {frameNumber}.',
+    'It is match time at {arena}. {player} takes on {opponent} in {frameNumber}.',
+    'Hello from {arena}. The clash is {player} against {opponent} in {frameNumber}.'
+  ],
+  introReply: [
+    'The atmosphere is buzzing and the table looks perfect.',
+    'Everything is set for a sharp tactical frame.',
+    'Plenty of intrigue in this matchup. Let us see who settles first.',
+    'Great to be with you as these two start their battle.'
   ],
   breakOff: [
     'Here comes the break-off from {player}. All about control and the baulk line.',
     '{player} to break the pack. The cue ball needs to stay safe in baulk.',
-    '{player} steps in for the opener. Gentle break, heavy on precision.'
+    '{player} steps in for the opener. Gentle break, heavy on precision.',
+    '{player} with the opening strike, looking for a tight safety.',
+    'Break-off time for {player}. Cue ball control is everything.'
   ],
   redPot: [
     'Red down for {player}. The break is alive.',
     '{player} drops a red and stays in position.',
-    'That red is clean. {player} keeps the visit going.'
+    'That red is clean. {player} keeps the visit going.',
+    '{player} sinks the red and keeps the cue ball close.',
+    'Solid red pot by {player}. This visit continues.'
   ],
   multiRed: [
     'Multiple reds fall and {player} opens the table.',
     '{player} with a double red. That is a strong start.',
-    'Two reds drop and {player} has options.'
+    'Two reds drop and {player} has options.',
+    '{player} clears more than one red and spreads the pack nicely.',
+    'A flurry of reds for {player}. The table is loosening up.'
   ],
   colorPot: [
     '{color} goes in for {player}. The cue ball is right in the lane.',
     'Nice color from {player}. That should reset on the spot.',
-    '{player} lands the {color}. This break is building.'
+    '{player} lands the {color}. This break is building.',
+    'Smooth on the {color}. {player} keeps the scoring touch.',
+    '{player} pockets the {color} and stays in control.'
   ],
   colorOrder: [
     '{color} disappears in order. {player} clears through the colors.',
     '{player} pots the {color} as the clearance continues.',
-    'That is the {color}, and the colors are now in sequence.'
+    'That is the {color}, and the colors are now in sequence.',
+    '{player} ticks off the {color} with the clearance still alive.',
+    'Sequence shot on the {color}. {player} stays in rhythm.'
   ],
   respot: [
     '{color} drops and returns to its spot. {player} keeps the rhythm.',
     'Color down and back on its mark. {player} stays on the attack.',
-    '{player} slots the {color}; it will be respotted for the next shot.'
+    '{player} slots the {color}; it will be respotted for the next shot.',
+    '{player} takes the {color} cleanly. It goes back to the spot.',
+    'Great on the {color}. Respotted and the break continues.'
   ],
   safety: [
     'A patient safety from {player}. Tucking the cue ball tight.',
     '{player} chooses the safety route. Pressure shifts to {opponent}.',
-    'Good containment. {player} leaves {opponent} long and awkward.'
+    'Good containment. {player} leaves {opponent} long and awkward.',
+    '{player} rolls in the safety. {opponent} has work to do.',
+    '{player} nudges it safe. Tough angle for {opponent} now.'
   ],
   snooker: [
     'That is a proper snooker. {opponent} can barely see the ball on.',
     '{player} hides the cue ball. {opponent} is in trouble now.',
-    'Excellent snooker. {opponent} will need a clever escape.'
+    'Excellent snooker. {opponent} will need a clever escape.',
+    '{player} leaves {opponent} snookered. A big tactical moment.',
+    'Severe snooker laid by {player}. {opponent} is boxed in.'
   ],
   freeBall: [
     'Free ball on. {player} can turn this into a big visit.',
     'Free ball opportunity for {player}. That changes the table.',
-    '{player} gets the free ball. Expect a tactical swing.'
+    '{player} gets the free ball. Expect a tactical swing.',
+    'Free ball called. {player} can punish from here.',
+    'With a free ball, {player} has a golden opening.'
   ],
   foul: [
     'Foul from {player}. {points} points to {opponent}.',
     '{player} commits a foul, giving {opponent} {points}.',
-    'That is a foul: {foulReason}. {opponent} collects {points}.'
+    'That is a foul: {foulReason}. {opponent} collects {points}.',
+    'Foul called on {player}. {opponent} takes {points}.',
+    'That will cost {player}. {points} to {opponent}.'
   ],
   miss: [
     'That one slides by. {player} misses the pot.',
     'Just off line for {player}. Chance swings to {opponent}.',
-    '{player} cannot convert. A look now for {opponent}.'
+    '{player} cannot convert. A look now for {opponent}.',
+    'A miss from {player}. {opponent} is back to the table.',
+    '{player} just misses. That opens a door for {opponent}.'
   ],
   breakBuild: [
     '{player} is building a break of {breakTotal}. Great cueing.',
     'Break at {breakTotal} for {player}. This is real momentum.',
-    '{player} is in the groove with {breakTotal} on the run.'
+    '{player} is in the groove with {breakTotal} on the run.',
+    '{player} moves to {breakTotal}. Composed and confident.',
+    '{breakTotal} on the board for {player}. This is a tidy visit.'
   ],
   century: [
     'That is a century! {player} hits {breakTotal}.',
     '{player} reaches the hundred. A beautiful snooker break.',
-    'Century break for {player}. {arena} appreciates the class.'
+    'Century break for {player}. {arena} appreciates the class.',
+    '{player} posts a century. That is elite control.',
+    'One hundred for {player}. The crowd loves it.'
   ],
   colorsOrder: [
     'Reds are gone. Colors in order from here.',
     'Now into the colors sequence. Every shot is vital.',
-    'Colors phase begins. Precision only from here.'
+    'Colors phase begins. Precision only from here.',
+    'We are down to the colors. One by one from here.',
+    'Only the colors remain. This is where frames are won.'
   ],
   frameBall: [
     'This could be frame ball for {player}.',
     'Frame ball moment for {player}. Big pressure shot.',
-    '{player} looking at the frame ball. One more clean strike.'
+    '{player} looking at the frame ball. One more clean strike.',
+    'Frame ball on. {player} can close this out.',
+    'It is frame ball for {player}. The pressure is real.'
   ],
   frameWin: [
     '{player} takes the frame. Scoreline {scoreline}.',
     'Frame secured by {player}. A composed finish.',
-    '{player} closes it out. The frame is theirs.'
+    '{player} closes it out. The frame is theirs.',
+    '{player} seals the frame. Score now {scoreline}.',
+    'That is the frame to {player}. Big result there.'
   ],
   outro: [
     'That concludes {frameNumber} at {arena}. Thanks for watching.',
     'From {arena}, that is the end of the frame. Great play.',
-    'Match coverage wraps here at {arena}. Appreciate you joining us.'
+    'Match coverage wraps here at {arena}. Appreciate you joining us.',
+    'That is all for {frameNumber} from {arena}.',
+    'We will close it there at {arena}. Thanks for being with us.'
+  ],
+  outroReply: [
+    'A fine display from both players. Until next time.',
+    'Great moments throughout that frame. See you again soon.',
+    'That was a fantastic battle. Thanks for watching.',
+    'Plenty to take from that. We will catch you in the next one.'
   ],
   turn: [
     'Over to {player} now.',
     '{player} steps in for the next visit.',
-    'Next shot belongs to {player}.'
+    'Next shot belongs to {player}.',
+    '{player} is back at the table.',
+    '{player} now with the chance.'
   ]
 });
 
@@ -156,25 +208,49 @@ export const createSnookerMatchCommentaryScript = ({
     opponent: players.B,
     scoreline
   };
-  const speaker = commentators[0] || 'Caster';
-  return [
+  const lead = commentators[0] || 'Caster';
+  const analyst = commentators[1] || lead;
+  const start = [
     {
-      speaker,
+      speaker: lead,
       text: buildSnookerCommentaryLine({
         event: EVENT_POOLS.intro,
-        speaker,
-        context
-      })
-    },
-    {
-      speaker,
-      text: buildSnookerCommentaryLine({
-        event: EVENT_POOLS.outro,
-        speaker,
+        speaker: lead,
         context
       })
     }
   ];
+  if (analyst && analyst !== lead) {
+    start.push({
+      speaker: analyst,
+      text: buildSnookerCommentaryLine({
+        event: EVENT_POOLS.introReply,
+        speaker: analyst,
+        context
+      })
+    });
+  }
+  const end = [
+    {
+      speaker: lead,
+      text: buildSnookerCommentaryLine({
+        event: EVENT_POOLS.outro,
+        speaker: lead,
+        context
+      })
+    }
+  ];
+  if (analyst && analyst !== lead) {
+    end.push({
+      speaker: analyst,
+      text: buildSnookerCommentaryLine({
+        event: EVENT_POOLS.outroReply,
+        speaker: analyst,
+        context
+      })
+    });
+  }
+  return { start, end };
 };
 
 export const SNOOKER_ROYAL_COMMENTARY_EVENTS = Object.freeze({

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -104,7 +104,10 @@ export const speakCommentaryLines = async (lines, {
     const utterance = new SpeechSynthesisUtterance(line.text);
     const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Steven);
 
-    if (voice) utterance.voice = voice;
+    if (voice) {
+      utterance.voice = voice;
+      if (voice.lang) utterance.lang = voice.lang;
+    }
     utterance.rate = settings.rate;
     utterance.pitch = settings.pitch;
     utterance.volume = settings.volume;


### PR DESCRIPTION
### Motivation
- Commentary was too repetitive and single-voiced and sometimes silent in embedded/browser contexts, so narration should be varied and reliably audible.  
- The game needs two commentators with distinct voices and the ability to address players by username.  
- Voice selection and playback should be more robust in constrained browsers (e.g. Telegram in-app browser) by priming Web Speech APIs on user interaction.

### Description
- Expanded commentary templates and added `introReply`/`outroReply` pools to increase script variation in `webapp/src/utils/snookerRoyalCommentary.js`.  
- Modified `createSnookerMatchCommentaryScript` to support two commentators (lead + analyst) and return structured `start`/`end` lines so both voices can speak.  
- Added dual-speaker support, new preset voice hints and speaker settings, speaker selection/alternation logic, and multi-line enqueueing (primary + follow-up turn lines) in `webapp/src/pages/Games/SnookerRoyal.jsx`.  
- Improved browser TTS priming by listening for `pointerdown`, `keydown`, `touchstart`, and `click` to unlock commentary and calling `speechSynthesis.resume()` / `getVoices()`, and ensured the `SpeechSynthesisUtterance` `lang` is set from the chosen voice in `webapp/src/utils/textToSpeech.js`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d99e64448329aaf0a1e3bd5925d8)