### PR TITLE
Use official snooker playfield sizes and align pocket camera offsets

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,13 +1,13 @@
 const BASE_TABLE_SCALE = 1.46;
 const BASE_TABLE_MOBILE_SCALE = 1.52;
 const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 5080; // double pool table width reference for snooker Royale
+const BASE_PLAYFIELD_WIDTH_MM = 3569; // official 12ft snooker playfield width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
   '12ft': {
     id: '12ft',
     label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 5080, heightMm: 2540 }), // double 9ft pool playfield
+    playfield: Object.freeze({ widthMm: 3569, heightMm: 1778 }), // official 12ft snooker playfield (11ft 8.5in x 5ft 10in)
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
@@ -25,7 +25,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 4470, heightMm: 2236 }), // double 8ft pool playfield
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // official 10ft snooker playfield
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,13 +1,13 @@
 const BASE_TABLE_SCALE = 1.46;
 const BASE_TABLE_MOBILE_SCALE = 1.52;
 const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 5080; // double pool table width reference for snooker Royale
+const BASE_PLAYFIELD_WIDTH_MM = 3569; // official 12ft snooker playfield width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
   '12ft': {
     id: '12ft',
     label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 5080, heightMm: 2540 }), // double 9ft pool playfield
+    playfield: Object.freeze({ widthMm: 3569, heightMm: 1778 }), // official 12ft snooker playfield (11ft 8.5in x 5ft 10in)
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
@@ -25,7 +25,7 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
   '10ft': {
     id: '10ft',
     label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 4470, heightMm: 2236 }), // double 8ft pool playfield
+    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // official 10ft snooker playfield
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1399,31 +1399,34 @@ const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.22; // lift the leather strap so i
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
+const POCKET_CAM_EDGE_SCALE = 0.2;
 const POCKET_CAM_BASE_MIN_OUTSIDE =
-  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.18 +
-  POCKET_VIS_R * 2.25 +
-  BALL_R * 1.6;
+  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
+    POCKET_VIS_R * 1.95 +
+    BALL_R * 1.1) *
+  POCKET_CAM_EDGE_SCALE;
 const POCKET_CAM_BASE_OUTWARD_OFFSET =
-  Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.34 +
-  POCKET_VIS_R * 2.28 +
-  BALL_R * 1.54;
+  (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 1.05 +
+    POCKET_VIS_R * 1.95 +
+    BALL_R * 1.05) *
+  POCKET_CAM_EDGE_SCALE;
 const POCKET_CAM = Object.freeze({
-  triggerDist: CAPTURE_R * 12,
-  dotThreshold: 0.22,
+  triggerDist: CAPTURE_R * 18,
+  dotThreshold: 0.15,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.06,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 0.98,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.9,
-  heightOffsetShortMultiplier: 0.96,
+  heightOffset: BALL_R * 0.9,
+  heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.04,
-  heightDrop: BALL_R * 0.45,
-  distanceScale: 0.96,
-  heightScale: 1.06,
-  focusBlend: 0.22,
-  lateralFocusShift: POCKET_VIS_R * 0.32,
-  railFocusLong: BALL_R * 8,
-  railFocusShort: BALL_R * 5.4
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
+  heightDrop: BALL_R * 0.2,
+  distanceScale: 0.82,
+  heightScale: 0.98,
+  focusBlend: 0,
+  lateralFocusShift: 0,
+  railFocusLong: BALL_R * 5.6,
+  railFocusShort: BALL_R * 6.6
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
 const POCKET_GUARANTEED_ALIGNMENT = 0.95;


### PR DESCRIPTION
### Motivation
- Replace the previous pool-derived playfield sizes with official snooker 12ft/10ft dimensions so Snooker Royal tables use real-world measurements.
- Align Snooker Royal pocket-camera placement/offset math with the Pool Royale implementation so corner-pocket camera distances and framing match the pool mode.

### Description
- Updated base playfield width and per-size `playfield` entries in `webapp/src/config/snookerClubTables.js` to use official 12ft (`3569×1778mm`) and 10ft (`3048×1524mm`) sizes and adjusted `BASE_PLAYFIELD_WIDTH_MM` accordingly.
- Applied the same size changes to `webapp/src/config/snookerRoyalTables.js` to keep club and royale table configs consistent.
- Tuned pocket camera math in `webapp/src/pages/Games/SnookerRoyal.jsx` by introducing `POCKET_CAM_EDGE_SCALE`, recalculating `POCKET_CAM_BASE_MIN_OUTSIDE` and `POCKET_CAM_BASE_OUTWARD_OFFSET`, and adjusting the `POCKET_CAM` parameters to mirror Pool Royale corner-pocket distances.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported ready at the local dev URL, indicating the front-end built and served successfully.
- Attempted to capture an in-browser preview via Playwright (`playwright` script) to validate Three.js table rendering, but the automated screenshot runs timed out and no image was produced.
- No unit test suite was executed as part of this change (`npm test` / Jest not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a63267a50832083cd7c00f504e03b)