### PR TITLE
Fix TonConnect manifest and return URLs to tonplaygram.com

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -58,12 +58,12 @@ export default function App() {
   useReferralClaim();
   useNativePushNotifications();
 
-  const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
-  const returnUrl = window.location.href;
+  const manifestUrl = 'https://tonplaygram.com/tonconnect-manifest.json';
+  const returnUrl = 'https://tonplaygram.com';
   const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
   const actionsConfiguration = {
     returnUrl,
-    twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
+    twaReturnUrl: telegramReturnUrl,
   };
 
   return (


### PR DESCRIPTION
### Motivation
- Restore TonConnect configuration to the original canonical source so wallets reliably connect by using the hosted manifest and stable return URLs.

### Description
- Change `manifestUrl` to `https://tonplaygram.com/tonconnect-manifest.json`, set `returnUrl` to `https://tonplaygram.com`, and always use the Telegram bot URL for `twaReturnUrl` in `webapp/src/App.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc2e06b2c8329a5fbe63e51f5723b)