### PR TITLE
Prevent backspin from reducing cue ball forward speed

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -547,8 +547,11 @@ public class BilliardsSolver
         if (!airborne)
         {
             Vec2 dir = b.Velocity.Normalized();
-            var forwardAccel = PhysicsConstants.RollAcceleration * b.ForwardSpin;
-            b.Velocity += dir * forwardAccel * dt;
+            if (b.ForwardSpin > 0)
+            {
+                var forwardAccel = PhysicsConstants.RollAcceleration * b.ForwardSpin;
+                b.Velocity += dir * forwardAccel * dt;
+            }
 
             var lateral = new Vec2(-dir.Y, dir.X);
             double speedFactor = 1.0;


### PR DESCRIPTION
### Motivation
- Backspin was reducing the cue ball's forward travel compared to a center hit; the change keeps forward travel consistent while still allowing top-spin to accelerate the ball.

### Description
- In `billiards/BilliardsSolver.cs` inside `ApplySpinForces`, the forward roll acceleration is now only applied when `b.ForwardSpin > 0`, preventing backspin from reducing forward velocity.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e08243d14832993b54d322916e9f4)