### PR TITLE
Adjust backspin handling to preserve forward travel in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1519,7 +1519,7 @@ const SPIN_DECAY = 0.9;
 const SPIN_ROLL_STRENGTH = BALL_R * 0.021 * SPIN_GLOBAL_SCALE;
 const BACKSPIN_ROLL_BOOST = 1.35;
 const CUE_BACKSPIN_ROLL_BOOST = 3.4;
-const BACKSPIN_POWER_COMPENSATION = 0.75; // boost forward velocity so draw shots travel like normal power
+const BACKSPIN_POWER_COMPENSATION = 0; // keep draw shots travelling at center-hit speed
 const BACKSPIN_POWER_MAX_BOOST = 1.75; // cap boost so draw shots don't overpower full-strength strokes
 const SPIN_ROLL_DECAY = 0.983;
 const SPIN_AIR_DECAY = 0.995; // hold spin energy while the cue ball travels straight pre-impact
@@ -1531,6 +1531,7 @@ const SWERVE_THRESHOLD = 0.82; // outer 18% of the spin control activates swerve
 const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
 const SWERVE_PRE_IMPACT_DRIFT = 0; // keep cue ball path straight even with side spin
 const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
+const PRE_IMPACT_BACKSPIN_ROLL_SCALE = 0.22; // reduce backspin drag before impact so draw shots keep their forward pace
 const SPIN_ENGLISH_DEFLECTION_SCALE = 0; // disable english deflection while preserving spin values
 const CUE_AFTER_SPIN_DEFLECTION_SCALE = 0; // remove spin deflection so the cue follow line tracks the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
@@ -25705,13 +25706,21 @@ const powerRef = useRef(hud.power);
                 TMP_VEC2_SPIN.multiplyScalar(
                   SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
                 );
-                if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
-                  TMP_VEC2_SPIN.multiplyScalar(BACKSPIN_ROLL_BOOST);
+                const backspinOpposes =
+                  b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0;
+                if (backspinOpposes) {
+                  const preImpactScale =
+                    preImpact && isCue ? PRE_IMPACT_BACKSPIN_ROLL_SCALE : 1;
+                  TMP_VEC2_SPIN.multiplyScalar(
+                    BACKSPIN_ROLL_BOOST * preImpactScale
+                  );
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
                   const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
+                  const alignedForward =
+                    isCue && forwardMag < 0 ? 0 : forwardMag;
+                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedForward);
                   b.vel.add(TMP_VEC2_AXIS);
                   TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
                   if (b.pendingSpin) {
@@ -25738,7 +25747,10 @@ const powerRef = useRef(hud.power);
                     b.pendingSpin.multiplyScalar(0);
                   }
                 }
-                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
+                const rollDecay =
+                  preImpact && isCue
+                    ? Math.pow(SPIN_AIR_DECAY, stepScale)
+                    : Math.pow(SPIN_ROLL_DECAY, stepScale);
                 b.spin.multiplyScalar(rollDecay);
                 if (isCue && b.swerveStrength > 0) {
                   b.swerveStrength *= rollDecay;


### PR DESCRIPTION
### Motivation
- Improve realism and playability for draw/stun shots so a center hit still travels forward while near-center low hits produce controlled backspin (stun/draw) without cancelling forward travel.
- Fix observed behavior where backspin prevented the cue ball from reaching its target because pre-impact backspin drag and power compensation were too strong.

### Description
- Set `BACKSPIN_POWER_COMPENSATION` to `0` to stop artificially boosting forward velocity for draw shots and keep travel speed equal to a center hit (`BACKSPIN_POWER_COMPENSATION` change). 
- Add `PRE_IMPACT_BACKSPIN_ROLL_SCALE` and apply it when scaling `BACKSPIN_ROLL_BOOST` so pre-impact backspin drag is reduced for the cue ball while preserving post-impact draw behavior (new constant and use in spin integration).
- Prevent pre-impact backspin from subtracting forward velocity by clamping the projected forward contribution when `isCue` and `forwardMag < 0` (avoid negative forward influence that cancels movement).
- Use `SPIN_AIR_DECAY` for pre-impact spin decay on the cue (`preImpact && isCue`), preserving spin energy while the cue ball travels straight before impact so stun/draw effects occur after contact.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbbf06a0c832987022b441360b195)