### PR TITLE
Pool Royale: tighten pocket camera FOV and apply pocket distance scale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1395,7 +1395,7 @@ const POCKET_CAM = Object.freeze({
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
   outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
   heightDrop: BALL_R * 0.2,
-  distanceScale: 0.96,
+  distanceScale: 0.82,
   heightScale: 0.98,
   focusBlend: 0,
   lateralFocusShift: 0,
@@ -5073,7 +5073,7 @@ const BACKSPIN_DIRECTION_PREVIEW = 0.68; // lerp strength that pulls the cue-bal
 const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
 const POCKET_VIEW_SMOOTH_TIME = 0.08; // seconds to ease pocket camera transitions
-const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
+const POCKET_CAMERA_FOV = Math.max(38, STANDING_VIEW_FOV * 0.88);
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
 const LONG_SHOT_ACTIVATION_DELAY_MS = 220;
 const LONG_SHOT_ACTIVATION_TRAVEL = PLAY_H * 0.28;
@@ -17257,8 +17257,10 @@ const powerRef = useRef(hud.power);
               anchorType === 'short'
                 ? POCKET_CAM.outwardOffsetShort ?? POCKET_CAM.outwardOffset
                 : POCKET_CAM.outwardOffset;
+            const distanceScale =
+              activeShotView.distanceScale ?? POCKET_CAM.distanceScale ?? 1;
             const cameraDistance =
-              baseDistance + Math.max(0, outwardOffsetMagnitude ?? 0);
+              (baseDistance + Math.max(0, outwardOffsetMagnitude ?? 0)) * distanceScale;
             const desiredPosition =
               activeShotView.fixedPos ??
               new THREE.Vector3(
@@ -17911,6 +17913,7 @@ const powerRef = useRef(hud.power);
             anchorOutward:
               anchorOutward?.normalize() ?? fallbackOutward,
             cameraDistance,
+            distanceScale: POCKET_CAM.distanceScale,
             lastRailHitAt: targetBall.lastRailHitAt ?? null,
             lastRailHitType: targetBall.lastRailHitType ?? null,
             predictedAlignment,


### PR DESCRIPTION
### Motivation
- Pocket camera shots were too wide and not sufficiently zoomed when following potted balls, so pocket views need tighter framing and closer camera distance.

### Description
- Narrow pocket camera field-of-view by changing `POCKET_CAMERA_FOV` to `Math.max(38, STANDING_VIEW_FOV * 0.88)` to produce a tighter framing.
- Reduce default pocket distance by updating `POCKET_CAM.distanceScale` from `0.96` to `0.82` to bring the pocket camera closer to the pocket.
- Apply the pocket distance scale when composing pocket-shot views by multiplying the computed `cameraDistance` by `activeShotView.distanceScale ?? POCKET_CAM.distanceScale`, and propagate `distanceScale` into the returned pocket view object.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched Vite and served the app (succeeded). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate the visual change which timed out (failed). 
- No unit tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5613a76c8320a029dad5a7ccac0f)