### PR TITLE
Adjust Snooker cushion angles, ball spacing, and camera/table scale

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 30,
-    sideCushionCutAngleDeg: 45,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 50,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 30,
-    sideCushionCutAngleDeg: 45,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 50,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 30,
-    sideCushionCutAngleDeg: 30,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 50,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 30,
-    sideCushionCutAngleDeg: 30,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 50,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -966,8 +966,8 @@ const TABLE_FOOTPRINT_SCALE = 1.05;
 const TABLE_SIZE_MULTIPLIER = 2; // snooker table is double the pool table size
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.92; // pull the entire table set closer so the arena feels larger while keeping proportions intact
-const CAMERA_DISPLAY_SCALE = TABLE_DISPLAY_SCALE / 0.88;
+const TABLE_DISPLAY_SCALE = 0.8; // match Pool Royale table height and display scale
+const CAMERA_DISPLAY_SCALE = 1;
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1630,14 +1630,14 @@ const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
 const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
 const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
-// angle for cushion cuts guiding balls into corner pockets (match Pool Royale physics defaults)
-const DEFAULT_CUSHION_CUT_ANGLE = 45;
+// angle for cushion cuts guiding balls into corner pockets (match Snooker Royale spec)
+const DEFAULT_CUSHION_CUT_ANGLE = 50;
 // middle pocket cushion cuts match the Pool Royale spec for identical cushion angles
 const DEFAULT_SIDE_CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
-const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 44;
-const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 46;
-const DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE = 45;
-const VISUAL_SIDE_CUSHION_CUT_ANGLE = 45;
+const MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 49;
+const MAX_SIDE_POCKET_PHYSICS_CUT_ANGLE = 51;
+const DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE = 50;
+const VISUAL_SIDE_CUSHION_CUT_ANGLE = 50;
 const SIDE_POCKET_CUT_SIGNS = [-1, 1];
 let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
@@ -1975,7 +1975,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2.05;
+  const rackGapBias = 0.002 * (ballRadius / 0.0525);
+  const columnSpacing = ballRadius * 2 + rackGapBias;
   const rowSpacing = columnSpacing * (Math.sqrt(3) / 2);
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
@@ -6500,7 +6501,7 @@ const isSnookerColourId = (colorId) => Boolean(SNOOKER_COLOR_SPOTS[colorId]);
 const resolveSnookerSpotKey = (colorId) => SNOOKER_COLOR_SPOTS[colorId] ?? null;
 const isRespotPositionClear = (pos, balls, reserved = [], ignoreId = null) => {
   if (!pos) return false;
-  const minDistance = BALL_R * 2.02;
+  const minDistance = BALL_R * 2;
   const minDistanceSq = minDistance * minDistance;
   for (const ball of balls) {
     if (!ball?.active) continue;
@@ -6538,7 +6539,7 @@ const resolveSnookerRespotPosition = (colorId, spots, balls, reserved = []) => {
       return candidatePos;
     }
   }
-  const minDistance = BALL_R * 2.02;
+  const minDistance = BALL_R * 2;
   const blockers = balls.filter((ball) => {
     if (!ball?.active) return false;
     const dx = ball.pos.x - baseSpot.x;
@@ -19140,6 +19141,8 @@ const powerRef = useRef(hud.power);
         if (variant === 'snooker') {
           const rackStartZ = SPOTS.pink[1] + BALL_R * 1.6;
           const rackPositions = generateRackPositions(15, 'triangle', BALL_R, rackStartZ);
+          const rackRowSpacing =
+            (BALL_R * 2 + 0.002 * (BALL_R / 0.0525)) * (Math.sqrt(3) / 2);
           const snookerPalette = {
             red: 0xb1262c,
             yellow: 0xf7d000,
@@ -19151,7 +19154,7 @@ const powerRef = useRef(hud.power);
             cue: 0xfafafa
           };
           rackPositions.forEach((pos, index) => {
-            const placement = pos || rackPositions[rackPositions.length - 1] || { x: 0, z: rackStartZ + index * BALL_R * 1.6 };
+            const placement = pos || rackPositions[rackPositions.length - 1] || { x: 0, z: rackStartZ + index * rackRowSpacing };
             addDecorBall(snookerPalette.red, null, 'solid', placement, SNOOKER_BALL_MATERIAL_VARIANT);
           });
           [
@@ -19639,10 +19642,12 @@ const powerRef = useRef(hud.power);
           BALL_R,
           rackStartZ
         );
+        const rackRowSpacing =
+          (BALL_R * 2 + 0.002 * (BALL_R / 0.0525)) * (Math.sqrt(3) / 2);
         for (let rid = 0; rid < rackColors.length; rid++) {
           const pos = rackPositions[rid] || rackPositions[rackPositions.length - 1] || {
             x: 0,
-            z: rackStartZ + rid * BALL_R * 1.9
+            z: rackStartZ + rid * rackRowSpacing
           };
           const color = getPoolBallColor(variantConfig, rid);
           const number = getPoolBallNumber(variantConfig, rid);


### PR DESCRIPTION
### Motivation
- Bring Snooker Royal cushion cuts into the requested spec so 30° cuts become 32° and 45° cuts become 50°. 
- Prevent decorative and respot ball overlaps by making rack spacing and respot clearance match actual ball radius. 
- Match Snooker Royal table height and camera framing to the Pool Royale setup by aligning display and camera scaling.

### Description
- Update physical table specs in `webapp/src/config/snookerClubTables.js` and `webapp/src/config/snookerRoyalTables.js` to set `cushionCutAngleDeg: 32` and `sideCushionCutAngleDeg: 50` for the snooker sizes. 
- In `webapp/src/pages/Games/SnookerRoyal.jsx` set `TABLE_DISPLAY_SCALE = 0.8` and `CAMERA_DISPLAY_SCALE = 1` to align standing/cue camera height/scale with Pool Royale, and change `DEFAULT_CUSHION_CUT_ANGLE` to `50` with side-pocket physics bounds `49..51` and visual side angle `50`. 
- Fix rack and ball placement logic by tightening rack spacing calculation to `columnSpacing = ballRadius * 2 + rackGapBias`, using a computed `rackRowSpacing` for fallback placements, and update respot clearance/min distances from `BALL_R * 2.02` to exactly `BALL_R * 2` so balls touch but do not overlap.

### Testing
- No automated tests were executed for this change; modifications were applied to the source files and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ad713adc83288270b01edcaf43e4)