### PR TITLE
Pool Royale: soften backspin, use snooker rail-overhead for broadcasts, slow cue stroke and show cue in replays

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1584,8 +1584,8 @@ const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes control
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
-const PLAYER_CUE_FORWARD_MIN_MS = 240;
-const PLAYER_CUE_FORWARD_MAX_MS = 520;
+const PLAYER_CUE_FORWARD_MIN_MS = 360;
+const PLAYER_CUE_FORWARD_MAX_MS = 780;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
@@ -4983,6 +4983,9 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
   z: PLAY_H * -0.078 // keep the existing vertical alignment
 });
+const RAIL_OVERHEAD_TOP_VIEW_MARGIN = 1.14;
+const RAIL_OVERHEAD_MIN_RADIUS_SCALE = 1.06;
+const RAIL_OVERHEAD_RADIUS_SCALE = 1.06;
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const REPLAY_TOP_VIEW_PHI = TOP_VIEW_PHI;
@@ -5088,7 +5091,7 @@ const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
 const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CUE_PULLBACK_DURATION_MS = 260;
-const AI_CUE_FORWARD_DURATION_MS = 240;
+const AI_CUE_FORWARD_DURATION_MS = 360;
 const AI_STROKE_VISIBLE_DURATION_MS =
   (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -15025,8 +15028,8 @@ const powerRef = useRef(hud.power);
         const aspect = Number.isFinite(hostAspect) ? hostAspect : 9 / 16; // fall back to worst-case portrait when unknown
         const tempCamera = new THREE.PerspectiveCamera(STANDING_VIEW_FOV, aspect);
         const topDownRadius = Math.max(
-          fitRadius(tempCamera, TOP_VIEW_MARGIN) * TOP_VIEW_RADIUS_SCALE,
-          CAMERA.minR * TOP_VIEW_MIN_RADIUS_SCALE
+          fitRadius(tempCamera, RAIL_OVERHEAD_TOP_VIEW_MARGIN) * RAIL_OVERHEAD_RADIUS_SCALE,
+          CAMERA.minR * RAIL_OVERHEAD_MIN_RADIUS_SCALE
         );
         return topDownRadius;
       };
@@ -18714,8 +18717,8 @@ const powerRef = useRef(hud.power);
               if (quat) {
                 cueStick.quaternion.set(quat.x, quat.y, quat.z, quat.w);
               }
-              cueStick.visible = cueSnapshot.visible ?? true;
-              cueAnimating = cueStick.visible;
+              cueStick.visible = true;
+              cueAnimating = true;
               syncCueShadow();
               return;
             }

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,8 +10,9 @@ export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.06;
+export const STUN_TOPSPIN_BIAS = -0.1;
 export const SPIN_RESPONSE_POWER = 1.35;
+export const BACKSPIN_RESPONSE_POWER = 1.25;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -150,9 +151,12 @@ export const normalizeSpinInput = (spin) => {
   const scale = eased / Math.max(clampedDistance, 1e-6);
   const result = { x: clamped.x * scale, y: clamped.y * scale };
   if (result.y < 0) {
+    const backspinStrength = Math.abs(result.y);
+    const easedBackspin = Math.pow(backspinStrength, BACKSPIN_RESPONSE_POWER);
+    result.y = clamp(-easedBackspin, -1, 1);
     const centerWeight = clamp(1 - Math.abs(clamped.x) / 0.25, 0, 1);
     const ringWeight = clamp((0.5 - clampedDistance) / 0.5, 0, 1);
-    const boost = 0.08 * centerWeight * ringWeight;
+    const boost = 0.04 * centerWeight * ringWeight;
     if (boost > 0) {
       result.y = clamp(result.y - boost, -1, 1);
     }


### PR DESCRIPTION
### Motivation
- Reduce the aggressive backspin response and increase center stun bias in the spin controller so the blue-marked backspin areas produce only a slight draw. 
- Use the same rail overhead/top-down framing used in Snooker Royal for broadcasting and replays (without changing the game’s 2D camera). 
- Slow the cue forward stroke so pushes are visible for both AI and players and ensure the cue is shown at the start of each replay.

### Description
- Tuned spin normalization in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`: increased `STUN_TOPSPIN_BIAS`, added `BACKSPIN_RESPONSE_POWER`, eased backspin using a power curve, and reduced the center/backspin boost to soften draw behavior. 
- Aligned broadcast/replay overhead framing in `webapp/src/pages/Games/PoolRoyale.jsx` by adding `RAIL_OVERHEAD_TOP_VIEW_MARGIN`, `RAIL_OVERHEAD_MIN_RADIUS_SCALE`, and `RAIL_OVERHEAD_RADIUS_SCALE` and using them when computing the rail/top-down broadcast distance so rail overhead replays match Snooker Royal coordinates. 
- Slowed cue forward stroke timings by increasing `AI_CUE_FORWARD_DURATION_MS` and `PLAYER_CUE_FORWARD_MIN_MS`/`PLAYER_CUE_FORWARD_MAX_MS` to make the forward push visibly slower. 
- Forced the cue stick to be visible when priming replays by ensuring `cueStick.visible = true` and `cueAnimating = true` in the replay priming path in `PoolRoyale.jsx` so the cue appears at the start of every replay.

### Testing
- Started the local dev preview with `npm --prefix webapp run dev` and confirmed Vite reported it was ready and serving the app (server started). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate visuals, but the screenshot timed out (Playwright timeout); no visual regression was captured. 
- No unit tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ae8452fb48320b25037e35b1bac56)