### PR TITLE
Enable Goal Rush commentary language selection without speech support

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -1075,9 +1075,7 @@
       if (preset.id === commentaryPresetId) {
         button.classList.add('active');
       }
-      button.disabled = !commentarySupported;
       button.addEventListener('click', () => {
-        if (!commentarySupported) return;
         commentaryPresetId = preset.id;
         try { localStorage.setItem(COMMENTARY_PRESET_STORAGE_KEY, preset.id); } catch {}
         populateCommentaryOptions();


### PR DESCRIPTION
### Motivation
- Allow players to select commentary language/preset in the Goal Rush UI even when the browser/webview lacks Web Speech support so the settings UI is interactive and language preferences can be persisted.

### Description
- Stop disabling commentary preset buttons and remove the early-return guard in the click handler in `webapp/public/goal-rush.html` so `populateCommentaryOptions()` always renders selectable buttons and clicks always set `commentaryPresetId` and write to `localStorage`.

### Testing
- Launched a local HTTP server (`python -m http.server 8000`) and ran a Playwright script to open `goal-rush.html`, trigger the commentary modal via `button[data-action="commentary"]`, and capture a screenshot (`artifacts/goal-rush-commentary.png`); the script completed and produced the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c9b464fc8329b072e0d93331658b)