### PR TITLE
PoolRoyale: fix cue pre-impact backspin (keeps cue moving) and update Albanian commentary to male voices

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -997,16 +997,30 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   },
   {
     id: 'albanian-booth',
-    label: 'Albanian Booth',
-    description: 'Shqip commentary with native cadence',
+    label: 'Albanian Booth (Male)',
+    description: 'Shqip commentary with authentic Albanian male cadence',
     language: 'sq-AL',
     voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
+      [POOL_ROYALE_SPEAKERS.lead]: [
+        'sq-AL',
+        'Albanian',
+        'male',
+        'Arben',
+        'Besnik',
+        'Luan'
+      ],
+      [POOL_ROYALE_SPEAKERS.analyst]: [
+        'sq-AL',
+        'Albanian',
+        'male',
+        'Altin',
+        'Dritan',
+        'Erion'
+      ]
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -25708,16 +25722,19 @@ const powerRef = useRef(hud.power);
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  const forwardKick = Math.max(0, forwardMag);
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardKick);
                   b.vel.add(TMP_VEC2_AXIS);
-                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
+                  TMP_VEC2_LATERAL
+                    .copy(TMP_VEC2_SPIN)
+                    .addScaledVector(launchDir, -forwardMag);
                   if (b.pendingSpin) {
                     b.pendingSpin.addScaledVector(
                       TMP_VEC2_LATERAL,
                       swerveScale > 0 ? swerveScale : 1
                     );
                   }
-                  const alignedSpeed = b.vel.dot(launchDir);
+                  const alignedSpeed = Math.max(0, b.vel.dot(launchDir));
                   TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
                   b.vel.copy(TMP_VEC2_AXIS);
                 } else {


### PR DESCRIPTION
### Motivation
- Prevent stun/backspin shots from causing the cue ball to stop or lose forward momentum before contacting the target. 
- Replace the existing Albanian commentary pairing so the booth uses authentic male Albanian voices and matching cadence settings.

### Description
- Clamp the pre-impact forward kick so backspin cannot produce a negative forward impulse by using `const forwardKick = Math.max(0, forwardMag)` when applying the spin contribution to forward velocity. 
- Recompute the lateral pending spin with `TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).addScaledVector(launchDir, -forwardMag)` and clamp the aligned speed with `Math.max(0, b.vel.dot(launchDir))` to avoid reversing the cueball before impact. 
- Update the Albanian commentary preset (`id: 'albanian-booth'`) by changing the `label` and `description`, swapping the analyst voice hints to male options, and aligning `speakerSettings` for a consistent male cadence. 
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da10e98148329b0bfb7cb5425d921)