### PR TITLE
Add SVG overlay mapping cushions and pockets to Pool Royale demo

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -43,6 +43,10 @@
         height: 100%;
         pointer-events: none;
       }
+      .table-mapping {
+        stroke-linejoin: round;
+        stroke-linecap: round;
+      }
       .cloth-shadow {
         position: absolute;
         top: var(--cloth-top);
@@ -188,6 +192,42 @@
         alt="Pool table"
       />
       <div id="cloth-shadow" class="cloth-shadow" aria-hidden="true"></div>
+      <svg
+        class="overlay table-mapping"
+        viewBox="0 0 1600 900"
+        aria-label="Pool table mapping"
+      >
+        <rect
+          x="200"
+          y="160"
+          width="1200"
+          height="580"
+          rx="60"
+          ry="60"
+          fill="none"
+          stroke="#f5d64e"
+          stroke-width="4"
+        />
+        <rect
+          x="120"
+          y="90"
+          width="1360"
+          height="720"
+          rx="90"
+          ry="90"
+          fill="none"
+          stroke="#e53935"
+          stroke-width="4"
+        />
+        <g fill="none" stroke="#1e88e5" stroke-width="4">
+          <circle cx="200" cy="160" r="60" />
+          <circle cx="800" cy="160" r="64" />
+          <circle cx="1400" cy="160" r="60" />
+          <circle cx="200" cy="740" r="60" />
+          <circle cx="800" cy="740" r="64" />
+          <circle cx="1400" cy="740" r="60" />
+        </g>
+      </svg>
       <svg id="frame" class="overlay debug-marker" viewBox="0 0 1000 1500"></svg>
       <div class="ball-layer">
         <div id="aim-line" class="aim-line debug-marker"></div>


### PR DESCRIPTION
### Motivation
- Provide a clear visual reference of the table layout for the Pool Royale demo by marking the playing field, cushions, and pockets to aid development and UX tuning.

### Description
- Add an SVG overlay to `examples/pool-royale/index.html` that draws the field as a thin yellow outline, the cushions as a thin red outline, and the six pockets as blue circles, plus a `.table-mapping` style for rounded strokes and an `aria-label` for accessibility.

### Testing
- Launched a local server with `python -m http.server` and captured a portrait screenshot using a Playwright script which produced the artifact `artifacts/pool-royale-mapping.png`, confirming the overlay renders as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f64b828083299abac23152737071)