### PR TITLE
Link Pool Royale inventory to TPC accounts and sort table-setup options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11406,54 +11406,66 @@ function PoolRoyaleGame({
     [commentaryPresetId]
   );
   const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const optionLabelSorter = useMemo(
+    () => new Intl.Collator('en', { numeric: true, sensitivity: 'base' }),
+    []
+  );
+  const sortByOptionLabel = useCallback(
+    (a, b) =>
+      optionLabelSorter.compare(
+        String(a?.label ?? a?.name ?? a?.id ?? ''),
+        String(b?.label ?? b?.name ?? b?.id ?? '')
+      ),
+    [optionLabelSorter]
+  );
   const availableTableFinishes = useMemo(
     () =>
       TABLE_FINISH_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('tableFinish', option.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableTableBases = useMemo(
     () =>
       POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
         isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableChromeOptions = useMemo(
     () =>
       CHROME_COLOR_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('chromeColor', option.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableRailMarkerColors = useMemo(
     () =>
       RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('railMarkerColor', option.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableClothOptions = useMemo(
     () =>
       CLOTH_COLOR_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('clothColor', option.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableEnvironmentHdris = useMemo(
     () =>
       POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
         isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availablePocketLiners = useMemo(
     () =>
       POCKET_LINER_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('pocketLiner', option.id, poolInventory)
-      ),
-    [poolInventory]
+      ).slice().sort(sortByOptionLabel),
+    [poolInventory, sortByOptionLabel]
   );
   const availableCueStyles = useMemo(
     () =>

--- a/webapp/src/utils/poolRoyalInventory.js
+++ b/webapp/src/utils/poolRoyalInventory.js
@@ -10,6 +10,7 @@ import {
 
 const STORAGE_KEY = 'poolRoyalInventoryByAccount';
 const MIGRATION_KEY = 'poolRoyalInventoryMigrated';
+const GUEST_MIGRATION_KEY = 'poolRoyalInventoryGuestMigrated';
 const inflightSync = new Map();
 
 const copyDefaults = () =>
@@ -30,6 +31,13 @@ const resolveAccountId = (accountId) => {
     if (stored) return stored;
   }
   return 'guest';
+};
+
+const storeAccountId = (accountId) => {
+  if (!accountId || accountId === 'guest') return;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem('accountId', accountId);
+  }
 };
 
 const readAllInventories = () => {
@@ -62,6 +70,22 @@ const readMigrationFlags = () => {
 const writeMigrationFlags = (payload) => {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem(MIGRATION_KEY, JSON.stringify(payload));
+};
+
+const readGuestMigrationFlags = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(GUEST_MIGRATION_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read Pool Royale guest migration flags', err);
+    return {};
+  }
+};
+
+const writeGuestMigrationFlags = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(GUEST_MIGRATION_KEY, JSON.stringify(payload));
 };
 
 const normalizeInventory = (rawInventory) => {
@@ -183,6 +207,22 @@ const syncWithServer = async (accountId, localInventory) => {
 };
 
 const readCachedInventory = (accountId) => {
+  storeAccountId(accountId);
+  if (accountId && accountId !== 'guest' && typeof window !== 'undefined') {
+    const guestFlags = readGuestMigrationFlags();
+    if (!guestFlags[accountId]) {
+      const inventories = readAllInventories();
+      const guestInventory = inventories.guest;
+      if (!isInventoryEmpty(guestInventory)) {
+        const merged = mergeInventories(guestInventory, inventories[accountId]);
+        writeAllInventories({
+          ...inventories,
+          [accountId]: merged
+        });
+      }
+      writeGuestMigrationFlags({ ...guestFlags, [accountId]: true });
+    }
+  }
   const inventories = readAllInventories();
   const normalized = normalizeInventory(inventories[accountId]);
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Ensure Pool Royale NFT purchases made while a user was a guest are merged into their linked TPC account so cosmetics appear in the table setup and remain tied to the user.
- Improve discoverability of unlocked options in the Table Setup menu by consistently sorting option lists by label.

### Description
- Persist the resolved account id to localStorage when reading cached inventory via `readCachedInventory` and add logic to merge `guest` inventory into a newly linked account using a `GUEST_MIGRATION_KEY` and guest migration flag helpers in `webapp/src/utils/poolRoyalInventory.js`.
- Add `storeAccountId`, `readGuestMigrationFlags`, and `writeGuestMigrationFlags` helpers and wire guest->account merge so guest unlocks are preserved and merged once per account.
- Introduce an `Intl.Collator`-based sorter and `sortByOptionLabel` callback in `webapp/src/pages/Games/PoolRoyale.jsx` and apply `.slice().sort(sortByOptionLabel)` to all available option lists (table finishes, bases, chrome, rail markers, cloth, HDRIs, pocket liners, etc.) so options render alphabetically by label.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and confirmed Vite reported the local dev URL and ready state (dev server launched successfully).
- Attempted an automated Playwright screenshot of `/games/poolroyale` to visually validate the Table Setup panel, but the Playwright run timed out and did not produce a screenshot.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fdaf090c8320930d255f2352f8cc)