### PR TITLE
Align SnookerRoyal sizing to Pool Royale: double footprint and match ball/pocket metrics

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,14 +1,14 @@
 const BASE_TABLE_SCALE = 1.46;
 const BASE_TABLE_MOBILE_SCALE = 1.52;
 const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_PLAYFIELD_WIDTH_MM = 5080; // double pool table width reference for snooker Royale
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
   '12ft': {
     id: '12ft',
     label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+    playfield: Object.freeze({ widthMm: 5080, heightMm: 2540 }), // double 9ft pool playfield
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
@@ -25,8 +25,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+    playfield: Object.freeze({ widthMm: 4470, heightMm: 2236 }), // double 8ft pool playfield
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,14 +1,14 @@
 const BASE_TABLE_SCALE = 1.46;
 const BASE_TABLE_MOBILE_SCALE = 1.52;
 const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3556; // reference 12 ft match table width
+const BASE_PLAYFIELD_WIDTH_MM = 5080; // double pool table width reference for snooker Royale
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
   '12ft': {
     id: '12ft',
     label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3556, heightMm: 1778 }), // 12' x 6'
-    ballDiameterMm: 52.5,
+    playfield: Object.freeze({ widthMm: 5080, heightMm: 2540 }), // double 9ft pool playfield
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
@@ -25,8 +25,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // 10' x 5'
-    ballDiameterMm: 52.5,
+    playfield: Object.freeze({ widthMm: 4470, heightMm: 2236 }), // double 8ft pool playfield
+    ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -942,10 +942,12 @@ function addPocketCuts(
 // Config
 // --------------------------------------------------
 // separate scales for table and balls
-// Dimensions tuned for an official 9ft pool table footprint while globally reduced
-// to fit comfortably inside the existing mobile arena presentation.
+// Dimensions tuned for a pool Royale footprint, then doubled for the snooker arena,
+// while keeping the same table height for mobile presentation.
 const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
+const TABLE_FOOTPRINT_SCALE = 0.82; // match the Pool Royale footprint scaling before doubling the table size
+const TABLE_SIZE_MULTIPLIER = 2; // snooker table is double the pool table size
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
 const TABLE_DISPLAY_SCALE = 0.88; // pull the entire table set ~12% closer so the arena feels more intimate without distorting proportions
@@ -1047,10 +1049,10 @@ const LOCK_REPLAY_CAMERA = false;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE = {
-    W: 72 * TABLE_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE,
+    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER,
+    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER,
     THICK: 1.8 * TABLE_SCALE,
-    WALL: 2.6 * TABLE_SCALE
+    WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.18;
 const RAIL_HEIGHT = TABLE.THICK * 1.82; // return rail height to the lower stance used previously so cushions no longer sit too tall
@@ -1106,11 +1108,11 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Match the Pool Royale pocket layout while keeping the current table footprint.
-  const WIDTH_REF = 3556;
-  const HEIGHT_REF = 1778;
-  const BALL_D_REF = 52.5;
-  const BAULK_FROM_BAULK_REF = 737; // Baulk line distance from the baulk cushion (29")
+  // Match the Pool Royale pocket layout and ball size for consistent sizing.
+  const WIDTH_REF = 2540;
+  const HEIGHT_REF = 1270;
+  const BALL_D_REF = 57.15;
+  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
@@ -1119,8 +1121,8 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Preserve the original 12ft snooker aspect ratio for the full playfield layout.
-  const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+  // Match the Pool Royale widened aspect ratio for identical pocket layout.
+  const TARGET_RATIO = 1.83;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1133,10 +1135,10 @@ const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   console.assert(
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
+    'Snooker table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1; // use official snooker ball diameter without extra scaling
+const BALL_SIZE_SCALE = 0.97; // match Pool Royale ball sizing
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1163,20 +1165,23 @@ const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
 const POCKET_CORNER_MOUTH_SCALE = CORNER_POCKET_SCALE_BOOST * CORNER_POCKET_EXTRA_SCALE;
-const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 0.958; // shrink the middle pocket mouth width a touch more so the radius tightens up further
+const SIDE_POCKET_MOUTH_REDUCTION_SCALE = 0.97; // match Pool Royale middle pocket mouth width
 const POCKET_SIDE_MOUTH_SCALE =
   (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
   POCKET_CORNER_MOUTH_SCALE *
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // keep the middle pocket mouth width identical to the corner pockets
-const SIDE_POCKET_CUT_SCALE = 0.954; // trim the middle cloth/rail cutouts a bit more so the openings follow the tighter pocket radius
+const SIDE_POCKET_CUT_SCALE = 0.985; // match Pool Royale middle pocket cut size
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
-const CORNER_POCKET_CENTER_INSET =
-  POCKET_VIS_R * 0.32 * POCKET_VISUAL_EXPANSION; // push the corner pocket centres and cuts a bit farther outward toward the rails
+const POCKET_CENTER_OUTWARD_SHIFT = TABLE.THICK * 0.045; // shift pocket centers outward to keep the pocket stack aligned away from the playfield
+const CORNER_POCKET_CENTER_INSET = Math.max(
+  0,
+  POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION - POCKET_CENTER_OUTWARD_SHIFT
+); // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
   POCKET_VIS_R * POCKET_VISUAL_EXPANSION * CORNER_POCKET_INWARD_SCALE;
@@ -7472,7 +7477,7 @@ function Table3D(
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.26; // shorten the corner cushions more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.14; // trim the cushion tips near middle pockets slightly further while keeping their cut angle intact
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal table use the same pocket layout/mouth sizes and ball sizing as the Pool Royale table while scaling the playfield footprint to be double the pool table size for the snooker arena.
- Keep the visual table height and mobile presentation consistent with the existing arena while ensuring pocket/cushion geometry aligns with Pool Royale handling.

### Description
- Adjusted runtime table dimensions in `SnookerRoyal.jsx` by introducing `TABLE_FOOTPRINT_SCALE` and `TABLE_SIZE_MULTIPLIER` and applying them to `TABLE.W`, `TABLE.H`, and `TABLE.WALL` so the snooker playfield is doubled while height remains consistent.
- Matched ball and pocket metrics to Pool Royale in `SnookerRoyal.jsx` by switching the reference playfield (`WIDTH_REF`/`HEIGHT_REF`), setting `BALL_D_REF` to the Pool Royale ball diameter, using `BALL_SIZE_SCALE = 0.97`, and updating pocket mouth/cut scale factors and pocket center offsets (including adding `POCKET_CENTER_OUTWARD_SHIFT`).
- Normalized cushion tip behavior by setting `SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00` so side cushions stop at the rail cut (same as Pool Royale behavior).
- Updated table metadata in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js` to use doubled playfield dimensions and the Pool Royale ball diameter for 12ft and 10ft entries so `resolveTableSize` yields consistent physical specs.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and observed Vite start successfully (server reported ready and listening).
- Attempted an end-to-end visual capture using Playwright to load `/games/snookerroyale` and take a screenshot, but the Playwright screenshot timed out (page screenshot exceeded timeout).
- No unit test suites were executed as part of this change (no `jest`/`vitest` runs were performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977531f2a5483299876f754d4ec27e1)