### PR TITLE
Align roulette wheel to pointer

### DIFF
--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -68,6 +68,7 @@ const RED_NUMBERS = new Set([
 
 const SEGMENT_ANGLE = 360 / ROULETTE_ORDER.length;
 const LABEL_OFFSET_ANGLE = -90 + SEGMENT_ANGLE / 2;
+const WHEEL_ROTATION_OFFSET = 90;
 const PRIZE_MAP = ROULETTE_ORDER.reduce((acc, value) => {
   if (value === 0) acc[value] = 5000;
   else acc[value] = value * 100;
@@ -99,7 +100,10 @@ export default function RouletteMini() {
     return null;
   }
 
-  const [spinState, setSpinState] = useState({ totalSpins: 0, rotation: 0 });
+  const [spinState, setSpinState] = useState({
+    totalSpins: 0,
+    rotation: WHEEL_ROTATION_OFFSET,
+  });
   const [spinning, setSpinning] = useState(false);
   const [outcome, setOutcome] = useState(null);
   const [showAd, setShowAd] = useState(false);
@@ -186,7 +190,10 @@ export default function RouletteMini() {
     const extraSpins = Math.floor(Math.random() * 3) + 4;
     const totalSpins = spinState.totalSpins + extraSpins;
     const rotation =
-      -totalSpins * 360 - index * SEGMENT_ANGLE - SEGMENT_ANGLE / 2;
+      WHEEL_ROTATION_OFFSET -
+      totalSpins * 360 -
+      index * SEGMENT_ANGLE -
+      SEGMENT_ANGLE / 2;
 
     setSpinning(true);
     setOutcome(null);


### PR DESCRIPTION
### Motivation
- Make the roulette wheel visual match the pointer: the 0 segment should sit under the triangle at rest and the winning segment should land under the triangle when the spin finishes.

### Description
- Add `WHEEL_ROTATION_OFFSET` and initialize `spinState.rotation` to `WHEEL_ROTATION_OFFSET` so the wheel starts aligned with the pointer.
- Apply `WHEEL_ROTATION_OFFSET` to the spin `rotation` calculation so the computed final rotation positions the selected `ROULETTE_ORDER` segment under the triangle.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` (Vite reported ready) — succeeded.
- Ran an automated Playwright script that opened `/mining` and captured `artifacts/roulette-mining.png` to verify the wheel alignment visually — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765480fa448329975362073a5b4fac)