### PR TITLE
Add Telegram-aware PWA install banner and fallback

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -22,7 +22,14 @@ export default function Layout({ children }) {
   const navigate = useNavigate();
   const [invite, setInvite] = useState(null);
   const inviteSoundRef = useRef(null);
-  const { canInstall, promptToInstall, dismiss } = usePwaInstallPrompt();
+  const {
+    canInstall,
+    canShowTelegramInstall,
+    mode,
+    promptToInstall,
+    openExternalInstall,
+    dismiss
+  } = usePwaInstallPrompt();
   const { isUpdating } = useAppUpdate();
 
   useEffect(() => {
@@ -120,6 +127,8 @@ export default function Layout({ children }) {
     }
   }, [location.pathname]);
 
+  const showPwaBanner = showNavbar && (canInstall || canShowTelegramInstall);
+
   return (
     <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
       {showHeader && (
@@ -171,8 +180,8 @@ export default function Layout({ children }) {
       />
 
       <PwaInstallBanner
-        canInstall={canInstall && showNavbar}
-        onInstall={promptToInstall}
+        mode={showPwaBanner ? mode : 'none'}
+        onInstall={mode === 'telegram' ? openExternalInstall : promptToInstall}
         onDismiss={dismiss}
       />
 

--- a/webapp/src/components/PwaInstallBanner.jsx
+++ b/webapp/src/components/PwaInstallBanner.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { Download } from 'lucide-react';
 
-export default function PwaInstallBanner({ canInstall, onInstall, onDismiss }) {
-  if (!canInstall) return null;
+export default function PwaInstallBanner({ mode = 'none', onInstall, onDismiss }) {
+  if (mode === 'none') return null;
+
+  const title =
+    mode === 'telegram' ? 'Install TonPlaygram on your device' : 'Install TonPlaygram for Telegram';
+  const description =
+    mode === 'telegram'
+      ? 'Open this page in Chrome or Safari, then add it to your home screen.'
+      : 'Add to Home Screen to cache the full game shell and cut reload times.';
+  const ctaLabel = mode === 'telegram' ? 'Open in browser' : 'Install now';
 
   return (
     <div className="fixed bottom-[5.5rem] inset-x-0 z-[60] px-4">
@@ -11,17 +19,15 @@ export default function PwaInstallBanner({ canInstall, onInstall, onDismiss }) {
           <Download className="text-accent drop-shadow" size={28} />
         </div>
         <div className="flex-1">
-          <p className="text-white text-lg leading-tight">Install TonPlaygram for Telegram</p>
-          <p className="text-sm text-text/80 mt-1">
-            Add to Home Screen to cache the full game shell and cut reload times.
-          </p>
+          <p className="text-white text-lg leading-tight">{title}</p>
+          <p className="text-sm text-text/80 mt-1">{description}</p>
           <div className="flex gap-3 mt-3">
             <button
               type="button"
               className="bg-primary text-white px-3 py-2 rounded-lg text-sm hover:bg-primary-hover transition"
               onClick={onInstall}
             >
-              Install now
+              {ctaLabel}
             </button>
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Telegram's in-app browser does not always expose the standard `beforeinstallprompt`, so users inside Telegram need a clear fallback to open the page in an external browser or follow platform-specific install steps. 
- Provide a seamless install UX for both standard browsers (prompt-based) and Telegram's embedded WebApp (open-in-browser guidance).

### Description
- Extend the PWA install hook (`webapp/src/hooks/usePwaInstallPrompt.js`) to detect Telegram, expose a `mode` (`prompt|telegram|none`), and add `openExternalInstall()` to open the current URL in an external browser or via `Telegram.WebApp.openLink`.
- Update the install banner (`webapp/src/components/PwaInstallBanner.jsx`) to accept `mode` and switch title/description/CTA between the standard install flow and the Telegram fallback.
- Wire the app layout (`webapp/src/components/Layout.jsx`) to show the appropriate banner when the site is viewed in Telegram or when the browser provides a PWA prompt, and to use the correct install handler depending on `mode`.
- Small behavioral tweak: remove `Telegram.WebApp.isExpanded` from `isStandalone` detection so Telegram-only detection is handled separately.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served on `http://localhost:4173` (Vite started successfully). (succeeded)
- Ran a Playwright script to load the app (injecting a fake `window.Telegram.WebApp`), captured a screenshot of the banner state for the Telegram fallback, and saved it to `artifacts/pwa-telegram-banner.png`. (succeeded)
- No unit or integration test suites were present/executed for these UI changes; changes were validated via the dev server + Playwright screenshot above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a44b76b608320894b9c363633d577)