### PR TITLE
Make commentary single-voice, language-aware, and use AI country names

### DIFF
--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -38,61 +38,61 @@ const DEFAULT_CONTEXT = Object.freeze({
   rackNumber: 'this rack'
 });
 
-const TEMPLATES = Object.freeze({
+const ENGLISH_TEMPLATES = Object.freeze({
   common: {
     intro: [
-      'Welcome to {arena}. {speaker} with {partner}. {player} faces {opponent} with the score {playerScore}-{opponentScore} in {variantName}.',
-      'It is match time at {arena}. {speaker} alongside {partner}. {player} versus {opponent}, {scoreline} in {variantName}.',
-      'Good evening from {arena}. {speaker} with {partner}. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
+      'Welcome to {arena}. {speaker} here. {player} faces {opponent}; {scoreline} in {variantName}.',
+      'Match time at {arena}. {speaker} with you. {player} versus {opponent} in {variantName}, {scoreline}.',
+      'Good evening from {arena}. {speaker} on the call. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
     ],
     introReply: [
-      'Thanks {speaker}. Points are precious tonight—every pot will matter for {player} and {opponent}.',
-      'Great to be here, {speaker}. The scoreboard reads {playerScore}-{opponentScore}, and the margins are razor thin.',
-      'Absolutely, {speaker}. {player} and {opponent} both need clean pots to turn points into control.'
+      'Thanks {speaker}. Points are precious—cue ball control and smart pattern play will decide it.',
+      'Great to be here, {speaker}. The margins are razor thin, and position play is everything.',
+      'Absolutely, {speaker}. {player} and {opponent} need clean pots and precise spin to control the table.'
     ],
     breakShot: [
-      '{player} steps in for the break; a sharp split sets up early pots.',
-      '{player} leans in. A controlled break can define the scoring chances.',
-      'Here comes the break from {player}. Cue ball control will be everything.'
+      '{player} steps in for the break; a sharp split sets up early pots and a clean cue-ball path.',
+      '{player} leans in. A controlled break and measured spin can define the first run.',
+      'Here comes the break from {player}. Cue-ball control will be everything.'
     ],
     breakResult: [
-      'Nice spread off the break, {speaker}. The rack is open now.',
-      'That break has cracked the pack—clean lanes for scoring chances, {speaker}.',
-      'Solid pop on the break. Control on the cue ball is the key from here.'
+      'Nice spread off the break, {speaker}. The rack is open with clear lanes.',
+      'That break has cracked the pack—plenty of options with cue-ball routes available.',
+      'Solid pop on the break. Now it is about speed control and touch.'
     ],
     openTable: [
-      'Early pattern here—{player} wants natural angles and quick pots.',
-      'Plenty of options with the open table; cue ball paths decide the points.',
-      '{player} is reading the table, looking for a simple route to the next pot.'
+      'Early pattern here—{player} wants natural angles and a simple route to the next pot.',
+      'Plenty of options with the open table; cue ball paths and spin control decide the points.',
+      '{player} is reading the table, mapping the next pot and the cue-ball landing zone.'
     ],
     safety: [
-      'A smart safety, {partner}. {player} tucks the cue ball behind a blocker.',
-      'That is a measured safety, leaving {opponent} long and awkward.',
-      '{player} turns down the pot and plays the safety battle to protect the score.'
+      'A smart safety. {player} tucks the cue ball behind a blocker.',
+      'That is a measured safety, leaving {opponent} long and awkward with no clean lane.',
+      '{player} turns down the pot and plays the percentage safety to protect the score.'
     ],
     pressure: [
       'Big moment. {player} needs this pot to keep the scoring run alive.',
-      'Pressure shot here for {player}; it is all about soft touch and points.',
+      'Pressure shot here for {player}; it is all about soft touch, spin, and position.',
       'This is where nerves show—{player} has to deliver for the scoreboard.'
     ],
     pot: [
-      '{player} pots {targetBall}.',
-      'Pot: {targetBall}.',
-      '{player} sends {targetBall} down.'
+      '{player} pots {targetBall} into {pocket}, cue ball held in good position.',
+      'Pot: {targetBall} in {pocket}.',
+      '{player} sends {targetBall} down the {pocket} with smooth control.'
     ],
     combo: [
-      '{player} combos {targetBall}.',
-      'Combination pot on {targetBall}.',
-      '{player} caroms {targetBall} into the {pocket}.'
+      '{player} combos {targetBall} into {pocket}, great sighting.',
+      'Combination pot on {targetBall} into the {pocket}.',
+      '{player} caroms {targetBall} into the {pocket} with precision.'
     ],
     bank: [
-      '{player} banks {targetBall} into the {pocket}.',
+      '{player} banks {targetBall} into the {pocket} with clean speed.',
       'Bank shot: {targetBall} in the {pocket}.',
-      '{player} sends {targetBall} off the cushion and down.'
+      '{player} sends {targetBall} off the cushion and down with control.'
     ],
     kick: [
       'Kick shot required—{player} goes one rail to find it.',
-      'Tough kick for {player}; cue ball needs to hit thin.',
+      'Tough kick for {player}; the cue ball needs a thin contact.',
       '{player} escapes with a kick. Excellent table awareness.'
     ],
     jump: [
@@ -101,13 +101,13 @@ const TEMPLATES = Object.freeze({
       'Jump shot executed; {player} gets the hit and stays in control.'
     ],
     miss: [
-      '{player} misses the pot.',
-      'No pot for {player}.',
-      '{player} comes up short.'
+      '{player} misses the pot and leaves a look for {opponent}.',
+      'No pot for {player}; the table opens up.',
+      '{player} comes up short and loses the table.'
     ],
     foul: [
       'Foul on {player}.',
-      'Foul called. {opponent} to the table.',
+      'Foul called. {opponent} to the table with control.',
       '{player} commits a foul.'
     ],
     inHand: [
@@ -117,7 +117,7 @@ const TEMPLATES = Object.freeze({
     ],
     runout: [
       '{player} is in rhythm—this could be a full clearance.',
-      'A runout is on. {player} just needs clean angles.',
+      'A runout is on. {player} just needs clean angles and speed control.',
       '{player} is stitching it together, ball by ball.'
     ],
     hillHill: [
@@ -126,7 +126,7 @@ const TEMPLATES = Object.freeze({
       'Final rack nerves—every shot feels heavier now.'
     ],
     frameWin: [
-      '{player} wins the rack.',
+      '{player} wins the rack with composed position play.',
       'Rack to {player}.',
       '{player} closes the rack.'
     ],
@@ -136,8 +136,8 @@ const TEMPLATES = Object.freeze({
       'Final score {playerScore}-{opponentScore}. {player} wins.'
     ],
     outro: [
-      'That wraps it up from {arena}. Thanks for joining us, {partner}.',
-      'From {arena}, that is full time. Great match tonight, {partner}.',
+      'That wraps it up from {arena}. Thanks for joining us.',
+      'From {arena}, that is full time. Great match tonight.',
       'A fantastic finish in {variantName}. Thanks for watching with us.'
     ]
   },
@@ -169,7 +169,7 @@ const TEMPLATES = Object.freeze({
     groupCall: [
       'Open table between {groupPrimary} and {groupSecondary}; {player} is looking to claim one.',
       '{player} can choose {groupPrimary} or {groupSecondary}—the first clean pot decides the pattern.',
-      'Plenty of options here, {partner}. {groupPrimary} and {groupSecondary} are both available.'
+      'Plenty of options here; {groupPrimary} and {groupSecondary} are both available.'
     ],
     inHand: [
       'Foul gives {opponent} ball in hand—prime time for an 8-ball run.',
@@ -187,7 +187,7 @@ const TEMPLATES = Object.freeze({
     groupCall: [
       'Open table between {groupPrimary} and {groupSecondary}; {player} will claim a set soon.',
       '{groupPrimary} versus {groupSecondary} in UK rules; the first clean pot sets the route.',
-      'UK rules in play, {partner}. {groupPrimary} and {groupSecondary} are both available.'
+      'UK rules in play. {groupPrimary} and {groupSecondary} are both available.'
     ],
     freeBall: [
       'Foul gives {player} a free ball—huge advantage in UK rules.',
@@ -199,6 +199,430 @@ const TEMPLATES = Object.freeze({
       'Everything goes through the black from here.',
       'Black ball time—perfect angle required.'
     ]
+  }
+});
+
+const LOCALIZED_TEMPLATES = Object.freeze({
+  en: ENGLISH_TEMPLATES,
+  zh: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        '欢迎来到{arena}。{speaker}为您带来解说。{player}对阵{opponent}，{scoreline}，{variantName}。'
+      ],
+      introReply: [
+        '谢谢{speaker}。今晚关键在于走位与旋转控制，每一杆都很重要。'
+      ],
+      breakShot: [
+        '{player}准备开球，良好的炸散与母球控制会带来早期机会。'
+      ],
+      breakResult: [
+        '开球炸散不错，球路已经打开，走位至关重要。'
+      ],
+      openTable: [
+        '球形较开，{player}在寻找最自然的走位线路。'
+      ],
+      safety: [
+        '{player}选择防守，把母球藏到安全位置。'
+      ],
+      pressure: [
+        '关键一杆，{player}需要稳住力度与旋转。'
+      ],
+      pot: [
+        '{player}将{targetBall}打进{pocket}，母球位置不错。'
+      ],
+      combo: [
+        '{player}组合球进{pocket}，击球线路清晰。'
+      ],
+      bank: [
+        '{player}打库进{pocket}，控制得当。'
+      ],
+      kick: [
+        '{player}必须踢库解球，考验手感。'
+      ],
+      jump: [
+        '{player}选择跳球，成功越过障碍。'
+      ],
+      miss: [
+        '{player}未能进球，机会交给{opponent}。'
+      ],
+      foul: [
+        '{player}犯规，{opponent}获得机会。'
+      ],
+      inHand: [
+        '{opponent}获得自由球。'
+      ],
+      runout: [
+        '{player}节奏很好，有机会一杆清台。'
+      ],
+      hillHill: [
+        '决胜局，压力拉满。'
+      ],
+      frameWin: [
+        '{player}拿下这一局。'
+      ],
+      matchWin: [
+        '比赛结束，{player}以{playerScore}-{opponentScore}获胜。'
+      ],
+      outro: [
+        '{arena}的比赛告一段落，感谢观看。'
+      ]
+    },
+    nineBall: {
+      variantName: '9球美式台球',
+      rotation: ['9球规则必须先击打最小号球。'],
+      goldenBreak: ['如果9号球在开球进袋就是金开球。'],
+      comboNine: ['{player}考虑组合9号球，这一杆可能结束本局。'],
+      pushOut: ['{player}选择推球，制造更好的局面。']
+    },
+    eightBallUs: {
+      variantName: '美式8球',
+      groupCall: ['开台阶段，{groupPrimary}与{groupSecondary}都可选择。'],
+      inHand: ['{opponent}自由球在手，清台机会很大。'],
+      eightBall: ['现在进入8号球阶段，走位决定胜负。']
+    },
+    eightBallUk: {
+      variantName: '英式8球',
+      groupCall: ['英式规则，{groupPrimary}与{groupSecondary}等待归属。'],
+      freeBall: ['{player}获得自由球与两次击球机会。'],
+      blackBall: ['黑球上台，角度要求很高。']
+    }
+  },
+  hi: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        '{arena} से स्वागत है। {speaker} आपके साथ हैं। {player} बनाम {opponent}, {scoreline}, {variantName} में।'
+      ],
+      introReply: [
+        'धन्यवाद {speaker}. आज नियंत्रण और स्पिन ही फ़र्क बनाएंगे।'
+      ],
+      breakShot: [
+        '{player} ब्रेक के लिए तैयार है—फैलाव और क्यू-बॉल कंट्रोल अहम है।'
+      ],
+      breakResult: [
+        'ब्रेक अच्छा रहा, टेबल खुल गई है और रास्ते साफ़ हैं।'
+      ],
+      openTable: [
+        'टेबल खुला है—{player} आसान पॉट और पोजिशन की तलाश में है।'
+      ],
+      safety: [
+        '{player} ने सुरक्षित खेला, क्यू-बॉल को ढक दिया।'
+      ],
+      pressure: [
+        'यह दबाव भरा शॉट है—टच और स्पिन दोनों ज़रूरी हैं।'
+      ],
+      pot: [
+        '{player} ने {targetBall} को {pocket} में पॉट किया, पोजिशन बढ़िया है।'
+      ],
+      combo: [
+        '{player} ने कॉम्बिनेशन से {targetBall} को {pocket} में भेजा।'
+      ],
+      bank: [
+        '{player} ने बैंक शॉट से {targetBall} को {pocket} में डाला।'
+      ],
+      kick: [
+        '{player} को किक शॉट खेलना पड़ेगा—कठिन प्रयास।'
+      ],
+      jump: [
+        '{player} ने जंप शॉट खेला और रास्ता बनाया।'
+      ],
+      miss: [
+        '{player} पॉट नहीं कर पाए, मौका {opponent} को मिलता है।'
+      ],
+      foul: [
+        '{player} से फाउल हो गया।'
+      ],
+      inHand: [
+        '{opponent} के लिए बॉल इन हैंड।'
+      ],
+      runout: [
+        '{player} रनआउट की स्थिति में है, बस साफ़ एंगल चाहिए।'
+      ],
+      hillHill: [
+        'निर्णायक रैक—तनाव चरम पर।'
+      ],
+      frameWin: [
+        '{player} ने यह रैक जीत लिया।'
+      ],
+      matchWin: [
+        'मैच समाप्त। {player} ने {playerScore}-{opponentScore} से जीता।'
+      ],
+      outro: [
+        '{arena} से यहीं तक, देखने के लिए धन्यवाद।'
+      ]
+    },
+    nineBall: {
+      variantName: '9-बॉल अमेरिकन',
+      rotation: ['9-बॉल में हमेशा सबसे छोटी बॉल पहले लगती है।'],
+      goldenBreak: ['ब्रेक पर 9 गिरा तो मैच वहीं खत्म।'],
+      comboNine: ['{player} 9 की कॉम्बिनेशन देख रहा है—बड़ा मौका।'],
+      pushOut: ['{player} पुश-आउट खेल कर बेहतर लाइन चाहता है।']
+    },
+    eightBallUs: {
+      variantName: 'अमेरिकन 8-बॉल',
+      groupCall: ['ओपन टेबल है; {groupPrimary} या {groupSecondary} चुन सकते हैं।'],
+      inHand: ['{opponent} को बॉल इन हैंड मिला—बड़ा फायदा।'],
+      eightBall: ['अब 8-बॉल का खेल, पोजिशन निर्णायक है।']
+    },
+    eightBallUk: {
+      variantName: 'यूके 8-बॉल',
+      groupCall: ['यूके नियमों में {groupPrimary} और {groupSecondary} खुले हैं।'],
+      freeBall: ['{player} को फ्री बॉल और दो विज़िट मिलती हैं।'],
+      blackBall: ['ब्लैक बॉल आ गई, एंगल बहुत जरूरी है।']
+    }
+  },
+  es: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Bienvenidos a {arena}. {speaker} con ustedes. {player} contra {opponent}, {scoreline}, en {variantName}.'
+      ],
+      introReply: [
+        'Gracias, {speaker}. Hoy manda el control de bola y el efecto.'
+      ],
+      breakShot: [
+        '{player} va al saque; abrir la mesa y controlar la blanca es clave.'
+      ],
+      breakResult: [
+        'Buen saque, la mesa está abierta y hay líneas claras.'
+      ],
+      openTable: [
+        'Mesa abierta; {player} busca ángulos naturales y posición.'
+      ],
+      safety: [
+        '{player} juega defensa y esconde la blanca.'
+      ],
+      pressure: [
+        'Golpe de presión; toque suave y efecto preciso.'
+      ],
+      pot: [
+        '{player} emboca {targetBall} en {pocket} y deja buena posición.'
+      ],
+      combo: [
+        '{player} juega combinación y mete {targetBall} en {pocket}.'
+      ],
+      bank: [
+        '{player} hace carambola a banda y mete {targetBall} en {pocket}.'
+      ],
+      kick: [
+        '{player} debe ir a banda para encontrar la bola.'
+      ],
+      jump: [
+        '{player} ejecuta un salto para superar el bloqueo.'
+      ],
+      miss: [
+        '{player} falla el tiro; oportunidad para {opponent}.'
+      ],
+      foul: [
+        'Falta de {player}.'
+      ],
+      inHand: [
+        '{opponent} tiene bola en mano.'
+      ],
+      runout: [
+        '{player} puede cerrar la mesa si mantiene el control.'
+      ],
+      hillHill: [
+        'Rack decisivo—máxima tensión.'
+      ],
+      frameWin: [
+        '{player} gana el rack.'
+      ],
+      matchWin: [
+        'Final: {player} gana {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'Desde {arena}, gracias por acompañarnos.'
+      ]
+    },
+    nineBall: {
+      variantName: '9 bolas americano',
+      rotation: ['En 9 bolas siempre se golpea primero la más baja.'],
+      goldenBreak: ['Si cae la 9 en el saque, se termina la partida.'],
+      comboNine: ['{player} mira la combinación a la 9, gran oportunidad.'],
+      pushOut: ['{player} usa el push-out para mejorar el tiro.']
+    },
+    eightBallUs: {
+      variantName: '8 bolas americano',
+      groupCall: ['Mesa abierta entre {groupPrimary} y {groupSecondary}.'],
+      inHand: ['{opponent} con bola en mano, ventaja clara.'],
+      eightBall: ['Ahora la 8 está en juego; la posición manda.']
+    },
+    eightBallUk: {
+      variantName: '8 bolas británico',
+      groupCall: ['Reglas UK: {groupPrimary} y {groupSecondary} aún abiertos.'],
+      freeBall: ['{player} tiene bola libre y dos visitas.'],
+      blackBall: ['La negra está en juego; el ángulo es clave.']
+    }
+  },
+  fr: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Bienvenue à {arena}. {speaker} est avec vous. {player} contre {opponent}, {scoreline}, en {variantName}.'
+      ],
+      introReply: [
+        'Merci, {speaker}. Le contrôle de blanche et l’effet feront la différence.'
+      ],
+      breakShot: [
+        '{player} s’installe pour la casse; ouvrir la table et contrôler la blanche est essentiel.'
+      ],
+      breakResult: [
+        'Bonne casse, la table est ouverte et les lignes sont propres.'
+      ],
+      openTable: [
+        'Table ouverte; {player} cherche les angles naturels et la bonne position.'
+      ],
+      safety: [
+        '{player} joue sécurité et cache la blanche.'
+      ],
+      pressure: [
+        'Coup sous pression; toucher doux et effet précis.'
+      ],
+      pot: [
+        '{player} empoche {targetBall} dans {pocket} et garde la position.'
+      ],
+      combo: [
+        '{player} joue la combinaison et empoche {targetBall} dans {pocket}.'
+      ],
+      bank: [
+        '{player} joue la bande et empoche {targetBall} dans {pocket}.'
+      ],
+      kick: [
+        '{player} doit jouer un coup de bande pour toucher la bille.'
+      ],
+      jump: [
+        '{player} tente un saut pour passer l’obstacle.'
+      ],
+      miss: [
+        '{player} manque l’empochage; opportunité pour {opponent}.'
+      ],
+      foul: [
+        'Faute de {player}.'
+      ],
+      inHand: [
+        '{opponent} a la bille en main.'
+      ],
+      runout: [
+        '{player} peut finir la table s’il garde le contrôle.'
+      ],
+      hillHill: [
+        'Manche décisive—tension maximale.'
+      ],
+      frameWin: [
+        '{player} remporte la manche.'
+      ],
+      matchWin: [
+        'Match terminé. {player} gagne {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'Depuis {arena}, merci de votre présence.'
+      ]
+    },
+    nineBall: {
+      variantName: '9-ball américain',
+      rotation: ['En 9-ball, on doit toucher la plus petite bille en premier.'],
+      goldenBreak: ['Si la 9 tombe à la casse, la partie est finie.'],
+      comboNine: ['{player} vise une combinaison sur la 9, gros coup.'],
+      pushOut: ['{player} joue un push-out pour améliorer l’angle.']
+    },
+    eightBallUs: {
+      variantName: '8-ball américain',
+      groupCall: ['Table ouverte entre {groupPrimary} et {groupSecondary}.'],
+      inHand: ['{opponent} a la bille en main, avantage net.'],
+      eightBall: ['La 8 est en jeu; la position est cruciale.']
+    },
+    eightBallUk: {
+      variantName: '8-ball UK',
+      groupCall: ['Règles UK: {groupPrimary} et {groupSecondary} sont ouverts.'],
+      freeBall: ['{player} a une bille libre et deux visites.'],
+      blackBall: ['La noire est en jeu; l’angle compte.']
+    }
+  },
+  ar: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'مرحبًا بكم في {arena}. {speaker} معكم. {player} ضد {opponent}، {scoreline} في {variantName}.'
+      ],
+      introReply: [
+        'شكرًا {speaker}. السيطرة على الكرة الأم والدوران ستكون حاسمة اليوم.'
+      ],
+      breakShot: [
+        '{player} يستعد للكسر؛ فتح الطاولة مع تحكم بالكرة الأم مهم جدًا.'
+      ],
+      breakResult: [
+        'كسر جيد، الطاولة مفتوحة والمسارات واضحة.'
+      ],
+      openTable: [
+        'الطاولة مفتوحة؛ {player} يبحث عن زوايا طبيعية ووضعية جيدة.'
+      ],
+      safety: [
+        '{player} يلعب أمانًا ويخفي الكرة الأم.'
+      ],
+      pressure: [
+        'ضربة تحت ضغط؛ لمسة ناعمة ودوران مضبوط.'
+      ],
+      pot: [
+        '{player} يودع {targetBall} في {pocket} ويثبت الوضعية.'
+      ],
+      combo: [
+        '{player} يلعب كومبو ويودع {targetBall} في {pocket}.'
+      ],
+      bank: [
+        '{player} يلعب بنك ويودع {targetBall} في {pocket}.'
+      ],
+      kick: [
+        '{player} يحتاج ضربة كيك للوصول إلى الكرة.'
+      ],
+      jump: [
+        '{player} ينفذ ضربة قفز لتجاوز العائق.'
+      ],
+      miss: [
+        '{player} يفوت الكرة؛ فرصة لـ {opponent}.'
+      ],
+      foul: [
+        'خطأ على {player}.'
+      ],
+      inHand: [
+        '{opponent} لديه كرة في اليد.'
+      ],
+      runout: [
+        '{player} يستطيع إنهاء الطاولة إذا حافظ على التحكم.'
+      ],
+      hillHill: [
+        'شووط حاسم—توتر كبير.'
+      ],
+      frameWin: [
+        '{player} يفوز بالشوط.'
+      ],
+      matchWin: [
+        'نهاية المباراة. {player} يفوز {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'من {arena}، شكرًا على المتابعة.'
+      ]
+    },
+    nineBall: {
+      variantName: '9 بول أمريكي',
+      rotation: ['في 9 بول يجب ضرب أقل كرة أولًا.'],
+      goldenBreak: ['إذا دخلت 9 في الكسر فالمباراة تنتهي فورًا.'],
+      comboNine: ['{player} ينظر إلى كومبو على 9—فرصة كبيرة.'],
+      pushOut: ['{player} يستخدم البوش آوت لتحسين الرؤية.']
+    },
+    eightBallUs: {
+      variantName: '8 بول أمريكي',
+      groupCall: ['طاولة مفتوحة بين {groupPrimary} و{groupSecondary}.'],
+      inHand: ['{opponent} يملك الكرة في اليد—أفضلية واضحة.'],
+      eightBall: ['الآن الكرة 8 في اللعب؛ الوضعية هي الفاصل.']
+    },
+    eightBallUk: {
+      variantName: '8 بول بريطاني',
+      groupCall: ['قواعد UK: {groupPrimary} و{groupSecondary} مفتوحة.'],
+      freeBall: ['{player} يحصل على كرة حرة وزيارتين.'],
+      blackBall: ['الكرة السوداء في اللعب؛ الزاوية مهمة جدًا.']
+    }
   }
 });
 
@@ -237,14 +661,33 @@ const pickRandom = (pool) => pool[Math.floor(Math.random() * pool.length)];
 const applyTemplate = (template, context) =>
   template.replace(/\{(\w+)\}/g, (_, key) => String(context[key] ?? `{${key}}`));
 
-const resolveVariantData = (variantId) => {
-  if (variantId === 'uk' || variantId === '8ball-uk') return TEMPLATES.eightBallUk;
-  if (variantId === 'american' || variantId === '8ball-us') return TEMPLATES.eightBallUs;
-  return TEMPLATES.nineBall;
+const resolveVariantData = (variantId, templates) => {
+  const source = templates || ENGLISH_TEMPLATES;
+  if (variantId === 'uk' || variantId === '8ball-uk') return source.eightBallUk;
+  if (variantId === 'american' || variantId === '8ball-us') return source.eightBallUs;
+  return source.nineBall;
 };
 
-export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Mason', context = {} }) => {
-  const resolvedVariant = resolveVariantData(variant);
+const resolveLanguageKey = (language = 'en') => {
+  const normalized = String(language || '').toLowerCase();
+  if (normalized.startsWith('zh')) return 'zh';
+  if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('es')) return 'es';
+  if (normalized.startsWith('fr')) return 'fr';
+  if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('en')) return 'en';
+  return normalized || 'en';
+};
+
+export const buildCommentaryLine = ({
+  event,
+  variant = '9ball',
+  speaker = POOL_ROYALE_SPEAKERS.analyst,
+  language = 'en',
+  context = {}
+}) => {
+  const templates = LOCALIZED_TEMPLATES[resolveLanguageKey(language)] || ENGLISH_TEMPLATES;
+  const resolvedVariant = resolveVariantData(variant, templates);
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,
@@ -256,7 +699,9 @@ export const buildCommentaryLine = ({ event, variant = '9ball', speaker = 'Mason
   };
 
   const eventPool =
-    resolvedVariant[EVENT_POOLS[event]] || TEMPLATES.common[EVENT_POOLS[event]] || TEMPLATES.common.pot;
+    resolvedVariant[EVENT_POOLS[event]] ||
+    templates.common[EVENT_POOLS[event]] ||
+    templates.common.pot;
 
   return applyTemplate(pickRandom(eventPool), mergedContext);
 };
@@ -265,7 +710,8 @@ export const createMatchCommentaryScript = ({
   variant = '9ball',
   ballSet = 'uk',
   players = { A: 'Player A', B: 'Player B' },
-  commentators = [POOL_ROYALE_SPEAKERS.lead, POOL_ROYALE_SPEAKERS.analyst],
+  commentators = [POOL_ROYALE_SPEAKERS.analyst],
+  language = 'en',
   scoreline = 'level at 0-0',
   scores = { A: 0, B: 0 },
   pots = { A: 0, B: 0 },
@@ -344,6 +790,7 @@ export const createMatchCommentaryScript = ({
         event: entry.event,
         variant,
         speaker,
+        language,
         context: { ...context, ...(entry.context ?? {}) }
       })
     };

--- a/webapp/src/utils/snookerRoyalCommentary.js
+++ b/webapp/src/utils/snookerRoyalCommentary.js
@@ -35,7 +35,7 @@ const EVENT_POOLS = Object.freeze({
   turn: 'turn'
 });
 
-const TEMPLATES = Object.freeze({
+const ENGLISH_TEMPLATES = Object.freeze({
   intro: [
     '{frameNumber} underway. {player} to break.',
     'Frame starts now. {player} on the break-off.',
@@ -46,8 +46,8 @@ const TEMPLATES = Object.freeze({
   introReply: [
     'Table is set. Early safety expected.',
     'We are live. First visit will set the tone.',
-    'Tactical opening here.',
-    'First shot is about control.'
+    'Tactical opening here, with cue-ball control key.',
+    'First shot is about control and soft spin.'
   ],
   breakOff: [
     '{player} breaks off, looking to keep it safe.',
@@ -60,7 +60,7 @@ const TEMPLATES = Object.freeze({
     'Red down. {player} stays at the table.',
     '{player} pots a red and holds position.',
     'Clean red for {player}.',
-    '{player} drops the red. Good cue ball.',
+    '{player} drops the red and keeps the cue ball in line.',
     'Red potted by {player}. Visit continues.'
   ],
   multiRed: [
@@ -74,14 +74,14 @@ const TEMPLATES = Object.freeze({
     '{color} potted by {player}.',
     '{player} lands the {color}.',
     'Color down. {player} keeps the break.',
-    '{player} takes the {color} clean.',
+    '{player} takes the {color} clean with perfect pace.',
     '{color} in. {player} stays in position.'
   ],
   colorOrder: [
     '{color} taken in order by {player}.',
     '{player} clears the {color}.',
     'That is the {color}. Clearance continues.',
-    '{player} ticks off the {color}.',
+    '{player} ticks off the {color} with tidy control.',
     'Sequence shot on the {color}.'
   ],
   respot: [
@@ -184,24 +184,161 @@ const TEMPLATES = Object.freeze({
   ]
 });
 
+const LOCALIZED_TEMPLATES = Object.freeze({
+  en: ENGLISH_TEMPLATES,
+  zh: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber}开始，{player}开球。'],
+    introReply: ['开局偏防守，母球控制很关键。'],
+    breakOff: ['{player}开球，力求安全回球。'],
+    redPot: ['红球进袋，{player}继续进攻。'],
+    multiRed: ['多颗红球落袋，局面被打开。'],
+    colorPot: ['{player}打进{color}，走位到位。'],
+    colorOrder: ['按顺序清彩球，{player}保持节奏。'],
+    respot: ['{color}进袋后重置回点位。'],
+    safety: ['{player}选择防守，母球藏好。'],
+    snooker: ['{player}做出斯诺克，{opponent}被挡住。'],
+    freeBall: ['{player}获得自由球机会。'],
+    foul: ['{player}犯规，{opponent}获得{points}分。'],
+    miss: ['{player}失误，机会给到{opponent}。'],
+    breakBuild: ['{player}单杆达到{breakTotal}。'],
+    century: ['单杆破百，{player}打出{breakTotal}。'],
+    colorsOrder: ['红球打完，进入彩球顺序阶段。'],
+    frameBall: ['{player}迎来制胜球机会。'],
+    frameWin: ['{player}赢下这一局，{scoreline}。'],
+    outro: ['{frameNumber}结束，比分{scoreline}。'],
+    outroReply: ['准备下一局。'],
+    turn: ['轮到{player}出杆。']
+  },
+  hi: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} शुरू, {player} ब्रेक पर।'],
+    introReply: ['शुरुआत में सुरक्षा और क्यू-बॉल नियंत्रण अहम है।'],
+    breakOff: ['{player} ब्रेक खेलता है, सुरक्षित वापसी की कोशिश।'],
+    redPot: ['लाल पॉट, {player} टेबल पर बना रहता है।'],
+    multiRed: ['कई रेड्स गिरती हैं, खेल खुलता है।'],
+    colorPot: ['{player} ने {color} पॉट किया, पोजिशन बढ़िया।'],
+    colorOrder: ['क्रम में रंग, {player} नियंत्रण में।'],
+    respot: ['{color} पॉट के बाद फिर स्पॉट पर।'],
+    safety: ['{player} ने सुरक्षा खेली।'],
+    snooker: ['{player} ने स्नूकर लगाया, {opponent} मुश्किल में।'],
+    freeBall: ['{player} को फ्री बॉल मिली।'],
+    foul: ['{player} से फाउल, {opponent} को {points} अंक।'],
+    miss: ['{player} चूका, मौका {opponent} को।'],
+    breakBuild: ['{player} का ब्रेक {breakTotal} तक।'],
+    century: ['सेंचुरी ब्रेक, {player} ने {breakTotal} बनाया।'],
+    colorsOrder: ['रेड्स खत्म, अब रंग क्रम में।'],
+    frameBall: ['{player} के पास फ्रेम बॉल है।'],
+    frameWin: ['{player} ने फ्रेम जीता, {scoreline}।'],
+    outro: ['{frameNumber} समाप्त, स्कोर {scoreline}।'],
+    outroReply: ['अगला फ्रेम तैयार।'],
+    turn: ['अब {player} की बारी।']
+  },
+  es: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} en marcha. {player} abre.'],
+    introReply: ['Inicio táctico; el control de blanca es clave.'],
+    breakOff: ['{player} rompe buscando dejarla segura.'],
+    redPot: ['Roja embocada, {player} sigue.'],
+    multiRed: ['Caen varias rojas, la mesa se abre.'],
+    colorPot: ['{player} emboca la {color} con buena posición.'],
+    colorOrder: ['Colores en orden, {player} mantiene el control.'],
+    respot: ['{color} embocada y re-ubicada en el punto.'],
+    safety: ['{player} juega seguridad.'],
+    snooker: ['{player} deja a {opponent} en snooker.'],
+    freeBall: ['Bola libre para {player}.'],
+    foul: ['Falta de {player}. {points} para {opponent}.'],
+    miss: ['{player} falla; entra {opponent}.'],
+    breakBuild: ['{player} sube a {breakTotal}.'],
+    century: ['Centena, {player} llega a {breakTotal}.'],
+    colorsOrder: ['Sin rojas; colores en secuencia.'],
+    frameBall: ['Bola de frame para {player}.'],
+    frameWin: ['{player} gana el frame. {scoreline}.'],
+    outro: ['{frameNumber} termina. {scoreline}.'],
+    outroReply: ['Preparando el siguiente frame.'],
+    turn: ['Turno de {player}.']
+  },
+  fr: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} lancé. {player} au break.'],
+    introReply: ['Début tactique; contrôle de blanche essentiel.'],
+    breakOff: ['{player} casse en sécurité.'],
+    redPot: ['Rouge empochée, {player} reste à la table.'],
+    multiRed: ['Plusieurs rouges tombent, le jeu s’ouvre.'],
+    colorPot: ['{player} empoche la {color} avec bonne position.'],
+    colorOrder: ['Couleurs en ordre, {player} garde la main.'],
+    respot: ['{color} empochée puis replacée.'],
+    safety: ['{player} joue sécurité.'],
+    snooker: ['{player} met {opponent} en snooker.'],
+    freeBall: ['Bille libre pour {player}.'],
+    foul: ['Faute de {player}. {points} pour {opponent}.'],
+    miss: ['{player} manque; {opponent} revient.'],
+    breakBuild: ['{player} monte à {breakTotal}.'],
+    century: ['Série de 100, {player} atteint {breakTotal}.'],
+    colorsOrder: ['Plus de rouges; couleurs en ordre.'],
+    frameBall: ['Bille de frame pour {player}.'],
+    frameWin: ['{player} gagne la frame. {scoreline}.'],
+    outro: ['{frameNumber} terminé. {scoreline}.'],
+    outroReply: ['On prépare la frame suivante.'],
+    turn: ['À {player} de jouer.']
+  },
+  ar: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} يبدأ. {player} على الكسر.'],
+    introReply: ['بداية تكتيكية؛ التحكم بالبيضاء مهم.'],
+    breakOff: ['{player} يكسر مع محاولة أمان.'],
+    redPot: ['كرة حمراء تدخل، {player} يبقى على الطاولة.'],
+    multiRed: ['سقوط عدة حمراء وفتح الطاولة.'],
+    colorPot: ['{player} يودع {color} مع وضعية جيدة.'],
+    colorOrder: ['الألوان بالترتيب، {player} يسيطر.'],
+    respot: ['{color} تدخل ثم تُعاد إلى النقطة.'],
+    safety: ['{player} يلعب أمانًا.'],
+    snooker: ['{player} يضع {opponent} في سنوكر.'],
+    freeBall: ['كرة حرة لـ {player}.'],
+    foul: ['خطأ على {player}. {points} لـ {opponent}.'],
+    miss: ['{player} يُخفق؛ الدور لـ {opponent}.'],
+    breakBuild: ['{player} يصل إلى {breakTotal}.'],
+    century: ['بريك مئة، {player} يصل إلى {breakTotal}.'],
+    colorsOrder: ['انتهت الحمراء؛ الألوان بالترتيب.'],
+    frameBall: ['كرة فريم لـ {player}.'],
+    frameWin: ['{player} يفوز بالفريم. {scoreline}.'],
+    outro: ['{frameNumber} ينتهي. {scoreline}.'],
+    outroReply: ['الاستعداد للفريم التالي.'],
+    turn: ['الدور على {player}.']
+  }
+});
+
 const pickRandom = (pool) => pool[Math.floor(Math.random() * pool.length)];
 
 const applyTemplate = (template, context) =>
   template.replace(/\{(\w+)\}/g, (_, key) => String(context[key] ?? `{${key}}`));
 
-export const buildSnookerCommentaryLine = ({ event, speaker = 'Caster', context = {} }) => {
+const resolveLanguageKey = (language = 'en') => {
+  const normalized = String(language || '').toLowerCase();
+  if (normalized.startsWith('zh')) return 'zh';
+  if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('es')) return 'es';
+  if (normalized.startsWith('fr')) return 'fr';
+  if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('en')) return 'en';
+  return normalized || 'en';
+};
+
+export const buildSnookerCommentaryLine = ({ event, speaker = 'Caster', language = 'en', context = {} }) => {
+  const templates = LOCALIZED_TEMPLATES[resolveLanguageKey(language)] || ENGLISH_TEMPLATES;
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,
     speaker
   };
-  const pool = TEMPLATES[EVENT_POOLS[event]] || TEMPLATES.redPot;
+  const pool = templates[EVENT_POOLS[event]] || templates.redPot;
   return applyTemplate(pickRandom(pool), mergedContext);
 };
 
 export const createSnookerMatchCommentaryScript = ({
   players = { A: 'Player A', B: 'Player B' },
   commentators = ['Caster'],
+  language = 'en',
   scoreline = 'level'
 } = {}) => {
   const context = {
@@ -217,6 +354,7 @@ export const createSnookerMatchCommentaryScript = ({
       text: buildSnookerCommentaryLine({
         event: EVENT_POOLS.intro,
         speaker: lead,
+        language,
         context
       })
     }
@@ -227,6 +365,7 @@ export const createSnookerMatchCommentaryScript = ({
       text: buildSnookerCommentaryLine({
         event: EVENT_POOLS.introReply,
         speaker: analyst,
+        language,
         context
       })
     });
@@ -237,6 +376,7 @@ export const createSnookerMatchCommentaryScript = ({
       text: buildSnookerCommentaryLine({
         event: EVENT_POOLS.outro,
         speaker: lead,
+        language,
         context
       })
     }
@@ -247,6 +387,7 @@ export const createSnookerMatchCommentaryScript = ({
       text: buildSnookerCommentaryLine({
         event: EVENT_POOLS.outroReply,
         speaker: analyst,
+        language,
         context
       })
     });


### PR DESCRIPTION
### Motivation
- Align commentary behavior with product requirements: use only the second commentator by default for both Snooker and Pool, allow players to select commentary language, and refer to AI opponents by their country names rather than the literal "AI" tag. 
- Improve commentary phrasing to sound more natural, professional and to reference positioning, spin and likely pots based on table state.

### Description
- Localized commentary templates were added and wired into generation: `LOCALIZED_TEMPLATES` and `ENGLISH_TEMPLATES` are defined and `buildCommentaryLine`/`buildSnookerCommentaryLine` now accept a `language` parameter to pick the correct template set (`webapp/src/utils/poolRoyaleCommentary.js`, `webapp/src/utils/snookerRoyalCommentary.js`).
- Commentary presets now include a `language` field and code passes the active preset language into commentary generation via `createMatchCommentaryScript` and per-line calls so language changes affect spoken text (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Default commentary speaker changed to only the analyst voice: speaker rotation/alternation removed and the single analyst speaker is used by default for both Pool and Snooker (templates and runtime selection updated in the same files above and `webapp/src/utils/poolRoyaleCommentary.js`).
- AI opponent naming: AI opponents are now referenced using country flag/emojis and resolved to readable country names for HUD and commentary via `resolveFlagLabel`, `aiFlag` and `aiFlagLabel`; `resolveSeatLabel` was updated to prefer these labels when the seat is an AI (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/SnookerRoyal.jsx`, and `webapp/src/utils/flagEmojis.js` usage).
- Templates and phrasing refreshed to emphasize position, cue-ball control and spin, and to include pockets/target references (many template changes in `poolRoyaleCommentary.js` and `snookerRoyalCommentary.js`).
- Minor housekeeping: removed unused speaker-turn counter and adjusted related logic to simplify speaker selection and to pass language options through enqueue/build flows.

### Testing
- Automated tests: none executed for this PR (no automated test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697604ec64348329aa44591dd16e5a9e)