### PR TITLE
Pool Royale: disable 2D broadcast/top-view, reduce shot power, slow cue forward, and stabilize pocket replay cameras

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1500,7 +1500,7 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 const SHOT_POWER_REDUCTION = 0.6375; // reduce overall shot strength by another 25%
 const SHOT_POWER_MULTIPLIER = 1.25;
 const SHOT_POWER_BOOST = 1.5;
-const SHOT_SPEED_MULTIPLIER = 1.38;
+const SHOT_SPEED_MULTIPLIER = 1.104;
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1584,8 +1584,8 @@ const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes control
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
-const PLAYER_CUE_FORWARD_MIN_MS = 360;
-const PLAYER_CUE_FORWARD_MAX_MS = 820;
+const PLAYER_CUE_FORWARD_MIN_MS = 450;
+const PLAYER_CUE_FORWARD_MAX_MS = 1025;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
@@ -2865,24 +2865,6 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
     smoothing: 0.14,
     avoidPocketCameras: false,
     forceActionActivation: true
-  },
-  {
-    id: 'rail-overhead-snooker2d',
-    label: 'Rail Overhead + Snooker 2D',
-    description:
-      'Broadcast rail heads paired with the snooker-style 2D top view framing.',
-    method: 'Overhead rail mounts with snooker 2D replay/top-view cuts.',
-    orbitBias: 0.68,
-    railPush: BALL_R * 6,
-    lateralDolly: BALL_R * 0.6,
-    focusLift: BALL_R * 5.4,
-    focusDepthBias: -BALL_R * 0.6,
-    focusPan: 0,
-    trackingBias: 0.52,
-    smoothing: 0.14,
-    avoidPocketCameras: false,
-    forceActionActivation: true,
-    topViewVariant: 'snooker2d'
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
@@ -5092,7 +5074,7 @@ const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
 const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CUE_PULLBACK_DURATION_MS = 260;
-const AI_CUE_FORWARD_DURATION_MS = 520;
+const AI_CUE_FORWARD_DURATION_MS = 700;
 const AI_STROKE_VISIBLE_DURATION_MS =
   (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -17244,7 +17226,7 @@ const powerRef = useRef(hud.power);
             const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.12;
             const focusPoint2D = focusBall?.active
               ? new THREE.Vector2(focusBall.pos.x, focusBall.pos.y)
-              : pocketCenter2D;
+              : activeShotView.lastBallPos?.clone?.() ?? pocketCenter2D;
             const focusTarget = new THREE.Vector3(
               focusPoint2D.x * worldScaleFactor,
               focusHeightLocal,
@@ -25775,10 +25757,9 @@ const powerRef = useRef(hud.power);
                   pocketView.holdUntil ?? now,
                   now + POCKET_VIEW_POST_POT_HOLD_MS
                 );
-                pocketView.lastBallPos.set(
-                  pocketView.pocketCenter.x,
-                  pocketView.pocketCenter.y
-                );
+                if (b?.pos) {
+                  pocketView.lastBallPos.set(b.pos.x, b.pos.y);
+                }
               }
               break;
             }


### PR DESCRIPTION
### Motivation
- Remove the snooker-style 2D top-view from broadcast/replay so broadcasts use rail overhead and pocket cameras only.
- Reduce overall shot power by 20% to match requested tuning for softer strikes.
- Slow the forward cue stroke for both player and AI to make forward push visibly slower.
- Prevent pocket camera zoom/tilt jumps in replay/pocket views by keeping the last ball view stable until switched.

### Description
- Removed the `rail-overhead-snooker2d` broadcast option from `BROADCAST_SYSTEM_OPTIONS` so the 2D top-view is no longer used for broadcasting or replay camera selection in `PoolRoyale.jsx`.
- Reduced shot speed scaling by changing `SHOT_SPEED_MULTIPLIER` from `1.38` to `1.104` to achieve ~20% less power during shots.
- Slowed player forward stroke by updating `PLAYER_CUE_FORWARD_MIN_MS` from `360` to `450` and `PLAYER_CUE_FORWARD_MAX_MS` from `820` to `1025` to lengthen player forward timing.
- Slowed AI forward stroke by increasing `AI_CUE_FORWARD_DURATION_MS` from `520` to `700` so AI forward push is visibly slower.
- Stabilized pocket/replay camera focus by using `activeShotView.lastBallPos` as the pocket focus fallback and storing the actual potted ball position into `pocketView.lastBallPos` when a ball is pocketed, preventing downward zoom/shift when the ball drops.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and observed Vite report `ready` and the app served at `http://localhost:4173/` (startup succeeded).
- Attempted an automated UI validation via Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot step timed out (Playwright `Page.screenshot` timed out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697afedefbd08320900f76f62ef34101)