### PR TITLE
Lower Chess board on table and make icon-only UI buttons

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -111,6 +111,23 @@ button {
   @apply px-2 py-1 bg-primary hover:bg-primary-hover text-white text-outline-black text-sm rounded;
 }
 
+.icon-only-button {
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+  border-radius: 9999px;
+  -webkit-text-stroke-width: 0;
+  text-shadow: none;
+}
+
+.icon-only-button:hover,
+.icon-only-button:focus {
+  background: transparent;
+  box-shadow: none;
+  outline: none;
+}
+
 body.mining-page button {
   @apply text-white-shadow;
 }

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -225,7 +225,7 @@ const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
 const PIECE_SCALE_FACTOR = 0.92;
 const PIECE_FOOTPRINT_RATIO = 0.86;
-const BOARD_GROUP_Y_OFFSET = -0.05;
+const BOARD_GROUP_Y_OFFSET = -0.09;
 const BOARD_MODEL_Y_OFFSET = -0.12;
 const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
@@ -9147,7 +9147,7 @@ function Chess3D({
             type="button"
             onClick={() => setConfigOpen((open) => !open)}
             aria-expanded={configOpen}
-            className="pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+            className="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -9187,7 +9187,7 @@ function Chess3D({
               type="button"
               onClick={() => replayLastMoveRef.current?.()}
               disabled={!canReplay}
-              className={`flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 focus:outline-none ${
+              className={`icon-only-button flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 focus:outline-none ${
                 canReplay ? 'hover:text-white' : 'cursor-not-allowed text-white/40'
               }`}
             >
@@ -9211,7 +9211,7 @@ function Chess3D({
             <button
               type="button"
               onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
-              className="flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+              className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             >
               {viewMode === '3d' ? '2D' : '3D'}
             </button>
@@ -9534,7 +9534,7 @@ function Chess3D({
             showInfo={false}
             showMute={false}
             className="fixed left-3 bottom-4 z-50 flex flex-col gap-4"
-            buttonClassName="pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+            buttonClassName="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.5rem] leading-none"
             labelClassName="sr-only"
             chatIcon="💬"
@@ -9545,7 +9545,7 @@ function Chess3D({
             showChat={false}
             showGift={false}
             className="fixed right-3 bottom-4 z-50 flex flex-col"
-            buttonClassName="pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+            buttonClassName="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.5rem] leading-none"
             labelClassName="sr-only"
             muteIconOn="🔇"


### PR DESCRIPTION
### Motivation
- Improve visual alignment by lowering the Chess Battle Royal board so it sits closer to the table surface.
- Remove framed/blue backgrounds from icon buttons so controls show only icons and match the desired minimal UI.

### Description
- Adjusted the board placement constant from `BOARD_GROUP_Y_OFFSET = -0.05` to `-0.09` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to lower the board group.
- Added a new CSS utility `.icon-only-button` in `webapp/src/index.css` to reset background, border and shadows for icon-only controls.
- Applied the `icon-only-button` class to Chess Battle Royal button elements and to the `BottomLeftIcons` `buttonClassName` usage in `webapp/src/pages/Games/ChessBattleRoyal.jsx` so those UI buttons render with icons only.

### Testing
- Launched the web dev server for the webapp with `npm --prefix webapp run dev` and confirmed Vite started successfully.
- Captured a visual smoke test by opening `/games/chessbattleroyal?mode=ai` in a headless browser and saving a screenshot (`artifacts/chess-battle-royal.png`), which completed successfully.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774be709e88329a5c5fea4b6a634fe)