### PR TITLE
Avoid cueball stall: remove impact velocity override and scale backspin roll boost

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25730,7 +25730,16 @@ const powerRef = useRef(hud.power);
                   SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
                 );
                 if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
-                  TMP_VEC2_SPIN.multiplyScalar(BACKSPIN_ROLL_BOOST);
+                  const backspinWeight = Math.max(0, -(b.spin?.y ?? 0));
+                  const backspinBoost =
+                    isCue && b.impacted && backspinWeight > 0
+                      ? THREE.MathUtils.lerp(
+                          BACKSPIN_ROLL_BOOST,
+                          CUE_BACKSPIN_ROLL_BOOST,
+                          THREE.MathUtils.clamp(backspinWeight, 0, 1)
+                        )
+                      : BACKSPIN_ROLL_BOOST;
+                  TMP_VEC2_SPIN.multiplyScalar(backspinBoost);
                 }
                 if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
                   const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();


### PR DESCRIPTION
### Motivation
- Previous change forced the cue-ball velocity at impact to match the previewed draw direction and caused the cue ball to stop short of the target, so the gameplay did not match the aim preview. 
- The intent is to preserve the original forward travel while still improving the cue-ball response to backspin so the red draw preview better reflects in-game behavior.

### Description
- Removed the impact-time velocity override helper `applyCueBackspinOnImpact` and its invocation so the cue ball is no longer forcibly reoriented at first contact. 
- Replaced the single unconditional backspin multiplier with a weighted boost computed from `backspinWeight` that linearly lerps between `BACKSPIN_ROLL_BOOST` and `CUE_BACKSPIN_ROLL_BOOST` when `isCue && b.impacted`, preserving pre-impact travel while strengthening draw proportionally. 
- Kept pre-/post-impact spin path intact (pre-impact alignment and pending spin drift logic remain) to avoid upsetting other spin behaviors. 
- Changes are in `webapp/src/pages/Games/PoolRoyale.jsx` (spin handling and removal of the impact velocity override). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e156075c8832983762a735a6ea0b2)