### PR TITLE
Reset red-first requirement after fouls/misses in Snooker rules

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -291,6 +291,12 @@ export class SnookerRoyalRules {
       nextActivePlayer = opponent;
       nextBreak = 0;
       nextFreeBall = Boolean(context.snookered);
+      if (state.phase === 'REDS_AND_COLORS') {
+        colorOnAfterRed = false;
+        if (redsRemaining === 0) {
+          nextPhase = 'COLORS_ORDER';
+        }
+      }
       if (
         state.phase === 'COLORS_ORDER' &&
         colorsRemaining.length === 1 &&
@@ -305,12 +311,10 @@ export class SnookerRoyalRules {
       nextActivePlayer = state.activePlayer === 'A' ? 'B' : 'A';
       nextBreak = 0;
       if (state.phase === 'REDS_AND_COLORS') {
-        if (redsRemaining === 0 && !state.colorOnAfterRed) {
+        if (redsRemaining === 0) {
           nextPhase = 'COLORS_ORDER';
-          colorOnAfterRed = false;
-        } else {
-          colorOnAfterRed = state.colorOnAfterRed ?? false;
         }
+        colorOnAfterRed = false;
       }
     } else {
       if (onRed) {


### PR DESCRIPTION
### Motivation
- Ensure the snooker turn flow enforces starting on a red after a foul or a missed turn during the reds-and-colors phase and to cleanly transition to the colors phase once no reds remain, matching the intended snooker gameplay rules.

### Description
- Update `src/rules/SnookerRoyalRules.ts` to clear `colorOnAfterRed` when a foul or an empty turn occurs and to set `nextPhase = 'COLORS_ORDER'` when `redsRemaining === 0` in those branches so the frame advances correctly and subsequent turns correctly require reds first.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d54d84b083298221278377fffe95)