### PR TITLE
Enable speech synthesis unlock in Telegram WebView

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -6,6 +6,7 @@ import './index.css';
 import { registerTelegramServiceWorker } from './pwa/registerServiceWorker.js';
 import { warmGameCaches } from './pwa/preloadGames.js';
 import { initNativeBridge } from './utils/nativeBridge.ts';
+import { registerSpeechSynthesisUnlock } from './utils/textToSpeech.js';
 
 async function bootstrap() {
   const isNative = Capacitor.isNativePlatform();
@@ -23,6 +24,8 @@ async function bootstrap() {
     // Register a Telegram-friendly service worker for instant updates
     void registerTelegramServiceWorker().finally(warmGameCaches);
   }
+
+  registerSpeechSynthesisUnlock();
 
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -10,6 +10,7 @@ const DEFAULT_SPEAKER_SETTINGS = {
 
 let audioContext;
 let audioContextUnlocked = false;
+let speechUnlockRegistered = false;
 
 const ensureAudioContext = () => {
   if (typeof window === 'undefined') return null;
@@ -93,6 +94,23 @@ export const primeSpeechSynthesis = () => {
   };
   utterance.onerror = utterance.onend;
   synth.speak(utterance);
+};
+
+export const registerSpeechSynthesisUnlock = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+  if (speechUnlockRegistered) return () => {};
+  speechUnlockRegistered = true;
+  const handler = () => {
+    primeSpeechSynthesis();
+  };
+  const options = { once: true, passive: true, capture: true };
+  const events = ['pointerdown', 'touchstart', 'mousedown', 'keydown'];
+  events.forEach((event) => document.addEventListener(event, handler, options));
+  return () => {
+    events.forEach((event) => document.removeEventListener(event, handler, options));
+  };
 };
 
 const loadVoices = (synth, timeoutMs = 3500) =>


### PR DESCRIPTION
### Motivation
- Web Speech (TTS) can be blocked in in-app browsers like Telegram WebView until a user gesture; commentary audio did not initialize in that environment.
- Provide a safe, one-time user-gesture hook that primes speech synthesis and the audio context so commentary works more reliably in Telegram and similar embedded browsers.

### Description
- Added `registerSpeechSynthesisUnlock` to `webapp/src/utils/textToSpeech.js` which attaches one-time listeners for `pointerdown`, `touchstart`, `mousedown`, and `keydown` to call `primeSpeechSynthesis` on first user interaction and returns an unregister function.
- Added a `speechUnlockRegistered` guard to avoid double registration and made the function a no-op on non-browser environments.
- Registered the unlock helper in the app bootstrap by importing and calling `registerSpeechSynthesisUnlock()` from `webapp/src/main.jsx` so the helper is active as soon as the app loads.
- Changes touch only TTS-related initialization and app bootstrap; implementation ensures safe defaults when `window`/`document` are absent.

### Testing
- No automated tests were executed for this change.
- The change is limited to runtime initialization and uses defensive checks to avoid affecting server-side or non-browser environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1aeccb24832995f22ad47db6240b)