### PR TITLE
Remove 50 FPS preset and make Domino Royal default 60 FPS

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -208,15 +208,6 @@ const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
-    renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: 'HD render • DPR 1.4 cap',
-    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
-  },
-  {
     id: 'fhd60',
     label: 'Full HD (60 Hz)',
     fps: 60,
@@ -288,23 +279,6 @@ function detectCoarsePointer() {
     }
   } catch (err) {
     // ignore
-  }
-  return false;
-}
-
-function detectLowRefreshDisplay() {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false;
-  }
-  const queries = ['(max-refresh-rate: 59hz)', '(max-refresh-rate: 50hz)', '(prefers-reduced-motion: reduce)'];
-  for (const query of queries) {
-    try {
-      if (window.matchMedia(query).matches) {
-        return true;
-      }
-    } catch (err) {
-      // ignore unsupported query
-    }
   }
   return false;
 }
@@ -405,17 +379,12 @@ function detectPreferredFrameRateId() {
   const isTouch = maxTouchPoints > 1;
   const deviceMemory = typeof navigator.deviceMemory === 'number' ? navigator.deviceMemory : null;
   const hardwareConcurrency = navigator.hardwareConcurrency ?? 4;
-  const lowRefresh = detectLowRefreshDisplay();
   const highRefresh = detectHighRefreshDisplay();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
-  if (lowRefresh) {
-    return 'hd50';
-  }
-
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'hd50';
+      return 'fhd60';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -16,7 +16,7 @@ const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
-const DEFAULT_FRAME_RATE_ID = 'balanced60';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const CHESS_PLAYER_FLAG_KEY = 'chessBattleRoyalPlayerFlag';
 const CHESS_AI_FLAG_KEY = 'chessBattleRoyalAiFlag';


### PR DESCRIPTION
### Motivation
- Ensure Domino Battle Royal does not expose a 50 FPS graphics preset and defaults to a consistent 60 FPS profile for smoother gameplay and parity with other game frames. 
- Simplify refresh-rate detection logic so devices that would previously fall back to 50 Hz now use the 60 FPS profile by default.

### Description
- Removed the `hd50` (50 FPS) entry from `FRAME_RATE_OPTIONS` in `webapp/public/domino-royal.html` so the 50 FPS preset is no longer available in the client. 
- Eliminated the `detectLowRefreshDisplay` usage and updated `detectPreferredFrameRateId` in `webapp/public/domino-royal.html` so it no longer returns the `hd50` preset, preferring `fhd60` for lower-end/limited devices. 
- Aligned the lobby default to 60 FPS by changing `DEFAULT_FRAME_RATE_ID` to `fhd60` in `webapp/src/pages/Games/DominoRoyalLobby.jsx` so new matches start with the 60 FPS profile.

### Testing
- Started a local static server with `python -m http.server 4173` hosting `webapp/public` and the server served `domino-royal.html` successfully. 
- Ran a Playwright script that loaded `http://127.0.0.1:4173/domino-royal.html` and produced a screenshot saved to `artifacts/domino-royal-60fps.png`, confirming the page loads with the updated defaults (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975fcb422b483298468c56cb3236f09)