### PR TITLE
Push bottom corner pocket cameras outward toward chrome plate edges

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5677,8 +5677,8 @@ const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
-  BL: new THREE.Vector2(-0.72, 1).normalize(),
-  BR: new THREE.Vector2(0.72, 1).normalize(),
+  BL: new THREE.Vector2(-1.2, 0.85).normalize(),
+  BR: new THREE.Vector2(1.2, 0.85).normalize(),
   TM: new THREE.Vector2(-1, 0).normalize(),
   BM: new THREE.Vector2(1, 0).normalize()
 });


### PR DESCRIPTION
### Motivation
- Move the bottom corner pocket camera anchors further toward the chrome plate corners so the corner-pocket views visually align with the reference photo while preserving existing camera height/logic.

### Description
- Update `POCKET_CAMERA_OUTWARD` in `webapp/src/pages/Games/PoolRoyale.jsx` by replacing the previous bottom corner vectors with the new outward values for `BL` and `BR` (`new THREE.Vector2(-1.2, 0.85).normalize()` and `new THREE.Vector2(1.2, 0.85).normalize()`).
- Keep all other pocket camera IDs and normalization logic unchanged.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which launched successfully.
- Captured a page screenshot via a Playwright script that produced `artifacts/pool-royale-root.png` after an initial timeout and a successful retry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a878ab88329b14e68ceee6af801)