### PR TITLE
Configure TonConnect TWA return URL from Telegram bot/start params

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -48,6 +48,7 @@ import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
+import { getTelegramReturnUrl } from './utils/telegram.js';
 
 export default function App() {
   useTelegramAuth();
@@ -56,10 +57,14 @@ export default function App() {
   useNativePushNotifications();
 
   const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
+  const twaReturnUrl = getTelegramReturnUrl();
 
   return (
     <BrowserRouter>
-      <TonConnectUIProvider manifestUrl={manifestUrl}>
+      <TonConnectUIProvider
+        manifestUrl={manifestUrl}
+        actionsConfiguration={{ twaReturnUrl }}
+      >
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -40,6 +40,40 @@ export function getTelegramId() {
   return null;
 }
 
+export function getTelegramBotUsername() {
+  if (typeof document === 'undefined') return '';
+  const meta = document.querySelector('meta[name="telegram:web_app:bot_username"]');
+  const content = meta?.getAttribute('content') || meta?.content || '';
+  return content.trim();
+}
+
+export function getTelegramStartParam() {
+  if (typeof window === 'undefined') return '';
+  const initStart =
+    window?.Telegram?.WebApp?.initDataUnsafe?.start_param ||
+    window?.Telegram?.WebApp?.initDataUnsafe?.startParam;
+  if (initStart) return String(initStart);
+  const params = new URLSearchParams(window.location.search);
+  const urlStart =
+    params.get('tgWebAppStartParam') ||
+    params.get('start_param') ||
+    params.get('startapp') ||
+    params.get('start') ||
+    params.get('ref');
+  if (urlStart) return urlStart;
+  return localStorage.getItem('telegramStartParam') || '';
+}
+
+export function getTelegramReturnUrl() {
+  if (typeof window === 'undefined') return undefined;
+  const botUsername = getTelegramBotUsername();
+  if (!botUsername) return undefined;
+  const startParam = getTelegramStartParam();
+  const base = `https://t.me/${botUsername}`;
+  if (!startParam) return base;
+  return `${base}?startapp=${encodeURIComponent(startParam)}`;
+}
+
 function generateAccountId() {
   if (typeof window === 'undefined') return null;
   if (window.crypto?.randomUUID) {


### PR DESCRIPTION
### Motivation
- Ensure TonConnect UI uses a proper return URL when opened from Telegram mini-apps so wallets (Telegram/Ton Keeper) can redirect back to the mini-app after the user approves/declines actions.

### Description
- Added helpers in `webapp/src/utils/telegram.js`: `getTelegramBotUsername`, `getTelegramStartParam`, and `getTelegramReturnUrl` to derive a TWA return URL from the page meta tag, init data, URL params, or stored start param.
- Wired the return URL into the TonConnect UI by importing `getTelegramReturnUrl` in `webapp/src/App.jsx` and passing it as `actionsConfiguration={{ twaReturnUrl }}` to `TonConnectUIProvider`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0030d26083298c73dfa586a07cca)