### PR TITLE
Adjust Pool Royale pocket cameras and add snooker top-view broadcast camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1373,7 +1373,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.26; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.36;
+const POCKET_CAM_EDGE_SCALE = 0.26;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -4977,6 +4977,12 @@ const BROADCAST_TOP_VIEW_PHI = 0;
 const BROADCAST_TOP_VIEW_RADIUS_SCALE = 1.06;
 const BROADCAST_TOP_VIEW_RESOLVED_PHI = BROADCAST_TOP_VIEW_PHI;
 const BROADCAST_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
+const SNOOKER_TOP_VIEW_MARGIN = 1.14;
+const SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const SNOOKER_TOP_VIEW_PHI = 0;
+const SNOOKER_TOP_VIEW_RADIUS_SCALE = 1.06;
+const SNOOKER_TOP_VIEW_RESOLVED_PHI = SNOOKER_TOP_VIEW_PHI;
+const SNOOKER_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
 const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI; // align broadcast overhead with the 2D top-view angle
@@ -16499,6 +16505,37 @@ const powerRef = useRef(hud.power);
           return { position, target: focusTarget, fov: STANDING_VIEW_FOV, minTargetY };
         };
 
+        const resolveSnookerTopViewCamera = ({
+          focusOverride = null,
+          minTargetY = null
+        } = {}) => {
+          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const focusTarget =
+            focusOverride?.clone?.() ??
+            TMP_VEC3_TOP_VIEW
+              .set(
+                playerOffsetRef.current + SNOOKER_TOP_VIEW_SCREEN_OFFSET.x,
+                ORBIT_FOCUS_BASE_Y,
+                SNOOKER_TOP_VIEW_SCREEN_OFFSET.z
+              )
+              .multiplyScalar(scale);
+          if (focusTarget && Number.isFinite(minTargetY)) {
+            focusTarget.y = Math.max(focusTarget.y ?? minTargetY, minTargetY);
+          }
+          const topRadiusBase =
+            fitRadius(camera, SNOOKER_TOP_VIEW_MARGIN) * SNOOKER_TOP_VIEW_RADIUS_SCALE;
+          const topRadius = clampOrbitRadius(
+            Math.max(topRadiusBase, CAMERA.minR * SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE)
+          );
+          const spherical = new THREE.Spherical(
+            topRadius,
+            SNOOKER_TOP_VIEW_RESOLVED_PHI,
+            Math.PI
+          );
+          const position = new THREE.Vector3().setFromSpherical(spherical).add(focusTarget);
+          return { position, target: focusTarget, fov: STANDING_VIEW_FOV, minTargetY };
+        };
+
         const resolveRailOverheadReplayCamera = ({
           focusOverride = null,
           minTargetY = null
@@ -18071,6 +18108,22 @@ const powerRef = useRef(hud.power);
           };
           if (topViewRef.current) {
             return baseSnapshot;
+          }
+          const snookerBroadcastCamera = resolveSnookerTopViewCamera({
+            focusOverride: targetSnapshot,
+            minTargetY
+          });
+          if (snookerBroadcastCamera?.position && snookerBroadcastCamera?.target) {
+            return {
+              position: snookerBroadcastCamera.position,
+              target: snookerBroadcastCamera.target,
+              fov: Number.isFinite(snookerBroadcastCamera.fov)
+                ? snookerBroadcastCamera.fov
+                : fovSnapshot,
+              minTargetY: Number.isFinite(snookerBroadcastCamera.minTargetY)
+                ? snookerBroadcastCamera.minTargetY
+                : minTargetY
+            };
           }
           const broadcastCamera = resolveBroadcastTopViewCamera({
             focusOverride: targetSnapshot,


### PR DESCRIPTION
### Motivation
- Tighter pocket framing: pull pocket broadcast cameras closer to the pocket edge while keeping their height so potted-ball framing matches the reference photos. 
- Add broadcast/replay option: introduce an additional top-view broadcast camera path that mirrors the Snooker Royal 2D top-view placement so replays and the broadcast feed can use that fixed overhead framing without modifying the live 2D gameplay camera coordinates. 

### Description
- Reduced pocket camera offset by updating `POCKET_CAM_EDGE_SCALE` from `0.36` to `0.26` to pull pocket cameras closer to the chrome/edge calculations used by pocket camera placement in `PoolRoyale.jsx`. 
- Added Snooker-style top-view constants (`SNOOKER_TOP_VIEW_*`) and a new `resolveSnookerTopViewCamera` helper that computes an overhead camera matching the snooker 2D framing. 
- Updated replay/broadcast snapshot logic (`captureReplayCameraSnapshot`) to prefer the new snooker top-view broadcast camera when available, falling back to the existing broadcast top-view camera otherwise. 
- All changes made in `webapp/src/pages/Games/PoolRoyale.jsx` and do not modify the existing 2D gameplay camera coordinates or behavior. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` which launched Vite and served the app successfully. 
- Attempted an automated browser screenshot using Playwright to validate camera framing, but the headless Chromium process crashed in this environment so the capture timed out and no screenshot was produced. 
- No unit test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a417bb61c8320948489c5413d4c48)