### PR TITLE
Fix TON Connect payment verification for NFT store purchases

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -118,7 +118,7 @@ import {
   texasHoldemAccountId
 } from '../utils/texasHoldemInventory.js';
 import { claimPurchase, getTonBalance } from '../utils/api.js';
-import { DEV_INFO } from '../utils/constants.js';
+import { ADSGRAM_WALLET, DEV_INFO } from '../utils/constants.js';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 const TYPE_LABELS = {
@@ -224,9 +224,13 @@ const TEXAS_TYPE_LABELS = {
 };
 
 const TON_ICON = '/assets/icons/TON.webp';
-const TON_STORE_ADDRESS = 'UQCQGCCgdpWaXoSSEp6F49I-pQ2KDDiQPeBzdM7bSRV86GtH';
+const TON_STORE_ADDRESS = ADSGRAM_WALLET;
 const TON_PRICE_MIN = 0.1;
 const TON_PRICE_MAX = 5;
+const TON_API_BASE_URL = 'https://tonapi.io/v2';
+const TON_TX_SEARCH_LIMIT = 20;
+const TON_TX_MAX_ATTEMPTS = 6;
+const TON_TX_RETRY_DELAY_MS = 2500;
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const SNOOKER_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNOOKER_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
@@ -257,6 +261,76 @@ const resolvePreviewShape = (slug, type, preferredShape) => {
 };
 
 const previewLabel = (shape) => PREVIEW_LABELS[shape] || PREVIEW_LABELS.default;
+
+const normalizeTonAddress = (address) => (address || '').trim().toLowerCase();
+
+const toBigIntSafe = (value) => {
+  try {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return BigInt(Math.trunc(value));
+    if (typeof value === 'string' && value.trim()) return BigInt(value.trim());
+  } catch (err) {
+    return null;
+  }
+  return null;
+};
+
+const fetchTonTransactions = async (address) => {
+  const url = `${TON_API_BASE_URL}/accounts/${encodeURIComponent(address)}/transactions?limit=${TON_TX_SEARCH_LIMIT}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Unable to load TON transactions.');
+  }
+  const data = await response.json();
+  if (Array.isArray(data?.transactions)) return data.transactions;
+  if (Array.isArray(data?.items)) return data.items;
+  if (Array.isArray(data)) return data;
+  return [];
+};
+
+const findMatchingTonTransaction = (transactions, { destination, amountNano, since }) => {
+  if (!Array.isArray(transactions)) return null;
+  const targetDestination = normalizeTonAddress(destination);
+  const targetAmount = toBigIntSafe(amountNano);
+  const sinceMs = typeof since === 'number' ? since : 0;
+  for (const tx of transactions) {
+    const timestamp = Number(tx?.utime ?? tx?.now ?? tx?.timestamp ?? 0);
+    if (Number.isFinite(timestamp) && sinceMs && timestamp * 1000 + 120000 < sinceMs) {
+      continue;
+    }
+    const outMessages = Array.isArray(tx?.out_msgs) ? tx.out_msgs : [];
+    for (const message of outMessages) {
+      const destinationAddress =
+        message?.destination?.address ||
+        message?.destination ||
+        message?.dst ||
+        message?.address;
+      if (normalizeTonAddress(destinationAddress) !== targetDestination) continue;
+      const amountValue = message?.value ?? message?.amount ?? message?.value?.nano ?? message?.amount?.nano;
+      const messageAmount = toBigIntSafe(amountValue);
+      if (targetAmount && messageAmount && messageAmount === targetAmount) {
+        return tx?.hash || tx?.transaction_id?.hash || null;
+      }
+    }
+  }
+  return null;
+};
+
+const resolveTonTransactionHash = async ({ address, destination, amountNano, since }) => {
+  for (let attempt = 0; attempt < TON_TX_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const transactions = await fetchTonTransactions(address);
+      const match = findMatchingTonTransaction(transactions, { destination, amountNano, since });
+      if (match) return match;
+    } catch (err) {
+      console.warn('Unable to resolve TON transaction hash yet.', err);
+    }
+    if (attempt < TON_TX_MAX_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, TON_TX_RETRY_DELAY_MS));
+    }
+  }
+  return '';
+};
 
 const DEFAULT_LIST_FORM = {
   itemId: '',
@@ -1358,6 +1432,7 @@ export default function Store() {
       setInfo('Unable to compute total TON payment.');
       return;
     }
+    const paymentStartedAt = Date.now();
     setIsPaying(true);
     resetStatus();
     try {
@@ -1370,7 +1445,16 @@ export default function Store() {
           }
         ]
       });
-      const txHash = result?.boc || result?.transaction?.hash || '';
+      let txHash = result?.transaction?.hash || '';
+      if (!txHash) {
+        const amountNano = toNanoTon(totalPrice);
+        txHash = await resolveTonTransactionHash({
+          address: walletAddress,
+          destination: TON_STORE_ADDRESS,
+          amountNano,
+          since: paymentStartedAt
+        });
+      }
       if (!txHash) {
         setInfo('Payment sent. Paste the transaction hash to verify delivery.');
         return;


### PR DESCRIPTION
### Motivation
- Payments made via TonConnect sometimes do not return a transaction hash, preventing automatic on-chain verification and delivery of purchased NFTs. 
- The store must use the shared store wallet so backend verification matches on-chain deposits. 
- Add a resilient client-side fallback to locate the transaction on TON and trigger the existing delivery flow automatically. 

### Description
- Use the shared store wallet address by importing `ADSGRAM_WALLET` and assigning it to `TON_STORE_ADDRESS` so client and server use the same deposit address. 
- Add TON API configuration constants `TON_API_BASE_URL`, `TON_TX_SEARCH_LIMIT`, `TON_TX_MAX_ATTEMPTS`, and `TON_TX_RETRY_DELAY_MS` for polling recent transactions. 
- Implement helpers `normalizeTonAddress`, `toBigIntSafe`, `fetchTonTransactions`, `findMatchingTonTransaction`, and `resolveTonTransactionHash` to query TON transactions and find a matching tx hash for a payment. 
- Update `initiateTonPayment` to record `paymentStartedAt`, attempt to use `result.transaction.hash` from `tonConnectUI.sendTransaction`, and fall back to `resolveTonTransactionHash` (searching recent transactions from the payer to `TON_STORE_ADDRESS` for the expected amount) before asking the user to paste a hash. 
- When a tx hash is found, the flow continues to call `handlePurchase` (which calls `claimPurchase`) so the NFT is verified and delivered automatically. 

### Testing
- No automated tests were run against these changes. 
- No unit/integration test scripts were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de564d6d483298ad8c0cd1634e9d0)