### PR TITLE
Improve side-pocket cushion alignment and enable fine-grained spin input

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -130,6 +130,7 @@ function applyTablePhysicsSpec(meta) {
       ? meta.cushionCutAngleDeg
       : DEFAULT_SIDE_CUSHION_CUT_ANGLE;
   SIDE_CUSHION_CUT_ANGLE = sideCushionAngle;
+  VISUAL_SIDE_CUSHION_CUT_ANGLE = sideCushionAngle;
   const sidePocketPhysicsAngle = Number.isFinite(meta?.sidePocketCutAngleDeg)
     ? meta.sidePocketCutAngleDeg
     : VISUAL_SIDE_CUSHION_CUT_ANGLE;
@@ -1125,7 +1126,7 @@ const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
 const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.1; // keep middle pocket centres closer to the mapped cushion cuts
-const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.24; // align middle pocket centres with the 45° cut mapping
+const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.08;
 const SIDE_POCKET_FIELD_PULL = 0; // keep the middle pocket centres perfectly centered to match the chrome cut symmetry
 const SIDE_POCKET_CLOTH_INWARD_PULL = 0; // keep the middle pocket cloth cutouts perfectly aligned to the pocket centres
 const CHALK_TOP_COLOR = 0xd9c489;
@@ -1631,11 +1632,11 @@ const SPIN_DECORATION_OFFSET_PERCENT = 58;
 const DEFAULT_CUSHION_CUT_ANGLE = 45;
 // match the corner-cushion cut angle on both sides of the corner pockets
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
-const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 44;
-const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 46;
+const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 20;
+const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 60;
 const DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE = 45;
-const VISUAL_SIDE_CUSHION_CUT_ANGLE = 45;
-const SIDE_POCKET_CUT_ANGLE_DEG = VISUAL_SIDE_CUSHION_CUT_ANGLE;
+let VISUAL_SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
+const SIDE_POCKET_CUT_ANGLE_DEG = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -133,11 +133,18 @@ export const computeQuantizedOffsetScaled = (
 export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
-  const distance = Math.hypot(x, y);
-  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  if (distance <= deadzone) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  return computeQuantizedOffsetScaled(x, y);
+  const normalized =
+    distance > 1e-6 ? { x: clamped.x / distance, y: clamped.y / distance } : { x: 0, y: 0 };
+  const travel = Math.max(1e-6, MAX_SPIN_OFFSET - deadzone);
+  const t = clamp((distance - deadzone) / travel, 0, 1);
+  const magnitude = t * MAX_SPIN_OFFSET;
+  return { x: normalized.x * magnitude, y: normalized.y * magnitude };
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Fix middle-pocket bias and make cushion cut angles match the table spec so balls interact with cushion cuts reliably. 
- Allow small, gradual spin application from the spin UI so light offsets between center and rings produce proportional spin rather than a hard dead zone.

### Description
- Sync visual and physics side-cushion cut handling by assigning `VISUAL_SIDE_CUSHION_CUT_ANGLE = sideCushionAngle` inside `applyTablePhysicsSpec` so the visual cut angle follows table metadata. 
- Broaden acceptable physics cut-angle bounds by changing `MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE` to `20` and `MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE` to `60` to allow sensible customization ranges. 
- Reduce middle-pocket outward bias by changing `SIDE_POCKET_OUTWARD_BIAS` from `TABLE.THICK * 0.24` to `TABLE.THICK * 0.08` so pocket centers align closer to cushion cuts. 
- Replace the quantized/noisy spin deadzone behavior in `normalizeSpinInput` with a clamped + linear ramp: inputs are clamped to `MAX_SPIN_OFFSET`, measured against a `deadzone` (`SPIN_STUN_RADIUS`/`STRAIGHT_SPIN_DEADZONE`), and then scaled linearly from zero to `MAX_SPIN_OFFSET` so light UI offsets apply small proportional spin.

### Testing
- Started the dev server with `npm run dev` inside `webapp` and the Vite server reported ready and serving at `http://localhost:4173/` (success). 
- Attempted an end-to-end visual capture by navigating to `/games/poolroyale` with Playwright to produce a screenshot, but the Playwright page screenshot timed out (failed to capture). 
- No automated unit tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b1fc61a48328849b74563330a913)