### PR TITLE
Pool Royale: adjust chrome trims, pocket/rail contact and broadcast camera flow

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -609,13 +609,13 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach 
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.52; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.04; // reduce the outer fascia extension so the outside edge trims back slightly
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.01; // trim the outer fascia extension so the outside edge tucks in slightly
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 0.96; // extend the plate ends slightly toward the corner pockets
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.975; // expand the middle fascia slightly so both flanks gain a touch more presence
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.12; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
-const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.008; // trim the outer fascia edge just a touch for a tighter outside finish
+const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.14; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
@@ -4944,9 +4944,9 @@ const DEFAULT_RAIL_LIMIT_X = PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET;
 const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
-const RAIL_LIMIT_PADDING = 0;
+const RAIL_LIMIT_PADDING = 0.1;
 const RAIL_CONTACT_RADIUS = BALL_R;
-const CUSHION_CUT_CONTACT_RADIUS = BALL_R * 0.92;
+const CUSHION_CUT_CONTACT_RADIUS = BALL_R;
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
 let CUSHION_SEGMENTS = [];
 const BREAK_VIEW = Object.freeze({
@@ -4990,7 +4990,6 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
 const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
-const USE_STANDING_BROADCAST_CAMERA = false; // use rail-overhead broadcast heads like Snooker Royal
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0215; // tighten cue camera distance so the cue ball and object ball appear larger
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
@@ -9189,7 +9188,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.36, Math.max(BALL_R * 10.5, PLAY_W * 0.27));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.28;
+  const brandPlateOutwardShift = endRailW * 0.34;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -9227,7 +9226,7 @@ export function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = longRailW * 0.62;
+  const railMarkerOutset = longRailW * 0.56;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -16394,25 +16393,6 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
-          if (USE_STANDING_BROADCAST_CAMERA) {
-            const fallbackTarget =
-              focusOverride?.clone?.() ??
-              lastCameraTargetRef.current?.clone?.() ??
-              new THREE.Vector3(
-                0,
-                TABLE_Y + TABLE.THICK + BALL_R * 2.5,
-                0
-              );
-            if (fallbackTarget && Number.isFinite(minTargetY)) {
-              fallbackTarget.y = Math.max(fallbackTarget.y ?? minTargetY, minTargetY);
-            }
-            return {
-              position: camera.position.clone(),
-              target: fallbackTarget,
-              fov: STANDING_VIEW_FOV,
-              minTargetY
-            };
-          }
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
           const activeRail =


### PR DESCRIPTION
### Motivation

- Bring Pool Royale chrome fascias, brand plates and rail markers into closer visual alignment with the Snooker Royal layout while tightening outside trims. 
- Fix angled-cushion/pocket calibration so balls contact the cushion cut reliably and don't bounce incorrectly at the cut. 
- Use the same rail-overhead broadcast selection flow as Snooker Royal for replay/head selection while keeping the 2D top view behavior unchanged.

### Description

- Trimmed the middle-pocket chrome plate outer reach by changing `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` from `1.04` to `1.01` and tightened the outer fascia finish by updating `CHROME_OUTER_FLUSH_TRIM_SCALE` from `0.008` to `0.012` in `PoolRoyale.jsx`.
- Increased rail contact padding (`RAIL_LIMIT_PADDING` set from `0` to `0.1`) and adjusted cushion-cut contact radius by changing `CUSHION_CUT_CONTACT_RADIUS` from `BALL_R * 0.92` to `BALL_R` to improve angle-cut collision detection.
- Aligned the Pool replay broadcast camera selection with the snooker rail-overhead rig by removing the `USE_STANDING_BROADCAST_CAMERA` fallback and always resolving replay cameras from the `broadcastCamerasRef` rig in `resolveRailOverheadReplayCamera`.
- Nudged branding and diamond marker positions by increasing `brandPlateOutwardShift` (`endRailW * 0.28` → `endRailW * 0.34`) and pulling rail markers slightly inward via `railMarkerOutset` (`longRailW * 0.62` → `longRailW * 0.56`) so branding plates sit a bit farther from center and diamond markers are closer to center.
- All edits were made in `webapp/src/pages/Games/PoolRoyale.jsx` and committed with the message `Adjust pool royale table trims and cameras`.

### Testing

- No automated unit or integration tests were executed for this change. 
- No automated test failures were observed because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786e44ead8832987c0bd0e25a236ee)