### PR TITLE
Adjust snooker rail height and rack spacing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1079,7 +1079,7 @@ const ENABLE_TABLE_MAPPING_LINES = false;
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_SIZE_MULTIPLIER
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
-const RAIL_HEIGHT = TABLE.THICK * 1.18; // shorten rails by ~35% so the stance sits lower
+const RAIL_HEIGHT = TABLE.THICK * 1.32;
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.012; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1979,8 +1979,8 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const columnSpacing = ballRadius * 2;
+  const rowSpacing = ballRadius * Math.sqrt(3);
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;


### PR DESCRIPTION
### Motivation
- Raise the snooker rail/jaw profile so cushions and wooden rails sit taller and better match the Pool Royale table stackup. 
- Remove the visible gaps when racking by using exact ball-radius packing so the rack positions match the physical ball radius precisely.

### Description
- Increased `RAIL_HEIGHT` to `TABLE.THICK * 1.32` in `webapp/src/pages/Games/SnookerRoyal.jsx` to produce taller rails and pocket jaws. 
- Replaced the previous rack spacing heuristics with exact radius packing by changing `columnSpacing` to `ballRadius * 2` and `rowSpacing` to `ballRadius * Math.sqrt(3)` in `webapp/src/pages/Games/SnookerRoyal.jsx` so racked balls touch without gaps. 
- Removed the small ad-hoc spacing fudge (`+ 0.002 * (ballRadius / 0.0525)` and `ballRadius * 1.9`) to ensure mathematically precise placement.

### Testing
- Launched the dev server with `npm --prefix webapp run dev`, which started Vite and reported the site served at `http://localhost:4173/`, indicating the app served successfully. 
- Attempted an automated Playwright screenshot of `http://127.0.0.1:4173/games/snookerroyale`, but the screenshot step timed out and failed. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f4763b6c8320959c503c633a9592)