### PR TITLE
Pool Royale: update cushion cut angles, reduce cue pull, gate AI cue pull, and record cue in replay

### DIFF
--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -13,8 +13,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 29,
-    sideCushionCutAngleDeg: 29,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
@@ -31,8 +31,8 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
       corner: 171.45,
       side: 152.4
     }),
-    cushionCutAngleDeg: 29,
-    sideCushionCutAngleDeg: 29,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });


### PR DESCRIPTION
### Motivation
- Align Pool Royale table geometry with the new spec by changing corner cushion cuts to 32° and middle/side pocket cuts to 65°. 
- Reduce the visible cue pull distance by ~40% so player and AI strokes match the requested visual scale. 
- Make AI cue animations pull only after the AI camera/cue view and spin adjustment are finished, and ensure the cue is captured in replay frames so replays show the stick at the same coordinates as live broadcast.

### Description
- Updated physical table specs in `webapp/src/config/poolRoyaleTables.js` to set `cushionCutAngleDeg` and `sideCushionCutAngleDeg` to `32` for 9ft and 8ft table presets. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` changed `DEFAULT_CUSHION_CUT_ANGLE` to `32`, and adjusted side-pocket physics/visual cut angle constants to use a 65° mapping (`MIN_SIDE_POCKET_PHYSICS_CUT_ANGLE = 64`, `MAX = 66`, `DEFAULT = 65`, `VISUAL_SIDE_CUSHION_CUT_ANGLE = 65`) and updated the related comment. 
- Added `CUE_PULL_DISTANCE_SCALE = 0.6` and applied it to `computePullTargetFromPower` so visual cue pull targets are reduced (~40% shorter). 
- Gate AI cue pull: introduced `aiCuePullReadyAtRef` and set it when beginning the AI cue view; AI cue pull remains at zero until the AI cue view/spin-adjust delay elapses, and `computeCuePull` is called with `instant` while AI is not yet ready to avoid visible premature pulls. 
- Ensure cue rendering for AI cue view: allow cue visibility when AI cue view is active and include a call to `recordReplayFrame(performance.now())` just before starting the stroke animation so the cue stick position is captured in the recorded replay frames. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979bbde0bb88328a8a0aadbdb2db6f8)