### PR TITLE
Fix TON connect button interaction

### DIFF
--- a/webapp/src/components/TonConnectButton.jsx
+++ b/webapp/src/components/TonConnectButton.jsx
@@ -1,11 +1,28 @@
 import React from 'react';
-import { TonConnectButton as ConnectButton } from '@tonconnect/ui-react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 export default function TonConnectButton({ small = false, className = '' }) {
-  const sizeClass = small ? 'px-1 py-0 text-xs' : 'px-3 py-1';
+  const [tonConnectUI] = useTonConnectUI();
+  const address = useTonAddress();
+  const sizeClass = small ? 'px-2 py-1 text-xs' : 'px-3 py-2 text-sm';
+
+  const handleClick = () => {
+    if (!tonConnectUI) return;
+    if (address) {
+      tonConnectUI.disconnect();
+    } else {
+      tonConnectUI.openModal();
+    }
+  };
+
+  const label = address ? 'TON Wallet Connected' : 'Connect TON Wallet';
   return (
-    <div className={`mt-2 ${className}`}>
-      <ConnectButton className={`lobby-tile cursor-pointer ${sizeClass}`} />
-    </div>
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`lobby-tile cursor-pointer w-full ${sizeClass} ${className}`}
+    >
+      {label}
+    </button>
   );
 }


### PR DESCRIPTION
### Motivation
- TON Connect's default UI wrapper did not reliably open the connect modal and did not provide an obvious way to disconnect, causing users trouble connecting their wallets.
- Update the button to explicitly control the TON Connect UI so the modal always opens and the connected state is actionable.

### Description
- Replace the wrapped `TonConnectButton` element with a custom button that uses `useTonConnectUI` and `useTonAddress` from `@tonconnect/ui-react` to control the modal and disconnect programmatically.
- Toggle between `tonConnectUI.openModal()` and `tonConnectUI.disconnect()` on click depending on whether an address is present.
- Update sizing and CSS utility classes to `px-2 py-1 text-xs` (small) and `px-3 py-2 text-sm` (default), and render a contextual label (`"Connect TON Wallet"` / `"TON Wallet Connected"`).
- Render the button as a full-width `lobby-tile` element for consistent layout across usages.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server reported ready, which succeeded.
- Ran a Playwright script that loaded `http://127.0.0.1:4173/` in a mobile viewport and produced a screenshot artifact of the updated button, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db55cdd648329b74ce02b8c8d4015)