### PR TITLE
Adjust Goal Rush quick-action visuals and positions

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -58,10 +58,18 @@
 
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
-    #quickActions{position:fixed;left:calc(0.75rem + env(safe-area-inset-left,0px));bottom:calc(env(safe-area-inset-bottom,0px) + 1rem);display:flex;flex-direction:column;gap:.6rem;z-index:6;pointer-events:auto;}
-    #quickActions .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:rgba(0,0,0,.6);border:1px solid rgba(255,255,255,.18);color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:0;}
-    #quickActions .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
-    #quickActions .quick-action .icon{font-size:1.1rem;line-height:1;}
+    .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.75rem);bottom:calc(env(safe-area-inset-bottom,0px) + 0.9rem);}
+    #quickActionGift{right:calc(env(safe-area-inset-right,0px) + 0.75rem);bottom:calc(env(safe-area-inset-bottom,0px) + 0.9rem);}
+    #quickActionInfo{right:calc(env(safe-area-inset-right,0px) + 0.2rem);top:calc(env(safe-area-inset-top,0px) + 0.6rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.2rem);top:calc(env(safe-area-inset-top,0px) + 3.3rem);}
+    #quickActionAudio{left:calc(env(safe-area-inset-left,0px) + 0.2rem);top:calc(env(safe-area-inset-top,0px) + 0.6rem);}
+    .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
+    #quickActionInfo .quick-action{width:2.6rem;height:2.6rem;}
+    .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
+    #quickActionInfo .quick-action span{font-size:.52rem;}
+    .quick-action .icon{font-size:1.1rem;line-height:1;}
+    #quickActionInfo .quick-action .icon{font-size:.95rem;}
     .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;z-index:7;}
     .modal-overlay.active{display:flex;}
     .modal-card{width:min(340px, 88vw);background:#0b1220;border:1px solid #233050;border-radius:16px;padding:1rem;color:#e5e7eb;box-shadow:0 18px 40px rgba(0,0,0,.5);display:flex;flex-direction:column;gap:.75rem;}
@@ -131,26 +139,34 @@
         </div>
       </div>
     </div>
-    <div id="quickActions" aria-label="Quick actions">
-      <button class="quick-action" type="button" data-action="chat">
+    <div id="quickActionChat" class="quick-action-slot" aria-label="Chat">
+      <button class="quick-action" id="quickActionChatButton" type="button" data-action="chat">
         <span class="icon" aria-hidden="true">💬</span>
         <span>Chat</span>
       </button>
+    </div>
+    <div id="quickActionGift" class="quick-action-slot" aria-label="Gift">
       <button class="quick-action" type="button" data-action="gift">
         <span class="icon" aria-hidden="true">🎁</span>
         <span>Gift</span>
       </button>
+    </div>
+    <div id="quickActionInfo" class="quick-action-slot" aria-label="Info">
       <button class="quick-action" type="button" data-action="info">
         <span class="icon" aria-hidden="true">ℹ️</span>
         <span>Info</span>
       </button>
-      <button class="quick-action" type="button" data-action="commentary">
-        <span class="icon" aria-hidden="true">🎙️</span>
-        <span>Audio</span>
-      </button>
+    </div>
+    <div id="quickActionMute" class="quick-action-slot" aria-label="Mute">
       <button class="quick-action" type="button" data-action="mute">
         <span class="icon" id="muteIcon" aria-hidden="true">🔊</span>
         <span id="muteLabel">Mute</span>
+      </button>
+    </div>
+    <div id="quickActionAudio" class="quick-action-slot" aria-label="Audio">
+      <button class="quick-action" type="button" data-action="commentary">
+        <span class="icon" aria-hidden="true">🎙️</span>
+        <span>Audio</span>
       </button>
     </div>
     <div class="canvasWrap">
@@ -1199,16 +1215,24 @@
     label.textContent = text;
     bubble.appendChild(label);
     document.body.appendChild(bubble);
-    const targets = [p1AvatarTop, p2AvatarTop];
-    const badge = targets[playerIndex];
-    if (badge) {
-      const rect = badge.getBoundingClientRect();
-      bubble.style.left = `${rect.left + rect.width / 2}px`;
-      bubble.style.top = `${rect.top - 12}px`;
-      bubble.style.transform = 'translate(-50%, -100%)';
+    const chatButton = document.getElementById('quickActionChatButton');
+    if (chatButton) {
+      const rect = chatButton.getBoundingClientRect();
+      bubble.style.left = `${rect.right + 12}px`;
+      bubble.style.top = `${rect.top + rect.height / 2}px`;
+      bubble.style.transform = 'translate(0, -50%)';
     } else {
-      bubble.style.left = '1rem';
-      bubble.style.bottom = '5.5rem';
+      const targets = [p1AvatarTop, p2AvatarTop];
+      const badge = targets[playerIndex];
+      if (badge) {
+        const rect = badge.getBoundingClientRect();
+        bubble.style.left = `${rect.left + rect.width / 2}px`;
+        bubble.style.top = `${rect.top - 12}px`;
+        bubble.style.transform = 'translate(-50%, -100%)';
+      } else {
+        bubble.style.left = '1rem';
+        bubble.style.bottom = '5.5rem';
+      }
     }
     setTimeout(() => bubble.remove(), 3000);
   }


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving chat/gift controls to the bottom edges, placing the audio control at the top-left, and stacking mute under a smaller info icon at the top-right so controls align with the requested layout and screen edges.
- Remove the rounded background chrome from quick-action buttons so only the icons are visible and lightweight on-screen.

### Description
- Updated `webapp/public/goal-rush.html` to introduce per-slot elements `#quickActionChat`, `#quickActionGift`, `#quickActionInfo`, `#quickActionMute`, and `#quickActionAudio` and to remove the previous stacked left/right cluster markup.
- Changed quick-action CSS to remove button backgrounds and borders (`background: transparent; border: none; box-shadow: none`) and made the info icon smaller with reduced icon/span sizing via `#quickActionInfo .quick-action` rules.
- Repositioned controls with fixed-position slots: chat/gift are anchored to the bottom safe-area edges, info is moved slightly farther right and higher, mute is stacked beneath info, and audio is placed further left at the top per the requested portrait adjustments.
- Adjusted `showChatBubble` so bubbles prefer positioning relative to the `#quickActionChatButton` (with an avatar-based fallback) so quick chat feedback aligns with the chat control.

### Testing
- Started a local static server with `python -m http.server 4173` serving `webapp/public`, which started successfully and served the updated page.
- Captured a headless screenshot of `http://127.0.0.1:4173/goal-rush.html` using a Playwright script at viewport `390x844`, which completed successfully and produced `artifacts/goal-rush-icons-updated.png` for visual verification.
- Verified the updated `showChatBubble` path and CSS changes by loading the page; the automated screenshot run completed without script errors (noting unrelated 404 for a missing sound asset observed in the server log).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977335861648329ae375ba550f38d31)