### PR TITLE
Revise Murlan Royale commentary voices and unlock flow

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -643,10 +643,11 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'english',
     label: 'English',
-    description: 'Mixed voices, classic English',
+    description: 'Classic English duo',
     language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.atlas, MURLAN_ROYALE_SPEAKERS.nova],
     voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: [
+      [MURLAN_ROYALE_SPEAKERS.atlas]: [
         'en-US',
         'English',
         'male',
@@ -655,7 +656,7 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Daniel',
         'Alex'
       ],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+      [MURLAN_ROYALE_SPEAKERS.nova]: [
         'en-GB',
         'English',
         'female',
@@ -666,132 +667,134 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       ]
     },
     speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.atlas]: { rate: 1, pitch: 0.96, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.nova]: { rate: 1.04, pitch: 1.06, volume: 1 }
     }
   },
   {
-    id: 'broadcast',
-    label: 'Broadcast',
-    description: 'Broadcast duo, mixed',
+    id: 'atlas',
+    label: 'Atlas',
+    description: 'Commanding play-by-play voice',
     language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.atlas],
     voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: [
-        'en-US',
-        'English',
-        'female',
-        'Zira',
-        'Aria',
-        'Jenny',
-        'Natasha'
-      ],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+      [MURLAN_ROYALE_SPEAKERS.atlas]: [
         'en-US',
         'English',
         'male',
-        'Microsoft Mark',
-        'Mark',
-        'Ryan',
+        'David',
+        'Guy',
+        'Brian',
         'Matthew'
       ]
     },
     speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.04, pitch: 1.08, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.98, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.atlas]: { rate: 0.98, pitch: 0.92, volume: 1 }
     }
   },
   {
-    id: 'deep-studio',
-    label: 'Deep Studio',
-    description: 'Deep studio with contrast',
+    id: 'nova',
+    label: 'Nova',
+    description: 'Bright strategic guidance',
     language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.nova],
     voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: [
+      [MURLAN_ROYALE_SPEAKERS.nova]: [
         'en-GB',
         'English',
-        'male',
-        'Piper',
-        'Coqui',
-        'George',
-        'Brian'
-      ],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: [
-        'en-AU',
-        'English',
         'female',
-        'Piper',
-        'Coqui',
-        'Karen',
-        'Nicole'
+        'Sonia',
+        'Hazel',
+        'Olivia',
+        'Serena'
       ]
     },
     speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 0.98, pitch: 0.9, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 1.08, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.nova]: { rate: 1.04, pitch: 1.08, volume: 1 }
     }
   },
   {
-    id: 'clear-analyst',
-    label: 'Clear Analyst',
-    description: 'Clear analyst focus',
+    id: 'orion',
+    label: 'Orion',
+    description: 'Deep, tactical delivery',
     language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.orion],
     voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: [
+      [MURLAN_ROYALE_SPEAKERS.orion]: [
         'en-AU',
         'English',
         'male',
-        'Alex',
-        'Daniel',
-        'Microsoft Guy'
-      ],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+        'William',
+        'James',
+        'Google Australian English',
+        'Microsoft James'
+      ]
+    },
+    speakerSettings: {
+      [MURLAN_ROYALE_SPEAKERS.orion]: { rate: 0.96, pitch: 0.9, volume: 1 }
+    }
+  },
+  {
+    id: 'juno',
+    label: 'Juno',
+    description: 'Energetic crowd hype',
+    language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.juno],
+    voiceHints: {
+      [MURLAN_ROYALE_SPEAKERS.juno]: [
         'en-US',
         'English',
         'female',
         'Ava',
         'Allison',
         'Samantha',
-        'Google US English'
+        'Zira'
       ]
     },
     speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 1, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.06, pitch: 1.08, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.juno]: { rate: 1.06, pitch: 1.12, volume: 1 }
     }
   },
   {
-    id: 'gritty-arena',
-    label: 'Gritty Arena',
-    description: 'Gritty arena voices',
+    id: 'vega',
+    label: 'Vega',
+    description: 'Precise, measured cadence',
     language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.vega],
     voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: ['en-US', 'English', 'male', 'Bruce', 'Ralph', 'Fred'],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['en-GB', 'English', 'female', 'Susan', 'Moira', 'Sally']
-    },
-    speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 0.96, pitch: 0.92, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 1.04, volume: 1 }
-    }
-  },
-  {
-    id: 'warm-story',
-    label: 'Warm Story',
-    description: 'Warm storyteller mix',
-    language: 'en',
-    voiceHints: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: [
+      [MURLAN_ROYALE_SPEAKERS.vega]: [
         'en-GB',
         'English',
-        'female',
-        'Google UK English Female',
-        'Serena',
-        'Olivia'
-      ],
-      [MURLAN_ROYALE_SPEAKERS.analyst]: ['en-US', 'English', 'male', 'Oliver', 'Liam', 'Michael']
+        'male',
+        'George',
+        'Ralph',
+        'Daniel',
+        'Oliver'
+      ]
     },
     speakerSettings: {
-      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 1.08, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 1.04, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.vega]: { rate: 0.98, pitch: 0.98, volume: 1 }
+    }
+  },
+  {
+    id: 'echo',
+    label: 'Echo',
+    description: 'Warm storyteller tone',
+    language: 'en',
+    commentators: [MURLAN_ROYALE_SPEAKERS.echo],
+    voiceHints: {
+      [MURLAN_ROYALE_SPEAKERS.echo]: [
+        'en-IE',
+        'English',
+        'female',
+        'Moira',
+        'Niamh',
+        'Olivia',
+        'Jenny'
+      ]
+    },
+    speakerSettings: {
+      [MURLAN_ROYALE_SPEAKERS.echo]: { rate: 1.02, pitch: 1.04, volume: 1 }
     }
   }
 ]);
@@ -1604,14 +1607,14 @@ export default function MurlanRoyaleArena({ search }) {
     [commentaryPresetId]
   );
   const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
-  const commentarySpeakers = useMemo(
-    () => [MURLAN_ROYALE_SPEAKERS.lead, MURLAN_ROYALE_SPEAKERS.analyst],
-    []
-  );
+  const commentarySpeakers = useMemo(() => {
+    const commentators = activeCommentaryPreset?.commentators ?? [];
+    return commentators.length ? commentators : [MURLAN_ROYALE_SPEAKERS.atlas];
+  }, [activeCommentaryPreset]);
   const pickCommentarySpeaker = useCallback(() => {
     const index = commentarySpeakerIndexRef.current;
     commentarySpeakerIndexRef.current = index + 1;
-    return commentarySpeakers[index % commentarySpeakers.length] || MURLAN_ROYALE_SPEAKERS.analyst;
+    return commentarySpeakers[index % commentarySpeakers.length] || commentarySpeakers[0];
   }, [commentarySpeakers]);
 
   useEffect(() => {
@@ -1709,6 +1712,7 @@ export default function MurlanRoyaleArena({ search }) {
         language: activeCommentaryPreset?.language ?? commentaryPresetId,
         context: {
           arena: 'Murlan Royale arena',
+          commentators: commentarySpeakers,
           ...context
         }
       });
@@ -1718,7 +1722,8 @@ export default function MurlanRoyaleArena({ search }) {
       activeCommentaryPreset?.language,
       commentaryPresetId,
       enqueueMurlanCommentary,
-      pickCommentarySpeaker
+      pickCommentarySpeaker,
+      commentarySpeakers
     ]
   );
 
@@ -1741,6 +1746,11 @@ export default function MurlanRoyaleArena({ search }) {
     }
     setCommentaryMuted((prev) => !prev);
   }, [commentaryMuted, unlockCommentary]);
+
+  const handleToggleConfig = useCallback(() => {
+    unlockCommentary();
+    setConfigOpen((prev) => !prev);
+  }, [unlockCommentary]);
 
   const handleSelectCommentaryPreset = useCallback(
     (presetId) => {
@@ -1773,11 +1783,13 @@ export default function MurlanRoyaleArena({ search }) {
     window.addEventListener('pointerdown', unlockCommentary);
     window.addEventListener('click', unlockCommentary);
     window.addEventListener('touchstart', unlockCommentary);
+    window.addEventListener('touchend', unlockCommentary);
     window.addEventListener('keydown', unlockCommentary);
     return () => {
       window.removeEventListener('pointerdown', unlockCommentary);
       window.removeEventListener('click', unlockCommentary);
       window.removeEventListener('touchstart', unlockCommentary);
+      window.removeEventListener('touchend', unlockCommentary);
       window.removeEventListener('keydown', unlockCommentary);
     };
   }, [unlockCommentary]);
@@ -1830,38 +1842,39 @@ export default function MurlanRoyaleArena({ search }) {
 
     if (!commentaryIntroPlayedRef.current) {
       commentaryIntroPlayedRef.current = true;
-      enqueueMurlanCommentary(
-        [
-          {
-            speaker: MURLAN_ROYALE_SPEAKERS.lead,
-            text: buildMurlanCommentaryLine({
-              event: 'intro',
-              speaker: MURLAN_ROYALE_SPEAKERS.lead,
-              language: activeCommentaryPreset?.language ?? commentaryPresetId,
-              context: { arena: 'Murlan Royale arena' }
-            })
-          },
-          {
-            speaker: MURLAN_ROYALE_SPEAKERS.analyst,
-            text: buildMurlanCommentaryLine({
-              event: 'introReply',
-              speaker: MURLAN_ROYALE_SPEAKERS.analyst,
-              language: activeCommentaryPreset?.language ?? commentaryPresetId,
-              context: { arena: 'Murlan Royale arena' }
-            })
-          },
-          {
-            speaker: MURLAN_ROYALE_SPEAKERS.lead,
-            text: buildMurlanCommentaryLine({
-              event: 'shuffle',
-              speaker: MURLAN_ROYALE_SPEAKERS.lead,
-              language: activeCommentaryPreset?.language ?? commentaryPresetId,
-              context: { arena: 'Murlan Royale arena' }
-            })
-          }
-        ],
-        { priority: true, preset: activeCommentaryPreset }
-      );
+      const [leadSpeaker, replySpeaker] = commentarySpeakers;
+      const introLines = [
+        {
+          speaker: leadSpeaker,
+          text: buildMurlanCommentaryLine({
+            event: 'intro',
+            speaker: leadSpeaker,
+            language: activeCommentaryPreset?.language ?? commentaryPresetId,
+            context: { arena: 'Murlan Royale arena', commentators: commentarySpeakers }
+          })
+        }
+      ];
+      if (replySpeaker && replySpeaker !== leadSpeaker) {
+        introLines.push({
+          speaker: replySpeaker,
+          text: buildMurlanCommentaryLine({
+            event: 'introReply',
+            speaker: replySpeaker,
+            language: activeCommentaryPreset?.language ?? commentaryPresetId,
+            context: { arena: 'Murlan Royale arena', commentators: commentarySpeakers }
+          })
+        });
+      }
+      introLines.push({
+        speaker: leadSpeaker,
+        text: buildMurlanCommentaryLine({
+          event: 'shuffle',
+          speaker: leadSpeaker,
+          language: activeCommentaryPreset?.language ?? commentaryPresetId,
+          context: { arena: 'Murlan Royale arena', commentators: commentarySpeakers }
+        })
+      });
+      enqueueMurlanCommentary(introLines, { priority: true, preset: activeCommentaryPreset });
     }
 
     if (gameState.lastActionId && gameState.lastActionId !== previousActionId) {
@@ -1913,6 +1926,7 @@ export default function MurlanRoyaleArena({ search }) {
     };
   }, [
     activeCommentaryPreset,
+    commentarySpeakers,
     commentaryPresetId,
     enqueueMurlanCommentary,
     enqueueMurlanCommentaryEvent,
@@ -3379,7 +3393,7 @@ export default function MurlanRoyaleArena({ search }) {
           <div className="pointer-events-none flex flex-col items-start gap-2">
             <button
               type="button"
-              onClick={() => setConfigOpen((prev) => !prev)}
+              onClick={handleToggleConfig}
               aria-expanded={configOpen}
               className={`pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-black/70 text-white shadow-lg backdrop-blur transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                 configOpen ? 'bg-black/60' : 'hover:bg-black/60'

--- a/webapp/src/utils/murlanRoyaleCommentary.js
+++ b/webapp/src/utils/murlanRoyaleCommentary.js
@@ -1,18 +1,42 @@
 export const MURLAN_ROYALE_SPEAKERS = Object.freeze({
-  lead: 'Mason',
-  analyst: 'Lena'
+  atlas: 'Atlas',
+  nova: 'Nova',
+  orion: 'Orion',
+  juno: 'Juno',
+  vega: 'Vega',
+  echo: 'Echo'
 });
 
 const SPEAKER_PROFILES = Object.freeze({
-  Mason: {
-    id: 'mason',
-    name: 'Mason',
+  Atlas: {
+    id: 'atlas',
+    name: 'Atlas',
     style: 'Play-by-play'
   },
-  Lena: {
-    id: 'lena',
-    name: 'Lena',
+  Nova: {
+    id: 'nova',
+    name: 'Nova',
     style: 'Color analyst'
+  },
+  Orion: {
+    id: 'orion',
+    name: 'Orion',
+    style: 'Tactician'
+  },
+  Juno: {
+    id: 'juno',
+    name: 'Juno',
+    style: 'Momentum reader'
+  },
+  Vega: {
+    id: 'vega',
+    name: 'Vega',
+    style: 'Precision caller'
+  },
+  Echo: {
+    id: 'echo',
+    name: 'Echo',
+    style: 'Hype specialist'
   }
 });
 
@@ -294,18 +318,23 @@ const resolveLanguageKey = (language = 'en') => {
 
 export const buildMurlanCommentaryLine = ({
   event,
-  speaker = MURLAN_ROYALE_SPEAKERS.analyst,
+  speaker = MURLAN_ROYALE_SPEAKERS.atlas,
   language = 'en',
   context = {}
 }) => {
   const templates = LOCALIZED_TEMPLATES[resolveLanguageKey(language)] || ENGLISH_TEMPLATES;
+  const commentators = Array.isArray(context.commentators) && context.commentators.length
+    ? context.commentators
+    : [speaker];
+  const partner =
+    commentators.length > 1
+      ? commentators.find((name) => name !== speaker) ?? commentators[0]
+      : context.partner ?? 'the desk';
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,
     speaker,
-    partner: speaker === MURLAN_ROYALE_SPEAKERS.lead
-      ? MURLAN_ROYALE_SPEAKERS.analyst
-      : MURLAN_ROYALE_SPEAKERS.lead
+    partner
   };
 
   const eventPool = templates.common[EVENT_POOLS[event]] || templates.common.play;
@@ -315,7 +344,7 @@ export const buildMurlanCommentaryLine = ({
 
 export const createMurlanMatchCommentaryScript = ({
   players = { A: 'Player A', B: 'Player B' },
-  commentators = [MURLAN_ROYALE_SPEAKERS.analyst],
+  commentators = [MURLAN_ROYALE_SPEAKERS.atlas, MURLAN_ROYALE_SPEAKERS.nova],
   language = 'en',
   scoreline = 'level at 0-0'
 } = {}) => {
@@ -323,7 +352,8 @@ export const createMurlanMatchCommentaryScript = ({
   const context = {
     player: players.A,
     opponent: players.B,
-    scoreline
+    scoreline,
+    commentators
   };
 
   const script = [


### PR DESCRIPTION
### Motivation
- Fix missing/unstable voice commentary playback and make the commentary options UI expose distinct character voices instead of duplicate female voices.
- Provide multiple, clearly different commentator characters so users can pick varied timbres and speaking styles.

### Description
- Replaced the old two-speaker mapping with a roster of six named characters and kept the original English duo as a preset, by editing `MURLAN_ROYALE_SPEAKERS` and `SPEAKER_PROFILES` in `webapp/src/utils/murlanRoyaleCommentary.js`.
- Added new commentary presets and per-preset `commentators` lists and `voiceHints`, and moved the default speaker to `atlas`; updated `speakerSettings` for each preset in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Updated speaker selection and partner resolution so `buildMurlanCommentaryLine` and the intro sequencing use the preset `commentators` list (supporting single or duo commentators), and changed default partner fallback from "the booth" to "the desk".
- Improved unlock/reliability by calling `unlockCommentary` when opening the table config, adding a `touchend` unlock listener, and wiring the config button to `handleToggleConfig` so user interactions reliably prime Web Speech on mobile/Telegram.

Files changed: `webapp/src/utils/murlanRoyaleCommentary.js`, `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app (server reported ready). (succeeded)
- Ran a Playwright script that opened `http://127.0.0.1:4173/games/murlanroyale`, toggled the settings, and captured a screenshot at `artifacts/murlan-commentary-options.png` to verify the new commentary options UI (succeeded).
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764e3c9e948329b53371aaef9c5ebc)