### PR TITLE
Lower chess board to table surface and add Murlan table-finish options

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,4 +1,5 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -67,6 +68,7 @@ export const CHESS_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES]);
 export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
   headStyle: ['current'],
@@ -82,6 +84,12 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tables: Object.freeze(
     CHESS_TABLE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableFinish: Object.freeze(
+    MURLAN_TABLE_FINISHES.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -123,6 +131,16 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
 });
 
 export const CHESS_BATTLE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `chess-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    previewShape: 'table'
+  })),
   ...CHESS_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
     id: `chess-table-${theme.id}`,
     type: 'tables',
@@ -176,6 +194,11 @@ export const CHESS_BATTLE_STORE_ITEMS = [
 export const CHESS_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tables', optionId: CHESS_TABLE_OPTIONS[0]?.id, label: CHESS_TABLE_OPTIONS[0]?.label },
   { type: 'chairColor', optionId: CHESS_CHAIR_OPTIONS[0]?.id, label: CHESS_CHAIR_OPTIONS[0]?.label },
+  {
+    type: 'tableFinish',
+    optionId: MURLAN_TABLE_FINISHES[0]?.id,
+    label: MURLAN_TABLE_FINISHES[0]?.label
+  },
   { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Pieces' },
   { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Pieces' },
   { type: 'boardTheme', optionId: 'classic', label: 'Classic Board' },

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -145,6 +145,7 @@ const AIR_HOCKEY_TYPE_LABELS = {
 
 const CHESS_TYPE_LABELS = {
   tables: 'Table Models',
+  tableFinish: 'Table Finish',
   chairColor: 'Chairs',
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',


### PR DESCRIPTION
### Motivation
- The chess board was visually floating above the table and needs to sit flush on the table surface like the Murlan Royale game. 
- The chess table should use the same finish presets/textures as the Murlan game so default appearance matches and players can pick the same finishes. 
- Expose the same table-finish option in the Chess customization UI and store so finishes can be selected/unlocked.

### Description
- Added `MURLAN_TABLE_FINISHES` into `chessBattleInventoryConfig.js` and surfaced finishes as `tableFinish` in `CHESS_BATTLE_DEFAULT_UNLOCKS`, `CHESS_BATTLE_OPTION_LABELS`, `CHESS_BATTLE_STORE_ITEMS`, and `CHESS_BATTLE_DEFAULT_LOADOUT` so finishes are available in inventory and store. 
- Added `tableFinish` label to the chess section in `webapp/src/pages/Store.jsx` so the store shows a `Table Finish` type for chess items. 
- In `ChessBattleRoyal.jsx` adjusted board vertical offset (`BOARD_GROUP_Y_OFFSET` set to `0`) and introduced `alignBoardGroupToTableSurface(boardGroup, tableInfo)` to align the procedural or loaded board group to the actual table surface (`tableInfo.surfaceY`) whenever the table or board is built/swapped. 
- Added `tableFinish` to the chess appearance flow and used the selected finish to select `woodOption` (so Murlan finish presets provide the wood textures), added a customization section and preview swatch rendering for `tableFinish`, and wired appearance normalization/fallbacks to include the new option. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported `ready` indicating the dev server ran successfully. 
- Attempted an automated Playwright screenshot of the Chess page but the headless browser crashed / timed out in this environment, so the visual verification run failed. 
- No unit tests (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977545926548329986622ebff73b682)