### PR TITLE
Improve Murlan Royale commentary: multi‑speaker presets, localization and better voice selection

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -664,11 +664,40 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Hazel',
         'Kate',
         'Emma'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'en-AU',
+        'en-US',
+        'English',
+        'male',
+        'James',
+        'Liam',
+        'Ryan'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'en-US',
+        'en-GB',
+        'English',
+        'female',
+        'Ava',
+        'Chloe',
+        'Samantha'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'en-US',
+        'English',
+        'male',
+        'Nathan',
+        'Brian',
+        'Christopher'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.94, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.12, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -694,11 +723,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Asha',
         'Priya',
         'Neha'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'male',
+        'Ravi',
+        'Kiran',
+        'Vikram'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'female',
+        'Anaya',
+        'Rani',
+        'Deepa'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'male',
+        'Sanjay',
+        'Ayaan',
+        'Manish'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.06, pitch: 1.02, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.96, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.12, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1.02, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -709,6 +768,8 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
     voiceHints: {
       [MURLAN_ROYALE_SPEAKERS.lead]: [
         'zh-CN',
+        'zh-TW',
+        'zh-HK',
         'zh',
         'Chinese',
         'male',
@@ -720,6 +781,8 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       ],
       [MURLAN_ROYALE_SPEAKERS.analyst]: [
         'zh-CN',
+        'zh-TW',
+        'zh-HK',
         'zh',
         'Chinese',
         'female',
@@ -728,11 +791,50 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Lin',
         'Microsoft Yaoyao',
         'Microsoft Xiaoxiao'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'zh-CN',
+        'zh-TW',
+        'zh-HK',
+        'zh',
+        'Chinese',
+        'male',
+        'Jun',
+        'Tao',
+        'Lei',
+        'Microsoft Yunxi'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'zh-CN',
+        'zh-TW',
+        'zh-HK',
+        'zh',
+        'Chinese',
+        'female',
+        'Lan',
+        'Qian',
+        'Min',
+        'Microsoft Xiaohan'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'zh-CN',
+        'zh-TW',
+        'zh-HK',
+        'zh',
+        'Chinese',
+        'male',
+        'Bo',
+        'Hao',
+        'Sheng',
+        'Microsoft Yunyang'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 1, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.1, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -760,11 +862,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Svetlana',
         'Irina',
         'Olga'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'male',
+        'Maksim',
+        'Nikolai',
+        'Yuri'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'female',
+        'Daria',
+        'Elena',
+        'Polina'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'male',
+        'Igor',
+        'Pavel',
+        'Roman'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.94, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.08, pitch: 1.08, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.96, volume: 1 }
     }
   },
   {
@@ -790,11 +922,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Isabella',
         'Lucia',
         'Camila'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'male',
+        'Diego',
+        'Sergio',
+        'Andres'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'female',
+        'Valeria',
+        'Mariana',
+        'Paula'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'male',
+        'Rafael',
+        'Javier',
+        'Mateo'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.05, pitch: 1, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.1, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.96, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.12, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1.02, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -818,11 +980,38 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Amelie',
         'Marie',
         'Charlotte'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'fr-FR',
+        'French',
+        'male',
+        'Julien',
+        'Antoine',
+        'Romain'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'fr-FR',
+        'French',
+        'female',
+        'Camille',
+        'Manon',
+        'Elise'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'fr-FR',
+        'French',
+        'male',
+        'Lucas',
+        'Thomas',
+        'Nicolas'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 0.98, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.96, pitch: 0.94, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.08, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -840,31 +1029,57 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Omar',
         'Khalid',
         'Hassan',
-        'en-US',
-        'English',
-        'male',
-        'David',
-        'Alex'
+        'Youssef',
+        'Mahmoud'
       ],
       [MURLAN_ROYALE_SPEAKERS.analyst]: [
         'ar-SA',
         'ar-EG',
         'ar',
         'Arabic',
+        'female',
+        'Layla',
+        'Mona',
+        'Nour',
+        'Hala'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
         'male',
-        'Omar',
-        'Khalid',
-        'Hassan',
-        'en-GB',
-        'English',
+        'Fadi',
+        'Rami',
+        'Tariq'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
+        'female',
+        'Sara',
+        'Salma',
+        'Yara'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
         'male',
-        'Guy',
-        'Daniel'
+        'Ziad',
+        'Karim',
+        'Adel'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.94, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.1, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -886,15 +1101,45 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'sq-AL',
         'sq',
         'Albanian',
+        'female',
+        'Bora',
+        'Elira',
+        'Arlinda'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
         'male',
-        'Besar',
+        'Kreshnik',
+        'Altin',
+        'Luan'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'female',
+        'Era',
+        'Jonida',
+        'Flora'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.sideline]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'male',
+        'Blerim',
         'Erion',
         'Gent'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.98, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.96, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.96, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.94, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.08, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.sideline]: { rate: 1, pitch: 0.98, volume: 1 }
     }
   }
 ]);
@@ -1857,7 +2102,13 @@ export default function MurlanRoyaleArena({ search }) {
   );
   const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
   const commentarySpeakers = useMemo(
-    () => [MURLAN_ROYALE_SPEAKERS.lead, MURLAN_ROYALE_SPEAKERS.analyst],
+    () => [
+      MURLAN_ROYALE_SPEAKERS.lead,
+      MURLAN_ROYALE_SPEAKERS.analyst,
+      MURLAN_ROYALE_SPEAKERS.tactician,
+      MURLAN_ROYALE_SPEAKERS.hype,
+      MURLAN_ROYALE_SPEAKERS.sideline
+    ],
     []
   );
   const pickCommentarySpeaker = useCallback(() => {

--- a/webapp/src/utils/murlanRoyaleCommentary.js
+++ b/webapp/src/utils/murlanRoyaleCommentary.js
@@ -1,6 +1,9 @@
 export const MURLAN_ROYALE_SPEAKERS = Object.freeze({
   lead: 'Mason',
-  analyst: 'Lena'
+  analyst: 'Lena',
+  tactician: 'Kai',
+  hype: 'Zara',
+  sideline: 'Omar'
 });
 
 const SPEAKER_PROFILES = Object.freeze({
@@ -13,6 +16,21 @@ const SPEAKER_PROFILES = Object.freeze({
     id: 'lena',
     name: 'Lena',
     style: 'Color analyst'
+  },
+  Kai: {
+    id: 'kai',
+    name: 'Kai',
+    style: 'Tactical analyst'
+  },
+  Zara: {
+    id: 'zara',
+    name: 'Zara',
+    style: 'Hype caster'
+  },
+  Omar: {
+    id: 'omar',
+    name: 'Omar',
+    style: 'Sideline reporter'
   }
 });
 
@@ -96,31 +114,52 @@ const LOCALIZED_DEFAULT_CONTEXT = Object.freeze({
 const LOCALIZED_SPEAKERS = Object.freeze({
   zh: {
     Mason: '梅森',
-    Lena: '莉娜'
+    Lena: '莉娜',
+    Kai: '凯',
+    Zara: '扎拉',
+    Omar: '奥马尔'
   },
   hi: {
     Mason: 'मोहन',
-    Lena: 'लीना'
+    Lena: 'लीना',
+    Kai: 'काई',
+    Zara: 'ज़ारा',
+    Omar: 'ओमर'
   },
   ru: {
     Mason: 'Мейсон',
-    Lena: 'Лена'
+    Lena: 'Лена',
+    Kai: 'Кай',
+    Zara: 'Зара',
+    Omar: 'Омар'
   },
   es: {
     Mason: 'Mason',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Zara: 'Zara',
+    Omar: 'Omar'
   },
   fr: {
     Mason: 'Mason',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Zara: 'Zara',
+    Omar: 'Omar'
   },
   ar: {
     Mason: 'ميسون',
-    Lena: 'لينا'
+    Lena: 'لينا',
+    Kai: 'كاي',
+    Zara: 'زارا',
+    Omar: 'عمر'
   },
   sq: {
     Mason: 'Mejson',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Zara: 'Zara',
+    Omar: 'Omar'
   }
 });
 
@@ -150,82 +189,100 @@ const ENGLISH_TEMPLATES = Object.freeze({
     intro: [
       'Welcome to {arena}. {speaker} with {partner} as {player} meets {opponent} in Murlan Royale.',
       'Live from {arena}. {speaker} alongside {partner} for tonight’s Murlan Royale showdown.',
-      '{speaker} on the call at {arena}. {player} versus {opponent}, and the tempo is about to spike.'
+      '{speaker} on the call at {arena}. {player} versus {opponent}, and the tempo is about to spike.',
+      'The lights are bright at {arena}. {speaker} with {partner}, and this hand is ready to explode.'
     ],
     introReply: [
       'Thanks {speaker}. Combo selection and tempo control will shape this hand.',
       'Great to be here, {speaker}. Watch the timing on bombs and the race to shed cards.',
-      'Absolutely, {speaker}. Disciplined passes and clean combos decide the edge.'
+      'Absolutely, {speaker}. Disciplined passes and clean combos decide the edge.',
+      'Could not be more excited, {speaker}. One fearless run can flip everything.'
     ],
     shuffle: [
       'Cards are in the air; opening hands are set.',
       'The deal is done. Let us see who claims the first lead.',
-      'Hands are live and the table is ready.'
+      'Hands are live and the table is ready.',
+      'Listen to that buzz—cards are live and the pressure is on.'
     ],
     firstMove: [
       '{player} opens with {combo}, setting the rhythm early.',
       'First lead belongs to {player} with {combo}.',
-      '{player} starts the action with {combo}.'
+      '{player} starts the action with {combo}.',
+      'What a confident opener from {player}: {combo}.'
     ],
     play: [
       '{player} plays {combo} and keeps the pressure on.',
       '{player} lays down {combo} with composed timing.',
-      'A confident play from {player}: {combo}.'
+      'A confident play from {player}: {combo}.',
+      '{player} fires {combo} and the crowd reacts.'
     ],
     pass: [
       '{player} passes and yields the tempo.',
       '{player} takes the pass; the table stays with {opponent}.',
-      '{player} lets it go—discipline over risk.'
+      '{player} lets it go—discipline over risk.',
+      'A careful pass from {player}; patience under pressure.'
     ],
     single: [
       '{player} drops {combo} to manage the pace.',
-      '{player} checks the tempo with {combo}.'
+      '{player} checks the tempo with {combo}.',
+      '{player} steadies the table with {combo}.'
     ],
     pair: [
       '{player} pairs up with {combo}.',
-      '{player} shows a pair: {combo}.'
+      '{player} shows a pair: {combo}.',
+      '{player} snaps out a pair and leans in.'
     ],
     trips: [
       '{player} rolls out trips—{combo}.',
-      '{player} commands the table with trips: {combo}.'
+      '{player} commands the table with trips: {combo}.',
+      'Trips on the felt! {player} with {combo}.'
     ],
     straight: [
       '{player} strings a straight: {combo}.',
-      'Straight down—{player} with {combo}.'
+      'Straight down—{player} with {combo}.',
+      'A smooth straight from {player}, {combo} on display.'
     ],
     flush: [
       '{player} delivers a flush and tightens control.',
-      'Flush on the felt—{player} with {combo}.'
+      'Flush on the felt—{player} with {combo}.',
+      '{player} flashes a flush and the tempo jumps.'
     ],
     fullHouse: [
       '{player} locks in a full house.',
-      'Full house played by {player}.'
+      'Full house played by {player}.',
+      '{player} slams a full house—what a moment.'
     ],
     straightFlush: [
       'Straight flush! {player} takes command.',
-      '{player} lands a straight flush and turns the hand.'
+      '{player} lands a straight flush and turns the hand.',
+      'A jaw-dropping straight flush from {player}!'
     ],
     bomb: [
       'Bomb on the table—{player} detonates {combo}.',
-      '{player} drops the bomb and swings the momentum.'
+      '{player} drops the bomb and swings the momentum.',
+      'Boom! {player} detonates {combo} and the arena erupts.'
     ],
     clearTable: [
       'The table clears. {player} takes the lead.',
-      'Reset on the table; {player} has control.'
+      'Reset on the table; {player} has control.',
+      'Clean sweep—{player} owns the tempo now.'
     ],
     close: [
       '{player} is down to {cardsLeft} cards—finish line in sight.',
-      '{player} has {cardsLeft} left; the endgame is near.'
+      '{player} has {cardsLeft} left; the endgame is near.',
+      '{player} is almost home with {cardsLeft} cards left.'
     ],
     win: [
       '{player} is out of cards and wins the hand.',
       '{player} closes it out—hand secured.',
-      '{player} finishes the run and takes the hand.'
+      '{player} finishes the run and takes the hand.',
+      'It is done! {player} clears the hand with authority.'
     ],
     outro: [
       'That wraps it up from {arena}. Thanks for joining us.',
       'From {arena}, that is full time. A sharp Murlan Royale battle.',
-      'A professional finish in {round}. Thanks for watching.'
+      'A professional finish in {round}. Thanks for watching.',
+      'That was a roller coaster from {arena}. Appreciate you staying with us.'
     ]
   }
 });
@@ -235,24 +292,78 @@ const LOCALIZED_TEMPLATES = Object.freeze({
   zh: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['欢迎来到{arena}。{speaker}与{partner}为您解说，{player}对阵{opponent}。'],
-      introReply: ['谢谢{speaker}。组合选择与节奏控制将决定胜负。'],
-      shuffle: ['发牌结束，比赛开始。'],
-      firstMove: ['{player}率先出牌：{combo}。'],
-      play: ['{player}打出{combo}，继续施压。'],
-      pass: ['{player}选择过牌，节奏让给{opponent}。'],
-      single: ['{player}出{combo}，稳住节奏。'],
-      pair: ['{player}亮出对子：{combo}。'],
-      trips: ['{player}打出三条：{combo}。'],
-      straight: ['{player}连顺：{combo}。'],
-      flush: ['{player}同花上桌：{combo}。'],
-      fullHouse: ['{player}打出葫芦。'],
-      straightFlush: ['同花顺！{player}掌控局面。'],
-      bomb: ['炸弹登场！{player}打出{combo}。'],
-      clearTable: ['桌面清空，{player}继续领先。'],
-      close: ['{player}只剩{cardsLeft}张牌。'],
-      win: ['{player}出完手牌，赢下本局。'],
-      outro: ['{arena}的比赛到此结束，感谢观看。']
+      intro: [
+        '欢迎来到{arena}。{speaker}与{partner}为您解说，{player}对阵{opponent}。',
+        '灯光聚焦{arena}！{speaker}联手{partner}，Murlan Royale大战开打。'
+      ],
+      introReply: [
+        '谢谢{speaker}。组合选择与节奏控制将决定胜负。',
+        '期待值拉满，{speaker}。一波连出就能改写局势。'
+      ],
+      shuffle: [
+        '发牌结束，比赛开始。',
+        '手牌已就位，气氛升温。'
+      ],
+      firstMove: [
+        '{player}率先出牌：{combo}。',
+        '漂亮的开局！{player}先手出{combo}。'
+      ],
+      play: [
+        '{player}打出{combo}，继续施压。',
+        '{player}果断出{combo}，节奏拉满。'
+      ],
+      pass: [
+        '{player}选择过牌，节奏让给{opponent}。',
+        '{player}稳住心态，暂时让出节奏。'
+      ],
+      single: [
+        '{player}出{combo}，稳住节奏。',
+        '{player}用{combo}调整步调。'
+      ],
+      pair: [
+        '{player}亮出对子：{combo}。',
+        '{player}对子出击，气势到位。'
+      ],
+      trips: [
+        '{player}打出三条：{combo}。',
+        '三条落桌！{player}火力全开。'
+      ],
+      straight: [
+        '{player}连顺：{combo}。',
+        '{player}顺子成型，观众沸腾。'
+      ],
+      flush: [
+        '{player}同花上桌：{combo}。',
+        '{player}同花成型，局面升温。'
+      ],
+      fullHouse: [
+        '{player}打出葫芦。',
+        '{player}满堂红到位！'
+      ],
+      straightFlush: [
+        '同花顺！{player}掌控局面。',
+        '惊艳同花顺！{player}直接接管比赛。'
+      ],
+      bomb: [
+        '炸弹登场！{player}打出{combo}。',
+        '轰！{player}炸弹爆发，气氛炸裂。'
+      ],
+      clearTable: [
+        '桌面清空，{player}继续领先。',
+        '清台成功，{player}掌控节奏。'
+      ],
+      close: [
+        '{player}只剩{cardsLeft}张牌。',
+        '{player}距离收官只差{cardsLeft}张。'
+      ],
+      win: [
+        '{player}出完手牌，赢下本局。',
+        '胜利到手！{player}干净利落拿下。'
+      ],
+      outro: [
+        '{arena}的比赛到此结束，感谢观看。',
+        '精彩落幕，我们下场再见！'
+      ]
     }
   },
   hi: {
@@ -350,47 +461,155 @@ const LOCALIZED_TEMPLATES = Object.freeze({
   ar: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['مرحبًا بكم في {arena}. معكم {speaker} و{partner}. {player} ضد {opponent}.'],
-      introReply: ['شكرًا {speaker}. اختيار التركيبات وإدارة الإيقاع سيحسمان اليد.'],
-      shuffle: ['تم توزيع الأوراق، لنبدأ.'],
-      firstMove: ['{player} يبدأ بـ {combo}.'],
-      play: ['{player} يلعب {combo} ويحافظ على الضغط.'],
-      pass: ['{player} يمرر ويترك الإيقاع لـ {opponent}.'],
-      single: ['{player} يهدئ اللعب بـ {combo}.'],
-      pair: ['{player} يضع زوجًا: {combo}.'],
-      trips: ['{player} يلعب ثلاثية: {combo}.'],
-      straight: ['{player} يصنع ستريت: {combo}.'],
-      flush: ['{player} يضع فلش: {combo}.'],
-      fullHouse: ['{player} يثبت فل هاوس.'],
-      straightFlush: ['ستريت فلش! {player} يسيطر على اليد.'],
-      bomb: ['قنبلة على الطاولة! {player} بـ {combo}.'],
-      clearTable: ['تم مسح الطاولة، {player} يتقدم.'],
-      close: ['لم يتبق لـ {player} سوى {cardsLeft} أوراق.'],
-      win: ['{player} أنهى أوراقه وفاز باليد.'],
-      outro: ['من {arena}، شكرًا لمتابعتكم.']
+      intro: [
+        'مرحبًا بكم في {arena}. معكم {speaker} و{partner}. {player} ضد {opponent}.',
+        'الأجواء مشتعلة في {arena}! {speaker} مع {partner} لنقل هذه المواجهة.'
+      ],
+      introReply: [
+        'شكرًا {speaker}. اختيار التركيبات وإدارة الإيقاع سيحسمان اليد.',
+        'الحماس في القمة يا {speaker}، أي اندفاع قد يقلب الطاولة.'
+      ],
+      shuffle: [
+        'تم توزيع الأوراق، لنبدأ.',
+        'الأوراق جاهزة والنبض يرتفع.'
+      ],
+      firstMove: [
+        '{player} يبدأ بـ {combo}.',
+        'بداية قوية من {player} بـ {combo}.'
+      ],
+      play: [
+        '{player} يلعب {combo} ويحافظ على الضغط.',
+        '{player} يضغط بإيقاع سريع مع {combo}.'
+      ],
+      pass: [
+        '{player} يمرر ويترك الإيقاع لـ {opponent}.',
+        '{player} يتروى ويترك الدور خصمه.'
+      ],
+      single: [
+        '{player} يهدئ اللعب بـ {combo}.',
+        '{player} يختار {combo} لضبط الإيقاع.'
+      ],
+      pair: [
+        '{player} يضع زوجًا: {combo}.',
+        '{player} يشعلها بزوجٍ قوي: {combo}.'
+      ],
+      trips: [
+        '{player} يلعب ثلاثية: {combo}.',
+        'ثلاثية نارية من {player}: {combo}.'
+      ],
+      straight: [
+        '{player} يصنع ستريت: {combo}.',
+        'ستريت رائع من {player} يلهب المدرجات.'
+      ],
+      flush: [
+        '{player} يضع فلش: {combo}.',
+        '{player} يفرض سيطرته بفلش أنيق.'
+      ],
+      fullHouse: [
+        '{player} يثبت فل هاوس.',
+        'فل هاوس مدهش من {player}!'
+      ],
+      straightFlush: [
+        'ستريت فلش! {player} يسيطر على اليد.',
+        'يا لها من لحظة! ستريت فلش لـ {player}.'
+      ],
+      bomb: [
+        'قنبلة على الطاولة! {player} بـ {combo}.',
+        'انفجار حقيقي! {player} يفجر {combo}.'
+      ],
+      clearTable: [
+        'تم مسح الطاولة، {player} يتقدم.',
+        'تنظيف كامل للطاولة، {player} يمسك بزمام اللعب.'
+      ],
+      close: [
+        'لم يتبق لـ {player} سوى {cardsLeft} أوراق.',
+        '{player} يقترب من النهاية بـ {cardsLeft} فقط.'
+      ],
+      win: [
+        '{player} أنهى أوراقه وفاز باليد.',
+        'انتهت! {player} يحسمها بحماس.'
+      ],
+      outro: [
+        'من {arena}، شكرًا لمتابعتكم.',
+        'كانت مواجهة مثيرة في {arena}، إلى اللقاء.'
+      ]
     }
   },
   sq: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['Mirë se vini në {arena}. {speaker} me {partner}. {player} kundër {opponent}.'],
-      introReply: ['Faleminderit {speaker}. Zgjedhja e kombinimeve dhe ritmi vendosin rezultatin.'],
-      shuffle: ['Kartat u shpërndanë, loja fillon.'],
-      firstMove: ['{player} hap me {combo}.'],
-      play: ['{player} luan {combo} dhe mban presionin.'],
-      pass: ['{player} kalon dhe i lë ritmin {opponent}.'],
-      single: ['{player} hedh {combo} për të kontrolluar ritmin.'],
-      pair: ['{player} nxjerr një çift: {combo}.'],
-      trips: ['{player} luan treshe: {combo}.'],
-      straight: ['{player} bën një drejtë: {combo}.'],
-      flush: ['{player} vendos një ngjyrë: {combo}.'],
-      fullHouse: ['{player} siguron një shtëpi të plotë.'],
-      straightFlush: ['Drejtë e ngjyrës! {player} merr kontrollin.'],
-      bomb: ['Bombë në tavolinë! {player} me {combo}.'],
-      clearTable: ['Tavolina pastrohet, {player} merr kontrollin.'],
-      close: ['{player} ka edhe {cardsLeft} letra.'],
-      win: ['{player} mbaron kartat dhe fiton dorën.'],
-      outro: ['Nga {arena}, faleminderit që na ndoqët.']
+      intro: [
+        'Mirë se vini në {arena}. {speaker} me {partner}. {player} kundër {opponent}.',
+        'Atmosfera është elektrizuese në {arena}! {speaker} me {partner} ju sjell këtë duel.'
+      ],
+      introReply: [
+        'Faleminderit {speaker}. Zgjedhja e kombinimeve dhe ritmi vendosin rezultatin.',
+        'Jam gati, {speaker}. Një shpërthim i vetëm mund ta përmbysë lojën.'
+      ],
+      shuffle: [
+        'Kartat u shpërndanë, loja fillon.',
+        'Kartat janë gati dhe tensioni rritet.'
+      ],
+      firstMove: [
+        '{player} hap me {combo}.',
+        'Fillim i fuqishëm nga {player} me {combo}.'
+      ],
+      play: [
+        '{player} luan {combo} dhe mban presionin.',
+        '{player} shton ritmin me {combo}.'
+      ],
+      pass: [
+        '{player} kalon dhe i lë ritmin {opponent}.',
+        '{player} tregohet i duruar dhe lëshon ritmin.'
+      ],
+      single: [
+        '{player} hedh {combo} për të kontrolluar ritmin.',
+        '{player} rregullon lojën me {combo}.'
+      ],
+      pair: [
+        '{player} nxjerr një çift: {combo}.',
+        '{player} shpërthen me çiftin {combo}.'
+      ],
+      trips: [
+        '{player} luan treshe: {combo}.',
+        'Treshe e fuqishme nga {player}: {combo}.'
+      ],
+      straight: [
+        '{player} bën një drejtë: {combo}.',
+        '{player} lidh drejtën dhe emocionon arenën.'
+      ],
+      flush: [
+        '{player} vendos një ngjyrë: {combo}.',
+        '{player} shton kontrollin me një ngjyrë elegante.'
+      ],
+      fullHouse: [
+        '{player} siguron një shtëpi të plotë.',
+        'Shtëpi e plotë! {player} ndez lojën.'
+      ],
+      straightFlush: [
+        'Drejtë e ngjyrës! {player} merr kontrollin.',
+        'Uau! Drejtë e ngjyrës nga {player}.'
+      ],
+      bomb: [
+        'Bombë në tavolinë! {player} me {combo}.',
+        'Shpërthim i madh! {player} hedh {combo}.'
+      ],
+      clearTable: [
+        'Tavolina pastrohet, {player} merr kontrollin.',
+        'Pastrohet gjithçka, {player} mban ritmin.'
+      ],
+      close: [
+        '{player} ka edhe {cardsLeft} letra.',
+        '{player} është pranë finishit me {cardsLeft} letra.'
+      ],
+      win: [
+        '{player} mbaron kartat dhe fiton dorën.',
+        'Mbaroi! {player} fiton me stil.'
+      ],
+      outro: [
+        'Nga {arena}, faleminderit që na ndoqët.',
+        'Spektakël i vërtetë nga {arena}. Faleminderit dhe mirupafshim.'
+      ]
     }
   }
 });
@@ -449,7 +668,13 @@ export const resolveMurlanLanguageKey = resolveLanguageKey;
 
 export const createMurlanMatchCommentaryScript = ({
   players = { A: 'Player A', B: 'Player B' },
-  commentators = [MURLAN_ROYALE_SPEAKERS.analyst],
+  commentators = [
+    MURLAN_ROYALE_SPEAKERS.lead,
+    MURLAN_ROYALE_SPEAKERS.analyst,
+    MURLAN_ROYALE_SPEAKERS.tactician,
+    MURLAN_ROYALE_SPEAKERS.hype,
+    MURLAN_ROYALE_SPEAKERS.sideline
+  ],
   language = 'en',
   scoreline = 'level at 0-0'
 } = {}) => {

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,11 +1,17 @@
 const DEFAULT_VOICE_HINTS = {
   Mason: ['en-US', 'English', 'Male', 'Google US English Male', 'David', 'Guy'],
-  Lena: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia', 'Hazel']
+  Lena: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia', 'Hazel'],
+  Kai: ['en-US', 'English', 'Male', 'Google US English', 'Daniel', 'Alex'],
+  Zara: ['en-GB', 'English', 'Female', 'Google UK English', 'Kate', 'Emma'],
+  Omar: ['en-US', 'English', 'Male', 'Google US English', 'David', 'Guy']
 };
 
 const DEFAULT_SPEAKER_SETTINGS = {
   Mason: { rate: 1, pitch: 0.95, volume: 1 },
-  Lena: { rate: 1.02, pitch: 1.05, volume: 1 }
+  Lena: { rate: 1.02, pitch: 1.05, volume: 1 },
+  Kai: { rate: 1.01, pitch: 0.98, volume: 1 },
+  Zara: { rate: 1.04, pitch: 1.06, volume: 1 },
+  Omar: { rate: 1, pitch: 0.96, volume: 1 }
 };
 
 export const getSpeechSynthesis = () => {
@@ -76,36 +82,54 @@ const loadVoices = (synth, timeoutMs = 3500) =>
     setTimeout(() => finalize(synth.getVoices()), timeoutMs);
   });
 
+const normalizeHints = (hints = []) =>
+  hints.map((hint) => String(hint || '').trim().toLowerCase()).filter(Boolean);
+
+const extractLanguageHints = (hints = []) =>
+  normalizeHints(hints).filter((hint) => /^[a-z]{2}(?:-[a-z0-9]+)?$/i.test(hint));
+
+const normalizeLangPrefix = (lang) => String(lang || '').toLowerCase().split(/[-_]/)[0] || '';
+
+const isHintedLanguageMatch = (voiceLang, hintedLanguages = []) => {
+  if (!voiceLang || !hintedLanguages.length) return false;
+  const voicePrefix = normalizeLangPrefix(voiceLang);
+  return hintedLanguages.some((hint) => normalizeLangPrefix(hint) === voicePrefix);
+};
+
 const findVoiceMatch = (voices, hints = []) => {
-  const normalizedHints = hints.map((hint) => hint.toLowerCase());
-  return (
-    voices.find((voice) => normalizedHints.some((hint) => voice.name.toLowerCase().includes(hint))) ||
-    voices.find((voice) => normalizedHints.some((hint) => voice.lang.toLowerCase().includes(hint))) ||
-    voices[0] ||
-    null
+  const normalizedHints = normalizeHints(hints);
+  if (!voices.length) return null;
+  const matchesByName = voices.find((voice) =>
+    normalizedHints.some((hint) => voice.name.toLowerCase().includes(hint))
   );
+  if (matchesByName) return matchesByName;
+  const matchesByLang = voices.find((voice) =>
+    normalizedHints.some((hint) => voice.lang.toLowerCase().includes(hint))
+  );
+  if (matchesByLang) return matchesByLang;
+  return normalizedHints.length ? null : voices[0] || null;
 };
 
 const findDistinctVoice = (voices, hints = [], usedVoices = new Set()) => {
   if (!voices.length) return null;
-  const normalizedHints = hints.map((hint) => hint.toLowerCase());
+  const normalizedHints = normalizeHints(hints);
   const matchesByName = voices.filter((voice) =>
     normalizedHints.some((hint) => voice.name.toLowerCase().includes(hint))
   );
   const matchesByLang = voices.filter((voice) =>
     normalizedHints.some((hint) => voice.lang.toLowerCase().includes(hint))
   );
-  const candidateLists = [matchesByName, matchesByLang, voices];
+  const candidateLists = normalizedHints.length ? [matchesByName, matchesByLang] : [voices];
   for (const candidates of candidateLists) {
     const match = candidates.find((voice) => !usedVoices.has(voice));
     if (match) return match;
   }
-  return voices[0] || null;
+  return normalizedHints.length ? null : voices.find((voice) => !usedVoices.has(voice)) || null;
 };
 
 const resolveHintedLanguage = (hints = [], fallback) => {
   const normalizedHints = hints.map((hint) => String(hint || '').trim()).filter(Boolean);
-  const matched = normalizedHints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(hint));
+  const matched = normalizedHints.find((hint) => /^[a-z]{2}(?:-[a-z0-9]+)?$/i.test(hint));
   if (matched) return matched;
   if (fallback) return fallback;
   if (typeof navigator !== 'undefined' && navigator.language) return navigator.language;
@@ -147,8 +171,13 @@ export const speakCommentaryLines = async (
     const speaker = line.speaker || 'Mason';
     const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
     const utterance = new SpeechSynthesisUtterance(line.text);
-    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
+    let voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
     const fallbackLang = resolveHintedLanguage(voiceHints[speaker] || voiceHints.Mason);
+    const hintedLanguages = extractLanguageHints(voiceHints[speaker] || voiceHints.Mason);
+
+    if (voice && hintedLanguages.length && !isHintedLanguageMatch(voice.lang, hintedLanguages)) {
+      voice = null;
+    }
 
     if (voice) {
       utterance.voice = voice;


### PR DESCRIPTION
### Motivation
- Make in-game voice commentary more natural and accurate across languages and environments (including Telegram webviews) by adding more commentators and improving localization.
- Ensure speech synthesis picks voices that match the requested language and avoid mismatched English voices in non-English presets.

### Description
- Added three new commentator roles and profiles (`Kai`, `Zara`, `Omar`) and updated `MURLAN_ROYALE_SPEAKERS` and `SPEAKER_PROFILES` to support five rotating commentators. (updated `webapp/src/utils/murlanRoyaleCommentary.js`)
- Expanded commentary presets to include five speakers per language and added/adjusted `voiceHints` and `speakerSettings` for English, Chinese, Hindi, Russian, Spanish, French, Arabic and Albanian presets, plus richer localized templates/lines for Chinese, Arabic and Albanian. (updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and `webapp/src/utils/murlanRoyaleCommentary.js`)
- Updated `createMurlanMatchCommentaryScript` and commentary rotation to include the new roles and use the expanded speaker pool by default. (updated `webapp/src/utils/murlanRoyaleCommentary.js` and `webapp/src/pages/Games/MurlanRoyaleArena.jsx`)
- Tightened speech synthesis selection logic to prefer name and language hints, added helpers to normalize/extract language hints, and made `findVoiceMatch`/`findDistinctVoice` respect language hints so non-English presets avoid falling back to English voices; also added default voice hints/settings for the new speakers. (updated `webapp/src/utils/textToSpeech.js`)

### Testing
- No automated tests were executed as part of this change; only code updates and a commit were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976732f05c88329b4e7ab99037d55ca)