### PR TITLE
Refine Pool Royale pocket and replay cameras

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1373,7 +1373,7 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.26; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
-const POCKET_CAM_EDGE_SCALE = 0.36;
+const POCKET_CAM_EDGE_SCALE = 0.2;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -2865,6 +2865,24 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     smoothing: 0.14,
     avoidPocketCameras: false,
     forceActionActivation: true
+  },
+  {
+    id: 'rail-overhead-snooker2d',
+    label: 'Rail Overhead + Snooker 2D',
+    description:
+      'Broadcast rail heads paired with the snooker-style 2D top view framing.',
+    method: 'Overhead rail mounts with snooker 2D replay/top-view cuts.',
+    orbitBias: 0.68,
+    railPush: BALL_R * 6,
+    lateralDolly: BALL_R * 0.6,
+    focusLift: BALL_R * 5.4,
+    focusDepthBias: -BALL_R * 0.6,
+    focusPan: 0,
+    trackingBias: 0.52,
+    smoothing: 0.14,
+    avoidPocketCameras: false,
+    forceActionActivation: true,
+    topViewVariant: 'snooker2d'
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
@@ -4977,6 +4995,30 @@ const BROADCAST_TOP_VIEW_PHI = 0;
 const BROADCAST_TOP_VIEW_RADIUS_SCALE = 1.06;
 const BROADCAST_TOP_VIEW_RESOLVED_PHI = BROADCAST_TOP_VIEW_PHI;
 const BROADCAST_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
+const BROADCAST_SNOOKER_TOP_VIEW_MARGIN = 1.14;
+const BROADCAST_SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const BROADCAST_SNOOKER_TOP_VIEW_PHI = 0;
+const BROADCAST_SNOOKER_TOP_VIEW_RADIUS_SCALE = 1.06;
+const BROADCAST_SNOOKER_TOP_VIEW_RESOLVED_PHI = BROADCAST_SNOOKER_TOP_VIEW_PHI;
+const BROADCAST_SNOOKER_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
+const BROADCAST_TOP_VIEW_VARIANTS = Object.freeze({
+  pool: Object.freeze({
+    margin: BROADCAST_TOP_VIEW_MARGIN,
+    minRadiusScale: BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE,
+    radiusScale: BROADCAST_TOP_VIEW_RADIUS_SCALE,
+    phi: BROADCAST_TOP_VIEW_RESOLVED_PHI,
+    screenOffset: BROADCAST_TOP_VIEW_SCREEN_OFFSET
+  }),
+  snooker2d: Object.freeze({
+    margin: BROADCAST_SNOOKER_TOP_VIEW_MARGIN,
+    minRadiusScale: BROADCAST_SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE,
+    radiusScale: BROADCAST_SNOOKER_TOP_VIEW_RADIUS_SCALE,
+    phi: BROADCAST_SNOOKER_TOP_VIEW_RESOLVED_PHI,
+    screenOffset: BROADCAST_SNOOKER_TOP_VIEW_SCREEN_OFFSET
+  })
+});
+const resolveBroadcastTopViewVariant = (variant) =>
+  BROADCAST_TOP_VIEW_VARIANTS[variant] ?? BROADCAST_TOP_VIEW_VARIANTS.pool;
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
 const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI; // align broadcast overhead with the 2D top-view angle
@@ -16472,27 +16514,32 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
+          const systemVariant =
+            broadcastSystemRef.current?.topViewVariant ??
+            activeBroadcastSystem?.topViewVariant ??
+            'pool';
+          const topViewConfig = resolveBroadcastTopViewVariant(systemVariant);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const focusTarget =
             focusOverride?.clone?.() ??
             TMP_VEC3_TOP_VIEW
               .set(
-                playerOffsetRef.current + BROADCAST_TOP_VIEW_SCREEN_OFFSET.x,
+                playerOffsetRef.current + topViewConfig.screenOffset.x,
                 ORBIT_FOCUS_BASE_Y,
-                BROADCAST_TOP_VIEW_SCREEN_OFFSET.z
+                topViewConfig.screenOffset.z
               )
               .multiplyScalar(scale);
           if (focusTarget && Number.isFinite(minTargetY)) {
             focusTarget.y = Math.max(focusTarget.y ?? minTargetY, minTargetY);
           }
           const topRadiusBase =
-            fitRadius(camera, BROADCAST_TOP_VIEW_MARGIN) * BROADCAST_TOP_VIEW_RADIUS_SCALE;
+            fitRadius(camera, topViewConfig.margin) * topViewConfig.radiusScale;
           const topRadius = clampOrbitRadius(
-            Math.max(topRadiusBase, CAMERA.minR * BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE)
+            Math.max(topRadiusBase, CAMERA.minR * topViewConfig.minRadiusScale)
           );
           const spherical = new THREE.Spherical(
             topRadius,
-            BROADCAST_TOP_VIEW_RESOLVED_PHI,
+            topViewConfig.phi,
             Math.PI
           );
           const position = new THREE.Vector3().setFromSpherical(spherical).add(focusTarget);
@@ -17162,6 +17209,7 @@ const powerRef = useRef(hud.power);
               pocketIdFromCenter(pocketCenter);
             if (anchorId !== activeShotView.anchorId) {
               activeShotView.anchorId = anchorId;
+              activeShotView.fixedPos = null;
               const latestOutward = getPocketCameraOutward(anchorId);
               if (latestOutward) {
                 activeShotView.anchorOutward = latestOutward;
@@ -17211,12 +17259,17 @@ const powerRef = useRef(hud.power);
                 : POCKET_CAM.outwardOffset;
             const cameraDistance =
               baseDistance + Math.max(0, outwardOffsetMagnitude ?? 0);
-            const desiredPosition = new THREE.Vector3(
-              (pocketCenter2D.x + outward.x * cameraDistance) * worldScaleFactor,
-              (TABLE_Y + TABLE.THICK + activeShotView.heightOffset * heightScale) *
-                worldScaleFactor,
-              (pocketCenter2D.y + outward.y * cameraDistance) * worldScaleFactor
-            );
+            const desiredPosition =
+              activeShotView.fixedPos ??
+              new THREE.Vector3(
+                (pocketCenter2D.x + outward.x * cameraDistance) * worldScaleFactor,
+                (TABLE_Y + TABLE.THICK + activeShotView.heightOffset * heightScale) *
+                  worldScaleFactor,
+                (pocketCenter2D.y + outward.y * cameraDistance) * worldScaleFactor
+              );
+            if (!activeShotView.fixedPos) {
+              activeShotView.fixedPos = desiredPosition.clone();
+            }
             const now = performance.now();
             if (focusBall?.active) {
               activeShotView.completed = false;
@@ -17296,63 +17349,30 @@ const powerRef = useRef(hud.power);
             ORBIT_FOCUS_BASE_Y,
             TOP_VIEW_SCREEN_OFFSET.z
           ).multiplyScalar(worldScaleFactor);
-          const overheadVariant = overheadBroadcastVariantRef.current ?? 'top';
-          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
-          const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
-          let overheadApplied = false;
-          if (overheadVariant === 'replay') {
-            const overheadCamera = resolveRailOverheadReplayCamera({
-              focusOverride: topFocusTarget,
-              minTargetY
-            });
-            if (overheadCamera?.position) {
-              const resolvedTarget = overheadCamera.target ?? topFocusTarget;
-              camera.up.set(0, 0, 1);
-              camera.position.copy(overheadCamera.position);
-              if (Number.isFinite(overheadCamera.fov) && camera.fov !== overheadCamera.fov) {
-                camera.fov = overheadCamera.fov;
-                camera.updateProjectionMatrix();
-              }
-              camera.lookAt(resolvedTarget);
-              renderCamera = camera;
-              lookTarget = resolvedTarget;
-              lastCameraTargetRef.current.copy(resolvedTarget);
-              broadcastArgs.focusWorld = resolvedTarget.clone();
-              broadcastArgs.targetWorld = resolvedTarget.clone();
-              broadcastArgs.orbitWorld = overheadCamera.position.clone();
-              if (broadcastCamerasRef.current) {
-                broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
-              }
-              broadcastArgs.lerp = 0.12;
-              overheadApplied = true;
-            }
+          const topRadiusBase = fitRadius(camera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE;
+          const topRadius = clampOrbitRadius(
+            Math.max(topRadiusBase, CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE)
+          );
+          const topTheta = Math.PI;
+          const topPhi = TOP_VIEW_RESOLVED_PHI;
+          TMP_SPH.set(topRadius, topPhi, topTheta);
+          camera.up.set(0, 0, 1);
+          camera.position.setFromSpherical(TMP_SPH);
+          camera.position.add(topFocusTarget);
+          const resolvedTarget = topFocusTarget.clone();
+          const resolvedPosition = camera.position.clone();
+          lookTarget = resolvedTarget;
+          lastCameraTargetRef.current.copy(resolvedTarget);
+          camera.updateProjectionMatrix();
+          camera.lookAt(resolvedTarget);
+          renderCamera = camera;
+          broadcastArgs.focusWorld = resolvedTarget.clone();
+          broadcastArgs.targetWorld = resolvedTarget.clone();
+          broadcastArgs.orbitWorld = resolvedPosition.clone();
+          if (broadcastCamerasRef.current) {
+            broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
           }
-          if (!overheadApplied) {
-            const topRadiusBase = fitRadius(camera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE;
-            const topRadius = clampOrbitRadius(
-              Math.max(topRadiusBase, CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE)
-            );
-            const topTheta = Math.PI;
-            const topPhi = TOP_VIEW_RESOLVED_PHI;
-            TMP_SPH.set(topRadius, topPhi, topTheta);
-            camera.up.set(0, 0, 1);
-            camera.position.setFromSpherical(TMP_SPH);
-            camera.position.add(topFocusTarget);
-            const resolvedTarget = topFocusTarget.clone();
-            const resolvedPosition = camera.position.clone();
-            lookTarget = resolvedTarget;
-            lastCameraTargetRef.current.copy(resolvedTarget);
-            camera.updateProjectionMatrix();
-            camera.lookAt(resolvedTarget);
-            renderCamera = camera;
-            broadcastArgs.focusWorld = resolvedTarget.clone();
-            broadcastArgs.targetWorld = resolvedTarget.clone();
-            broadcastArgs.orbitWorld = resolvedPosition.clone();
-            if (broadcastCamerasRef.current) {
-              broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
-            }
-            broadcastArgs.lerp = 0.12;
-          }
+          broadcastArgs.lerp = 0.12;
         } else {
           camera.up.set(0, 1, 0);
           TMP_SPH.copy(sph);
@@ -17855,17 +17875,10 @@ const powerRef = useRef(hud.power);
               }
             : null;
           const now = performance.now();
-          const effectiveDist = forcedEarly
-            ? Math.min(best.dist, POCKET_CAM.triggerDist)
-            : best.dist;
           const minOutside = isSidePocket
             ? POCKET_CAM.minOutside
             : POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside;
-          const cameraDistance = THREE.MathUtils.clamp(
-            effectiveDist * POCKET_CAM.distanceScale,
-            minOutside,
-            POCKET_CAM.maxOutside
-          );
+          const cameraDistance = minOutside;
           const broadcastRailDir = isSidePocket
             ? resolveShortRailBroadcastDirection({
                 pocketCenter: best.center,


### PR DESCRIPTION
### Motivation
- Pull pocket cameras closer to the pocket chrome edges to better match reference framing while preserving camera heights.  
- Keep pocket cameras spatially fixed per anchor so they only rotate to track the incoming ball and do not drift between shots.  
- Ensure replay/top-view rendering uses the same 2D top-view framing as gameplay (do not switch to the rail-overhead replay framing), while leaving the game 2D camera unchanged.  

### Description
- Tightened the pocket placement scale by changing `POCKET_CAM_EDGE_SCALE` to `0.2` in `PoolRoyale.jsx` so pocket cameras sit closer to pocket edges.  
- Added a per-shot fixed pocket position by introducing and using `activeShotView.fixedPos` (reset when the anchor changes and set to the computed desired position) so pocket cameras remain stationary and only `lookAt` the moving target.  
- Stabilized pocket camera distance by forcing `cameraDistance` to `minOutside` for pocket shots instead of using the variable `effectiveDist`, preventing per-shot drift.  
- Removed the rail-overhead override path in the top/replay top-view branch so replay top-view always uses the gameplay `TOP_VIEW` framing, and added broadcast variants via `BROADCAST_TOP_VIEW_VARIANTS` and `resolveBroadcastTopViewVariant` as well as a `rail-overhead-snooker2d` system option used by `resolveBroadcastTopViewCamera`.  

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported the app ready (succeeded).  
- Attempted a Playwright screenshot of `/games/poolroyale` to visually validate framing, but the headless Chromium process crashed in this environment (failed).  
- No automated unit tests (`jest`) or snapshot tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a417bb61c8320948489c5413d4c48)