### PR TITLE
Adjust Pool Royale pocket camera inward offset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1374,7 +1374,7 @@ const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // rais
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
-const POCKET_CAM_OUTWARD_MULTIPLIER = 1.85;
+const POCKET_CAM_OUTWARD_MULTIPLIER = 1.7;
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +


### PR DESCRIPTION
### Motivation
- Pocket camera views for Pool Royale were sitting slightly too far outward, so the pocket framing needs to be pulled a bit closer for better visual composition.

### Description
- Reduce `POCKET_CAM_OUTWARD_MULTIPLIER` from `1.85` to `1.7` in `webapp/src/pages/Games/PoolRoyale.jsx`, which lowers the computed `POCKET_CAM_BASE_OUTWARD_OFFSET` and moves pocket cameras slightly inward.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 5173` and confirmed the local server responded `HTTP/1.1 200 OK`; attempted an automated Playwright screenshot but the headless browser crashed (SIGSEGV) so no visual capture was produced, and no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb9f9846c832992fe68ea54e10e86)