### PR TITLE
Increase Pool Royale ball size by 15% and smooth cue stroke easing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1111,7 +1111,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 0.97; // shrink balls ~3% for a tighter match to the real table size
+const BALL_SIZE_SCALE = 0.97 * 1.15; // scale balls up 15% while keeping the base real-table match
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -18329,7 +18329,8 @@ const powerRef = useRef(hud.power);
           }
           if (localTime <= pullEnd && pullback > 0) {
             const t = THREE.MathUtils.clamp(localTime / Math.max(pullback, 1e-6), 0, 1);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            const eased = easeOutCubic(t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -18341,7 +18342,8 @@ const powerRef = useRef(hud.power);
             );
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            const eased = easeInCubic(t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -18354,7 +18356,8 @@ const powerRef = useRef(hud.power);
             tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
             tmpReplayCueB.set(settleSnap.x, settleSnap.y, settleSnap.z);
             cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            const eased = easeInOutSine(t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -18367,7 +18370,8 @@ const powerRef = useRef(hud.power);
             tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
             tmpReplayCueB.set(idleSnap.x, idleSnap.y, idleSnap.z);
             cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, t);
+            const eased = easeInOutSine(t);
+            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
@@ -18431,7 +18435,8 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            cueStick.position.lerpVectors(warmupPos, startPos, t);
+            const eased = easeOutCubic(t);
+            cueStick.position.lerpVectors(warmupPos, startPos, eased);
             syncCueShadow();
             return true;
           }
@@ -18441,7 +18446,7 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = 1 - Math.pow(1 - t, 3);
+            const eased = easeInCubic(t);
             cueStick.position.lerpVectors(startPos, impactPos, eased);
             syncCueShadow();
             return true;
@@ -18452,10 +18457,11 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
+            const eased = easeInOutSine(t);
             cueStick.position.lerpVectors(
               impactPos,
               settlePos ?? impactPos,
-              t
+              eased
             );
             syncCueShadow();
             return true;
@@ -18466,7 +18472,8 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            cueStick.position.lerpVectors(impactPos, idlePos, t);
+            const eased = easeInOutSine(t);
+            cueStick.position.lerpVectors(impactPos, idlePos, eased);
             syncCueShadow();
             return true;
           }
@@ -21177,7 +21184,10 @@ const powerRef = useRef(hud.power);
         const target = amplifiedMax * ratio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
         return Math.min(target, visualMax);
       };
+      // Easing functions adapted from https://easings.net (MIT License).
+      const easeInCubic = (t) => t * t * t;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const easeInOutSine = (t) => -(Math.cos(Math.PI * t) - 1) / 2;
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
         const horiz = Math.hypot(vec.x ?? 0, vec.z ?? 0);
@@ -21827,7 +21837,7 @@ const powerRef = useRef(hud.power);
                 const t = forwardDuration > 0
                   ? THREE.MathUtils.clamp((now - pullEndTime) / forwardDuration, 0, 1)
                   : 1;
-                const eased = easeOutCubic(t);
+                const eased = easeInCubic(t);
                 cueStick.position.lerpVectors(pullPos, idlePos, eased);
               } else if (now <= settleTime) {
                 cueStick.position.copy(idlePos);


### PR DESCRIPTION
### Motivation
- Make the playfield visuals match the requested larger balls by increasing ball scale across the Pool Royale table and keep related geometry, pockets and shadows consistent. 
- Replace the previous linear cue stroke motion with smoother, well-known easing curves so pull-back / forward animations read better during player/AI shots and in replay playback.

### Description
- Increased the effective ball size by multiplying `BALL_SIZE_SCALE` by `1.15`, which updates all derived values (`BALL_DIAMETER`, `BALL_R`, `BALL_GEOMETRY`, `BALL_SHADOW_GEOMETRY`, `BALL_CENTER_Y`, etc.) so ball size is consistent everywhere on the table. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Added small easing helpers (`easeInCubic`, `easeOutCubic`, `easeInOutSine`) and a reference comment, then applied them to the cue stroke interpolation paths used for live strokes and replay playback so pullback / impact / settle / return use non-linear easing for a more natural motion. (updates in replay stroke interpolation, `animateStroke`, and `updateCueStroke` in `PoolRoyale.jsx`)
- Kept visual compensation and obstruction logic unchanged so the cue still respects camera/view alignment and obstruction handling while using the new easing curves.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite started and reported the site served (local dev server ready), confirming the build is loadable in development mode; this succeeded. 
- Attempted an automated browser capture using Playwright to validate visuals, but Chromium crashed with a SIGSEGV in this environment so screenshot verification failed. 
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cf421028832991cfbd12651309e3)