### PR TITLE
Enable Pool Royale commentary audio priming

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -39,7 +39,7 @@ import {
   createMatchCommentaryScript,
   POOL_ROYALE_SPEAKERS
 } from '../../utils/poolRoyaleCommentary.js';
-import { getSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -13179,6 +13179,7 @@ const powerRef = useRef(hud.power);
     if (typeof window === 'undefined') return undefined;
     const unlockCommentary = () => {
       if (commentaryReadyRef.current) return;
+      primeSpeechSynthesis();
       commentaryReadyRef.current = true;
       const pending = pendingCommentaryLinesRef.current;
       if (pending) {

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -11,6 +11,29 @@ const DEFAULT_SPEAKER_SETTINGS = {
 export const getSpeechSynthesis = () =>
   typeof window !== 'undefined' && 'speechSynthesis' in window ? window.speechSynthesis : null;
 
+export const primeSpeechSynthesis = () => {
+  const synth = getSpeechSynthesis();
+  if (!synth || synth.speaking || synth.pending) return;
+  if (typeof synth.resume === 'function') {
+    try {
+      synth.resume();
+    } catch {}
+  }
+  const utterance = new SpeechSynthesisUtterance(' ');
+  utterance.volume = 0;
+  utterance.rate = 1;
+  utterance.pitch = 1;
+  utterance.onend = () => {
+    if (typeof synth.cancel === 'function') {
+      try {
+        synth.cancel();
+      } catch {}
+    }
+  };
+  utterance.onerror = utterance.onend;
+  synth.speak(utterance);
+};
+
 const loadVoices = (synth, timeoutMs = 2500) =>
   new Promise((resolve) => {
     if (!synth) {


### PR DESCRIPTION
### Motivation
- Telegram WebView often blocks immediate speech playback until a user gesture primes the speech API, causing commentary to be silent when first unlocked.

### Description
- Added `primeSpeechSynthesis` to `webapp/src/utils/textToSpeech.js` which issues a silent, zero-volume `SpeechSynthesisUtterance` and cancels it to prime voices and resume the synth.
- Imported and invoked `primeSpeechSynthesis` from `webapp/src/pages/Games/PoolRoyale.jsx` inside the commentary unlock handler bound to user gesture events (`pointerdown`, `click`, `touchstart`, `keydown`).
- Kept existing commentary queue and mute handling logic intact so priming only occurs once when commentary is unlocked.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e7147fc08329894aa31b4f4670f2)