### PR TITLE
Align Snooker table sizing and ball/pocket specs with Pool Royale

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,6 +1,6 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
+const BASE_TABLE_SCALE = 2.88;
+const BASE_TABLE_MOBILE_SCALE = 2.88;
+const BASE_TABLE_COMPACT_SCALE = 2.88;
 const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
@@ -8,31 +8,31 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     id: '12ft',
     label: '12 ft (Championship)',
     playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
-      scale: 1.56,
-      mobileScale: 1.68,
-      compactScale: 1.48
+      scale: 3.12,
+      mobileScale: 3.44,
+      compactScale: 2.96
     })
   },
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
     playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,6 +1,6 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
+const BASE_TABLE_SCALE = 2.88;
+const BASE_TABLE_MOBILE_SCALE = 2.88;
+const BASE_TABLE_COMPACT_SCALE = 2.88;
 const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
@@ -8,31 +8,31 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     id: '12ft',
     label: '12 ft (Championship)',
     playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
-      scale: 1.56,
-      mobileScale: 1.68,
-      compactScale: 1.48
+      scale: 3.12,
+      mobileScale: 3.44,
+      compactScale: 2.96
     })
   },
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
     playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });


### PR DESCRIPTION
### Motivation
- Make Snooker Royale and Snooker Club tables visually and physically match Pool Royale by using the same ball diameter and pocket layout while preserving existing layout geometry. 
- Present the snooker playfield at roughly double the visual scale of the pool table for mobile-friendly play while keeping the same table layout.

### Description
- Increased base table scale constants in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js` from `1.46/1.52/1.36` to `2.88` to achieve the doubled visual size. 
- Updated `ballDiameterMm` from `52.5` to `57.15` to match the Pool Royale ball size. 
- Aligned side cushion behavior by changing `sideCushionCutAngleDeg` from `45` to `27` to match pool cushion geometry. 
- Adjusted `scaleOverrides` values to `scale: 3.12`, `mobileScale: 3.44`, and `compactScale: 2.96` so derived `scale`, `mobileScale`, and `compactScale` values reflect the new sizing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977531f2a5483299876f754d4ec27e1)