### PR TITLE
Improve Telegram PWA fullscreen and game asset prefetch

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <meta name="application-name" content="TonPlaygram" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="telegram:web_app:bot_username" content="TonPlaygramBot" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/webapp/public/service-worker.js
+++ b/webapp/public/service-worker.js
@@ -44,16 +44,28 @@ const APP_SHELL = [
 ];
 
 const PREFETCH_RUNTIME_ASSETS = [
+  '/flag-emojis.js',
+  '/free-kick-api.js',
   '/goal-rush.html',
   '/goal-rush-api.js',
+  '/goal-rush-bracket.html',
+  '/goal-rush-calibration.json',
+  '/init.js',
   '/texas-holdem.html',
   '/texas-holdem.js',
+  '/lib/texasHoldem.js',
+  '/lib/texasHoldemGame.js',
   '/domino-royal.html',
   '/murlan-royale.html',
   '/roulette.html',
   '/chess-royale.html',
+  '/pool-royale-bracket.html',
   '/pool-royale-api.js',
+  '/lib/poolAi.js',
+  '/snooker-royale-bracket.html',
   '/snooker-royale-api.js',
+  '/game-preloads/pool-royale-preload.txt',
+  '/game-preloads/snooker-royale-preload.txt',
   '/power-slider.js',
   '/power-slider.css'
 ];

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -45,11 +45,13 @@ import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
 import Layout from './components/Layout.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
+import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 
 export default function App() {
   useTelegramAuth();
+  useTelegramFullscreen();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/hooks/useTelegramFullscreen.js
+++ b/webapp/src/hooks/useTelegramFullscreen.js
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+import { isTelegramWebView } from '../utils/telegram.js';
+
+const setViewportVars = () => {
+  const tg = window?.Telegram?.WebApp;
+  const height = tg?.viewportHeight || window.innerHeight;
+  const stableHeight = tg?.viewportStableHeight || height;
+  document.documentElement.style.setProperty('--tg-viewport-height', `${height}px`);
+  document.documentElement.style.setProperty('--tg-viewport-stable-height', `${stableHeight}px`);
+};
+
+export default function useTelegramFullscreen() {
+  useEffect(() => {
+    if (!isTelegramWebView()) return;
+
+    const tg = window.Telegram?.WebApp;
+    document.body.classList.add('telegram-fullscreen');
+
+    tg?.ready?.();
+    tg?.expand?.();
+    tg?.disableVerticalSwipes?.();
+    tg?.setHeaderColor?.('#0b0f1a');
+    tg?.setBackgroundColor?.('#0b0f1a');
+
+    setViewportVars();
+
+    const onResize = () => setViewportVars();
+    window.addEventListener('resize', onResize);
+
+    const onViewportChanged = () => setViewportVars();
+    tg?.onEvent?.('viewportChanged', onViewportChanged);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      tg?.offEvent?.('viewportChanged', onViewportChanged);
+      document.body.classList.remove('telegram-fullscreen');
+    };
+  }, []);
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -28,6 +28,22 @@ body {
   background-color: #0c1020;
 }
 
+#root {
+  min-height: 100%;
+}
+
+body.telegram-fullscreen {
+  min-height: var(--tg-viewport-stable-height, 100dvh);
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+body.telegram-fullscreen #root {
+  min-height: var(--tg-viewport-stable-height, 100dvh);
+}
+
 /* Outline text with contrasting edges */
 [class*='text-blue-'],
 [class*='text-sky-'],

--- a/webapp/src/pwa/preloadGames.js
+++ b/webapp/src/pwa/preloadGames.js
@@ -3,16 +3,28 @@ import { APP_BUILD } from '../config/buildInfo.js';
 const RUNTIME_CACHE_NAME = `tonplaygram-runtime-${APP_BUILD}`;
 
 const GAME_ENTRYPOINTS = [
+  '/flag-emojis.js',
+  '/free-kick-api.js',
   '/goal-rush.html',
   '/goal-rush-api.js',
+  '/goal-rush-bracket.html',
+  '/goal-rush-calibration.json',
+  '/init.js',
   '/texas-holdem.html',
   '/texas-holdem.js',
+  '/lib/texasHoldem.js',
+  '/lib/texasHoldemGame.js',
   '/domino-royal.html',
   '/murlan-royale.html',
   '/roulette.html',
   '/chess-royale.html',
+  '/pool-royale-bracket.html',
   '/pool-royale-api.js',
+  '/lib/poolAi.js',
+  '/snooker-royale-bracket.html',
   '/snooker-royale-api.js',
+  '/game-preloads/pool-royale-preload.txt',
+  '/game-preloads/snooker-royale-preload.txt',
   '/power-slider.js',
   '/power-slider.css'
 ];


### PR DESCRIPTION
### Motivation
- Provide a true fullscreen, safe-area aware PWA experience when the app runs inside the Telegram WebApp and ensure games load faster in that environment by prefetching more open-source assets.
- Reduce perceived load times for games by adding additional game entrypoints and library files to the runtime prefetch lists so the shell/service worker can warm caches ahead of play.

### Description
- Add `useTelegramFullscreen` hook that detects Telegram WebApp, expands the WebApp, disables vertical swipes, sets Telegram theme colors, and exposes viewport-safe CSS variables (`--tg-viewport-height`, `--tg-viewport-stable-height`).
- Wire `useTelegramFullscreen` into app startup (`App.jsx`) and add safe-area/fullscreen styles to `index.css` gated behind a `telegram-fullscreen` body class.
- Enable `viewport-fit=cover` in HTML templates (`webapp/index.html` and `webapp/public/index.html`) for correct fullscreen rendering on modern mobile browsers and Telegram WebApp.
- Expand runtime prefetch lists used by both the client warmers and the service worker (`preloadGames.js` and `public/service-worker.js`) to include additional game entrypoints, preloads and library files (init scripts, game preloads, libs, bracket pages, calibration files, etc.) so the service worker and runtime cache more assets.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and verified Vite reported the local server (succeeded).
- Ran a headless Playwright script that navigated to the running dev server and captured a screenshot to validate rendering and Telegram fullscreen styling (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ae9aadf308320907f46b770bf5b3a)