### PR TITLE
Increase Snooker Royal table scale and adjust 2D top-view camera

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -965,7 +965,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.8; // shrink the table footprint slightly less so the playfield reads larger
+const TABLE_DISPLAY_SCALE = 1.06; // shrink the table footprint slightly less so the playfield reads larger
 const CAMERA_DISPLAY_SCALE = 1;
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
@@ -4980,9 +4980,10 @@ const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // match the Pool Royale 2D framing
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
 const TOP_VIEW_RADIUS_SCALE = 1.04; // match the Pool Royale 2D framing
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
+const TOP_VIEW_SCREEN_OFFSET_SCALE = 0.8 / TABLE_DISPLAY_SCALE;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
-  z: PLAY_H * -0.078 // keep the existing vertical alignment
+  x: PLAY_W * -0.045 * TOP_VIEW_SCREEN_OFFSET_SCALE,
+  z: PLAY_H * -0.078 * TOP_VIEW_SCREEN_OFFSET_SCALE
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // match Pool Royale rail overhead framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = 1.06; // match Pool Royale rail overhead framing


### PR DESCRIPTION
### Motivation
- Enlarge the Snooker Royal table and all on-table elements by ~30–35% while preserving layout proportions. 
- Ensure the 2D/top-down camera coordinates stay aligned with the Pool Royale 2D camera after the size change.

### Description
- Updated the table display scale by changing `TABLE_DISPLAY_SCALE` from `0.8` to `1.06` in `webapp/src/pages/Games/SnookerRoyal.jsx` to grow the table and contents.
- Introduced `TOP_VIEW_SCREEN_OFFSET_SCALE` and applied it to `TOP_VIEW_SCREEN_OFFSET` so the 2D camera offsets (`x` and `z`) are scaled to match Pool Royale behavior.
- Changes are localized to `webapp/src/pages/Games/SnookerRoyal.jsx` and preserve existing layout math and world scaling so proportions remain identical.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` which launched Vite successfully and exposed the site at `http://localhost:4173/` (success).
- Attempted automated visual verification using Playwright to capture a screenshot of `/games/snookerroyale`, but the Playwright runs timed out or crashed (failures); no screenshot was produced.
- No unit tests were executed for this change (`npm test` / Jest was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b23c576508328ba14087e0e7aeb3c)