### PR TITLE
Adjust Pool Royale camera switching for breaks and direct shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21403,7 +21403,9 @@ const powerRef = useRef(hud.power);
           toggleChalkAssist(null);
         }
         const shotStartTime = performance.now();
-        const forcedCueView = aiShotCueViewRef.current;
+        const frameStateCurrent = frameRef.current ?? null;
+        const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
+        const forcedCueView = aiShotCueViewRef.current && !isBreakShot;
         setAiShotCueViewActive(false);
         setAiShotPreviewActive(false);
         alignStandingCameraToAim(cue, aimDirRef.current);
@@ -21425,7 +21427,10 @@ const powerRef = useRef(hud.power);
         shotContextRef.current = {
           placedFromHand,
           contactMade: false,
-          cushionAfterContact: false
+          cushionAfterContact: false,
+          isBreakShot,
+          forceStandingBroadcast: false,
+          restrictPocketToTarget: false
         };
         setShootingState(true);
         powerImpactHoldRef.current = Math.max(
@@ -21490,240 +21495,248 @@ const powerRef = useRef(hud.power);
             : null
         };
         if (shotPrediction.railNormal) replayTags.add('bank');
-          const intentTimestamp = performance.now();
-          if (shotPrediction.ballId && !isShortShot) {
-            const isDirectHit =
-              shotPrediction.railNormal === null || shotPrediction.railNormal === undefined;
-            pocketSwitchIntentRef.current = {
-              ballId: shotPrediction.ballId,
-              allowEarly: isDirectHit,
-              forced: isDirectHit,
-              createdAt: intentTimestamp
-            };
-          } else {
-            pocketSwitchIntentRef.current = null;
-          }
-          lastPocketBallRef.current = null;
-          const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
-          lastShotPower = clampedPower;
-          const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
-          if (isMaxPowerShot) {
-            powerImpactHoldRef.current = Math.max(
-              powerImpactHoldRef.current || 0,
-              performance.now() + MAX_POWER_CAMERA_HOLD_MS
-            );
-          }
-          if (aiOpponentEnabled && hudRef.current?.turn === 1) {
-            powerImpactHoldRef.current = Math.max(
-              powerImpactHoldRef.current || 0,
-              performance.now() + AI_POST_SHOT_CAMERA_HOLD_MS
-            );
-          }
-          const spinMagnitude = Math.hypot(
-            spinRef.current?.x ?? 0,
-            spinRef.current?.y ?? 0
+        const intentTimestamp = performance.now();
+        if (shotPrediction.ballId && !isShortShot) {
+          const isDirectHit =
+            shotPrediction.railNormal === null || shotPrediction.railNormal === undefined;
+          pocketSwitchIntentRef.current = {
+            ballId: shotPrediction.ballId,
+            allowEarly: isDirectHit,
+            forced: isDirectHit,
+            createdAt: intentTimestamp
+          };
+        } else {
+          pocketSwitchIntentRef.current = null;
+        }
+        lastPocketBallRef.current = null;
+        const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
+        lastShotPower = clampedPower;
+        const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
+        if (isMaxPowerShot) {
+          powerImpactHoldRef.current = Math.max(
+            powerImpactHoldRef.current || 0,
+            performance.now() + MAX_POWER_CAMERA_HOLD_MS
           );
-          const isPowerShot = clampedPower >= POWER_REPLAY_THRESHOLD;
-          if (isPowerShot) replayTags.add('power');
-          if (spinMagnitude >= SPIN_REPLAY_THRESHOLD) replayTags.add('spin');
-          const shouldRecordReplay = true;
-          const preferZoomReplay =
-            replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
-          const frameStateCurrent = frameRef.current ?? null;
-          const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
-          const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
-          const base = shotAimDir
-            .clone()
-            .multiplyScalar(speedBase * powerScale);
-          const predictedCueSpeed = base.length();
-          shotPrediction.speed = predictedCueSpeed;
-          if (shouldRecordReplay) {
-            const frameTiming = frameTimingRef.current;
-            const frameTimeMs =
-              frameTiming && Number.isFinite(frameTiming.targetMs) && frameTiming.targetMs > 0
-                ? frameTiming.targetMs
-                : 1000 / 60;
-            shotRecording = {
-              longShot: replayTags.has('long'),
-              targetBallId: shotPrediction.ballId ?? null,
-              startTime: performance.now(),
-              startState: captureBallSnapshot(),
-              frames: [],
-              cuePath: [],
-              frameTimeMs,
-              replayTags: Array.from(replayTags),
-              zoomOnly: preferZoomReplay
-            };
-            shotReplayRef.current = shotRecording;
-            recordReplayFrame(shotRecording.startTime);
-          } else {
-            shotRecording = null;
-            shotReplayRef.current = null;
-          }
-          const allowLongShotCameraSwitch =
-            !isShortShot &&
-            (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD);
-          const broadcastSystem =
-            broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
-          const suppressPocketCameras = broadcastSystem?.avoidPocketCameras;
-          const forceActionActivation = broadcastSystem?.forceActionActivation;
-          const orbitSnapshot = sphRef.current
-            ? {
-                radius: sphRef.current.radius,
-                phi: sphRef.current.phi,
-                theta: sphRef.current.theta
-              }
-            : null;
-          const standingBounds = cameraBoundsRef.current?.standing;
-          const followView = standingBounds
-            ? {
-                orbitSnapshot: {
-                  radius: clampOrbitRadius(
-                    standingBounds.radius ?? sphRef.current?.radius ?? BREAK_VIEW.radius
-                  ),
-                  phi: THREE.MathUtils.clamp(
-                    standingBounds.phi,
-                    CAMERA.minPhi,
-                    CAMERA.maxPhi
-                  ),
-                  theta: sphRef.current?.theta ?? 0
-                }
-              }
-            : orbitSnapshot
-              ? { orbitSnapshot }
-              : null;
-          const actionView = allowLongShotCameraSwitch
-            ? makeActionCameraView(
-                cue,
-                shotPrediction.ballId,
-                followView,
-                shotPrediction.railNormal,
-                {
-                  longShot: isLongShot,
-                  travelDistance: predictedTravel
-                }
-              )
-            : null;
-          const earlyPocketView =
-            !suppressPocketCameras && shotPrediction.ballId && followView
-              ? makePocketCameraView(shotPrediction.ballId, followView, {
-                  forceEarly: true
-                })
-              : null;
-          if (actionView && cameraRef.current) {
-            actionView.smoothedPos = cameraRef.current.position.clone();
-            const storedTarget = lastCameraTargetRef.current?.clone();
-            if (storedTarget) actionView.smoothedTarget = storedTarget;
-          }
-          const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const baseSide = physicsSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
-          if (physicsSpin.y < 0) {
-            spinTop *= BACKSPIN_MULTIPLIER;
-          } else if (physicsSpin.y > 0) {
-            spinTop *= TOPSPIN_MULTIPLIER;
-          }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar((physicsSpin.x ?? 0) * BALL_R);
-            TMP_VEC3_C.y += (physicsSpin.y ?? 0) * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode =
-            spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
-          const swerveSettings = resolveSwerveSettings(
-            physicsSpin,
-            clampedPower,
-            cue.spinMode === 'swerve',
-            liftStrength
+        }
+        if (aiOpponentEnabled && hudRef.current?.turn === 1) {
+          powerImpactHoldRef.current = Math.max(
+            powerImpactHoldRef.current || 0,
+            performance.now() + AI_POST_SHOT_CAMERA_HOLD_MS
           );
-          cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
-          cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          const topSpinWeight = Math.max(0, physicsSpin.y || 0);
-          if (
-            clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
-            liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
-            topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
-          ) {
-            const powerRatio = THREE.MathUtils.clamp(
-              (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const liftRatio = THREE.MathUtils.clamp(
-              (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const spinRatio = THREE.MathUtils.clamp(
-              (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
-                Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
-              0,
-              1
-            );
-            const jumpStrength =
-              (0.25 + 0.75 * powerRatio) *
-              (0.4 + 0.6 * liftRatio) *
-              (0.55 + 0.45 * spinRatio);
-            const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
-            const physicsHeight =
-              (jumpVelocity * jumpVelocity) /
-              (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
-            const jumpHeight = Math.min(
-              MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
-              physicsHeight
-            );
-            cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
-            cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
-          }
-          playCueHit(clampedPower * 0.6);
-
-          if (cameraRef.current && sphRef.current) {
-            topViewRef.current = false;
-            topViewLockedRef.current = false;
-            setIsTopDownView(false);
-            const sph = sphRef.current;
-            const bounds = cameraBoundsRef.current;
-            const standingView = bounds?.standing;
-            if (standingView) {
-              sph.radius = clampOrbitRadius(standingView.radius);
-              sph.phi = THREE.MathUtils.clamp(
-                standingView.phi,
-                CAMERA.minPhi,
-                CAMERA.maxPhi
-              );
-              syncBlendToSpherical();
+        }
+        const spinMagnitude = Math.hypot(
+          spinRef.current?.x ?? 0,
+          spinRef.current?.y ?? 0
+        );
+        const isPowerShot = clampedPower >= POWER_REPLAY_THRESHOLD;
+        if (isPowerShot) replayTags.add('power');
+        if (spinMagnitude >= SPIN_REPLAY_THRESHOLD) replayTags.add('spin');
+        const shouldRecordReplay = true;
+        const preferZoomReplay =
+          replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
+        const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
+        const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
+        const base = shotAimDir
+          .clone()
+          .multiplyScalar(speedBase * powerScale);
+        const predictedCueSpeed = base.length();
+        shotPrediction.speed = predictedCueSpeed;
+        const isBankShot = Boolean(shotPrediction.railNormal);
+        const isDirectShot = Boolean(shotPrediction.ballId) && !isBankShot;
+        shotContextRef.current.isBreakShot = isBreakShot;
+        shotContextRef.current.forceStandingBroadcast = isBankShot;
+        shotContextRef.current.restrictPocketToTarget = isDirectShot && !isBreakShot;
+        if (shouldRecordReplay) {
+          const frameTiming = frameTimingRef.current;
+          const frameTimeMs =
+            frameTiming && Number.isFinite(frameTiming.targetMs) && frameTiming.targetMs > 0
+              ? frameTiming.targetMs
+              : 1000 / 60;
+          shotRecording = {
+            longShot: replayTags.has('long'),
+            targetBallId: shotPrediction.ballId ?? null,
+            startTime: performance.now(),
+            startState: captureBallSnapshot(),
+            frames: [],
+            cuePath: [],
+            frameTimeMs,
+            replayTags: Array.from(replayTags),
+            zoomOnly: preferZoomReplay
+          };
+          shotReplayRef.current = shotRecording;
+          recordReplayFrame(shotRecording.startTime);
+        } else {
+          shotRecording = null;
+          shotReplayRef.current = null;
+        }
+        const allowLongShotCameraSwitch =
+          !isShortShot &&
+          (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD);
+        const broadcastSystem =
+          broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
+        const suppressPocketCameras = broadcastSystem?.avoidPocketCameras;
+        const forceActionActivation = broadcastSystem?.forceActionActivation;
+        const orbitSnapshot = sphRef.current
+          ? {
+              radius: sphRef.current.radius,
+              phi: sphRef.current.phi,
+              theta: sphRef.current.theta
             }
-            updateCamera();
-          }
+          : null;
+        const standingBounds = cameraBoundsRef.current?.standing;
+        const followView = standingBounds
+          ? {
+              orbitSnapshot: {
+                radius: clampOrbitRadius(
+                  standingBounds.radius ?? sphRef.current?.radius ?? BREAK_VIEW.radius
+                ),
+                phi: THREE.MathUtils.clamp(
+                  standingBounds.phi,
+                  CAMERA.minPhi,
+                  CAMERA.maxPhi
+                ),
+                theta: sphRef.current?.theta ?? 0
+              }
+            }
+          : orbitSnapshot
+            ? { orbitSnapshot }
+            : null;
+        const allowActionCamera =
+          allowLongShotCameraSwitch && !isBreakShot && !isBankShot && !isDirectShot;
+        const actionView = allowActionCamera
+          ? makeActionCameraView(
+              cue,
+              shotPrediction.ballId,
+              followView,
+              shotPrediction.railNormal,
+              {
+                longShot: isLongShot,
+                travelDistance: predictedTravel
+              }
+            )
+          : null;
+        const earlyPocketView =
+          !suppressPocketCameras &&
+          !isBankShot &&
+          shotPrediction.ballId &&
+          followView
+            ? makePocketCameraView(shotPrediction.ballId, followView, {
+                forceEarly: true
+              })
+            : null;
+        if (actionView && cameraRef.current) {
+          actionView.smoothedPos = cameraRef.current.position.clone();
+          const storedTarget = lastCameraTargetRef.current?.clone();
+          if (storedTarget) actionView.smoothedTarget = storedTarget;
+        }
+        const ranges = spinRangeRef.current || {};
+        const powerSpinScale = 0.55 + clampedPower * 0.45;
+        const baseSide = physicsSpin.x * (ranges.side ?? 0);
+        let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
+        let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+        if (physicsSpin.y < 0) {
+          spinTop *= BACKSPIN_MULTIPLIER;
+        } else if (physicsSpin.y > 0) {
+          spinTop *= TOPSPIN_MULTIPLIER;
+        }
+        cue.vel.copy(base);
+        if (cue.spin) {
+          cue.spin.set(spinSide, spinTop);
+        }
+        if (cue.omega) {
+          cue.omega.set(0, 0, 0);
+          TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
+          if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
+          TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
+          if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
+          TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar((physicsSpin.x ?? 0) * BALL_R);
+          TMP_VEC3_C.y += (physicsSpin.y ?? 0) * BALL_R;
+          const impulseMag = BALL_MASS * base.length();
+          TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+          TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+          cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+        }
+        if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+        cue.spinMode =
+          spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
+        const swerveSettings = resolveSwerveSettings(
+          physicsSpin,
+          clampedPower,
+          cue.spinMode === 'swerve',
+          liftStrength
+        );
+        cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
+        cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+        resetSpinRef.current?.();
+        cueLiftRef.current.lift = 0;
+        cueLiftRef.current.startLift = 0;
+        cue.impacted = false;
+        cue.launchDir = shotAimDir.clone().normalize();
+        maxPowerLiftTriggered = false;
+        cue.lift = 0;
+        cue.liftVel = 0;
+        const topSpinWeight = Math.max(0, physicsSpin.y || 0);
+        if (
+          clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+          liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+          topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+        ) {
+          const powerRatio = THREE.MathUtils.clamp(
+            (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const liftRatio = THREE.MathUtils.clamp(
+            (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const spinRatio = THREE.MathUtils.clamp(
+            (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+              Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+            0,
+            1
+          );
+          const jumpStrength =
+            (0.25 + 0.75 * powerRatio) *
+            (0.4 + 0.6 * liftRatio) *
+            (0.55 + 0.45 * spinRatio);
+          const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+          const physicsHeight =
+            (jumpVelocity * jumpVelocity) /
+            (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+          const jumpHeight = Math.min(
+            MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+            physicsHeight
+          );
+          cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+          cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+        }
+        playCueHit(clampedPower * 0.6);
 
-          // animate cue stick forward
-          const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
+        if (cameraRef.current && sphRef.current) {
+          topViewRef.current = false;
+          topViewLockedRef.current = false;
+          setIsTopDownView(false);
+          const sph = sphRef.current;
+          const bounds = cameraBoundsRef.current;
+          const standingView = bounds?.standing;
+          if (standingView) {
+            sph.radius = clampOrbitRadius(standingView.radius);
+            sph.phi = THREE.MathUtils.clamp(
+              standingView.phi,
+              CAMERA.minPhi,
+              CAMERA.maxPhi
+            );
+            syncBlendToSpherical();
+          }
+          updateCamera();
+        }
+
+        // animate cue stick forward
+        const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
           dir.normalize();
           if (cue?.pos) {
@@ -21845,7 +21858,10 @@ const powerRef = useRef(hud.power);
             forwardPreviewHold
           );
           const holdUntil = powerImpactHoldRef.current || 0;
-          const holdActive = holdUntil > performance.now();
+          const forceImmediatePocket = Boolean(
+            earlyPocketView && (isDirectShot || isBreakShot)
+          );
+          const holdActive = !forceImmediatePocket && holdUntil > performance.now();
           let pocketViewActivated = false;
           if (earlyPocketView && !isMaxPowerShot) {
             const now = performance.now();
@@ -21864,7 +21880,7 @@ const powerRef = useRef(hud.power);
             } else {
               suspendedActionView = null;
             }
-            if (holdUntil > 0) {
+            if (holdUntil > 0 && !forceImmediatePocket) {
               const baseDelay = earlyPocketView.activationDelay ?? 0;
               earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
             }
@@ -25467,6 +25483,7 @@ const powerRef = useRef(hud.power);
         const suppressPocketCameras =
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
+        const forceStandingBroadcast = shotContextRef.current?.forceStandingBroadcast;
         const pocketHoldActive =
           powerImpactHoldRef.current &&
           performance.now() < powerImpactHoldRef.current;
@@ -25478,6 +25495,7 @@ const powerRef = useRef(hud.power);
         }
         if (
           !suppressPocketCameras &&
+          !forceStandingBroadcast &&
           shooting &&
           !topViewRef.current
         ) {
@@ -25519,9 +25537,15 @@ const powerRef = useRef(hud.power);
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
             const movingCount = movingBalls.length;
+            const isBreakShot = shotContextRef.current?.isBreakShot;
+            const restrictPocketToTarget = shotContextRef.current?.restrictPocketToTarget;
+            const targetBallId = shotPrediction?.ballId ?? null;
             const lastPocketBall = lastPocketBallRef.current;
             let bestPocketView = null;
             for (const ball of ballsList) {
+              if (restrictPocketToTarget && targetBallId != null && ball.id !== targetBallId) {
+                continue;
+              }
               if (!ball.active) continue;
               const resumeView = orbitSnapshot ? { orbitSnapshot } : null;
               const matchesIntent = pocketIntent?.ballId === ball.id;
@@ -25538,6 +25562,7 @@ const powerRef = useRef(hud.power);
               const qualifiesAsGuaranteed =
                 isDirectPrediction && predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
               const allowDuringChaos =
+                isBreakShot ||
                 movingCount <= POCKET_CHAOS_MOVING_THRESHOLD ||
                 matchesIntent ||
                 qualifiesAsGuaranteed ||


### PR DESCRIPTION
### Motivation
- Prevent jarring camera behavior on the opening break by keeping the broadcast on the standing view and avoiding cue/action zooms for breaks. 
- Ensure pocket cameras are used for direct one-to-one shots (cue + target) and for balls clearly heading to pockets, while avoiding pocket captures when a bank shot should stay in standing broadcast.
- Reduce noisy pocket camera switching during chaotic multi-ball movement except for allowed break scenarios.

### Description
- On shot start, detect break shots and avoid enabling AI cue/close cue view by setting `forcedCueView` only when not a break. 
- Add `isBreakShot`, `forceStandingBroadcast`, and `restrictPocketToTarget` flags to `shotContextRef.current` to drive broadcast decisions. 
- Mark bank (rail) shots to force standing broadcast and mark direct (non-bank) predicted targets to restrict pocket-camera selection to the predicted target when appropriate. 
- Change early/queued pocket activation logic to allow immediate pocket activation for direct shots and breaks (bypass hold delays), and prevent pocket switching when `forceStandingBroadcast` is set. 
- Update pocket-camera candidate selection to honor `restrictPocketToTarget` and allow break shots to qualify as pocket candidates even when many balls are moving (adjust `allowDuringChaos`). 
- Files modified: `webapp/src/pages/Games/PoolRoyale.jsx` (camera / pocket-selection and shot-start logic). 

### Testing
- Started local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported ready (local server served). 
- Attempted an automated visual check using Playwright to capture a screenshot, but the Playwright run timed out and did not complete. 
- No automated unit tests were run as part of this change; changes were committed (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a621ef4ec8320a6a149c77124f915)