### PR TITLE
Adjust Snooker Royale rail height and rack spacing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1079,7 +1079,8 @@ const ENABLE_TABLE_MAPPING_LINES = false;
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
-const RAIL_HEIGHT = TABLE.THICK * 1.18; // shorten rails by ~35% so the stance sits lower
+const RAIL_HEIGHT_SCALE = 1.12;
+const RAIL_HEIGHT = TABLE.THICK * 1.18 * RAIL_HEIGHT_SCALE;
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.012; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1091,9 +1092,9 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.025; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
 const POCKET_JAW_DEPTH_SCALE = 1.08; // extend the jaw bodies so the underside reaches deeper below the cloth
-const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114; // lower the visible rim so the pocket lips sit nearer the cloth plane
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.03; // allow the jaw extrusion to extend farther down without lifting the top
-const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.18; // keep the underside tight to the cloth depth instead of the deeper pocket floor
+const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114 * RAIL_HEIGHT_SCALE;
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.03 * RAIL_HEIGHT_SCALE;
+const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.18 * RAIL_HEIGHT_SCALE;
 const POCKET_JAW_EDGE_FLUSH_START = 0.1; // hold the thicker centre section longer before easing toward the chrome trim
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.12; // thin the outer lips more aggressively while leaving the centre crown unchanged
@@ -1341,8 +1342,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.072; // lower the cushion base slightly so the lip sits closer to the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226; // trim the cushion tops further so they sit a touch lower than before
+const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.072 * RAIL_HEIGHT_SCALE;
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.226 * RAIL_HEIGHT_SCALE;
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -1979,8 +1980,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const columnSpacing = ballRadius * 2;
+  const rowSpacing = ballRadius * Math.sqrt(3);
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;


### PR DESCRIPTION
### Motivation

- Align Snooker Royale cushions/jaws/wood rails with the Pool Royale table stance by increasing rail height and related offsets.
- Eliminate visible gaps in the snooker rack by using exact ball-radius spacing so racked balls touch precisely.

### Description

- Introduced `RAIL_HEIGHT_SCALE` and applied it to `RAIL_HEIGHT` and related pocket/jaw offsets (`POCKET_JAW_VERTICAL_LIFT`, `POCKET_JAW_BOTTOM_CLEARANCE`, `POCKET_JAW_FLOOR_CONTACT_LIFT`).
- Scaled cushion geometry by `RAIL_HEIGHT_SCALE` via `CUSHION_EXTRA_LIFT` and `CUSHION_HEIGHT_DROP` to keep cushions/cushion tops consistent with raised rails.
- Replaced the rack spacing heuristics with precise packing distances by setting `columnSpacing = ballRadius * 2` and `rowSpacing = ballRadius * Math.sqrt(3)` inside `generateRackPositions` so racked balls align with exact radii.
- Changes are in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing

- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready and served the app locally at `http://localhost:4173/` (succeeded).
- Attempted an automated Playwright screenshot of `/games/snookerroyale` to verify visual changes, but the Playwright run timed out (failed).
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f4763b6c8320959c503c633a9592)