### PR TITLE
Fix TonConnect return flow for Telegram web app

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -48,6 +48,7 @@ import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
+import { isTelegramWebView } from './utils/telegram.js';
 
 export default function App() {
   useTelegramAuth();
@@ -56,10 +57,18 @@ export default function App() {
   useNativePushNotifications();
 
   const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
+  const returnUrl = window.location.href;
+  const twaReturnUrl = 'https://t.me/TonPlaygramBot/webapp';
 
   return (
     <BrowserRouter>
-      <TonConnectUIProvider manifestUrl={manifestUrl}>
+      <TonConnectUIProvider
+        manifestUrl={manifestUrl}
+        actionsConfiguration={{
+          returnUrl,
+          twaReturnUrl: isTelegramWebView() ? twaReturnUrl : undefined,
+        }}
+      >
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />


### PR DESCRIPTION
### Motivation
- Ensure the TonConnect UI returns the user to the correct page after wallet approval and that the flow works inside the Telegram WebApp/TWA.

### Description
- Add `actionsConfiguration` to `TonConnectUIProvider` in `webapp/src/App.jsx`, setting `returnUrl` to `window.location.href` and conditionally providing `twaReturnUrl` when `isTelegramWebView()` is true so Telegram mini app flows return to `https://t.me/TonPlaygramBot/webapp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0030d26083298c73dfa586a07cca)