### PR TITLE
Tweak cue backspin & stun response for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1519,6 +1519,7 @@ const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021 * SPIN_GLOBAL_SCALE;
 const BACKSPIN_ROLL_BOOST = 1.35;
 const CUE_BACKSPIN_ROLL_BOOST = 3.4;
+const PRE_IMPACT_BACKSPIN_ATTENUATION = 0.18;
 const BACKSPIN_POWER_COMPENSATION = 0.75; // boost forward velocity so draw shots travel like normal power
 const BACKSPIN_POWER_MAX_BOOST = 1.75; // cap boost so draw shots don't overpower full-strength strokes
 const SPIN_ROLL_DECAY = 0.983;
@@ -25711,7 +25712,11 @@ const powerRef = useRef(hud.power);
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  const adjustedForwardMag =
+                    forwardMag < 0
+                      ? forwardMag * PRE_IMPACT_BACKSPIN_ATTENUATION
+                      : forwardMag;
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(adjustedForwardMag);
                   b.vel.add(TMP_VEC2_AXIS);
                   TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
                   if (b.pendingSpin) {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const MAX_SPIN_OFFSET = 1;
-export const SPIN_STUN_RADIUS = 0.16;
+export const SPIN_STUN_RADIUS = 0.08;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
@@ -11,6 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
+export const BACKSPIN_RESPONSE_POWER = 1.35;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -136,6 +137,9 @@ export const normalizeSpinInput = (spin) => {
   const distance = Math.hypot(x, y);
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
+  }
+  if (y < 0) {
+    y = -Math.pow(Math.abs(y), BACKSPIN_RESPONSE_POWER);
   }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };


### PR DESCRIPTION
### Motivation
- Improve realism of stun/draw/backspin hits so center shots still travel forward while low-offset backspin produces subtle stun/draw behavior. 
- Current low backspin inputs produced too much backward influence and sometimes prevented the cue ball from reaching its target.

### Description
- Reduce the spin deadzone by lowering `SPIN_STUN_RADIUS` from `0.16` to `0.08` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so slight offsets produce graded stun/draw effects. 
- Add a soft backspin response curve by introducing `BACKSPIN_RESPONSE_POWER` and remapping small negative Y input with `y = -Math.pow(abs(y), BACKSPIN_RESPONSE_POWER)` in `normalizeSpinInput` so light draw inputs yield milder effective backspin. 
- Attenuate pre-impact forward velocity contribution from backspin by adding `PRE_IMPACT_BACKSPIN_ATTENUATION` and applying it to negative forward projections before they are added to the cue velocity in `webapp/src/pages/Games/PoolRoyale.jsx`, preserving forward travel while keeping backspin for post-impact behavior. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbbf06a0c832987022b441360b195)