### PR TITLE
Enable speech synthesis unlock for Telegram webview

### DIFF
--- a/webapp/src/main.jsx
+++ b/webapp/src/main.jsx
@@ -6,6 +6,7 @@ import './index.css';
 import { registerTelegramServiceWorker } from './pwa/registerServiceWorker.js';
 import { warmGameCaches } from './pwa/preloadGames.js';
 import { initNativeBridge } from './utils/nativeBridge.ts';
+import { installSpeechSynthesisUnlock } from './utils/textToSpeech.js';
 
 async function bootstrap() {
   const isNative = Capacitor.isNativePlatform();
@@ -18,6 +19,8 @@ async function bootstrap() {
   if (window.Telegram?.WebApp?.disableVerticalSwipes) {
     window.Telegram.WebApp.disableVerticalSwipes();
   }
+
+  installSpeechSynthesisUnlock();
 
   if (!isNative) {
     // Register a Telegram-friendly service worker for instant updates

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -10,6 +10,8 @@ const DEFAULT_SPEAKER_SETTINGS = {
 
 let audioContext;
 let audioContextUnlocked = false;
+let speechUnlockInstalled = false;
+let speechUnlockHandler;
 
 const ensureAudioContext = () => {
   if (typeof window === 'undefined') return null;
@@ -47,6 +49,29 @@ const unlockAudioContext = () => {
         audioContextUnlocked = false;
       }
     });
+};
+
+const createSpeechUnlockHandler = () => {
+  if (speechUnlockHandler) return speechUnlockHandler;
+  speechUnlockHandler = () => {
+    const synth = getSpeechSynthesis();
+    if (!synth) return;
+    ensureSpeechUnlocked(synth);
+    primeSpeechSynthesis();
+  };
+  return speechUnlockHandler;
+};
+
+export const installSpeechSynthesisUnlock = () => {
+  if (typeof window === 'undefined' || speechUnlockInstalled) return;
+  if (!getSpeechSynthesis()) return;
+  speechUnlockInstalled = true;
+  const handler = createSpeechUnlockHandler();
+  const options = { once: true, passive: true };
+  window.addEventListener('pointerdown', handler, options);
+  window.addEventListener('touchend', handler, options);
+  window.addEventListener('click', handler, options);
+  window.addEventListener('keydown', handler, options);
 };
 
 export const getSpeechSynthesis = () => {


### PR DESCRIPTION
### Motivation
- Telegram in-app browsers (and some mobile webviews) often require a user gesture to enable Web Speech and AudioContext, which prevents commentary TTS from playing automatically in Chrome/Telegram webview.

### Description
- Add a one-time gesture-based unlock helper exported as `installSpeechSynthesisUnlock` that attaches `pointerdown`, `touchend`, `click`, and `keydown` listeners and calls `ensureSpeechUnlocked` + `primeSpeechSynthesis` when triggered in `webapp/src/utils/textToSpeech.js`.
- Invoke `installSpeechSynthesisUnlock()` during app bootstrap in `webapp/src/main.jsx` so the unlock is installed early for Telegram WebApp sessions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1aeccb24832995f22ad47db6240b)