### PR TITLE
Store: enable detail modal scrolling, prioritize table/chair thumbnails, and shrink thumbnail images

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1073,6 +1073,19 @@ export default function Store() {
           if (sortOption === 'price-low') return a.price - b.price;
           if (sortOption === 'price-high') return b.price - a.price;
           if (sortOption === 'alpha') return a.displayLabel.localeCompare(b.displayLabel);
+          const featuredRank = (item) => {
+            const label = item.typeLabel?.toLowerCase() || '';
+            const hasThumbnail = Boolean(item.thumbnail);
+            const isTableOrChair = label.includes('table') || label.includes('chair') || label.includes('stool');
+            if (hasThumbnail && isTableOrChair) return 0;
+            if (hasThumbnail) return 1;
+            if (isTableOrChair) return 2;
+            return 3;
+          };
+          const rankDiff = featuredRank(a) - featuredRank(b);
+          if (rankDiff !== 0) return rankDiff;
+          const nameDiff = a.displayLabel.localeCompare(b.displayLabel);
+          if (nameDiff !== 0) return nameDiff;
           return a.slug.localeCompare(b.slug);
         });
     },
@@ -1724,7 +1737,7 @@ export default function Store() {
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+        <div className="w-full max-w-4xl max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-start justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">{gameName} • {detailItem.typeLabel}</p>
@@ -2090,11 +2103,12 @@ export default function Store() {
     const wrapperClass = isCompact
       ? 'relative h-16 w-20 overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-[0_16px_30px_-24px_rgba(0,0,0,0.9)]'
       : 'relative h-32 w-full overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-[0_18px_40px_-22px_rgba(0,0,0,0.9)]';
+    const imageClass = isCompact ? 'h-full w-full object-contain p-2' : 'h-full w-full object-contain p-3';
 
     if (item.thumbnail) {
       return (
         <div className={wrapperClass}>
-          <img src={item.thumbnail} alt={item.displayLabel || item.name} className="h-full w-full object-cover" loading="lazy" />
+          <img src={item.thumbnail} alt={item.displayLabel || item.name} className={imageClass} loading="lazy" />
           <div className="absolute inset-0 bg-gradient-to-br from-black/10 via-transparent to-black/60" />
           <div className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}>
             {label}


### PR DESCRIPTION
### Motivation
- Improve mobile/portrait UX so users can scroll long item details when they tap the store "View" button. 
- Surface high-quality product screenshots (tables, chairs, stools) in featured sorting to make visually clean thumbnails appear earlier. 
- Slightly reduce image content size inside thumbnails so visuals look cleaner while preserving existing card frames.

### Description
- Updated `webapp/src/pages/Store.jsx` to make the detail modal scrollable by wrapping the modal content with `max-h-[calc(100vh-2rem)]` and `overflow-y-auto` so the modal fits and scrolls on small viewports. 
- Added a featured ranking function in the store filtering/sort logic to prioritize items whose `typeLabel` matches table/chair/stool and that have a `thumbnail`, with stable fallbacks by name and slug. 
- Changed thumbnail rendering to use `object-contain` with small padding (`p-2`/`p-3`) instead of `object-cover` so the image inside the existing rounded frames appears slightly smaller while keeping the frames intact. 
- All edits are contained in `webapp/src/pages/Store.jsx` (UI-only changes).

### Testing
- Started the dev server with `npm --prefix webapp run dev` and verified Vite served the app at `http://localhost:4173`. 
- Ran a Playwright script (Python) that opened `http://127.0.0.1:4173/store/all`, clicked the first "View" button and captured a screenshot at `artifacts/store-modal-scroll.png` to confirm the modal is scrollable and thumbnails render with the new sizing (screenshot produced successfully). 
- No unit test suite (`jest`) was run as this is a visual/UI change. All automated steps executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dbe3c07448329b0e9abcd6dc289d7)