### PR TITLE
Add Russian commentary across games and localize Chess commentary

### DIFF
--- a/webapp/src/utils/airHockeyCommentary.js
+++ b/webapp/src/utils/airHockeyCommentary.js
@@ -121,6 +121,24 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       outro: ['{arena} से धन्यवाद, अगली बार फिर मिलते हैं।']
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Добро пожаловать на {arena}. {speaker} и {partner} с вами: {player} против {opponent}, {scoreline}.'],
+      introReply: ['Спасибо {speaker}. Скорость, углы и контроль решат исход.'],
+      faceoff: ['Первые касание у {player}.'],
+      pressure: ['Ключевой момент для {player}.'],
+      attack: ['{player} ускоряется в атаку.'],
+      save: ['Отличный сэйв от {opponent}.'],
+      post: ['В штангу! {player} был близок.'],
+      goal: ['Гол! {player} забивает — {scoreline}.'],
+      equalizer: ['{player} сравнивает счет, {scoreline}.'],
+      leadChange: ['{player} выходит вперед, {scoreline}.'],
+      matchPoint: ['Матчбол у {player}, еще один гол до {targetScore}.'],
+      matchWin: ['Матч окончен. {player} побеждает {playerScore}-{opponentScore}.'],
+      outro: ['Спасибо, что были с нами на {arena}.']
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -220,6 +238,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';

--- a/webapp/src/utils/chessBattleCommentary.js
+++ b/webapp/src/utils/chessBattleCommentary.js
@@ -94,6 +94,129 @@ const ENGLISH_TEMPLATES = Object.freeze({
   }
 });
 
+const LOCALIZED_TEMPLATES = Object.freeze({
+  en: ENGLISH_TEMPLATES,
+  zh: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['欢迎来到{arena}。{speaker}为您解说，{player}对阵{opponent}。'],
+      introReply: ['谢谢{speaker}。精准计算与耐心布局将决定胜负。'],
+      opening: ['{player}以{piece}走到{toSquare}，展开开局。'],
+      move: ['{player}将{piece}走到{toSquare}，稳健推进。'],
+      capture: ['{player}在{toSquare}吃掉{capturedPiece}。'],
+      check: ['将军！{opponent}必须应对。'],
+      checkmate: ['将杀！{winner}锁定胜局。'],
+      stalemate: ['僵局，无子可走，棋局和棋。'],
+      promotion: ['{player}在{toSquare}升变。'],
+      castle: ['{player}在{castleSide}侧王车易位，国王安全。'],
+      endgame: ['进入残局，细节决定成败。'],
+      outro: ['来自{arena}的比赛结束，感谢观看。']
+    }
+  },
+  hi: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['{arena} से स्वागत है। {speaker} के साथ {player} बनाम {opponent}।'],
+      introReply: ['धन्यवाद {speaker}. सटीक गणना और धैर्यपूर्ण चालें निर्णायक होंगी।'],
+      opening: ['{player} {piece} को {toSquare} पर विकसित करता है।'],
+      move: ['{player} {piece} को {toSquare} पर ले जाता है।'],
+      capture: ['{player} ने {toSquare} पर {capturedPiece} लिया।'],
+      check: ['चेक! {opponent} को जवाब देना होगा।'],
+      checkmate: ['चेकमेट! {winner} जीत गया।'],
+      stalemate: ['स्टेलमेट—कोई वैध चाल नहीं, खेल ड्रॉ।'],
+      promotion: ['{player} {toSquare} पर प्रोमोशन करता है।'],
+      castle: ['{player} {castleSide} कैसल करता है, राजा सुरक्षित।'],
+      endgame: ['एंडगेम में हम हैं—हर टेम्पो अहम है।'],
+      outro: ['{arena} से बस इतना ही, धन्यवाद।']
+    }
+  },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Добро пожаловать на {arena}. {speaker} в эфире: {player} против {opponent}.'],
+      introReply: ['Спасибо, {speaker}. Точный расчёт и терпеливое маневрирование решат исход.'],
+      opening: ['{player} развивает {piece} на {toSquare}.'],
+      move: ['{player} переводит {piece} на {toSquare}.'],
+      capture: ['{player} берет {capturedPiece} на {toSquare}.'],
+      check: ['Шах! {opponent} должен отвечать.'],
+      checkmate: ['Мат. {winner} завершает партию.'],
+      stalemate: ['Пат — ходов нет, ничья.'],
+      promotion: ['{player} делает превращение на {toSquare}.'],
+      castle: ['{player} рокирует на {castleSide}, король в безопасности.'],
+      endgame: ['Эндшпиль: точность решает всё.'],
+      outro: ['Из {arena} — спасибо за просмотр.']
+    }
+  },
+  es: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Bienvenidos a {arena}. {speaker} con ustedes: {player} contra {opponent}.'],
+      introReply: ['Gracias {speaker}. Cálculo preciso y maniobra paciente decidirán.'],
+      opening: ['{player} desarrolla {piece} a {toSquare}.'],
+      move: ['{player} lleva la {piece} a {toSquare}.'],
+      capture: ['{player} captura {capturedPiece} en {toSquare}.'],
+      check: ['¡Jaque! {opponent} debe responder.'],
+      checkmate: ['Jaque mate. {winner} gana la partida.'],
+      stalemate: ['Tablas por ahogado; no hay jugadas legales.'],
+      promotion: ['{player} corona en {toSquare}.'],
+      castle: ['{player} enroca por el lado {castleSide}.'],
+      endgame: ['Estamos en el final; cada tempo cuenta.'],
+      outro: ['Desde {arena}, gracias por acompañarnos.']
+    }
+  },
+  fr: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Bienvenue à {arena}. {speaker} avec vous : {player} contre {opponent}.'],
+      introReply: ['Merci {speaker}. Calcul précis et manœuvre patiente feront la différence.'],
+      opening: ['{player} développe {piece} en {toSquare}.'],
+      move: ['{player} joue {piece} vers {toSquare}.'],
+      capture: ['{player} capture {capturedPiece} en {toSquare}.'],
+      check: ['Échec ! {opponent} doit répondre.'],
+      checkmate: ['Échec et mat. {winner} gagne la partie.'],
+      stalemate: ['Pat : aucune case légale, partie nulle.'],
+      promotion: ['{player} promeut en {toSquare}.'],
+      castle: ['{player} roque côté {castleSide}.'],
+      endgame: ['Nous sommes en finale; chaque tempo compte.'],
+      outro: ['Depuis {arena}, merci de votre présence.']
+    }
+  },
+  ar: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['مرحبًا بكم في {arena}. معكم {speaker}: {player} ضد {opponent}.'],
+      introReply: ['شكرًا {speaker}. الحساب الدقيق والمناورة الهادئة سيحسمان اللقاء.'],
+      opening: ['{player} يطور {piece} إلى {toSquare}.'],
+      move: ['{player} ينقل {piece} إلى {toSquare}.'],
+      capture: ['{player} يلتقط {capturedPiece} على {toSquare}.'],
+      check: ['كش! على {opponent} الرد.'],
+      checkmate: ['كش مات. {winner} يحسم المباراة.'],
+      stalemate: ['تعادل بالجمود؛ لا توجد حركات قانونية.'],
+      promotion: ['{player} يرقّي في {toSquare}.'],
+      castle: ['{player} يقوم بالتبييت جهة {castleSide}.'],
+      endgame: ['دخلنا النهاية؛ كل نقلة محسوبة.'],
+      outro: ['من {arena}، شكرًا للمتابعة.']
+    }
+  },
+  sq: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Mirë se vini në {arena}. {speaker} me ju: {player} kundër {opponent}.'],
+      introReply: ['Faleminderit {speaker}. Llogaritja e saktë dhe manovra e duruar vendosin ndeshjen.'],
+      opening: ['{player} zhvillon {piece} në {toSquare}.'],
+      move: ['{player} lëviz {piece} në {toSquare}.'],
+      capture: ['{player} kap {capturedPiece} në {toSquare}.'],
+      check: ['Shah! {opponent} duhet të përgjigjet.'],
+      checkmate: ['Shah mat. {winner} fiton lojën.'],
+      stalemate: ['Barazim nga pat—nuk ka lëvizje të ligjshme.'],
+      promotion: ['{player} promovon në {toSquare}.'],
+      castle: ['{player} bën rokadë në anën {castleSide}.'],
+      endgame: ['Jemi në fundlojë; çdo tempo vlen.'],
+      outro: ['Nga {arena}, faleminderit që na ndoqët.']
+    }
+  }
+});
+
 const EVENT_POOLS = Object.freeze({
   intro: 'intro',
   introReply: 'introReply',
@@ -116,8 +239,15 @@ const applyTemplate = (template, context) =>
 
 const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
+  if (normalized.startsWith('zh')) return 'zh';
+  if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
+  if (normalized.startsWith('es')) return 'es';
+  if (normalized.startsWith('fr')) return 'fr';
+  if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('sq')) return 'sq';
   if (normalized.startsWith('en')) return 'en';
-  return 'en';
+  return normalized || 'en';
 };
 
 export const buildChessCommentaryLine = ({
@@ -126,7 +256,7 @@ export const buildChessCommentaryLine = ({
   language = 'en',
   context = {}
 }) => {
-  const templates = resolveLanguageKey(language) === 'en' ? ENGLISH_TEMPLATES : ENGLISH_TEMPLATES;
+  const templates = LOCALIZED_TEMPLATES[resolveLanguageKey(language)] || ENGLISH_TEMPLATES;
   const mergedContext = {
     ...DEFAULT_CONTEXT,
     ...context,

--- a/webapp/src/utils/ludoBattleRoyaleCommentary.js
+++ b/webapp/src/utils/ludoBattleRoyaleCommentary.js
@@ -126,6 +126,23 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       outro: ['{arena} से यही अपडेट। धन्यवाद।']
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Добро пожаловать на {arena}. {speaker} в эфире: {player} против {opponent}.'],
+      introReply: ['Спасибо {speaker}. Безопасные клетки и захваты зададут темп.'],
+      diceRoll: ['{player} бросает {roll}. Варианты открываются.'],
+      extraTurn: ['Шестёрка для {player} — ещё один ход.'],
+      enter: ['{player} вводит фишку в игру.'],
+      move: ['{player} продвигается на {roll} клеток.'],
+      capture: ['{player} берет {opponent} и отправляет в базу.'],
+      safe: ['{player} встает на безопасную клетку.'],
+      homeStretch: ['{player} в финишной зоне, {tokensHome} фишек дома.'],
+      goal: ['{player} приводит ещё одну фишку домой. Всего {tokensHome}.'],
+      win: ['Матч окончен: {player} побеждает.'],
+      outro: ['Это всё с {arena}. Спасибо за просмотр.']
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -220,6 +237,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -372,6 +372,90 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       blackBall: ['ब्लैक बॉल आ गई, एंगल बहुत जरूरी है।']
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Добро пожаловать на {arena}. {speaker} в эфире. {player} против {opponent}, {scoreline}, {variantName}.'
+      ],
+      introReply: [
+        'Спасибо, {speaker}. Контроль битка и позиция решат исход.'
+      ],
+      breakShot: [
+        '{player} готовит разбой; важно раскрыть пирамиду и удержать биток.'
+      ],
+      breakResult: [
+        'Хороший разбой — стол открыт, линии видны.'
+      ],
+      openTable: [
+        'Стол открыт; {player} ищет естественные углы и позицию.'
+      ],
+      safety: [
+        '{player} играет в защиту и прячет биток.'
+      ],
+      pressure: [
+        'Удар под давлением; мягкое касание и точный винт обязательны.'
+      ],
+      pot: [
+        '{player} кладет {targetBall} в {pocket} и сохраняет позицию.'
+      ],
+      combo: [
+        '{player} делает комбинацию: {targetBall} в {pocket}.'
+      ],
+      bank: [
+        '{player} бьет с борта и кладет {targetBall} в {pocket}.'
+      ],
+      kick: [
+        '{player} вынужден играть кик, чтобы найти шар.'
+      ],
+      jump: [
+        '{player} исполняет джамп, обходя блок.'
+      ],
+      miss: [
+        '{player} мажет, шанс у {opponent}.'
+      ],
+      foul: [
+        'Фол у {player}.'
+      ],
+      inHand: [
+        'Биток с руки у {opponent}.'
+      ],
+      runout: [
+        '{player} может закрыть стол, если удержит контроль.'
+      ],
+      hillHill: [
+        'Решающая партия — максимальное напряжение.'
+      ],
+      frameWin: [
+        '{player} забирает этот фрейм.'
+      ],
+      matchWin: [
+        'Матч окончен. {player} побеждает {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'Из {arena} — спасибо, что были с нами.'
+      ]
+    },
+    nineBall: {
+      variantName: 'американский 9-болл',
+      rotation: ['В 9-болле нужно бить по самому младшему шару первым.'],
+      goldenBreak: ['Если девятка падает с разбоя — партия заканчивается.'],
+      comboNine: ['{player} нацеливается на комбинацию в девятку — большой шанс.'],
+      pushOut: ['{player} использует пуш-аут для лучшей позиции.']
+    },
+    eightBallUs: {
+      variantName: 'американский 8-болл',
+      groupCall: ['Открытый стол между {groupPrimary} и {groupSecondary}.'],
+      inHand: ['{opponent} с битком в руке — серьёзное преимущество.'],
+      eightBall: ['Теперь 8-й шар в игре; позиция решает всё.']
+    },
+    eightBallUk: {
+      variantName: 'британский 8-болл',
+      groupCall: ['Правила UK: {groupPrimary} и {groupSecondary} ещё открыты.'],
+      freeBall: ['{player} получает свободный шар и два визита.'],
+      blackBall: ['Чёрный шар в игре — нужен идеальный угол.']
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -756,6 +840,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';

--- a/webapp/src/utils/snakeAndLadderCommentary.js
+++ b/webapp/src/utils/snakeAndLadderCommentary.js
@@ -167,6 +167,47 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ]
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Добро пожаловать на {arena}. {speaker} и {partner} с вами. {player} против {opponent}.'
+      ],
+      introReply: [
+        'Спасибо {speaker}. Быстрая гонка: лестницы поднимают, змеи наказывают.'
+      ],
+      roll: [
+        '{player} бросает {roll}.'
+      ],
+      ladder: [
+        '{player} поднимается с {from} на {to}, рывок {delta}.'
+      ],
+      snake: [
+        '{player} попадает на змею: с {from} на {to}.'
+      ],
+      bonus: [
+        '{player} получает бонусный бросок.'
+      ],
+      capture: [
+        '{player} отправляет {victim} назад на старт.'
+      ],
+      exactNeeded: [
+        '{player} нужен точный {need}, чтобы финишировать.'
+      ],
+      startBlocked: [
+        '{player} нужна шестёрка, чтобы войти.'
+      ],
+      needSix: [
+        '{player} нужна шестёрка.'
+      ],
+      win: [
+        '{player} достигает финиша и побеждает!'
+      ],
+      outro: [
+        'Это была гонка на {arena}. Спасибо за просмотр.'
+      ]
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -342,6 +383,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';

--- a/webapp/src/utils/snookerRoyalCommentary.js
+++ b/webapp/src/utils/snookerRoyalCommentary.js
@@ -234,6 +234,30 @@ const LOCALIZED_TEMPLATES = Object.freeze({
     outroReply: ['अगला फ्रेम तैयार।'],
     turn: ['अब {player} की बारी।']
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    intro: ['{frameNumber} начинается. {player} на разбо́е.'],
+    introReply: ['Тактическое начало; контроль битка решит многое.'],
+    breakOff: ['{player} выполняет разбой, стараясь сыграть безопасно.'],
+    redPot: ['Красный в лузе, {player} остается у стола.'],
+    multiRed: ['Несколько красных падают — позиция раскрывается.'],
+    colorPot: ['{player} кладет {color} и держит позицию.'],
+    colorOrder: ['Цвета по порядку, {player} контролирует стол.'],
+    respot: ['{color} забит и возвращен на точку.'],
+    safety: ['{player} играет защиту и прячет биток.'],
+    snooker: ['{player} ставит {opponent} в снукер.'],
+    freeBall: ['Свободный шар для {player}.'],
+    foul: ['Фол у {player}. {points} для {opponent}.'],
+    miss: ['{player} промахивается; шанс у {opponent}.'],
+    breakBuild: ['Серия {player} достигает {breakTotal}.'],
+    century: ['Сотенная серия: {player} набирает {breakTotal}.'],
+    colorsOrder: ['Красные закончились; цвета по порядку.'],
+    frameBall: ['Фреймбол для {player}.'],
+    frameWin: ['{player} берет фрейм. {scoreline}.'],
+    outro: ['{frameNumber} завершен. {scoreline}.'],
+    outroReply: ['Подготовка следующего фрейма.'],
+    turn: ['Ход {player}.']
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     intro: ['{frameNumber} en marcha. {player} abre.'],
@@ -341,6 +365,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';

--- a/webapp/src/utils/texasHoldemCommentary.js
+++ b/webapp/src/utils/texasHoldemCommentary.js
@@ -176,6 +176,28 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       outro: ['यहाँ से विदा, धन्यवाद।']
     }
   },
+  ru: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: ['Добро пожаловать на {arena}. {speaker} и {partner} в эфире.'],
+      introReply: ['Спасибо {speaker}. Терпение и позиция решают всё.'],
+      newHand: ['Новая раздача начинается.'],
+      blinds: ['Блайнды поставлены, действие за {player}.'],
+      flop: ['Флоп на столе — новая текстура.'],
+      turn: ['Терн открыт, давление растет.'],
+      river: ['Ривер на столе, финальные решения.'],
+      check: ['{player} чек.'],
+      call: ['{player} коллирует {amount}.'],
+      bet: ['{player} ставит {amount}.'],
+      raise: ['{player} повышает до {amount}.'],
+      fold: ['{player} фолдит.'],
+      allIn: ['{player} идет олл-ин на {amount}.'],
+      showdown: ['Переходим к шоудауну.'],
+      potWin: ['{player} забирает банк {pot}.'],
+      potSplit: ['Банк делится, {player} делят {pot}.'],
+      outro: ['Сессия завершена, спасибо за просмотр.']
+    }
+  },
   es: {
     ...ENGLISH_TEMPLATES,
     common: {
@@ -275,6 +297,7 @@ const resolveLanguageKey = (language = 'en') => {
   const normalized = String(language || '').toLowerCase();
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('hi')) return 'hi';
+  if (normalized.startsWith('ru')) return 'ru';
   if (normalized.startsWith('es')) return 'es';
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';


### PR DESCRIPTION
### Motivation
- Ensure all game commentary modules offer the same language coverage as the Murlan Royale set by adding missing Russian templates and language handling. 
- Make Chess Battle Royal use the same localized-template mechanism so it can serve the same set of languages as other games.

### Description
- Added Russian commentary templates to `webapp/src/utils/poolRoyaleCommentary.js`, `webapp/src/utils/snookerRoyalCommentary.js`, `webapp/src/utils/ludoBattleRoyaleCommentary.js`, `webapp/src/utils/airHockeyCommentary.js`, `webapp/src/utils/snakeAndLadderCommentary.js`, and `webapp/src/utils/texasHoldemCommentary.js`. 
- Updated language resolution in each modified module by adding `ru` handling in `resolveLanguageKey` so Russian is selectable. 
- Implemented `LOCALIZED_TEMPLATES` for `webapp/src/utils/chessBattleCommentary.js`, added multiple localized templates (including Russian), and switched template selection to use `LOCALIZED_TEMPLATES` via `resolveLanguageKey`. 
- Minor string/grammar fix in `snakeAndLadderCommentary.js` and wired files into the staged changes for commit.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976fcff689c8329ace59ab5858974b2)