### PR TITLE
Improve Pool Royale commentary: dual commentators, distinct voices, queued TTS and gameplay-driven lines

### DIFF
--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -1,12 +1,17 @@
+export const POOL_ROYALE_SPEAKERS = Object.freeze({
+  lead: 'Mason',
+  analyst: 'Lena'
+});
+
 const SPEAKER_PROFILES = Object.freeze({
-  Steven: {
-    id: 'steven',
-    name: 'Steven',
+  Mason: {
+    id: 'mason',
+    name: 'Mason',
     style: 'Play-by-play'
   },
-  John: {
-    id: 'john',
-    name: 'John',
+  Lena: {
+    id: 'lena',
+    name: 'Lena',
     style: 'Color analyst'
   }
 });
@@ -237,13 +242,15 @@ const resolveVariantData = (variantId) => {
   return TEMPLATES.nineBall;
 };
 
-export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Steven', context = {} }) => {
+export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Mason', context = {} }) => {
   const resolvedVariant = resolveVariantData(variant);
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,
     speaker,
-    partner: speaker === 'Steven' ? 'John' : 'Steven',
+    partner: speaker === POOL_ROYALE_SPEAKERS.lead
+      ? POOL_ROYALE_SPEAKERS.analyst
+      : POOL_ROYALE_SPEAKERS.lead,
     variantName: resolvedVariant.variantName
   };
 
@@ -257,7 +264,7 @@ export const createMatchCommentaryScript = ({
   variant = '9ball',
   ballSet = 'uk',
   players = { A: 'Player A', B: 'Player B' },
-  commentators = ['Steven', 'John'],
+  commentators = [POOL_ROYALE_SPEAKERS.lead, POOL_ROYALE_SPEAKERS.analyst],
   scoreline = 'level at 0-0',
   scores = { A: 0, B: 0 },
   pots = { A: 0, B: 0 },

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,11 +1,11 @@
 const DEFAULT_VOICE_HINTS = {
-  Steven: ['en-GB', 'English', 'Male', 'Google UK English Male'],
-  John: ['en-US', 'English', 'Male', 'Google US English']
+  Mason: ['en-US', 'English', 'Male', 'Google US English Male', 'David', 'Guy'],
+  Lena: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia', 'Hazel']
 };
 
 const DEFAULT_SPEAKER_SETTINGS = {
-  Steven: { rate: 1, pitch: 0.95, volume: 1 },
-  John: { rate: 1.02, pitch: 1.05, volume: 1 }
+  Mason: { rate: 1, pitch: 0.95, volume: 1 },
+  Lena: { rate: 1.02, pitch: 1.05, volume: 1 }
 };
 
 export const getSpeechSynthesis = () =>
@@ -69,7 +69,7 @@ const findDistinctVoice = (voices, hints = [], usedVoices = new Set()) => {
 
 export const resolveVoiceForSpeaker = (speaker, voices = []) => {
   if (!voices.length) return null;
-  const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Steven;
+  const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Mason;
   return findVoiceMatch(voices, hints);
 };
 
@@ -81,10 +81,10 @@ export const speakCommentaryLines = async (lines, {
   if (!synth || !Array.isArray(lines) || lines.length === 0) return;
 
   const voices = await loadVoices(synth);
-  const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Steven'))];
+  const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Mason'))];
   const usedVoices = new Set();
   const speakerVoices = uniqueSpeakers.reduce((acc, speaker) => {
-    const voice = findDistinctVoice(voices, voiceHints[speaker] || voiceHints.Steven, usedVoices);
+    const voice = findDistinctVoice(voices, voiceHints[speaker] || voiceHints.Mason, usedVoices);
     if (voice) {
       usedVoices.add(voice);
       acc[speaker] = voice;
@@ -99,10 +99,10 @@ export const speakCommentaryLines = async (lines, {
   }
 
   for (const line of lines) {
-    const speaker = line.speaker || 'Steven';
-    const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Steven;
+    const speaker = line.speaker || 'Mason';
+    const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
     const utterance = new SpeechSynthesisUtterance(line.text);
-    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Steven);
+    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
 
     if (voice) utterance.voice = voice;
     utterance.rate = settings.rate;


### PR DESCRIPTION
### Motivation
- Make voice commentary audible and varied in the Pool Royale experience with multiple distinct commentator voices and commentary lines tied to real gameplay events. 
- Replace hard-coded commentator identities and same-voice fallbacks (`Steven`/`John`) with a flexible lead/analyst pairing and presets so the commentary addresses players by username and supports male/female mixes. 
- Ensure commentary behaves correctly on touch/Telegram webviews by improving unlock handling and queuing rather than attempting immediate playback that may be blocked by the browser. 

### Description
- Replaced the hard-coded commentators with `POOL_ROYALE_SPEAKERS` (`lead`/`analyst`) and updated internal `SPEAKER_PROFILES` names to `Mason` and `Lena` in `webapp/src/utils/poolRoyaleCommentary.js`, and defaulted `buildCommentaryLine` and `createMatchCommentaryScript` to use the new speaker identities. 
- Updated TTS defaults in `webapp/src/utils/textToSpeech.js` to include `Mason`/`Lena` voice hints and matching `DEFAULT_SPEAKER_SETTINGS`, and adjusted voice resolution to prefer the new keys so different presets select distinct voices. 
- Refreshed commentary presets in `webapp/src/pages/Games/PoolRoyale.jsx` to use the new speaker keys and added multiple presets with male/female mixes so each preset can yield two different voices. 
- Implemented a queued commentary system and improved unlock behavior in `PoolRoyale.jsx` by adding `enqueuePoolCommentary`, `playNextCommentary`, `COMMENTARY_QUEUE_LIMIT`, `COMMENTARY_MIN_INTERVAL_MS`, and unlocking on `pointerdown`, `click`, `touchstart`, and `keydown`; this prevents blocked playback and drains a queue safely. 
- Hooked commentary into actual shot outcomes by adding `maybeSpeakShotCommentary` which inspects `safeState`, fouls, pots, replay tags and enqueues context-aware lines (e.g., `pot`, `bank`, `foul`, `inHand`, `matchWin`) so commentary reflects the real gameplay and uses player display names. 
- Kept previous templates/variation usage (`buildCommentaryLine`) so lines remain variable (random picks per event) and now reference real player names via context instead of `Steven`/`John`. 

### Testing
- No automated tests were executed for this change set. 
- Changes were committed locally (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/utils/poolRoyaleCommentary.js`, `webapp/src/utils/textToSpeech.js`) and are ready for review and runtime verification in a browser that supports Web Speech API.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d97fec10832989c2850090b90dae)