### PR TITLE
Push corner pocket cameras outward to rail edge and align diagonals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1391,12 +1391,12 @@ const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 18,
   dotThreshold: 0.15,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 0.98,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.6,
   maxOutside: BALL_R * 30,
   heightOffset: BALL_R * 0.9,
   heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9,
   heightDrop: BALL_R * 0.2,
   distanceScale: 1,
   heightScale: 1,
@@ -5677,8 +5677,8 @@ const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
-  BL: new THREE.Vector2(-0.72, 1).normalize(),
-  BR: new THREE.Vector2(0.72, 1).normalize(),
+  BL: new THREE.Vector2(-1, 1).normalize(),
+  BR: new THREE.Vector2(1, 1).normalize(),
   TM: new THREE.Vector2(-1, 0).normalize(),
   BM: new THREE.Vector2(1, 0).normalize()
 });


### PR DESCRIPTION
### Motivation
- Make corner-pocket camera views sit on the outer wooden rail edge where the short and long rails meet so the viewport matches the reference look. 
- Ensure short-rail (corner) camera anchors are moved farther outward than the previous attempt so the view is visually on the corner rail edge.
- Normalize corner outward directions to exact corner diagonals so the camera orientation matches the table corners.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to increase the short-rail minimum outside distance by setting `POCKET_CAM.minOutsideShort` to `POCKET_CAM_BASE_MIN_OUTSIDE * 1.6`.
- Increased the short-rail outward offset by setting `POCKET_CAM.outwardOffsetShort` to `POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9`.
- Aligned corner pocket outward vectors to exact diagonals by setting `POCKET_CAMERA_OUTWARD.BL` to `new THREE.Vector2(-1, 1).normalize()` and `POCKET_CAMERA_OUTWARD.BR` to `new THREE.Vector2(1, 1).normalize()`.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the Vite server reported ready (local and network URLs), which succeeded.
- Captured a page screenshot using a Playwright script that saved `artifacts/pool-royale-root.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a878ab88329b14e68ceee6af801)