### PR TITLE
Update Pool Royale AI recalculation, spin bias, and pocket camera focus

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12465,6 +12465,7 @@ function PoolRoyaleGame({
   const aiPlanCacheRef = useRef({ key: null, plan: null });
   const aiPlanningRef = useRef(null);
   const aiTurnShotCountRef = useRef(0);
+  const aiLastPlannedShotRef = useRef(0);
   const lastTurnRef = useRef(0);
   useEffect(() => {
     aiPlanningRef.current = aiPlanning;
@@ -17247,8 +17248,13 @@ const powerRef = useRef(hud.power);
               activeShotView.anchorOutward = outward.clone();
             }
             const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.12;
+            const focusBallPos2D = focusBall?.pos
+              ? new THREE.Vector2(focusBall.pos.x, focusBall.pos.y)
+              : activeShotView.lastBallPos?.clone?.() ?? null;
             const focusPoint2D =
-              activeShotView.fixedTarget2D?.clone?.() ?? pocketCenter2D;
+              focusBallPos2D ??
+              activeShotView.fixedTarget2D?.clone?.() ??
+              pocketCenter2D;
             const focusTarget = new THREE.Vector3(
               focusPoint2D.x * worldScaleFactor,
               focusHeightLocal,
@@ -23234,6 +23240,12 @@ const powerRef = useRef(hud.power);
         };
         const startAiThinking = () => {
           stopAiThinking();
+          if (aiLastPlannedShotRef.current !== aiTurnShotCountRef.current) {
+            aiLastPlannedShotRef.current = aiTurnShotCountRef.current;
+            aiPlanRef.current = null;
+            aiPlanCacheRef.current = { key: null, plan: null };
+            setAiPlanning(null);
+          }
           if (!allStopped(balls)) {
             aiPlanRef.current = null;
             setAiPlanning(null);

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.02;
+export const STUN_TOPSPIN_BIAS = -0.01;
 export const SPIN_RESPONSE_POWER = 1.35;
 
 export const SPIN_DIRECTIONS = [


### PR DESCRIPTION
### Motivation
- Ensure AI re-evaluates its shot plan after each AI attempt so it recalculates once balls come to rest. 
- Slightly reduce the forward-roll/topspin bias for near-center strikes so the cue ball does not roll as strongly forward. 
- Make pocket camera framing focus on the incoming/target ball rather than always aiming at the pocket center for clearer action framing.

### Description
- Add `aiLastPlannedShotRef` and reset `aiPlanRef`/`aiPlanCacheRef` when `startAiThinking` sees a new AI shot count to force fresh plan computation (`PoolRoyale.jsx`).
- Change pocket view focus point to prefer the incoming ball position (`focusBall.pos`) or the last known ball position (`activeShotView.lastBallPos`) before falling back to the pocket center (`PoolRoyale.jsx`).
- Reduce the stun/center topspin bias by changing `STUN_TOPSPIN_BIAS` from `-0.02` to `-0.01` to slightly lessen forward roll on center/near-center hits (`poolRoyaleSpinUtils.js`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b22d7cd2c8328854c4ec71c4f94eb)