### PR TITLE
Guard Domino Royal inventory storage access

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2866,8 +2866,12 @@ const copyDominoDefaults = () =>
 const resolveDominoAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== "undefined") {
-    const stored = window.localStorage.getItem("accountId");
-    if (stored) return stored;
+    try {
+      const stored = window.localStorage.getItem("accountId");
+      if (stored) return stored;
+    } catch (error) {
+      console.warn("Failed to read Domino account id, using guest", error);
+    }
   }
   return "guest";
 };
@@ -2885,7 +2889,11 @@ const readDominoInventories = () => {
 
 const writeDominoInventories = (payload) => {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(DOMINO_INVENTORY_STORAGE_KEY, JSON.stringify(payload));
+  try {
+    window.localStorage.setItem(DOMINO_INVENTORY_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn("Failed to persist domino inventory", error);
+  }
 };
 
 const normalizeDominoInventory = (rawInventory) => {

--- a/webapp/src/utils/dominoRoyalInventory.js
+++ b/webapp/src/utils/dominoRoyalInventory.js
@@ -15,8 +15,12 @@ const copyDefaults = () =>
 const resolveAccountId = (accountId) => {
   if (accountId) return accountId;
   if (typeof window !== 'undefined') {
-    const stored = window.localStorage.getItem('accountId');
-    if (stored) return stored;
+    try {
+      const stored = window.localStorage.getItem('accountId');
+      if (stored) return stored;
+    } catch (err) {
+      console.warn('Failed to read domino account id, using guest', err);
+    }
   }
   return 'guest';
 };
@@ -34,7 +38,11 @@ const readAllInventories = () => {
 
 const writeAllInventories = (payload) => {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.warn('Failed to persist domino inventory', err);
+  }
 };
 
 const normalizeInventory = (rawInventory) => {


### PR DESCRIPTION
### Motivation

- Prevent Domino Royal from crashing when `localStorage` is unavailable or throws (e.g. private/restricted storage environments) by failing gracefully and falling back to a guest account.

### Description

- Wrap `localStorage` read in `resolveDominoAccountId` in `webapp/public/domino-royal.html` with a `try/catch` and fall back to `"guest"` while logging the error.  
- Wrap `localStorage.setItem` in `writeDominoInventories` in `webapp/public/domino-royal.html` with a `try/catch` and log on failure.  
- Apply the same defensive handling in `webapp/src/utils/dominoRoyalInventory.js` by protecting `resolveAccountId` reads and `writeAllInventories` writes with `try/catch` and logging.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697620c9d1ac832983246cb471aaa5d5)