### PR TITLE
Fix snooker foul sequencing, respot placement, and shot power

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -239,7 +239,7 @@ export class SnookerRoyalRules {
       : inColorsOrder
         ? colorsRemaining[0] ?? null
         : onColorAfterRed
-          ? declaredBall
+          ? declaredBall ?? null
           : 'RED';
     const foulBallOn = freeBallActive && nominatedFreeBall
       ? [nominatedFreeBall]
@@ -254,13 +254,15 @@ export class SnookerRoyalRules {
     } else if (context.contactMade === false || !firstContact) {
       foulReason = 'no contact';
     } else {
-      const requiresNomination = freeBallActive || onColorAfterRed;
+      const requiresNomination = freeBallActive;
       if (requiresNomination && !nominatedBall) {
         foulReason = 'no nomination';
       } else if (freeBallActive && onRed && nominatedBall === 'RED') {
         foulReason = 'invalid nomination';
       } else if (onColorAfterRed && declaredBall === 'RED') {
         foulReason = 'invalid nomination';
+      } else if (onColorAfterRed && !declaredBall && firstContact === 'RED') {
+        foulReason = 'wrong ball';
       } else if (requiredFirstContact && firstContact !== requiredFirstContact) {
         foulReason = 'wrong ball';
       }
@@ -367,12 +369,12 @@ export class SnookerRoyalRules {
         }
       } else if (onColorAfterRed) {
         const legalColor = freeBallActive ? nominatedFreeBall : declaredBall;
-        const scoredColor =
-          legalColor &&
-          (pottedColorsExcludingFreeBall.some((entry) => entry.color === legalColor) ||
+        const scoredColor = legalColor
+          ? (pottedColorsExcludingFreeBall.some((entry) => entry.color === legalColor) ||
             freeBallPotted)
             ? legalColor
-            : null;
+            : null
+          : pottedColorsExcludingFreeBall[0]?.color ?? null;
         if (scoredColor) {
           const scored = COLOR_VALUES[ballOnValue ?? scoredColor] || 0;
           scores[state.activePlayer] += scored;
@@ -436,12 +438,8 @@ export class SnookerRoyalRules {
         if (colorsOrderTarget && pottedNonCueColors.includes(colorsOrderTarget)) {
           removeColor(colorsOrderTarget);
         }
-      } else {
-        pottedColors.forEach((entry) => {
-          if (entry.color !== 'RED') restoreBallState(entry.ball);
-        });
       }
-    } else {
+    } else if (!foulReason) {
       pottedColors.forEach((entry) => {
         if (entry.color !== 'RED') restoreBallState(entry.ball);
       });


### PR DESCRIPTION
### Motivation
- Correct incorrect fouling when a color is potted after a red so valid red->color->red sequences are not flagged as fouls.
- Ensure potted snooker colors are respotted to their proper spots or to a nearby legal position when the spot is blocked (placed behind the blocking ball when possible).
- Increase Snooker Royal shot power as requested to make breaks more forceful.

### Description
- Adjusted nomination and first-contact logic in `SnookerRoyalRules.applyShot` to stop requiring a declared color for the after-red state and to handle missing declarations without incorrectly marking legal colors as fouls.
- Updated scoring logic so when no declared color is provided on the after-red shot a potted color is accepted (first potted color is used) and scoring flows correctly.
- Changed potted-color restore/removal behavior to avoid respotting colors on fouls and to restore potted colors only when appropriate in the current phase.
- Enhanced `resolveSnookerRespotPosition` in `webapp/src/pages/Games/SnookerRoyal.jsx` to search alternate spots and, when the base spot is blocked, identify the closest blocking ball and place the respot behind that ball (offset by the minimum clearance) while preserving collision-free placement.
- Prevented respotting after foul resolution by switching respot checks to use the resolved `safeState` and skipping respots when `safeState.foul` is present.
- Increased `SHOT_POWER_MULTIPLIER` in `webapp/src/pages/Games/SnookerRoyal.jsx` to `4.21875` to raise overall shot power scaling.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697904a5e5dc832888d6baeee34d7a91)