### PR TITLE
Pool Royale: preserve cue forward travel with backspin and switch Albanian commentary to male voices

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -997,16 +997,16 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   },
   {
     id: 'albanian-booth',
-    label: 'Albanian Booth',
-    description: 'Shqip commentary with native cadence',
+    label: 'Albanian Booth (Male)',
+    description: 'Shqip commentary with a native male Albanian accent',
     language: 'sq-AL',
     voiceHints: {
       [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
+      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan']
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.01, pitch: 0.97, volume: 1 }
     }
   },
   {
@@ -25702,6 +25702,18 @@ const powerRef = useRef(hud.power);
                 TMP_VEC2_SPIN.multiplyScalar(
                   SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
                 );
+                if (
+                  preImpact &&
+                  isCue &&
+                  b.launchDir &&
+                  (b.spin?.y ?? 0) < -1e-4
+                ) {
+                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
+                  const forwardInfluence = TMP_VEC2_SPIN.dot(launchDir);
+                  if (forwardInfluence < 0) {
+                    TMP_VEC2_SPIN.addScaledVector(launchDir, -forwardInfluence);
+                  }
+                }
                 if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
                   TMP_VEC2_SPIN.multiplyScalar(BACKSPIN_ROLL_BOOST);
                 }


### PR DESCRIPTION
### Motivation
- Prevent the cue ball from stopping before impact when a backspin or stun shot is applied so draw/stun effects are applied at collision rather than cancelling forward travel beforehand.
- Replace the existing Albanian commentary pairing with a male-only Albanian voice to ensure a consistent native male Albanian accent for both play-by-play and analyst lines.

### Description
- Adjusted the pre-impact spin roll computation in `webapp/src/pages/Games/PoolRoyale.jsx` to ensure the spin contribution does not subtract the cue ball forward component when `preImpact && isCue` and backspin is present, preserving forward travel until impact. (Inserted a projection-correction on `TMP_VEC2_SPIN` when backspin would otherwise oppose the launch direction.)
- Updated the `POOL_ROYALE_COMMENTARY_PRESETS` entry for `albanian-booth` in `webapp/src/pages/Games/PoolRoyale.jsx` to use a male lead and male analyst voice, changed the label to `Albanian Booth (Male)`, and tweaked speaker settings and description.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da10e98148329b0bfb7cb5425d921)