### PR TITLE
Improve Pool Royale commentary: neutral roles, varied voices, queueing, and gameplay-triggered lines

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -915,18 +915,22 @@ const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
+const COMMENTARY_LEAD_ID = 'Lead';
+const COMMENTARY_ANALYST_ID = 'Analyst';
+const COMMENTARY_QUEUE_LIMIT = 4;
+const COMMENTARY_MIN_INTERVAL_MS = 1300;
 const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'arena-duo',
     label: 'Arena duo',
     description: 'UK female lead with US male analyst',
     voiceHints: {
-      Steven: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia'],
-      John: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
+      [COMMENTARY_LEAD_ID]: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia'],
+      [COMMENTARY_ANALYST_ID]: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
     },
     speakerSettings: {
-      Steven: { rate: 1, pitch: 1.02, volume: 1 },
-      John: { rate: 1.03, pitch: 0.98, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 1, pitch: 1.02, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1.03, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -934,12 +938,12 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     label: 'Atlantic booth',
     description: 'US female lead with UK male analyst',
     voiceHints: {
-      Steven: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira'],
-      John: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
+      [COMMENTARY_LEAD_ID]: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira'],
+      [COMMENTARY_ANALYST_ID]: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
     },
     speakerSettings: {
-      Steven: { rate: 1.02, pitch: 0.98, volume: 1 },
-      John: { rate: 1, pitch: 0.92, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 1.02, pitch: 0.98, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1, pitch: 0.92, volume: 1 }
     }
   },
   {
@@ -947,12 +951,12 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     label: 'Pacific desk',
     description: 'Australian male with US female analyst',
     voiceHints: {
-      Steven: ['Google Australian English', 'en-AU', 'English', 'male', 'Australia', 'Lee', 'William'],
-      John: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira']
+      [COMMENTARY_LEAD_ID]: ['Google Australian English', 'en-AU', 'English', 'male', 'Australia', 'Lee', 'William'],
+      [COMMENTARY_ANALYST_ID]: ['Google US English Female', 'en-US', 'English', 'female', 'US', 'Samantha', 'Zira']
     },
     speakerSettings: {
-      Steven: { rate: 1.01, pitch: 0.96, volume: 1 },
-      John: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 1.01, pitch: 0.96, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1.04, pitch: 1.06, volume: 1 }
     }
   },
   {
@@ -960,12 +964,12 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     label: 'Emerald studio',
     description: 'Irish female with UK male analyst',
     voiceHints: {
-      Steven: ['Google Irish English Female', 'en-IE', 'English', 'female', 'Ireland', 'Moira'],
-      John: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
+      [COMMENTARY_LEAD_ID]: ['Google Irish English Female', 'en-IE', 'English', 'female', 'Ireland', 'Moira'],
+      [COMMENTARY_ANALYST_ID]: ['Google UK English Male', 'en-GB', 'English', 'male', 'UK', 'Daniel', 'Arthur']
     },
     speakerSettings: {
-      Steven: { rate: 0.98, pitch: 0.9, volume: 1 },
-      John: { rate: 1.01, pitch: 1, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 0.98, pitch: 0.9, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1.01, pitch: 1, volume: 1 }
     }
   },
   {
@@ -973,12 +977,12 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     label: 'Global mix',
     description: 'Indian female with US male analyst',
     voiceHints: {
-      Steven: ['Google Indian English Female', 'en-IN', 'English', 'female', 'India', 'Asha', 'Raveena'],
-      John: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
+      [COMMENTARY_LEAD_ID]: ['Google Indian English Female', 'en-IN', 'English', 'female', 'India', 'Asha', 'Raveena'],
+      [COMMENTARY_ANALYST_ID]: ['Google US English Male', 'en-US', 'English', 'male', 'US', 'David', 'Guy']
     },
     speakerSettings: {
-      Steven: { rate: 1.02, pitch: 1.06, volume: 1 },
-      John: { rate: 1, pitch: 1.01, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 1.02, pitch: 1.06, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1, pitch: 1.01, volume: 1 }
     }
   },
   {
@@ -986,12 +990,12 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     label: 'Northern call',
     description: 'Canadian male with UK female analyst',
     voiceHints: {
-      Steven: ['Google Canadian English', 'en-CA', 'English', 'male', 'Canada', 'Liam'],
-      John: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia', 'Hazel']
+      [COMMENTARY_LEAD_ID]: ['Google Canadian English', 'en-CA', 'English', 'male', 'Canada', 'Liam'],
+      [COMMENTARY_ANALYST_ID]: ['Google UK English Female', 'en-GB', 'English', 'female', 'UK', 'Sonia', 'Hazel']
     },
     speakerSettings: {
-      Steven: { rate: 0.99, pitch: 0.97, volume: 1 },
-      John: { rate: 1.01, pitch: 1.03, volume: 1 }
+      [COMMENTARY_LEAD_ID]: { rate: 0.99, pitch: 0.97, volume: 1 },
+      [COMMENTARY_ANALYST_ID]: { rate: 1.01, pitch: 1.03, volume: 1 }
     }
   }
 ]);
@@ -10832,6 +10836,10 @@ function PoolRoyaleGame({
   const commentaryGreetingPlayedRef = useRef(false);
   const commentaryReadyRef = useRef(false);
   const pendingCommentaryLinesRef = useRef(null);
+  const commentaryQueueRef = useRef([]);
+  const commentarySpeakingRef = useRef(false);
+  const commentaryLastEventAtRef = useRef(0);
+  const commentarySpeakerIndexRef = useRef(0);
   const commentaryScriptRef = useRef({ start: [], end: [] });
   const commentaryScriptPlayedRef = useRef(false);
   const commentaryOutroPlayedRef = useRef(false);
@@ -10849,6 +10857,8 @@ function PoolRoyaleGame({
       const synth = getSpeechSynthesis();
       synth?.cancel();
       pendingCommentaryLinesRef.current = null;
+      commentaryQueueRef.current = [];
+      commentarySpeakingRef.current = false;
     }
   }, [commentaryMuted]);
   useEffect(() => {
@@ -12893,11 +12903,11 @@ const powerRef = useRef(hud.power);
       const commentaryVariant = activeVariant?.id ?? variantKey ?? '9ball';
       return [
         {
-          speaker: 'Steven',
+          speaker: COMMENTARY_LEAD_ID,
           text: buildCommentaryLine({
             event: 'intro',
             variant: commentaryVariant,
-            speaker: 'Steven',
+            speaker: COMMENTARY_LEAD_ID,
             context: {
               player: playerName,
               opponent: opponentName,
@@ -12912,11 +12922,11 @@ const powerRef = useRef(hud.power);
           })
         },
         {
-          speaker: 'John',
+          speaker: COMMENTARY_ANALYST_ID,
           text: buildCommentaryLine({
             event: 'introReply',
             variant: commentaryVariant,
-            speaker: 'John',
+            speaker: COMMENTARY_ANALYST_ID,
             context: {
               player: playerName,
               opponent: opponentName,
@@ -12982,25 +12992,58 @@ const powerRef = useRef(hud.power);
     ]
   );
 
-  const speakPoolCommentary = useCallback(
-    async (lines, preset = activeCommentaryPreset) => {
+  const playNextCommentary = useCallback(async () => {
+    if (commentarySpeakingRef.current) return;
+    const next = commentaryQueueRef.current.shift();
+    if (!next) return;
+    commentarySpeakingRef.current = true;
+    await speakCommentaryLines(next.lines, {
+      speakerSettings: next.preset?.speakerSettings,
+      voiceHints: next.preset?.voiceHints
+    });
+    commentarySpeakingRef.current = false;
+    if (commentaryQueueRef.current.length) {
+      playNextCommentary();
+    }
+  }, []);
+  const enqueuePoolCommentary = useCallback(
+    (lines, { priority = false, preset = activeCommentaryPreset } = {}) => {
       if (!Array.isArray(lines) || lines.length === 0) return;
       if (commentaryMutedRef.current || isGameMuted()) return;
       if (!commentaryReadyRef.current) {
         pendingCommentaryLinesRef.current = lines;
         return;
       }
-      const synth = getSpeechSynthesis();
-      if (!synth) return;
-      try {
-        synth.cancel();
-      } catch {}
-      await speakCommentaryLines(lines, {
-        speakerSettings: preset?.speakerSettings,
-        voiceHints: preset?.voiceHints
-      });
+      const now = performance.now();
+      if (!priority && now - commentaryLastEventAtRef.current < COMMENTARY_MIN_INTERVAL_MS) return;
+      if (!priority && commentaryQueueRef.current.length >= COMMENTARY_QUEUE_LIMIT) return;
+      commentaryQueueRef.current.push({ lines, preset });
+      if (!commentarySpeakingRef.current) {
+        playNextCommentary();
+      }
+      commentaryLastEventAtRef.current = now;
     },
-    [activeCommentaryPreset]
+    [activeCommentaryPreset, playNextCommentary]
+  );
+  const buildGameplayCommentaryLines = useCallback(
+    ({ event, context }) => {
+      const speakerOrder = [COMMENTARY_LEAD_ID, COMMENTARY_ANALYST_ID];
+      const speaker =
+        speakerOrder[commentarySpeakerIndexRef.current % speakerOrder.length] ?? COMMENTARY_LEAD_ID;
+      commentarySpeakerIndexRef.current += 1;
+      return [
+        {
+          speaker,
+          text: buildCommentaryLine({
+            event,
+            variant: activeVariant?.id ?? variantKey ?? '9ball',
+            speaker,
+            context
+          })
+        }
+      ];
+    },
+    [activeVariant?.id, variantKey]
   );
   useEffect(() => {
     const fullScript = buildMatchCommentaryScript();
@@ -13013,16 +13056,28 @@ const powerRef = useRef(hud.power);
     commentaryOutroPlayedRef.current = false;
     commentaryGreetingPlayedRef.current = false;
     pendingCommentaryLinesRef.current = null;
+    commentaryQueueRef.current = [];
+    commentarySpeakingRef.current = false;
+    commentarySpeakerIndexRef.current = 0;
   }, [buildMatchCommentaryScript, initialFrame]);
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const unlockCommentary = () => {
       if (commentaryReadyRef.current) return;
+      const synth = getSpeechSynthesis();
+      if (synth) {
+        try {
+          synth.resume?.();
+        } catch {}
+        try {
+          synth.getVoices();
+        } catch {}
+      }
       commentaryReadyRef.current = true;
       const pending = pendingCommentaryLinesRef.current;
       if (pending) {
         pendingCommentaryLinesRef.current = null;
-        speakPoolCommentary(pending);
+        enqueuePoolCommentary(pending, { priority: true });
       }
     };
     window.addEventListener('pointerdown', unlockCommentary);
@@ -13031,7 +13086,7 @@ const powerRef = useRef(hud.power);
       window.removeEventListener('pointerdown', unlockCommentary);
       window.removeEventListener('keydown', unlockCommentary);
     };
-  }, [speakPoolCommentary]);
+  }, [enqueuePoolCommentary]);
   useEffect(() => {
     if (commentaryScriptPlayedRef.current) return;
     if (commentaryMutedRef.current || isGameMuted()) return;
@@ -13040,8 +13095,8 @@ const powerRef = useRef(hud.power);
     if (!startLines.length) return;
     commentaryScriptPlayedRef.current = true;
     commentaryGreetingPlayedRef.current = true;
-    speakPoolCommentary(startLines);
-  }, [frameState.frameOver, speakPoolCommentary]);
+    enqueuePoolCommentary(startLines, { priority: true });
+  }, [enqueuePoolCommentary, frameState.frameOver]);
   useEffect(() => {
     if (!frameState.frameOver) return;
     if (commentaryOutroPlayedRef.current) return;
@@ -13049,22 +13104,22 @@ const powerRef = useRef(hud.power);
     const endLines = commentaryScriptRef.current.end;
     if (!endLines.length) return;
     commentaryOutroPlayedRef.current = true;
-    speakPoolCommentary(endLines);
-  }, [frameState.frameOver, speakPoolCommentary]);
+    enqueuePoolCommentary(endLines, { priority: true });
+  }, [enqueuePoolCommentary, frameState.frameOver]);
 
   const handleCommentaryPresetSelect = useCallback(
     (preset) => {
       if (!preset?.id) return;
       setCommentaryPresetId(preset.id);
       if (commentaryMutedRef.current || isGameMuted()) return;
-      speakPoolCommentary(
+      enqueuePoolCommentary(
         [
           {
-            speaker: 'Steven',
+            speaker: COMMENTARY_LEAD_ID,
             text: buildCommentaryLine({
               event: 'intro',
               variant: activeVariant?.id ?? variantKey ?? '9ball',
-              speaker: 'Steven',
+              speaker: COMMENTARY_LEAD_ID,
               context: {
                 player: player.name || 'Player A',
                 opponent: opponentLabel || 'Player B',
@@ -13084,7 +13139,7 @@ const powerRef = useRef(hud.power);
             })
           }
         ],
-        preset
+        { priority: true, preset }
       );
     },
     [
@@ -13095,7 +13150,7 @@ const powerRef = useRef(hud.power);
       frameState?.players,
       opponentLabel,
       player.name,
-      speakPoolCommentary,
+      enqueuePoolCommentary,
       variantKey
     ]
   );
@@ -13110,13 +13165,13 @@ const powerRef = useRef(hud.power);
     const timer = window.setTimeout(() => {
       if (cancelled || commentaryGreetingPlayedRef.current) return;
       commentaryGreetingPlayedRef.current = true;
-      speakPoolCommentary(buildCommentaryGreetingLines());
+      enqueuePoolCommentary(buildCommentaryGreetingLines(), { priority: true });
     }, 1200);
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [buildCommentaryGreetingLines, commentaryMuted, speakPoolCommentary]);
+  }, [buildCommentaryGreetingLines, commentaryMuted, enqueuePoolCommentary]);
   useEffect(() => {
     const nextName = playerName || getTelegramUsername() || 'Player';
     const nextAvatar = playerAvatar || getTelegramPhotoUrl();
@@ -23246,6 +23301,56 @@ const powerRef = useRef(hud.power);
               setPocketGlowTone(dropEntry, shotWasFoul ? 'foul' : 'good');
             }
           });
+        }
+        const objectPots = potted.filter((entry) => entry.id !== 'cue');
+        const shotPotCount = objectPots.length;
+        let commentaryEvent = null;
+        if (shotWasFoul) {
+          commentaryEvent = 'foul';
+        } else if (shotPotCount > 0) {
+          if (shotPotCount > 1) {
+            commentaryEvent = 'combo';
+          } else if (shotContextRef.current.cushionAfterContact) {
+            commentaryEvent = 'bank';
+          } else {
+            commentaryEvent = 'pot';
+          }
+        } else if (shotContextRef.current.contactMade) {
+          commentaryEvent = 'miss';
+        }
+        if (commentaryEvent) {
+          const playerAName = framePlayerAName || player.name || 'Player A';
+          const playerBName =
+            framePlayerBName || opponentDisplayName || opponentLabel || (isOnlineMatch ? 'Opponent' : 'AI');
+          const shooterName = shooterSeat === 'A' ? playerAName : playerBName;
+          const opponentName = shooterSeat === 'A' ? playerBName : playerAName;
+          const scoreA = safeState?.players?.A?.score ?? frameState?.players?.A?.score ?? 0;
+          const scoreB = safeState?.players?.B?.score ?? frameState?.players?.B?.score ?? 0;
+          const pocketLabels = {
+            TL: 'the top-left corner pocket',
+            TM: 'the top middle pocket',
+            TR: 'the top-right corner pocket',
+            BL: 'the bottom-left corner pocket',
+            BM: 'the bottom middle pocket',
+            BR: 'the bottom-right corner pocket'
+          };
+          const lastPocket = objectPots[objectPots.length - 1]?.pocket;
+          const opponentSeat = shooterSeat === 'A' ? 'B' : 'A';
+          const playerPots =
+            (pottedBySeat?.[shooterSeat]?.length ?? 0) + (shotPotCount || 0);
+          const opponentPots = pottedBySeat?.[opponentSeat]?.length ?? 0;
+          const context = {
+            player: shooterName,
+            opponent: opponentName,
+            playerScore: shooterSeat === 'A' ? scoreA : scoreB,
+            opponentScore: shooterSeat === 'A' ? scoreB : scoreA,
+            playerPoints: shooterSeat === 'A' ? scoreA : scoreB,
+            opponentPoints: shooterSeat === 'A' ? scoreB : scoreA,
+            playerPots,
+            opponentPots,
+            pocket: pocketLabels[lastPocket] || 'the pocket'
+          };
+          enqueuePoolCommentary(buildGameplayCommentaryLines({ event: commentaryEvent, context }));
         }
         if (metaState && typeof metaState === 'object') {
           const assignments = metaState.assignments || null;

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -1,12 +1,12 @@
 const SPEAKER_PROFILES = Object.freeze({
-  Steven: {
-    id: 'steven',
-    name: 'Steven',
+  Lead: {
+    id: 'lead',
+    name: 'Lead',
     style: 'Play-by-play'
   },
-  John: {
-    id: 'john',
-    name: 'John',
+  Analyst: {
+    id: 'analyst',
+    name: 'Analyst',
     style: 'Color analyst'
   }
 });
@@ -35,14 +35,14 @@ const DEFAULT_CONTEXT = Object.freeze({
 const TEMPLATES = Object.freeze({
   common: {
     intro: [
-      'Welcome to {arena}. {speaker} with {partner}. {player} faces {opponent} with the score {playerScore}-{opponentScore} in {variantName}.',
-      'It is match time at {arena}. {speaker} alongside {partner}. {player} versus {opponent}, {scoreline} in {variantName}.',
-      'Good evening from {arena}. {speaker} with {partner}. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
+      'Welcome to {arena}. Our booth is ready as {player} faces {opponent} with the score {playerScore}-{opponentScore} in {variantName}.',
+      'It is match time at {arena}. {player} versus {opponent}, {scoreline} in {variantName}.',
+      'Good evening from {arena}. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
     ],
     introReply: [
-      'Thanks {speaker}. Points are precious tonight—every pot will matter for {player} and {opponent}.',
-      'Great to be here, {speaker}. The scoreboard reads {playerScore}-{opponentScore}, and the margins are razor thin.',
-      'Absolutely, {speaker}. {player} and {opponent} both need clean pots to turn points into control.'
+      'Points are precious tonight—every pot will matter for {player} and {opponent}.',
+      'Great to be here. The scoreboard reads {playerScore}-{opponentScore}, and the margins are razor thin.',
+      '{player} and {opponent} both need clean pots to turn points into control.'
     ],
     breakShot: [
       '{player} steps in for the break; a sharp split sets up early pots.',
@@ -50,8 +50,8 @@ const TEMPLATES = Object.freeze({
       'Here comes the break from {player}. Cue ball control will be everything.'
     ],
     breakResult: [
-      'Nice spread off the break, {speaker}. The rack is open now.',
-      'That break has cracked the pack—clean lanes for scoring chances, {speaker}.',
+      'Nice spread off the break. The rack is open now.',
+      'That break has cracked the pack—clean lanes for scoring chances.',
       'Solid pop on the break. Control on the cue ball is the key from here.'
     ],
     openTable: [
@@ -60,7 +60,7 @@ const TEMPLATES = Object.freeze({
       '{player} is reading the table, looking for a simple route to the next pot.'
     ],
     safety: [
-      'A smart safety, {partner}. {player} tucks the cue ball behind a blocker.',
+      'A smart safety. {player} tucks the cue ball behind a blocker.',
       'That is a measured safety, leaving {opponent} long and awkward.',
       '{player} turns down the pot and plays the safety battle to protect the score.'
     ],
@@ -130,8 +130,8 @@ const TEMPLATES = Object.freeze({
       '{player} wins it, and {arena} appreciates a professional display.'
     ],
     outro: [
-      'That wraps it up from {arena}. Thanks for joining us, {partner}.',
-      'From {arena}, that is full time. Great match tonight, {partner}.',
+      'That wraps it up from {arena}. Thanks for joining us.',
+      'From {arena}, that is full time. Great match tonight.',
       'A fantastic finish in {variantName}. Thanks for watching with us.'
     ]
   },
@@ -163,7 +163,7 @@ const TEMPLATES = Object.freeze({
     groupCall: [
       'Open table between {groupPrimary} and {groupSecondary}; {player} is looking to claim one.',
       '{player} can choose {groupPrimary} or {groupSecondary}—the first clean pot decides the pattern.',
-      'Plenty of options here, {partner}. {groupPrimary} and {groupSecondary} are both available.'
+      'Plenty of options here. {groupPrimary} and {groupSecondary} are both available.'
     ],
     inHand: [
       'Foul gives {opponent} ball in hand—prime time for an 8-ball run.',
@@ -181,7 +181,7 @@ const TEMPLATES = Object.freeze({
     groupCall: [
       'Open table between {groupPrimary} and {groupSecondary}; {player} will claim a set soon.',
       '{groupPrimary} versus {groupSecondary} in UK rules; the first clean pot sets the route.',
-      'UK rules in play, {partner}. {groupPrimary} and {groupSecondary} are both available.'
+      'UK rules in play. {groupPrimary} and {groupSecondary} are both available.'
     ],
     freeBall: [
       'Foul gives {player} a free ball—huge advantage in UK rules.',
@@ -237,13 +237,13 @@ const resolveVariantData = (variantId) => {
   return TEMPLATES.nineBall;
 };
 
-export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Steven', context = {} }) => {
+export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Lead', context = {} }) => {
   const resolvedVariant = resolveVariantData(variant);
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,
     speaker,
-    partner: speaker === 'Steven' ? 'John' : 'Steven',
+    partner: speaker === 'Lead' ? 'Analyst' : 'Lead',
     variantName: resolvedVariant.variantName
   };
 
@@ -257,7 +257,7 @@ export const createMatchCommentaryScript = ({
   variant = '9ball',
   ballSet = 'uk',
   players = { A: 'Player A', B: 'Player B' },
-  commentators = ['Steven', 'John'],
+  commentators = ['Lead', 'Analyst'],
   scoreline = 'level at 0-0',
   scores = { A: 0, B: 0 },
   pots = { A: 0, B: 0 },

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,11 +1,11 @@
 const DEFAULT_VOICE_HINTS = {
-  Steven: ['en-GB', 'English', 'Male', 'Google UK English Male'],
-  John: ['en-US', 'English', 'Male', 'Google US English']
+  Lead: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia'],
+  Analyst: ['en-US', 'English', 'Male', 'Google US English Male', 'David', 'Guy']
 };
 
 const DEFAULT_SPEAKER_SETTINGS = {
-  Steven: { rate: 1, pitch: 0.95, volume: 1 },
-  John: { rate: 1.02, pitch: 1.05, volume: 1 }
+  Lead: { rate: 1, pitch: 1.02, volume: 1 },
+  Analyst: { rate: 1.02, pitch: 0.98, volume: 1 }
 };
 
 export const getSpeechSynthesis = () =>
@@ -69,7 +69,7 @@ const findDistinctVoice = (voices, hints = [], usedVoices = new Set()) => {
 
 export const resolveVoiceForSpeaker = (speaker, voices = []) => {
   if (!voices.length) return null;
-  const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Steven;
+  const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Lead;
   return findVoiceMatch(voices, hints);
 };
 
@@ -81,10 +81,10 @@ export const speakCommentaryLines = async (lines, {
   if (!synth || !Array.isArray(lines) || lines.length === 0) return;
 
   const voices = await loadVoices(synth);
-  const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Steven'))];
+  const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Lead'))];
   const usedVoices = new Set();
   const speakerVoices = uniqueSpeakers.reduce((acc, speaker) => {
-    const voice = findDistinctVoice(voices, voiceHints[speaker] || voiceHints.Steven, usedVoices);
+    const voice = findDistinctVoice(voices, voiceHints[speaker] || voiceHints.Lead, usedVoices);
     if (voice) {
       usedVoices.add(voice);
       acc[speaker] = voice;
@@ -99,10 +99,10 @@ export const speakCommentaryLines = async (lines, {
   }
 
   for (const line of lines) {
-    const speaker = line.speaker || 'Steven';
-    const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Steven;
+    const speaker = line.speaker || 'Lead';
+    const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Lead;
     const utterance = new SpeechSynthesisUtterance(line.text);
-    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Steven);
+    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Lead);
 
     if (voice) utterance.voice = voice;
     utterance.rate = settings.rate;


### PR DESCRIPTION
### Motivation
- Make voice commentary audible and more natural by removing hard-coded personal names and using neutral booth roles so voice selection can vary by preset.
- Provide varied, context-sensitive commentary (not the same script every time) and address playback/unlock issues that prevent speech on constrained browsers by adding resume/voice-loading safeguards.
- Ensure commentary references real players (usernames) and supports two alternating commentators with mixed-gender voice presets and distinct voices per speaker.

### Description
- Replaced named commentators with neutral roles in `webapp/src/utils/poolRoyaleCommentary.js` by renaming `Steven`/`John` to `Lead`/`Analyst` and refreshed templates to avoid repeating `{speaker}`/`{partner}` while keeping player-focused placeholders like `{player}`/`{opponent}`.
- Updated `webapp/src/utils/textToSpeech.js` defaults to `Lead`/`Analyst` voice hints and speaker settings, and made the voice resolution/select logic use the new defaults so two distinct voices can be chosen where available.
- Implemented commentary queueing, rate-limiting, unlock/resume handling and a `playNextCommentary`/`enqueuePoolCommentary` flow in `webapp/src/pages/Games/PoolRoyale.jsx` to avoid overlapping speech and to work around browser voice loading constraints by resuming the synthesizer on first user interaction.
- Added gameplay-driven commentary triggers inside shot resolution to enqueue contextual lines (events such as `pot`, `combo`, `bank`, `foul`, `miss`) with a `buildGameplayCommentaryLines` helper that alternates speakers and injects runtime context (player names, scores, pockets, pots) so commentary calls players by username.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d97fec10832989c2850090b90dae)