### PR TITLE
Pool Royale: tighten chrome plates, set 45° side-cut physics, and improve ball-in-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -131,7 +131,7 @@ function applyTablePhysicsSpec(meta) {
       : DEFAULT_SIDE_CUSHION_CUT_ANGLE;
   SIDE_CUSHION_CUT_ANGLE = sideCushionAngle;
   SIDE_POCKET_PHYSICS_CUT_ANGLE = clamp(
-    SIDE_CUSHION_CUT_ANGLE + 7,
+    SIDE_CUSHION_CUT_ANGLE,
     MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE,
     MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE
   );
@@ -611,7 +611,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to r
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.982; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0; // keep the middle fascia centered so trims remove evenly from inside and outside edges
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.06; // pull the middle chrome plates slightly toward table center while keeping the rounded cut position unchanged
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.095; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
@@ -1570,10 +1570,10 @@ const SPIN_DECORATION_OFFSET_PERCENT = 58;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets
-const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
-const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 32;
-const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 38;
-const DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE = 34;
+const DEFAULT_SIDE_CUSHION_CUT_ANGLE = VISUAL_SIDE_CUSHION_CUT_ANGLE;
+const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 45;
+const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 45;
+const DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE = VISUAL_SIDE_CUSHION_CUT_ANGLE;
 const VISUAL_SIDE_CUSHION_CUT_ANGLE = 45;
 const SIDE_POCKET_CUT_ANGLE_DEG = VISUAL_SIDE_CUSHION_CUT_ANGLE;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
@@ -20180,6 +20180,45 @@ const powerRef = useRef(hud.power);
         }
         return clamped;
       };
+      const resolveInHandPlacement = (
+        point,
+        { clearanceMultiplier = 2.05, maxRadius = BALL_R * 3.2 } = {}
+      ) => {
+        const clamped = clampInHandPosition(point);
+        if (!clamped) return null;
+        if (isSpotFree(clamped, clearanceMultiplier)) return clamped;
+        const step = Math.max(BALL_R * 0.35, 0.002);
+        const ringCount = Math.max(1, Math.ceil(maxRadius / step));
+        const angleSteps = 16;
+        let best = null;
+        let bestClearance = -Infinity;
+        for (let ring = 1; ring <= ringCount; ring += 1) {
+          const radius = step * ring;
+          for (let i = 0; i < angleSteps; i += 1) {
+            const angle = (Math.PI * 2 * i) / angleSteps;
+            TMP_VEC2_A.set(
+              clamped.x + Math.cos(angle) * radius,
+              clamped.y + Math.sin(angle) * radius
+            );
+            const candidate = clampInHandPosition(TMP_VEC2_A);
+            if (!candidate) continue;
+            if (isSpotFree(candidate, clearanceMultiplier)) {
+              return candidate;
+            }
+            let minDist = Infinity;
+            for (const ball of balls) {
+              if (!ball.active || ball === cue) continue;
+              const dist = candidate.distanceTo(ball.pos);
+              if (dist < minDist) minDist = dist;
+            }
+            if (minDist > bestClearance) {
+              bestClearance = minDist;
+              best = candidate.clone();
+            }
+          }
+        }
+        return best;
+      };
       const defaultInHandPosition = () =>
         clampInHandPosition(
           new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
@@ -20204,24 +20243,23 @@ const powerRef = useRef(hud.power);
       const tryUpdatePlacement = (raw, commit = false) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand)) return false;
-        const clamped = clampInHandPosition(raw);
+        const clamped = resolveInHandPlacement(raw);
         if (!clamped) return false;
-        if (!isSpotFree(clamped)) return false;
         cue.active = false;
         updateCuePlacement(clamped);
         inHandDrag.lastPos = clamped;
-      if (commit) {
-        cue.active = true;
-        inHandDrag.lastPos = null;
-        cueBallPlacedFromHandRef.current = true;
-        if (hudRef.current?.inHand) {
-          const nextHud = { ...hudRef.current, inHand: false };
-          hudRef.current = nextHud;
-          setHud(nextHud);
+        if (commit) {
+          cue.active = true;
+          inHandDrag.lastPos = null;
+          cueBallPlacedFromHandRef.current = true;
+          if (hudRef.current?.inHand) {
+            const nextHud = { ...hudRef.current, inHand: false };
+            hudRef.current = nextHud;
+            setHud(nextHud);
+          }
         }
-      }
-      return true;
-    };
+        return true;
+      };
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
         const forwardBias = Math.max(baulkZ - BALL_R * 0.6, -PLAY_H / 2 + BALL_R);
@@ -20293,10 +20331,10 @@ const powerRef = useRef(hud.power);
         for (const clearance of clearanceLevels) {
           for (const group of candidateGroups) {
             for (const raw of group) {
-              const clamped = clampInHandPosition(raw);
-              if (!clamped) continue;
-              if (!isSpotFree(clamped, clearance)) continue;
-              return clamped;
+              const resolved = resolveInHandPlacement(raw, {
+                clearanceMultiplier: clearance
+              });
+              if (resolved) return resolved;
             }
           }
         }
@@ -20335,12 +20373,11 @@ const powerRef = useRef(hud.power);
                 offset.set(1, 0);
               }
               offset.setLength(BALL_R * 2.05);
-              const nudged = clampInHandPosition(
-                nearest.pos.clone().add(offset)
+              const nudged = resolveInHandPlacement(
+                nearest.pos.clone().add(offset),
+                { clearanceMultiplier: 2.02 }
               );
-              if (nudged && isSpotFree(nudged, 2.02)) {
-                return nudged;
-              }
+              if (nudged) return nudged;
             }
             const searchDirs = [
               [1, 0],
@@ -20359,11 +20396,10 @@ const powerRef = useRef(hud.power);
                 TMP_VEC2_A.copy(best);
                 TMP_VEC2_A.x += dx * stepSize * stepIdx;
                 TMP_VEC2_A.y += dz * stepSize * stepIdx;
-                const candidate = clampInHandPosition(TMP_VEC2_A);
-                if (!candidate) continue;
-                if (isSpotFree(candidate, 2.02)) {
-                  return candidate;
-                }
+                const candidate = resolveInHandPlacement(TMP_VEC2_A, {
+                  clearanceMultiplier: 2.02
+                });
+                if (candidate) return candidate;
               }
             }
           } else {
@@ -20373,14 +20409,23 @@ const powerRef = useRef(hud.power);
         const fallback = allowFullTableInHand()
           ? defaultInHandPosition()
           : clampInHandPosition(new THREE.Vector2(0, forwardBias));
-        if (fallback && isSpotFree(fallback, 2.0)) {
-          return fallback;
-        }
+        const fallbackResolved = resolveInHandPlacement(fallback, {
+          clearanceMultiplier: 2.0,
+          maxRadius: BALL_R * 4
+        });
+        if (fallbackResolved) return fallbackResolved;
         const baulkCenter = defaultInHandPosition();
-        if (baulkCenter && isSpotFree(baulkCenter, 2.0)) {
-          return baulkCenter;
-        }
-        return null;
+        const baulkResolved = resolveInHandPlacement(baulkCenter, {
+          clearanceMultiplier: 2.0,
+          maxRadius: BALL_R * 4
+        });
+        if (baulkResolved) return baulkResolved;
+        return resolveInHandPlacement(
+          allowFullTableInHand()
+            ? new THREE.Vector2(0, 0)
+            : new THREE.Vector2(0, baulkZ),
+          { clearanceMultiplier: 1.7, maxRadius: BALL_R * 5 }
+        );
       };
       const autoPlaceAiCueBall = () => {
         const currentHud = hudRef.current;
@@ -27168,7 +27213,7 @@ const powerRef = useRef(hud.power);
             </span>
           </div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
-            Tap and hold, then slide to place
+            Tap or drag to place
           </span>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Fix pocket geometry so middle chrome plates sit slightly inward while pocket rounded cuts and jaws remain aligned for more realistic visuals and collisions.
- Remap the side-pocket / cushion cut logic to use a consistent 45° physics cut so side-pocket cushion reflections behave predictably and match visual guidance.
- Provide a robust, mobile-friendly ball-in-hand placement flow that snaps to the nearest legal spot for both player and AI, eliminating frozen/blocked placements and improving precision on portrait screens.

### Description
- Pulled middle chrome plates slightly toward the table centre by changing `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `0` to `-0.06` in `webapp/src/pages/Games/PoolRoyale.jsx` so chrome visually hugs the rail while keeping rounded cuts unchanged.
- Aligned side-pocket cushion physics to 45° by updating constants: set `DEFAULT_SIDE_CUSHION_CUT_ANGLE` and `DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE` to `VISUAL_SIDE_CUSHION_CUT_ANGLE` and clamped `MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE`/`MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE` to `45`; updated `applyTablePhysicsSpec` to map `SIDE_POCKET_PHYSICS_CUT_ANGLE` to `SIDE_CUSHION_CUT_ANGLE` (removed the previous +7° offset).
- Implemented `resolveInHandPlacement` to robustly find the nearest legal cue-ball placement by sampling concentric rings around the requested point and returning the best-clearance candidate; integrated this into player placement (`tryUpdatePlacement`) and AI placement (`findAiInHandPlacement` / `autoPlaceAiCueBall`) so both use the same snap/resolution logic.
- Improved on-screen guidance text for ball-in-hand to be mobile-friendly by changing the instruction from `Tap and hold, then slide to place` to `Tap or drag to place`.
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` (pocket geometry constants, physics mapping, and the in-hand placement logic/UI string).

### Testing
- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported the server as ready (`Local: http://localhost:4173/`). Outcome: success.
- Loaded the Pool Royale page and captured a visual smoke test via Playwright with a headful page visit and screenshot; the script completed and produced `artifacts/poolroyale.png`. Outcome: success.
- No unit test suite (e.g. `npm test`/`jest`) or automated physics regression tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697650ca10d48329bea59c82b68eec7b)