### PR TITLE
Prefer lower-res HDRIs for Domino Royal on Telegram/mobile

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2978,15 +2978,24 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
   return options.filter((option) => isDominoOptionUnlocked(key, option.id, inventory));
 }
 
-const HDRI_RESOLUTION_ORDER = Object.freeze(['4k']);
+const HDRI_RESOLUTION_ORDER = Object.freeze(['1k', '2k', '4k']);
+const isTelegramWebView = /Telegram/i.test(navigator.userAgent || '') || Boolean(window?.Telegram?.WebApp);
+const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '');
+const isLowMemoryDevice = typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4;
+const isLowCoreDevice = typeof navigator.hardwareConcurrency === 'number' && navigator.hardwareConcurrency <= 4;
+function resolveHdriResolutionOrder() {
+  if (prefersUhd) return ['4k'];
+  const lowProfile = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
+  return lowProfile ? ['1k', '2k', '4k'] : ['2k', '4k'];
+}
 let activeEnvironmentHdri = null;
 
 async function loadHdriEnvironment(variant) {
   if (!variant?.assetId) return null;
   const preferred = Array.isArray(variant.preferredResolutions)
-    ? variant.preferredResolutions.filter((res) => res === '4k')
+    ? variant.preferredResolutions.filter((res) => HDRI_RESOLUTION_ORDER.includes(res))
     : [];
-  const order = preferred.length ? preferred : HDRI_RESOLUTION_ORDER;
+  const order = preferred.length ? preferred : resolveHdriResolutionOrder();
   let lastError = null;
   for (const res of order) {
     const cacheKey = `${variant.id}:${res}`;


### PR DESCRIPTION
### Motivation
- The Domino Royal 3D arena can load large 4k HDRI environments which increase memory/GPU use and may crash in-app browsers like Telegram or on low-end mobile devices.
- The change aims to reduce HDRI load pressure by preferring smaller environment maps for low-profile clients while preserving an explicit UHD override when requested via the `uhd` query param.

### Description
- Added `HDRI_RESOLUTION_ORDER` and device/profile detection (`isTelegramWebView`, `isMobileDevice`, `isLowMemoryDevice`, `isLowCoreDevice`) to identify low-profile clients.
- Introduced `resolveHdriResolutionOrder()` to return an ordered list of preferred HDRI resolutions based on client profile and the existing `prefersUhd` flag.
- Modified `loadHdriEnvironment()` to filter `variant.preferredResolutions` against supported resolutions and to iterate the resolution order returned by `resolveHdriResolutionOrder()` instead of always using `4k` first.
- Kept existing behavior that honors the `uhd=1` override by returning `['4k']` when `prefersUhd` is true.

### Testing
- No automated tests were run against the modified code as part of this change.
- The patch was applied and committed to `webapp/public/domino-royal.html` and the repository commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ff8a1df88329b555bda964dd4267)