### PR TITLE
Scope app form styles to avoid TonConnect modal conflicts

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -123,11 +123,11 @@ h6 {
   box-shadow: inset 0 0 10px rgba(0, 247, 255, 0.4);
 }
 
-button {
+#root button {
   @apply px-2 py-1 bg-primary hover:bg-primary-hover text-white text-outline-black text-sm rounded;
 }
 
-.icon-only-button {
+#root .icon-only-button {
   background: transparent;
   border: none;
   padding: 0;
@@ -137,14 +137,14 @@ button {
   text-shadow: none;
 }
 
-.icon-only-button:hover,
-.icon-only-button:focus {
+#root .icon-only-button:hover,
+#root .icon-only-button:focus {
   background: transparent;
   box-shadow: none;
   outline: none;
 }
 
-body.mining-page button {
+body.mining-page #root button {
   @apply text-white-shadow;
 }
 
@@ -154,14 +154,14 @@ body.mining-page button {
   will-change: transform;
 }
 
-input {
+#root input {
   border-color: #facc15;
   color: #facc15;
   box-shadow: 0 0 6px rgba(250, 204, 21, 0.6);
 }
 
-button:focus,
-input:focus {
+#root button:focus,
+#root input:focus {
   outline: none;
   box-shadow: 0 0 10px #facc15;
 }


### PR DESCRIPTION
### Motivation
- TonConnect UI widgets are rendered outside the app root and were inheriting global `button`/`input` styles, which broke wallet modal appearance and interaction.
- Scoping form styles to the app container prevents the app stylesheet from unintentionally styling external widgets like TonConnect.

### Description
- Restricted global form selectors by prefixing them with `#root` in `webapp/src/index.css` so `button`, `input`, and related focus/hover rules only apply inside the app root. 
- Adjusted `body.mining-page` rule to target `body.mining-page #root button` so mining-page button styles remain scoped.
- This is a single-file, style-only change that avoids touching TonConnect UI markup or library code.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which launched Vite successfully. (passed)
- Ran a Playwright script that opened `http://127.0.0.1:4173/`, interacted with `#ton-connect-button`, and captured a screenshot `artifacts/tonconnect-modal.png` to verify the TonConnect modal is no longer styled by the app (succeeded).
- No unit tests were applicable to this style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db55cdd648329b74ce02b8c8d4015)