### PR TITLE
Improve Telegram Web Speech unlock handling

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -65,7 +65,6 @@ const createSpeechUnlockHandler = () => {
 
 export const installSpeechSynthesisUnlock = () => {
   if (typeof window === 'undefined' || speechUnlockInstalled) return;
-  if (!getSpeechSynthesis()) return;
   speechUnlockInstalled = true;
   const handler = createSpeechUnlockHandler();
   const isTelegram = typeof window !== 'undefined' && Boolean(window.Telegram?.WebApp);
@@ -88,11 +87,20 @@ export const installSpeechSynthesisUnlock = () => {
 
 export const getSpeechSynthesis = () => {
   if (typeof window === 'undefined') return null;
+  let synth = null;
   try {
-    return window.speechSynthesis || window.webkitSpeechSynthesis || null;
+    synth = window.speechSynthesis;
   } catch {
-    return null;
+    synth = null;
   }
+  if (!synth) {
+    try {
+      synth = window.webkitSpeechSynthesis;
+    } catch {
+      synth = null;
+    }
+  }
+  return synth || null;
 };
 
 const ensureSpeechUnlocked = (synth) => {
@@ -112,7 +120,7 @@ const ensureSpeechUnlocked = (synth) => {
 
 export const primeSpeechSynthesis = () => {
   const synth = getSpeechSynthesis();
-  if (!synth || synth.speaking || synth.pending) return;
+  if (!synth || synth.speaking || synth.pending || typeof SpeechSynthesisUtterance === 'undefined') return;
   ensureSpeechUnlocked(synth);
   const utterance = new SpeechSynthesisUtterance('.');
   utterance.volume = 0.01;
@@ -129,7 +137,15 @@ export const primeSpeechSynthesis = () => {
     }
   };
   utterance.onerror = utterance.onend;
-  synth.speak(utterance);
+  try {
+    synth.speak(utterance);
+  } catch {
+    if (typeof synth.cancel === 'function') {
+      try {
+        synth.cancel();
+      } catch {}
+    }
+  }
 };
 
 const loadVoices = (synth, timeoutMs = 3500) =>
@@ -138,6 +154,7 @@ const loadVoices = (synth, timeoutMs = 3500) =>
       resolve([]);
       return;
     }
+    ensureSpeechUnlocked(synth);
     const existing = synth.getVoices();
     if (existing.length) {
       resolve(existing);
@@ -266,8 +283,13 @@ export const speakCommentaryLines = async (
           synth.cancel();
         } catch {}
       }
-      synth.speak(utterance);
-      setTimeout(() => ensureSpeechUnlocked(synth), 0);
+      try {
+        synth.speak(utterance);
+        setTimeout(() => ensureSpeechUnlocked(synth), 0);
+      } catch {
+        clearTimeout(timeoutId);
+        finish();
+      }
     });
   }
 };


### PR DESCRIPTION
### Motivation
- Commentary in Telegram's in-app browser can fail because Web Speech may be injected late or under a vendor-prefixed API, so unlock/priming must be more resilient.
- Prevent runtime exceptions when `speechSynthesis` or `SpeechSynthesisUtterance` are absent or when `speak()` throws, to avoid breaking gameplay/commentary flows.

### Description
- Keep speech unlock event listeners active even if no `speechSynthesis` is present at install time by removing the early return from `installSpeechSynthesisUnlock` so Telegram visibility/focus handlers can trigger later initialization.
- Harden `getSpeechSynthesis` to try `window.speechSynthesis` first and fall back to `window.webkitSpeechSynthesis` with careful try/catch handling.
- Guard `primeSpeechSynthesis` with a check for `SpeechSynthesisUtterance` and wrap calls to `synth.speak()` in `try/catch` to safely handle engines that throw.
- Call `ensureSpeechUnlocked` before voice loading and wrap `synth.speak()` calls in `speakCommentaryLines` with `try/catch` and appropriate fallback timing to avoid stuck promises.

### Testing
- Ran lint with `npm run lint`; the command executed but the run failed due to extensive pre-existing lint errors elsewhere in the repository (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e3f463620832981599f323c57b69f)