### PR TITLE
Fix TON Connect return flow for Telegram TWA and persist restored sessions

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -44,6 +44,7 @@ import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
 import Layout from './components/Layout.jsx';
+import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
@@ -58,11 +59,13 @@ export default function App() {
   useNativePushNotifications();
 
   const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
-  const returnUrl = window.location.href;
-  const telegramReturnUrl = `https://t.me/${BOT_USERNAME}/webapp`;
+  const startParam = window?.Telegram?.WebApp?.initDataUnsafe?.start_param;
+  const telegramReturnUrl = startParam
+    ? `https://t.me/${BOT_USERNAME}/webapp?startapp=${startParam}`
+    : `https://t.me/${BOT_USERNAME}/webapp`;
   const actionsConfiguration = {
-    returnUrl,
-    twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
+    returnStrategy: 'back',
+    twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : undefined,
   };
 
   return (
@@ -71,6 +74,7 @@ export default function App() {
         manifestUrl={manifestUrl}
         actionsConfiguration={actionsConfiguration}
       >
+        <TonConnectSync />
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useTonConnectUI } from '@tonconnect/ui-react';
+
+export default function TonConnectSync() {
+  const [tonConnectUI] = useTonConnectUI();
+
+  useEffect(() => {
+    let cancelled = false;
+    tonConnectUI.connectionRestored.then((restored) => {
+      if (!restored || cancelled) return;
+      const address = tonConnectUI.account?.address;
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+      }
+    });
+
+    const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
+      const address = wallet?.account?.address || '';
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+        tonConnectUI.closeModal();
+      } else {
+        localStorage.removeItem('walletAddress');
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [tonConnectUI]);
+
+  return null;
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
-import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { useTonAddress } from '@tonconnect/ui-react';
 
 const xIcon = (
   <img
@@ -44,7 +44,6 @@ export default function Home() {
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
-  const [tonConnectUI] = useTonConnectUI();
 
   useEffect(() => {
     ping()


### PR DESCRIPTION
### Motivation
- Ensure the app correctly restores and reflects a TON wallet connection when returning from external wallets, especially from Telegram TWA with `startapp` parameters.
- Make TonConnect action return behavior deterministic to avoid unpredictable navigation or missing UI updates after signing.
- Persist restored session account into local storage so the UI shows the connected address without requiring a manual refresh.

### Description
- Build a Telegram-aware TWA return URL from `window.Telegram.WebApp.initDataUnsafe.start_param` and use it as `actionsConfiguration.twaReturnUrl` only when running inside the Telegram webview in `App.jsx`.
- Set `actionsConfiguration.returnStrategy = 'back'` instead of passing `returnUrl` so TonConnect actions use a deterministic return strategy in `App.jsx`.
- Add `TonConnectSync` component that waits for `tonConnectUI.connectionRestored` to persist the restored `walletAddress`, subscribes to `tonConnectUI.onStatusChange` to update/clear `localStorage` and close the modal on successful connect, and performs cleanup on unmount; mount this component inside `TonConnectUIProvider` in `App.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9a4b24748329b7de7d6657bdee1e)