### PR TITLE
Quantize spin controller to 8-direction snaps

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -110,6 +110,7 @@ export const computeQuantizedOffsetScaled = (
   const level1Mag = options.level1Mag ?? SPIN_LEVEL1_MAG;
   const level2Mag = options.level2Mag ?? SPIN_LEVEL2_MAG;
   const level3Mag = options.level3Mag ?? SPIN_LEVEL3_MAG;
+  const angleStep = options.angleStepRad ?? Math.PI / 4;
 
   const raw = clampToMaxOffset(rawX, rawY, maxOffset);
   const distance = Math.hypot(raw.x, raw.y);
@@ -126,8 +127,14 @@ export const computeQuantizedOffsetScaled = (
   if (mag === 0 || distance <= 1e-6) {
     return { x: 0, y: 0 };
   }
-  const scale = mag / distance;
-  return { x: raw.x * scale, y: raw.y * scale };
+  const angle = Math.atan2(raw.y, raw.x);
+  const snappedAngle = angleStep > 0
+    ? Math.round(angle / angleStep) * angleStep
+    : angle;
+  return {
+    x: Math.cos(snappedAngle) * mag,
+    y: Math.sin(snappedAngle) * mag
+  };
 };
 
 export const normalizeSpinInput = (spin) => {


### PR DESCRIPTION
### Motivation
- Make the spin control behave like the reference photo by snapping user input to clear cardinal and diagonal directions while keeping the existing axis orientation and ring-based magnitude system.
- Stabilize spin input so small radial deviations map to consistent play effects and visual markers.

### Description
- Added an `angleStep` option to `computeQuantizedOffsetScaled` and defaulted it to `Math.PI / 4` to quantize directions into 8 angles (N, NE, E, SE, S, SW, W, NW).
- Reworked `computeQuantizedOffsetScaled` to compute the input angle via `Math.atan2`, snap that angle to the nearest `angleStep`, and return `x`/`y` as `cos(snappedAngle) * mag` and `sin(snappedAngle) * mag` while preserving the existing ring magnitude logic.
- Kept previous limits and ring magnitude selection (`stunRadius`, `ring1Radius`, `ring2Radius`, `ring3Radius`, and `level*Mag`) intact so only direction quantization changes the output.
- Modified file: `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e27d515688329a06ed9fbc1a1b496)