### PR TITLE
Restore side-spin rail throw, tighten pocket cameras, and expand commentary (Albanian/Italian + UK labels)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -994,6 +994,34 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 0.98, pitch: 0.96, volume: 1 },
       [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
     }
+  },
+  {
+    id: 'balkan-booth',
+    label: 'Albanian Booth',
+    description: 'Albanian commentary with authentic cadence',
+    language: 'sq',
+    voiceHints: {
+      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'male', 'Arben', 'Dritan', 'Erion'],
+      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'female', 'Elira', 'Arta', 'Sara']
+    },
+    speakerSettings: {
+      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.05, volume: 1 }
+    }
+  },
+  {
+    id: 'italian-spotlight',
+    label: 'Italian Desk',
+    description: 'Italian play-by-play with classic flair',
+    language: 'it',
+    voiceHints: {
+      [POOL_ROYALE_SPEAKERS.lead]: ['it-IT', 'Italian', 'male', 'Luca', 'Marco', 'Gianni'],
+      [POOL_ROYALE_SPEAKERS.analyst]: ['it-IT', 'Italian', 'female', 'Giulia', 'Sofia', 'Chiara']
+    },
+    speakerSettings: {
+      [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.08, volume: 1 }
+    }
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
@@ -1375,7 +1403,7 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
-const POCKET_CAM_INWARD_SCALE = 0.85; // pull pocket cameras further inward for tighter framing
+const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -6214,6 +6242,25 @@ function applyRailImpulse(ball, impact) {
       TMP_VEC3_D.copy(TMP_VEC3_B).cross(impulseT),
       1 / BALL_INERTIA
     );
+  }
+  if (impact?.tangent && ball.omega && RAIL_SPIN_THROW_SCALE !== 0) {
+    const sideSpin = ball.omega.y;
+    if (Math.abs(sideSpin) > 1e-4) {
+      const throwScale =
+        clamp(
+          sideSpin / Math.max(RAIL_SPIN_THROW_REF_SPEED, 1e-6),
+          -1,
+          1
+        ) * RAIL_SPIN_THROW_SCALE;
+      if (Math.abs(throwScale) > 1e-6) {
+        TMP_VEC3_F.set(impact.tangent.x, 0, impact.tangent.y);
+        if (TMP_VEC3_F.lengthSq() > 1e-8) {
+          TMP_VEC3_F.normalize();
+          TMP_VEC3_C.addScaledVector(TMP_VEC3_F, throwScale);
+          ball.omega.y *= 1 - Math.min(Math.abs(throwScale) * 0.35, 0.35);
+        }
+      }
+    }
   }
   ball.vel.set(TMP_VEC3_C.x, TMP_VEC3_C.z);
 }
@@ -11145,6 +11192,10 @@ function PoolRoyaleGame({
     () => activeVariant?.id === 'uk' && activeVariant?.ballSet === 'american',
     [activeVariant]
   );
+  const isUkClassicSet = useMemo(
+    () => activeVariant?.id === 'uk' && !isUkAmericanSet,
+    [activeVariant, isUkAmericanSet]
+  );
   const activeTableSize = useMemo(
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
@@ -11398,6 +11449,7 @@ function PoolRoyaleGame({
   const commentaryQueueRef = useRef([]);
   const commentarySpeakingRef = useRef(false);
   const commentaryLastEventAtRef = useRef(0);
+  const commentaryIntroPlayedRef = useRef(false);
   const pendingCommentaryLinesRef = useRef(null);
   useEffect(() => {
     skipAllReplaysRef.current = skipAllReplays;
@@ -13458,6 +13510,8 @@ const powerRef = useRef(hud.power);
       const colorKey = String(entry.color || '').toUpperCase();
       const idValue = typeof entry.id === 'string' ? entry.id : '';
       if (colorKey === 'CUE' || entry.id === 'cue') return 'the cue ball';
+      if (isUkClassicSet && colorKey === 'RED') return 'a red';
+      if (isUkClassicSet && colorKey === 'YELLOW') return 'a yellow';
       const idMatch = /(\d+)/.exec(idValue) || /BALL_(\d+)/.exec(colorKey);
       if (idMatch) return `the ${parseInt(idMatch[1], 10)} ball`;
       if (colorKey === 'BLACK') return isUkAmericanSet ? 'the 8 ball' : 'the black';
@@ -13471,7 +13525,7 @@ const powerRef = useRef(hud.power);
       if (colorKey === 'SOLID') return 'a solid';
       return `the ${colorKey.toLowerCase()}`;
     },
-    [isUkAmericanSet]
+    [isUkAmericanSet, isUkClassicSet]
   );
 
   const resolvePotSummary = useCallback(
@@ -13619,6 +13673,33 @@ const powerRef = useRef(hud.power);
     return POOL_ROYALE_SPEAKERS.analyst;
   }, []);
 
+  const resolveTournamentRecap = useCallback(
+    (language = 'en') => {
+      if (!tournamentMode || typeof window === 'undefined') return '';
+      try {
+        const raw = window.localStorage.getItem(tournamentLastResultKey);
+        if (!raw) return '';
+        const parsed = JSON.parse(raw);
+        const scoreA = Number(parsed?.p1);
+        const scoreB = Number(parsed?.p2);
+        if (!Number.isFinite(scoreA) || !Number.isFinite(scoreB)) return '';
+        const scoreline = `${scoreA}-${scoreB}`;
+        const normalized = String(language || '').toLowerCase();
+        if (normalized.startsWith('it')) {
+          return `Arriva da un successo ${scoreline} nel turno precedente.`;
+        }
+        if (normalized.startsWith('sq')) {
+          return `Vjen pas fitores ${scoreline} në raundin e kaluar.`;
+        }
+        return `Coming off a ${scoreline} win in the last round.`;
+      } catch (err) {
+        console.warn('Failed to read tournament recap', err);
+        return '';
+      }
+    },
+    [tournamentLastResultKey, tournamentMode]
+  );
+
   const enqueuePoolCommentaryEvent = useCallback(
     (event, context = {}, options = {}) => {
       const speaker = options.speaker ?? resolveCommentarySpeaker();
@@ -13645,6 +13726,66 @@ const powerRef = useRef(hud.power);
       variantKey
     ]
   );
+
+  useEffect(() => {
+    if (commentaryIntroPlayedRef.current) return;
+    if (!commentarySupported) return;
+    if (hud.turn == null) return;
+    const scoreA = frameState?.players?.A?.score ?? 0;
+    const scoreB = frameState?.players?.B?.score ?? 0;
+    const scoreline = resolveScoreline(scoreA, scoreB);
+    const language = activeCommentaryPreset?.language ?? commentaryPresetId;
+    const tournamentRecap = resolveTournamentRecap(language);
+    const context = {
+      player: resolveSeatLabel('A'),
+      opponent: resolveSeatLabel('B'),
+      playerScore: scoreA,
+      opponentScore: scoreB,
+      playerPoints: scoreA,
+      opponentPoints: scoreB,
+      scoreline,
+      ballSet: activeVariant?.ballSet,
+      tournamentRecap
+    };
+    const lines = [
+      {
+        speaker: POOL_ROYALE_SPEAKERS.lead,
+        text: buildCommentaryLine({
+          event: 'intro',
+          variant: activeVariant?.id ?? variantKey ?? '9ball',
+          speaker: POOL_ROYALE_SPEAKERS.lead,
+          language,
+          context
+        })
+      },
+      {
+        speaker: POOL_ROYALE_SPEAKERS.analyst,
+        text: buildCommentaryLine({
+          event: 'introReply',
+          variant: activeVariant?.id ?? variantKey ?? '9ball',
+          speaker: POOL_ROYALE_SPEAKERS.analyst,
+          language,
+          context
+        })
+      }
+    ];
+    enqueuePoolCommentary(lines, { priority: true, preset: activeCommentaryPreset });
+    commentaryIntroPlayedRef.current = true;
+  }, [
+    activeCommentaryPreset,
+    activeVariant?.ballSet,
+    activeVariant?.id,
+    commentaryPresetId,
+    commentarySupported,
+    enqueuePoolCommentary,
+    frameState?.players?.A?.score,
+    frameState?.players?.B?.score,
+    hud.turn,
+    resolveScoreline,
+    resolveSeatLabel,
+    resolveTournamentRecap,
+    variantKey
+  ]);
 
   const maybeSpeakShotCommentary = useCallback(
     ({
@@ -26935,7 +27076,13 @@ const powerRef = useRef(hud.power);
                 : colorKey.startsWith('BALL_')
                   ? /BALL_(\d+)/.exec(colorKey)
                   : null;
-            const ballNumber = idMatch ? parseInt(idMatch[1], 10) : null;
+            const isUkRedYellow =
+              isUkClassicSet && (colorKey === 'RED' || colorKey === 'YELLOW');
+            const ballNumber = isUkRedYellow
+              ? null
+              : idMatch
+                ? parseInt(idMatch[1], 10)
+                : null;
             const isStripe =
               (isUkAmericanSet && ballNumber != null && ballNumber >= 9) ||
               colorKey === 'STRIPE';
@@ -26958,7 +27105,9 @@ const powerRef = useRef(hud.power);
                     ? 'ST'
                     : isSolid
                       ? 'SO'
-                      : colorKey.charAt(0);
+                      : isUkRedYellow
+                        ? ''
+                        : colorKey.charAt(0);
             const badgeNumber =
               ballNumber != null ? ballNumber : colorKey === 'BLACK' ? 8 : null;
             const textColor = colorKey === 'BLACK' ? '#f8fafc' : '#0f172a';
@@ -26981,7 +27130,9 @@ const powerRef = useRef(hud.power);
               pattern: isStripe ? 'stripe' : 'solid',
               number: ballNumber ?? (colorKey === 'BLACK' ? 8 : null)
             });
-            const altLabel = `Pocketed ${label}`;
+            const altLabel = isUkRedYellow
+              ? `Pocketed ${colorKey.toLowerCase()} ball`
+              : `Pocketed ${label}`;
             return (
               <span
                 key={`${entry.id ?? colorKey}-${index}`}
@@ -27034,6 +27185,7 @@ const powerRef = useRef(hud.power);
       darkenHex,
       getBallPreview,
       isUkAmericanSet,
+      isUkClassicSet,
       pottedGap,
       pottedNumberBadgeSize,
       pottedTokenSize

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -35,12 +35,14 @@ const DEFAULT_CONTEXT = Object.freeze({
   groupPrimary: 'reds',
   groupSecondary: 'yellows',
   ballSet: 'uk',
-  rackNumber: 'this rack'
+  rackNumber: 'this rack',
+  tournamentRecap: ''
 });
 
 const ENGLISH_TEMPLATES = Object.freeze({
   common: {
     intro: [
+      'Welcome to {arena}. {speaker} with you for {player} versus {opponent}. {tournamentRecap}',
       'Welcome to {arena}. {speaker} here. {player} faces {opponent}; {scoreline} in {variantName}.',
       'Match time at {arena}. {speaker} with you. {player} versus {opponent} in {variantName}, {scoreline}.',
       'Good evening from {arena}. {speaker} on the call. {player} and {opponent} are locked at {playerScore}-{opponentScore}.'
@@ -78,7 +80,12 @@ const ENGLISH_TEMPLATES = Object.freeze({
     pot: [
       '{player} pots {targetBall} into {pocket}, cue ball held in good position.',
       'Pot: {targetBall} in {pocket}.',
-      '{player} sends {targetBall} down the {pocket} with smooth control.'
+      '{player} sends {targetBall} down the {pocket} with smooth control.',
+      'Superb pot on {targetBall} into {pocket}, and the cue ball is set for the next shot.',
+      '{player} drops {targetBall} in {pocket} and leaves a perfect angle for the next target.',
+      'Beautiful touch on {targetBall} into {pocket}; position play is spot on.',
+      '{player} knocks {targetBall} into {pocket}, cue ball drifting into prime position.',
+      'Clinical pot on {targetBall} to {pocket}—that leaves a natural path to the next ball.'
     ],
     combo: [
       '{player} combos {targetBall} into {pocket}, great sighting.',
@@ -628,7 +635,7 @@ const LOCALIZED_TEMPLATES = Object.freeze({
     ...ENGLISH_TEMPLATES,
     common: {
       intro: [
-        'Mirë se vini në {arena}. Me ju është {speaker}. {player} përballë {opponent}; {scoreline} në {variantName}.'
+        'Mirë se vini në {arena}. Me ju është {speaker}. {player} përballë {opponent}. {tournamentRecap}'
       ],
       introReply: [
         'Faleminderit, {speaker}. Kontrolli i topit të bardhë dhe pozicionimi vendosin gjithçka.'
@@ -649,7 +656,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         'Goditje me presion; prekja e butë dhe efekti janë vendimtarë.'
       ],
       pot: [
-        '{player} fut {targetBall} në {pocket} dhe ruan pozicionin.'
+        '{player} fut {targetBall} në {pocket} dhe ruan pozicionin.',
+        'Goditje elegante: {targetBall} në {pocket}, topi i bardhë gati për goditjen tjetër.',
+        '{player} e fut {targetBall} në {pocket} me kontroll të pastër dhe kënd të përsosur.'
       ],
       combo: [
         '{player} bën kombinim dhe fut {targetBall} në {pocket}.'
@@ -707,6 +716,92 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       freeBall: ['{player} ka top të lirë dhe dy vizita.'],
       blackBall: ['Tani topi i zi; kërkohet kënd i përsosur.']
     }
+  },
+  it: {
+    ...ENGLISH_TEMPLATES,
+    common: {
+      intro: [
+        'Benvenuti a {arena}. {speaker} con voi per {player} contro {opponent}. {tournamentRecap}'
+      ],
+      introReply: [
+        'Grazie, {speaker}. Controllo della battente e posizione faranno la differenza.'
+      ],
+      breakShot: [
+        '{player} si prepara al break: apertura e controllo della bianca sono fondamentali.'
+      ],
+      breakResult: [
+        'Buon break, tavolo aperto e linee chiare.'
+      ],
+      openTable: [
+        'Tavolo aperto; {player} cerca angoli naturali e continuità.'
+      ],
+      safety: [
+        '{player} sceglie la difesa e nasconde la battente.'
+      ],
+      pressure: [
+        'Tiro di pressione: tocco morbido ed effetto preciso.'
+      ],
+      pot: [
+        '{player} imbuca {targetBall} in {pocket} e tiene una buona posizione.',
+        'Gran pot su {targetBall} in {pocket}, la bianca resta perfetta per la prossima.',
+        '{player} manda {targetBall} in {pocket} con controllo e lascia un angolo ideale.'
+      ],
+      combo: [
+        '{player} gioca la combinazione e imbuca {targetBall} in {pocket}.'
+      ],
+      bank: [
+        '{player} va di sponda e imbuca {targetBall} in {pocket}.'
+      ],
+      kick: [
+        '{player} deve andare di sponda per trovare la palla.'
+      ],
+      jump: [
+        '{player} esegue un salto per superare l’ostacolo.'
+      ],
+      miss: [
+        '{player} sbaglia la pot; occasione per {opponent}.'
+      ],
+      foul: [
+        'Fallo di {player}.'
+      ],
+      inHand: [
+        '{opponent} ha palla in mano.'
+      ],
+      runout: [
+        '{player} è in ritmo; la chiusura è possibile.'
+      ],
+      hillHill: [
+        'Rack decisivo—tensione al massimo.'
+      ],
+      frameWin: [
+        '{player} vince il rack.'
+      ],
+      matchWin: [
+        'Match finito. {player} vince {playerScore}-{opponentScore}.'
+      ],
+      outro: [
+        'Da {arena} è tutto, grazie per averci seguito.'
+      ]
+    },
+    nineBall: {
+      variantName: '9-bilie americano',
+      rotation: ['Nel 9-bilie si colpisce sempre per prima la più bassa.'],
+      goldenBreak: ['Se la 9 entra al break, è finita subito.'],
+      comboNine: ['{player} vede la combinazione sulla 9—chance enorme.'],
+      pushOut: ['{player} gioca il push-out per migliorare la posizione.']
+    },
+    eightBallUs: {
+      variantName: '8-bilie americano',
+      groupCall: ['Tavolo aperto tra {groupPrimary} e {groupSecondary}.'],
+      inHand: ['{opponent} ha palla in mano—grande vantaggio.'],
+      eightBall: ['Ora la 8 è in gioco; la posizione decide.']
+    },
+    eightBallUk: {
+      variantName: '8-bilie UK',
+      groupCall: ['Regole UK: {groupPrimary} e {groupSecondary} sono ancora aperti.'],
+      freeBall: ['{player} ha una free ball e due visite.'],
+      blackBall: ['La nera è in gioco; l’angolo è decisivo.']
+    }
   }
 });
 
@@ -760,6 +855,7 @@ const resolveLanguageKey = (language = 'en') => {
   if (normalized.startsWith('fr')) return 'fr';
   if (normalized.startsWith('ar')) return 'ar';
   if (normalized.startsWith('sq')) return 'sq';
+  if (normalized.startsWith('it')) return 'it';
   if (normalized.startsWith('en')) return 'en';
   return normalized || 'en';
 };


### PR DESCRIPTION
### Motivation
- Restore realistic post-impact side-spin behaviour (rail “throw”) while keeping the pre-impact aim/preview lines visually straight. 
- Tighten pocket camera framing for better pot visuals. 
- Improve commentary: add Albanian and Italian voice presets, richer pot compliments, and make commentary aware of tournament recap context; treat UK red/yellow balls as color labels (no numbers on HUD potted row).

### Description
- Physics: reintroduced a rail-side spin throw in cushion impulse handling inside `applyRailImpulse` so side spin contributes a lateral throw on rail impacts while damping ball angular velocity slightly (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Cameras: pulled pocket cameras slightly inward by changing `POCKET_CAM_INWARD_SCALE` from `0.85` to `0.82` and propagated the scale into pocket camera geometry (`webapp/src/pages/Games/PoolRoyale.jsx`).
- UK ball labeling & HUD: added `isUkClassicSet` detection and updated `resolveBallLabel` and the potted-row renderer to show red/yellow as color labels and to hide numeric badges for those UK red/yellow balls (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Commentary: added Albanian (`sq`) and Italian (`it`) commentary presets to `POOL_ROYALE_COMMENTARY_PRESETS`, expanded pot compliment templates and localized intros, and extended `resolveLanguageKey` to accept Italian (`webapp/src/utils/poolRoyaleCommentary.js`).
- Intro & tournament recap: added an intro playback effect that enqueues lead/analyst intro lines (with optional tournament recap pulled from `localStorage`) the first time commentary is available (`webapp/src/pages/Games/PoolRoyale.jsx`).
- UI text/content: added multiple new pot compliment templates and localized intro variants for sq/it and ensured `buildCommentaryLine` picks them via language key.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported the server ready (local/ network URLs). (success)
- Attempted an automated UI screenshot via Playwright against the running dev server, but the screenshot step timed out (Playwright timeout). (failed)
- No unit test or CI suite was executed as part of this change; code edits were saved and committed locally. (n/a)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce3ab0bf483298a5dd512e86c7287)