### PR TITLE
Push corner pocket cameras further outward and normalize corner diagonals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1391,12 +1391,12 @@ const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 18,
   dotThreshold: 0.15,
   minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 0.98,
+  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 + BALL_DIAMETER * 3,
   maxOutside: BALL_R * 30,
   heightOffset: BALL_R * 0.9,
   heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1,
+  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 + BALL_DIAMETER * 3,
   heightDrop: BALL_R * 0.2,
   distanceScale: 1,
   heightScale: 1,
@@ -5677,8 +5677,8 @@ const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
-  BL: new THREE.Vector2(-0.72, 1).normalize(),
-  BR: new THREE.Vector2(0.72, 1).normalize(),
+  BL: new THREE.Vector2(-1, 1).normalize(),
+  BR: new THREE.Vector2(1, 1).normalize(),
   TM: new THREE.Vector2(-1, 0).normalize(),
   BM: new THREE.Vector2(1, 0).normalize()
 });


### PR DESCRIPTION
### Motivation
- Corner pocket cameras were still visually short of the rail join so the corner views need to move farther outward by another ball diameter to match the rail edge.  
- Corner outward vectors used approximated values and should be exact diagonals for consistent, symmetric camera orientation at table corners.

### Description
- Increased `POCKET_CAM.minOutsideShort` to `POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 + BALL_DIAMETER * 3` in `webapp/src/pages/Games/PoolRoyale.jsx` to move short-rail corner cameras farther outside.  
- Increased `POCKET_CAM.outwardOffsetShort` to `POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 + BALL_DIAMETER * 3` to push the short-rail outward offset further.  
- Normalized corner outward vectors by setting `POCKET_CAMERA_OUTWARD.BL` to `new THREE.Vector2(-1, 1).normalize()` and `POCKET_CAMERA_OUTWARD.BR` to `new THREE.Vector2(1, 1).normalize()` for exact diagonal directions.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, which succeeded.  
- Ran a Playwright screenshot script; the first `page.goto` attempt timed out (failed), then a subsequent run succeeded and saved `artifacts/pool-royale-root.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a878ab88329b14e68ceee6af801)