### PR TITLE
Adjust spin tuning and aim-preview deflection in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,14 +1,14 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.7;
-export const SPIN_STUN_RADIUS = 0.16;
+export const MAX_SPIN_OFFSET = 0.62;
+export const SPIN_STUN_RADIUS = 0.2;
 export const SPIN_RING1_RADIUS = 0.32;
-export const SPIN_RING2_RADIUS = 0.52;
+export const SPIN_RING2_RADIUS = 0.48;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0.22 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 


### PR DESCRIPTION
### Motivation
- Reduce maximum visual spin magnitude and expand the stun (no-spin) zone so the spin controller is softer while preserving existing direction mapping. 
- Allow players to aim closer to center for stun shots while keeping the current spin directions unchanged. 
- Show the deflection on the target ball aim line caused by applied spin and update cue-follow visuals (including backspin backward indicator) in real time.

### Description
- Tuned spin quantization parameters in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by updating `MAX_SPIN_OFFSET`, `SPIN_STUN_RADIUS`, `SPIN_RING2_RADIUS` and the `SPIN_LEVEL*_MAG` values to soften spin and enlarge the stun deadzone. 
- Added `resolveTargetSpinDeflection` helper in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a spin-influenced deflected target direction from live spin, power and lift inputs. 
- Integrated the spin-deflected direction into local and remote aim previews by applying `resolveTargetSpinDeflection` when building the target aim line so the target line updates in real time with spin and power. 
- Updated cue-follow visuals so the cue-follow line changes color to red when backspin causes the cue-follow direction to go backwards, and mirrored these spin-influenced follow adjustments for remote aims.

### Testing
- Started the web preview dev server with `npm --prefix webapp run dev` and Vite reported ready on `http://localhost:5173/`, which succeeded. 
- Attempted an automated Playwright screenshot against `http://127.0.0.1:5173/games/poolroyale` to validate visual changes, but the headless browser failed to launch (Playwright/Chromium crash), so the screenshot step failed. 
- No unit tests or Jest runs were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d61158848328987b0e4949bef623)