### PR TITLE
Align pool-royale spin control with radial clamp

### DIFF
--- a/examples/pool-royale/index.html
+++ b/examples/pool-royale/index.html
@@ -346,8 +346,13 @@
         const cy = r.height / 2;
         const dx = e.clientX - r.left - cx;
         const dy = e.clientY - r.top - cy;
-        const nx = Math.max(Math.min(dx / cx, 1), -1);
-        const ny = Math.max(Math.min(dy / cy, 1), -1);
+        const radius = Math.min(cx, cy);
+        const distance = Math.hypot(dx, dy);
+        const clamped = distance > radius && distance > 0 ? radius / distance : 1;
+        const clampedDx = dx * clamped;
+        const clampedDy = dy * clamped;
+        const nx = clampedDx / radius;
+        const ny = clampedDy / radius;
         // invert the vertical component so positive y is top spin
         const rawSpin = { x: nx, y: -ny };
         // ease the response so tiny adjustments near centre produce gentle spin


### PR DESCRIPTION
### Motivation
- Clamp pointer input to the circular spin controller so edge positions map consistently to spin output while keeping the existing top/back and left/right direction mapping.

### Description
- Update `setSpin` in `examples/pool-royale/index.html` to compute a `radius`, clamp the raw pointer offset to that radius, derive normalized `nx`/`ny`, and preserve the previous vertical inversion and easing logic so small inputs remain gentle.

### Testing
- No automated tests were run for this small UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e27d515688329a06ed9fbc1a1b496)