### PR TITLE
Enable Snooker Royal commentary in Telegram webviews

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -119,3 +119,32 @@ export const speakCommentaryLines = async (lines, {
     });
   }
 };
+
+export const primeSpeechSynthesis = async () => {
+  const synth = getSpeechSynthesis();
+  if (!synth || typeof SpeechSynthesisUtterance === 'undefined') return false;
+  try {
+    synth.resume?.();
+  } catch {}
+  try {
+    const utterance = new SpeechSynthesisUtterance(' ');
+    utterance.volume = 0;
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    await new Promise((resolve) => {
+      let settled = false;
+      const finalize = () => {
+        if (settled) return;
+        settled = true;
+        resolve(true);
+      };
+      utterance.onend = finalize;
+      utterance.onerror = finalize;
+      synth.speak(utterance);
+      setTimeout(finalize, 250);
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
### Motivation
- Fix cases where voice commentary does not play in constrained environments (Telegram in-app browser) by ensuring the SpeechSynthesis API is primed and unlocked reliably.
- Improve user experience by auto-unlocking commentary on additional interaction events and adding a Telegram-specific fallback when user gestures are not detected.

### Description
- Add a priming helper `primeSpeechSynthesis` in `webapp/src/utils/textToSpeech.js` that attempts to resume the `speechSynthesis` and speaks a silent utterance to warm the engine.  (new function)
- Import and call `primeSpeechSynthesis` from `webapp/src/pages/Games/SnookerRoyal.jsx` during commentary unlock flow to improve playback reliability. (call added adjacent to existing `synth.resume`/`getVoices` calls)
- Expand commentary unlock listeners to include additional DOM events on `document` and use passive listener options for touch/pointer handlers. (added `document` listeners and `listenerOptions`)
- Add Telegram-specific fallbacks: detect Telegram webview with `isTelegramWebView()`, set a short auto-unlock timeout, and hook into `window.Telegram.WebApp` `viewportChanged` events to unlock/prime commentary when the Telegram bridge updates the viewport. (timeout and bridge hook added, with proper cleanup)

### Testing
- No automated tests were executed for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e72613508329b19753b65edde06c)