### PR TITLE
Expand snooker table footprint to 12ft while preserving ball & pocket sizes

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -958,10 +958,11 @@ function addPocketCuts(
 // Config
 // --------------------------------------------------
 // separate scales for table and balls
-// Dimensions tuned for the Pool Royale footprint for identical table sizing and layout.
+// Dimensions tuned for the official 12ft snooker footprint while preserving the current layout.
 const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
 const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while keeping the table height unchanged
+const TABLE_PLAYFIELD_UPSCALE = 1.5; // scale an 8ft pool footprint up to the official 12ft snooker length
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
@@ -1066,8 +1067,8 @@ const ENABLE_TABLE_MAPPING_LINES = false;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE = {
-    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
+    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_PLAYFIELD_UPSCALE,
+    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE * TABLE_PLAYFIELD_UPSCALE,
     THICK: 1.8 * TABLE_SCALE,
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
   };
@@ -1154,10 +1155,11 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
     'Snooker table inner ratio must match the widened 1.83:1 target after scaling.'
   );
-const MM_TO_UNITS = innerLong / WIDTH_REF;
-const MARKINGS_MM_TO_UNITS = innerLong / WIDTH_REF;
+const LAYOUT_MM_TO_UNITS = innerLong / WIDTH_REF;
+const MARKINGS_MM_TO_UNITS = LAYOUT_MM_TO_UNITS;
+const COMPONENT_MM_TO_UNITS = LAYOUT_MM_TO_UNITS / TABLE_PLAYFIELD_UPSCALE;
 const BALL_SIZE_SCALE = 1.1155; // increase balls 15% from the previous tuned size for stronger table presence
-const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
+const BALL_DIAMETER = BALL_D_REF * COMPONENT_MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const ENABLE_BALL_FLOOR_SHADOWS = true;
@@ -1190,8 +1192,8 @@ const POCKET_SIDE_MOUTH_SCALE =
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // keep the middle pocket mouth width identical to the corner pockets
 const SIDE_POCKET_CUT_SCALE = 0.985; // match Pool Royale middle pocket cut size
 const POCKET_CORNER_MOUTH =
-  CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
-const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
+  CORNER_MOUTH_REF * COMPONENT_MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
+const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * COMPONENT_MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
@@ -1206,7 +1208,7 @@ const CORNER_CHROME_NOTCH_RADIUS =
 const SIDE_CHROME_NOTCH_RADIUS = SIDE_POCKET_RADIUS * POCKET_VISUAL_EXPANSION;
 const CORNER_RAIL_NOTCH_INSET =
   POCKET_VIS_R * 0.078 * POCKET_VISUAL_EXPANSION; // let the rail and chrome cutouts follow the outward corner pocket shift
-const POCKET_MOUTH_TOLERANCE = 0.5 * MM_TO_UNITS;
+const POCKET_MOUTH_TOLERANCE = 0.5 * COMPONENT_MM_TO_UNITS;
 console.assert(
   Math.abs(POCKET_CORNER_MOUTH - POCKET_VIS_R * 2) <= POCKET_MOUTH_TOLERANCE,
   'Corner pocket mouth width mismatch.'
@@ -1216,7 +1218,7 @@ console.assert(
   'Side pocket mouth width mismatch.'
 );
 console.assert(
-  Math.abs(BALL_DIAMETER - BALL_R * 2) <= 0.1 * MM_TO_UNITS,
+  Math.abs(BALL_DIAMETER - BALL_R * 2) <= 0.1 * COMPONENT_MM_TO_UNITS,
   'Ball diameter mismatch after scaling.'
 );
 const CLOTH_LIFT = (() => {
@@ -14294,7 +14296,7 @@ const powerRef = useRef(hud.power);
           ? worldScaleFactor
           : WORLD_SCALE * tableScale;
         const floorWorldY = FLOOR_Y * resolvedWorldScale + worldOffsetY;
-        const unitsPerMeter = MM_TO_UNITS * 1000 * resolvedWorldScale;
+        const unitsPerMeter = LAYOUT_MM_TO_UNITS * 1000 * resolvedWorldScale;
         const cameraHeightMeters = Math.max(
           activeVariant?.cameraHeightM ?? DEFAULT_HDRI_CAMERA_HEIGHT_M,
           MIN_HDRI_CAMERA_HEIGHT_M


### PR DESCRIPTION
### Motivation
- Increase the playable Snooker Royal table footprint from the smaller pool footprint to the official 12ft snooker playfield while keeping the existing pocket layout and ball sizes unchanged.
- Preserve current visual/layout proportions and Three.js preview behavior while aligning environment conversions to the larger table.

### Description
- Add `TABLE_PLAYFIELD_UPSCALE` and apply it to `TABLE.W` and `TABLE.H` so the table footprint scales up to 12ft while keeping component thicknesses unchanged.
- Split unit conversion into `LAYOUT_MM_TO_UNITS` (for scene/layout scaling) and `COMPONENT_MM_TO_UNITS` (for balls/pockets) so markings scale with the new playfield while balls and pocket mouths use the original sizes.
- Update ball sizing to compute `BALL_DIAMETER` from `COMPONENT_MM_TO_UNITS` and update pocket mouth, tolerance, and related asserts to use `COMPONENT_MM_TO_UNITS` so physical playables remain unchanged.
- Use `LAYOUT_MM_TO_UNITS` for environment conversions (`unitsPerMeter`) so skybox/HDRI and camera metrics remain consistent with the enlarged playfield.

### Testing
- Started the dev preview server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which reported Vite ready and served the app successfully.
- Attempted an automated Three.js preview capture with Playwright to verify the table visually, but the Playwright/Chromium run failed with a browser crash (SIGSEGV) so the screenshot step did not complete.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ae91822788320bf74ddb376efb0cd)