### PR TITLE
Align Snooker Royale cushion cuts with Pool Royale logic

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6599,6 +6599,15 @@ function updateCushionSegmentsFromTable(table) {
     if (dir.lengthSq() < 1e-6) return;
     segments.push({ start, end, type });
   };
+  const resolveAngle = (angles, key, fallback) =>
+    typeof angles?.[key] === 'number' ? angles[key] : fallback;
+  const computeCutOffset = (depth, cutLength, angleDeg) => {
+    if (!Number.isFinite(depth) || depth <= 0) return Math.max(0, cutLength);
+    const rad = THREE.MathUtils.degToRad(angleDeg);
+    const tan = Math.tan(rad);
+    const angleOffset = tan > MICRO_EPS ? depth / tan : cutLength;
+    return Math.max(0, Math.min(cutLength, angleOffset));
+  };
   table.userData.cushions.forEach((cushion) => {
     const data = cushion.userData || {};
     if (typeof data.horizontal !== 'boolean' || !data.side) return;
@@ -6606,16 +6615,25 @@ function updateCushionSegmentsFromTable(table) {
     const cutEnds = data.cutEnds || {};
     const minCut = Math.max(0, cutEnds.min || 0);
     const maxCut = Math.max(0, cutEnds.max || 0);
-    const cutInsetBase = RAIL_CONTACT_RADIUS * 0.18;
-    const minInset = Math.min(minCut, cutInsetBase);
-    const maxInset = Math.min(maxCut, cutInsetBase);
-    const minInner = minCut + minInset;
-    const maxInner = maxCut + maxInset;
+    const cutTypes = data.cutTypes || {};
+    const minTypeScale = cutTypes.min === 'side' ? 0.2 : 1;
+    const maxTypeScale = cutTypes.max === 'side' ? 0.2 : 1;
+    const cutInsetBase = RAIL_CONTACT_RADIUS * 0.12;
+    const minInset = Math.min(minCut, cutInsetBase * minTypeScale);
+    const maxInset = Math.min(maxCut, cutInsetBase * maxTypeScale);
+    const cutAngles = data.cutAngles || {};
+    const cutAnglesByEnd = data.cutAnglesByEnd || {};
+    const defaultAngle = resolveAngle(cutAngles, 'cutAngle', CUSHION_CUT_ANGLE);
+    const minAngle = resolveAngle(cutAnglesByEnd, 'min', defaultAngle);
+    const maxAngle = resolveAngle(cutAnglesByEnd, 'max', defaultAngle);
     if (data.horizontal) {
       const innerZ = data.side < 0 ? box.max.z : box.min.z;
       const outerZ = data.side < 0 ? box.min.z : box.max.z;
-      const leftInner = new THREE.Vector2(box.min.x + minInner, innerZ);
-      const rightInner = new THREE.Vector2(box.max.x - maxInner, innerZ);
+      const depth = Math.abs(innerZ - outerZ);
+      const leftCut = computeCutOffset(depth, minCut + minInset, minAngle);
+      const rightCut = computeCutOffset(depth, maxCut + maxInset, maxAngle);
+      const leftInner = new THREE.Vector2(box.min.x + leftCut, innerZ);
+      const rightInner = new THREE.Vector2(box.max.x - rightCut, innerZ);
       const leftOuter = new THREE.Vector2(box.min.x, outerZ);
       const rightOuter = new THREE.Vector2(box.max.x, outerZ);
       if (rightInner.x - leftInner.x > MICRO_EPS) {
@@ -6626,8 +6644,11 @@ function updateCushionSegmentsFromTable(table) {
     } else {
       const innerX = data.side < 0 ? box.max.x : box.min.x;
       const outerX = data.side < 0 ? box.min.x : box.max.x;
-      const bottomInner = new THREE.Vector2(innerX, box.min.z + minInner);
-      const topInner = new THREE.Vector2(innerX, box.max.z - maxInner);
+      const depth = Math.abs(innerX - outerX);
+      const bottomCut = computeCutOffset(depth, minCut + minInset, minAngle);
+      const topCut = computeCutOffset(depth, maxCut + maxInset, maxAngle);
+      const bottomInner = new THREE.Vector2(innerX, box.min.z + bottomCut);
+      const topInner = new THREE.Vector2(innerX, box.max.z - topCut);
       const bottomOuter = new THREE.Vector2(outerX, box.min.z);
       const topOuter = new THREE.Vector2(outerX, box.max.z);
       if (topInner.y - bottomInner.y > MICRO_EPS) {
@@ -9604,7 +9625,7 @@ function Table3D(
     const rightDistanceToSidePocket = Math.abs(worldZRight);
     const leftCloserToCenter = leftDistanceToSidePocket < rightDistanceToSidePocket;
     const side = horizontal ? (z >= 0 ? 1 : -1) : x >= 0 ? 1 : -1;
-    const sidePocketCuts = !horizontal
+    const cutConfig = !horizontal
       ? {
           leftCutAngle: leftCloserToCenter
             ? CUSHION_CUT_ANGLE
@@ -9613,9 +9634,16 @@ function Table3D(
             ? VISUAL_SIDE_CUSHION_CUT_ANGLE
             : CUSHION_CUT_ANGLE
         }
-      : undefined;
-    const cutLengths = computeCushionCutLengths(len, horizontal, sidePocketCuts);
-    const geo = cushionProfileAdvanced(len, horizontal, sidePocketCuts);
+      : {};
+    const resolvedCutAngles = {
+      cutAngle: CUSHION_CUT_ANGLE,
+      leftCutAngle: cutConfig.leftCutAngle ?? CUSHION_CUT_ANGLE,
+      rightCutAngle: cutConfig.rightCutAngle ?? CUSHION_CUT_ANGLE,
+      leftStraightEdge: cutConfig.leftStraightEdge,
+      rightStraightEdge: cutConfig.rightStraightEdge
+    };
+    const cutLengths = computeCushionCutLengths(len, horizontal, resolvedCutAngles);
+    const geo = cushionProfileAdvanced(len, horizontal, resolvedCutAngles);
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
     const orientationScale = horizontal ? SHORT_CUSHION_HEIGHT_SCALE : 1;
@@ -9686,9 +9714,20 @@ function Table3D(
     const leftWorld = leftLocal.clone().applyMatrix4(group.matrixWorld);
     const rightWorld = rightLocal.clone().applyMatrix4(group.matrixWorld);
     const leftIsMin = horizontal ? leftWorld.x <= rightWorld.x : leftWorld.z <= rightWorld.z;
+    const leftCutType = horizontal ? 'corner' : leftCloserToCenter ? 'side' : 'corner';
+    const rightCutType = horizontal ? 'corner' : leftCloserToCenter ? 'corner' : 'side';
     group.userData.cutEnds = {
       min: leftIsMin ? cutLengths.leftCut : cutLengths.rightCut,
       max: leftIsMin ? cutLengths.rightCut : cutLengths.leftCut
+    };
+    group.userData.cutTypes = {
+      min: leftIsMin ? leftCutType : rightCutType,
+      max: leftIsMin ? rightCutType : leftCutType
+    };
+    group.userData.cutAngles = resolvedCutAngles;
+    group.userData.cutAnglesByEnd = {
+      min: leftIsMin ? resolvedCutAngles.leftCutAngle : resolvedCutAngles.rightCutAngle,
+      max: leftIsMin ? resolvedCutAngles.rightCutAngle : resolvedCutAngles.leftCutAngle
     };
     table.add(group);
     table.userData.cushions.push(group);


### PR DESCRIPTION
### Motivation
- Ensure Snooker Royale uses the exact cushion cut-angle/offset behavior already implemented in Pool Royale so angled cushion collisions and pocket entries match across modes.
- Make cushion cut bias and inset scaling precise and type-aware to avoid balls being incorrectly blocked by rail geometry.

### Description
- Added `resolveAngle` and `computeCutOffset` helpers and applied them to cushion segment computation to derive angle-dependent cut offsets from depth and configured cut angles in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Read and respect per-cushion metadata (`cutTypes`, `cutAngles`, `cutAnglesByEnd`) and use a type-aware inset scale so `side` vs `corner` cuts produce different inset behavior during segment generation.
- Unified the `addCushion` call path to build `resolvedCutAngles` and use them when computing `cutLengths` and geometry (`cushionProfileAdvanced`), and record `cutTypes`, `cutAngles` and `cutAnglesByEnd` on `group.userData` for downstream consumers.
- Changes localize to `webapp/src/pages/Games/SnookerRoyal.jsx` and mirror the same logic and parameters used in the Pool Royale counterpart for cushion cuts.

### Testing
- No automated tests were executed for this change.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d006f9d083289f8b91c00b88d49d)