### PR TITLE
Disable ball deflection and add spin-aware aim preview in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1247,7 +1247,7 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const BALL_BALL_FRICTION = 0.18;
+const BALL_BALL_FRICTION = 0;
 const RAIL_FRICTION = 0.16;
 const STOP_EPS = 0.02;
 const STOP_SOFTENING = 0.9; // ease balls into a stop instead of hard-braking at the speed threshold
@@ -24779,15 +24779,26 @@ const powerRef = useRef(hud.power);
               cueFollowDirSpinAdjusted.normalize();
             }
           }
+          const spinMagnitude = Math.min(
+            1,
+            Math.hypot(physicsSpin.x || 0, physicsSpin.y || 0)
+          );
+          const spinLengthScale = 0.6 + spinMagnitude * 0.9;
           const cueFollowLength =
-            BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
+            BALL_R *
+            (12 + powerStrength * 18) *
+            (1 + spinVerticalInfluence * 0.4) *
+            spinLengthScale;
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
           const cueBackwards = cueFollowDirSpinAdjusted.dot(dir) < 0;
-          cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
+          const cueSpinsAfterImpact = spinMagnitude > 0.05;
+          cueAfter.material.color.setHex(
+            cueSpinsAfterImpact || cueBackwards ? 0xff3b3b : 0x7ce7ff
+          );
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           if (impactRingEnabled) {
@@ -25054,15 +25065,26 @@ const powerRef = useRef(hud.power);
               cueFollowDirSpinAdjusted.normalize();
             }
           }
+          const spinMagnitude = Math.min(
+            1,
+            Math.hypot(remotePhysicsSpin.x || 0, remotePhysicsSpin.y || 0)
+          );
+          const spinLengthScale = 0.6 + spinMagnitude * 0.9;
           const cueFollowLength =
-            BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
+            BALL_R *
+            (12 + powerStrength * 18) *
+            (1 + spinVerticalInfluence * 0.4) *
+            spinLengthScale;
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
           const cueBackwards = cueFollowDirSpinAdjusted.dot(baseDir) < 0;
-          cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
+          const cueSpinsAfterImpact = spinMagnitude > 0.05;
+          cueAfter.material.color.setHex(
+            cueSpinsAfterImpact || cueBackwards ? 0xff3b3b : 0x7ce7ff
+          );
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;


### PR DESCRIPTION
### Motivation
- Remove unintended target-ball deflection caused by ball-ball friction so the object ball follows the aim line exactly. 
- Provide clearer visual feedback for when the cue ball will retain spin after impact by scaling and tinting the post-impact cue-ball direction preview.

### Description
- Set `BALL_BALL_FRICTION` to `0` in `webapp/src/pages/Games/PoolRoyale.jsx` to eliminate friction-based deflection of the target ball. 
- Compute `spinMagnitude` from the current spin and apply a `spinLengthScale` to the post-impact cue-ball guide length so preview line length grows with spin. 
- Tint the post-impact cue-ball preview red when spin is likely to persist after impact (or when the preview indicates a backwards cue path), and apply this behavior for both local and remote aim previews in `PoolRoyale.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b9adb5e3083298000e3fd3c28ec6c)