### PR TITLE
Tune Pool Royale spin controller and add spin-deflection + backspin cue-line indicator

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,15 +1,15 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.7;
-export const SPIN_STUN_RADIUS = 0.16;
-export const SPIN_RING1_RADIUS = 0.32;
-export const SPIN_RING2_RADIUS = 0.52;
+export const MAX_SPIN_OFFSET = 0.68;
+export const SPIN_STUN_RADIUS = 0.21;
+export const SPIN_RING1_RADIUS = 0.34;
+export const SPIN_RING2_RADIUS = 0.54;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0.22 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
-export const STRAIGHT_SPIN_DEADZONE = 0.02;
+export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL2_MAG = 0.38 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL3_MAG = 0.78 * MAX_SPIN_OFFSET;
+export const STRAIGHT_SPIN_DEADZONE = 0.06;
 export const STUN_TOPSPIN_BIAS = 0;
 
 export const SPIN_DIRECTIONS = [


### PR DESCRIPTION
### Motivation
- Make the spin controller produce gentler, more playable stun behavior near centre while limiting extreme spin magnitudes so the UI matches the provided reference.
- Show the effect of side-spin on the target-ball aiming preview so players see deflection in real time when they move the spin dot or change power.
- Provide a clear visual cue when backspin will make the cue-ball follow line reverse by tinting the cue-follow line red.

### Description
- Adjusted spin control constants in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by tuning `MAX_SPIN_OFFSET`, `SPIN_STUN_RADIUS`, `SPIN_RING*` radii, `SPIN_LEVEL*_MAG` values and `STRAIGHT_SPIN_DEADZONE` to allow easier stun input near center and reduce overall spin magnitude.
- Added `applySpinDeflectionToTargetDir` to `webapp/src/pages/Games/PoolRoyale.jsx` and applied it to object-ball aim previews so the target line is deflected by side-spin scaled by shot power in both local and remote-aim code paths.
- Updated cue-follow preview generation (both player and remote aim) to compute when the follow line will point backwards under draw/backspin and set the cue-after line color to red (`0xff3b30`) when that occurs.

### Testing
- No unit or integration tests were run after these edits.
- A Playwright-based screenshot attempt was tried but failed due to the browser crashing in this environment, so visual validation was not completed.
- The changes were tested locally via code edit and committed; runtime verification in the running app was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d61158848328987b0e4949bef623)