### PR TITLE
Refine pre-impact spin handling and Albanian booth voice settings in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -997,16 +997,30 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   },
   {
     id: 'albanian-booth',
-    label: 'Albanian Booth',
-    description: 'Shqip commentary with native cadence',
+    label: 'Albanian Booth (Male)',
+    description: 'Shqip commentary with authentic Albanian male cadence',
     language: 'sq-AL',
     voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
+      [POOL_ROYALE_SPEAKERS.lead]: [
+        'sq-AL',
+        'Albanian',
+        'male',
+        'Arben',
+        'Besnik',
+        'Luan'
+      ],
+      [POOL_ROYALE_SPEAKERS.analyst]: [
+        'sq-AL',
+        'Albanian',
+        'male',
+        'Altin',
+        'Dritan',
+        'Erion'
+      ]
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },
-      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.05, pitch: 1.06, volume: 1 }
+      [POOL_ROYALE_SPEAKERS.analyst]: { rate: 1.02, pitch: 0.98, volume: 1 }
     }
   },
   {
@@ -25708,16 +25722,16 @@ const powerRef = useRef(hud.power);
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
-                  b.vel.add(TMP_VEC2_AXIS);
-                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
+                  TMP_VEC2_LATERAL
+                    .copy(TMP_VEC2_SPIN)
+                    .addScaledVector(launchDir, -forwardMag);
                   if (b.pendingSpin) {
                     b.pendingSpin.addScaledVector(
                       TMP_VEC2_LATERAL,
                       swerveScale > 0 ? swerveScale : 1
                     );
                   }
-                  const alignedSpeed = b.vel.dot(launchDir);
+                  const alignedSpeed = Math.max(0, b.vel.dot(launchDir));
                   TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
                   b.vel.copy(TMP_VEC2_AXIS);
                 } else {


### PR DESCRIPTION
### Motivation
- Preserve natural backspin/stun behavior so backspin can reverse or stun the cue ball only when physics allow contact. 
- Make the Albanian commentary preset use authentic male voices and matching cadence settings for a consistent booth pairing.

### Description
- Stop applying the forward spin kick before impact by removing the pre-impact forward velocity addition and instead keeping the cue velocity aligned to the launch direction using `Math.max(0, b.vel.dot(launchDir))` so negative aligned speeds are clamped to zero. 
- Preserve and forward the lateral spin component into `b.pendingSpin` by computing the lateral vector with `TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).addScaledVector(launchDir, -forwardMag)` and applying it (scaled by `swerveScale`) without injecting forward impulse. 
- Update the Albanian commentary preset in `webapp/src/pages/Games/PoolRoyale.jsx` by changing the `label` and `description`, switching the analyst `voiceHints` to male names, and aligning `speakerSettings` for consistent male cadence. 
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da10e98148329b0bfb7cb5425d921)