### PR TITLE
Fix domino commentary voice unlock and queuing

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -695,7 +695,7 @@ const speechSynth = (() => {
 })();
 let commentaryVoices = [];
 let commentaryPresetId = COMMENTARY_PRESETS[0]?.id || 'atlas';
-let commentaryMuted = prefersReducedAudio();
+let commentaryMuted = false;
 let commentaryQueue = [];
 let commentarySpeaking = false;
 let commentaryReady = false;
@@ -876,13 +876,12 @@ function buildCommentaryLine(kind, context = {}) {
 }
 
 function ensureSpeechUnlocked() {
-  if (!speechSynth || commentaryUnlocked) return;
+  if (!speechSynth) return;
   try {
     speechSynth.resume();
   } catch (error) {
     console.warn('Failed to resume speech synthesis', error);
   }
-  commentaryUnlocked = true;
 }
 
 function scheduleCommentaryVoicesRetry() {
@@ -904,8 +903,12 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   if (!commentaryVoices.length) {
     scheduleCommentaryVoicesRetry();
   }
+  if (!commentaryUnlocked) {
+    if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
+    commentaryQueue.push({ text, options: { interrupt, priority, kind } });
+    return;
+  }
   ensureSpeechUnlocked();
-  if (!commentaryUnlocked) return;
   const now = performance.now();
   if (!priority && now - commentaryLastEventAt < COMMENTARY_MIN_INTERVAL_MS) return;
   if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
@@ -971,6 +974,15 @@ if (speechSynth) {
 function unlockInteractiveAudio() {
   ensureAudioContext();
   ensureSpeechUnlocked();
+  if (!commentaryUnlocked) {
+    commentaryUnlocked = true;
+    if (!commentarySpeaking && commentaryQueue.length) {
+      const next = commentaryQueue.shift();
+      if (next) {
+        speakCommentary(next.text, next.options);
+      }
+    }
+  }
 }
 
 ['pointerdown', 'touchstart', 'keydown'].forEach((eventName) => {


### PR DESCRIPTION
### Motivation
- The Domino game commentary was default-muted by `prefersReducedAudio()` and speech lines could be lost before the browser allowed TTS playback. 
- User interactions are required to unlock speech synthesis in many browsers, so commentary should queue until the first interaction rather than silently dropping lines. 
- Improve reliability of the announcer so queued lines play once audio is unlocked.

### Description
- Changed the default mute behavior by setting `commentaryMuted` to `false` instead of `prefersReducedAudio()` so commentary is not auto-muted. 
- Simplified `ensureSpeechUnlocked()` so it only attempts `speechSynthesis.resume()` and no longer flips `commentaryUnlocked` itself. 
- Updated `speakCommentary()` to queue lines when `commentaryUnlocked` is `false`, respecting `COMMENTARY_QUEUE_LIMIT` and `priority` rules, instead of returning early and dropping lines. 
- Enhanced `unlockInteractiveAudio()` to set `commentaryUnlocked = true` on first user interaction and flush the queued commentary by invoking `speakCommentary()` for the next queued line.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976385facc083299719abf11d427ef6)