### PR TITLE
Align Pool Royale pockets, cushion cuts, and broadcast rigs with Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -605,7 +605,7 @@ const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so 
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0; // keep fascia placement identical to snooker
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.62; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.52; // trim fascia span so the middle plates finish at the side rail edge
@@ -1339,27 +1339,27 @@ const POCKET_WALL_HEIGHT = TABLE.THICK * 0.7 - POCKET_WALL_OPEN_TRIM;
 const POCKET_NET_DEPTH = TABLE.THICK * 2.26;
 const POCKET_NET_SEGMENTS = 64;
 const POCKET_DROP_DEPTH = POCKET_NET_DEPTH * 1.05; // drop deeper so potted balls meet the chrome holders cleanly
-const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.68; // stop the fall slightly above the ring/strap junction
+const POCKET_DROP_STRAP_DEPTH = POCKET_DROP_DEPTH * 0.74; // stop the fall slightly above the ring/strap junction
 const POCKET_NET_RING_RADIUS_SCALE = 0.88; // widen the ring so balls pass cleanly through before rolling onto the holder rails
 const POCKET_NET_RING_TUBE_RADIUS = BALL_R * 0.14; // thicker chrome to read as a connector between net and holder rails
-const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.1; // lift the ring so the holder assembly sits higher
-const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.22; // match Snooker Royal pocket net lift for identical potted-ball framing
+const POCKET_NET_RING_VERTICAL_OFFSET = BALL_R * 0.06; // lift the ring so the holder assembly sits higher
+const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.16; // match Snooker Royal pocket net lift for identical potted-ball framing
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
 const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.6); // stretch the holder run so it comfortably fits 7 balls
-const POCKET_GUIDE_DROP = BALL_R * 0.08;
+const POCKET_GUIDE_DROP = BALL_R * 0.12;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
 const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
-const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.1; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.01; // lift the chrome holder rails so the short L segments meet the ring
-const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.11; // nudge the L segments toward the leather strap
+const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
 const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.78; // keep the ball rest point unchanged while the chrome guides extend
-const POCKET_HOLDER_REST_DROP = BALL_R * 1.82; // drop the resting spot so potted balls settle onto the chrome rails
+const POCKET_HOLDER_REST_DROP = BALL_R * 2.18; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
 const POCKET_HOLDER_RUN_ENTRY_SCALE = BALL_DIAMETER * 0.9; // scale entry speed into a believable roll along the holders
@@ -1368,7 +1368,7 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.42; // align strap height with Snooker Royal for identical potted-ball rests
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so it meets the raised holder rails
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -4990,7 +4990,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
 const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
-const USE_STANDING_BROADCAST_CAMERA = true; // keep broadcast cuts aligned with the standing camera instead of side-rail rigs
+const USE_STANDING_BROADCAST_CAMERA = false; // use rail-overhead broadcast heads like Snooker Royal
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
@@ -6511,6 +6511,15 @@ function updateCushionSegmentsFromTable(table) {
     if (dir.lengthSq() < 1e-6) return;
     segments.push({ start, end, type });
   };
+  const resolveAngle = (angles, key, fallback) =>
+    typeof angles?.[key] === 'number' ? angles[key] : fallback;
+  const computeCutOffset = (depth, cutLength, angleDeg) => {
+    if (!Number.isFinite(depth) || depth <= 0) return Math.max(0, cutLength);
+    const rad = THREE.MathUtils.degToRad(angleDeg);
+    const tan = Math.tan(rad);
+    const angleOffset = tan > MICRO_EPS ? depth / tan : cutLength;
+    return Math.max(0, Math.min(cutLength, angleOffset));
+  };
   table.userData.cushions.forEach((cushion) => {
     const data = cushion.userData || {};
     if (typeof data.horizontal !== 'boolean' || !data.side) return;
@@ -6518,16 +6527,25 @@ function updateCushionSegmentsFromTable(table) {
     const cutEnds = data.cutEnds || {};
     const minCut = Math.max(0, cutEnds.min || 0);
     const maxCut = Math.max(0, cutEnds.max || 0);
+    const cutTypes = data.cutTypes || {};
+    const minTypeScale = cutTypes.min === 'side' ? 0.2 : 1;
+    const maxTypeScale = cutTypes.max === 'side' ? 0.2 : 1;
     const cutInsetBase = RAIL_CONTACT_RADIUS * 0.12;
-    const minInset = Math.min(minCut, cutInsetBase);
-    const maxInset = Math.min(maxCut, cutInsetBase);
-    const minInner = minCut + minInset;
-    const maxInner = maxCut + maxInset;
+    const minInset = Math.min(minCut, cutInsetBase * minTypeScale);
+    const maxInset = Math.min(maxCut, cutInsetBase * maxTypeScale);
+    const cutAngles = data.cutAngles || {};
+    const cutAnglesByEnd = data.cutAnglesByEnd || {};
+    const defaultAngle = resolveAngle(cutAngles, 'cutAngle', CUSHION_CUT_ANGLE);
+    const minAngle = resolveAngle(cutAnglesByEnd, 'min', defaultAngle);
+    const maxAngle = resolveAngle(cutAnglesByEnd, 'max', defaultAngle);
     if (data.horizontal) {
       const innerZ = data.side < 0 ? box.max.z : box.min.z;
       const outerZ = data.side < 0 ? box.min.z : box.max.z;
-      const leftInner = new THREE.Vector2(box.min.x + minInner, innerZ);
-      const rightInner = new THREE.Vector2(box.max.x - maxInner, innerZ);
+      const depth = Math.abs(innerZ - outerZ);
+      const leftCut = computeCutOffset(depth, minCut + minInset, minAngle);
+      const rightCut = computeCutOffset(depth, maxCut + maxInset, maxAngle);
+      const leftInner = new THREE.Vector2(box.min.x + leftCut, innerZ);
+      const rightInner = new THREE.Vector2(box.max.x - rightCut, innerZ);
       const leftOuter = new THREE.Vector2(box.min.x, outerZ);
       const rightOuter = new THREE.Vector2(box.max.x, outerZ);
       if (rightInner.x - leftInner.x > MICRO_EPS) {
@@ -6538,8 +6556,11 @@ function updateCushionSegmentsFromTable(table) {
     } else {
       const innerX = data.side < 0 ? box.max.x : box.min.x;
       const outerX = data.side < 0 ? box.min.x : box.max.x;
-      const bottomInner = new THREE.Vector2(innerX, box.min.z + minInner);
-      const topInner = new THREE.Vector2(innerX, box.max.z - maxInner);
+      const depth = Math.abs(innerX - outerX);
+      const bottomCut = computeCutOffset(depth, minCut + minInset, minAngle);
+      const topCut = computeCutOffset(depth, maxCut + maxInset, maxAngle);
+      const bottomInner = new THREE.Vector2(innerX, box.min.z + bottomCut);
+      const topInner = new THREE.Vector2(innerX, box.max.z - topCut);
       const bottomOuter = new THREE.Vector2(outerX, box.min.z);
       const topOuter = new THREE.Vector2(outerX, box.max.z);
       if (topInner.y - bottomInner.y > MICRO_EPS) {
@@ -9684,7 +9705,7 @@ export function Table3D(
     const rightDistanceToSidePocket = Math.abs(worldZRight);
     const leftCloserToCenter = leftDistanceToSidePocket < rightDistanceToSidePocket;
     const side = horizontal ? (z >= 0 ? 1 : -1) : x >= 0 ? 1 : -1;
-    const sidePocketCuts = !horizontal
+    const cutConfig = !horizontal
       ? {
           leftCutAngle: leftCloserToCenter
             ? CUSHION_CUT_ANGLE
@@ -9693,9 +9714,16 @@ export function Table3D(
             ? VISUAL_SIDE_CUSHION_CUT_ANGLE
             : CUSHION_CUT_ANGLE
         }
-      : undefined;
-    const cutLengths = computeCushionCutLengths(len, horizontal, sidePocketCuts);
-    const geo = cushionProfileAdvanced(len, horizontal, sidePocketCuts);
+      : {};
+    const resolvedCutAngles = {
+      cutAngle: CUSHION_CUT_ANGLE,
+      leftCutAngle: cutConfig.leftCutAngle ?? CUSHION_CUT_ANGLE,
+      rightCutAngle: cutConfig.rightCutAngle ?? CUSHION_CUT_ANGLE,
+      leftStraightEdge: cutConfig.leftStraightEdge,
+      rightStraightEdge: cutConfig.rightStraightEdge
+    };
+    const cutLengths = computeCushionCutLengths(len, horizontal, resolvedCutAngles);
+    const geo = cushionProfileAdvanced(len, horizontal, resolvedCutAngles);
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
     const orientationScale = horizontal ? SHORT_CUSHION_HEIGHT_SCALE : 1;
@@ -9766,9 +9794,20 @@ export function Table3D(
     const leftWorld = leftLocal.clone().applyMatrix4(group.matrixWorld);
     const rightWorld = rightLocal.clone().applyMatrix4(group.matrixWorld);
     const leftIsMin = horizontal ? leftWorld.x <= rightWorld.x : leftWorld.z <= rightWorld.z;
+    const leftCutType = horizontal ? 'corner' : leftCloserToCenter ? 'side' : 'corner';
+    const rightCutType = horizontal ? 'corner' : leftCloserToCenter ? 'corner' : 'side';
     group.userData.cutEnds = {
       min: leftIsMin ? cutLengths.leftCut : cutLengths.rightCut,
       max: leftIsMin ? cutLengths.rightCut : cutLengths.leftCut
+    };
+    group.userData.cutTypes = {
+      min: leftIsMin ? leftCutType : rightCutType,
+      max: leftIsMin ? rightCutType : leftCutType
+    };
+    group.userData.cutAngles = resolvedCutAngles;
+    group.userData.cutAnglesByEnd = {
+      min: leftIsMin ? resolvedCutAngles.leftCutAngle : resolvedCutAngles.rightCutAngle,
+      max: leftIsMin ? resolvedCutAngles.rightCutAngle : resolvedCutAngles.leftCutAngle
     };
     table.add(group);
     table.userData.cushions.push(group);


### PR DESCRIPTION
### Motivation
- Match the Pool Royale pocket jaw, chrome-plate and leather-strap layout/placement to the Snooker Royal reference so holders read and behave identically. 
- Fix cushion cut geometry and collision handling so angle cuts deflect balls from the true cut angle (no phantom straight-cushion rebounds). 
- Use the same rail-overhead broadcast rig behavior as Snooker Royal for replay/broadcasts while keeping the 2D top camera and UI unchanged.

### Description
- Tuning constants: adjusted chrome/pocket and holder values such as `CHROME_SIDE_PLATE_POCKET_SPAN_SCALE`, `POCKET_DROP_STRAP_DEPTH`, `POCKET_NET_RING_VERTICAL_OFFSET`, `POCKET_NET_VERTICAL_LIFT`, `POCKET_GUIDE_DROP`, `POCKET_GUIDE_FLOOR_DROP`, `POCKET_GUIDE_VERTICAL_DROP`, `POCKET_HOLDER_REST_DROP`, and `POCKET_STRAP_VERTICAL_LIFT` to align visual/physical holder geometry with Snooker Royal. 
- Broadcast change: set `USE_STANDING_BROADCAST_CAMERA` to `false` so Pool Royale uses the rail-overhead broadcast rigs like Snooker Royal (2D camera / 2D button unchanged). 
- Cushion/cut physics: overhauled cushion cut handling in `updateCushionSegmentsFromTable` and `addCushion` to compute cut offsets from configured angles and pocket/cushion depth (added `resolveAngle` and `computeCutOffset` helpers), produce accurate `cut` vs `rail` segments for collision checks, and prevent mid-pocket phantom deflections. 
- Metadata: store per-cushion and per-jaw metadata on `group.userData` (e.g. `cutTypes`, `cutAngles`, `cutAnglesByEnd`, and `cutEnds`) so physics and rendering use the same resolved geometry.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (local dev server started successfully). 
- Attempted an automated browser check (Playwright) to capture `/games/poolroyale`, but the screenshot attempt timed out and did not complete. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978560fb40883299653c3483aa713c9)