### PR TITLE
Link Pool Royale inventory to local account and sort table setup options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -208,6 +208,21 @@ function detectHighRefreshDisplay() {
   return false;
 }
 
+const sortOptionsByLabel = (options, { getLabel, getId, defaultId } = {}) => {
+  if (!Array.isArray(options)) return [];
+  const label = getLabel || ((option) => option?.label ?? option?.name ?? option?.id ?? '');
+  const idResolver = getId || ((option) => option?.id);
+  return [...options].sort((a, b) => {
+    if (defaultId) {
+      if (idResolver(a) === defaultId) return -1;
+      if (idResolver(b) === defaultId) return 1;
+    }
+    const labelA = label(a);
+    const labelB = label(b);
+    return String(labelA).localeCompare(String(labelB));
+  });
+};
+
 const randomPick = (list) => list[Math.floor(Math.random() * list.length)];
 
 const wait = (ms = 0) =>
@@ -11408,57 +11423,85 @@ function PoolRoyaleGame({
   const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
   const availableTableFinishes = useMemo(
     () =>
-      TABLE_FINISH_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('tableFinish', option.id, poolInventory)
+      sortOptionsByLabel(
+        TABLE_FINISH_OPTIONS.filter((option) =>
+          isPoolOptionUnlocked('tableFinish', option.id, poolInventory)
+        ),
+        { defaultId: DEFAULT_TABLE_FINISH_ID }
       ),
     [poolInventory]
   );
   const availableTableBases = useMemo(
     () =>
-      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
-        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      sortOptionsByLabel(
+        POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
+          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+        ),
+        { getLabel: (option) => option?.name, defaultId: DEFAULT_TABLE_BASE_ID }
       ),
     [poolInventory]
   );
   const availableChromeOptions = useMemo(
     () =>
-      CHROME_COLOR_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('chromeColor', option.id, poolInventory)
+      sortOptionsByLabel(
+        CHROME_COLOR_OPTIONS.filter((option) =>
+          isPoolOptionUnlocked('chromeColor', option.id, poolInventory)
+        ),
+        { defaultId: DEFAULT_CHROME_COLOR_ID }
       ),
     [poolInventory]
   );
   const availableRailMarkerColors = useMemo(
     () =>
-      RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('railMarkerColor', option.id, poolInventory)
+      sortOptionsByLabel(
+        RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
+          isPoolOptionUnlocked('railMarkerColor', option.id, poolInventory)
+        ),
+        { defaultId: DEFAULT_RAIL_MARKER_COLOR_ID }
       ),
     [poolInventory]
   );
   const availableClothOptions = useMemo(
     () =>
-      CLOTH_COLOR_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('clothColor', option.id, poolInventory)
+      sortOptionsByLabel(
+        CLOTH_COLOR_OPTIONS.filter((option) =>
+          isPoolOptionUnlocked('clothColor', option.id, poolInventory)
+        ),
+        { defaultId: DEFAULT_CLOTH_COLOR_ID }
       ),
     [poolInventory]
   );
   const availableEnvironmentHdris = useMemo(
     () =>
-      POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
-        isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
+      sortOptionsByLabel(
+        POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
+          isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
+        ),
+        { getLabel: (option) => option?.name, defaultId: POOL_ROYALE_DEFAULT_HDRI_ID }
       ),
     [poolInventory]
   );
   const availablePocketLiners = useMemo(
     () =>
-      POCKET_LINER_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('pocketLiner', option.id, poolInventory)
+      sortOptionsByLabel(
+        POCKET_LINER_OPTIONS.filter((option) =>
+          isPoolOptionUnlocked('pocketLiner', option.id, poolInventory)
+        ),
+        { defaultId: DEFAULT_POCKET_LINER_OPTION_ID }
       ),
     [poolInventory]
   );
   const availableCueStyles = useMemo(
     () =>
-      CUE_FINISH_OPTIONS.map((finish, index) => ({ preset: finish, index })).filter(({ preset }) =>
-        isCueFinishUnlocked(preset.id, poolInventory)
+      sortOptionsByLabel(
+        CUE_FINISH_OPTIONS.map((finish, index) => ({ preset: finish, index })).filter(({ preset }) =>
+          isCueFinishUnlocked(preset.id, poolInventory)
+        ),
+        {
+          getLabel: (option) => option?.preset?.label,
+          getId: (option) => option?.preset?.id,
+          defaultId: DEFAULT_CUE_STYLE_ID
+        }
       ),
     [isCueFinishUnlocked, poolInventory]
   );

--- a/webapp/src/utils/poolRoyalInventory.js
+++ b/webapp/src/utils/poolRoyalInventory.js
@@ -7,6 +7,7 @@ import {
   getPoolRoyalInventoryRemote,
   setPoolRoyalInventoryRemote
 } from './api.js';
+import { getPlayerId } from './telegram.js';
 
 const STORAGE_KEY = 'poolRoyalInventoryByAccount';
 const MIGRATION_KEY = 'poolRoyalInventoryMigrated';
@@ -28,6 +29,8 @@ const resolveAccountId = (accountId) => {
   if (typeof window !== 'undefined') {
     const stored = window.localStorage.getItem('accountId');
     if (stored) return stored;
+    const generated = getPlayerId();
+    if (generated) return generated;
   }
   return 'guest';
 };


### PR DESCRIPTION
### Motivation
- Ensure purchased Pool Royale items are associated with the player's local TPC account instead of falling back to a guest inventory so users keep their NFTs across sessions.
- Make the Table Setup menu easier to use by sorting option lists and pinning defaults to the top so users find their unlocked finishes, cloths and bases faster.

### Description
- Use `getPlayerId` in `webapp/src/utils/poolRoyalInventory.js` so `resolveAccountId` will return a generated/local account id when none is stored or provided, avoiding fallback to `'guest'` for real players.
- Add a `sortOptionsByLabel` helper in `webapp/src/pages/Games/PoolRoyale.jsx` that sorts option arrays by label and can pin a `defaultId` to the top, with customizable label and id resolvers.
- Replace the various `available*` `useMemo` option filters (table finishes, bases, chrome, rail markers, cloth options, HDRIs, pocket liners, cue styles) to run through `sortOptionsByLabel` so lists are ordered and defaults are shown first.
- For cue styles and other non-trivial entries, use custom `getLabel`/`getId` to sort complex option shapes (e.g. `{ preset, index }`).

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev` and confirmed Vite reported the dev server URL (server started successfully). 
- Attempted an automated Playwright screenshot to validate the Table Setup UI (`/games/poolroyale`) but the script timed out while waiting for the setup control and failed to capture the screenshot (timeout). 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fdaf090c8320930d255f2352f8cc)