### PR TITLE
Align corner pocket camera anchors to chrome plate corners

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5677,8 +5677,8 @@ const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
-  BL: new THREE.Vector2(-0.72, 1).normalize(),
-  BR: new THREE.Vector2(0.72, 1).normalize(),
+  BL: new THREE.Vector2(-1, 1).normalize(),
+  BR: new THREE.Vector2(1, 1).normalize(),
   TM: new THREE.Vector2(-1, 0).normalize(),
   BM: new THREE.Vector2(1, 0).normalize()
 });


### PR DESCRIPTION
### Motivation
- Place pocket cameras exactly at the corner chrome plate anchors so corner-pocket views match the red corner marks while preserving existing height/logic.

### Description
- Update `POCKET_CAMERA_OUTWARD` in `webapp/src/pages/Games/PoolRoyale.jsx` to use exact diagonal outward vectors for `BL` and `BR` (`new THREE.Vector2(-1,1)` and `new THREE.Vector2(1,1)`) replacing the previous scaled values.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and captured a page screenshot via a Playwright run, which completed and produced `artifacts/pool-royale-root.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a878ab88329b14e68ceee6af801)