### PR TITLE
Improve TON Connect restoration on return

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -44,6 +44,7 @@ import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
 import Layout from './components/Layout.jsx';
+import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
@@ -71,6 +72,7 @@ export default function App() {
         manifestUrl={manifestUrl}
         actionsConfiguration={actionsConfiguration}
       >
+        <TonConnectSync />
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { useTonConnectUI } from '@tonconnect/ui-react';
+
+export default function TonConnectSync() {
+  const [tonConnectUI] = useTonConnectUI();
+
+  useEffect(() => {
+    const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
+      const address = wallet?.account?.address || '';
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+        tonConnectUI.closeModal();
+      } else {
+        localStorage.removeItem('walletAddress');
+      }
+    });
+
+    return () => unsubscribe();
+  }, [tonConnectUI]);
+
+  useEffect(() => {
+    let restoring = false;
+
+    const syncFromWallet = () => {
+      const address = tonConnectUI.wallet?.account?.address;
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+        tonConnectUI.closeModal();
+      }
+    };
+
+    const restore = async () => {
+      if (restoring) return;
+      restoring = true;
+      try {
+        await tonConnectUI.restoreConnection();
+        syncFromWallet();
+      } catch (err) {
+        console.warn('TON connection restore failed', err);
+      } finally {
+        restoring = false;
+      }
+    };
+
+    restore();
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        restore();
+      }
+    };
+
+    window.addEventListener('focus', restore);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.removeEventListener('focus', restore);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [tonConnectUI]);
+
+  return null;
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
-import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { useTonAddress } from '@tonconnect/ui-react';
 
 const xIcon = (
   <img
@@ -44,7 +44,6 @@ export default function Home() {
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
-  const [tonConnectUI] = useTonConnectUI();
 
   useEffect(() => {
     ping()


### PR DESCRIPTION
### Motivation
- Ensure the app picks up wallet confirmations that happen outside the webview (e.g. Tonkeeper) and resumes the connected state when the user returns to the app.
- Persist the connected wallet address and close the TON Connect modal automatically after a successful reconnect so the UI reflects the connection without a manual refresh.
- Centralize TON Connect state syncing to a single component and remove duplicate/unused imports.

### Description
- Add a new `TonConnectSync` component at `webapp/src/components/TonConnectSync.jsx` that keeps the wallet address in `localStorage`, closes the connect modal on successful connection, and listens to `onStatusChange` updates from `tonConnectUI`.
- Add a restore flow in `TonConnectSync` which calls `tonConnectUI.restoreConnection()`, runs on initial mount, and re-runs when the app regains focus or becomes visible, with a `restoring` guard to avoid concurrent restores.
- Wire `TonConnectSync` into the application root by mounting it inside `TonConnectUIProvider` in `webapp/src/App.jsx` so it runs globally for the app.
- Remove an unused `useTonConnectUI` import from `webapp/src/pages/Home.jsx` to keep address handling centralized in `TonConnectSync`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9a4b24748329b7de7d6657bdee1e)