### PR TITLE
Fix TonConnect manifest and return URLs

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -58,8 +58,11 @@ export default function App() {
   useReferralClaim();
   useNativePushNotifications();
 
-  const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
-  const returnUrl = window.location.href;
+  const isHttpOrigin = ['http:', 'https:'].includes(window.location.protocol);
+  const manifestUrl = isHttpOrigin
+    ? `${window.location.origin}/tonconnect-manifest.json`
+    : 'https://tonplaygram.com/tonconnect-manifest.json';
+  const returnUrl = isHttpOrigin ? window.location.origin : 'https://tonplaygram.com';
   const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
   const actionsConfiguration = {
     returnUrl,


### PR DESCRIPTION
### Motivation
- Wallet connections failed in some environments (native/TWA/Telegram) because the app used a local manifest/return URL that isn't valid when not served over `http(s)`, so use a public manifest and stable return URL for those cases.

### Description
- Detect if the app is running on an `http:`/`https:` origin and set `manifestUrl` to `window.location.origin + '/tonconnect-manifest.json'` for normal hosts and to the public `https://tonplaygram.com/tonconnect-manifest.json` when not; this logic is implemented in `webapp/src/App.jsx`.
- Use the origin as `returnUrl` for `http(s)` runs and a stable `https://tonplaygram.com` return URL for non-HTTP origins and keep the `twaReturnUrl` pointing to the Telegram bot when in the Telegram WebView.
- During the rollout a transient attempt to import `@tonconnect/ui-react/styles.css` in `webapp/src/main.jsx` was reverted because the package does not expose that specifier and caused a Vite dependency error.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and encountered a missing `./styles.css` specifier error after adding the stylesheet import, which was then removed to resolve the build error (failure then fixed).
- Ran an automated Playwright smoke script that opened `http://127.0.0.1:4173/` in a mobile viewport and produced a screenshot `artifacts/tonconnect-home.png`, confirming the homepage loads (success).
- Committed the fix to `webapp/src/App.jsx` and verified repository status updated without unrelated artifacts (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dfc6c3b488329ae93acae96b48738)