### PR TITLE
Pool Royale: show spin indicator on cue-follow line and remove spin deflection from target line

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24779,15 +24779,21 @@ const powerRef = useRef(hud.power);
               cueFollowDirSpinAdjusted.normalize();
             }
           }
-          const cueFollowLength =
-            BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
+          const spinMagnitude = Math.hypot(physicsSpin.x || 0, physicsSpin.y || 0);
+          const spinIndicator = THREE.MathUtils.clamp(spinMagnitude, 0, 1);
+          const spinIndicatorActive = spinIndicator > 1e-3;
+          const cueFollowLength = spinIndicatorActive
+            ? BALL_R * (6 + spinIndicator * 30)
+            : BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
           const cueBackwards = cueFollowDirSpinAdjusted.dot(dir) < 0;
-          cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
+          cueAfter.material.color.setHex(
+            spinIndicatorActive ? 0xff3b3b : cueBackwards ? 0xff3b3b : 0x7ce7ff
+          );
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           if (impactRingEnabled) {
@@ -24934,19 +24940,8 @@ const powerRef = useRef(hud.power);
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + powerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
-            const spinTargetDir = resolveTargetSpinDeflection(
-              rawTargetDir,
-              cueDir,
-              physicsSpin,
-              powerStrength,
-              liftStrength
-            );
             const tDir =
-              spinTargetDir && spinTargetDir.lengthSq() > 1e-8
-                ? spinTargetDir
-                : rawTargetDir.lengthSq() > 1e-8
-                  ? rawTargetDir.normalize()
-                  : dir.clone();
+              rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : dir.clone();
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
               BALL_CENTER_Y,
@@ -25054,15 +25049,21 @@ const powerRef = useRef(hud.power);
               cueFollowDirSpinAdjusted.normalize();
             }
           }
-          const cueFollowLength =
-            BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
+          const spinMagnitude = Math.hypot(remotePhysicsSpin.x || 0, remotePhysicsSpin.y || 0);
+          const spinIndicator = THREE.MathUtils.clamp(spinMagnitude, 0, 1);
+          const spinIndicatorActive = spinIndicator > 1e-3;
+          const cueFollowLength = spinIndicatorActive
+            ? BALL_R * (6 + spinIndicator * 30)
+            : BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
           const cueBackwards = cueFollowDirSpinAdjusted.dot(baseDir) < 0;
-          cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
+          cueAfter.material.color.setHex(
+            spinIndicatorActive ? 0xff3b3b : cueBackwards ? 0xff3b3b : 0x7ce7ff
+          );
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;
@@ -25104,18 +25105,8 @@ const powerRef = useRef(hud.power);
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + powerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
-            const spinTargetDir = resolveTargetSpinDeflection(
-              rawTargetDir,
-              cueDir,
-              remotePhysicsSpin,
-              powerStrength
-            );
             const tDir =
-              spinTargetDir && spinTargetDir.lengthSq() > 1e-8
-                ? spinTargetDir
-                : rawTargetDir.lengthSq() > 1e-8
-                  ? rawTargetDir.normalize()
-                  : baseDir.clone();
+              rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : baseDir.clone();
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
               BALL_CENTER_Y,


### PR DESCRIPTION
### Motivation

- Make aiming visuals match the actual collision outcome by removing pre-impact spin/power deflection from the target-ball guide so the target line points to where the object ball will actually go. 
- Provide clearer feedback about cue-ball spin after contact by showing the cue-follow direction line in red when spin is present and scaling its length with spin magnitude so players can see spin amount and direction at a glance.

### Description

- Changed aiming visuals in `webapp/src/pages/Games/PoolRoyale.jsx` to scale the cue-follow guide length based on applied spin magnitude and to switch its color to red when spin is active for both local and remote aim previews. 
- Removed the use of `resolveTargetSpinDeflection` when building the target-ball guide so the target line now uses the straight contact normal (`rawTargetDir`) instead of a spin/power-adjusted vector. 
- Added a small threshold and clamped spin indicator to keep changes stable when spin is near zero and preserved other existing aim/tick rendering and opacity behavior.

### Testing

- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported the app ready and listening, which validates the app builds and serves the changed bundle. (Succeeded)
- Attempted an automated visual smoke check with Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot step timed out; no screenshot produced. (Failed/timeboxed)
- No unit tests were executed for this change since it is a visual tweak to runtime rendering logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b9adb5e3083298000e3fd3c28ec6c)