### PR TITLE
Improve Pool Royale spin control and collision gating

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,6 +11,7 @@ export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
+export const SPIN_RESPONSE_EXPONENT = 1.35;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -142,12 +143,13 @@ export const normalizeSpinInput = (spin) => {
   const clampedDistance = Math.hypot(clamped.x, clamped.y);
   const range = Math.max(1 - deadzone, 1e-6);
   const t = clamp((clampedDistance - deadzone) / range, 0, 1);
+  const eased = Math.pow(t, SPIN_RESPONSE_EXPONENT);
   if (t <= 1e-6 || clampedDistance <= 1e-6) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
   const dirX = clamped.x / clampedDistance;
   const dirY = clamped.y / clampedDistance;
-  return { x: dirX * t, y: dirY * t };
+  return { x: dirX * eased, y: dirY * eased };
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Allow finer, more natural spin control mapping so users can apply partial spin across the control radius rather than a harsh linear mapping. 
- Prevent balls from escaping through pocket jaw/cut geometry when they are not actually moving into the pocket. 
- Improve AI shot consistency by validating planned aim/impact before the AI commits to fire.

### Description
- Tuned the spin input response by adding `SPIN_RESPONSE_EXPONENT` and applying an eased curve in `normalizeSpinInput` to give more granular control near the center and smoother full-range behaviour (`webapp/src/pages/Games/poolRoyaleSpinUtils.js`).
- In the cushion/rail reflection code, compute the nearest pocket center and detect whether a ball is moving into that pocket, and avoid skipping cut-segment collisions when the ball is not moving into the pocket to reduce balls passing through the jaw gaps (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added AI plan validation before firing which normalizes and verifies pot plans (checks aim direction and verifies a predicted impact matches the planned target) and falls back to safety plans only when validation fails to reduce inconsistent AI behaviour (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were executed as part of this change.
- Changes were implemented and committed to the working branch (two files modified: `poolRoyaleSpinUtils.js` and `PoolRoyale.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f48440dc8328a29e9cef2221b073)