### PR TITLE
Pool Royale: fix side-pocket camera, cue replay visibility, and chrome plate position

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -614,7 +614,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to r
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.982; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.045; // nudge the middle fascia inward so it sits closer to the table center without moving the pocket cut
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.065; // nudge the middle fascia inward so it sits closer to the table center without moving the pocket cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.095; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
@@ -17329,7 +17329,9 @@ const powerRef = useRef(hud.power);
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
           const forcedEarly = forceEarly && shotPrediction?.ballId === ballId;
-          if (best.dist > POCKET_CAM.triggerDist && !forcedEarly) return null;
+          const allowForcedEarly =
+            forcedEarly && (!isSidePocket || best.dist <= POCKET_CAM.triggerDist);
+          if (best.dist > POCKET_CAM.triggerDist && !allowForcedEarly) return null;
           const baseHeightOffset = POCKET_CAM.heightOffset;
           const shortPocketHeightMultiplier =
             POCKET_CAM.heightOffsetShortMultiplier ?? 1;
@@ -17353,7 +17355,7 @@ const powerRef = useRef(hud.power);
               }
             : null;
           const now = performance.now();
-          const effectiveDist = forcedEarly
+          const effectiveDist = allowForcedEarly
             ? Math.min(best.dist, POCKET_CAM.triggerDist)
             : best.dist;
           const minOutside = isSidePocket
@@ -17399,7 +17401,7 @@ const powerRef = useRef(hud.power);
             lastRailHitAt: targetBall.lastRailHitAt ?? null,
             lastRailHitType: targetBall.lastRailHitType ?? null,
             predictedAlignment,
-            forcedEarly
+            forcedEarly: allowForcedEarly
           };
         };
         const fit = (m = STANDING_VIEW.margin) => {
@@ -17650,7 +17652,8 @@ const powerRef = useRef(hud.power);
           }
         };
 
-        const applyReplayFrame = (frameA, frameB, alpha) => {
+        const applyReplayFrame = (frameA, frameB, alpha, options = {}) => {
+          const { allowCueSnapshot = true } = options;
           if (!frameA) return false;
           const aMap = new Map(frameA.balls.map((entry) => [entry.id, entry]));
           const bMap = frameB ? new Map(frameB.balls.map((entry) => [entry.id, entry])) : null;
@@ -17725,9 +17728,9 @@ const powerRef = useRef(hud.power);
               }
             }
           });
-          const cueStateA = frameA.cue ?? null;
-          const cueStateB = frameB?.cue ?? cueStateA;
-          if (cueStick && (cueStateA || cueStateB)) {
+          const cueStateA = allowCueSnapshot ? frameA.cue ?? null : null;
+          const cueStateB = allowCueSnapshot ? frameB?.cue ?? cueStateA : null;
+          if (allowCueSnapshot && cueStick && (cueStateA || cueStateB)) {
             const posA = normalizeVector3Snapshot(cueStateA?.position);
             const posB = normalizeVector3Snapshot(cueStateB?.position, posA);
             if (posA && posB) {
@@ -23561,7 +23564,9 @@ const powerRef = useRef(hud.power);
             const alpha = frameB
               ? THREE.MathUtils.clamp((targetTime - frameA.t) / span, 0, 1)
               : 0;
-            const hasCueSnapshot = applyReplayFrame(frameA, frameB, alpha);
+            const hasCueSnapshot = applyReplayFrame(frameA, frameB, alpha, {
+              allowCueSnapshot: !playback?.cueStroke
+            });
             if (!hasCueSnapshot) {
               applyReplayCueStroke(playback, targetTime);
             }
@@ -23728,7 +23733,7 @@ const powerRef = useRef(hud.power);
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
-          (isPlayerTurn || previewingAiShot || aiCueViewActive);
+          (isPlayerTurn || previewingAiShot || aiCueViewActive || aiTakingShot);
         if (
           cue?.pos &&
           !sliderInstanceRef.current?.dragging &&


### PR DESCRIPTION
### Motivation
- Reduce brief freeze/stutter and misplaced camera switches when shots target middle (side) pockets and ensure replays/AI shots display the cue correctly.
- Move the chrome side plates slightly inward for a more centered visual without altering the pocket cut.

### Description
- Nudge middle chrome fascia inward by adjusting `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `-0.045` to `-0.065` to shift chrome plates toward the table center.
- Tighten pocket-camera early activation logic in `makePocketCameraView` to prevent forcing an early side-pocket camera unless the ball is within the trigger distance (introduces `allowForcedEarly` and uses it for `forcedEarly` handling).
- Add an `allowCueSnapshot` option to `applyReplayFrame` and prefer using `cueStroke`-driven replay animation when `playback.cueStroke` exists by calling `applyReplayFrame(..., { allowCueSnapshot: !playback?.cueStroke })` so replay cue-stroke animation is used when available.
- Allow AI shots to show the cue stick by including `aiTakingShot` in the `canShowCue` predicate so AI aiming/stroke phases keep the cue visible.

### Testing
- Started the webapp dev server (`npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`) which launched Vite successfully and served the site (success).
- Attempted an automated visual test via Playwright to capture a screenshot, but Chromium crashed in the container environment (failure); crash is environmental and unrelated to logic changes.
- No unit tests were run as part of this change; repository commit completed (`git commit`) and the modified file was committed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69767551d8e08329820defd7877f6cf9)