### PR TITLE
Integrate professional voice commentary for Chess Battle Royal

### DIFF
--- a/webapp/src/utils/chessBattleCommentary.js
+++ b/webapp/src/utils/chessBattleCommentary.js
@@ -1,0 +1,178 @@
+export const CHESS_BATTLE_SPEAKERS = Object.freeze({
+  lead: 'Victor',
+  analyst: 'Elena'
+});
+
+const SPEAKER_PROFILES = Object.freeze({
+  Victor: {
+    id: 'victor',
+    name: 'Victor',
+    style: 'Play-by-play'
+  },
+  Elena: {
+    id: 'elena',
+    name: 'Elena',
+    style: 'Color analyst'
+  }
+});
+
+const DEFAULT_CONTEXT = Object.freeze({
+  player: 'White',
+  opponent: 'Black',
+  arena: 'Chess Battle Royal arena',
+  scoreline: 'all square',
+  piece: 'piece',
+  fromSquare: 'the starting square',
+  toSquare: 'the target square',
+  capturedPiece: 'piece',
+  castleSide: 'king-side',
+  winner: 'White'
+});
+
+const ENGLISH_TEMPLATES = Object.freeze({
+  common: {
+    intro: [
+      'Welcome to {arena}. {speaker} with you as {player} takes on {opponent}.',
+      'Live from {arena}, {speaker} on the call. {player} versus {opponent} is underway.',
+      'Good evening from {arena}. {speaker} here for {player} against {opponent}.'
+    ],
+    introReply: [
+      'Thanks {speaker}. Expect precise calculation and patient maneuvering from both sides.',
+      'Great to be here, {speaker}. This one should be decided by central control and king safety.',
+      'Absolutely, {speaker}. It is a battle of plans—structure, tempo, and tactics.'
+    ],
+    opening: [
+      '{player} is staking early central control with {piece} to {toSquare}.',
+      'Opening phase here—{player} develops with {piece} to {toSquare}.',
+      '{player} keeps it principled, putting {piece} on {toSquare}.'
+    ],
+    move: [
+      'A calm improving move: {player} plays {piece} to {toSquare}.',
+      '{player} repositions the {piece} to {toSquare}, keeping the structure intact.',
+      '{player} chooses {piece} to {toSquare}, a measured positional step.'
+    ],
+    capture: [
+      '{player} captures on {toSquare}, taking the {capturedPiece}.',
+      'Exchange on {toSquare}—{player} removes the {capturedPiece}.',
+      '{player} goes tactical, {piece} captures the {capturedPiece} on {toSquare}.'
+    ],
+    check: [
+      'Check on the board—{player} forces the king to respond.',
+      '{player} delivers check, tightening the net.',
+      'That is check; {opponent} must find a precise reply.'
+    ],
+    checkmate: [
+      'Checkmate. {winner} seals the result.',
+      'That is mate—{winner} finishes it clinically.',
+      'Checkmate on the board. {winner} takes the game.'
+    ],
+    stalemate: [
+      'Stalemate. No legal moves, and the game is drawn.',
+      'It is stalemate—nothing available for the side to move.',
+      'Draw by stalemate. The position is locked.'
+    ],
+    promotion: [
+      'Promotion on {toSquare}; {player} has a new queen.',
+      '{player} promotes on {toSquare}, a decisive upgrade.',
+      'Pawn promotion arrives for {player} on {toSquare}.'
+    ],
+    castle: [
+      '{player} castles {castleSide}, tucking the king to safety.',
+      'Castling {castleSide} for {player}; king safety first.',
+      '{player} completes {castleSide} castling, activating the rook.'
+    ],
+    endgame: [
+      'We are in the endgame now—every tempo matters.',
+      'Endgame phase: piece activity and king placement are critical.',
+      'The endgame is here; precision will decide it.'
+    ],
+    outro: [
+      'That concludes the clash from {arena}. Thanks for joining us.',
+      'From {arena}, that is full time. Appreciate your company.',
+      'A fine finish here at {arena}. Thanks for watching.'
+    ]
+  }
+});
+
+const EVENT_POOLS = Object.freeze({
+  intro: 'intro',
+  introReply: 'introReply',
+  opening: 'opening',
+  move: 'move',
+  capture: 'capture',
+  check: 'check',
+  checkmate: 'checkmate',
+  stalemate: 'stalemate',
+  promotion: 'promotion',
+  castle: 'castle',
+  endgame: 'endgame',
+  outro: 'outro'
+});
+
+const pickRandom = (pool) => pool[Math.floor(Math.random() * pool.length)];
+
+const applyTemplate = (template, context) =>
+  template.replace(/\{(\w+)\}/g, (_, key) => String(context[key] ?? `{${key}}`));
+
+const resolveLanguageKey = (language = 'en') => {
+  const normalized = String(language || '').toLowerCase();
+  if (normalized.startsWith('en')) return 'en';
+  return 'en';
+};
+
+export const buildChessCommentaryLine = ({
+  event,
+  speaker = CHESS_BATTLE_SPEAKERS.lead,
+  language = 'en',
+  context = {}
+}) => {
+  const templates = resolveLanguageKey(language) === 'en' ? ENGLISH_TEMPLATES : ENGLISH_TEMPLATES;
+  const mergedContext = {
+    ...DEFAULT_CONTEXT,
+    ...context,
+    speaker,
+    partner: speaker === CHESS_BATTLE_SPEAKERS.lead
+      ? CHESS_BATTLE_SPEAKERS.analyst
+      : CHESS_BATTLE_SPEAKERS.lead
+  };
+  const eventPool = templates.common[EVENT_POOLS[event]] || templates.common.move;
+  return applyTemplate(pickRandom(eventPool), mergedContext);
+};
+
+export const createChessMatchCommentaryScript = ({
+  players = { white: 'White', black: 'Black' },
+  commentators = [CHESS_BATTLE_SPEAKERS.lead, CHESS_BATTLE_SPEAKERS.analyst],
+  language = 'en',
+  arena = 'Chess Battle Royal arena'
+} = {}) => {
+  const [lead, analyst] = commentators;
+  const context = {
+    player: players.white,
+    opponent: players.black,
+    arena
+  };
+
+  const script = [
+    { speaker: lead, event: EVENT_POOLS.intro },
+    { speaker: analyst, event: EVENT_POOLS.introReply },
+    { speaker: lead, event: EVENT_POOLS.opening }
+  ];
+
+  return script.map((entry) => ({
+    speaker: entry.speaker,
+    text: buildChessCommentaryLine({
+      event: entry.event,
+      speaker: entry.speaker,
+      language,
+      context
+    })
+  }));
+};
+
+export const CHESS_BATTLE_COMMENTARY_EVENTS = Object.freeze({
+  ...EVENT_POOLS
+});
+
+export const CHESS_BATTLE_COMMENTATORS = Object.freeze({
+  ...SPEAKER_PROFILES
+});


### PR DESCRIPTION
### Motivation
- Provide broadcast-style, professional chess commentary for Chess Battle Royal mirroring the Pool Royale commentary system and improving spectator experience.
- Deliver spoken play-by-play and analyst lines for key events (moves, captures, checks, promotions, castling, checkmate/stalemate, endgame) using the existing text-to-speech infrastructure.

### Description
- Added a new commentary utility `webapp/src/utils/chessBattleCommentary.js` that contains speaker profiles, English templates, `buildChessCommentaryLine` and `createChessMatchCommentaryScript` helpers. 
- Wired the commentary into `webapp/src/pages/Games/ChessBattleRoyal.jsx` by importing the builders and `textToSpeech` helpers and introducing commentary presets, storage keys (`COMMENTARY_PRESET_STORAGE_KEY`, `COMMENTARY_MUTE_STORAGE_KEY`), and defaults. 
- Implemented commentary runtime: ready/unlock logic, queueing, rate limiting, per-event enqueue helpers (`enqueueChessCommentaryEvent`), `playNextCommentary`, speaker rotation, and intro/outro script playback on match start. 
- Hooked commentary generation into the move resolution flow to build contextual lines (resolved piece labels, from/to squares, capture, castling, promotion, check, checkmate, stalemate, opening/endgame heuristics) and enqueue appropriate events; added a settings toggle in the Chess settings panel to mute/unmute commentary.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported the app as ready (dev server reachable); this succeeded.
- Automated headless browser check navigated to `http://127.0.0.1:4173/games/chessbattleroyal` and captured a screenshot of the settings panel showing the new Commentary toggle, which completed successfully and produced `artifacts/chess-commentary-settings.png`.
- No unit or CI test suites (`npm test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763a2d9bc08329bc3d1b3629a8569b)