### PR TITLE
Fix spin horizontal mapping and center scaling

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,14 +1,14 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.7;
+export const MAX_SPIN_OFFSET = 1;
 export const SPIN_STUN_RADIUS = 0.16;
-export const SPIN_RING1_RADIUS = 0.32;
-export const SPIN_RING2_RADIUS = 0.52;
+export const SPIN_RING1_RADIUS = 0.33;
+export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = 0.18 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL2_MAG = 0.45 * MAX_SPIN_OFFSET;
-export const SPIN_LEVEL3_MAG = 0.9 * MAX_SPIN_OFFSET;
+export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
+export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
+export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 
@@ -51,28 +51,28 @@ export const SPIN_DIRECTIONS = [
   {
     id: 'top-left',
     label: 'TOPSPIN + LEFT',
-    offset: { x: -0.45, y: 0.45 },
+    offset: { x: -SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'top-right',
     label: 'TOPSPIN + RIGHT',
-    offset: { x: 0.45, y: 0.45 },
+    offset: { x: SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
   },
   {
     id: 'back-left',
     label: 'BACKSPIN + LEFT',
-    offset: { x: -0.45, y: -0.45 },
+    offset: { x: -SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   },
   {
     id: 'back-right',
     label: 'BACKSPIN + RIGHT',
-    offset: { x: 0.45, y: -0.45 },
+    offset: { x: SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
     effect:
       'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   }
@@ -137,7 +137,7 @@ export const normalizeSpinInput = (spin) => {
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  return computeQuantizedOffsetScaled(x, y);
+  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };
 
 export const mapUiOffsetToCueFrame = (
@@ -179,7 +179,7 @@ export const mapSpinForPhysics = (spin, options = {}) => {
   const quantized = normalizeSpinInput(adjusted);
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    quantized.x,
+    -quantized.x,
     quantized.y,
     cameraRight,
     cameraUp,


### PR DESCRIPTION
### Motivation
- Users reported the spin controller produced reversed left/right responses and that hits near the center produced stronger spin than hits near the edges, so the controller must map on-screen directions exactly and make closer-to-center inputs produce less spin.

### Description
- Replace the quantized ring-based normalization with linear clamping by returning `clampToMaxOffset(x, y, MAX_SPIN_OFFSET)` from `normalizeSpinInput`, and flip the horizontal mapping by negating the UI X when converting to physics in `mapSpinForPhysics` (`-quantized.x`).

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6e9c55e48329afc69659b03a2142)