### PR TITLE
Fix TON Connect button interaction

### DIFF
--- a/webapp/src/components/TonConnectButton.jsx
+++ b/webapp/src/components/TonConnectButton.jsx
@@ -1,11 +1,25 @@
 import React from 'react';
-import { TonConnectButton as ConnectButton } from '@tonconnect/ui-react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 export default function TonConnectButton({ small = false, className = '' }) {
+  const [tonConnectUI] = useTonConnectUI();
+  const tonAddress = useTonAddress();
   const sizeClass = small ? 'px-1 py-0 text-xs' : 'px-3 py-1';
+  const label = tonAddress ? 'Wallet connected' : 'Connect TON Wallet';
+  const handleClick = () => {
+    if (!tonConnectUI) return;
+    tonConnectUI.openModal();
+  };
   return (
     <div className={`mt-2 ${className}`}>
-      <ConnectButton className={`lobby-tile cursor-pointer ${sizeClass}`} />
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`lobby-tile cursor-pointer ${sizeClass} w-full`}
+        aria-label={tonAddress ? 'TON wallet connected' : 'Connect TON wallet'}
+      >
+        {label}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Users reported unreliable TON Connect behavior; the intent is to make the connect flow explicit and consistent across clients by opening the TON Connect modal programmatically and showing a clear connect/connected label.

### Description
- Replaced the wrapped `TonConnectButton` UI component with a simple button that calls `tonConnectUI.openModal()` using `useTonConnectUI` to ensure the modal opens reliably.
- Added `useTonAddress` to surface a clear `Connect TON Wallet / Wallet connected` label and appropriate `aria-label` for accessibility.
- Kept the existing visual styling by reusing the `lobby-tile` classes and made the button full width for consistent layout.
- Updated `webapp/src/components/TonConnectButton.jsx` to implement these changes.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and Vite reported ready (succeeded).
- Ran a Playwright screenshot workflow: Chromium-based run failed with a headless crash (failed), then a Firefox-based run completed and produced a screenshot of the updated button (succeeded).
- Changes were staged and committed (`Fix TON Connect button interaction`) after verification steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db55cdd648329b74ce02b8c8d4015)