### PR TITLE
Pool Royale: continuous spin control, rail collision fixes, and AI cache precision

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5909,7 +5909,6 @@ function reflectRails(ball) {
     let bestPenetration = 0;
     for (const segment of CUSHION_SEGMENTS) {
       if (!segment?.normal || !segment?.start || !segment?.end) continue;
-      if (nearPocket && segment.type === 'rail') continue;
       if (inCaptureZone && segment.type === 'cut') continue;
       const velocityToward = ball.vel.dot(segment.normal);
       if (velocityToward >= 0) continue;
@@ -22799,8 +22798,8 @@ const powerRef = useRef(hud.power);
             .slice()
             .sort((a, b) => a.id - b.id)
             .map((ball) => {
-              const x = Math.round(ball.x * 10);
-              const y = Math.round(ball.y * 10);
+              const x = Math.round(ball.x * 100);
+              const y = Math.round(ball.y * 100);
               return `${ball.id}:${ball.colour}:${ball.pocketed ? 1 : 0}:${x}:${y}`;
             })
             .join('|');

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -134,10 +134,20 @@ export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
   const distance = Math.hypot(x, y);
-  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  if (distance <= deadzone) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  return computeQuantizedOffsetScaled(x, y);
+  const clamped = clampToUnitCircle(x, y);
+  const clampedDistance = Math.hypot(clamped.x, clamped.y);
+  const range = Math.max(1 - deadzone, 1e-6);
+  const t = clamp((clampedDistance - deadzone) / range, 0, 1);
+  if (t <= 1e-6 || clampedDistance <= 1e-6) {
+    return { x: 0, y: STUN_TOPSPIN_BIAS };
+  }
+  const dirX = clamped.x / clampedDistance;
+  const dirY = clamped.y / clampedDistance;
+  return { x: dirX * t, y: dirY * t };
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Prevent cue/object balls escaping between pocket jaws and angled cuts by ensuring rail segments are always considered during rail collision detection.  
- Improve the spin controller so users can apply a continuous amount of spin across the entire control area instead of only presets or edge-only values.  
- Reduce AI planning inconsistencies caused by overly coarse state hashing so repeated-shot plans remain stable.

### Description
- Change spin normalization in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to use a continuous deadzone→edge curve that scales direction and magnitude smoothly instead of mapping to quantized rings.  
- Adjust rail collision logic in `reflectRails` inside `webapp/src/pages/Games/PoolRoyale.jsx` to stop skipping `rail` segments when near pockets so cushion/rail segments always participate in collision checks.  
- Increase position quantization precision in the AI state cache key in `webapp/src/pages/Games/PoolRoyale.jsx` from rounding to 10ths to rounding to 100ths to reduce stale/colliding cache keys and improve AI shot consistency.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f48440dc8328a29e9cef2221b073)