### PR TITLE
Skip stake checks for local Texas Hold'em

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -69,16 +69,18 @@ export default function TexasHoldemLobby() {
     let accountId;
     try {
       accountId = await ensureAccountId();
-      const balRes = await getAccountBalance(accountId);
-      if ((balRes.balance || 0) < stake.amount) {
-        alert('Insufficient balance');
-        return;
-      }
       tgId = getTelegramId();
-      await addTransaction(tgId, -stake.amount, 'stake', {
-        game: 'texasholdem',
-        accountId,
-      });
+      if (mode === 'online') {
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'texasholdem',
+          accountId,
+        });
+      }
     } catch {}
 
     const params = new URLSearchParams();


### PR DESCRIPTION
### Motivation
- Allow launching Texas Hold'em in local mode without requiring a TPC account balance or performing stake debits while still including the Telegram ID in launch parameters.

### Description
- In `webapp/src/pages/Games/TexasHoldemLobby.jsx` call `getTelegramId` earlier and guard the balance check and `addTransaction` stake debit behind `mode === 'online'` so local games skip `getAccountBalance`/`addTransaction` but keep `tgId`/`accountId` in the URL params.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764b2e7e68832997a7cff5215b03bd)