### PR TITLE
Add source-based thumbnails for store items

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -1,4 +1,5 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { khronosThumb, polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const AIR_HOCKEY_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -284,9 +285,33 @@ const AIR_HOCKEY_HDRI_VARIANTS = Object.freeze(
   RAW_AIR_HOCKEY_HDRI_VARIANTS.map((variant) => ({
     ...variant,
     preferredResolutions: HDRI_RESOLUTION_STACK,
+    thumbnail: polyHavenThumb(variant.assetId),
     ...(AIR_HOCKEY_HDRI_PLACEMENTS[variant.id] || {})
   }))
 );
+
+const TABLE_FINISH_THUMBNAILS = Object.freeze({
+  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
+  oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  woodTable001: polyHavenThumb('wood_table_001'),
+  darkWood: polyHavenThumb('dark_wood'),
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+});
+
+const TABLE_BASE_THUMBNAILS = Object.freeze({
+  classicCylinders: swatchThumbnail(['#8f6243', '#6f3a2f', '#fef3c7']),
+  openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
+  coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
+  gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
+  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+});
+
+const FIELD_THUMBNAILS = Object.freeze({
+  'bust-marble': polyHavenThumb('marble_bust_01'),
+  'bust-onyx': polyHavenThumb('marble_bust_01'),
+  'clearcoat-ruby': khronosThumb('ClearCoatCarPaint'),
+  'clearcoat-azure': khronosThumb('ClearCoatCarPaint')
+});
 
 const AIR_HOCKEY_TABLE_FINISHES = Object.freeze([
   Object.freeze({
@@ -460,6 +485,7 @@ const AIR_HOCKEY_CUSHION_CLOTH_OPTIONS = Object.freeze(
       palette: variant.palette,
       detail: variant.detail,
       swatches: variant.swatches,
+      thumbnail: variant.thumbnail,
       price: variant.price,
       sourceId: variant.sourceId,
       description: variant.description
@@ -527,7 +553,8 @@ export const AIR_HOCKEY_STORE_ITEMS = [
     name: `${field.name} Surface`,
     price: 520 + idx * 20,
     description: field.description,
-    swatches: field.swatches
+    swatches: field.swatches,
+    thumbnail: FIELD_THUMBNAILS[field.id] || swatchThumbnail(field.swatches)
   })),
   ...AIR_HOCKEY_TABLE_FINISHES.map((finish) => ({
     id: `finish-${finish.id}`,
@@ -535,20 +562,117 @@ export const AIR_HOCKEY_STORE_ITEMS = [
     optionId: finish.id,
     name: `${finish.name} Finish`,
     price: finish.price,
-    description: finish.description
+    description: finish.description,
+    thumbnail: TABLE_FINISH_THUMBNAILS[finish.id]
   })),
-  { id: 'puck-volt', type: 'puck', optionId: 'volt', name: 'Volt Puck', price: 220, description: 'High-voltage yellow puck glow.' },
-  { id: 'puck-magenta', type: 'puck', optionId: 'magenta', name: 'Magenta Puck', price: 240, description: 'Magenta puck with vivid emissive edge.' },
-  { id: 'puck-frost', type: 'puck', optionId: 'frost', name: 'Frost Puck', price: 260, description: 'Frost-white puck with cyan glow.' },
-  { id: 'puck-jade', type: 'puck', optionId: 'jade', name: 'Jade Puck', price: 280, description: 'Deep jade puck with emerald shine.' },
-  { id: 'mallet-cyan', type: 'mallet', optionId: 'cyan', name: 'Cyan Mallets', price: 260, description: 'Cyan mallets with midnight knobs.' },
-  { id: 'mallet-amber', type: 'mallet', optionId: 'amber', name: 'Amber Mallets', price: 280, description: 'Amber mallets with dark wood knobs.' },
-  { id: 'mallet-violet', type: 'mallet', optionId: 'violet', name: 'Violet Mallets', price: 300, description: 'Violet mallets with indigo knobs.' },
-  { id: 'mallet-lime', type: 'mallet', optionId: 'lime', name: 'Lime Mallets', price: 320, description: 'Lime mallets with forest knobs.' },
-  { id: 'goal-crimson', type: 'goals', optionId: 'crimsonNet', name: 'Crimson Net Goals', price: 330, description: 'Crimson goal nets with deep ember glow.' },
-  { id: 'goal-cobalt', type: 'goals', optionId: 'cobaltNet', name: 'Cobalt Net Goals', price: 360, description: 'Cobalt nets with electric blue emissive.' },
-  { id: 'goal-amber', type: 'goals', optionId: 'amberNet', name: 'Amber Net Goals', price: 390, description: 'Amber nets with warm metallic shine.' },
-  { id: 'goal-ghost', type: 'goals', optionId: 'ghostNet', name: 'Ghost Net Goals', price: 420, description: 'Ghostly pale nets with steel glow.' },
+  {
+    id: 'puck-volt',
+    type: 'puck',
+    optionId: 'volt',
+    name: 'Volt Puck',
+    price: 220,
+    description: 'High-voltage yellow puck glow.',
+    thumbnail: swatchThumbnail(['#eab308', '#854d0e', '#fef08a'])
+  },
+  {
+    id: 'puck-magenta',
+    type: 'puck',
+    optionId: 'magenta',
+    name: 'Magenta Puck',
+    price: 240,
+    description: 'Magenta puck with vivid emissive edge.',
+    thumbnail: swatchThumbnail(['#be185d', '#9f1239', '#fda4af'])
+  },
+  {
+    id: 'puck-frost',
+    type: 'puck',
+    optionId: 'frost',
+    name: 'Frost Puck',
+    price: 260,
+    description: 'Frost-white puck with cyan glow.',
+    thumbnail: swatchThumbnail(['#e0f2fe', '#0ea5e9', '#bae6fd'])
+  },
+  {
+    id: 'puck-jade',
+    type: 'puck',
+    optionId: 'jade',
+    name: 'Jade Puck',
+    price: 280,
+    description: 'Deep jade puck with emerald shine.',
+    thumbnail: swatchThumbnail(['#064e3b', '#10b981', '#6ee7b7'])
+  },
+  {
+    id: 'mallet-cyan',
+    type: 'mallet',
+    optionId: 'cyan',
+    name: 'Cyan Mallets',
+    price: 260,
+    description: 'Cyan mallets with midnight knobs.',
+    thumbnail: swatchThumbnail(['#22d3ee', '#0f172a', '#cffafe'])
+  },
+  {
+    id: 'mallet-amber',
+    type: 'mallet',
+    optionId: 'amber',
+    name: 'Amber Mallets',
+    price: 280,
+    description: 'Amber mallets with dark wood knobs.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#451a03', '#fde68a'])
+  },
+  {
+    id: 'mallet-violet',
+    type: 'mallet',
+    optionId: 'violet',
+    name: 'Violet Mallets',
+    price: 300,
+    description: 'Violet mallets with indigo knobs.',
+    thumbnail: swatchThumbnail(['#a855f7', '#312e81', '#e9d5ff'])
+  },
+  {
+    id: 'mallet-lime',
+    type: 'mallet',
+    optionId: 'lime',
+    name: 'Lime Mallets',
+    price: 320,
+    description: 'Lime mallets with forest knobs.',
+    thumbnail: swatchThumbnail(['#84cc16', '#1a2e05', '#ecfccb'])
+  },
+  {
+    id: 'goal-crimson',
+    type: 'goals',
+    optionId: 'crimsonNet',
+    name: 'Crimson Net Goals',
+    price: 330,
+    description: 'Crimson goal nets with deep ember glow.',
+    thumbnail: swatchThumbnail(['#ef4444', '#7f1d1d', '#fecaca'])
+  },
+  {
+    id: 'goal-cobalt',
+    type: 'goals',
+    optionId: 'cobaltNet',
+    name: 'Cobalt Net Goals',
+    price: 360,
+    description: 'Cobalt nets with electric blue emissive.',
+    thumbnail: swatchThumbnail(['#60a5fa', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'goal-amber',
+    type: 'goals',
+    optionId: 'amberNet',
+    name: 'Amber Net Goals',
+    price: 390,
+    description: 'Amber nets with warm metallic shine.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a'])
+  },
+  {
+    id: 'goal-ghost',
+    type: 'goals',
+    optionId: 'ghostNet',
+    name: 'Ghost Net Goals',
+    price: 420,
+    description: 'Ghostly pale nets with steel glow.',
+    thumbnail: swatchThumbnail(['#e5e7eb', '#6b7280', '#f8fafc'])
+  },
   ...AIR_HOCKEY_CUSHION_CLOTH_OPTIONS.map((variant, idx) => ({
     id: `cushion-cloth-${variant.id}`,
     type: 'cushionCloth',
@@ -556,7 +680,8 @@ export const AIR_HOCKEY_STORE_ITEMS = [
     name: variant.name,
     price: variant.price ?? 680 + idx * 8,
     description: variant.description,
-    swatches: variant.swatches
+    swatches: variant.swatches,
+    thumbnail: variant.thumbnail
   })),
   ...AIR_HOCKEY_TABLE_BASES.map((variant) => ({
     id: `base-${variant.id}`,
@@ -564,7 +689,8 @@ export const AIR_HOCKEY_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} Base`,
     price: 0,
-    description: variant.description
+    description: variant.description,
+    thumbnail: TABLE_BASE_THUMBNAILS[variant.id]
   })),
   ...AIR_HOCKEY_HDRI_VARIANTS.map((variant) => ({
     id: `hdri-${variant.id}`,
@@ -572,7 +698,8 @@ export const AIR_HOCKEY_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} HDRI`,
     price: variant.price,
-    description: variant.description
+    description: variant.description,
+    thumbnail: variant.thumbnail
   }))
 ];
 

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -4,6 +4,7 @@ import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
 } from './poolRoyaleInventoryConfig.js';
+import { swatchThumbnail } from './storeThumbnails.js';
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
 
@@ -139,6 +140,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     price: finish.price ?? 980 + idx * 40,
     description: finish.description,
     swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
   ...CHESS_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
@@ -163,31 +165,176 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     thumbnail: option.thumbnail,
     previewShape: 'chair'
   })),
-  { id: 'chess-side-marble', type: 'sideColor', optionId: 'marble', name: 'Marble Pieces', price: 1400, description: 'Premium marble-inspired pieces for either side.' },
-  { id: 'chess-side-forest', type: 'sideColor', optionId: 'darkForest', name: 'Dark Forest Pieces', price: 1300, description: 'Deep forest hue pieces with luxe accents.' },
-  { id: 'chess-side-royal', type: 'sideColor', optionId: 'royalWave', name: 'Royal Wave Pieces', price: 420, description: 'Royal blue quick-select palette.' },
-  { id: 'chess-side-rose', type: 'sideColor', optionId: 'roseMist', name: 'Rose Mist Pieces', price: 420, description: 'Rosy quick-select palette with soft glow.' },
-  { id: 'chess-side-amethyst', type: 'sideColor', optionId: 'amethyst', name: 'Amethyst Pieces', price: 460, description: 'Amethyst quick-select palette with sheen.' },
-  { id: 'chess-side-cinder', type: 'sideColor', optionId: 'cinderBlaze', name: 'Cinder Blaze Pieces', price: 480, description: 'Molten orange-on-charcoal palette for fiery showdowns.' },
-  { id: 'chess-side-arctic', type: 'sideColor', optionId: 'arcticDrift', name: 'Arctic Drift Pieces', price: 520, description: 'Icy stone palette with frosted metallic hints.' },
-  { id: 'chess-board-ivorySlate', type: 'boardTheme', optionId: 'ivorySlate', name: 'Ivory/Slate Board', price: 380, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-forest', type: 'boardTheme', optionId: 'forest', name: 'Forest Board', price: 410, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-sand', type: 'boardTheme', optionId: 'sand', name: 'Sand/Brown Board', price: 440, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-ocean', type: 'boardTheme', optionId: 'ocean', name: 'Ocean Board', price: 470, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-violet', type: 'boardTheme', optionId: 'violet', name: 'Violet Board', price: 500, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-chrome', type: 'boardTheme', optionId: 'chrome', name: 'Chrome Board', price: 540, description: 'Alternate board palette for fast swaps.' },
-  { id: 'chess-board-nebula', type: 'boardTheme', optionId: 'nebulaGlass', name: 'Nebula Glass Board', price: 580, description: 'Cosmic glass palette with deep-space contrasts.' },
-  { id: 'chess-head-ruby', type: 'headStyle', optionId: 'headRuby', name: 'Ruby Pawn Heads', price: 310, description: 'Unlocks an additional pawn head glass preset.' },
-  { id: 'chess-head-sapphire', type: 'headStyle', optionId: 'headSapphire', name: 'Sapphire Pawn Heads', price: 335, description: 'Unlocks an additional pawn head glass preset.' },
-  { id: 'chess-head-chrome', type: 'headStyle', optionId: 'headChrome', name: 'Chrome Pawn Heads', price: 360, description: 'Unlocks an additional pawn head glass preset.' },
-  { id: 'chess-head-gold', type: 'headStyle', optionId: 'headGold', name: 'Gold Pawn Heads', price: 385, description: 'Unlocks an additional pawn head glass preset.' },
+  {
+    id: 'chess-side-marble',
+    type: 'sideColor',
+    optionId: 'marble',
+    name: 'Marble Pieces',
+    price: 1400,
+    description: 'Premium marble-inspired pieces for either side.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#e2e8f0', '#cbd5f5'])
+  },
+  {
+    id: 'chess-side-forest',
+    type: 'sideColor',
+    optionId: 'darkForest',
+    name: 'Dark Forest Pieces',
+    price: 1300,
+    description: 'Deep forest hue pieces with luxe accents.',
+    thumbnail: swatchThumbnail(['#14532d', '#0f3d23', '#86efac'])
+  },
+  {
+    id: 'chess-side-royal',
+    type: 'sideColor',
+    optionId: 'royalWave',
+    name: 'Royal Wave Pieces',
+    price: 420,
+    description: 'Royal blue quick-select palette.',
+    thumbnail: swatchThumbnail(['#3b82f6', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'chess-side-rose',
+    type: 'sideColor',
+    optionId: 'roseMist',
+    name: 'Rose Mist Pieces',
+    price: 420,
+    description: 'Rosy quick-select palette with soft glow.',
+    thumbnail: swatchThumbnail(['#ef4444', '#be123c', '#fecaca'])
+  },
+  {
+    id: 'chess-side-amethyst',
+    type: 'sideColor',
+    optionId: 'amethyst',
+    name: 'Amethyst Pieces',
+    price: 460,
+    description: 'Amethyst quick-select palette with sheen.',
+    thumbnail: swatchThumbnail(['#8b5cf6', '#6d28d9', '#ddd6fe'])
+  },
+  {
+    id: 'chess-side-cinder',
+    type: 'sideColor',
+    optionId: 'cinderBlaze',
+    name: 'Cinder Blaze Pieces',
+    price: 480,
+    description: 'Molten orange-on-charcoal palette for fiery showdowns.',
+    thumbnail: swatchThumbnail(['#ff6b35', '#7f1d1d', '#fed7aa'])
+  },
+  {
+    id: 'chess-side-arctic',
+    type: 'sideColor',
+    optionId: 'arcticDrift',
+    name: 'Arctic Drift Pieces',
+    price: 520,
+    description: 'Icy stone palette with frosted metallic hints.',
+    thumbnail: swatchThumbnail(['#bcd7ff', '#7aa2f7', '#e2e8f0'])
+  },
+  {
+    id: 'chess-board-ivorySlate',
+    type: 'boardTheme',
+    optionId: 'ivorySlate',
+    name: 'Ivory/Slate Board',
+    price: 380,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#64748b', '#e2e8f0'])
+  },
+  {
+    id: 'chess-board-forest',
+    type: 'boardTheme',
+    optionId: 'forest',
+    name: 'Forest Board',
+    price: 410,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#065f46', '#134e4a', '#bbf7d0'])
+  },
+  {
+    id: 'chess-board-sand',
+    type: 'boardTheme',
+    optionId: 'sand',
+    name: 'Sand/Brown Board',
+    price: 440,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#d6c7a1', '#8b6b4f', '#fef3c7'])
+  },
+  {
+    id: 'chess-board-ocean',
+    type: 'boardTheme',
+    optionId: 'ocean',
+    name: 'Ocean Board',
+    price: 470,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'chess-board-violet',
+    type: 'boardTheme',
+    optionId: 'violet',
+    name: 'Violet Board',
+    price: 500,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe'])
+  },
+  {
+    id: 'chess-board-chrome',
+    type: 'boardTheme',
+    optionId: 'chrome',
+    name: 'Chrome Board',
+    price: 540,
+    description: 'Alternate board palette for fast swaps.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
+  },
+  {
+    id: 'chess-board-nebula',
+    type: 'boardTheme',
+    optionId: 'nebulaGlass',
+    name: 'Nebula Glass Board',
+    price: 580,
+    description: 'Cosmic glass palette with deep-space contrasts.',
+    thumbnail: swatchThumbnail(['#312e81', '#111827', '#a855f7'])
+  },
+  {
+    id: 'chess-head-ruby',
+    type: 'headStyle',
+    optionId: 'headRuby',
+    name: 'Ruby Pawn Heads',
+    price: 310,
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: swatchThumbnail(['#b91c1c', '#7f1d1d', '#fecaca'])
+  },
+  {
+    id: 'chess-head-sapphire',
+    type: 'headStyle',
+    optionId: 'headSapphire',
+    name: 'Sapphire Pawn Heads',
+    price: 335,
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'chess-head-chrome',
+    type: 'headStyle',
+    optionId: 'headChrome',
+    name: 'Chrome Pawn Heads',
+    price: 360,
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
+  },
+  {
+    id: 'chess-head-gold',
+    type: 'headStyle',
+    optionId: 'headGold',
+    name: 'Gold Pawn Heads',
+    price: 385,
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#b45309', '#fde68a'])
+  },
   ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
     id: `chess-hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
     name: `${variant.name} HDRI`,
     price: variant.price ?? 1400 + idx * 30,
-    description: 'Pool Royale HDRI environment, tuned for chess table promos.'
+    description: 'Pool Royale HDRI environment, tuned for chess table promos.',
+    thumbnail: variant.thumbnail
   }))
 ];
 

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,5 +1,6 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: [
@@ -51,6 +52,45 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   }))
 });
 
+const DOMINO_TABLE_WOOD_THUMBNAILS = Object.freeze({
+  oakEstate: polyHavenThumb('oak_veneer_01'),
+  teakStudio: polyHavenThumb('kitchen_wood')
+});
+
+const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
+  crimson: swatchThumbnail(['#960019', '#4a0012', '#fecaca']),
+  emerald: swatchThumbnail(['#0f6a2f', '#054d24', '#bbf7d0']),
+  arctic: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe']),
+  sunset: swatchThumbnail(['#ea580c', '#c2410c', '#fed7aa']),
+  violet: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe']),
+  amber: swatchThumbnail(['#b7791f', '#92571a', '#fde68a'])
+});
+
+const DOMINO_TABLE_BASE_THUMBNAILS = Object.freeze({
+  obsidian: swatchThumbnail(['#141414', '#1f232a', '#94a3b8']),
+  forestBronze: swatchThumbnail(['#101714', '#1f2d24', '#4ade80']),
+  midnightChrome: swatchThumbnail(['#0f172a', '#1e2f4a', '#93c5fd']),
+  emberCopper: swatchThumbnail(['#231312', '#5c2d1b', '#fdba74']),
+  violetShadow: swatchThumbnail(['#1f1130', '#3f1b5b', '#c4b5fd']),
+  desertGold: swatchThumbnail(['#1c1a12', '#5a4524', '#fcd34d'])
+});
+
+const DOMINO_STYLE_THUMBNAILS = Object.freeze({
+  imperialIvory: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0']),
+  obsidianPlatinum: swatchThumbnail(['#1f2937', '#6b7280', '#e5e7eb']),
+  midnightRose: swatchThumbnail(['#881337', '#1f2937', '#fecdd3']),
+  auroraJade: swatchThumbnail(['#047857', '#0f172a', '#86efac']),
+  frostedOpal: swatchThumbnail(['#f8fafc', '#c7d2fe', '#e2e8f0']),
+  carbonVolt: swatchThumbnail(['#0f172a', '#111827', '#fde047']),
+  sandstoneAurora: swatchThumbnail(['#d6c7a1', '#7c2d12', '#fcd34d'])
+});
+
+const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
+  marksmanAmber: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a']),
+  iceTracer: swatchThumbnail(['#e0f2fe', '#0ea5e9', '#bae6fd']),
+  violetPulse: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe'])
+});
+
 export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze(
   Object.entries(DOMINO_ROYAL_OPTION_SETS).reduce((acc, [type, options]) => {
     acc[type] = options.length ? [options[0].id] : [];
@@ -77,7 +117,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 780,
-    description: 'Alternate premium wood finish for your Domino Royal arena.'
+    description: 'Alternate premium wood finish for your Domino Royal arena.',
+    thumbnail: DOMINO_TABLE_WOOD_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableCloth.slice(1).map((option, idx) => ({
     id: `domino-cloth-${option.id}`,
@@ -85,7 +126,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 340 + idx * 30,
-    description: 'Unlock a new felt tone for the Domino Royal table surface.'
+    description: 'Unlock a new felt tone for the Domino Royal table surface.',
+    thumbnail: DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableBase.slice(1).map((option, idx) => ({
     id: `domino-base-${option.id}`,
@@ -93,7 +135,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 520 + idx * 40,
-    description: 'Swap in a different pedestal finish beneath the table.'
+    description: 'Swap in a different pedestal finish beneath the table.',
+    thumbnail: DOMINO_TABLE_BASE_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
     id: `domino-table-theme-${option.id}`,
@@ -101,7 +144,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 900 + idx * 45,
-    description: option.description || 'Apply the Murlan Royale table collection to Domino.'
+    description: option.description || 'Apply the Murlan Royale table collection to Domino.',
+    thumbnail: MURLAN_TABLE_THEMES.find((theme) => theme.id === option.id)?.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.environmentHdri.slice(1).map((option, idx) => ({
     id: `domino-hdri-${option.id}`,
@@ -109,7 +153,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: POOL_ROYALE_HDRI_VARIANTS[idx + 1]?.price || 1200 + idx * 80,
-    description: 'HDRI environment from the Pool/Murlan Royale library.'
+    description: 'HDRI environment from the Pool/Murlan Royale library.',
+    thumbnail: POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === option.id)?.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.dominoStyle.slice(1).map((option, idx) => ({
     id: `domino-style-${option.id}`,
@@ -117,7 +162,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 820 + idx * 40,
-    description: 'Premium domino material set for tiles and pips.'
+    description: 'Premium domino material set for tiles and pips.',
+    thumbnail: DOMINO_STYLE_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.highlightStyle.slice(1).map((option, idx) => ({
     id: `domino-highlight-${option.id}`,
@@ -125,7 +171,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 260 + idx * 40,
-    description: 'Unlocks a new tracer highlight for the table setup.'
+    description: 'Unlocks a new tracer highlight for the table setup.',
+    thumbnail: DOMINO_HIGHLIGHT_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.chairTheme.slice(1).map((option, idx) => ({
     id: `domino-chair-${option.id}`,
@@ -133,7 +180,8 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 300 + idx * 25,
-    description: option.description || 'Murlan Royale seating set for Domino Royal.'
+    description: option.description || 'Murlan Royale seating set for Domino Royal.',
+    thumbnail: MURLAN_STOOL_THEMES.find((theme) => theme.id === option.id)?.thumbnail
   }))
 ];
 

--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -6,6 +6,7 @@ import {
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
+import { swatchThumbnail } from './storeThumbnails.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
@@ -66,6 +67,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Pool Royale HDRI environment tuned for wide-table arenas.',
     swatches: variant.swatches,
+    thumbnail: variant.thumbnail,
     previewShape: 'table'
   })),
   ...TOKEN_PALETTE_OPTIONS.slice(1).map((option, idx) => ({
@@ -74,7 +76,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     optionId: option.id,
     name: `${option.label} Palette`,
     price: 260 + idx * 20,
-    description: 'Alternate pawn color palette for every side.'
+    description: 'Alternate pawn color palette for every side.',
+    thumbnail: swatchThumbnail(option.swatches.map((value) => `#${value.toString(16).padStart(6, '0')}`))
   })),
   ...TOKEN_STYLE_OPTIONS.slice(1).map((option) => ({
     id: `ludo-style-${option.id}`,
@@ -82,7 +85,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 450,
-    description: 'Swap the token mesh set for a new silhouette.'
+    description: 'Swap the token mesh set for a new silhouette.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#1f2937', '#94a3b8'])
   })),
   ...TOKEN_PIECE_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-piece-${option.id}`,
@@ -90,7 +94,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 300 + idx * 20,
-    description: 'Unlock an alternate piece identity for your pawns.'
+    description: 'Unlock an alternate piece identity for your pawns.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#0f172a', '#fbbf24'])
   })),
   ...CHESS_BATTLE_STORE_ITEMS.filter((item) => ['sideColor', 'headStyle'].includes(item.type))
 ];

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -43,6 +43,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     price: finish.price ?? 980 + idx * 40,
     description: finish.description,
     swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
   {
@@ -51,7 +52,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: 'solstice',
     name: 'Solstice Deck',
     price: 260,
-    description: 'Sun-baked backs with warm metallic edgework.'
+    description: 'Sun-baked backs with warm metallic edgework.',
+    thumbnail: CARD_THEMES.find((theme) => theme.id === 'solstice')?.thumbnail
   },
   {
     id: 'cards-nebula',
@@ -59,7 +61,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: 'nebula',
     name: 'Nebula Deck',
     price: 300,
-    description: 'Cosmic purples with glowing starlit accents.'
+    description: 'Cosmic purples with glowing starlit accents.',
+    thumbnail: CARD_THEMES.find((theme) => theme.id === 'nebula')?.thumbnail
   },
   {
     id: 'cards-jade',
@@ -67,7 +70,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: 'jade',
     name: 'Jade Deck',
     price: 280,
-    description: 'Emerald gradients with luminous jade borders.'
+    description: 'Emerald gradients with luminous jade borders.',
+    thumbnail: CARD_THEMES.find((theme) => theme.id === 'jade')?.thumbnail
   },
   {
     id: 'cards-ember',
@@ -75,7 +79,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: 'ember',
     name: 'Ember Deck',
     price: 320,
-    description: 'Fiery orange backs with charcoal cores.'
+    description: 'Fiery orange backs with charcoal cores.',
+    thumbnail: CARD_THEMES.find((theme) => theme.id === 'ember')?.thumbnail
   },
   {
     id: 'cards-onyx',
@@ -83,7 +88,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: 'onyx',
     name: 'Onyx Deck',
     price: 340,
-    description: 'Monochrome slate backs with steel edging.'
+    description: 'Monochrome slate backs with steel edging.',
+    thumbnail: CARD_THEMES.find((theme) => theme.id === 'onyx')?.thumbnail
   }
 ].concat(
   MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
@@ -111,6 +117,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Pool Royale HDRI environment tuned for Murlan promos.',
     swatches: variant.swatches,
+    thumbnail: variant.thumbnail,
     previewShape: 'table'
   }))
 );

--- a/webapp/src/config/murlanTableFinishes.js
+++ b/webapp/src/config/murlanTableFinishes.js
@@ -1,4 +1,5 @@
 import { POOL_ROYALE_OPTION_LABELS } from './poolRoyaleInventoryConfig.js';
+import { polyHavenThumb } from './storeThumbnails.js';
 
 export const MURLAN_TABLE_FINISHES = Object.freeze([
   Object.freeze({
@@ -7,6 +8,7 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
     description: 'Weathered peeling paint wood rails with a reclaimed finish.',
     price: 980,
     swatches: ['#a89f95', '#b8b3aa'],
+    thumbnail: polyHavenThumb('wood_peeling_paint_weathered'),
     woodOption: Object.freeze({
       id: 'peelingPaintWeathered',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.peelingPaintWeathered,
@@ -20,6 +22,7 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
     description: 'Warm oak veneer rails with smooth satin polish.',
     price: 990,
     swatches: ['#b9854e', '#c89a64'],
+    thumbnail: polyHavenThumb('oak_veneer_01'),
     woodOption: Object.freeze({
       id: 'oakVeneer01',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.oakVeneer01,
@@ -33,6 +36,7 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
     description: 'Balanced walnut-brown rails inspired by classic table slabs.',
     price: 1000,
     swatches: ['#8f6243', '#a4724f'],
+    thumbnail: polyHavenThumb('wood_table_001'),
     woodOption: Object.freeze({
       id: 'woodTable001',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.woodTable001,
@@ -46,6 +50,7 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
     description: 'Deep espresso rails with strong grain contrast.',
     price: 1010,
     swatches: ['#2f241f', '#3d2f2a'],
+    thumbnail: polyHavenThumb('dark_wood'),
     woodOption: Object.freeze({
       id: 'darkWood',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.darkWood,
@@ -59,6 +64,7 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     price: 1020,
     swatches: ['#5b2f26', '#6f3a2f'],
+    thumbnail: polyHavenThumb('rosewood_veneer_01'),
     woodOption: Object.freeze({
       id: 'rosewoodVeneer01',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.rosewoodVeneer01,

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -1,10 +1,54 @@
+import { swatchThumbnail } from './storeThumbnails.js';
+
 export const MURLAN_OUTFIT_THEMES = [
-  { id: 'midnight', label: 'Royal Blue', baseColor: '#1f3c88', accentColor: '#f5d547', glow: '#0f172a' },
-  { id: 'ember', label: 'Neon Red', baseColor: '#a31621', accentColor: '#ff8e3c', glow: '#22080b' },
-  { id: 'glacier', label: 'Ice', baseColor: '#1b8dbf', accentColor: '#9ff0ff', glow: '#082433' },
-  { id: 'forest', label: 'Forest', baseColor: '#1b7f4a', accentColor: '#b5f44a', glow: '#071f11' },
-  { id: 'royal', label: 'Violet', baseColor: '#6b21a8', accentColor: '#f0abfc', glow: '#220a35' },
-  { id: 'onyx', label: 'Onyx', baseColor: '#1f2937', accentColor: '#9ca3af', glow: '#090b10' }
+  {
+    id: 'midnight',
+    label: 'Royal Blue',
+    baseColor: '#1f3c88',
+    accentColor: '#f5d547',
+    glow: '#0f172a',
+    thumbnail: swatchThumbnail(['#1f3c88', '#0f172a', '#f5d547'])
+  },
+  {
+    id: 'ember',
+    label: 'Neon Red',
+    baseColor: '#a31621',
+    accentColor: '#ff8e3c',
+    glow: '#22080b',
+    thumbnail: swatchThumbnail(['#a31621', '#22080b', '#ff8e3c'])
+  },
+  {
+    id: 'glacier',
+    label: 'Ice',
+    baseColor: '#1b8dbf',
+    accentColor: '#9ff0ff',
+    glow: '#082433',
+    thumbnail: swatchThumbnail(['#1b8dbf', '#082433', '#9ff0ff'])
+  },
+  {
+    id: 'forest',
+    label: 'Forest',
+    baseColor: '#1b7f4a',
+    accentColor: '#b5f44a',
+    glow: '#071f11',
+    thumbnail: swatchThumbnail(['#1b7f4a', '#071f11', '#b5f44a'])
+  },
+  {
+    id: 'royal',
+    label: 'Violet',
+    baseColor: '#6b21a8',
+    accentColor: '#f0abfc',
+    glow: '#220a35',
+    thumbnail: swatchThumbnail(['#6b21a8', '#220a35', '#f0abfc'])
+  },
+  {
+    id: 'onyx',
+    label: 'Onyx',
+    baseColor: '#1f2937',
+    accentColor: '#9ca3af',
+    glow: '#090b10',
+    thumbnail: swatchThumbnail(['#1f2937', '#090b10', '#9ca3af'])
+  }
 ];
 
 const POLYHAVEN_THUMB = (id) => `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -1,3 +1,5 @@
+import { polyHavenThumb } from './storeThumbnails.js';
+
 const normalizeHex = (value) => {
   const asString = typeof value === 'number' ? value.toString(16).padStart(6, '0') : String(value || '').replace('#', '');
   return `#${asString.slice(0, 6)}`;
@@ -168,6 +170,7 @@ const createVariantsForMaterial = (material) => {
         sparkle: material.sparkle,
         stray: material.stray,
         detail: material.detail,
+        thumbnail: polyHavenThumb(material.sourceId),
         price,
         swatches: createSwatches(hex),
         description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,4 +1,5 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -284,9 +285,46 @@ export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
     preferredResolutions: HDRI_RESOLUTION_STACK,
+    thumbnail: polyHavenThumb(variant.assetId),
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))
 );
+
+const TABLE_FINISH_THUMBNAILS = Object.freeze({
+  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
+  oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  woodTable001: polyHavenThumb('wood_table_001'),
+  darkWood: polyHavenThumb('dark_wood'),
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+});
+
+const POCKET_LINER_THUMBNAILS = Object.freeze({
+  fabric_leather_02: polyHavenThumb('fabric_leather_02'),
+  fabric_leather_01: polyHavenThumb('fabric_leather_01'),
+  brown_leather: polyHavenThumb('brown_leather'),
+  leather_red_02: polyHavenThumb('leather_red_02'),
+  leather_red_03: polyHavenThumb('leather_red_03'),
+  leather_white: polyHavenThumb('leather_white')
+});
+
+const CUE_STYLE_THUMBNAILS = Object.freeze({
+  'redwood-ember': swatchThumbnail(['#7f1d1d', '#b91c1c', '#fde68a']),
+  'birch-frost': swatchThumbnail(['#f8fafc', '#e2e8f0', '#bae6fd']),
+  'wenge-nightfall': swatchThumbnail(['#0f172a', '#1f2937', '#64748b']),
+  'mahogany-heritage': swatchThumbnail(['#7c2d12', '#b45309', '#fbbf24']),
+  'walnut-satin': swatchThumbnail(['#5b3a29', '#8b5e34', '#f3d9b1']),
+  'carbon-matrix': swatchThumbnail(['#0b0f16', '#111827', '#94a3b8']),
+  'maple-horizon': swatchThumbnail(['#f5e6c8', '#d4b790', '#fde68a']),
+  'graphite-aurora': swatchThumbnail(['#1f2937', '#4b5563', '#c7d2fe'])
+});
+
+const BASE_VARIANT_THUMBNAILS = Object.freeze({
+  classicCylinders: swatchThumbnail(['#8f6243', '#6f3a2f', '#fef3c7']),
+  openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
+  coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
+  gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
+  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+});
 
 export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
   POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
@@ -403,7 +441,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'peelingPaintWeathered',
     name: 'Wood Peeling Paint Weathered Finish',
     price: 980,
-    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.peelingPaintWeathered
   },
   {
     id: 'finish-oakVeneer01',
@@ -411,7 +450,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'oakVeneer01',
     name: 'Oak Veneer 01 Finish',
     price: 990,
-    description: 'Warm oak veneer rails with smooth satin polish.'
+    description: 'Warm oak veneer rails with smooth satin polish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01
   },
   {
     id: 'finish-woodTable001',
@@ -419,7 +459,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'woodTable001',
     name: 'Wood Table 001 Finish',
     price: 1000,
-    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.woodTable001
   },
   {
     id: 'finish-darkWood',
@@ -427,7 +468,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'darkWood',
     name: 'Dark Wood Finish',
     price: 1010,
-    description: 'Deep espresso rails with strong grain contrast.'
+    description: 'Deep espresso rails with strong grain contrast.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.darkWood
   },
   {
     id: 'finish-rosewoodVeneer01',
@@ -435,7 +477,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'rosewoodVeneer01',
     name: 'Rosewood Veneer 01 Finish',
     price: 1020,
-    description: 'Rosewood veneer rails with rich, reddish undertones.'
+    description: 'Rosewood veneer rails with rich, reddish undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
   },
   {
     id: 'chrome-chrome',
@@ -443,7 +486,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'chrome',
     name: 'Mirror Chrome Fascias',
     price: 360,
-    description: 'Polished chrome plates to swap in for the fascia set.'
+    description: 'Polished chrome plates to swap in for the fascia set.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
   },
   {
     id: 'railMarkers-pearl',
@@ -451,7 +495,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'pearl',
     name: 'Pearl Diamonds',
     price: 280,
-    description: 'Pearlescent diamond markers with soft sheen.'
+    description: 'Pearlescent diamond markers with soft sheen.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0'])
   },
   {
     id: 'railMarkers-chrome',
@@ -459,7 +504,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'chrome',
     name: 'Chrome Diamonds',
     price: 240,
-    description: 'Chrome-lined diamond markers that match fascia shine.'
+    description: 'Chrome-lined diamond markers that match fascia shine.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
   },
   ...POOL_ROYALE_CLOTH_VARIANTS.map((variant) => ({
     id: `cloth-${variant.id}`,
@@ -467,7 +513,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: variant.name,
     price: variant.price,
-    description: variant.description
+    description: variant.description,
+    thumbnail: variant.thumbnail
   })),
   {
     id: 'pocket-fabric-leather-02',
@@ -475,7 +522,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'fabric_leather_02',
     name: 'Fabric Leather 02 Pocket Jaws',
     price: 520,
-    description: 'Warm stitched leather weave liners for the classic Pool Royale look.'
+    description: 'Warm stitched leather weave liners for the classic Pool Royale look.',
+    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_02
   },
   {
     id: 'pocket-fabric-leather-01',
@@ -483,7 +531,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'fabric_leather_01',
     name: 'Fabric Leather 01 Pocket Jaws',
     price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.'
+    description: 'Soft-grain leather weave liners with a mellow brown finish.',
+    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_01
   },
   {
     id: 'pocket-brown-leather',
@@ -491,7 +540,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'brown_leather',
     name: 'Brown Leather Pocket Jaws',
     price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.'
+    description: 'Deep brown leather pockets with natural creases and aged texture.',
+    thumbnail: POCKET_LINER_THUMBNAILS.brown_leather
   },
   {
     id: 'pocket-leather-red-02',
@@ -499,7 +549,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'leather_red_02',
     name: 'Leather Red 02 Pocket Jaws',
     price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.'
+    description: 'Bold red leather liners with pronounced seams and worn highlights.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_02
   },
   {
     id: 'pocket-leather-red-03',
@@ -507,7 +558,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'leather_red_03',
     name: 'Leather Red 03 Pocket Jaws',
     price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
+    description: 'Deep crimson leather pocket liners with subtle stitch detailing.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_03
   },
   {
     id: 'pocket-leather-white',
@@ -515,7 +567,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'leather_white',
     name: 'Leather White Pocket Jaws',
     price: 590,
-    description: 'Bright white leather pockets with crisp seam definition and clean grain.'
+    description: 'Bright white leather pockets with crisp seam definition and clean grain.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_white
   },
   {
     id: 'cue-redwood',
@@ -523,7 +576,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'redwood-ember',
     name: 'Redwood Ember Cue',
     price: 310,
-    description: 'Rich redwood cue butt with ember accents.'
+    description: 'Rich redwood cue butt with ember accents.',
+    thumbnail: CUE_STYLE_THUMBNAILS['redwood-ember']
   },
   {
     id: 'cue-wenge',
@@ -531,7 +585,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'wenge-nightfall',
     name: 'Wenge Nightfall Cue',
     price: 340,
-    description: 'Deep wenge finish with high-contrast stripes.'
+    description: 'Deep wenge finish with high-contrast stripes.',
+    thumbnail: CUE_STYLE_THUMBNAILS['wenge-nightfall']
   },
   {
     id: 'cue-mahogany',
@@ -539,7 +594,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'mahogany-heritage',
     name: 'Mahogany Heritage Cue',
     price: 325,
-    description: 'Classic mahogany cue with heritage grain highlights.'
+    description: 'Classic mahogany cue with heritage grain highlights.',
+    thumbnail: CUE_STYLE_THUMBNAILS['mahogany-heritage']
   },
   {
     id: 'cue-walnut',
@@ -547,7 +603,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'walnut-satin',
     name: 'Walnut Satin Cue',
     price: 295,
-    description: 'Satin walnut cue butt with balanced contrast.'
+    description: 'Satin walnut cue butt with balanced contrast.',
+    thumbnail: CUE_STYLE_THUMBNAILS['walnut-satin']
   },
   {
     id: 'cue-carbon',
@@ -555,7 +612,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbon-matrix',
     name: 'Carbon Matrix Cue',
     price: 380,
-    description: 'Carbon fiber cue with metallic weave highlights.'
+    description: 'Carbon fiber cue with metallic weave highlights.',
+    thumbnail: CUE_STYLE_THUMBNAILS['carbon-matrix']
   },
   {
     id: 'cue-maple',
@@ -563,7 +621,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'maple-horizon',
     name: 'Maple Horizon Cue',
     price: 300,
-    description: 'Bright maple cue with horizon banding.'
+    description: 'Bright maple cue with horizon banding.',
+    thumbnail: CUE_STYLE_THUMBNAILS['maple-horizon']
   },
   {
     id: 'cue-graphite',
@@ -571,7 +630,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'graphite-aurora',
     name: 'Graphite Aurora Cue',
     price: 360,
-    description: 'Graphite weave cue with aurora-inspired tint.'
+    description: 'Graphite weave cue with aurora-inspired tint.',
+    thumbnail: CUE_STYLE_THUMBNAILS['graphite-aurora']
   },
   ...POOL_ROYALE_BASE_VARIANTS.map((variant) => ({
     id: `base-${variant.id}`,
@@ -579,7 +639,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} Base`,
     price: 0,
-    description: variant.description
+    description: variant.description,
+    thumbnail: BASE_VARIANT_THUMBNAILS[variant.id]
   })),
   ...POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     id: `hdri-${variant.id}`,
@@ -587,7 +648,8 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} HDRI`,
     price: variant.price,
-    description: variant.description
+    description: variant.description,
+    thumbnail: variant.thumbnail
   }))
 ];
 

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -1,5 +1,6 @@
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -71,6 +72,81 @@ export const SNAKE_TOKEN_COLOR_OPTIONS = Object.freeze([
   { id: 'cinderBlaze', label: 'Cinder Blaze', color: '#ff6b35' },
   { id: 'arcticDrift', label: 'Arctic Drift', color: '#bcd7ff' }
 ]);
+
+const SNAKE_TABLE_FINISH_THUMBNAILS = Object.freeze({
+  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
+  oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  woodTable001: polyHavenThumb('wood_table_001'),
+  darkWood: polyHavenThumb('dark_wood'),
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+});
+
+const SNAKE_FLOOR_TEXTURE_THUMBNAILS = Object.freeze({
+  paving_stones_02: swatchThumbnail(['#9ca3af', '#6b7280', '#e2e8f0']),
+  paving_stones_07: swatchThumbnail(['#94a3b8', '#64748b', '#cbd5f5']),
+  paving_stones_08: swatchThumbnail(['#a3a3a3', '#525252', '#e5e5e5']),
+  paving_stones_12: swatchThumbnail(['#cbd5f5', '#94a3b8', '#e2e8f0']),
+  cobblestone_floor_03: polyHavenThumb('cobblestone_floor_03'),
+  cobblestone_floor_05: polyHavenThumb('cobblestone_floor_05'),
+  concrete_pavers_01: swatchThumbnail(['#94a3b8', '#475569', '#e2e8f0']),
+  concrete_pavers_02: polyHavenThumb('concrete_pavers_02'),
+  stone_floor_05: swatchThumbnail(['#9ca3af', '#4b5563', '#e5e7eb']),
+  stone_floor_06: swatchThumbnail(['#a8a29e', '#78716c', '#f5f5f4'])
+});
+
+const SNAKE_WALL_TEXTURE_THUMBNAILS = Object.freeze({
+  brick_wall_02: polyHavenThumb('brick_wall_02'),
+  brick_wall_03: swatchThumbnail(['#b91c1c', '#7f1d1d', '#fecaca']),
+  castle_wall_01: swatchThumbnail(['#9ca3af', '#6b7280', '#e5e7eb']),
+  concrete_wall_002: swatchThumbnail(['#94a3b8', '#475569', '#e2e8f0']),
+  concrete_wall_004: polyHavenThumb('concrete_wall_004'),
+  painted_wall_01: swatchThumbnail(['#e2e8f0', '#cbd5f5', '#f8fafc']),
+  plaster_wall_01: swatchThumbnail(['#f5f5f4', '#d6d3d1', '#e7e5e4']),
+  stone_wall_02: polyHavenThumb('stone_wall_02'),
+  stone_wall_03: polyHavenThumb('stone_wall_03'),
+  tiles_wall_01: swatchThumbnail(['#e5e7eb', '#94a3b8', '#f8fafc'])
+});
+
+const SNAKE_THEME_THUMBNAILS = Object.freeze({
+  arenaTheme: {
+    crystalLagoon: swatchThumbnail(['#0ea5e9', '#0f766e', '#99f6e4']),
+    royalEmber: swatchThumbnail(['#f97316', '#7c2d12', '#fde68a'])
+  },
+  boardPalette: {
+    glacierGlass: swatchThumbnail(['#38bdf8', '#1d4ed8', '#e0f2fe']),
+    jadeSanctum: swatchThumbnail(['#10b981', '#065f46', '#bbf7d0'])
+  },
+  snakeSkin: {
+    midnightCobra: swatchThumbnail(['#1f2937', '#111827', '#c4b5fd']),
+    emberSerpent: swatchThumbnail(['#f97316', '#7c2d12', '#fdba74'])
+  },
+  diceTheme: {
+    onyxChrome: swatchThumbnail(['#111827', '#1f2937', '#e5e7eb']),
+    auroraQuartz: swatchThumbnail(['#22d3ee', '#a855f7', '#f0abfc'])
+  },
+  railTheme: {
+    obsidianSteel: swatchThumbnail(['#1f2937', '#0f172a', '#93c5fd']),
+    emberBrass: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a'])
+  },
+  tokenFinish: {
+    matteVelvet: swatchThumbnail(['#6b7280', '#1f2937', '#e2e8f0']),
+    holographicPulse: swatchThumbnail(['#a855f7', '#22d3ee', '#f0abfc'])
+  },
+  headStyle: {
+    headRuby: swatchThumbnail(['#b91c1c', '#7f1d1d', '#fecaca']),
+    headSapphire: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe']),
+    headChrome: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc']),
+    headGold: swatchThumbnail(['#f59e0b', '#b45309', '#fde68a'])
+  },
+  tokenShape: {
+    pawn: swatchThumbnail(['#f8fafc', '#1f2937', '#94a3b8']),
+    knight: swatchThumbnail(['#f8fafc', '#1f2937', '#a855f7']),
+    bishop: swatchThumbnail(['#f8fafc', '#1f2937', '#22c55e']),
+    rook: swatchThumbnail(['#f8fafc', '#1f2937', '#f97316']),
+    queen: swatchThumbnail(['#f8fafc', '#1f2937', '#ec4899']),
+    king: swatchThumbnail(['#f8fafc', '#1f2937', '#f59e0b'])
+  }
+});
 
 export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   arenaTheme: ['nebulaAtrium'],
@@ -144,7 +220,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'crystalLagoon',
     name: 'Crystal Lagoon Arena',
     price: 680,
-    description: 'Tropical teal lighting with lagoon accents and bright rim lights.'
+    description: 'Tropical teal lighting with lagoon accents and bright rim lights.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.arenaTheme.crystalLagoon
   },
   {
     id: 'arena-royalEmber',
@@ -152,7 +229,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'royalEmber',
     name: 'Royal Ember Arena',
     price: 720,
-    description: 'Amber floor grid with ember glow and royal purple carpet trim.'
+    description: 'Amber floor grid with ember glow and royal purple carpet trim.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.arenaTheme.royalEmber
   },
   {
     id: 'board-glacierGlass',
@@ -160,7 +238,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'glacierGlass',
     name: 'Glacier Glass Board',
     price: 540,
-    description: 'Icy glass surface with electric blue highlights and deep navy sides.'
+    description: 'Icy glass surface with electric blue highlights and deep navy sides.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.boardPalette.glacierGlass
   },
   {
     id: 'board-jadeSanctum',
@@ -168,7 +247,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'jadeSanctum',
     name: 'Jade Sanctum Board',
     price: 560,
-    description: 'Jade marble tones with golden ladders and warm ladder highlights.'
+    description: 'Jade marble tones with golden ladders and warm ladder highlights.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.boardPalette.jadeSanctum
   },
   {
     id: 'skin-midnightCobra',
@@ -176,7 +256,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'midnightCobra',
     name: 'Midnight Cobra Skin',
     price: 490,
-    description: 'Midnight blue scales with violet diamonds and cool edge strokes.'
+    description: 'Midnight blue scales with violet diamonds and cool edge strokes.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.snakeSkin.midnightCobra
   },
   {
     id: 'skin-emberSerpent',
@@ -184,7 +265,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'emberSerpent',
     name: 'Ember Serpent Skin',
     price: 520,
-    description: 'Ember-toned scales with molten orange diamonds and glowing strokes.'
+    description: 'Ember-toned scales with molten orange diamonds and glowing strokes.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.snakeSkin.emberSerpent
   },
   {
     id: 'dice-onyxChrome',
@@ -192,7 +274,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'onyxChrome',
     name: 'Onyx Chrome Dice',
     price: 450,
-    description: 'Dark chrome dice with bright rim piping and crisp white pips.'
+    description: 'Dark chrome dice with bright rim piping and crisp white pips.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.diceTheme.onyxChrome
   },
   {
     id: 'dice-auroraQuartz',
@@ -200,7 +283,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'auroraQuartz',
     name: 'Aurora Quartz Dice',
     price: 470,
-    description: 'Iridescent quartz finish with neon cyan pips and pink rims.'
+    description: 'Iridescent quartz finish with neon cyan pips and pink rims.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.diceTheme.auroraQuartz
   },
   {
     id: 'rail-obsidianSteel',
@@ -208,7 +292,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'obsidianSteel',
     name: 'Obsidian Steel Rails',
     price: 620,
-    description: 'Graphite rails with steel nets and cool blue ladder hardware.'
+    description: 'Graphite rails with steel nets and cool blue ladder hardware.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.obsidianSteel
   },
   {
     id: 'rail-emberBrass',
@@ -216,7 +301,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'emberBrass',
     name: 'Ember Brass Rails',
     price: 640,
-    description: 'Brass and ember rails with warm ladder rungs and vivid nets.'
+    description: 'Brass and ember rails with warm ladder rungs and vivid nets.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.emberBrass
   },
   {
     id: 'token-matteVelvet',
@@ -224,7 +310,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'matteVelvet',
     name: 'Matte Velvet Tokens',
     price: 430,
-    description: 'Soft velvet finish with muted sheen and gentle accent glow.'
+    description: 'Soft velvet finish with muted sheen and gentle accent glow.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.tokenFinish.matteVelvet
   },
   {
     id: 'token-holographicPulse',
@@ -232,7 +319,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'holographicPulse',
     name: 'Holographic Pulse Tokens',
     price: 520,
-    description: 'Holographic core with shimmering pulse highlights for each token.'
+    description: 'Holographic core with shimmering pulse highlights for each token.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.tokenFinish.holographicPulse
   },
   {
     id: 'snake-head-ruby',
@@ -240,7 +328,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'headRuby',
     name: 'Ruby Pawn Heads',
     price: 310,
-    description: 'Unlocks an additional pawn head glass preset.'
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.headStyle.headRuby
   },
   {
     id: 'snake-head-sapphire',
@@ -248,7 +337,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'headSapphire',
     name: 'Sapphire Pawn Heads',
     price: 335,
-    description: 'Unlocks an additional pawn head glass preset.'
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.headStyle.headSapphire
   },
   {
     id: 'snake-head-chrome',
@@ -256,7 +346,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'headChrome',
     name: 'Chrome Pawn Heads',
     price: 360,
-    description: 'Unlocks an additional pawn head glass preset.'
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.headStyle.headChrome
   },
   {
     id: 'snake-head-gold',
@@ -264,7 +355,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: 'headGold',
     name: 'Gold Pawn Heads',
     price: 385,
-    description: 'Unlocks an additional pawn head glass preset.'
+    description: 'Unlocks an additional pawn head glass preset.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.headStyle.headGold
   },
   ...SNAKE_TOKEN_COLOR_OPTIONS.map((option, idx) => ({
     id: `snake-token-color-${option.id}`,
@@ -273,7 +365,8 @@ export const SNAKE_STORE_ITEMS = [
     name: `${option.label} Tokens`,
     price: 420 + idx * 35,
     description: `Chess Battle Royal ${option.label.toLowerCase()} palette for snake tokens.`,
-    swatches: [option.color, '#0f172a']
+    swatches: [option.color, '#0f172a'],
+    thumbnail: swatchThumbnail([option.color, '#0f172a', '#f8fafc'])
   })),
   ...SNAKE_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `finish-${finish.id}`,
@@ -281,7 +374,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: finish.id,
     name: `${finish.label} Finish`,
     price: 980 + idx * 15,
-    description: `${finish.label} finish imported from Pool Royale.`
+    description: `${finish.label} finish imported from Pool Royale.`,
+    thumbnail: SNAKE_TABLE_FINISH_THUMBNAILS[finish.id]
   })),
   ...SNAKE_FLOOR_TEXTURE_OPTIONS.map((option, idx) => ({
     id: `snake-floor-${option.id}`,
@@ -289,7 +383,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 640 + idx * 18,
-    description: `Poly Haven pavement texture: ${option.label}.`
+    description: `Poly Haven pavement texture: ${option.label}.`,
+    thumbnail: SNAKE_FLOOR_TEXTURE_THUMBNAILS[option.id]
   })),
   ...SNAKE_WALL_TEXTURE_OPTIONS.map((option, idx) => ({
     id: `snake-wall-${option.id}`,
@@ -297,7 +392,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 620 + idx * 16,
-    description: `Poly Haven wall texture: ${option.label}.`
+    description: `Poly Haven wall texture: ${option.label}.`,
+    thumbnail: SNAKE_WALL_TEXTURE_THUMBNAILS[option.id]
   })),
   ...SNAKE_TOKEN_SHAPE_OPTIONS.map((option, idx) => ({
     id: `snake-token-${option.id}`,
@@ -305,7 +401,8 @@ export const SNAKE_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 480 + idx * 35,
-    description: `Chess Battle Royal ${option.label.toLowerCase()} piece token.`
+    description: `Chess Battle Royal ${option.label.toLowerCase()} piece token.`,
+    thumbnail: SNAKE_THEME_THUMBNAILS.tokenShape[option.id]
   }))
 ].concat(
   MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
@@ -334,6 +431,7 @@ export const SNAKE_STORE_ITEMS = [
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Pool Royale HDRI environment tuned for Snake & Ladder.',
     swatches: variant.swatches,
+    thumbnail: variant.thumbnail,
     previewShape: 'table'
   }))
 );

--- a/webapp/src/config/snookerRoyalClothPresets.js
+++ b/webapp/src/config/snookerRoyalClothPresets.js
@@ -1,3 +1,5 @@
+import { polyHavenThumb } from './storeThumbnails.js';
+
 const normalizeHex = (value) => {
   const asString = typeof value === 'number' ? value.toString(16).padStart(6, '0') : String(value || '').replace('#', '');
   return `#${asString.slice(0, 6)}`;
@@ -168,6 +170,7 @@ const createVariantsForMaterial = (material) => {
         sparkle: material.sparkle,
         stray: material.stray,
         detail: material.detail,
+        thumbnail: polyHavenThumb(material.sourceId),
         price,
         swatches: createSwatches(hex),
         description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`

--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -1,4 +1,5 @@
 import { SNOOKER_ROYALE_CLOTH_VARIANTS } from './snookerRoyalClothPresets.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const SNOOKER_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -284,9 +285,46 @@ export const SNOOKER_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_SNOOKER_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
     preferredResolutions: HDRI_RESOLUTION_STACK,
+    thumbnail: polyHavenThumb(variant.assetId),
     ...(SNOOKER_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))
 );
+
+const TABLE_FINISH_THUMBNAILS = Object.freeze({
+  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
+  oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  woodTable001: polyHavenThumb('wood_table_001'),
+  darkWood: polyHavenThumb('dark_wood'),
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+});
+
+const POCKET_LINER_THUMBNAILS = Object.freeze({
+  fabric_leather_02: polyHavenThumb('fabric_leather_02'),
+  fabric_leather_01: polyHavenThumb('fabric_leather_01'),
+  brown_leather: polyHavenThumb('brown_leather'),
+  leather_red_02: polyHavenThumb('leather_red_02'),
+  leather_red_03: polyHavenThumb('leather_red_03'),
+  leather_white: polyHavenThumb('leather_white')
+});
+
+const CUE_STYLE_THUMBNAILS = Object.freeze({
+  'redwood-ember': swatchThumbnail(['#7f1d1d', '#b91c1c', '#fde68a']),
+  'birch-frost': swatchThumbnail(['#f8fafc', '#e2e8f0', '#bae6fd']),
+  'wenge-nightfall': swatchThumbnail(['#0f172a', '#1f2937', '#64748b']),
+  'mahogany-heritage': swatchThumbnail(['#7c2d12', '#b45309', '#fbbf24']),
+  'walnut-satin': swatchThumbnail(['#5b3a29', '#8b5e34', '#f3d9b1']),
+  'carbon-matrix': swatchThumbnail(['#0b0f16', '#111827', '#94a3b8']),
+  'maple-horizon': swatchThumbnail(['#f5e6c8', '#d4b790', '#fde68a']),
+  'graphite-aurora': swatchThumbnail(['#1f2937', '#4b5563', '#c7d2fe'])
+});
+
+const BASE_VARIANT_THUMBNAILS = Object.freeze({
+  classicCylinders: swatchThumbnail(['#8f6243', '#6f3a2f', '#fef3c7']),
+  openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
+  coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
+  gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
+  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+});
 
 export const SNOOKER_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
   SNOOKER_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
@@ -403,7 +441,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'peelingPaintWeathered',
     name: 'Wood Peeling Paint Weathered Finish',
     price: 980,
-    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.peelingPaintWeathered
   },
   {
     id: 'finish-oakVeneer01',
@@ -411,7 +450,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'oakVeneer01',
     name: 'Oak Veneer 01 Finish',
     price: 990,
-    description: 'Warm oak veneer rails with smooth satin polish.'
+    description: 'Warm oak veneer rails with smooth satin polish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01
   },
   {
     id: 'finish-woodTable001',
@@ -419,7 +459,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'woodTable001',
     name: 'Wood Table 001 Finish',
     price: 1000,
-    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.woodTable001
   },
   {
     id: 'finish-darkWood',
@@ -427,7 +468,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'darkWood',
     name: 'Dark Wood Finish',
     price: 1010,
-    description: 'Deep espresso rails with strong grain contrast.'
+    description: 'Deep espresso rails with strong grain contrast.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.darkWood
   },
   {
     id: 'finish-rosewoodVeneer01',
@@ -435,7 +477,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'rosewoodVeneer01',
     name: 'Rosewood Veneer 01 Finish',
     price: 1020,
-    description: 'Rosewood veneer rails with rich, reddish undertones.'
+    description: 'Rosewood veneer rails with rich, reddish undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
   },
   {
     id: 'chrome-chrome',
@@ -443,7 +486,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'chrome',
     name: 'Mirror Chrome Fascias',
     price: 360,
-    description: 'Polished chrome plates to swap in for the fascia set.'
+    description: 'Polished chrome plates to swap in for the fascia set.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
   },
   {
     id: 'railMarkers-pearl',
@@ -451,7 +495,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'pearl',
     name: 'Pearl Diamonds',
     price: 280,
-    description: 'Pearlescent diamond markers with soft sheen.'
+    description: 'Pearlescent diamond markers with soft sheen.',
+    thumbnail: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0'])
   },
   {
     id: 'railMarkers-chrome',
@@ -459,7 +504,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'chrome',
     name: 'Chrome Diamonds',
     price: 240,
-    description: 'Chrome-lined diamond markers that match fascia shine.'
+    description: 'Chrome-lined diamond markers that match fascia shine.',
+    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
   },
   ...SNOOKER_ROYALE_CLOTH_VARIANTS.map((variant) => ({
     id: `cloth-${variant.id}`,
@@ -467,7 +513,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: variant.name,
     price: variant.price,
-    description: variant.description
+    description: variant.description,
+    thumbnail: variant.thumbnail
   })),
   {
     id: 'pocket-fabric-leather-02',
@@ -475,7 +522,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'fabric_leather_02',
     name: 'Fabric Leather 02 Pocket Jaws',
     price: 520,
-    description: 'Warm stitched leather weave liners for the classic Snooker Royal look.'
+    description: 'Warm stitched leather weave liners for the classic Snooker Royal look.',
+    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_02
   },
   {
     id: 'pocket-fabric-leather-01',
@@ -483,7 +531,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'fabric_leather_01',
     name: 'Fabric Leather 01 Pocket Jaws',
     price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.'
+    description: 'Soft-grain leather weave liners with a mellow brown finish.',
+    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_01
   },
   {
     id: 'pocket-brown-leather',
@@ -491,7 +540,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'brown_leather',
     name: 'Brown Leather Pocket Jaws',
     price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.'
+    description: 'Deep brown leather pockets with natural creases and aged texture.',
+    thumbnail: POCKET_LINER_THUMBNAILS.brown_leather
   },
   {
     id: 'pocket-leather-red-02',
@@ -499,7 +549,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'leather_red_02',
     name: 'Leather Red 02 Pocket Jaws',
     price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.'
+    description: 'Bold red leather liners with pronounced seams and worn highlights.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_02
   },
   {
     id: 'pocket-leather-red-03',
@@ -507,7 +558,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'leather_red_03',
     name: 'Leather Red 03 Pocket Jaws',
     price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.'
+    description: 'Deep crimson leather pocket liners with subtle stitch detailing.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_03
   },
   {
     id: 'pocket-leather-white',
@@ -515,7 +567,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'leather_white',
     name: 'Leather White Pocket Jaws',
     price: 590,
-    description: 'Bright white leather pockets with crisp seam definition and clean grain.'
+    description: 'Bright white leather pockets with crisp seam definition and clean grain.',
+    thumbnail: POCKET_LINER_THUMBNAILS.leather_white
   },
   {
     id: 'cue-redwood',
@@ -523,7 +576,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'redwood-ember',
     name: 'Redwood Ember Cue',
     price: 310,
-    description: 'Rich redwood cue butt with ember accents.'
+    description: 'Rich redwood cue butt with ember accents.',
+    thumbnail: CUE_STYLE_THUMBNAILS['redwood-ember']
   },
   {
     id: 'cue-wenge',
@@ -531,7 +585,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'wenge-nightfall',
     name: 'Wenge Nightfall Cue',
     price: 340,
-    description: 'Deep wenge finish with high-contrast stripes.'
+    description: 'Deep wenge finish with high-contrast stripes.',
+    thumbnail: CUE_STYLE_THUMBNAILS['wenge-nightfall']
   },
   {
     id: 'cue-mahogany',
@@ -539,7 +594,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'mahogany-heritage',
     name: 'Mahogany Heritage Cue',
     price: 325,
-    description: 'Classic mahogany cue with heritage grain highlights.'
+    description: 'Classic mahogany cue with heritage grain highlights.',
+    thumbnail: CUE_STYLE_THUMBNAILS['mahogany-heritage']
   },
   {
     id: 'cue-walnut',
@@ -547,7 +603,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'walnut-satin',
     name: 'Walnut Satin Cue',
     price: 295,
-    description: 'Satin walnut cue butt with balanced contrast.'
+    description: 'Satin walnut cue butt with balanced contrast.',
+    thumbnail: CUE_STYLE_THUMBNAILS['walnut-satin']
   },
   {
     id: 'cue-carbon',
@@ -555,7 +612,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'carbon-matrix',
     name: 'Carbon Matrix Cue',
     price: 380,
-    description: 'Carbon fiber cue with metallic weave highlights.'
+    description: 'Carbon fiber cue with metallic weave highlights.',
+    thumbnail: CUE_STYLE_THUMBNAILS['carbon-matrix']
   },
   {
     id: 'cue-maple',
@@ -563,7 +621,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'maple-horizon',
     name: 'Maple Horizon Cue',
     price: 300,
-    description: 'Bright maple cue with horizon banding.'
+    description: 'Bright maple cue with horizon banding.',
+    thumbnail: CUE_STYLE_THUMBNAILS['maple-horizon']
   },
   {
     id: 'cue-graphite',
@@ -571,7 +630,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: 'graphite-aurora',
     name: 'Graphite Aurora Cue',
     price: 360,
-    description: 'Graphite weave cue with aurora-inspired tint.'
+    description: 'Graphite weave cue with aurora-inspired tint.',
+    thumbnail: CUE_STYLE_THUMBNAILS['graphite-aurora']
   },
   ...SNOOKER_ROYALE_BASE_VARIANTS.map((variant) => ({
     id: `base-${variant.id}`,
@@ -579,7 +639,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} Base`,
     price: 0,
-    description: variant.description
+    description: variant.description,
+    thumbnail: BASE_VARIANT_THUMBNAILS[variant.id]
   })),
   ...SNOOKER_ROYALE_HDRI_VARIANTS.map((variant) => ({
     id: `hdri-${variant.id}`,
@@ -587,7 +648,8 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     optionId: variant.id,
     name: `${variant.name} HDRI`,
     price: variant.price,
-    description: variant.description
+    description: variant.description,
+    thumbnail: variant.thumbnail
   }))
 ];
 

--- a/webapp/src/config/storeThumbnails.js
+++ b/webapp/src/config/storeThumbnails.js
@@ -1,0 +1,34 @@
+const POLYHAVEN_THUMB_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs';
+const POLYHAVEN_ASSET_ALIASES = {
+  rosewood_veneer_01: 'rosewood_veneer1'
+};
+
+const resolvePolyHavenId = (id) => POLYHAVEN_ASSET_ALIASES[id] ?? id;
+
+const encodeSvg = (svg) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+
+export const polyHavenThumb = (id) =>
+  `${POLYHAVEN_THUMB_BASE}/${resolvePolyHavenId(id)}.png?width=256&height=256`;
+
+export const khronosThumb = (modelId) =>
+  `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/${modelId}/screenshot/screenshot.jpg`;
+
+export const swatchThumbnail = (colors = []) => {
+  const [primary = '#1f2937', secondary = '#0f172a', accent = '#ffffff'] = colors;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+    <defs>
+      <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="${primary}"/>
+        <stop offset="100%" stop-color="${secondary}"/>
+      </linearGradient>
+      <radialGradient id="s" cx="35%" cy="30%" r="70%">
+        <stop offset="0%" stop-color="${accent}" stop-opacity="0.6"/>
+        <stop offset="100%" stop-color="${secondary}" stop-opacity="0"/>
+      </radialGradient>
+    </defs>
+    <rect width="256" height="256" rx="36" fill="url(#g)"/>
+    <circle cx="92" cy="82" r="120" fill="url(#s)"/>
+    <rect x="40" y="168" width="176" height="12" rx="6" fill="${accent}" opacity="0.35"/>
+  </svg>`;
+  return encodeSvg(svg);
+};

--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -2,6 +2,7 @@ import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from './texasHoldemOptions.js';
+import { polyHavenThumb } from './storeThumbnails.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS,
@@ -26,6 +27,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
     description: 'Weathered peeling paint wood rails with a reclaimed finish.',
     price: 980,
     swatches: ['#a89f95', '#b8b3aa'],
+    thumbnail: polyHavenThumb('wood_peeling_paint_weathered'),
     woodOption: {
       id: 'peelingPaintWeathered',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.peelingPaintWeathered,
@@ -39,6 +41,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
     description: 'Warm oak veneer rails with smooth satin polish.',
     price: 990,
     swatches: ['#b9854e', '#c89a64'],
+    thumbnail: polyHavenThumb('oak_veneer_01'),
     woodOption: {
       id: 'oakVeneer01',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.oakVeneer01,
@@ -52,6 +55,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
     description: 'Balanced walnut-brown rails inspired by classic table slabs.',
     price: 1000,
     swatches: ['#8f6243', '#a4724f'],
+    thumbnail: polyHavenThumb('wood_table_001'),
     woodOption: {
       id: 'woodTable001',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.woodTable001,
@@ -65,6 +69,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
     description: 'Deep espresso rails with strong grain contrast.',
     price: 1010,
     swatches: ['#2f241f', '#3d2f2a'],
+    thumbnail: polyHavenThumb('dark_wood'),
     woodOption: {
       id: 'darkWood',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.darkWood,
@@ -78,6 +83,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     price: 1020,
     swatches: ['#5b2f26', '#6f3a2f'],
+    thumbnail: polyHavenThumb('rosewood_veneer_01'),
     woodOption: {
       id: 'rosewoodVeneer01',
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.rosewoodVeneer01,
@@ -126,7 +132,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     name: `${option.label} Finish`,
     price: option.price,
     description: option.description,
-    swatches: option.swatches
+    swatches: option.swatches,
+    thumbnail: option.thumbnail
   })),
   ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-wood-${option.id}`,
@@ -134,7 +141,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 540 + idx * 40,
-    description: "Unlock an alternate wood finish for your Hold'em arena table."
+    description: "Unlock an alternate wood finish for your Hold'em arena table.",
+    thumbnail: option.thumbnail
   })),
   ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-cloth-${option.id}`,
@@ -142,7 +150,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 360 + idx * 35,
-    description: "Swap in a premium felt tone for your poker table."
+    description: "Swap in a premium felt tone for your poker table.",
+    thumbnail: option.thumbnail
   })),
   ...TABLE_BASE_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-base-${option.id}`,
@@ -150,7 +159,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 420 + idx * 35,
-    description: 'Upgrade the pedestal finish beneath your Hold\'em surface.'
+    description: 'Upgrade the pedestal finish beneath your Hold\'em surface.',
+    thumbnail: option.thumbnail
   })),
   ...TEXAS_CHAIR_THEME_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-chair-${option.id}`,
@@ -176,7 +186,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     name: variant.label,
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Poly Haven HDRI environment used in Murlan Royale.',
-    swatches: variant.swatches
+    swatches: variant.swatches,
+    thumbnail: variant.thumbnail
   })),
   ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-shape-${option.id}`,
@@ -184,7 +195,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 680 + idx * 80,
-    description: 'Change the poker table silhouette.'
+    description: 'Change the poker table silhouette.',
+    thumbnail: option.thumbnail
   })),
   ...CARD_THEMES.slice(1).map((option, idx) => ({
     id: `texas-card-${option.id}`,
@@ -192,7 +204,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: `${option.label} Cards`,
     price: 460 + idx * 35,
-    description: 'Add a fresh premium deck style to the arena.'
+    description: 'Add a fresh premium deck style to the arena.',
+    thumbnail: option.thumbnail
   }))
 ];
 

--- a/webapp/src/utils/cardThemes.js
+++ b/webapp/src/utils/cardThemes.js
@@ -1,3 +1,5 @@
+import { swatchThumbnail } from '../config/storeThumbnails.js';
+
 export const CARD_THEMES = [
   {
     id: 'aurora',
@@ -8,7 +10,8 @@ export const CARD_THEMES = [
     backColor: '#0f172a',
     backGradient: ['#1f2937', '#0b1220'],
     backAccent: 'rgba(148, 163, 184, 0.35)',
-    hiddenColor: '#0b1020'
+    hiddenColor: '#0b1020',
+    thumbnail: swatchThumbnail(['#1f2937', '#0b1220', '#e2e8f0'])
   },
   {
     id: 'solstice',
@@ -19,7 +22,8 @@ export const CARD_THEMES = [
     backColor: '#78350f',
     backGradient: ['#b45309', '#7c2d12'],
     backAccent: 'rgba(255, 221, 148, 0.4)',
-    hiddenColor: '#3d1a05'
+    hiddenColor: '#3d1a05',
+    thumbnail: swatchThumbnail(['#b45309', '#7c2d12', '#fde68a'])
   },
   {
     id: 'nebula',
@@ -30,7 +34,8 @@ export const CARD_THEMES = [
     backColor: '#312e81',
     backGradient: ['#5b21b6', '#312e81'],
     backAccent: 'rgba(196, 181, 253, 0.4)',
-    hiddenColor: '#1e1b4b'
+    hiddenColor: '#1e1b4b',
+    thumbnail: swatchThumbnail(['#5b21b6', '#312e81', '#e9d5ff'])
   },
   {
     id: 'jade',
@@ -41,7 +46,8 @@ export const CARD_THEMES = [
     backColor: '#064e3b',
     backGradient: ['#047857', '#064e3b'],
     backAccent: 'rgba(74, 222, 128, 0.45)',
-    hiddenColor: '#022c22'
+    hiddenColor: '#022c22',
+    thumbnail: swatchThumbnail(['#047857', '#064e3b', '#bbf7d0'])
   },
   {
     id: 'ember',
@@ -52,7 +58,8 @@ export const CARD_THEMES = [
     backColor: '#7c2d12',
     backGradient: ['#ea580c', '#7c2d12'],
     backAccent: 'rgba(251, 146, 60, 0.45)',
-    hiddenColor: '#3b1306'
+    hiddenColor: '#3b1306',
+    thumbnail: swatchThumbnail(['#ea580c', '#7c2d12', '#fed7aa'])
   },
   {
     id: 'onyx',
@@ -63,7 +70,8 @@ export const CARD_THEMES = [
     backColor: '#1f2937',
     backGradient: ['#111827', '#1f2937'],
     backAccent: 'rgba(148, 163, 184, 0.5)',
-    hiddenColor: '#0b0f17'
+    hiddenColor: '#0b0f17',
+    thumbnail: swatchThumbnail(['#111827', '#1f2937', '#e5e7eb'])
   }
 ];
 

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
+import { swatchThumbnail } from '../config/storeThumbnails.js';
 import {
   applyWoodTextures,
   WOOD_FINISH_PRESETS,
@@ -150,6 +151,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       clipPath:
         'polygon(50% 0%, 80% 10%, 100% 40%, 100% 60%, 80% 90%, 50% 100%, 20% 90%, 0% 60%, 0% 40%, 20% 10%)'
     },
+    thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
       const topShape = createRegularPolygonShape(8, radius);
       const feltShape = createRegularPolygonShape(8, radius * 0.8);
@@ -163,6 +165,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     preview: {
       borderRadius: '50% / 35%'
     },
+    thumbnail: swatchThumbnail(['#0b1220', '#111827', '#f97316']),
     createShapes: ({ radius }) => {
       const width = radius * 2.1;
       const height = radius * 1.45;
@@ -178,6 +181,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     preview: {
       borderRadius: '18%'
     },
+    thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#a855f7']),
     createShapes: ({ radius, scaleFactor }) => {
       const factor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : radius / 0.9 || 1;
       const outerHalf = 0.95 * factor;

--- a/webapp/src/utils/tableCustomizationOptions.js
+++ b/webapp/src/utils/tableCustomizationOptions.js
@@ -1,5 +1,6 @@
 import { WOOD_FINISH_PRESETS, WOOD_GRAIN_OPTIONS, WOOD_GRAIN_OPTIONS_BY_ID } from './woodMaterials.js';
 import { CARD_THEMES } from './cardThemes.js';
+import { polyHavenThumb, swatchThumbnail } from '../config/storeThumbnails.js';
 
 const numberToHex = (value) => `#${value.toString(16).padStart(6, '0')}`;
 const normalizeHex = (value) => (typeof value === 'number' ? numberToHex(value) : value);
@@ -67,20 +68,89 @@ export const WOOD_PRESETS_BY_ID = Object.freeze(
 );
 
 export const TABLE_WOOD_OPTIONS = [
-  { id: 'lightNatural', label: 'Light Natural', presetId: 'birch', grainId: 'ph_wood_floor_01' },
-  { id: 'warmBrown', label: 'Warm Brown', presetId: 'walnut', grainId: 'ph_wood_floor_02' },
-  { id: 'cleanStrips', label: 'Clean Strips', presetId: 'oak', grainId: 'ph_wood_floor_03' },
-  { id: 'oldWoodFloor', label: 'Old Wood Floor', presetId: 'smokedOak', grainId: 'ph_old_wood_floor' }
+  {
+    id: 'lightNatural',
+    label: 'Light Natural',
+    presetId: 'birch',
+    grainId: 'ph_wood_floor_01',
+    thumbnail: polyHavenThumb('oak_veneer_01')
+  },
+  {
+    id: 'warmBrown',
+    label: 'Warm Brown',
+    presetId: 'walnut',
+    grainId: 'ph_wood_floor_02',
+    thumbnail: polyHavenThumb('wood_table_001')
+  },
+  {
+    id: 'cleanStrips',
+    label: 'Clean Strips',
+    presetId: 'oak',
+    grainId: 'ph_wood_floor_03',
+    thumbnail: polyHavenThumb('wood_peeling_paint_weathered')
+  },
+  {
+    id: 'oldWoodFloor',
+    label: 'Old Wood Floor',
+    presetId: 'smokedOak',
+    grainId: 'ph_old_wood_floor',
+    thumbnail: polyHavenThumb('old_wood_floor')
+  }
 ];
 
 export const TABLE_CLOTH_OPTIONS = [
-  { id: 'crimson', label: 'Crimson Cloth', feltTop: '#960019', feltBottom: '#4a0012', emissive: '#210308' },
-  { id: 'emerald', label: 'Emerald Cloth', feltTop: '#0f6a2f', feltBottom: '#054d24', emissive: '#021a0b' },
-  { id: 'arctic', label: 'Arctic Cloth', feltTop: '#2563eb', feltBottom: '#1d4ed8', emissive: '#071a42' },
-  { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', emissive: '#320e03' },
-  { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', emissive: '#1f0a47' },
-  { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', emissive: '#2b1402' },
-  ...POLY_HAVEN_CLOTHS.map((option) => buildClothOption(option.id, option.label, option.base))
+  {
+    id: 'crimson',
+    label: 'Crimson Cloth',
+    feltTop: '#960019',
+    feltBottom: '#4a0012',
+    emissive: '#210308',
+    thumbnail: swatchThumbnail(['#960019', '#4a0012', '#fecaca'])
+  },
+  {
+    id: 'emerald',
+    label: 'Emerald Cloth',
+    feltTop: '#0f6a2f',
+    feltBottom: '#054d24',
+    emissive: '#021a0b',
+    thumbnail: swatchThumbnail(['#0f6a2f', '#054d24', '#bbf7d0'])
+  },
+  {
+    id: 'arctic',
+    label: 'Arctic Cloth',
+    feltTop: '#2563eb',
+    feltBottom: '#1d4ed8',
+    emissive: '#071a42',
+    thumbnail: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'sunset',
+    label: 'Sunset Cloth',
+    feltTop: '#ea580c',
+    feltBottom: '#c2410c',
+    emissive: '#320e03',
+    thumbnail: swatchThumbnail(['#ea580c', '#c2410c', '#fed7aa'])
+  },
+  {
+    id: 'violet',
+    label: 'Violet Cloth',
+    feltTop: '#7c3aed',
+    feltBottom: '#5b21b6',
+    emissive: '#1f0a47',
+    thumbnail: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe'])
+  },
+  {
+    id: 'amber',
+    label: 'Amber Cloth',
+    feltTop: '#b7791f',
+    feltBottom: '#92571a',
+    emissive: '#2b1402',
+    thumbnail: swatchThumbnail(['#b7791f', '#92571a', '#fde68a'])
+  },
+  ...POLY_HAVEN_CLOTHS.map((option) => ({
+    ...buildClothOption(option.id, option.label, option.base),
+    thumbnail: polyHavenThumb(option.id)
+  }))
 ];
 
 export const TABLE_BASE_OPTIONS = [
@@ -91,7 +161,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#0b0d10',
     trimColor: '#1f232a',
     metalness: 0.75,
-    roughness: 0.35
+    roughness: 0.35,
+    thumbnail: swatchThumbnail(['#141414', '#1f232a', '#94a3b8'])
   },
   {
     id: 'forestBronze',
@@ -100,7 +171,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#0a0f0c',
     trimColor: '#1f2d24',
     metalness: 0.7,
-    roughness: 0.38
+    roughness: 0.38,
+    thumbnail: swatchThumbnail(['#101714', '#1f2d24', '#4ade80'])
   },
   {
     id: 'midnightChrome',
@@ -109,7 +181,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#0a1020',
     trimColor: '#1e2f4a',
     metalness: 0.78,
-    roughness: 0.32
+    roughness: 0.32,
+    thumbnail: swatchThumbnail(['#0f172a', '#1e2f4a', '#93c5fd'])
   },
   {
     id: 'emberCopper',
@@ -118,7 +191,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#140707',
     trimColor: '#5c2d1b',
     metalness: 0.68,
-    roughness: 0.4
+    roughness: 0.4,
+    thumbnail: swatchThumbnail(['#231312', '#5c2d1b', '#fdba74'])
   },
   {
     id: 'violetShadow',
@@ -127,7 +201,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#130622',
     trimColor: '#3f1b5b',
     metalness: 0.74,
-    roughness: 0.36
+    roughness: 0.36,
+    thumbnail: swatchThumbnail(['#1f1130', '#3f1b5b', '#c4b5fd'])
   },
   {
     id: 'desertGold',
@@ -136,7 +211,8 @@ export const TABLE_BASE_OPTIONS = [
     columnColor: '#0f0d06',
     trimColor: '#5a4524',
     metalness: 0.72,
-    roughness: 0.39
+    roughness: 0.39,
+    thumbnail: swatchThumbnail(['#1c1a12', '#5a4524', '#fcd34d'])
   }
 ];
 


### PR DESCRIPTION
### Motivation
- Provide accurate, source-backed thumbnails for store inventory so items (cloths, finishes, cues, HDRIs, tokens, etc.) show original Poly Haven/Khronos/swatch previews instead of generic images.
- Keep PR free of binary assets while linking to external thumbs and encoded SVG swatches as fallbacks.

### Description
- Add `webapp/src/config/storeThumbnails.js` with helpers `polyHavenThumb`, `khronosThumb`, and `swatchThumbnail` to standardize thumbnail URLs and small SVG swatches.
- Wire thumbnail metadata into inventories and option sets across games: Pool, Snooker, Air Hockey, Texas Hold'em, Chess, Ludo, Domino, Snake and Murlan by adding `thumbnail` fields for cloth variants, table finishes, HDRIs, pocket liners, cue styles, card themes, base/table variants, token palettes/styles, and table shapes.
- Enhance cloth presets (`poolRoyaleClothPresets.js`, `snookerRoyalClothPresets.js`) to include source thumbnails and add swatch thumbnails for many programmatic/paint-style options to avoid embedding binaries.
- Keep binary-free PR content (only code changes and data URLs); existing chair/table GLTF binaries were not added to the commit.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (server ready), which succeeded.
- Captured a store page screenshot with a Playwright script against `http://127.0.0.1:5173/store/poolroyale` to validate thumbnails render, with the final run producing a screenshot artifact (initial attempts timed out but the scripted run completed successfully).
- Performed HTTP HEAD checks (`curl -I`) against representative Poly Haven/Khronos thumbnail URLs to verify availability (many assets returned HTTP 200 while some asset aliases were handled), which helped tune aliases in `storeThumbnails.js`.
- No unit tests were modified; these are UI/data-only updates and the automated smoke checks above completed (Playwright screenshot succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697deb0827248329931c2ddc42105598)