### PR TITLE
Adjust Snooker Royale table geometry and start state

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -149,7 +149,7 @@ export class SnookerRoyalRules {
       freeBall: false,
       hud: buildHud(base, scores, base.ballOn),
       state: {
-        ballInHand: false
+        ballInHand: true
       }
     } satisfies SnookerMeta;
     return base;

--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -13,7 +13,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
@@ -31,7 +31,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
+    sideCushionCutAngleDeg: 30,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 30,
+    sideCushionCutAngleDeg: 30,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -962,7 +962,7 @@ function addPocketCuts(
 // while keeping the same table height for mobile presentation.
 const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
-const TABLE_FOOTPRINT_SCALE = 0.82; // match the Pool Royale footprint scaling before doubling the table size
+const TABLE_FOOTPRINT_SCALE = 1.05;
 const TABLE_SIZE_MULTIPLIER = 2; // snooker table is double the pool table size
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
@@ -1975,8 +1975,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const columnSpacing = ballRadius * 2.05;
+  const rowSpacing = columnSpacing * (Math.sqrt(3) / 2);
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;


### PR DESCRIPTION
### Motivation
- Make Snooker Royale physics match requested specs by changing cushion cut angles from 27° to 30° and ensure the table appears wider (≈25–30%) while keeping pocket layout and markings intact.
- Prevent overlapping balls in the initial rack by increasing rack spacing to match the larger table footprint.
- Start frames with the cue-ball available `ballInHand` so user/AI can place the ball at the start.

### Description
- Updated snooker table physical specs to use 30° cushion cuts by changing `cushionCutAngleDeg` and `sideCushionCutAngleDeg` in `webapp/src/config/snookerRoyalTables.js` and `webapp/src/config/snookerClubTables.js`.
- Increased the playable table footprint by changing `TABLE_FOOTPRINT_SCALE` in `webapp/src/pages/Games/SnookerRoyal.jsx` to make the table ~25–30% wider while keeping pocket sizing and markings.
- Adjusted rack spacing in `webapp/src/pages/Games/SnookerRoyal.jsx` by modifying `generateRackPositions` to use `columnSpacing = ballRadius * 2.05` and `rowSpacing = columnSpacing * (Math.sqrt(3) / 2)` to reduce overlapping balls.
- Enabled ball-in-hand at frame start by setting the initial snooker frame meta `state.ballInHand` to `true` in `src/rules/SnookerRoyalRules.ts` so the player/AI can place the cue ball when a frame begins.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev`; the Vite dev server started and served the site on `http://localhost:4173/` (success).
- Attempted an automated visual verification via a Playwright screenshot script targeting `/games/snookerroyale`, but the Playwright run timed out (failed to capture screenshot).
- No unit tests (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979a203130083289afac2e89ce7a4c1)