### PR TITLE
Murlan Royale: add multi-commentator voices, improve localization and WebSpeech resume

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -664,11 +664,38 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Hazel',
         'Kate',
         'Emma'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'en-US',
+        'English',
+        'male',
+        'Matthew',
+        'James',
+        'Michael'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'en-GB',
+        'English',
+        'female',
+        'Amy',
+        'Olivia',
+        'Serena'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'en-US',
+        'English',
+        'male',
+        'George',
+        'Mark',
+        'Brian'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.08, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.96, pitch: 0.92, volume: 1 }
     }
   },
   {
@@ -694,11 +721,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Asha',
         'Priya',
         'Neha'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'male',
+        'Rohan',
+        'Vijay',
+        'Karan'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'female',
+        'Ananya',
+        'Kiran',
+        'Deepa'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'hi-IN',
+        'hi',
+        'Hindi',
+        'male',
+        'Suresh',
+        'Ajay',
+        'Prakash'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.06, pitch: 1.02, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.12, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 1.02, pitch: 1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.98, pitch: 0.96, volume: 1 }
     }
   },
   {
@@ -711,28 +768,60 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'zh-CN',
         'zh',
         'Chinese',
+        'Mandarin',
         'male',
         'Li',
         'Wei',
         'Chen',
-        'Microsoft Huihui',
-        'Microsoft Kangkang'
+        'Microsoft Kangkang',
+        'Microsoft Yunxi'
       ],
       [MURLAN_ROYALE_SPEAKERS.analyst]: [
         'zh-CN',
         'zh',
         'Chinese',
+        'Mandarin',
         'female',
         'Mei',
         'Xia',
         'Lin',
-        'Microsoft Yaoyao',
-        'Microsoft Xiaoxiao'
+        'Microsoft Xiaoxiao',
+        'Microsoft Yaoyao'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'zh-CN',
+        'zh',
+        'Chinese',
+        'male',
+        'Bo',
+        'Jia',
+        'Haoyu'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'zh-CN',
+        'zh',
+        'Chinese',
+        'female',
+        'Xue',
+        'Na',
+        'Jing'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'zh-CN',
+        'zh',
+        'Chinese',
+        'male',
+        'Guo',
+        'Shun',
+        'Hong'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 1, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.08, pitch: 1.08, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 1, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.97, pitch: 0.95, volume: 1 }
     }
   },
   {
@@ -760,11 +849,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Svetlana',
         'Irina',
         'Olga'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'male',
+        'Pavel',
+        'Nikolai',
+        'Kirill'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'female',
+        'Maria',
+        'Elena',
+        'Daria'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'ru-RU',
+        'ru',
+        'Russian',
+        'male',
+        'Oleg',
+        'Viktor',
+        'Yuri'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.07, pitch: 1.04, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.96, pitch: 0.94, volume: 1 }
     }
   },
   {
@@ -790,11 +909,41 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Isabella',
         'Lucia',
         'Camila'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'male',
+        'Diego',
+        'Andres',
+        'Sergio'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'female',
+        'Elena',
+        'Sofia',
+        'Valeria'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'es-ES',
+        'es-MX',
+        'Spanish',
+        'male',
+        'Ramon',
+        'Alberto',
+        'Hector'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.05, pitch: 1, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.1, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.1, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.12, pitch: 1.12, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 1, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.97, pitch: 0.95, volume: 1 }
     }
   },
   {
@@ -818,11 +967,38 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'Amelie',
         'Marie',
         'Charlotte'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'fr-FR',
+        'French',
+        'male',
+        'Julien',
+        'Antoine',
+        'Lucas'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'fr-FR',
+        'French',
+        'female',
+        'Claire',
+        'Camille',
+        'Lea'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'fr-FR',
+        'French',
+        'male',
+        'Bernard',
+        'Olivier',
+        'Gerard'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 0.98, pitch: 0.96, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.06, pitch: 1.08, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.95, pitch: 0.94, volume: 1 }
     }
   },
   {
@@ -839,32 +1015,55 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'male',
         'Omar',
         'Khalid',
-        'Hassan',
-        'en-US',
-        'English',
-        'male',
-        'David',
-        'Alex'
+        'Hassan'
       ],
       [MURLAN_ROYALE_SPEAKERS.analyst]: [
         'ar-SA',
         'ar-EG',
         'ar',
         'Arabic',
+        'female',
+        'Amira',
+        'Layla',
+        'Noor'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
         'male',
-        'Omar',
-        'Khalid',
-        'Hassan',
-        'en-GB',
-        'English',
+        'Fadi',
+        'Sami',
+        'Karim'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
+        'female',
+        'Hala',
+        'Rana',
+        'Maya'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'ar-SA',
+        'ar-EG',
+        'ar',
+        'Arabic',
         'male',
-        'Guy',
-        'Daniel'
+        'Youssef',
+        'Mahmoud',
+        'Adel'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1, pitch: 0.95, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.06, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.96, pitch: 0.92, volume: 1 }
     }
   },
   {
@@ -886,15 +1085,45 @@ const MURLAN_ROYALE_COMMENTARY_PRESETS = Object.freeze([
         'sq-AL',
         'sq',
         'Albanian',
+        'female',
+        'Besa',
+        'Elira',
+        'Gentiana'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.hype]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
         'male',
-        'Besar',
-        'Erion',
-        'Gent'
+        'Ardit',
+        'Lorik',
+        'Florian'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.tactician]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'female',
+        'Anisa',
+        'Bruna',
+        'Erisa'
+      ],
+      [MURLAN_ROYALE_SPEAKERS.veteran]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'male',
+        'Besnik',
+        'Luan',
+        'Skender'
       ]
     },
     speakerSettings: {
       [MURLAN_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.98, volume: 1 },
-      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.96, volume: 1 }
+      [MURLAN_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.96, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.hype]: { rate: 1.06, pitch: 1.02, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.tactician]: { rate: 0.98, pitch: 0.98, volume: 1 },
+      [MURLAN_ROYALE_SPEAKERS.veteran]: { rate: 0.96, pitch: 0.94, volume: 1 }
     }
   }
 ]);
@@ -1857,7 +2086,13 @@ export default function MurlanRoyaleArena({ search }) {
   );
   const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
   const commentarySpeakers = useMemo(
-    () => [MURLAN_ROYALE_SPEAKERS.lead, MURLAN_ROYALE_SPEAKERS.analyst],
+    () => [
+      MURLAN_ROYALE_SPEAKERS.lead,
+      MURLAN_ROYALE_SPEAKERS.analyst,
+      MURLAN_ROYALE_SPEAKERS.hype,
+      MURLAN_ROYALE_SPEAKERS.tactician,
+      MURLAN_ROYALE_SPEAKERS.veteran
+    ],
     []
   );
   const pickCommentarySpeaker = useCallback(() => {
@@ -1978,6 +2213,11 @@ export default function MurlanRoyaleArena({ search }) {
     if (commentaryReadyRef.current) return;
     primeSpeechSynthesis();
     const synth = getSpeechSynthesis();
+    if (typeof synth?.resume === 'function') {
+      try {
+        synth.resume();
+      } catch {}
+    }
     synth?.getVoices?.();
     commentaryReadyRef.current = true;
     const pending = pendingCommentaryLinesRef.current;
@@ -2033,6 +2273,22 @@ export default function MurlanRoyaleArena({ search }) {
       window.removeEventListener('keydown', unlockCommentary);
     };
   }, [unlockCommentary]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible' || commentaryMutedRef.current) return;
+      primeSpeechSynthesis();
+      const synth = getSpeechSynthesis();
+      if (typeof synth?.resume === 'function') {
+        try {
+          synth.resume();
+        } catch {}
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
 
   useEffect(() => {
     if (!gameState) return;

--- a/webapp/src/utils/murlanRoyaleCommentary.js
+++ b/webapp/src/utils/murlanRoyaleCommentary.js
@@ -1,6 +1,9 @@
 export const MURLAN_ROYALE_SPEAKERS = Object.freeze({
   lead: 'Mason',
-  analyst: 'Lena'
+  analyst: 'Lena',
+  hype: 'Kai',
+  tactician: 'Nora',
+  veteran: 'Rafi'
 });
 
 const SPEAKER_PROFILES = Object.freeze({
@@ -13,8 +16,31 @@ const SPEAKER_PROFILES = Object.freeze({
     id: 'lena',
     name: 'Lena',
     style: 'Color analyst'
+  },
+  Kai: {
+    id: 'kai',
+    name: 'Kai',
+    style: 'Hype caster'
+  },
+  Nora: {
+    id: 'nora',
+    name: 'Nora',
+    style: 'Tactical analyst'
+  },
+  Rafi: {
+    id: 'rafi',
+    name: 'Rafi',
+    style: 'Veteran commentator'
   }
 });
+
+const SPEAKER_ROTATION = Object.freeze([
+  MURLAN_ROYALE_SPEAKERS.lead,
+  MURLAN_ROYALE_SPEAKERS.analyst,
+  MURLAN_ROYALE_SPEAKERS.hype,
+  MURLAN_ROYALE_SPEAKERS.tactician,
+  MURLAN_ROYALE_SPEAKERS.veteran
+]);
 
 const DEFAULT_CONTEXT = Object.freeze({
   player: 'Player A',
@@ -96,31 +122,52 @@ const LOCALIZED_DEFAULT_CONTEXT = Object.freeze({
 const LOCALIZED_SPEAKERS = Object.freeze({
   zh: {
     Mason: '梅森',
-    Lena: '莉娜'
+    Lena: '莉娜',
+    Kai: '凯',
+    Nora: '诺拉',
+    Rafi: '拉菲'
   },
   hi: {
     Mason: 'मोहन',
-    Lena: 'लीना'
+    Lena: 'लीना',
+    Kai: 'काई',
+    Nora: 'नोरा',
+    Rafi: 'रफ़ी'
   },
   ru: {
     Mason: 'Мейсон',
-    Lena: 'Лена'
+    Lena: 'Лена',
+    Kai: 'Кай',
+    Nora: 'Нора',
+    Rafi: 'Раф'
   },
   es: {
     Mason: 'Mason',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Nora: 'Nora',
+    Rafi: 'Rafi'
   },
   fr: {
     Mason: 'Mason',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Nora: 'Nora',
+    Rafi: 'Rafi'
   },
   ar: {
     Mason: 'ميسون',
-    Lena: 'لينا'
+    Lena: 'لينا',
+    Kai: 'كاي',
+    Nora: 'نورا',
+    Rafi: 'رافي'
   },
   sq: {
     Mason: 'Mejson',
-    Lena: 'Lena'
+    Lena: 'Lena',
+    Kai: 'Kai',
+    Nora: 'Nora',
+    Rafi: 'Rafi'
   }
 });
 
@@ -150,82 +197,118 @@ const ENGLISH_TEMPLATES = Object.freeze({
     intro: [
       'Welcome to {arena}. {speaker} with {partner} as {player} meets {opponent} in Murlan Royale.',
       'Live from {arena}. {speaker} alongside {partner} for tonight’s Murlan Royale showdown.',
-      '{speaker} on the call at {arena}. {player} versus {opponent}, and the tempo is about to spike.'
+      '{speaker} on the call at {arena}. {player} versus {opponent}, and the tempo is about to spike.',
+      'The lights are up at {arena}. {speaker} here with {partner} for a high-voltage Murlan Royale.',
+      'An electric crowd at {arena}. {speaker} and {partner} ready for {player} versus {opponent}.'
     ],
     introReply: [
       'Thanks {speaker}. Combo selection and tempo control will shape this hand.',
       'Great to be here, {speaker}. Watch the timing on bombs and the race to shed cards.',
-      'Absolutely, {speaker}. Disciplined passes and clean combos decide the edge.'
+      'Absolutely, {speaker}. Disciplined passes and clean combos decide the edge.',
+      'You can feel the tension, {speaker}. One burst of courage can flip this hand.',
+      'Ready for the shock moments, {speaker}. The smallest slip turns into heartbreak.'
     ],
     shuffle: [
       'Cards are in the air; opening hands are set.',
       'The deal is done. Let us see who claims the first lead.',
-      'Hands are live and the table is ready.'
+      'Hands are live and the table is ready.',
+      'The shuffle sets the stage—every heartbeat counts.',
+      'Deal complete. The drama starts now.'
     ],
     firstMove: [
       '{player} opens with {combo}, setting the rhythm early.',
       'First lead belongs to {player} with {combo}.',
-      '{player} starts the action with {combo}.'
+      '{player} starts the action with {combo}.',
+      '{player} strikes first with {combo}—bold and brave.',
+      'An early spark from {player}: {combo}.'
     ],
     play: [
       '{player} plays {combo} and keeps the pressure on.',
       '{player} lays down {combo} with composed timing.',
-      'A confident play from {player}: {combo}.'
+      'A confident play from {player}: {combo}.',
+      '{player} fires {combo} with a surge of energy.',
+      '{player} drops {combo}—the crowd loves that swagger.'
     ],
     pass: [
       '{player} passes and yields the tempo.',
       '{player} takes the pass; the table stays with {opponent}.',
-      '{player} lets it go—discipline over risk.'
+      '{player} lets it go—discipline over risk.',
+      '{player} backs off, maybe a touch of caution there.',
+      '{player} hesitates and passes—tension rising.'
     ],
     single: [
       '{player} drops {combo} to manage the pace.',
-      '{player} checks the tempo with {combo}.'
+      '{player} checks the tempo with {combo}.',
+      '{player} slips in {combo}, calm but focused.',
+      '{player} fires a single {combo}—measured control.'
     ],
     pair: [
       '{player} pairs up with {combo}.',
-      '{player} shows a pair: {combo}.'
+      '{player} shows a pair: {combo}.',
+      'Pair on the felt—{player} stays aggressive.',
+      '{player} answers with a sharp pair: {combo}.'
     ],
     trips: [
       '{player} rolls out trips—{combo}.',
-      '{player} commands the table with trips: {combo}.'
+      '{player} commands the table with trips: {combo}.',
+      'Trips hit the table! {player} flexes with {combo}.',
+      '{player} unleashes trips—momentum swings.'
     ],
     straight: [
       '{player} strings a straight: {combo}.',
-      'Straight down—{player} with {combo}.'
+      'Straight down—{player} with {combo}.',
+      '{player} lines up a straight—smooth and precise.',
+      'A sharp straight from {player}: {combo}.'
     ],
     flush: [
       '{player} delivers a flush and tightens control.',
-      'Flush on the felt—{player} with {combo}.'
+      'Flush on the felt—{player} with {combo}.',
+      'A silky flush from {player}, the table gasps.',
+      '{player} slides in a flush—pressure spikes.'
     ],
     fullHouse: [
       '{player} locks in a full house.',
-      'Full house played by {player}.'
+      'Full house played by {player}.',
+      'Full house! {player} draws a roar from the crowd.',
+      '{player} nails the full house—massive moment.'
     ],
     straightFlush: [
       'Straight flush! {player} takes command.',
-      '{player} lands a straight flush and turns the hand.'
+      '{player} lands a straight flush and turns the hand.',
+      'What a shocker—straight flush by {player}!',
+      '{player} slams a straight flush—momentum explodes.'
     ],
     bomb: [
       'Bomb on the table—{player} detonates {combo}.',
-      '{player} drops the bomb and swings the momentum.'
+      '{player} drops the bomb and swings the momentum.',
+      'Boom! {player} shocks the table with {combo}.',
+      '{player} detonates a bomb—jaw-dropping swing.'
     ],
     clearTable: [
       'The table clears. {player} takes the lead.',
-      'Reset on the table; {player} has control.'
+      'Reset on the table; {player} has control.',
+      'Clean slate now—{player} surges ahead.',
+      'Table wiped! {player} is in command.'
     ],
     close: [
       '{player} is down to {cardsLeft} cards—finish line in sight.',
-      '{player} has {cardsLeft} left; the endgame is near.'
+      '{player} has {cardsLeft} left; the endgame is near.',
+      '{player} sits at {cardsLeft} cards—every breath counts.',
+      '{player} is nearly out—tension and hope collide.'
     ],
     win: [
       '{player} is out of cards and wins the hand.',
       '{player} closes it out—hand secured.',
-      '{player} finishes the run and takes the hand.'
+      '{player} finishes the run and takes the hand.',
+      '{player} erupts with a win—what a finish!',
+      '{player} claims it at the line—pure delight.'
     ],
     outro: [
       'That wraps it up from {arena}. Thanks for joining us.',
       'From {arena}, that is full time. A sharp Murlan Royale battle.',
-      'A professional finish in {round}. Thanks for watching.'
+      'A professional finish in {round}. Thanks for watching.',
+      'That was a roller coaster at {arena}. Until next time.',
+      'From {arena}, hearts racing—thank you for being with us.'
     ]
   }
 });
@@ -235,24 +318,32 @@ const LOCALIZED_TEMPLATES = Object.freeze({
   zh: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['欢迎来到{arena}。{speaker}与{partner}为您解说，{player}对阵{opponent}。'],
-      introReply: ['谢谢{speaker}。组合选择与节奏控制将决定胜负。'],
-      shuffle: ['发牌结束，比赛开始。'],
-      firstMove: ['{player}率先出牌：{combo}。'],
-      play: ['{player}打出{combo}，继续施压。'],
-      pass: ['{player}选择过牌，节奏让给{opponent}。'],
-      single: ['{player}出{combo}，稳住节奏。'],
-      pair: ['{player}亮出对子：{combo}。'],
-      trips: ['{player}打出三条：{combo}。'],
-      straight: ['{player}连顺：{combo}。'],
-      flush: ['{player}同花上桌：{combo}。'],
-      fullHouse: ['{player}打出葫芦。'],
-      straightFlush: ['同花顺！{player}掌控局面。'],
-      bomb: ['炸弹登场！{player}打出{combo}。'],
-      clearTable: ['桌面清空，{player}继续领先。'],
-      close: ['{player}只剩{cardsLeft}张牌。'],
-      win: ['{player}出完手牌，赢下本局。'],
-      outro: ['{arena}的比赛到此结束，感谢观看。']
+      intro: [
+        '欢迎来到{arena}。{speaker}与{partner}为您解说，{player}对阵{opponent}。',
+        '{arena}灯光闪耀，{speaker}和{partner}陪您见证这场对决。',
+        '{speaker}在解说席，{player}对{opponent}，节奏马上拉满。'
+      ],
+      introReply: [
+        '谢谢{speaker}。组合选择与节奏控制将决定胜负。',
+        '太激动了，{speaker}。一个失误就可能翻盘。',
+        '没错，{speaker}。炸弹时机决定胜负。'
+      ],
+      shuffle: ['发牌结束，比赛开始。', '洗牌完成，紧张感拉满。', '牌已到位，激情开场。'],
+      firstMove: ['{player}率先出牌：{combo}。', '{player}抢先出手，{combo}气势十足。'],
+      play: ['{player}打出{combo}，继续施压。', '{player}果断出{combo}，全场沸腾。'],
+      pass: ['{player}选择过牌，节奏让给{opponent}。', '{player}按兵不动，场面略显紧张。'],
+      single: ['{player}出{combo}，稳住节奏。', '{player}单张出击，稳健推进。'],
+      pair: ['{player}亮出对子：{combo}。', '对子落桌，{player}信心十足。'],
+      trips: ['{player}打出三条：{combo}。', '{player}三条上桌，气氛升温。'],
+      straight: ['{player}连顺：{combo}。', '{player}顺子连出，观众惊呼。'],
+      flush: ['{player}同花上桌：{combo}。', '同花！{player}掌控节奏。'],
+      fullHouse: ['{player}打出葫芦。', '葫芦落地，{player}大势占优。'],
+      straightFlush: ['同花顺！{player}掌控局面。', '太震撼了！同花顺由{player}完成。'],
+      bomb: ['炸弹登场！{player}打出{combo}。', '轰的一声！{player}炸弹震场。'],
+      clearTable: ['桌面清空，{player}继续领先。', '清台成功，{player}气势如虹。'],
+      close: ['{player}只剩{cardsLeft}张牌。', '{player}进入收尾阶段，只剩{cardsLeft}张。'],
+      win: ['{player}出完手牌，赢下本局。', '{player}赢了！全场欢呼。'],
+      outro: ['{arena}的比赛到此结束，感谢观看。', '精彩落幕，{arena}感谢您的陪伴。']
     }
   },
   hi: {
@@ -350,47 +441,63 @@ const LOCALIZED_TEMPLATES = Object.freeze({
   ar: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['مرحبًا بكم في {arena}. معكم {speaker} و{partner}. {player} ضد {opponent}.'],
-      introReply: ['شكرًا {speaker}. اختيار التركيبات وإدارة الإيقاع سيحسمان اليد.'],
-      shuffle: ['تم توزيع الأوراق، لنبدأ.'],
-      firstMove: ['{player} يبدأ بـ {combo}.'],
-      play: ['{player} يلعب {combo} ويحافظ على الضغط.'],
-      pass: ['{player} يمرر ويترك الإيقاع لـ {opponent}.'],
-      single: ['{player} يهدئ اللعب بـ {combo}.'],
-      pair: ['{player} يضع زوجًا: {combo}.'],
-      trips: ['{player} يلعب ثلاثية: {combo}.'],
-      straight: ['{player} يصنع ستريت: {combo}.'],
-      flush: ['{player} يضع فلش: {combo}.'],
-      fullHouse: ['{player} يثبت فل هاوس.'],
-      straightFlush: ['ستريت فلش! {player} يسيطر على اليد.'],
-      bomb: ['قنبلة على الطاولة! {player} بـ {combo}.'],
-      clearTable: ['تم مسح الطاولة، {player} يتقدم.'],
-      close: ['لم يتبق لـ {player} سوى {cardsLeft} أوراق.'],
-      win: ['{player} أنهى أوراقه وفاز باليد.'],
-      outro: ['من {arena}، شكرًا لمتابعتكم.']
+      intro: [
+        'مرحبًا بكم في {arena}. معكم {speaker} و{partner}. {player} ضد {opponent}.',
+        '{arena} تشتعل بالحماس. {speaker} و{partner} ينقلان لكم المواجهة.',
+        'هنا {arena}، {speaker} و{partner} جاهزان للمباراة الكبيرة.'
+      ],
+      introReply: [
+        'شكرًا {speaker}. اختيار التركيبات وإدارة الإيقاع سيحسمان اليد.',
+        'الأجواء مشحونة، {speaker}. لحظة واحدة قد تقلب كل شيء.',
+        'صحيح {speaker}. التوقيت المثالي هو الفارق.'
+      ],
+      shuffle: ['تم توزيع الأوراق، لنبدأ.', 'خلط الأوراق انتهى، التوتر يبدأ الآن.', 'الأوراق جاهزة والحماس حاضر.'],
+      firstMove: ['{player} يبدأ بـ {combo}.', '{player} يفتتح بـ {combo} وبثقة عالية.'],
+      play: ['{player} يلعب {combo} ويحافظ على الضغط.', '{player} يطلق {combo} والجمهور يتفاعل.'],
+      pass: ['{player} يمرر ويترك الإيقاع لـ {opponent}.', '{player} يتراجع قليلًا، التوتر يرتفع.'],
+      single: ['{player} يهدئ اللعب بـ {combo}.', '{player} يدير الإيقاع بورقة {combo}.'],
+      pair: ['{player} يضع زوجًا: {combo}.', 'زوج قوي من {player}: {combo}.'],
+      trips: ['{player} يلعب ثلاثية: {combo}.', '{player} بثلاثية تشعل الأجواء.'],
+      straight: ['{player} يصنع ستريت: {combo}.', 'ستريت جميل من {player} يثير الدهشة.'],
+      flush: ['{player} يضع فلش: {combo}.', 'فلش رائع! {player} يضغط بقوة.'],
+      fullHouse: ['{player} يثبت فل هاوس.', 'فل هاوس لـ {player} وسط صيحات الجمهور.'],
+      straightFlush: ['ستريت فلش! {player} يسيطر على اليد.', 'يا له من لحظة! ستريت فلش من {player}.'],
+      bomb: ['قنبلة على الطاولة! {player} بـ {combo}.', 'انفجار مفاجئ! {player} يرمي {combo}.'],
+      clearTable: ['تم مسح الطاولة، {player} يتقدم.', 'الطاولة نظيفة و{player} يتقدم بثقة.'],
+      close: ['لم يتبق لـ {player} سوى {cardsLeft} أوراق.', '{player} يقترب من النهاية بـ {cardsLeft} أوراق.'],
+      win: ['{player} أنهى أوراقه وفاز باليد.', 'فوز حاسم لـ {player}!'],
+      outro: ['من {arena}، شكرًا لمتابعتكم.', '{arena} تقول شكرًا لكم، إلى اللقاء.']
     }
   },
   sq: {
     ...ENGLISH_TEMPLATES,
     common: {
-      intro: ['Mirë se vini në {arena}. {speaker} me {partner}. {player} kundër {opponent}.'],
-      introReply: ['Faleminderit {speaker}. Zgjedhja e kombinimeve dhe ritmi vendosin rezultatin.'],
-      shuffle: ['Kartat u shpërndanë, loja fillon.'],
-      firstMove: ['{player} hap me {combo}.'],
-      play: ['{player} luan {combo} dhe mban presionin.'],
-      pass: ['{player} kalon dhe i lë ritmin {opponent}.'],
-      single: ['{player} hedh {combo} për të kontrolluar ritmin.'],
-      pair: ['{player} nxjerr një çift: {combo}.'],
-      trips: ['{player} luan treshe: {combo}.'],
-      straight: ['{player} bën një drejtë: {combo}.'],
-      flush: ['{player} vendos një ngjyrë: {combo}.'],
-      fullHouse: ['{player} siguron një shtëpi të plotë.'],
-      straightFlush: ['Drejtë e ngjyrës! {player} merr kontrollin.'],
-      bomb: ['Bombë në tavolinë! {player} me {combo}.'],
-      clearTable: ['Tavolina pastrohet, {player} merr kontrollin.'],
-      close: ['{player} ka edhe {cardsLeft} letra.'],
-      win: ['{player} mbaron kartat dhe fiton dorën.'],
-      outro: ['Nga {arena}, faleminderit që na ndoqët.']
+      intro: [
+        'Mirë se vini në {arena}. {speaker} me {partner}. {player} kundër {opponent}.',
+        '{arena} ndizet! {speaker} dhe {partner} sjellin atmosferën e ndeshjes.',
+        '{speaker} në mikrofon, {player} përballë {opponent} në një duel të fortë.'
+      ],
+      introReply: [
+        'Faleminderit {speaker}. Zgjedhja e kombinimeve dhe ritmi vendosin rezultatin.',
+        'Ndjehet tensioni, {speaker}. Një gabim i vogël dhe gjithçka ndryshon.',
+        'Po, {speaker}. Bombat dhe pasimet e mençura bëjnë diferencën.'
+      ],
+      shuffle: ['Kartat u shpërndanë, loja fillon.', 'Shpërndarja mbaroi, emocionet rriten.', 'Kartat janë gati, loja ndizet.'],
+      firstMove: ['{player} hap me {combo}.', '{player} nis fuqishëm me {combo}.'],
+      play: ['{player} luan {combo} dhe mban presionin.', '{player} hedh {combo} dhe ndez publikun.'],
+      pass: ['{player} kalon dhe i lë ritmin {opponent}.', '{player} tërhiqet pak, tensioni rritet.'],
+      single: ['{player} hedh {combo} për të kontrolluar ritmin.', '{player} luan një {combo} të qetë.'],
+      pair: ['{player} nxjerr një çift: {combo}.', 'Çift i fortë nga {player}: {combo}.'],
+      trips: ['{player} luan treshe: {combo}.', '{player} hedh treshe dhe publiku shpërthen.'],
+      straight: ['{player} bën një drejtë: {combo}.', 'Drejtë e bukur nga {player}, habi në sallë.'],
+      flush: ['{player} vendos një ngjyrë: {combo}.', 'Ngjyrë elegante nga {player}, presioni rritet.'],
+      fullHouse: ['{player} siguron një shtëpi të plotë.', 'Shtëpi e plotë! {player} merr hov.'],
+      straightFlush: ['Drejtë e ngjyrës! {player} merr kontrollin.', 'Moment i madh! {player} me drejtë të ngjyrës.'],
+      bomb: ['Bombë në tavolinë! {player} me {combo}.', 'Shpërthim befasues! {player} hedh {combo}.'],
+      clearTable: ['Tavolina pastrohet, {player} merr kontrollin.', 'Tavolina pastër, {player} kryeson.'],
+      close: ['{player} ka edhe {cardsLeft} letra.', '{player} është pranë fundit me {cardsLeft} letra.'],
+      win: ['{player} mbaron kartat dhe fiton dorën.', 'Fitore madhështore për {player}!'],
+      outro: ['Nga {arena}, faleminderit që na ndoqët.', '{arena} ju falënderon, shihemi së shpejti.']
     }
   }
 });
@@ -422,9 +529,10 @@ export const buildMurlanCommentaryLine = ({
   const languageKey = resolveLanguageKey(language);
   const templates = LOCALIZED_TEMPLATES[languageKey] || ENGLISH_TEMPLATES;
   const localizedDefaults = LOCALIZED_DEFAULT_CONTEXT[languageKey] || {};
+  const speakerIndex = SPEAKER_ROTATION.indexOf(speaker);
   const partner =
-    speaker === MURLAN_ROYALE_SPEAKERS.lead
-      ? MURLAN_ROYALE_SPEAKERS.analyst
+    speakerIndex >= 0
+      ? SPEAKER_ROTATION[(speakerIndex + 1) % SPEAKER_ROTATION.length]
       : MURLAN_ROYALE_SPEAKERS.lead;
   const localizedSpeakers = LOCALIZED_SPEAKERS[languageKey] || {};
   const resolvedArena =


### PR DESCRIPTION
### Motivation
- Make in-game voice commentary more realistic and reliable by adding multiple commentators per language and improving localized phrasing and tone. 
- Fix non-native mixes (Chinese/Arabic/Albanian) and ensure commentary works more robustly in constrained browsers (Telegram / in-app browsers) by improving speech API resume behavior.

### Description
- Added three additional commentator roles (`hype`, `tactician`, `veteran`) and a `SPEAKER_ROTATION` so commentary cycles across five speakers; updated `SPEAKER_PROFILES` and localized speaker names in `webapp/src/utils/murlanRoyaleCommentary.js`.
- Expanded English templates with more expressive variants and refreshed localized templates for Chinese (`zh`), Arabic (`ar`) and Albanian (`sq`) to keep language-consistent phrasing and varied emotional tones.
- Extended commentary presets in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to include voice hints and `speakerSettings` for the new speakers across supported language presets so the TTS voice selection can pick distinct voices per commentator.
- Improved unlock/resume behavior for Web Speech by calling `synth.resume()` in `unlockCommentary` and adding a `visibilitychange` handler to prime/resume speech when the document becomes visible to help in-app browsers (e.g., Telegram) reliably initialize commentary.

### Testing
- No automated tests were executed for this change (`unit`/`CI` not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976732f05c88329b4e7ab99037d55ca)