### PR TITLE
Add Albanian commentary language for Pool Royale and Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1004,6 +1004,20 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
       [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
     }
+  },
+  {
+    id: 'albanian',
+    label: 'Albanian',
+    description: 'Male voice, Shqip',
+    language: 'sq',
+    voiceHints: {
+      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
+      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
+    },
+    speakerSettings: {
+      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
+    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1048,6 +1048,20 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
       [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.94, volume: 1 },
       [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 0.98, volume: 0.98 }
     }
+  },
+  {
+    id: 'albanian',
+    label: 'Albanian',
+    description: 'Male play-by-play in Albanian.',
+    language: 'sq',
+    voiceHints: {
+      [COMMENTARY_SPEAKER_LEAD]: ['sq-AL', 'sq', 'albanian', 'male', 'google'],
+      [COMMENTARY_SPEAKER_ANALYST]: ['sq-AL', 'sq', 'albanian', 'male', 'google']
+    },
+    speakerSettings: {
+      [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.96, volume: 1 },
+      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 0.98, volume: 0.98 }
+    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = SNOOKER_ROYAL_COMMENTARY_PRESETS[0]?.id || 'atlas';

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -623,6 +623,90 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       freeBall: ['{player} يحصل على كرة حرة وزيارتين.'],
       blackBall: ['الكرة السوداء في اللعب؛ الزاوية مهمة جدًا.']
     }
+  },
+  sq: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Mirë se vini në {arena}. {speaker} me ju. {player} kundër {opponent}; {scoreline} në {variantName}.'
+      ],
+      introReply: [
+        'Faleminderit {speaker}. Kontrolli i topit të bardhë dhe pozicionimi vendosin gjithçka.'
+      ],
+      breakShot: [
+        '{player} gati për thyerjen; shpërndarja dhe kontrolli i të bardhit janë kyçe.'
+      ],
+      breakResult: [
+        'Thyerje e mirë, topat janë hapur dhe ka linja të pastra.'
+      ],
+      openTable: [
+        'Tavolina është e hapur; {player} kërkon kënde natyrale dhe vazhdim të lehtë.'
+      ],
+      safety: [
+        '{player} luan siguri dhe fsheh topin e bardhë.'
+      ],
+      pressure: [
+        'Goditje me presion; prekja e butë dhe efekti janë vendimtarë.'
+      ],
+      pot: [
+        '{player} fut {targetBall} në {pocket} dhe mban pozicionin.'
+      ],
+      combo: [
+        '{player} kombinon {targetBall} në {pocket}.'
+      ],
+      bank: [
+        '{player} bën bankë dhe fut {targetBall} në {pocket}.'
+      ],
+      kick: [
+        '{player} duhet të godasë në bankinë për ta gjetur.'
+      ],
+      jump: [
+        '{player} përdor jump për të kaluar bllokimin.'
+      ],
+      miss: [
+        '{player} e humb, shans për {opponent}.'
+      ],
+      foul: [
+        'Faull nga {player}.'
+      ],
+      inHand: [
+        'Top në dorë për {opponent}.'
+      ],
+      runout: [
+        '{player} është në ritëm—mund të pastrojë gjithë tavolinën.'
+      ],
+      hillHill: [
+        'Rack vendimtar; tension maksimal.'
+      ],
+      frameWin: [
+        '{player} fiton këtë rack.'
+      ],
+      matchWin: [
+        'Ndeshja mbaron. {player} fiton {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'Kaq nga {arena}. Faleminderit që na ndoqët.'
+      ]
+    },
+    nineBall: {
+      variantName: '9-ball amerikan',
+      rotation: ['Në 9-ball duhet goditur gjithmonë topi me numrin më të vogël.'],
+      goldenBreak: ['Nëse 9 futet në thyerje, është golden break.'],
+      comboNine: ['{player} sheh kombinimin për 9—shans i madh.'],
+      pushOut: ['{player} luan push-out për një pozicion më të mirë.']
+    },
+    eightBallUs: {
+      variantName: '8-ball amerikan',
+      groupCall: ['Tavolinë e hapur; {groupPrimary} ose {groupSecondary} janë të lira.'],
+      inHand: ['Faulli i jep {opponent} top në dorë—mundësi e madhe.'],
+      eightBall: ['Tani 8-shi është në lojë; pozicioni është gjithçka.']
+    },
+    eightBallUk: {
+      variantName: '8-ball britanik',
+      groupCall: ['Rregullat UK: {groupPrimary} dhe {groupSecondary} janë të hapura.'],
+      freeBall: ['{player} ka free ball dhe dy vizita.'],
+      blackBall: ['Tani topi i zi; kërkohet kënd perfekt.']
+    }
   }
 });
 
@@ -675,6 +759,7 @@ const resolveLanguageKey = (language = 'en') => {
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('sq')) return 'sq';
   if (normalized.startsWith('en')) return 'en';
   return normalized || 'en';
 };

--- a/webapp/src/utils/snookerRoyalCommentary.js
+++ b/webapp/src/utils/snookerRoyalCommentary.js
@@ -305,6 +305,30 @@ const LOCALIZED_TEMPLATES = Object.freeze({
     outro: ['{frameNumber} ينتهي. {scoreline}.'],
     outroReply: ['الاستعداد للفريم التالي.'],
     turn: ['الدور على {player}.']
+  },
+  sq: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} nis. {player} në break.'],
+    introReply: ['Fillim taktik; kontrolli i topit të bardhë është kyç.'],
+    breakOff: ['{player} bën break-off, kërkon siguri.'],
+    redPot: ['E kuqja futet, {player} qëndron në tavolinë.'],
+    multiRed: ['Bien disa të kuqe; loja hapet.'],
+    colorPot: ['{player} fut {color} me pozicion të mirë.'],
+    colorOrder: ['Ngjyrat në rend; {player} mban kontrollin.'],
+    respot: ['{color} futet dhe rikthehet në pikë.'],
+    safety: ['{player} luan siguri.'],
+    snooker: ['{player} lë {opponent} në snooker.'],
+    freeBall: ['Free ball për {player}.'],
+    foul: ['Faull nga {player}. {points} për {opponent}.'],
+    miss: ['{player} gabon; rradha për {opponent}.'],
+    breakBuild: ['{player} shkon në {breakTotal}.'],
+    century: ['Shekullor; {player} arrin {breakTotal}.'],
+    colorsOrder: ['Të kuqet mbaruan; ngjyrat në rend.'],
+    frameBall: ['Top i frame-it për {player}.'],
+    frameWin: ['{player} fiton frame-in. {scoreline}.'],
+    outro: ['{frameNumber} përfundon. {scoreline}.'],
+    outroReply: ['Përgatitet frame-i tjetër.'],
+    turn: ['Rradha e {player}.']
   }
 });
 
@@ -320,6 +344,7 @@ const resolveLanguageKey = (language = 'en') => {
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('sq')) return 'sq';
   if (normalized.startsWith('en')) return 'en';
   return normalized || 'en';
 };


### PR DESCRIPTION
### Motivation

- Add Albanian commentary support so players can select and hear commentary in Albanian for both Pool Royale and Snooker Royal.

### Description

- Added an `albanian` commentary preset entry to `POOL_ROYALE_COMMENTARY_PRESETS` in `webapp/src/pages/Games/PoolRoyale.jsx` including `language: 'sq'`, `voiceHints` and `speakerSettings`.
- Added an `albanian` commentary preset entry to `SNOOKER_ROYAL_COMMENTARY_PRESETS` in `webapp/src/pages/Games/SnookerRoyal.jsx` including `language: 'sq'`, `voiceHints` and `speakerSettings`.
- Added localized Albanian templates (`sq`) to `LOCALIZED_TEMPLATES` in `webapp/src/utils/poolRoyaleCommentary.js` and `webapp/src/utils/snookerRoyalCommentary.js` containing commonly used commentary lines translated to Albanian.
- Updated `resolveLanguageKey` in both commentary utilities to recognize `sq` (Albanian) language keys so `buildCommentaryLine`/`buildSnookerCommentaryLine` return Albanian templates when requested.

### Testing

- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported ready, indicating the frontend served successfully (success).
- Attempted a Playwright screenshot of the Pool Royale page to validate the UI and commentary selector, but Chromium crashed during headless launch resulting in a Playwright `TargetClosedError` (failed).
- No unit tests or `npm test` were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69760fe7abb48329a494e2c278fb2d79)