### PR TITLE
Tighten Pool Royale pocket camera framing and reduce shot power by 25%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1375,6 +1375,7 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
+const POCKET_CAM_INWARD_SCALE = 0.92; // pull pocket cameras slightly closer for a tighter, saner framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -1390,13 +1391,17 @@ const POCKET_CAM_BASE_OUTWARD_OFFSET =
 const POCKET_CAM = Object.freeze({
   triggerDist: CAPTURE_R * 18,
   dotThreshold: 0.15,
-  minOutside: POCKET_CAM_BASE_MIN_OUTSIDE,
-  minOutsideShort: POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 + BALL_DIAMETER * 2.5,
+  minOutside: POCKET_CAM_BASE_MIN_OUTSIDE * POCKET_CAM_INWARD_SCALE,
+  minOutsideShort:
+    POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
+    BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
   heightOffset: BALL_R * 0.9,
   heightOffsetShortMultiplier: 0.9,
-  outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET,
-  outwardOffsetShort: POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 + BALL_DIAMETER * 2.5,
+  outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
+  outwardOffsetShort:
+    POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 * POCKET_CAM_INWARD_SCALE +
+    BALL_DIAMETER * 2.5,
   heightDrop: BALL_R * 0.2,
   distanceScale: 1,
   heightScale: 1,
@@ -1499,9 +1504,9 @@ const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the c
 const SPIN_ENGLISH_DEFLECTION_SCALE = 0; // disable english deflection while preserving spin values
 const CUE_AFTER_SPIN_DEFLECTION_SCALE = 0; // remove spin deflection so the cue follow line tracks the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
-// Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
+// Apply an additional 25% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
-const SHOT_POWER_REDUCTION = 0.85;
+const SHOT_POWER_REDUCTION = 0.75;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Make pocket camera views a bit tighter/saner so pocket framing feels closer and clearer during potting shots.
- Reduce overall shot power to make strikes softer and more consistent with mobile play pacing (requested 25% reduction). 

### Description
- Added `POCKET_CAM_INWARD_SCALE` and applied it to pocket camera offsets by scaling `minOutside`, `minOutsideShort`, `outwardOffset`, and `outwardOffsetShort` in `POCKET_CAM` for slightly inward camera placement. 
- Reduced global shot power by changing `SHOT_POWER_REDUCTION` from `0.85` to `0.75` and updated the accompanying comment to reflect a 25% reduction. 
- All edits were made in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change (no test suite executed during the edit). 
- The file was updated and committed successfully (`webapp/src/pages/Games/PoolRoyale.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ccb5ccf008329a3a97f7ee62a1bf2)