### PR TITLE
Snooker: use 30° cushion cuts, widen table, fix rack spacing, enable ball-in-hand

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -149,7 +149,7 @@ export class SnookerRoyalRules {
       freeBall: false,
       hud: buildHud(base, scores, base.ballOn),
       state: {
-        ballInHand: false
+        ballInHand: true
       }
     } satisfies SnookerMeta;
     return base;

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -13,7 +13,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
@@ -31,7 +31,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
+    sideCushionCutAngleDeg: 30,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
+    sideCushionCutAngleDeg: 30,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1062,7 +1062,7 @@ const ENABLE_TRIPOD_CAMERAS = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const ENABLE_TABLE_MAPPING_LINES = false;
-  const TABLE_FIELD_EXPANSION = 1.3; // expand the snooker playfield by ~30% to make the table wider and taller
+  const TABLE_FIELD_EXPANSION = 1.65; // expand the snooker playfield by ~27% to make the table wider and taller
   const TABLE_SIZE_BOOST = 1.28 * TABLE_FIELD_EXPANSION;
   const TABLE_BASE_SCALE = 1.2 * TABLE_SIZE_BOOST;
   const TABLE_WIDTH_SCALE = 1.3; // maintain the existing wide snooker proportions
@@ -1975,8 +1975,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const columnSpacing = ballRadius * 2.06 + 0.002 * (ballRadius / 0.0525);
+  const rowSpacing = ballRadius * 2.02;
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;
@@ -19151,7 +19151,7 @@ const powerRef = useRef(hud.power);
             cue: 0xfafafa
           };
           rackPositions.forEach((pos, index) => {
-            const placement = pos || rackPositions[rackPositions.length - 1] || { x: 0, z: rackStartZ + index * BALL_R * 1.6 };
+            const placement = pos || rackPositions[rackPositions.length - 1] || { x: 0, z: rackStartZ + index * BALL_R * 2.02 };
             addDecorBall(snookerPalette.red, null, 'solid', placement, SNOOKER_BALL_MATERIAL_VARIANT);
           });
           [
@@ -19642,7 +19642,7 @@ const powerRef = useRef(hud.power);
         for (let rid = 0; rid < rackColors.length; rid++) {
           const pos = rackPositions[rid] || rackPositions[rackPositions.length - 1] || {
             x: 0,
-            z: rackStartZ + rid * BALL_R * 1.9
+            z: rackStartZ + rid * BALL_R * 2.02
           };
           const color = getPoolBallColor(variantConfig, rid);
           const number = getPoolBallNumber(variantConfig, rid);


### PR DESCRIPTION
### Motivation
- Align snooker cushion geometry with expected 30° cuts instead of 27° in snooker variants so cushion geometry/physics match the snooker spec.
- Prevent ball overlap in racks and decorative placements by increasing rack spacing and slightly widening the snooker playfield.
- Start frames with the cue ball available for placement so player/AI can move the ball-in-hand at kickoff.

### Description
- Updated snooker table configs to use 30° cushion cuts by changing `cushionCutAngleDeg`/`sideCushionCutAngleDeg` to `30` in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js`.
- Increased snooker playfield expansion factor from `1.3` to `1.65` in `webapp/src/pages/Games/SnookerRoyal.jsx` to make the table ~25–30% wider/taller while preserving pocket layout and markings.
- Increased rack spacing to avoid overlapping balls by adjusting `columnSpacing` and `rowSpacing` and using `2.02` row spacing where racks are laid out in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Enabled ball-in-hand at frame start by setting `ballInHand: true` in the initial frame meta in `src/rules/SnookerRoyalRules.ts`.

### Testing
- Launched the webapp dev server (`npm --prefix webapp run dev`) and `vite` reported ready and served the site on the local/network host, so the UI code changes were served successfully (Vite ready).
- Attempted to run the full dev concurrently (webapp + bot), but the bot process failed due to a missing `compression` dependency causing the concurrent process to exit (bot server error); this prevented a full end-to-end run with the bot.
- Tried automated page rendering capture using Playwright to validate the Snooker Royal page, but the screenshot attempts timed out (page rendering/screenshot timed out), so no rendered screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979a203130083289afac2e89ce7a4c1)