### PR TITLE
Improve store thumbnails, modal scrolling, and sort prioritization

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1070,6 +1070,8 @@ export default function Store() {
           );
         })
         .sort((a, b) => {
+          const thumbnailPriority = Number(Boolean(b.thumbnail)) - Number(Boolean(a.thumbnail));
+          if (thumbnailPriority !== 0) return thumbnailPriority;
           if (sortOption === 'price-low') return a.price - b.price;
           if (sortOption === 'price-high') return b.price - a.price;
           if (sortOption === 'alpha') return a.displayLabel.localeCompare(b.displayLabel);
@@ -1723,8 +1725,8 @@ export default function Store() {
     const usageDetails = resolveUsageDetails(detailItem, gameName);
 
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+      <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/70 px-4 py-6">
+        <div className="w-full max-w-4xl max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-start justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">{gameName} • {detailItem.typeLabel}</p>
@@ -2092,9 +2094,12 @@ export default function Store() {
       : 'relative h-32 w-full overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-[0_18px_40px_-22px_rgba(0,0,0,0.9)]';
 
     if (item.thumbnail) {
+      const imageClassName = isCompact
+        ? 'h-full w-full object-contain p-1.5'
+        : 'h-full w-full object-contain p-2';
       return (
         <div className={wrapperClass}>
-          <img src={item.thumbnail} alt={item.displayLabel || item.name} className="h-full w-full object-cover" loading="lazy" />
+          <img src={item.thumbnail} alt={item.displayLabel || item.name} className={imageClassName} loading="lazy" />
           <div className="absolute inset-0 bg-gradient-to-br from-black/10 via-transparent to-black/60" />
           <div className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}>
             {label}


### PR DESCRIPTION
### Motivation
- Fix the store detail modal that did not allow scrolling on small screens so users can view long item details. 
- Make thumbnail images appear slightly smaller inside their frames while preserving the frame look so screenshots look cleaner. 
- Prioritize items that have screenshot thumbnails when sorting so products with clean previews surface first.

### Description
- Updated `webapp/src/pages/Store.jsx` to render thumbnails with `object-contain` and small padding (`p-1.5` / `p-2`) instead of `object-cover` so images sit smaller inside existing frames. 
- Made the detail modal scrollable by adding `overflow-y-auto` and `max-h-[calc(100vh-3rem)]` and extra padding to the modal wrapper in `renderDetailModal`. 
- Adjusted the store sorting in `applyFilters` to compute a `thumbnailPriority` (`Number(Boolean(item.thumbnail))`) and apply that before the other sort criteria (price/alpha/slug) so items with `thumbnail` appear first. 

### Testing
- Started the dev server with `npm run dev`, and Vite reported the app ready at `http://localhost:4173/`. 
- Attempted an automated visual check with Playwright to capture `/store/all`, but the headless browser crashed (`TargetClosedError` / SIGSEGV) so no screenshot was produced. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbe3c07448329b0e9abcd6dc289d7)