### PR TITLE
Expand Snooker playfield and normalize ball scaling

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1062,7 +1062,7 @@ const ENABLE_TRIPOD_CAMERAS = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const ENABLE_TABLE_MAPPING_LINES = false;
-  const TABLE_FIELD_EXPANSION = 1.3; // expand the snooker playfield by ~30% to make the table wider and taller
+  const TABLE_FIELD_EXPANSION = 1.5;
   const TABLE_SIZE_BOOST = 1.28 * TABLE_FIELD_EXPANSION;
   const TABLE_BASE_SCALE = 1.2 * TABLE_SIZE_BOOST;
   const TABLE_WIDTH_SCALE = 1.3; // maintain the existing wide snooker proportions
@@ -1159,7 +1159,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MM_TO_UNITS = innerLong / (WIDTH_REF * TABLE_FIELD_EXPANSION);
 const MARKINGS_MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 0.96; // trim ball sizing slightly for tighter snooker proportions
+const BALL_SIZE_SCALE = 0.97;
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -4821,6 +4821,7 @@ function applySnookerScaling({
     SIDE_MOUTH_REF * mmToUnits * POCKET_SIDE_MOUTH_SCALE;
   const actualCornerMouth = POCKET_VIS_R * 2;
   const actualSideMouth = SIDE_POCKET_RADIUS * 2;
+  const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5;
   console.assert(
     Math.abs(actualCornerMouth - expectedCornerMouth) <= POCKET_MOUTH_TOLERANCE,
     'applySnookerScaling: corner pocket mouth mismatch.'
@@ -4841,14 +4842,49 @@ function applySnookerScaling({
     const halfWidth = width / 2;
     const baulkZ = -halfWidth + BAULK_FROM_BAULK_REF * mmToUnits;
     const markingY = markings.baulkLine.position.y;
+    const lineThickness = Math.max(expectedRadius * 0.08, 0.1);
+    if (markings.baulkLine.geometry) {
+      markings.baulkLine.geometry.dispose();
+    }
+    markings.baulkLine.geometry = new THREE.PlaneGeometry(
+      PLAY_W - SIDE_RAIL_INNER_THICKNESS * 0.4,
+      lineThickness
+    );
     markings.baulkLine.position.set(center.x, markingY, baulkZ);
     if (markings.dArc) {
+      const dRadius = D_RADIUS_REF * mmToUnits;
+      const dThickness = Math.max(lineThickness * 0.75, expectedRadius * 0.07);
+      if (markings.dArc.geometry) {
+        markings.dArc.geometry.dispose();
+      }
+      markings.dArc.geometry = new THREE.RingGeometry(
+        Math.max(0.001, dRadius - dThickness),
+        dRadius,
+        64,
+        1,
+        0,
+        Math.PI
+      );
       markings.dArc.position.set(center.x, markingY, baulkZ);
     }
     if (Array.isArray(markings.spots) && markings.spots.length >= 6) {
       const [yellow, brown, green, blue, pink, black] = markings.spots;
       const spotY = yellow?.position?.y ?? markingY;
       const dRadius = D_RADIUS_REF * mmToUnits;
+      const spotRadius = expectedRadius * 0.26;
+      const updateSpot = (spot) => {
+        if (!spot) return;
+        if (spot.geometry) {
+          spot.geometry.dispose();
+        }
+        spot.geometry = new THREE.CircleGeometry(spotRadius, 32);
+      };
+      updateSpot(yellow);
+      updateSpot(brown);
+      updateSpot(green);
+      updateSpot(blue);
+      updateSpot(pink);
+      updateSpot(black);
       if (yellow) yellow.position.set(-dRadius, spotY, baulkZ);
       if (brown) brown.position.set(0, spotY, baulkZ);
       if (green) green.position.set(dRadius, spotY, baulkZ);
@@ -4860,24 +4896,24 @@ function applySnookerScaling({
       if (black) black.position.set(0, spotY, blackZ);
     }
   }
+  const baseBallRadius = BALL_GEOMETRY?.parameters?.radius ?? BALL_R;
+  const ballScale =
+    Number.isFinite(baseBallRadius) && baseBallRadius > 0
+      ? expectedRadius / baseBallRadius
+      : 1;
   if (Array.isArray(balls)) {
-    const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5;
     balls.forEach((ball) => {
       if (!ball) return;
       ball.colliderRadius = expectedRadius;
       const mesh = ball.mesh;
       if (!mesh) return;
-      const baseRadius = mesh.geometry?.parameters?.radius;
-      if (Number.isFinite(baseRadius) && baseRadius > 0) {
-        const scale = expectedRadius / baseRadius;
-        mesh.scale.setScalar(scale);
-      }
+      mesh.scale.setScalar(ballScale);
     });
   }
   void cushions;
   void camera;
   void ui;
-  return { mmToUnits };
+  return { mmToUnits, ballScale };
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
@@ -13235,6 +13271,7 @@ const powerRef = useRef(hud.power);
   }, []);
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
+  const ballMeshScaleRef = useRef(1);
   const pocketDropRef = useRef(new Map());
   const pocketRestIndexRef = useRef(new Map());
   const snookerSpotsRef = useRef(null);
@@ -19664,7 +19701,7 @@ const powerRef = useRef(hud.power);
             Object.entries(SPOTS).map(([k, [x, z]]) => [k, add(k, finishPalette[k], x, z)])
           );
 
-      applySnookerScaling({
+      const scaling = applySnookerScaling({
         tableInnerRect: {
           width: PLAY_H,
           height: PLAY_W,
@@ -19677,6 +19714,10 @@ const powerRef = useRef(hud.power);
         camera,
         ui: null
       });
+      ballMeshScaleRef.current =
+        Number.isFinite(scaling?.ballScale) && scaling.ballScale > 0
+          ? scaling.ballScale
+          : 1;
 
       cueRef.current = cue;
       ballsRef.current = balls;
@@ -23246,12 +23287,13 @@ const powerRef = useRef(hud.power);
             ball.pos.set(respot.x, respot.z);
             if (ball.mesh) {
               ball.mesh.visible = true;
-              ball.mesh.scale.set(1, 1, 1);
+              ball.mesh.scale.setScalar(ballMeshScaleRef.current || 1);
               ball.mesh.position.set(respot.x, BALL_CENTER_Y, respot.z);
             }
             if (ball.shadow) {
               ball.shadow.visible = true;
               ball.shadow.position.set(respot.x, BALL_SHADOW_Y, respot.z);
+              ball.shadow.scale.setScalar(ballMeshScaleRef.current || 1);
             }
             pocketDropRef.current.delete(ball.id);
             reserved.push(respot);
@@ -23355,7 +23397,7 @@ const powerRef = useRef(hud.power);
               if (stateBall.onTable) {
                 if (!simBall.active) {
                   pocketDropRef.current.delete(simBall.id);
-                  simBall.mesh.scale.set(1, 1, 1);
+                  simBall.mesh.scale.setScalar(ballMeshScaleRef.current || 1);
                   const [sx, sy] = SPOTS[name];
                   simBall.active = true;
                   simBall.mesh.visible = true;
@@ -25068,7 +25110,7 @@ const powerRef = useRef(hud.power);
                 resting: false
               };
               b.mesh.visible = true;
-              b.mesh.scale.set(1, 1, 1);
+              b.mesh.scale.setScalar(ballMeshScaleRef.current || 1);
               b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
               pocketDropRef.current.set(b.id, dropEntry);
               const mappedColor = toBallColorId(b.id);
@@ -25189,7 +25231,7 @@ const powerRef = useRef(hud.power);
               if (entry.resting) {
                 mesh.visible = true;
                 mesh.position.set(entry.toX ?? runFromX, targetY, entry.toZ ?? runFromZ);
-                mesh.scale.set(1, 1, 1);
+                mesh.scale.setScalar(ballMeshScaleRef.current || 1);
                 return;
               }
               entry.velocityY =
@@ -25209,7 +25251,7 @@ const powerRef = useRef(hud.power);
               let posX = xDrop;
               let posZ = zDrop;
               mesh.visible = true;
-              mesh.scale.set(1, 1, 1);
+              mesh.scale.setScalar(ballMeshScaleRef.current || 1);
               if (entry.rollStartAt && now >= entry.rollStartAt) {
                 const runSpeed = Math.max(MICRO_EPS, entry.runSpeed ?? POCKET_HOLDER_RUN_SPEED_MIN);
                 const rollDuration = Math.max(MICRO_EPS, (entry.restDistance ?? 0) / runSpeed);


### PR DESCRIPTION
### Motivation
- Increase Snooker Royal playfield size by ~15–20% while preserving the same layout, aspect ratio and table height. 
- Replace and recalibrate the D-line / semicircular `D` arc and the white spot markings so they scale correctly with the enlarged playfield. 
- Ensure balls keep consistent physical size when potted or respotted and match Pool Royale sizing so they no longer shrink or overlap.

### Description
- Increased playfield expansion by changing `TABLE_FIELD_EXPANSION` from `1.3` to `1.5` and nudged `BALL_SIZE_SCALE` from `0.96` to `0.97` in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Reworked `applySnookerScaling` to compute `expectedRadius` and update markings geometry dynamically by disposing and recreating the baulk line plane, `dArc` ring and spot `CircleGeometry` using the scaled radii.
- Centralized ball mesh scaling calculation by returning `ballScale` from `applySnookerScaling`, added `ballMeshScaleRef` to the component, and applied `mesh.scale.setScalar(ballMeshScaleRef.current)` and corresponding shadow scale in respot, potted/pocket-drop, replay and simulation code paths to prevent per-event shrinkage.
- Replaced ad-hoc `mesh.scale.set(1,1,1)` calls with the new scaled value so respotted and potted balls keep the same visual size and collider radius is updated (`ball.colliderRadius = expectedRadius`).

### Testing
- Started the dev preview with `npm --prefix webapp run dev` and Vite reported the dev server ready on the expected port, which indicates the app builds/serves successfully; this step succeeded. 
- Attempted an automated Three.js preview screenshot via Playwright to validate visuals, but the Playwright run crashed / timed out (browser SIGSEGV / timeout), so the screenshot step failed. 
- No unit tests were executed as part of this change; changes were committed with `git commit` after local validation of the running dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979bdb7e72c8328aa38e0f8384f4857)