### PR TITLE
Boost cue power for low-spin shots in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1549,6 +1549,8 @@ const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
+const LOW_SPIN_POWER_THRESHOLD = 0.08; // start boosting once the tip moves into low-spin territory
+const LOW_SPIN_POWER_BOOST = 0.18; // compensate for backspin energy loss without changing spin values
 const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
 const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
@@ -21733,6 +21735,17 @@ const powerRef = useRef(hud.power);
         }
         return { side, vert, hasSpin };
       };
+      const resolveLowSpinPowerBoost = (spin) => {
+        const backspin = Math.max(0, -(spin?.y ?? 0));
+        if (backspin <= LOW_SPIN_POWER_THRESHOLD) return 1;
+        const normalized = THREE.MathUtils.clamp(
+          (backspin - LOW_SPIN_POWER_THRESHOLD) /
+            Math.max(1 - LOW_SPIN_POWER_THRESHOLD, 1e-6),
+          0,
+          1
+        );
+        return 1 + normalized * LOW_SPIN_POWER_BOOST;
+      };
 
       const applyShotAtImpact = (payload) => {
         if (!payload || payload.applied) return;
@@ -21973,7 +21986,9 @@ const powerRef = useRef(hud.power);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
+          const powerScale =
+            (SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower) *
+            resolveLowSpinPowerBoost(appliedSpin);
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = shotAimDir
             .clone()


### PR DESCRIPTION
### Motivation
- Low side/backspin (low spin) shots felt underpowered because backspin reduces cue-ball forward energy, so low-spin inputs need compensated launch power without changing the spin itself.

### Description
- Added tuning constants `LOW_SPIN_POWER_THRESHOLD` and `LOW_SPIN_POWER_BOOST` to `PoolRoyale.jsx` to control when and how much extra power is applied.
- Implemented `resolveLowSpinPowerBoost(spin)` which computes a multiplicative power boost based on backspin magnitude while leaving spin values unchanged.
- Applied the low-spin boost to the shot launch speed by multiplying the existing `powerScale` with `resolveLowSpinPowerBoost(appliedSpin)` in the shot firing path in `webapp/src/pages/Games/PoolRoyale.jsx`.
- The change only affects the computed launch speed and does not modify the applied `spin` or spin mapping functions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de7a87a5c8329ad30c6f8ad34894d)