### PR TITLE
Snooker: increase table scale, align cameras/cushions to Pool Royale, remove mapping overlay, and add ball-tracking rules

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal table visually larger while keeping the exact layout and pocket behavior, and reuse Pool Royale camera framing and cushion geometry so physics/angles remain consistent between modes.
- Remove developer mapping overlays (visual markers) from the table build so the table visuals match production expectations.
- Implement proper snooker rule state tracking (potted/respot logic, red counts, free-ball, fouls) so game logic follows official snooker flow and can persist ball state.

### Description
- Increased table width scaling by changing `TABLE_WIDTH_SCALE` from `1.25` to `1.3` and set `RAIL_LIMIT_PADDING` to `0` to align standing/cue camera limits with Pool Royale in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Brought cushion/cut geometry closer to Pool Royale by adjusting cushion constants (`CUSHION_RAIL_FLUSH`, `CUSHION_CORNER_CLEARANCE_REDUCTION`) and added long/short rail cushion trim variables used when deriving cushion extents in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Removed the table mapping overlay (mapping group, mapping lines and marker rendering) to eliminate visible mapping markers from the snooker table build in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Matched side cushion cut angles to Pool Royale by changing `sideCushionCutAngleDeg` from `45` to `27` in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js` so cushion cut logic is identical.
- Enhanced snooker rules to track ball states and respots by adding ball model helpers and state management: imported `Ball` type and added `buildInitialBalls`, `ensureBalls`, `setBallOnTable`, `potReds`, and respot/remove logic; updated `getInitialFrame` and `applyShot` to maintain `balls`, update `redsRemaining`, handle cue potted/fouls/free-ball respots and colors order in `src/rules/SnookerRoyalRules.ts`.

### Testing
- No automated tests were executed as part of this change (no test suite run in this session).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977bcf775b48329ab2191d592ebdd12)