### PR TITLE
Fix snake menu alignment

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3468,7 +3468,7 @@ export default function SnakeAndLadder() {
             <span className="leading-none">Menu</span>
           </button>
           {showConfig && (
-            <div className="absolute right-0 mt-2 w-[min(22rem,80vw)] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">
+            <div className="absolute left-0 mt-2 w-[min(22rem,80vw)] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">
               <div className="flex items-center justify-between">
                 <span className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-sky-200/80">
                   Table Setup


### PR DESCRIPTION
### Motivation
- The game settings menu for Snake & Ladder opened on the wrong side of the menu button in portrait view, so the UI needs the menu anchored to the button's left edge to expand toward the right side of the screen.

### Description
- Replace `right-0` with `left-0` on the menu container in `webapp/src/pages/Games/SnakeAndLadder.jsx` so the settings panel is anchored to the left of the menu button.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` which launched Vite successfully, and attempted an automated Playwright screenshot run which failed due to a Chromium SIGSEGV in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697badc99da883299871adc6db979be3)