### PR TITLE
Fix Pool Royale cue replay visibility, cue timing, and commentary voices

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -998,11 +998,11 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'albanian-booth',
     label: 'Albanian Booth',
-    description: 'Albanian commentary with authentic cadence',
-    language: 'sq',
+    description: 'Shqip commentary with native cadence',
+    language: 'sq-AL',
     voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'sq', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'sq', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
+      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
+      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
@@ -1012,11 +1012,11 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'italian-gallery',
     label: 'Italian Gallery',
-    description: 'Italian commentary with rich pacing',
-    language: 'it',
+    description: 'Italian booth with authentic broadcast rhythm',
+    language: 'it-IT',
     voiceHints: {
       [POOL_ROYALE_SPEAKERS.lead]: ['it-IT', 'it', 'Italian', 'male', 'Marco', 'Luca', 'Giovanni', 'Alessandro'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['it-IT', 'it', 'Italian', 'female', 'Giulia', 'Chiara', 'Francesca', 'Elena']
+      [POOL_ROYALE_SPEAKERS.analyst]: ['it-IT', 'Italian', 'female', 'Giulia']
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1, pitch: 0.98, volume: 1 },
@@ -1599,7 +1599,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.18; // widen the visible air gap so the blue tip never kisses the cue ball
-const CUE_TIP_GAP = BALL_R * 1.02 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
+const CUE_TIP_GAP = BALL_R * 1.12 + CUE_TIP_CLEARANCE; // pull the blue tip farther back so it stays visible
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -1612,14 +1612,14 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_PULL_RETURN_PUSH = 0.78; // push the cue forward to its start point more decisively after a pull
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // ensure the forward push is visible even on short strokes
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.4; // ensure the forward push is visible even on short strokes
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 2.6; // cap the forward travel so the cue never overshoots the ball too far
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
-const PLAYER_CUE_FORWARD_MIN_MS = 560;
-const PLAYER_CUE_FORWARD_MAX_MS = 1280;
+const PLAYER_CUE_FORWARD_MIN_MS = 700;
+const PLAYER_CUE_FORWARD_MAX_MS = 1500;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
@@ -5113,7 +5113,7 @@ const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
 const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CUE_PULLBACK_DURATION_MS = 260;
-const AI_CUE_FORWARD_DURATION_MS = 820;
+const AI_CUE_FORWARD_DURATION_MS = 980;
 const AI_STROKE_VISIBLE_DURATION_MS =
   (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -5163,7 +5163,7 @@ const PLAYER_FORWARD_SLOWDOWN = 1;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1;
+const REPLAY_CUE_STROKE_SLOWDOWN = 1.6;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 24;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -18674,7 +18674,29 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return;
           }
+          const applyCueSnapshot = () => {
+            const frames = playback?.frames ?? [];
+            if (!frames.length) return false;
+            let frameIndex = 0;
+            while (frameIndex < frames.length - 1 && frames[frameIndex + 1].t <= targetTime) {
+              frameIndex += 1;
+            }
+            const cueSnapshot = frames[frameIndex]?.cue ?? frames[0]?.cue ?? null;
+            if (!cueSnapshot?.position) return false;
+            const pos = normalizeVector3Snapshot(cueSnapshot.position);
+            if (!pos) return false;
+            cueStick.position.set(pos.x, pos.y, pos.z);
+            const quat = normalizeQuaternionSnapshot(cueSnapshot.rotation);
+            if (quat) {
+              cueStick.quaternion.set(quat.x, quat.y, quat.z, quat.w);
+            }
+            cueStick.visible = cueSnapshot.visible ?? true;
+            cueAnimating = cueStick.visible;
+            syncCueShadow();
+            return true;
+          };
           if (!stroke) {
+            if (applyCueSnapshot()) return;
             const cuePath = playback?.cuePath ?? [];
             const cueBall = cueRef.current || cue;
             const cueBallPos = cueBall?.mesh?.position ?? null;
@@ -18727,9 +18749,11 @@ const powerRef = useRef(hud.power);
             settleSnap
           );
           if (!warmupSnap || !startSnap || !impactSnap || !settleSnap || !idleSnap) {
-            cueStick.visible = false;
-            cueAnimating = false;
-            syncCueShadow();
+            if (!applyCueSnapshot()) {
+              cueStick.visible = false;
+              cueAnimating = false;
+              syncCueShadow();
+            }
             return;
           }
           const replayScale = REPLAY_CUE_STROKE_SLOWDOWN;
@@ -26045,6 +26069,20 @@ const powerRef = useRef(hud.power);
         const suppressPocketCameras =
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
+        const earlyPocketIntent = pocketSwitchIntentRef.current;
+        if (earlyPocketIntent && earlyPocketIntent.createdAt) {
+          const now = performance.now();
+          if (now - earlyPocketIntent.createdAt <= POCKET_INTENT_TIMEOUT_MS) {
+            const cueBall = cueRef.current;
+            const cueSpeed =
+              cueBall?.vel && typeof cueBall.vel.length === 'function'
+                ? cueBall.vel.length() * frameScale
+                : 0;
+            if (earlyPocketIntent.allowEarly && cueSpeed > STOP_EPS) {
+              powerImpactHoldRef.current = 0;
+            }
+          }
+        }
         const pocketHoldActive =
           powerImpactHoldRef.current &&
           performance.now() < powerImpactHoldRef.current;

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -237,9 +237,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         'Buonasera dalla {arena}. {speaker} al commento. {player} e {opponent} sono {playerScore}-{opponentScore}.'
       ],
       introReply: [
-        'Grazie {speaker}. La differenza la farà il controllo della battente e la gestione delle linee.',
-        'Felice di esserci, {speaker}. Qui il posizionamento è tutto.',
-        'Esatto, {speaker}. {player} e {opponent} hanno bisogno di imbucate pulite e rotazione precisa.'
+        'Grazie {speaker}. Qui conta il controllo della battente e la gestione degli angoli.',
+        'Felice di esserci, {speaker}. Nel pool, posizionamento e tempi di gioco fanno la differenza.',
+        'Esatto, {speaker}. {player} e {opponent} cercano imbucate pulite con rotazione precisa.'
       ],
       breakShot: [
         '{player} va al break; una buona apertura crea subito opportunità.',
@@ -267,10 +267,10 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         'Qui si vede il sangue freddo di {player}.'
       ],
       pot: [
-        '{player} imbuca {targetBall} in {pocket}, con la battente in buona posizione.',
-        'Imbucata: {targetBall} in {pocket}.',
-        '{player} manda {targetBall} in {pocket} con controllo.',
-        'Che imbucata! {player} lascia la battente perfetta per il prossimo tiro.'
+        '{player} imbuca {targetBall} in {pocket} e lascia la battente in posizione.',
+        'Imbucata netta: {targetBall} in {pocket}.',
+        '{player} manda {targetBall} in {pocket} con controllo di battente.',
+        'Che imbucata! {player} tiene la battente perfetta per il colpo successivo.'
       ],
       combo: [
         '{player} combina {targetBall} in {pocket}.',
@@ -279,7 +279,7 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ],
       bank: [
         '{player} di sponda: {targetBall} in {pocket}.',
-        'Banca riuscita: {targetBall} in {pocket}.',
+        'Sponda riuscita: {targetBall} in {pocket}.',
         '{player} manda {targetBall} di sponda con grande controllo.'
       ],
       kick: [
@@ -299,7 +299,7 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ],
       foul: [
         'Fallo di {player}.',
-        'Fallo: {opponent} torna al tavolo con controllo.',
+        'Fallo: {opponent} torna al tavolo con palla in mano.',
         '{player} commette fallo.'
       ],
       inHand: [
@@ -329,7 +329,7 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ],
       tournamentRecall: [
         '{player} arriva da {previousResult} nel round precedente: fiducia alta.',
-        'L’ultimo turno è finito {previousResult}; ci aspettiamo una prova da professionista.',
+        'L’ultimo turno è finito {previousResult}; ci aspettiamo una prova di livello.',
         'Con lo slancio di {previousResult}, {player} sembra pronto a un’altra prova solida.'
       ],
       outro: [
@@ -893,15 +893,16 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         'Goditje me presion; prekja e butë dhe efekti janë vendimtarë.'
       ],
       pot: [
-        '{player} fut {targetBall} në {pocket} dhe ruan pozicionin.',
+        '{player} fut {targetBall} në {pocket} dhe ruan pozicionin e topit të bardhë.',
         'Goditje shumë e pastër nga {player}; topi i bardhë bie në pozicion perfekt.',
-        'Super finishing: {player} fut {targetBall} dhe mban kënd të mirë për tjetrin.'
+        'Mbyllje elegante: {player} fut {targetBall} dhe mban kënd të mirë për tjetrin.'
       ],
       combo: [
         '{player} bën kombinim dhe fut {targetBall} në {pocket}.'
       ],
       bank: [
-        '{player} godet nga banka dhe fut {targetBall} në {pocket}.'
+        '{player} godet nga banka dhe fut {targetBall} në {pocket}.',
+        'Bankë e bukur nga {player}; {targetBall} bie në {pocket}.'
       ],
       kick: [
         '{player} duhet ta gjejë topin përmes bankës.'
@@ -913,14 +914,17 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         '{player} e humb; shans për {opponent}.'
       ],
       foul: [
-        'Faull nga {player}.'
+        'Faull nga {player}.',
+        'Gabim nga {player}; {opponent} rikthehet në tavolinë.'
       ],
       inHand: [
-        'Top në dorë për {opponent}.'
+        'Top në dorë për {opponent}.',
+        '{opponent} ka top në dorë dhe përparësi të qartë.'
       ],
       runout: [
         '{player} është në ritëm—mund të mbyllë gjithë tavolinën.',
-        '{player} ka planin dhe kërkon vetëm pozicion të butë për mbyllje.'
+        '{player} ka planin dhe kërkon vetëm pozicion të butë për mbyllje.',
+        '{player} po e ndërton serinë me qetësi.'
       ],
       hillHill: [
         'Rack vendimtar; tension maksimal.'


### PR DESCRIPTION
### Motivation
- Make in-replay cue stick visible and show the forward push so replays reflect the real stroke. 
- Improve in-play cue visibility for player and AI strokes so the push-forward is readable on portrait screens. 
- Ensure Albanian commentary uses native Shqip cues and restrict Italian analyst voices to the intended native speaker. 
- Let pocket-camera switches activate earlier when a pocket intent exists and the cue ball has started moving.

### Description
- Update commentary presets in `PoolRoyale.jsx` to use `language: 'sq-AL'`, change the Albanian preset description to "Shqip...", and simplify voice hints to prefer Albanian native cues; restrict the Italian analyst voice to a single native female (`'Giulia'`).
- Increase visual spacing and motion for the cue by raising `CUE_TIP_GAP`, increasing `CUE_FOLLOW_THROUGH_MIN` and `CUE_FOLLOW_THROUGH_MAX`, and lengthening player forward timing via `PLAYER_CUE_FORWARD_MIN_MS` / `PLAYER_CUE_FORWARD_MAX_MS` and `AI_CUE_FORWARD_DURATION_MS` to make forward push more visible.
- Slow replay stroke playback by changing `REPLAY_CUE_STROKE_SLOWDOWN` so replays show clearer pull/push timing.
- Add a replay fallback (`applyCueSnapshot`) inside `applyReplayCueStroke` that uses recorded cue snapshots (`playback.frames[].cue`) when `cueStroke` data is missing or invalid so the cue is visible at the start of replays.
- Add early-pocket intent handling: if a recent pocket intent exists and the cue ball has started moving, clear the post-impact camera hold (`powerImpactHoldRef.current = 0`) to allow earlier pocket-camera activation.

### Testing
- Started a local static server with `python -m http.server 8000 --directory /workspace/TonPlaygramWebApp/webapp` which launched successfully. 
- Attempted an automated screenshot via Playwright to validate visual changes but the headless Chromium process crashed in the container, so the visual test failed and no screenshot was produced. 
- Ran repository checks (`git status`) and committed the changes with `git commit` which succeeded.
- No other automated unit or integration tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf7e0d88c8329a5e5fb9e17b9e043)