### PR TITLE
Improve speech synthesis unlock reliability in Telegram in-app browser

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -12,6 +12,16 @@ let audioContext;
 let audioContextUnlocked = false;
 let speechUnlockInstalled = false;
 let speechUnlockHandler;
+let speechUnlockComplete = false;
+let speechUnlockListenersInstalled = false;
+
+const speechUnlockEvents = ['pointerdown', 'touchstart', 'touchend', 'click', 'keydown'];
+
+const removeSpeechUnlockListeners = () => {
+  if (typeof window === 'undefined' || !speechUnlockListenersInstalled) return;
+  speechUnlockListenersInstalled = false;
+  speechUnlockEvents.forEach((event) => window.removeEventListener(event, speechUnlockHandler));
+};
 
 const ensureAudioContext = () => {
   if (typeof window === 'undefined') return null;
@@ -58,20 +68,20 @@ const createSpeechUnlockHandler = () => {
     if (!synth) return;
     ensureSpeechUnlocked(synth);
     primeSpeechSynthesis();
+    if (audioContextUnlocked || speechUnlockComplete) {
+      removeSpeechUnlockListeners();
+    }
   };
   return speechUnlockHandler;
 };
 
 export const installSpeechSynthesisUnlock = () => {
   if (typeof window === 'undefined' || speechUnlockInstalled) return;
-  if (!getSpeechSynthesis()) return;
   speechUnlockInstalled = true;
   const handler = createSpeechUnlockHandler();
-  const options = { once: true, passive: true };
-  window.addEventListener('pointerdown', handler, options);
-  window.addEventListener('touchend', handler, options);
-  window.addEventListener('click', handler, options);
-  window.addEventListener('keydown', handler, options);
+  speechUnlockListenersInstalled = true;
+  const options = { passive: true };
+  speechUnlockEvents.forEach((event) => window.addEventListener(event, handler, options));
 };
 
 export const getSpeechSynthesis = () => {
@@ -118,6 +128,7 @@ export const primeSpeechSynthesis = () => {
   };
   utterance.onerror = utterance.onend;
   synth.speak(utterance);
+  speechUnlockComplete = true;
 };
 
 const loadVoices = (synth, timeoutMs = 3500) =>


### PR DESCRIPTION
### Motivation
- Telegram in-app browser and other mobile browsers often block audio/speech until a user gesture; keeping unlock logic simple caused commentary to remain silent for some users. 
- Make the speech/audio unlock flow more robust so commentary starts after real user interaction rather than depending on a single event or early guard.

### Description
- Add `speechUnlockEvents` (pointer/touch/click/keydown) and attach listeners for broader gesture coverage via `installSpeechSynthesisUnlock` instead of single-use handlers. 
- Track listener and priming state with `speechUnlockListenersInstalled` and `speechUnlockComplete`, and add `removeSpeechUnlockListeners` to remove handlers only after unlock/priming succeeds. 
- Ensure `createSpeechUnlockHandler` calls `ensureSpeechUnlocked` + `primeSpeechSynthesis` and removes listeners when either the audio context is unlocked or priming completes. 
- Mark priming completion in `primeSpeechSynthesis` by setting `speechUnlockComplete = true` to stop redundant unlock attempts.

### Testing
- No automated tests were executed for this change. 
- No CI/build verification was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2948b7948329b53f9fc6da85b1fa)