### PR TITLE
Adjust Pool Royale pocket cameras and add Snooker 2D broadcast/replay camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1373,7 +1373,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.26; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.46;
+const POCKET_CAM_EDGE_SCALE = 0.4;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -2865,6 +2865,24 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     smoothing: 0.14,
     avoidPocketCameras: false,
     forceActionActivation: true
+  },
+  {
+    id: 'snooker-overhead-2d',
+    label: 'Snooker 2D Overhead',
+    description:
+      'Broadcast top-down camera aligned to the Snooker Royale 2D framing.',
+    method: 'Snooker 2D top cam',
+    orbitBias: 0.68,
+    railPush: BALL_R * 6,
+    lateralDolly: BALL_R * 0.6,
+    focusLift: BALL_R * 5.4,
+    focusDepthBias: -BALL_R * 0.6,
+    focusPan: 0,
+    trackingBias: 0.52,
+    smoothing: 0.14,
+    avoidPocketCameras: false,
+    forceActionActivation: true,
+    replayCamera: 'snooker-2d'
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
@@ -4964,6 +4982,15 @@ const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
+});
+const SNOOKER_TOP_VIEW_MARGIN = 1.14;
+const SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const SNOOKER_TOP_VIEW_PHI = 0;
+const SNOOKER_TOP_VIEW_RADIUS_SCALE = 1.06;
+const SNOOKER_TOP_VIEW_RESOLVED_PHI = SNOOKER_TOP_VIEW_PHI;
+const SNOOKER_TOP_VIEW_SCREEN_OFFSET = Object.freeze({
+  x: PLAY_W * -0.045,
+  z: PLAY_H * -0.078
 });
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
@@ -13992,12 +14019,14 @@ const powerRef = useRef(hud.power);
         if (rec) {
           const frameTime = Number.isFinite(payload.frameTs) ? payload.frameTs : now;
           const rel = Math.max(0, frameTime - (rec.startTime ?? frameTime));
+          const cameraSnapshot = captureReplayCameraSnapshotRef.current
+            ? captureReplayCameraSnapshotRef.current()
+            : null;
           rec.frames.push({
             t: rel,
             balls: payload.layout,
-            camera: captureReplayCameraSnapshotRef.current
-              ? captureReplayCameraSnapshotRef.current()
-              : null
+            camera: cameraSnapshot?.main ?? cameraSnapshot ?? null,
+            snookerCamera: cameraSnapshot?.snookerTop ?? null
           });
           const cueEntry = payload.layout.find((entry) => String(entry.id) === 'cue');
           const cuePos = cueEntry?.mesh?.position || cueEntry?.pos;
@@ -16462,6 +16491,33 @@ const powerRef = useRef(hud.power);
           return { position, target: focusTarget, fov: STANDING_VIEW_FOV, minTargetY };
         };
 
+        const resolveSnookerTopViewCamera = ({
+          focusOverride = null,
+          minTargetY = null
+        } = {}) => {
+          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const focusTarget =
+            focusOverride?.clone?.() ??
+            TMP_VEC3_TOP_VIEW
+              .set(
+                playerOffsetRef.current + SNOOKER_TOP_VIEW_SCREEN_OFFSET.x,
+                ORBIT_FOCUS_BASE_Y,
+                SNOOKER_TOP_VIEW_SCREEN_OFFSET.z
+              )
+              .multiplyScalar(scale);
+          if (focusTarget && Number.isFinite(minTargetY)) {
+            focusTarget.y = Math.max(focusTarget.y ?? minTargetY, minTargetY);
+          }
+          const topRadiusBase =
+            fitRadius(camera, SNOOKER_TOP_VIEW_MARGIN) * SNOOKER_TOP_VIEW_RADIUS_SCALE;
+          const topRadius = clampOrbitRadius(
+            Math.max(topRadiusBase, CAMERA.minR * SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE)
+          );
+          const spherical = new THREE.Spherical(topRadius, SNOOKER_TOP_VIEW_RESOLVED_PHI, Math.PI);
+          const position = new THREE.Vector3().setFromSpherical(spherical).add(focusTarget);
+          return { position, target: focusTarget, fov: STANDING_VIEW_FOV, minTargetY };
+        };
+
         const resolveRailOverheadReplayCamera = ({
           focusOverride = null,
           minTargetY = null
@@ -18026,11 +18082,22 @@ const powerRef = useRef(hud.power);
           if (positionSnapshot.y < minTargetY) {
             positionSnapshot.y = minTargetY;
           }
+          const snookerTopSnapshot = resolveSnookerTopViewCamera({ minTargetY });
           return {
-            position: positionSnapshot,
-            target: targetSnapshot,
-            fov: fovSnapshot,
-            minTargetY
+            main: {
+              position: positionSnapshot,
+              target: targetSnapshot,
+              fov: fovSnapshot,
+              minTargetY
+            },
+            snookerTop: snookerTopSnapshot
+              ? {
+                  position: snookerTopSnapshot.position,
+                  target: snookerTopSnapshot.target,
+                  fov: snookerTopSnapshot.fov,
+                  minTargetY: snookerTopSnapshot.minTargetY
+                }
+              : null
           };
         };
         captureReplayCameraSnapshotRef.current = captureReplayCameraSnapshot;
@@ -18101,7 +18168,8 @@ const powerRef = useRef(hud.power);
           shotRecording.frames.push({
             t: relative,
             balls: snapshot,
-            camera: cameraSnapshot,
+            camera: cameraSnapshot?.main ?? cameraSnapshot ?? null,
+            snookerCamera: cameraSnapshot?.snookerTop ?? null,
             cue: cueSnapshot
           });
           const cueBall = balls.find((b) => b.id === 'cue');
@@ -18579,6 +18647,16 @@ const powerRef = useRef(hud.power);
           return { frames, cuePath, duration, cueStroke };
         };
 
+        const resolveReplayFrameCamera = (frame) => {
+          if (!frame) return null;
+          const broadcastSystem =
+            broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
+          if (broadcastSystem?.replayCamera === 'snooker-2d') {
+            return frame.snookerCamera ?? frame.camera ?? null;
+          }
+          return frame.camera ?? null;
+        };
+
         const storeReplayCameraFrame = () => {
           const activeCamera = activeRenderCameraRef.current ?? camera;
           const storedTarget =
@@ -18694,7 +18772,7 @@ const powerRef = useRef(hud.power);
           primeReplayCueStick(replayPlayback);
           const path = replayPlayback.cuePath ?? [];
           if (!LOCK_REPLAY_CAMERA) {
-            const initialCamera = trimmed.frames?.[0]?.camera ?? null;
+            const initialCamera = resolveReplayFrameCamera(trimmed.frames?.[0] ?? null);
             if (initialCamera) {
               replayFrameCameraRef.current = {
                 frameA: initialCamera,
@@ -24166,8 +24244,8 @@ const powerRef = useRef(hud.power);
             }
             updateReplayTrail(playback.cuePath, targetTime);
             if (!LOCK_REPLAY_CAMERA) {
-              const frameCameraA = frameA?.camera ?? null;
-              const frameCameraB = frameB?.camera ?? frameCameraA;
+              const frameCameraA = resolveReplayFrameCamera(frameA ?? null);
+              const frameCameraB = resolveReplayFrameCamera(frameB ?? null) ?? frameCameraA;
               if (frameCameraA || frameCameraB) {
                 replayFrameCameraRef.current = {
                   frameA: frameCameraA ?? frameCameraB,


### PR DESCRIPTION
### Motivation
- Pull pocket cameras slightly closer to the pocket rails so pocket cams line up with the chrome plate edge while keeping their vertical framing unchanged. 
- Add a broadcast camera option that matches the Snooker Royale 2D top-view framing for use in broadcast mode and for replay frames without altering the in-game 2D camera coordinates.

### Description
- Reduced `POCKET_CAM_EDGE_SCALE` (closer pocket camera proximity) to bring pocket cameras nearer the pocket chrome edge while preserving height and other pocket cam behavior.
- Added Snooker-aligned top-view constants (`SNOOKER_*`) and a new broadcast option `snooker-overhead-2d` in `BROADCAST_SYSTEM_OPTIONS` to expose a Snooker 2D overhead broadcast mode.
- Implemented `resolveSnookerTopViewCamera` to compute a Snooker-style top camera snapshot and updated `captureReplayCameraSnapshot` to return both the `main` camera snapshot and a `snookerTop` snapshot (keeps the original main snapshot intact).
- Persisted `snookerCamera` in recorded frames for both local shot recordings and incoming remote recordings so the Snooker-aligned top view is available in replay data.
- Added `resolveReplayFrameCamera` which selects `snookerCamera` for replay playback when the active broadcast system is configured to use the Snooker 2D replay camera, and wired replay initialization and per-frame replay camera selection to use this resolver.
- Small wiring changes to ensure existing 2D/main camera behavior remains unchanged during gameplay and that the Snooker camera is an additional snapshot used only for broadcasting/replay when selected.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and Vite reported ready (local dev server started successfully). 
- Ran an automated Playwright screenshot attempt to validate the scene, but the headless Chromium crashed / timed out in this environment (Playwright error), so visual verification failed. 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a315f459083209a0dc8cf6353c2a2)