### PR TITLE
Fix Pool Royale commentary voice unlocks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13203,6 +13203,9 @@ const powerRef = useRef(hud.power);
         enqueuePoolCommentary(pending.lines, pending);
       }
     };
+    if (navigator?.userActivation?.hasBeenActive) {
+      unlockCommentary();
+    }
     window.addEventListener('pointerdown', unlockCommentary);
     window.addEventListener('click', unlockCommentary);
     window.addEventListener('touchstart', unlockCommentary);


### PR DESCRIPTION
### Motivation
- Commentary voice in Pool Royale sometimes failed to start in embedded/webview environments (e.g. Telegram) due to speech synthesis not being properly primed or the page already having user activation handled by the host.
- Improve reliability and language selection so spoken commentary is audible and uses an appropriate voice/language fallback.

### Description
- Warm up speech synthesis in `webapp/src/utils/textToSpeech.js` by setting a tiny non-zero prime volume in `primeSpeechSynthesis`, assigning `utterance.lang` from `navigator.language`, and adding `resolveHintedLanguage` to pick a sensible fallback language when no matching voice is found.
- Use language-aware fallbacks when no `SpeechSynthesisVoice` was matched so `speakCommentaryLines` will still set `utterance.lang` and speak text in a reasonable locale.
- In `webapp/src/pages/Games/PoolRoyale.jsx` call the existing `unlockCommentary` logic immediately when `navigator.userActivation.hasBeenActive` is true so commentary unlocks in environments where the user activation already occurred (for example Telegram's WebApp tap).

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697623d873b48329932bfd24e72d0a00)