### PR TITLE
Lock pocket cameras and match FOV to standing view

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5054,7 +5054,7 @@ const BACKSPIN_DIRECTION_PREVIEW = 0.68; // lerp strength that pulls the cue-bal
 const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
 const POCKET_VIEW_SMOOTH_TIME = 0.08; // seconds to ease pocket camera transitions
-const POCKET_CAMERA_FOV = Math.max(38, STANDING_VIEW_FOV * 0.88);
+const POCKET_CAMERA_FOV = STANDING_VIEW_FOV;
 const LONG_SHOT_DISTANCE = PLAY_H * 0.5;
 const LONG_SHOT_ACTIVATION_DELAY_MS = 220;
 const LONG_SHOT_ACTIVATION_TRAVEL = PLAY_H * 0.28;
@@ -17248,13 +17248,11 @@ const powerRef = useRef(hud.power);
               activeShotView.anchorOutward = outward.clone();
             }
             const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.12;
-            const focusBallPos2D = focusBall?.pos
-              ? new THREE.Vector2(focusBall.pos.x, focusBall.pos.y)
-              : activeShotView.lastBallPos?.clone?.() ?? null;
             const focusPoint2D =
-              focusBallPos2D ??
-              activeShotView.fixedTarget2D?.clone?.() ??
-              pocketCenter2D;
+              activeShotView.fixedTarget2D?.clone?.() ?? pocketCenter2D;
+            if (!activeShotView.fixedTarget2D) {
+              activeShotView.fixedTarget2D = focusPoint2D.clone();
+            }
             const focusTarget = new THREE.Vector3(
               focusPoint2D.x * worldScaleFactor,
               focusHeightLocal,


### PR DESCRIPTION
### Motivation
- Prevent pocket cameras from zooming or shifting during play so pocket views remain fixed and match the reference framing.
- Ensure pocket camera framing remains consistent with the standing view to avoid unexpected visual jumps.

### Description
- Set `POCKET_CAMERA_FOV` to `STANDING_VIEW_FOV` to remove automatic pocket-camera zoom differences.
- Replace dynamic pocket-focus logic so the pocket view uses `activeShotView.fixedTarget2D` (initialized from the pocket center) instead of following the moving `focusBall`, locking the camera target per-pocket.
- Ensure `activeShotView.fixedPos` / `fixedTarget2D` are created once for a pocket view so the camera remains stable while active.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (local and network URLs). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the screenshot step timed out (Playwright `Page.screenshot` timed out). 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3429d08883289eb0e81f0fe84bf7)