### PR TITLE
Align Pool Royale broadcast scaling and table trim

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -609,7 +609,7 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach 
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.52; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.04; // reduce the outer fascia extension so the outside edge trims back slightly
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.0; // trim the outside edge slightly more around the middle pockets
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 0.96; // extend the plate ends slightly toward the corner pockets
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.975; // expand the middle fascia slightly so both flanks gain a touch more presence
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.12; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
@@ -910,6 +910,7 @@ const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% wi
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
 const TABLE_DISPLAY_SCALE = 0.8; // shrink the table footprint slightly less so the playfield reads larger
+const CAMERA_DISPLAY_SCALE = TABLE_DISPLAY_SCALE / 0.88; // mirror Snooker Royal broadcast scaling without changing the 2D view
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -4946,7 +4947,7 @@ let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = 0;
 const RAIL_CONTACT_RADIUS = BALL_R;
-const CUSHION_CUT_CONTACT_RADIUS = BALL_R * 0.92;
+const CUSHION_CUT_CONTACT_RADIUS = BALL_R;
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
 let CUSHION_SEGMENTS = [];
 const BREAK_VIEW = Object.freeze({
@@ -4985,7 +4986,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
   const halfLength = PLAY_H / 2 + BROADCAST_MARGIN_LENGTH;
   const widthDistance = (halfWidth / Math.tan(halfHorizontal)) * TOP_VIEW_RADIUS_SCALE;
   const lengthDistance = (halfLength / Math.tan(halfVertical)) * TOP_VIEW_RADIUS_SCALE;
-  return Math.max(widthDistance, lengthDistance);
+  return Math.max(widthDistance, lengthDistance) * CAMERA_DISPLAY_SCALE;
 };
 const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
 const SHORT_RAIL_CAMERA_DISTANCE =
@@ -9189,7 +9190,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.36, Math.max(BALL_R * 10.5, PLAY_W * 0.27));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.28;
+  const brandPlateOutwardShift = endRailW * 0.34;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -9227,7 +9228,7 @@ export function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = longRailW * 0.62;
+  const railMarkerOutset = longRailW * 0.54;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;


### PR DESCRIPTION
### Motivation
- Bring Pool Royale visuals and broadcast behaviour in line with the Snooker Royal reference so the rail-mounted broadcast heads match TV-style framing while keeping the existing 2D top view unchanged. 
- Fix pocket/angle calibration so angled cushion cuts register contacts reliably and reduce glancing bounces on the cushion cuts. 
- Tweak chrome/branded trim and rail marker placement to match reference layout: slightly trim middle-pocket chrome, push branding plates outward, and pull diamond markers inward. 

### Description
- Added `CAMERA_DISPLAY_SCALE` and applied it to `computeTopViewBroadcastDistance` to align Pool Royale broadcast distances with Snooker Royal while preserving the 2D view (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjusted cushion cut contact calibration by changing `CUSHION_CUT_CONTACT_RADIUS` from `BALL_R * 0.92` to `BALL_R` to improve angled-cut collisions (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Trimmed chrome fascia by setting `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` from `1.04` to `1.0` to reduce the outer chrome extension around the middle pockets (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated table decoration offsets by increasing `brandPlateOutwardShift` (`endRailW * 0.28` → `endRailW * 0.34`) and reducing `railMarkerOutset` (`longRailW * 0.62` → `longRailW * 0.54`) to move branding plates slightly outward and pull diamond markers closer to the center (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were run as part of this change; only static inspection and repository checks were performed locally and the modified file was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786e44ead8832987c0bd0e25a236ee)