### PR TITLE
Enhance snooker cue follow-through visibility

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -20869,10 +20869,13 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(startPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
+          const baseFollowThrough = BALL_R * 0.16;
           const followThroughPull = THREE.MathUtils.clamp(
-            topSpinWeight * clampedPower * BALL_R * 0.35,
-            0,
-            BALL_R * 0.35
+            baseFollowThrough +
+              clampedPower * BALL_R * 0.2 +
+              topSpinWeight * clampedPower * BALL_R * 0.35,
+            BALL_R * 0.12,
+            BALL_R * 0.5
           );
           const impactPos = buildCuePosition(-followThroughPull);
           cueStick.visible = true;


### PR DESCRIPTION
### Motivation
- Make the cue stick forward stroke more visible and obvious during player shots, AI shots and replay playback by increasing and scaling the follow-through distance.

### Description
- Adjust the follow-through computation in `webapp/src/pages/Games/SnookerRoyal.jsx` to introduce a `baseFollowThrough`, add a `clampedPower` contribution and scale with `topSpinWeight`, then clamp `followThroughPull` to a larger min/max range so forward strokes are noticeably longer and clearer in all contexts.

### Testing
- No automated tests were executed for this visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765365f9d08329a7eea3f4db429542)