### PR TITLE
Fix Goal Rush quick action buttons

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -139,35 +139,37 @@
         </div>
       </div>
     </div>
-    <div id="quickActionChat" class="quick-action-slot" aria-label="Chat">
-      <button class="quick-action" id="quickActionChatButton" type="button" data-action="chat">
-        <span class="icon" aria-hidden="true">💬</span>
-        <span>Chat</span>
-      </button>
-    </div>
-    <div id="quickActionGift" class="quick-action-slot" aria-label="Gift">
-      <button class="quick-action" type="button" data-action="gift">
-        <span class="icon" aria-hidden="true">🎁</span>
-        <span>Gift</span>
-      </button>
-    </div>
-    <div id="quickActionInfo" class="quick-action-slot" aria-label="Info">
-      <button class="quick-action" type="button" data-action="info">
-        <span class="icon" aria-hidden="true">ℹ️</span>
-        <span>Info</span>
-      </button>
-    </div>
-    <div id="quickActionMute" class="quick-action-slot" aria-label="Mute">
-      <button class="quick-action" type="button" data-action="mute">
-        <span class="icon" id="muteIcon" aria-hidden="true">🔊</span>
-        <span id="muteLabel">Mute</span>
-      </button>
-    </div>
-    <div id="quickActionAudio" class="quick-action-slot" aria-label="Audio">
-      <button class="quick-action" type="button" data-action="commentary">
-        <span class="icon" aria-hidden="true">🎙️</span>
-        <span>Audio</span>
-      </button>
+    <div id="quickActions">
+      <div id="quickActionChat" class="quick-action-slot" aria-label="Chat">
+        <button class="quick-action" id="quickActionChatButton" type="button" data-action="chat">
+          <span class="icon" aria-hidden="true">💬</span>
+          <span>Chat</span>
+        </button>
+      </div>
+      <div id="quickActionGift" class="quick-action-slot" aria-label="Gift">
+        <button class="quick-action" type="button" data-action="gift">
+          <span class="icon" aria-hidden="true">🎁</span>
+          <span>Gift</span>
+        </button>
+      </div>
+      <div id="quickActionInfo" class="quick-action-slot" aria-label="Info">
+        <button class="quick-action" type="button" data-action="info">
+          <span class="icon" aria-hidden="true">ℹ️</span>
+          <span>Info</span>
+        </button>
+      </div>
+      <div id="quickActionMute" class="quick-action-slot" aria-label="Mute">
+        <button class="quick-action" type="button" data-action="mute">
+          <span class="icon" id="muteIcon" aria-hidden="true">🔊</span>
+          <span id="muteLabel">Mute</span>
+        </button>
+      </div>
+      <div id="quickActionAudio" class="quick-action-slot" aria-label="Audio">
+        <button class="quick-action" type="button" data-action="commentary">
+          <span class="icon" aria-hidden="true">🎙️</span>
+          <span>Audio</span>
+        </button>
+      </div>
     </div>
     <div class="canvasWrap">
       <canvas id="game" width="720" height="1280" aria-label="Goal Rush Field"></canvas>


### PR DESCRIPTION
### Motivation
- The delegated click handler could not target the quick-action controls, causing the chat/gift/info/mute/audio buttons to be unresponsive.

### Description
- Wrap all quick-action button elements in a new parent container with `id="quickActions"` so the page's delegated click listener can find and handle taps; change made in `webapp/public/goal-rush.html`.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c3491ad08329b477b7ef2c785edc)