### PR TITLE
Fix TON connect button modal

### DIFF
--- a/webapp/src/components/TonConnectButton.jsx
+++ b/webapp/src/components/TonConnectButton.jsx
@@ -1,11 +1,23 @@
-import React from 'react';
-import { TonConnectButton as ConnectButton } from '@tonconnect/ui-react';
+import React, { useCallback } from 'react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 export default function TonConnectButton({ small = false, className = '' }) {
+  const [tonConnectUI] = useTonConnectUI();
+  const walletAddress = useTonAddress();
   const sizeClass = small ? 'px-1 py-0 text-xs' : 'px-3 py-1';
+  const label = walletAddress ? 'Wallet connected' : 'Connect TON Wallet';
+  const handleClick = useCallback(() => {
+    tonConnectUI.openModal();
+  }, [tonConnectUI]);
   return (
     <div className={`mt-2 ${className}`}>
-      <ConnectButton className={`lobby-tile cursor-pointer ${sizeClass}`} />
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`lobby-tile cursor-pointer ${sizeClass}`}
+      >
+        {label}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure the TON Connect flow reliably opens the wallet modal and surface connected state by replacing the embedded widget with an explicit button that opens the modal.

### Description
- Replaced the `@tonconnect/ui-react` embedded button with a custom button in `webapp/src/components/TonConnectButton.jsx` that uses `useTonConnectUI` and `useTonAddress` to show connection state and call `tonConnectUI.openModal()` on click.

### Testing
- Started the dev server with `npm run dev` (Vite reported ready at `http://localhost:4173/`) and attempted an automated Playwright check for the new button, but the headless Chromium process crashed so the browser-based verification failed (see logs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dfc6c3b488329ae93acae96b48738)