### PR TITLE
Adjust snooker rail/jaw verticals and tighten rack spacing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1079,7 +1079,7 @@ const ENABLE_TABLE_MAPPING_LINES = false;
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
-const RAIL_HEIGHT = TABLE.THICK * 1.18; // shorten rails by ~35% so the stance sits lower
+const RAIL_HEIGHT = POOL_TABLE_THICKNESS * 1.18;
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.012; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1091,9 +1091,9 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.025; // flare the exterior jaw edge slightly so the chrome-facing finish broadens without widening the mouth
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
 const POCKET_JAW_DEPTH_SCALE = 1.08; // extend the jaw bodies so the underside reaches deeper below the cloth
-const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.114; // lower the visible rim so the pocket lips sit nearer the cloth plane
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.03; // allow the jaw extrusion to extend farther down without lifting the top
-const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.18; // keep the underside tight to the cloth depth instead of the deeper pocket floor
+const POCKET_JAW_VERTICAL_LIFT = POOL_TABLE_THICKNESS * 0.114; // lower the visible rim so the pocket lips sit nearer the cloth plane
+const POCKET_JAW_BOTTOM_CLEARANCE = POOL_TABLE_THICKNESS * 0.03; // allow the jaw extrusion to extend farther down without lifting the top
+const POCKET_JAW_FLOOR_CONTACT_LIFT = POOL_TABLE_THICKNESS * 0.18; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.1; // hold the thicker centre section longer before easing toward the chrome trim
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
 const POCKET_JAW_EDGE_TAPER_SCALE = 0.12; // thin the outer lips more aggressively while leaving the centre crown unchanged
@@ -1117,7 +1117,7 @@ const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.74; // extend the corner jaw reach
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // push the middle jaw reach a touch wider so the openings read larger
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
-const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
+const SIDE_POCKET_JAW_VERTICAL_TWEAK = POOL_TABLE_THICKNESS * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.072; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
@@ -1127,7 +1127,7 @@ const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
 const SIDE_POCKET_RIM_DEPTH_RATIO = POCKET_RIM_DEPTH_RATIO; // keep the middle pocket rims identical to the jaw fascia depth
 const POCKET_RIM_SURFACE_OFFSET_SCALE = 0.02; // lift the rim slightly so the taller parts avoid z-fighting while staying aligned
-const POCKET_RIM_SURFACE_ABSOLUTE_LIFT = TABLE.THICK * 0.052; // ensure the rim clears the jaw top even when the rails compress
+const POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POOL_TABLE_THICKNESS * 0.052; // ensure the rim clears the jaw top even when the rails compress
 const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; // reuse the corner elevation so the middle rims sit flush
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
@@ -1979,8 +1979,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const columnSpacing = ballRadius * 2;
+  const rowSpacing = ballRadius * Math.sqrt(3);
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;


### PR DESCRIPTION
### Motivation
- Align snooker rail and pocket jaw vertical measurements with the Pool Royale table baseline so cushions/jaws match the pool table height. 
- Remove gaps in the snooker rack by using exact geometric spacing based on the ball radius for an exact-packed rack.

### Description
- Updated vertical measurement drivers in `webapp/src/pages/Games/SnookerRoyal.jsx` to derive `RAIL_HEIGHT`, `POCKET_JAW_VERTICAL_LIFT`, `POCKET_JAW_BOTTOM_CLEARANCE`, `POCKET_JAW_FLOOR_CONTACT_LIFT`, `SIDE_POCKET_JAW_VERTICAL_TWEAK`, and `POCKET_RIM_SURFACE_ABSOLUTE_LIFT` from the `POOL_TABLE_THICKNESS` baseline instead of the local snooker `TABLE.THICK` to raise rail/jaw elements. 
- Reworked the rack generator spacing in `generateRackPositions` to use exact circle packing math by setting `columnSpacing = ballRadius * 2` and `rowSpacing = ballRadius * Math.sqrt(3)` so balls are positioned with the precise radius-based spacing (hexagonal close packing) and remove visible gaps. 
- Committed changes to `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready and served the app (local/ network URLs), which indicates the changed page can be loaded. (succeeded)
- Attempted a Playwright screenshot of `/games/snookerroyale` to visually validate table and rack, but the screenshot step timed out (Playwright `screenshot` timed out). (failed)
- No unit tests (`jest`) were executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f4763b6c8320959c503c633a9592)