### PR TITLE
Fix Telegram return URLs and add TON Connect state sync

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -44,6 +44,7 @@ import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
 import Layout from './components/Layout.jsx';
+import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
@@ -59,7 +60,7 @@ export default function App() {
 
   const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
   const returnUrl = window.location.href;
-  const telegramReturnUrl = `https://t.me/${BOT_USERNAME}/webapp`;
+  const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
   const actionsConfiguration = {
     returnUrl,
     twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
@@ -71,6 +72,7 @@ export default function App() {
         manifestUrl={manifestUrl}
         actionsConfiguration={actionsConfiguration}
       >
+        <TonConnectSync />
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -26,7 +26,7 @@ export default function LoginOptions({ onAuthenticated, onTonConnected }) {
   const handleOpenTelegram = () => {
     setCtaMessage('Opening Telegram…');
     const deepLink = 'tg://resolve?domain=TonPlaygramBot&startapp=account';
-    const fallback = 'https://t.me/TonPlaygramBot/webapp';
+    const fallback = 'https://t.me/TonPlaygramBot?startapp=account';
     window.location.href = deepLink;
     setTimeout(() => {
       window.open(fallback, '_blank', 'noopener');

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useTonConnectUI } from '@tonconnect/ui-react';
+
+export default function TonConnectSync() {
+  const [tonConnectUI] = useTonConnectUI();
+
+  useEffect(() => {
+    const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
+      const address = wallet?.account?.address || '';
+      if (address) {
+        localStorage.setItem('walletAddress', address);
+        tonConnectUI.closeModal();
+      } else {
+        localStorage.removeItem('walletAddress');
+      }
+    });
+
+    return () => unsubscribe();
+  }, [tonConnectUI]);
+
+  return null;
+}

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
-import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
+import { useTonAddress } from '@tonconnect/ui-react';
 
 const xIcon = (
   <img
@@ -44,7 +44,6 @@ export default function Home() {
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
-  const [tonConnectUI] = useTonConnectUI();
 
   useEffect(() => {
     ping()


### PR DESCRIPTION
### Motivation
- Ensure TON Connect flows return to the app correctly when invoked from Telegram by using the `startapp=account` parameter for TWA/mini-app routing.
- Persist and surface the connected wallet address in the app state so the UI reflects successful connections without requiring a manual refresh.
- Make the Telegram login deep link and fallback URL consistent with the connect flow to improve reliability across clients.

### Description
- Updated the Telegram return URL used for TON Connect in `webapp/src/App.jsx` to `https://t.me/${BOT_USERNAME}?startapp=account` and wired `TonConnectSync` into the `TonConnectUIProvider` so it runs for the whole app. 
- Added `webapp/src/components/TonConnectSync.jsx` which subscribes to `TonConnectUI` status changes, writes the connected `walletAddress` to `localStorage`, removes it on disconnect, and closes the TON Connect modal on successful connection. 
- Aligned the Telegram fallback link in `webapp/src/components/LoginOptions.jsx` to use `https://t.me/TonPlaygramBot?startapp=account` to match the TWA return behavior. 
- Removed an unused `useTonConnectUI` import from `webapp/src/pages/Home.jsx` to keep address/state handling centralized.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9a4b24748329b7de7d6657bdee1e)