### PR TITLE
Nudge short-rail mapping overlay outward for more precise pocket alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10214,6 +10214,7 @@ export function Table3D(
 
   const mappingLineLift = Math.max(MICRO_EPS * 8, TABLE.THICK * 0.002);
   const mappingLineY = clothPlaneWorld + mappingLineLift;
+  const SHORT_RAIL_MAPPING_OUTSET = TABLE.THICK * 0.02;
   const mappingGroup = new THREE.Group();
   mappingGroup.name = 'tableMappingOverlay';
   const fieldLineMaterial = new THREE.LineBasicMaterial({
@@ -10280,8 +10281,10 @@ export function Table3D(
         }
       };
       if (data.horizontal) {
-        const innerZ = data.side < 0 ? box.max.z : box.min.z;
-        const outerZ = data.side < 0 ? box.min.z : box.max.z;
+        const shortRailOutset =
+          data.side < 0 ? -SHORT_RAIL_MAPPING_OUTSET : SHORT_RAIL_MAPPING_OUTSET;
+        const innerZ = (data.side < 0 ? box.max.z : box.min.z) + shortRailOutset;
+        const outerZ = (data.side < 0 ? box.min.z : box.max.z) + shortRailOutset;
         pushPoint(box.min.x, outerZ);
         pushPoint(box.min.x + minCut, innerZ);
         pushPoint(box.max.x - maxCut, innerZ);


### PR DESCRIPTION
### Motivation
- The short-rail cushion mapping overlay needed to be pushed slightly outward so the red mapping line on the short rails aligns more closely with the visible rail/pocket geometry while preserving the existing cushion cut angles.

### Description
- Introduced `SHORT_RAIL_MAPPING_OUTSET` and set it to `TABLE.THICK * 0.02` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Applied a signed outset (`shortRailOutset`) to horizontal cushion mapping points and added the outset to `innerZ` and `outerZ` so the mapping line moves outward on the short rails without changing cut geometry.
- All other mapping logic and vertical-rail mapping remain unchanged.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and confirmed Vite served the app successfully (server ready at `http://localhost:4173/`).
- Attempted an automated visual check using a Playwright screenshot, but the headless Chromium process crashed (SIGSEGV) and the screenshot run failed. 
- No unit or integration tests were executed for this visual tweak; changes were committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772b8a8a7c8329992eb2fcf8269628)