### PR TITLE
Fix TON Connect state sync

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -44,6 +44,7 @@ import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
 import Layout from './components/Layout.jsx';
+import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
@@ -71,6 +72,7 @@ export default function App() {
         manifestUrl={manifestUrl}
         actionsConfiguration={actionsConfiguration}
       >
+        <TonConnectSync />
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useTonConnectUI } from '@tonconnect/ui-react';
+
+export default function TonConnectSync() {
+  const [tonConnectUI] = useTonConnectUI();
+
+  useEffect(() => {
+    const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
+      const address = wallet?.account?.address || '';
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+        tonConnectUI.closeModal();
+      } else {
+        localStorage.removeItem('walletAddress');
+      }
+    });
+
+    return () => unsubscribe();
+  }, [tonConnectUI]);
+
+  return null;
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
-import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { useTonAddress } from '@tonconnect/ui-react';
 
 const xIcon = (
   <img
@@ -44,7 +44,6 @@ export default function Home() {
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
-  const [tonConnectUI] = useTonConnectUI();
 
   useEffect(() => {
     ping()


### PR DESCRIPTION
### Motivation
- Make the app reliably persist the connected TON wallet address and update UI state after a user connects with TON Connect.
- Ensure the connect modal is closed after a successful connection so the app reflects the connected state without user refresh.

### Description
- Add a new `TonConnectSync` component that subscribes to `TonConnectUI` status changes and writes `walletAddress` to `localStorage`, removes it when disconnected, and closes the modal on successful connect (`webapp/src/components/TonConnectSync.jsx`).
- Wire `TonConnectSync` into the global provider so it runs for the whole app (`webapp/src/App.jsx`).
- Remove an unused `useTonConnectUI` hook import from the `Home` page to avoid confusion and keep address handling centralized (`webapp/src/pages/Home.jsx`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9a4b24748329b7de7d6657bdee1e)