### PR TITLE
SnookerRoyal: increase table footprint, boost shot power, and align spin/cushion behavior with Pool Royale

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -14,7 +14,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -32,7 +32,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       side: 127
     }),
     cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 45,
+    sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal table visually larger (25–30% wider) while keeping layout proportions and pocket sizes intact. 
- Increase shot strength by ~50% so launches and breaks open racks faster. 
- Reuse and align spin handling and cushion-cut angles with the already-tested Pool Royale logic for consistent rebound/swerve behavior.

### Description
- Increased the Snooker playfield footprint by changing `TABLE_FOOTPRINT_SCALE` from `0.82` to `1.05` in `webapp/src/pages/Games/SnookerRoyal.jsx`, preserving existing layout math and pocket sizes. 
- Raised shot strength by adding `SHOT_POWER_BOOST = 1.5` and folding it into `SHOT_FORCE_BOOST` so `SHOT_BASE_SPEED` and related speed/force constants scale accordingly in `SnookerRoyal.jsx`. 
- Switched Snooker spin processing to reuse Pool Royale utilities by importing `mapSpinForPhysics`, `normalizeSpinInput`, and `SPIN_STUN_RADIUS` from `./poolRoyaleSpinUtils.js` and wired `computeSpinOffsets` and shot-impact spin mapping to use `normalizeSpinInput` and `mapSpinForPhysics`. 
- Tightened spin limits and tuning by adjusting `MAX_SPIN_CONTACT_OFFSET` and related constants and bumping `BACKSPIN_MULTIPLIER` for stronger draw responsiveness. 
- Improved spin legality checks by using `SPIN_STUN_RADIUS` and adding view-based visibility gating (`SPIN_VIEW_BLOCK_THRESHOLD`) inside `checkSpinLegality2D`. 
- Aligned snooker cushion metadata to Pool Royale by setting `sideCushionCutAngleDeg` to `27` in `webapp/src/config/snookerClubTables.js` so cushion-cut angles and physics are consistent across modes. 
- Files changed: `webapp/src/pages/Games/SnookerRoyal.jsx` and `webapp/src/config/snookerClubTables.js` (see diffs for details). 

### Testing
- No automated unit or integration tests were executed in this run; changes were applied and committed locally (`git` commit recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697853209ef08329b28e71593c3a156a)