### PR TITLE
Snooker Royal: enlarge table, sync cushion/pocket physics, remove mapping markers, and improve rules tracking

### DIFF
--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal table visually larger while preserving the exact layout and pocket geometry. 
- Reuse the Pool Royale camera framing and cushion/pocket physics logic so cue/standing cameras and cushion behavior match across modes. 
- Remove unneeded table mapping overlay markers and ensure cushion cuts/angles use the same logic as Pool Royale. 
- Implement robust frame/rules bookkeeping so potted balls, respots, reds counting and phase transitions follow the official snooker flow.

### Description
- Increased the snooker table footprint by adjusting `TABLE_WIDTH_SCALE` from `1.25` to `1.3` in `webapp/src/pages/Games/SnookerRoyal.jsx`, preserving aspect and pocket mouth assertions so the visual layout remains identical but larger. 
- Disabled the mapping overlay by default via a new `ENABLE_TABLE_MAPPING_LINES` flag and wrapped the mapping overlay generation so markers are not added unless explicitly enabled (changes in `SnookerRoyal.jsx`). 
- Aligned cushion and side-pocket physics to the Pool Royale logic by introducing/standardizing cut-angle constants, side-pocket physics cut angle clamping, and by adding rail/cut contact radius and cushion-segment handling; added `updateCushionSegmentsFromTable` and integrated it into table build and `reflectRails` logic (changes in `SnookerRoyal.jsx` and `webapp/src/config/snookerRoyalTables.js`). 
- Reworked snooker rules to track ball state across shots: added ball array initialization and bookkeeping (reds, colours, cue), updated scoring/redsRemaining handling, respot/remove helpers, and correct phase transition to `COLORS_ORDER` when reds are exhausted (changes in `src/rules/SnookerRoyalRules.ts`). 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and the Vite server reported ready and served the site at `http://localhost:4173/`. 
- Attempted an automated visual smoke test with Playwright to capture a screenshot of `/games/snookerroyale`, but Chromium crashed in the container (SIGSEGV/TargetClosedError), so the screenshot did not complete. 
- No unit test suite was executed as part of this change; runtime smoke check (dev server) succeeded while the headless browser capture failed due to environment Chromium instability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977bcf775b48329ab2191d592ebdd12)