### PR TITLE
Adjust Snake & Ladder icon layout: move settings, add info/mute stack, restyle icons

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3462,7 +3462,7 @@ export default function SnakeAndLadder() {
             type="button"
             aria-label={showConfig ? 'Close game settings' : 'Open game settings'}
             onClick={() => setShowConfig((prev) => !prev)}
-            className="p-2 text-lg text-gray-100 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            className="bg-transparent p-2 text-lg text-gray-100 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
           >
             ⚙️
           </button>
@@ -3672,7 +3672,7 @@ export default function SnakeAndLadder() {
             showChat={false}
             showGift={false}
             order={['info', 'mute']}
-            buttonClassName="flex flex-col items-center text-white/90 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
           />
@@ -3690,7 +3690,7 @@ export default function SnakeAndLadder() {
             showInfo={false}
             showMute={false}
             order={['chat', 'gift']}
-            buttonClassName="flex flex-col items-center text-white/90 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
           />

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3450,13 +3450,19 @@ export default function SnakeAndLadder() {
           frameRate={frameRateValue}
         />
       </div>
-      <div className="absolute top-3 right-3 z-30 pointer-events-auto">
+      <div
+        className="absolute z-30 pointer-events-auto"
+        style={{
+          top: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
+          left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
+        }}
+      >
         <div className="relative">
           <button
             type="button"
             aria-label={showConfig ? 'Close game settings' : 'Open game settings'}
             onClick={() => setShowConfig((prev) => !prev)}
-            className="rounded-full bg-black/70 p-2 text-lg text-gray-100 shadow-lg backdrop-blur transition hover:bg-black/60"
+            className="p-2 text-lg text-gray-100 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
           >
             ⚙️
           </button>
@@ -3655,10 +3661,25 @@ export default function SnakeAndLadder() {
         </div>
       </div>
       <div className="relative z-10 flex flex-col justify-end items-center w-full h-full p-4 pb-32 space-y-4 pointer-events-none">
-        {/* Bottom left controls */}
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
+            style={{
+              right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
+              top: 'calc(4.5rem + env(safe-area-inset-top, 0px))'
+            }}
+            className="fixed z-30 flex flex-col items-center gap-2"
+            showChat={false}
+            showGift={false}
+            order={['info', 'mute']}
+            buttonClassName="flex flex-col items-center text-white/90 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            iconClassName="text-2xl leading-none"
+            labelClassName="sr-only"
+          />
+        </div>
+        {/* Bottom left controls */}
+        <div className="pointer-events-auto w-full">
+          <BottomLeftIcons
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
             style={{
@@ -3666,9 +3687,12 @@ export default function SnakeAndLadder() {
               bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
             }}
             className="fixed z-20 flex flex-col items-center gap-2"
-            buttonClassName="w-[3.15rem] h-[3.15rem] rounded-[14px] bg-black/60 border border-white/20 text-white flex flex-col items-center justify-center gap-1 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur-md"
-            iconClassName="text-[1.1rem] leading-none"
-            labelClassName="text-[0.6rem] font-extrabold tracking-[0.08em] uppercase"
+            showInfo={false}
+            showMute={false}
+            order={['chat', 'gift']}
+            buttonClassName="flex flex-col items-center text-white/90 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            iconClassName="text-2xl leading-none"
+            labelClassName="sr-only"
           />
         </div>
         {/* Player photos stacked vertically */}


### PR DESCRIPTION
### Motivation
- Improve on-screen icon placement for portrait mobile: place configuration on the top-left, info + mute stacked near the top-right under the pot, and move chat/gift slightly down to avoid overlap. 
- Make the control icons appear as icon-only controls (no framed/background buttons) for a cleaner UI and to match the requested look.

### Description
- Moved the settings (configuration) button to the top-left and removed its framed background, keeping accessibility attributes and the settings popup unchanged. 
- Added a compact info/mute stack at the top-right by reusing the `BottomLeftIcons` component configured to render only `info` and `mute` in that position. 
- Repositioned the chat and gift controls down to the bottom-left area and removed framed backgrounds by adjusting the `BottomLeftIcons` props to show only `chat` and `gift` with icon-only styling. 
- Simplified button/icon classes so labels are screen-reader only (`sr-only`) and visual buttons are icon-only, with accessible focus styles preserved.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to serve the app locally and verify layout changes. 
- Captured a visual test screenshot of the Snake page using a Playwright script against `http://127.0.0.1:4173/games/snake`, saved to `artifacts/snake-icons.png`, and the script completed successfully. 
- No unit tests were modified or required; the changes are visual/layout-only and were validated via the automated screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697739c0943483298b61e359f0357aa2)