### PR TITLE
Adjust Pool Royale cushion angles, spin behavior, pocket holders, and increase shot power

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 29,
+    sideCushionCutAngleDeg: 29,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 29,
+    sideCushionCutAngleDeg: 29,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1349,13 +1349,13 @@ const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
 const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.6); // stretch the holder run so it comfortably fits 7 balls
-const POCKET_GUIDE_DROP = BALL_R * 0.1;
+const POCKET_GUIDE_DROP = BALL_R * 0.12;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
 const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
 const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.03; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.06; // lift the chrome holder rails so the short L segments meet the ring
 const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
@@ -1369,7 +1369,7 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.26; // lift the leather strap so it meets the raised holder rails
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so it meets the raised holder rails
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -1498,7 +1498,7 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 // Pool Royale power pass: lift overall shot strength by another 25%.
 // Pool Royale request: increase shot power by an additional 50% for stronger strikes.
 const SHOT_POWER_REDUCTION = 0.6375; // reduce overall shot strength by another 25%
-const SHOT_POWER_MULTIPLIER = 1.25;
+const SHOT_POWER_MULTIPLIER = 1.5;
 const SHOT_POWER_BOOST = 1.5;
 const SHOT_SPEED_MULTIPLIER = 1.15;
 const SHOT_FORCE_BOOST =
@@ -6149,6 +6149,29 @@ function applyRailImpulse(ball, impact) {
     );
   }
   ball.vel.set(TMP_VEC3_C.x, TMP_VEC3_C.z);
+}
+
+function resolveSpinFrame(ball) {
+  const speed = Math.max(ball?.vel?.length?.() ?? 0, 0);
+  const forward =
+    speed > 1e-6
+      ? TMP_VEC2_FORWARD.copy(ball.vel).normalize()
+      : ball?.launchDir
+        ? TMP_VEC2_FORWARD.copy(ball.launchDir).normalize()
+        : TMP_VEC2_FORWARD.set(0, 1);
+  const lateral = TMP_VEC2_LATERAL.set(-forward.y, forward.x);
+  return { forward, lateral, speed };
+}
+
+function resolveSpinWorldVector(ball, output) {
+  if (!ball?.spin) return null;
+  const { forward, lateral } = resolveSpinFrame(ball);
+  const sideSpin =
+    ball.spinMode === 'swerve' ? -(ball.spin.x || 0) : (ball.spin.x || 0);
+  const forwardSpin = ball.spin.y || 0;
+  const target = output ?? TMP_VEC2_SPIN;
+  target.copy(lateral).multiplyScalar(sideSpin).addScaledVector(forward, forwardSpin);
+  return target;
 }
 
 
@@ -25038,6 +25061,54 @@ const powerRef = useRef(hud.power);
                 b.vel.x = TMP_VEC3_A.x;
                 b.vel.y = TMP_VEC3_A.z;
                 b.omega.copy(TMP_VEC3_C);
+              }
+            }
+            if (b.spin && b.spin.lengthSq() > 1e-6) {
+              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
+              if (swerveTravel) {
+                const swerveStrength = Math.max(0, b.swerveStrength ?? 0);
+                const swervePower = Math.max(0, b.swervePowerStrength ?? 0);
+                const swervePowerScale =
+                  swerveStrength > 0 ? 0.85 + swervePower * 0.9 : 0;
+                const swerveScale =
+                  swerveStrength > 0
+                    ? (0.6 + swerveStrength * 0.9) * swervePowerScale
+                    : 0;
+                const rollMultiplier =
+                  SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6);
+                const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
+                if (worldSpin && swerveScale > 0) {
+                  const { forward } = resolveSpinFrame(b);
+                  const forwardMag = worldSpin.dot(forward);
+                  TMP_VEC2_AXIS.copy(forward).multiplyScalar(forwardMag);
+                  TMP_VEC2_LATERAL.copy(worldSpin).sub(TMP_VEC2_AXIS);
+                  TMP_VEC2_LATERAL.multiplyScalar(
+                    SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
+                  );
+                  b.vel.addScaledVector(
+                    TMP_VEC2_LATERAL,
+                    SWERVE_PRE_IMPACT_DRIFT * swerveScale
+                  );
+                  if (b.pendingSpin) {
+                    b.pendingSpin.addScaledVector(TMP_VEC2_LATERAL, swerveScale);
+                  }
+                }
+                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
+                b.spin.multiplyScalar(rollDecay);
+                b.swerveStrength = Math.max(0, b.swerveStrength ?? 0) * rollDecay;
+                if (b.swerveStrength < 1e-3) {
+                  b.swerveStrength = 0;
+                  b.swervePowerStrength = 0;
+                }
+              }
+              if (b.spin.lengthSq() < 1e-6) {
+                b.spin.set(0, 0);
+                if (b.pendingSpin) b.pendingSpin.set(0, 0);
+                if (isCue) {
+                  b.spinMode = 'standard';
+                  b.swerveStrength = 0;
+                  b.swervePowerStrength = 0;
+                }
               }
             }
             b.pos.addScaledVector(b.vel, stepScale);

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -12,6 +12,8 @@ export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 export const SPIN_RESPONSE_POWER = 1.35;
+export const LOW_CENTER_BACKSPIN_BOOST = 0.12;
+export const LOW_CENTER_BACKSPIN_MAX_X = 0.22;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -148,7 +150,24 @@ export const normalizeSpinInput = (spin) => {
   );
   const eased = Math.pow(normalizedDistance, SPIN_RESPONSE_POWER);
   const scale = eased / Math.max(clampedDistance, 1e-6);
-  return { x: clamped.x * scale, y: clamped.y * scale };
+  const normalized = { x: clamped.x * scale, y: clamped.y * scale };
+  const lowCenter =
+    clamped.y < -deadzone &&
+    Math.abs(clamped.x) <= LOW_CENTER_BACKSPIN_MAX_X &&
+    clampedDistance <= SPIN_RING2_RADIUS * 0.98;
+  if (lowCenter) {
+    const depth = clamp(
+      (-clamped.y - deadzone) / Math.max(SPIN_RING1_RADIUS - deadzone, 1e-6),
+      0,
+      1
+    );
+    normalized.y = clamp(
+      normalized.y - LOW_CENTER_BACKSPIN_BOOST * depth,
+      -1,
+      1
+    );
+  }
+  return normalized;
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Update cushion cut angles from 27° to 29° to match the requested physical trim and mapping adjustments across Pool Royale table specs. 
- Improve spinning controller so low-center backspin behaves stronger when the red dot is placed low near center and swerve shots better align the cue ball with the aiming line. 
- Increase shot power by 20% to meet the requested power boost. 
- Align thin chrome pocket holder layout and distances with the Snooker Royal reference for consistent holder geometry and spacing.

### Description
- Changed cushion cut angles in `webapp/src/config/poolRoyaleTables.js` from `27` to `29` for both table sizes. 
- Added low-center backspin tuning constants and logic to `normalizeSpinInput` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` (`LOW_CENTER_BACKSPIN_BOOST`, `LOW_CENTER_BACKSPIN_MAX_X`) to bias slightly more backspin when UI input is low near center. 
- Increased overall shot power by bumping `SHOT_POWER_MULTIPLIER` from `1.25` to `1.5` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Adjusted pocket holder/chrome rail geometry constants (`POCKET_GUIDE_DROP`, `POCKET_GUIDE_VERTICAL_DROP`, `POCKET_STRAP_VERTICAL_LIFT`) in `webapp/src/pages/Games/PoolRoyale.jsx` to match Snooker Royal spacing. 
- Added `resolveSpinFrame` and `resolveSpinWorldVector` helpers and integrated swerve pre-impact drift logic into the physics loop in `webapp/src/pages/Games/PoolRoyale.jsx` so swerve-mode cueball motion better matches the aiming preview during swerves.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported ready (network/local URLs) which indicates the build served successfully. (success) 
- Attempted to run the combined dev startup (concurrently) which failed due to a missing package in the bot server process (error from `node bot/server.js` referencing `compression`), then retried the single webapp dev run which succeeded. (partial success/failure) 
- Tried to capture a visual smoke-check via Playwright by loading `/games/poolroyale` and taking a screenshot, but the Playwright screenshot timed out after multiple attempts. (failed)
- No automated unit tests were executed as part of this change set. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979028563408328b97262956ae421e2)