### PR TITLE
Fix spin input scaling and presets

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,14 +1,14 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.7;
+export const MAX_SPIN_OFFSET = 1;
 export const SPIN_STUN_RADIUS = 0.16;
-export const SPIN_RING1_RADIUS = 0.32;
-export const SPIN_RING2_RADIUS = 0.52;
+export const SPIN_RING1_RADIUS = 0.33;
+export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
+export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
+export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 
@@ -51,28 +51,28 @@ export const SPIN_DIRECTIONS = [
   {
     id: 'top-left',
     label: 'TOPSPIN + LEFT',
-    offset: { x: -0.45, y: 0.45 },
+    offset: { x: -SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'top-right',
     label: 'TOPSPIN + RIGHT',
-    offset: { x: 0.45, y: 0.45 },
+    offset: { x: SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'back-left',
     label: 'BACKSPIN + LEFT',
-    offset: { x: -0.45, y: -0.45 },
+    offset: { x: -SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   },
   {
     id: 'back-right',
     label: 'BACKSPIN + RIGHT',
-    offset: { x: 0.45, y: -0.45 },
+    offset: { x: SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   }


### PR DESCRIPTION
### Motivation
- Make the spin input directions and strength match the provided on-screen reference so visual directions on a portrait phone produce the expected cue-ball behaviour and speed.
- Keep the visual layout of the spin controller unchanged while aligning logical quantization and presets to the reference diagram.

### Description
- In `webapp/src/pages/Games/poolRoyaleSpinUtils.js` set `MAX_SPIN_OFFSET` to `1`, changed `SPIN_RING1_RADIUS` to `0.33` and `SPIN_RING2_RADIUS` to `0.66`, and made `SPIN_LEVEL{1,2,3}_MAG` use the ring radii so ring quantization maps directly to full-strength offsets.
- Updated diagonal spin presets in `SPIN_DIRECTIONS` to use `SPIN_RING2_RADIUS` for consistent mid-ring diagonal strength instead of hardcoded `0.45` values.
- Restored/adjusted the spin controller constants and inline styles in `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/SnookerRoyal.jsx` (`SPIN_CONTROL_DIAMETER_PX`, `SPIN_RING_THICKNESS_PX`, `SPIN_DECORATION_RADII`, `SPIN_DECORATION_DOT_SIZE_PX`, `SPIN_DECORATION_OFFSET_PERCENT`) so the UI sizing and decoration remain consistent with the intended portrait layout.
- Kept the mapping pipeline intact (`normalizeSpinInput` → `computeQuantizedOffsetScaled` → `mapSpinForPhysics`) but changed the quantization radii and magnitudes so on-screen directions produce the expected physics input.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready at `http://localhost:4173/` (succeeded).
- Attempted an automated visual capture with Playwright (`page.goto('/games/poolroyale')` + `page.screenshot`), but the Playwright run timed out so no screenshot was produced (failed).
- No unit tests were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6e9c55e48329afc69659b03a2142)