### PR TITLE
Add Hindi, Chinese and Russian commentary presets for Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -732,6 +732,111 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     }
   },
   {
+    id: 'saffron-table',
+    label: 'Indian Table',
+    description: 'Hindi commentary with lively pacing',
+    language: 'hi',
+    voiceHints: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'male',
+        'Raj',
+        'Amit',
+        'Arjun',
+        'en-IN',
+        'English',
+        'male',
+        'Ravi',
+        'Prakash'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'female',
+        'Asha',
+        'Priya',
+        'Neha',
+        'en-IN',
+        'English',
+        'female',
+        'Sneha'
+      ]
+    },
+    speakerSettings: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.06, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 }
+    }
+  },
+  {
+    id: 'mandarin-glow',
+    label: 'Chinese Broadcast',
+    description: 'Mandarin booth with crisp calls',
+    language: 'zh',
+    voiceHints: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: [
+        'zh-CN',
+        'zh',
+        'Chinese',
+        'male',
+        'Li',
+        'Wei',
+        'Chen',
+        'Microsoft Huihui',
+        'Microsoft Kangkang'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+        'zh-CN',
+        'zh',
+        'Chinese',
+        'female',
+        'Mei',
+        'Xia',
+        'Lin',
+        'Microsoft Yaoyao',
+        'Microsoft Xiaoxiao'
+      ]
+    },
+    speakerSettings: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+    }
+  },
+  {
+    id: 'moscow-mics',
+    label: 'Russian Booth',
+    description: 'Russian commentary with steady cadence',
+    language: 'ru',
+    voiceHints: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'male',
+        'Dmitri',
+        'Ivan',
+        'Sergey',
+        'Alexey'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.analyst]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'female',
+        'Anna',
+        'Svetlana',
+        'Irina',
+        'Olga'
+      ]
+    },
+    speakerSettings: {
+      [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 }
+    }
+  },
+  {
     id: 'latin-pulse',
     label: 'Latin Pulse',
     description: 'Spanish play-by-play with lively color',

--- a/webapp/src/utils/murlanRoyaleCommentary.js
+++ b/webapp/src/utils/murlanRoyaleCommentary.js
@@ -181,6 +181,29 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       outro: ['{arena} से इतना ही, देखने के लिए धन्यवाद।']
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Добро пожаловать на {arena}. {speaker} и {partner}. {player} против {opponent}.'],
+      introReply: ['Спасибо, {speaker}. Темп и комбинации решат эту раздачу.'],
+      shuffle: ['Раздача завершена, начинаем.'],
+      firstMove: ['{player} открывает комбинацией {combo}.'],
+      play: ['{player} играет {combo} и держит давление.'],
+      pass: ['{player} пасует, темп у {opponent}.'],
+      single: ['{player} контролирует темп с {combo}.'],
+      pair: ['{player} показывает пару: {combo}.'],
+      trips: ['{player} выкладывает сет: {combo}.'],
+      straight: ['У {player} стрит: {combo}.'],
+      flush: ['{player} кладет флеш: {combo}.'],
+      fullHouse: ['{player} собирает фул-хаус.'],
+      straightFlush: ['Стрит-флеш! {player} берет контроль.'],
+      bomb: ['Бомба на столе! {player} с {combo}.'],
+      clearTable: ['Стол очищен, лидирует {player}.'],
+      close: ['У {player} осталось {cardsLeft} карт.'],
+      win: ['{player} выходит из карт и выигрывает.'],
+      outro: ['С {arena} на этом всё, спасибо за игру.']
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -284,6 +307,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';


### PR DESCRIPTION
### Motivation
- Provide additional commentary language options (Russian, Hindi/Indian, Chinese/Mandarin) so Murlan Royale can present localized voice commentary and templates.

### Description
- Added three new commentary presets in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (`saffron-table` for Hindi, `mandarin-glow` for Chinese, and `moscow-mics` for Russian) with `language`, `voiceHints`, and `speakerSettings` entries.
- Added Russian localized templates to `webapp/src/utils/murlanRoyaleCommentary.js` and included `ru` in the `LOCALIZED_TEMPLATES` mapping.
- Extended the language resolution function `resolveLanguageKey` to recognize `ru` so Russian templates are selected when requested.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` which reported Vite ready and served the site on `http://localhost:4173/` (succeeded). 
- Executed an automated Playwright script that navigated to `/games/murlanroyale`, interacted with the commentary controls and produced a screenshot at `artifacts/murlan-commentary.png` (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976653559d883298ea0ab9f801b6e07)