### PR TITLE
Tweak Pool Royale spin, align rail-overhead broadcast camera, and slow cue stroke/replay cue visibility

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -6,11 +6,11 @@ const getSigns = (vec) => ({
 });
 
 describe('Pool Royale spin controller mapping', () => {
-  it('maps the center to a slight topspin stun bias', () => {
+  it('maps the center to a slight stun bias with minimal roll', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(center.y).toBeGreaterThan(0);
-    expect(center.y).toBeLessThanOrEqual(STUN_TOPSPIN_BIAS);
+    expect(center.y).toBeLessThanOrEqual(0);
+    expect(center.y).toBeGreaterThanOrEqual(STUN_TOPSPIN_BIAS);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.06;
+export const STUN_TOPSPIN_BIAS = -0.02;
 export const SPIN_RESPONSE_POWER = 1.35;
 
 export const SPIN_DIRECTIONS = [
@@ -150,9 +150,9 @@ export const normalizeSpinInput = (spin) => {
   const scale = eased / Math.max(clampedDistance, 1e-6);
   const result = { x: clamped.x * scale, y: clamped.y * scale };
   if (result.y < 0) {
-    const centerWeight = clamp(1 - Math.abs(clamped.x) / 0.25, 0, 1);
-    const ringWeight = clamp((0.5 - clampedDistance) / 0.5, 0, 1);
-    const boost = 0.08 * centerWeight * ringWeight;
+    const centerWeight = clamp(1 - Math.abs(clamped.x) / 0.3, 0, 1);
+    const ringWeight = clamp((0.45 - clampedDistance) / 0.45, 0, 1);
+    const boost = 0.04 * centerWeight * ringWeight;
     if (boost > 0) {
       result.y = clamp(result.y - boost, -1, 1);
     }


### PR DESCRIPTION
### Motivation

- Reduce excessive backspin/forward rolling when the spin controller is near-center so the cue ball shows a light stun/draw instead of strong backspin.  
- Use the same rail-overhead broadcast/replay framing used by Snooker Royal so broadcast and replay overheads match exact coordinates.  
- Slow down the visible cue forward stroke for AI and players and ensure the cue stick is shown at the start of replays for clarity.

### Description

- Softened near-center stun/backspin by changing `STUN_TOPSPIN_BIAS` from `-0.06` to `-0.02` and reduced the backspin boost math in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.  
- Adjusted the spin-center weighting thresholds (`centerWeight`, `ringWeight`) and reduced the boost multiplier to make draw/stun near-center much milder.  
- Aligned Pool Royale rail-overhead broadcast/replay framing with Snooker Royal by introducing `RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE` and `RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE` and using them when computing top-view broadcast distances in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Switched `captureReplayCameraSnapshot` to prefer the rail-overhead replay camera rig (via `resolveRailOverheadReplayCamera`) so replays/broadcasts use the same overhead coordinates; made related snapshot resolution changes.  
- Slowed cue forward strokes by increasing `PLAYER_CUE_FORWARD_MIN_MS`/`PLAYER_CUE_FORWARD_MAX_MS` and `AI_CUE_FORWARD_DURATION_MS` to make the cue push-forward visibly slower.  
- Ensured the cue stick is visible at the start of replays by priming the cue stick position/visibility when replay playback begins (`primeReplayCueStick` / replay initialization changes).  
- Updated `test/poolRoyaleSpinController.test.js` expectations to match the new stun bias behavior.

### Testing

- Updated unit test `test/poolRoyaleSpinController.test.js` to reflect the adjusted stun/backspin mapping (file changed).  
- No automated test suite was executed as part of this change (no CI/test run was requested here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ae8452fb48320b25037e35b1bac56)