### PR TITLE
Align spin input to screen directions and retune spin strength/swerve

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1490,9 +1490,9 @@ const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to keep the cue ball rolling after rebounds
 const SWERVE_THRESHOLD = 0.82; // outer 18% of the spin control activates swerve behaviour
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
-const SWERVE_PRE_IMPACT_DRIFT = 0; // keep cue ball path straight even with side spin
+const SWERVE_PRE_IMPACT_DRIFT = 0.35; // allow a visible curve before the cue ball hits the object ball
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
-const SPIN_ENGLISH_DEFLECTION_SCALE = 0; // disable english deflection while preserving spin values
+const SPIN_ENGLISH_DEFLECTION_SCALE = 0.35; // align side-spin deflection with the reference spin directions
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,14 +1,14 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.7;
+export const MAX_SPIN_OFFSET = 1;
 export const SPIN_STUN_RADIUS = 0.16;
-export const SPIN_RING1_RADIUS = 0.32;
-export const SPIN_RING2_RADIUS = 0.52;
+export const SPIN_RING1_RADIUS = 0.33;
+export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL1_MAG = 0.33 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL2_MAG = 0.66 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL3_MAG = 1 * MAX_SPIN_OFFSET;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 
@@ -166,7 +166,7 @@ export const mapUiOffsetToCueFrame = (
       : { x: 0, z: 1 };
   const side = { x: -forwardPlanar.z, z: forwardPlanar.x };
   return {
-    x: -(offsetWorld.x * side.x + offsetWorld.z * side.z),
+    x: offsetWorld.x * side.x + offsetWorld.z * side.z,
     y: offsetWorld.x * forwardPlanar.x + offsetWorld.z * forwardPlanar.z
   };
 };


### PR DESCRIPTION
### Motivation
- Make on-screen spin directions map exactly to the visual directions on the mobile portrait UI and match the reference photo's behaviour. 
- Retune spin quantization and swerve/english deflection so the cue-ball curve and carry match the expected amount of lateral travel and speed from the reference.

### Description
- Fixed the UI→cue-frame mapping by removing the inverted X sign in `mapUiOffsetToCueFrame` so screen left/right translate directly to cue left/right in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Increased reachable spin range and retuned quantization by setting `MAX_SPIN_OFFSET = 1` and updating `SPIN_RING*` radii and `SPIN_LEVEL*_MAG` values in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Re-enabled and adjusted pre-impact swerve and english deflection for Pool Royale by changing `SWERVE_PRE_IMPACT_DRIFT` to `0.35` and `SPIN_ENGLISH_DEFLECTION_SCALE` to `0.35` in `webapp/src/pages/Games/PoolRoyale.jsx` to better match reference curve behaviour.
- Small spin-control visual parameter adjustments (control diameter, ring thickness, decoration sizing and colors) were applied in `PoolRoyale.jsx` and `SnookerRoyal.jsx` but the primary intent of this change is the spin logic and mapping.

### Testing
- No automated tests were run as part of this change; no unit or integration test suites were executed. 
- Changes were committed locally and prepared for PR, but no CI/build or visual capture was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6e9c55e48329afc69659b03a2142)