### PR TITLE
Limit commentary to English and remove language selection (keep mute toggle)

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -594,48 +594,6 @@ const COMMENTARY_PRESETS = [
         pitch: 1.18
       }
     ]
-  },
-  {
-    id: 'sage-nova',
-    name: 'Sage & Nova',
-    tone: 'Tactical Coach + Cyber Analyst',
-    voices: [
-      {
-        id: 'sage',
-        role: 'playByPlay',
-        voiceHints: ['en-GB', 'en-US', 'daniel', 'mark', 'google'],
-        rate: 0.98,
-        pitch: 0.96
-      },
-      {
-        id: 'nova',
-        role: 'color',
-        voiceHints: ['en-US', 'female', 'neural', 'assistant', 'google'],
-        rate: 1.0,
-        pitch: 1.06
-      }
-    ]
-  },
-  {
-    id: 'blaze-echo',
-    name: 'Blaze & Echo',
-    tone: 'Arena Hype + Calm Ref',
-    voices: [
-      {
-        id: 'blaze',
-        role: 'playByPlay',
-        voiceHints: ['en-US', 'guy', 'ryan', 'ben', 'google'],
-        rate: 1.06,
-        pitch: 1.04
-      },
-      {
-        id: 'echo',
-        role: 'color',
-        voiceHints: ['en-AU', 'en-GB', 'audrey', 'oliver', 'google'],
-        rate: 0.94,
-        pitch: 0.9
-      }
-    ]
   }
 ];
 const COMMENTARY_LINES = {
@@ -5057,36 +5015,11 @@ function refreshConfigUI() {
   const commentaryWrapper = document.createElement('div');
   commentaryWrapper.className = 'config-section';
   const commentaryLabel = document.createElement('h4');
-  commentaryLabel.textContent = 'Commentary crew (2 voices)';
+  commentaryLabel.textContent = 'Commentary';
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  commentaryGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(150px, 1fr))';
   const commentarySupported = Boolean(speechSynth);
-  COMMENTARY_PRESETS.forEach((preset) => {
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'config-option';
-    if (preset.id === commentaryPresetId) {
-      button.classList.add('active');
-    }
-    button.disabled = !commentarySupported;
-    const label = document.createElement('span');
-    label.textContent = preset.name;
-    button.appendChild(label);
-    const helper = document.createElement('div');
-    helper.textContent = preset.tone;
-    helper.style.fontSize = '0.65rem';
-    helper.style.color = 'rgba(226,232,240,0.78)';
-    helper.style.fontWeight = '700';
-    helper.style.lineHeight = '1.35';
-    button.appendChild(helper);
-    button.addEventListener('click', () => {
-      setCommentaryPresetId(preset.id);
-      announceCommentary('greeting', { player: human }, { priority: true, interrupt: true });
-    });
-    commentaryGrid.appendChild(button);
-  });
   const muteButton = document.createElement('button');
   muteButton.type = 'button';
   muteButton.className = 'config-option';

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -206,7 +206,6 @@
         <h3 id="commentaryTitle">Commentary</h3>
         <button class="modal-close" id="commentaryClose" type="button" aria-label="Close commentary">✕</button>
       </div>
-      <div class="commentary-options" id="commentaryOptions"></div>
       <button class="commentary-toggle" id="commentaryMute" type="button">
         <span>Mute commentary</span>
         <span id="commentaryMuteState">Off</span>
@@ -710,121 +709,7 @@
   });
 
   const GOAL_RUSH_TEMPLATES = Object.freeze({
-    en: ENGLISH_COMMENTARY,
-    zh: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['欢迎来到{arena}。{speaker}为您带来解说。{player}对阵{opponent}，{scoreline}。'],
-        introReply: ['谢谢{speaker}。关键在于速度与角度选择。'],
-        kickoff: ['开球开始，先手很关键。'],
-        goal: ['{player}进球！射门干净利落。'],
-        ownGoal: ['乌龙球，{player}不走运。'],
-        post: ['击中门柱，差之毫厘。'],
-        save: ['{opponent}神扑，反应很快。'],
-        counter: ['快速反击，{player}冲起来了。'],
-        pressure: ['压力时刻，{player}需要稳定处理。'],
-        leadChange: ['{player}反超比分，节奏变化很快。'],
-        equalizer: ['扳平比分！{player}追了回来。'],
-        matchPoint: ['赛点！{player}只差一球。'],
-        matchWin: ['比赛结束，{player}以{scoreline}获胜。'],
-        outro: ['{arena}的解说到此结束，感谢观看。']
-      }
-    },
-    hi: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['{arena} से स्वागत है। {speaker} आपके साथ हैं। {player} बनाम {opponent}, स्कोर {scoreline}।'],
-        introReply: ['धन्यवाद {speaker}. आज गति और सही एंगल निर्णायक होंगे।'],
-        kickoff: ['किकऑफ शुरू—पहला टच बहुत अहम है।'],
-        goal: ['{player} का गोल! शानदार फिनिश।'],
-        ownGoal: ['ओन गोल—{player} के खिलाफ दुर्भाग्य।'],
-        post: ['पोस्ट लगा! बेहद करीब।'],
-        save: ['{opponent} का शानदार बचाव।'],
-        counter: ['तेज़ काउंटर—{player} आगे बढ़ रहा है।'],
-        pressure: ['दबाव भरा पल—{player} को सटीकता चाहिए।'],
-        leadChange: ['लीड बदल गई—{player} आगे निकल गया।'],
-        equalizer: ['बराबरी! {player} ने स्कोर सम किया।'],
-        matchPoint: ['मैच पॉइंट—{player} बस एक गोल दूर।'],
-        matchWin: ['मैच खत्म। {player} {scoreline} से जीतता है।'],
-        outro: ['{arena} से यहीं तक, देखने के लिए धन्यवाद।']
-      }
-    },
-    es: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['Bienvenidos a {arena}. {speaker} con ustedes. {player} contra {opponent}, {scoreline}.'],
-        introReply: ['Gracias {speaker}. La velocidad y los ángulos van a decidir.'],
-        kickoff: ['Arranca el saque, el primer toque importa mucho.'],
-        goal: ['¡Gol de {player}! Definición limpia.'],
-        ownGoal: ['Autogol, mala fortuna para {player}.'],
-        post: ['¡Al poste! Se quedó a nada.'],
-        save: ['Gran atajada de {opponent}.'],
-        counter: ['Contraataque rápido, {player} acelera.'],
-        pressure: ['Momento de presión para {player}; necesita precisión.'],
-        leadChange: ['Cambio de líder: {player} se pone arriba.'],
-        equalizer: ['Empate. {player} iguala el marcador.'],
-        matchPoint: ['Punto de partido para {player}, un gol más.'],
-        matchWin: ['Final del partido. {player} gana {scoreline}.'],
-        outro: ['Desde {arena}, gracias por acompañarnos.']
-      }
-    },
-    fr: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['Bienvenue à {arena}. {speaker} avec vous. {player} contre {opponent}, {scoreline}.'],
-        introReply: ['Merci {speaker}. La vitesse et les angles feront la différence.'],
-        kickoff: ['Engagement lancé, le premier toucher compte.'],
-        goal: ['But de {player} ! Finition propre.'],
-        ownGoal: ['But contre son camp, malchance pour {player}.'],
-        post: ['Sur le poteau ! À un souffle.'],
-        save: ['Super arrêt de {opponent}.'],
-        counter: ['Contre rapide, {player} accélère.'],
-        pressure: ['Moment sous pression pour {player}; précision requise.'],
-        leadChange: ['Changement de leader : {player} passe devant.'],
-        equalizer: ['Égalisation ! {player} revient au score.'],
-        matchPoint: ['Balle de match pour {player}, un but suffit.'],
-        matchWin: ['Fin du match. {player} s’impose {scoreline}.'],
-        outro: ['Depuis {arena}, merci de nous avoir suivis.']
-      }
-    },
-    ar: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['مرحبًا بكم في {arena}. {speaker} معكم. {player} ضد {opponent}، {scoreline}.'],
-        introReply: ['شكرًا {speaker}. السرعة والزوايا ستحسم اللقاء.'],
-        kickoff: ['بداية اللعب، اللمسة الأولى مهمة جدًا.'],
-        goal: ['هدف لـ{player}! إنهاء رائع.'],
-        ownGoal: ['هدف عكسي، سوء حظ لـ{player}.'],
-        post: ['كرة في القائم! كانت قريبة جدًا.'],
-        save: ['تصدي رائع من {opponent}.'],
-        counter: ['هجمة مرتدة سريعة، {player} ينطلق.'],
-        pressure: ['لحظة ضغط على {player}—الدقة مطلوبة.'],
-        leadChange: ['تبدل القيادة؛ {player} يتقدم.'],
-        equalizer: ['تعادل! {player} يعيد المباراة.'],
-        matchPoint: ['نقطة مباراة لـ{player}، هدف واحد فقط.'],
-        matchWin: ['نهاية المباراة. {player} يفوز {scoreline}.'],
-        outro: ['من {arena}، شكرًا على المتابعة.']
-      }
-    },
-    sq: {
-      ...ENGLISH_COMMENTARY,
-      common: {
-        intro: ['Mirë se vini në {arena}. Me ju është {speaker}. {player} kundër {opponent}, {scoreline}.'],
-        introReply: ['Faleminderit {speaker}. Shpejtësia dhe këndet vendosin rezultatin.'],
-        kickoff: ['Nisja u dha, prekja e parë është kyçe.'],
-        goal: ['Gol për {player}! Përfundim i pastër.'],
-        ownGoal: ['Autogol, fat i keq për {player}.'],
-        post: ['Në shtyllë! Iku shumë pak.'],
-        save: ['Mbrojtje e madhe nga {opponent}.'],
-        counter: ['Kundërsulm i shpejtë, {player} po vrapon.'],
-        pressure: ['Moment presioni për {player}; kërkohet saktësi.'],
-        leadChange: ['Ndryshim epërsie—{player} kalon përpara.'],
-        equalizer: ['Barazim! {player} e kthen ndeshjen.'],
-        matchPoint: ['Pikë ndeshjeje për {player}, edhe një gol.'],
-        matchWin: ['Fundi i ndeshjes. {player} fiton {scoreline}.'],
-        outro: ['Kaq nga {arena}. Faleminderit që na ndoqët.']
-      }
-    }
+    en: ENGLISH_COMMENTARY
   });
 
   const GOAL_RUSH_COMMENTARY_PRESETS = Object.freeze([
@@ -841,90 +726,6 @@
         Kai: { rate: 0.98, pitch: 0.95, volume: 1 },
         Sofia: { rate: 1.02, pitch: 1.02, volume: 0.98 }
       }
-    },
-    {
-      id: 'mandarin',
-      label: 'Mandarin',
-      description: '普通话解说',
-      language: 'zh',
-      voiceHints: {
-        Kai: ['zh-CN', 'zh', 'mandarin', 'male', 'google'],
-        Sofia: ['zh-CN', 'zh', 'mandarin', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 1, pitch: 0.95, volume: 1 },
-        Sofia: { rate: 1.02, pitch: 1, volume: 0.98 }
-      }
-    },
-    {
-      id: 'hindi',
-      label: 'Hindi',
-      description: 'हिंदी कमेंट्री',
-      language: 'hi',
-      voiceHints: {
-        Kai: ['hi-IN', 'hi', 'hindi', 'male', 'google'],
-        Sofia: ['hi-IN', 'hi', 'hindi', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 1.02, pitch: 0.96, volume: 1 },
-        Sofia: { rate: 1.04, pitch: 1, volume: 0.98 }
-      }
-    },
-    {
-      id: 'spanish',
-      label: 'Spanish',
-      description: 'Relato en español',
-      language: 'es',
-      voiceHints: {
-        Kai: ['es-ES', 'es', 'spanish', 'male', 'google'],
-        Sofia: ['es-ES', 'es', 'spanish', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 1, pitch: 0.96, volume: 1 },
-        Sofia: { rate: 1.02, pitch: 1, volume: 0.98 }
-      }
-    },
-    {
-      id: 'french',
-      label: 'French',
-      description: 'Commentaires en français',
-      language: 'fr',
-      voiceHints: {
-        Kai: ['fr-FR', 'fr', 'french', 'male', 'google'],
-        Sofia: ['fr-FR', 'fr', 'french', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 0.98, pitch: 0.94, volume: 1 },
-        Sofia: { rate: 1, pitch: 0.98, volume: 0.98 }
-      }
-    },
-    {
-      id: 'arabic',
-      label: 'Arabic',
-      description: 'تعليق عربي',
-      language: 'ar',
-      voiceHints: {
-        Kai: ['ar-SA', 'ar', 'arabic', 'male', 'google'],
-        Sofia: ['ar-SA', 'ar', 'arabic', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 1, pitch: 0.94, volume: 1 },
-        Sofia: { rate: 1.02, pitch: 0.98, volume: 0.98 }
-      }
-    },
-    {
-      id: 'albanian',
-      label: 'Albanian',
-      description: 'Komentim shqip',
-      language: 'sq',
-      voiceHints: {
-        Kai: ['sq-AL', 'sq', 'albanian', 'male', 'google'],
-        Sofia: ['sq-AL', 'sq', 'albanian', 'female', 'google']
-      },
-      speakerSettings: {
-        Kai: { rate: 1, pitch: 0.96, volume: 1 },
-        Sofia: { rate: 1.02, pitch: 0.98, volume: 0.98 }
-      }
     }
   ]);
 
@@ -935,14 +736,8 @@
 
   const resolveLanguageKey = (language = 'en') => {
     const normalized = String(language || '').toLowerCase();
-    if (normalized.startsWith('zh')) return 'zh';
-    if (normalized.startsWith('hi')) return 'hi';
-    if (normalized.startsWith('es')) return 'es';
-    if (normalized.startsWith('fr')) return 'fr';
-    if (normalized.startsWith('ar')) return 'ar';
-    if (normalized.startsWith('sq')) return 'sq';
     if (normalized.startsWith('en')) return 'en';
-    return normalized || 'en';
+    return 'en';
   };
 
   const pickRandom = (pool) => pool[Math.floor(Math.random() * pool.length)];

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -114,90 +114,6 @@ const AIR_HOCKEY_COMMENTARY_PRESETS = Object.freeze([
       [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Zë mashkulli, shqip.',
-    language: 'sq',
-    voiceHints: {
-      [AIR_HOCKEY_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [AIR_HOCKEY_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = AIR_HOCKEY_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -551,7 +467,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
   const [muted, setMuted] = useState(isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && AIR_HOCKEY_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -2423,14 +2339,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     }
   }, [selections]);
 
-  const handleCommentaryPresetSelect = useCallback(
-    (preset) => {
-      if (!preset?.id) return;
-      setCommentaryPresetId(preset.id);
-    },
-    []
-  );
-
   const renderOptionRow = (label, key) => {
     const options = (AIR_HOCKEY_CUSTOMIZATION[key] || []).filter((option) =>
       isAirHockeyOptionUnlocked(key, option.id, airInventory)
@@ -2656,31 +2564,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             </div>
             <div className="rounded-xl border border-white/10 bg-white/5 p-3">
               <div>
-                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary language</p>
-                <p className="mt-1 text-[0.7rem] text-white/60">Select the voice crew for air hockey.</p>
-              </div>
-              <div className="mt-2 grid gap-2">
-                {AIR_HOCKEY_COMMENTARY_PRESETS.map((preset) => {
-                  const active = preset.id === commentaryPresetId;
-                  return (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      onClick={() => handleCommentaryPresetSelect(preset)}
-                      aria-pressed={active}
-                      className={`w-full rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                        active
-                          ? 'border-sky-300 bg-sky-300/15 text-sky-100 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                          : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                      }`}
-                    >
-                      <span className="block">{preset.label}</span>
-                      <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                        {preset.description}
-                      </span>
-                    </button>
-                  );
-                })}
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
               </div>
               <button
                 type="button"

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -443,90 +443,6 @@ const LUDO_BATTLE_COMMENTARY_PRESETS = Object.freeze([
       [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Zë mashkulli, shqip.',
-    language: 'sq',
-    voiceHints: {
-      [LUDO_BATTLE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [LUDO_BATTLE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [LUDO_BATTLE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [LUDO_BATTLE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = LUDO_BATTLE_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -2735,7 +2651,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   }, [resolvedAccountId]);
   const [configOpen, setConfigOpen] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(() => !isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && LUDO_BATTLE_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -3125,11 +3041,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     });
     enqueueLudoCommentary(script, { priority: true, preset: activeCommentaryPreset });
   }, [activeCommentaryPreset, commentaryPresetId, commentarySpeakers, enqueueLudoCommentary, players]);
-
-  const handleCommentaryPresetSelect = useCallback((preset) => {
-    if (!preset?.id) return;
-    setCommentaryPresetId(preset.id);
-  }, []);
 
   const seatAnchorMap = useMemo(() => {
     const map = new Map();
@@ -5589,32 +5500,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                     </label>
                     <div>
                       <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">
-                        Commentary language
+                        Commentary
                       </h3>
-                      <div className="mt-2 grid grid-cols-1 gap-2">
-                        {LUDO_BATTLE_COMMENTARY_PRESETS.map((preset) => {
-                          const active = preset.id === commentaryPresetId;
-                          return (
-                            <button
-                              key={preset.id}
-                              type="button"
-                              onClick={() => handleCommentaryPresetSelect(preset)}
-                              aria-pressed={active}
-                              disabled={!commentarySupported}
-                              className={`rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                                active
-                                  ? 'border-sky-300 bg-sky-300 text-black shadow-[0_0_18px_rgba(56,189,248,0.55)]'
-                                  : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                              } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                            >
-                              <span className="block">{preset.label}</span>
-                              <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                                {preset.description}
-                              </span>
-                            </button>
-                          );
-                        })}
-                      </div>
                       <button
                         type="button"
                         onClick={() => setCommentaryMuted((prev) => !prev)}

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -651,90 +651,6 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Zë mashkulli, shqip.',
-    language: 'sq',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = MURLAN_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -1335,7 +1251,7 @@ export default function MurlanRoyaleArena({ search }) {
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
   const [muted, setMuted] = useState(isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && MURLAN_ROYALE_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -3385,31 +3301,7 @@ export default function MurlanRoyaleArena({ search }) {
                     </div>
                   </div>
                   <div className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary language</p>
-                    <div className="grid gap-2">
-                      {MURLAN_ROYALE_COMMENTARY_PRESETS.map((preset) => {
-                        const active = preset.id === commentaryPresetId;
-                        return (
-                          <button
-                            key={preset.id}
-                            type="button"
-                            onClick={() => setCommentaryPresetId(preset.id)}
-                            aria-pressed={active}
-                            disabled={!commentarySupported}
-                            className={`w-full rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              active
-                                ? 'border-sky-300 bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.45)]'
-                                : 'border-white/10 bg-white/5 text-white/80 hover:border-white/20'
-                            } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                          >
-                            <span className="block">{preset.label}</span>
-                            <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                              {preset.description}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</p>
                     <button
                       type="button"
                       onClick={() => setCommentaryMuted((prev) => !prev)}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -934,90 +934,6 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Zë mashkulli, shqip.',
-    language: 'sq',
-    voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -10834,7 +10750,7 @@ function PoolRoyaleGame({
     }
     return false;
   });
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && POOL_ROYALE_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -13218,13 +13134,6 @@ const powerRef = useRef(hud.power);
     };
   }, [enqueuePoolCommentary]);
 
-  const handleCommentaryPresetSelect = useCallback(
-    (preset) => {
-      if (!preset?.id) return;
-      setCommentaryPresetId(preset.id);
-    },
-    []
-  );
   useEffect(() => {
     document.title = 'Pool Royale 3D';
   }, []);
@@ -26371,31 +26280,8 @@ const powerRef = useRef(hud.power);
               </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Commentary language
+                  Commentary
                 </h3>
-                <div className="mt-2 grid grid-cols-1 gap-2">
-                  {POOL_ROYALE_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => handleCommentaryPresetSelect(preset)}
-                        aria-pressed={active}
-                        className={`rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_18px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="block">{preset.label}</span>
-                        <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
                 <button
                   type="button"
                   onClick={() => setCommentaryMuted((prev) => !prev)}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -192,90 +192,6 @@ const SNAKE_COMMENTARY_PRESETS = Object.freeze([
       [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Zë mashkulli, shqip.',
-    language: 'sq',
-    voiceHints: {
-      [SNAKE_LADDER_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [SNAKE_LADDER_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [SNAKE_LADDER_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [SNAKE_LADDER_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = SNAKE_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -1185,7 +1101,7 @@ export default function SnakeAndLadder() {
   const [showInfo, setShowInfo] = useState(false);
   const [showExactHelp, setShowExactHelp] = useState(false);
   const [muted, setMuted] = useState(isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && SNAKE_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -3562,31 +3478,7 @@ export default function SnakeAndLadder() {
                 </label>
               </div>
               <div className="mt-4 space-y-2">
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary language</h3>
-                <div className="grid gap-2">
-                  {SNAKE_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => setCommentaryPresetId(preset.id)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`w-full rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_18px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="block">{preset.label}</span>
-                        <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</h3>
                 <button
                   type="button"
                   onClick={() => setCommentaryMuted((prev) => !prev)}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -978,93 +978,9 @@ const SNOOKER_ROYAL_COMMENTARY_PRESETS = Object.freeze([
       [COMMENTARY_SPEAKER_LEAD]: { rate: 0.98, pitch: 0.92, volume: 1 },
       [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 0.98, volume: 0.98 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin Chinese',
-    description: 'Male play-by-play in Mandarin.',
-    language: 'zh',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['zh-CN', 'zh', 'mandarin', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['zh-CN', 'zh', 'mandarin', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.95, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 1, volume: 0.98 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male play-by-play in Hindi.',
-    language: 'hi',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['hi-IN', 'hi', 'hindi', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['hi-IN', 'hi', 'hindi', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 1.02, pitch: 0.96, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.04, pitch: 1, volume: 0.98 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male play-by-play in Spanish.',
-    language: 'es',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['es-ES', 'es', 'spanish', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['es-ES', 'es', 'spanish', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.96, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 1, volume: 0.98 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male play-by-play in French.',
-    language: 'fr',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['fr-FR', 'fr', 'french', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['fr-FR', 'fr', 'french', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 0.98, pitch: 0.94, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1, pitch: 0.98, volume: 0.98 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male play-by-play in Arabic.',
-    language: 'ar',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['ar-SA', 'ar', 'arabic', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['ar-SA', 'ar', 'arabic', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.94, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 0.98, volume: 0.98 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Shqip',
-    description: 'Komentim mashkullor në shqip.',
-    language: 'sq',
-    voiceHints: {
-      [COMMENTARY_SPEAKER_LEAD]: ['sq-AL', 'sq', 'albanian', 'male', 'google'],
-      [COMMENTARY_SPEAKER_ANALYST]: ['sq-AL', 'sq', 'albanian', 'male', 'google']
-    },
-    speakerSettings: {
-      [COMMENTARY_SPEAKER_LEAD]: { rate: 1, pitch: 0.96, volume: 1 },
-      [COMMENTARY_SPEAKER_ANALYST]: { rate: 1.02, pitch: 0.98, volume: 0.98 }
-    }
   }
 ]);
-const DEFAULT_COMMENTARY_PRESET_ID = SNOOKER_ROYAL_COMMENTARY_PRESETS[0]?.id || 'atlas';
+const DEFAULT_COMMENTARY_PRESET_ID = SNOOKER_ROYAL_COMMENTARY_PRESETS[0]?.id || 'english';
 const DEFAULT_TABLE_BASE_ID = SNOOKER_ROYALE_BASE_VARIANTS[0]?.id || 'classicCylinders';
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
@@ -10807,7 +10723,7 @@ function SnookerRoyalGame({
     }
     return false;
   });
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = safeLocalStorageGet(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && SNOOKER_ROYAL_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -12245,22 +12161,6 @@ function SnookerRoyalGame({
       getAlternateCommentarySpeaker,
       resolveSeatLabel
     ]
-  );
-  const handleCommentaryPresetSelect = useCallback(
-    (preset) => {
-      if (!preset?.id) return;
-      setCommentaryPresetId(preset.id);
-      if (commentaryMutedRef.current || isGameMuted()) return;
-      enqueueSnookerCommentaryEvent(
-        'intro',
-        {
-          player: resolveSeatLabel('A'),
-          opponent: resolveSeatLabel('B')
-        },
-        { priority: true, preset }
-      );
-    },
-    [enqueueSnookerCommentaryEvent, resolveSeatLabel]
   );
   useEffect(() => {
     const script = createSnookerMatchCommentaryScript({
@@ -25990,30 +25890,6 @@ const powerRef = useRef(hud.power);
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Commentary
                 </h3>
-                <div className="mt-2 grid grid-cols-1 gap-2">
-                  {SNOOKER_ROYAL_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => handleCommentaryPresetSelect(preset)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_18px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="block">{preset.label}</span>
-                        <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
                 <button
                   type="button"
                   onClick={() => setCommentaryMuted((prev) => !prev)}

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -282,90 +282,6 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
       [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
       [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
     }
-  },
-  {
-    id: 'mandarin',
-    label: 'Mandarin',
-    description: 'Male voice, 中文',
-    language: 'zh',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['zh-CN', 'zh', 'Chinese', 'Mandarin', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'hindi',
-    label: 'Hindi',
-    description: 'Male voice, हिंदी',
-    language: 'hi',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['hi-IN', 'Hindi', 'India', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['hi-IN', 'Hindi', 'India', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'spanish',
-    label: 'Spanish',
-    description: 'Male voice, Español',
-    language: 'es',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'Español', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.97, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.97, volume: 1 }
-    }
-  },
-  {
-    id: 'french',
-    label: 'French',
-    description: 'Male voice, Français',
-    language: 'fr',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['fr-FR', 'French', 'Français', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['fr-FR', 'French', 'Français', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
-  },
-  {
-    id: 'arabic',
-    label: 'Arabic',
-    description: 'Male voice, العربية',
-    language: 'ar',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['ar-SA', 'ar-EG', 'Arabic', 'العربية', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
-    }
-  },
-  {
-    id: 'albanian',
-    label: 'Albanian',
-    description: 'Male voice, Shqip',
-    language: 'sq',
-    voiceHints: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male'],
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'Shqip', 'male']
-    },
-    speakerSettings: {
-      [TEXAS_HOLDEM_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [TEXAS_HOLDEM_SPEAKERS.analyst]: { rate: 1, pitch: 0.96, volume: 1 }
-    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -2660,7 +2576,7 @@ function TexasHoldemArena({ search }) {
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
   const [muted, setMuted] = useState(isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && TEXAS_HOLDEM_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -5227,31 +5143,7 @@ function TexasHoldemArena({ search }) {
                 </div>
               ))}
               <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary language</p>
-                <div className="grid gap-2">
-                  {TEXAS_HOLDEM_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => setCommentaryPresetId(preset.id)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`rounded-2xl border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.2em] transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                          active
-                            ? 'border-sky-300 bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="block">{preset.label}</span>
-                        <span className="mt-1 block text-[9px] font-semibold uppercase tracking-[0.18em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</p>
                 <button
                   type="button"
                   onClick={() => setCommentaryMuted((prev) => !prev)}


### PR DESCRIPTION
### Motivation
- Make voice commentary English-only across games and remove per-game language selection while retaining a single mute control to simplify settings and default the experience to English.
- Reduce UI complexity by removing multi-language presets/options and any handlers that change commentary presets.

### Description
- Removed non-English commentary presets and templates, leaving only English variants (notably in `webapp/public/goal-rush.html` and various `webapp/src/pages/Games/*` and `webapp/src/components/*` files). 
- Removed commentary language selection UI and preset buttons from game config modals and pages, replacing headings like `Commentary language` with `Commentary` and keeping only the mute toggle button and support note.
- Eliminated or simplified preset-change handlers and state mutation where present by removing setter usage (converted `const [commentaryPresetId, setCommentaryPresetId]` to `const [commentaryPresetId]` where appropriate) and removing `handleCommentaryPresetSelect` or `setCommentaryPresetId` calls.
- Simplified language resolution in `goal-rush` to always return English and reduced multi-language templates to the English template.
- Key modified files include `webapp/public/domino-royal.html`, `webapp/public/goal-rush.html`, and these React components/pages: `AirHockey3D.jsx`, `LudoBattleRoyal.jsx`, `MurlanRoyaleArena.jsx`, `PoolRoyale.jsx`, `SnakeAndLadder.jsx`, `SnookerRoyal.jsx`, and `TexasHoldemArena.jsx`.

### Testing
- Launched a local static server with `python -m http.server` to host `webapp/public`, and the server started successfully. (succeeded)
- Attempted an automated UI check using Playwright to open `goal-rush.html` and capture a screenshot, but the headless browser crashed (SIGSEGV/TargetClosedError), so the Playwright run failed; no screenshot was produced. (failed)
- Performed repository scans and manual inspections (`rg`, `sed`) to confirm the language presets and UI elements were removed or simplified across targeted files. (inspection; succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976309adb5c8329b962ebd205aaa6f6)