### PR TITLE
Pool Royale: raise cushions/rails, extend pocket jaws, and tune spin controller

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.62;
-export const SPIN_STUN_RADIUS = 0.2;
+export const MAX_SPIN_OFFSET = 0.68;
+export const SPIN_STUN_RADIUS = 0.24;
 export const SPIN_RING1_RADIUS = 0.32;
 export const SPIN_RING2_RADIUS = 0.48;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
@@ -10,8 +10,9 @@ export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL2_MAG = 0.42 * MAX_SPIN_OFFSET;
 export const SPIN_LEVEL3_MAG = 0.82 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.01;
+export const STUN_TOPSPIN_BIAS = 0;
 export const SPIN_RESPONSE_POWER = 1.35;
+export const SPIN_OUTPUT_GAIN = 1.08;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -156,6 +157,13 @@ export const normalizeSpinInput = (spin) => {
     if (boost > 0) {
       result.y = clamp(result.y - boost, -1, 1);
     }
+  }
+  const gain = Number.isFinite(SPIN_OUTPUT_GAIN) ? SPIN_OUTPUT_GAIN : 1;
+  if (gain !== 1) {
+    return {
+      x: clamp(result.x * gain, -1, 1),
+      y: clamp(result.y * gain, -1, 1)
+    };
   }
   return result;
 };


### PR DESCRIPTION
### Motivation
- Prevent balls escaping between cushions and pocket jaws by aligning cushions and making pocket jaws slightly deeper/taller while preserving original placements. 
- Make the wooden rails / jaws sit marginally higher to match the cushion lift so visuals/physics remain coherent. 
- Slightly increase spin responsiveness off the controller while enlarging the central stun zone so centre hits produce less spin and stronger stun.

### Description
- Raised the rail stack by increasing `RAIL_HEIGHT` and adjusted pocket jaw geometry by increasing `POCKET_JAW_DEPTH_SCALE` and `POCKET_JAW_VERTICAL_LIFT` in `PoolRoyale.jsx`. 
- Lifted cushions a bit by changing `CUSHION_EXTRA_LIFT` and `CUSHION_HEIGHT_DROP` so cushion tops/noses move upward to match the jaws. 
- Captured pocket jaw metadata (`table.userData.pocketJaws`) when building jaws and added conversion of jaw arcs into collision segments in `updateCushionSegmentsFromTable` so jaw arcs are included in cushion mapping. 
- Updated collision logic in `reflectRails` to respect jaw capture radii (skip jaw collisions while a ball is already in the jaw capture zone) to avoid false escapes. 
- Tuned spin controller in `poolRoyaleSpinUtils.js` by increasing `MAX_SPIN_OFFSET`, expanding `SPIN_STUN_RADIUS`, setting `STUN_TOPSPIN_BIAS` to `0`, and adding `SPIN_OUTPUT_GAIN` applied in `normalizeSpinInput` to raise overall spin output while keeping centre hits less spinny.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and Vite reported ready (server start succeeded). 
- Attempted automated visual verification with a Playwright script to capture a screenshot of `/games/poolroyale`, but the Playwright browser process crashed (`TargetClosedError`) so the screenshot step failed. 
- No unit/test-suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b45d89c848328906c3a91275097f9)