### PR TITLE
Adjust Pool Royale chrome plates, cushion collision mapping, and AI cue visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -585,7 +585,7 @@ const CHROME_CORNER_NOTCH_EXPANSION_SCALE = 1; // no scaling so the notch mirror
 const CHROME_CORNER_DIMENSION_SCALE = 1; // keep the fascia dimensions identical to the cushion span so both surfaces meet cleanly
 const CHROME_CORNER_WIDTH_SCALE = 0.978; // shave the chrome plate slightly so it ends at the jaw line on the long rail
 const CHROME_CORNER_HEIGHT_SCALE = 0.962; // mirror the trim on the short rail so the fascia meets the jaw corner without overlap
-const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.02; // align corner fascia offset with the snooker chrome plates
+const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.045; // pull the corner fascia slightly closer to the table center
 const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0; // let the corner fascia terminate precisely where the cushion noses stop
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0; // stop pulling the chrome off the short-rail centreline so the jaws stay flush
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker baseline
@@ -614,7 +614,7 @@ const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1; // allow the plate ends to r
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.982; // trim the middle fascia width a touch so both flanks stay inside the pocket reveal
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.092; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.07; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.11; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0; // allow the fascia to run the full distance from cushion edge to wood rail with no setback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.095; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
@@ -4947,6 +4947,7 @@ let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = 0;
 const RAIL_CONTACT_RADIUS = BALL_R * 0.985;
 const CUSHION_CUT_CONTACT_RADIUS = BALL_R * 0.945;
+const CUSHION_COLLISION_OUTSET = BALL_R * 0.12; // push collision segments outward so impacts occur exactly on the cushion faces
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
 let CUSHION_SEGMENTS = [];
 const BREAK_VIEW = Object.freeze({
@@ -6526,8 +6527,14 @@ function updateCushionSegmentsFromTable(table) {
     if (data.horizontal) {
       const innerZ = data.side < 0 ? box.max.z : box.min.z;
       const outerZ = data.side < 0 ? box.min.z : box.max.z;
-      const leftInner = new THREE.Vector2(box.min.x + minInner, innerZ);
-      const rightInner = new THREE.Vector2(box.max.x - maxInner, innerZ);
+      const outwardSign = Math.sign(outerZ - innerZ) || 1;
+      const shiftedInnerZ = clamp(
+        innerZ + outwardSign * CUSHION_COLLISION_OUTSET,
+        Math.min(innerZ, outerZ) + MICRO_EPS,
+        Math.max(innerZ, outerZ) - MICRO_EPS
+      );
+      const leftInner = new THREE.Vector2(box.min.x + minInner, shiftedInnerZ);
+      const rightInner = new THREE.Vector2(box.max.x - maxInner, shiftedInnerZ);
       const leftOuter = new THREE.Vector2(box.min.x, outerZ);
       const rightOuter = new THREE.Vector2(box.max.x, outerZ);
       if (rightInner.x - leftInner.x > MICRO_EPS) {
@@ -6538,8 +6545,14 @@ function updateCushionSegmentsFromTable(table) {
     } else {
       const innerX = data.side < 0 ? box.max.x : box.min.x;
       const outerX = data.side < 0 ? box.min.x : box.max.x;
-      const bottomInner = new THREE.Vector2(innerX, box.min.z + minInner);
-      const topInner = new THREE.Vector2(innerX, box.max.z - maxInner);
+      const outwardSign = Math.sign(outerX - innerX) || 1;
+      const shiftedInnerX = clamp(
+        innerX + outwardSign * CUSHION_COLLISION_OUTSET,
+        Math.min(innerX, outerX) + MICRO_EPS,
+        Math.max(innerX, outerX) - MICRO_EPS
+      );
+      const bottomInner = new THREE.Vector2(shiftedInnerX, box.min.z + minInner);
+      const topInner = new THREE.Vector2(shiftedInnerX, box.max.z - maxInner);
       const bottomOuter = new THREE.Vector2(outerX, box.min.z);
       const topOuter = new THREE.Vector2(outerX, box.max.z);
       if (topInner.y - bottomInner.y > MICRO_EPS) {
@@ -24153,7 +24166,7 @@ const powerRef = useRef(hud.power);
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
-          (isPlayerTurn || previewingAiShot || aiCueViewActive);
+          (isPlayerTurn || previewingAiShot || aiCueViewActive || isAiTurn);
         if (
           cue?.pos &&
           !sliderInstanceRef.current?.dragging &&


### PR DESCRIPTION
### Motivation
- Pull the chrome fascia plates slightly closer to the table center so chrome visuals align with the playfield without changing pocket geometry.
- Fix cushion collision mapping near middle pockets and angled cuts so balls contact cushions at the correct face (avoid early bounces off invisible cut lines).
- Ensure the cue stick is visible when the AI is shooting so AI shots and replays show the cue animation.

### Description
- Tweaked chrome plate placement by changing `CHROME_CORNER_CENTER_OUTSET_SCALE` from `-0.02` to `-0.045` and `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE` from `-0.07` to `-0.11` to nudge chrome plates inward while keeping pocket cuts unchanged.
- Added `CUSHION_COLLISION_OUTSET` (`BALL_R * 0.12`) and applied it when generating cushion segments in `updateCushionSegmentsFromTable` so the inner collision line is shifted outward to the cushion face for both horizontal and vertical cushions.
- Updated cushion segment construction to use `shiftedInnerX` / `shiftedInnerZ` (clamped) so `rail` and `cut` segments register at the corrected collision line rather than the visual nose position.
- Allowed the cue stick to be shown during AI turns by including `isAiTurn` in the `canShowCue` condition so AI shots and replay frames include the cue snapshot and animation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977782c9a5c832987543b4fa2831261)