### PR TITLE
Make Snake & Ladder settings a visible 'Menu' button

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3460,11 +3460,12 @@ export default function SnakeAndLadder() {
         <div className="relative">
           <button
             type="button"
-            aria-label={showConfig ? 'Close game settings' : 'Open game settings'}
+            aria-label={showConfig ? 'Close game settings menu' : 'Open game settings menu'}
             onClick={() => setShowConfig((prev) => !prev)}
-            className="bg-transparent p-2 text-lg text-gray-100 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            className="flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
           >
-            ⚙️
+            <span className="text-base leading-none">☰</span>
+            <span className="leading-none">Menu</span>
           </button>
           {showConfig && (
             <div className="absolute right-0 mt-2 w-[min(22rem,80vw)] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">


### PR DESCRIPTION
### Motivation
- Improve discoverability of the game settings on small/mobile screens by replacing the small gear icon with an explicit, labeled menu control.

### Description
- Replace the gear-only settings toggle in `webapp/src/pages/Games/SnakeAndLadder.jsx` with a labeled `Menu` button, updating the button markup, styling classes and `aria-label` to `Open game settings menu` / `Close game settings menu`.
- Keep the existing settings panel behavior (`showConfig`) and existing settings content unchanged; this is purely a visibility/UX adjustment.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and verified the UI by loading `/games/snake` in a headless browser and saving a screenshot to `artifacts/snake-menu-button.png`, which completed successfully.
- No unit or integration tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba947c7c883299aa4b49ed4d74d74)