### PR TITLE
Fix TonConnect manifest resolution & remove broken UI CSS import

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -58,7 +58,11 @@ export default function App() {
   useReferralClaim();
   useNativePushNotifications();
 
-  const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
+  const manifestOverride = import.meta.env.VITE_TONCONNECT_MANIFEST_URL;
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const isHttpOrigin = origin.startsWith('http://') || origin.startsWith('https://');
+  const manifestUrl = manifestOverride
+    || (isHttpOrigin ? `${origin}/tonconnect-manifest.json` : 'https://tonplaygram.com/tonconnect-manifest.json');
   const returnUrl = window.location.href;
   const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
   const actionsConfiguration = {


### PR DESCRIPTION
### Motivation
- TonConnect fails to initialize when the app is served from non-HTTP origins (native/embedded contexts), so the provider needs a reliable manifest URL.
- An attempted import of `@tonconnect/ui-react/styles.css` caused Vite to fail because that package does not export `styles.css`.
- Remove an accidental generated `gradle-wrapper.jar` file from the repo to keep the tree clean.

### Description
- Use a configurable manifest URL via `VITE_TONCONNECT_MANIFEST_URL` and fall back to a secure hosted manifest when the app is not served from an `http(s)` origin by updating `webapp/src/App.jsx` to compute `manifestUrl` accordingly.
- Removed the invalid `import '@tonconnect/ui-react/styles.css'` that caused dependency resolution errors by editing `webapp/src/main.jsx`.
- Deleted the untracked `webapp/android/gradle/wrapper/gradle-wrapper.jar` file from the repository.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready on the local and network addresses, indicating the previous import error was resolved.
- Captured a page screenshot via a Playwright script which completed and produced an artifact (`artifacts/tonconnect-login.png`).
- Verified the original `Missing "./styles.css" specifier` error occurred when the incorrect CSS import was present and that the error no longer appears after the import removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db55cdd648329b74ce02b8c8d4015)