### PR TITLE
Pool Royale: push pocket cams further, remove cue-follow deflection, snap straight top/backspin

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -137,6 +137,9 @@ export const normalizeSpinInput = (spin) => {
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
+  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE && Math.abs(y) > STRAIGHT_SPIN_DEADZONE) {
+    x = 0;
+  }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };
 


### PR DESCRIPTION
### Motivation
- Improve pocket-camera framing on mobile by moving pocket cameras farther outward so pocket drop shots are clearer. 
- Keep cueball spin behavior present but remove visual deflections in the cue-follow preview so the visual aim matches the actual aim. 
- Ensure straight vertical hits produce true topspin/backspin (hits above center → topspin, below center → backspin) while leaving diagonal/english directions unchanged.

### Description
- Increased pocket camera outward multiplier by setting `POCKET_CAM_OUTWARD_MULTIPLIER` to `1.52` in `webapp/src/pages/Games/PoolRoyale.jsx` so pocket cams sit farther from the table center. 
- Restored power-weighted backspin preview by adding a `powerStrength` parameter to `resolveBackspinPreviewLerp` and passing `powerStrength` at preview call sites so backspin preview responds to shot strength while keeping the preview lerp bounded. 
- Removed spin-induced lateral/vertical adjustments from the cue-follow preview and simplified the follow-length calculation so the cue-follow line tracks the aim line (no deflection) in `PoolRoyale.jsx`. 
- Snapped straight top/backspin to the vertical axis in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by zeroing the sideways component when the input is within the straight deadzone so pure up/down hits produce true follow/draw. 
- Minor related tweaks present in the diff include locking the visual aim to the AI plan during AI preview and prioritizing `plan.potChance` in pot sorting to make AI targeting more deterministic (changes are in `PoolRoyale.jsx`).

### Testing
- No automated tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c631d55f88329b71c14d5a5c183e4)