### PR TITLE
Push corner pocket cameras outward and align to corner diagonals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1391,12 +1391,12 @@ const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 18,
   dotThreshold: 0.15,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 0.98,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.22,
   maxOutside: BALL_R * 30,
   heightOffset: BALL_R * 0.9,
   heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.35,
   heightDrop: BALL_R * 0.2,
   distanceScale: 1,
   heightScale: 1,
@@ -5677,8 +5677,8 @@ const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
-  BL: new THREE.Vector2(-0.72, 1).normalize(),
-  BR: new THREE.Vector2(0.72, 1).normalize(),
+  BL: new THREE.Vector2(-1, 1).normalize(),
+  BR: new THREE.Vector2(1, 1).normalize(),
   TM: new THREE.Vector2(-1, 0).normalize(),
   BM: new THREE.Vector2(1, 0).normalize()
 });


### PR DESCRIPTION
### Motivation
- Ensure corner-pocket camera views sit closer to the chrome plate edges so the viewport matches the reference photo by moving cameras farther toward the table corners.
- Improve the short-rail corner camera positioning when side/short heuristics resolve to corner pockets.

### Description
- Increased the short-rail minimum outside distance by changing `POCKET_CAM.minOutsideShort` from `POCKET_CAM_BASE_MIN_OUTSIDE * 0.98` to `* 1.22` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Increased the short-rail outward offset by changing `POCKET_CAM.outwardOffsetShort` from `POCKET_CAM_BASE_OUTWARD_OFFSET * 1` to `* 1.35` in the same file.
- Aligned corner pocket outward vectors to exact diagonals by updating `POCKET_CAMERA_OUTWARD.BL` and `POCKET_CAMERA_OUTWARD.BR` from `new THREE.Vector2(-0.72,1)`/`new THREE.Vector2(0.72,1)` to `new THREE.Vector2(-1,1)`/`new THREE.Vector2(1,1)` (normalized).

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server came up successfully.
- Captured a page screenshot using a Playwright script which produced `artifacts/pool-royale-root.png`, and the run completed successfully after one retry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a878ab88329b14e68ceee6af801)