### PR TITLE
Pool Royale: replace swerve spin with roll-only spin controller

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1528,10 +1528,7 @@ const LIFT_SPIN_AIR_DRIFT = SPIN_ROLL_STRENGTH * 1.45; // inject extra sideways 
 const RAIL_SPIN_THROW_SCALE = BALL_R * 0.36; // let cushion contacts inherit noticeable throw from active side spin
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to keep the cue ball rolling after rebounds
-const SWERVE_THRESHOLD = 0.82; // outer 18% of the spin control activates swerve behaviour
-const SWERVE_TRAVEL_MULTIPLIER = 0.55; // dampen sideways drift while swerve is active so it stays believable
-const SWERVE_PRE_IMPACT_DRIFT = 0; // keep cue ball path straight even with side spin
-const PRE_IMPACT_SPIN_DRIFT = 0.06; // reapply stored sideways swerve once the cue ball is rolling after impact
+const SWERVE_THRESHOLD = 1; // Pool Royale uses roll-only spin (no swerve mode)
 const SPIN_ENGLISH_DEFLECTION_SCALE = 0; // disable english deflection while preserving spin values
 const CUE_AFTER_SPIN_DEFLECTION_SCALE = 0; // remove spin deflection so the cue follow line tracks the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
@@ -1550,6 +1547,8 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_MULTIPLIER;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
+const SPIN_TABLE_DIAMETER_REF = 44; // reference table length in ball diameters (real-world pool)
+const SPIN_SPEED_REF = SHOT_BASE_SPEED * 1.05; // speed that yields full spin transfer
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
 const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
@@ -6217,41 +6216,81 @@ function resolveSpinFrame(ball) {
 function resolveSpinWorldVector(ball, output) {
   if (!ball?.spin) return null;
   const { forward, lateral } = resolveSpinFrame(ball);
-  const sideSpin =
-    ball.spinMode === 'swerve' ? -(ball.spin.x || 0) : (ball.spin.x || 0);
+  const sideSpin = ball.spin.x || 0;
   const forwardSpin = ball.spin.y || 0;
   const target = output ?? TMP_VEC2_SPIN;
   target.copy(lateral).multiplyScalar(sideSpin).addScaledVector(forward, forwardSpin);
   return target;
 }
 
+function resolveSpinScale(speed = 0) {
+  const tableRatio = Math.max(PLAY_W, PLAY_H) / Math.max(BALL_R * 2, 1e-6);
+  const tableScale = THREE.MathUtils.clamp(
+    tableRatio / SPIN_TABLE_DIAMETER_REF,
+    0.85,
+    1.2
+  );
+  const speedScale = THREE.MathUtils.clamp(
+    speed / Math.max(SPIN_SPEED_REF, 1e-6),
+    0.35,
+    1.35
+  );
+  return { tableScale, speedScale };
+}
+
 function applySpinImpulse(ball, scale = 1) {
   if (!ball?.spin) return false;
   if (ball.spin.lengthSq() < 1e-6) return false;
-  const { forward, lateral, speed } = resolveSpinFrame(ball);
-  const sideSpin = ball.spin.x || 0;
+  const { forward, speed } = resolveSpinFrame(ball);
   const forwardSpin = ball.spin.y || 0;
-  const swerveScale = 0.8 + Math.min(speed, 8) * 0.15;
-  const liftScale = 0.35 + Math.min(speed, 6) * 0.08;
-  const lateralKick = sideSpin * SPIN_STRENGTH * swerveScale * scale;
+  const { tableScale, speedScale } = resolveSpinScale(speed);
+  const liftScale = (0.35 + speedScale * 0.55) * tableScale;
   const forwardKick = forwardSpin * SPIN_STRENGTH * liftScale * scale * 0.5;
-  if (Math.abs(lateralKick) > 1e-8) {
-    ball.vel.addScaledVector(lateral, lateralKick);
-  }
   if (Math.abs(forwardKick) > 1e-8) {
     ball.vel.addScaledVector(forward, forwardKick);
-  }
-  if (ball.id === 'cue' && ball.spinMode === 'swerve') {
-    ball.spinMode = 'standard';
-    ball.swerveStrength = 0;
-    ball.swervePowerStrength = 0;
   }
   const decayFactor = Math.pow(SPIN_DECAY, Math.max(scale, 0.5));
   ball.spin.multiplyScalar(decayFactor);
   if (ball.spin.lengthSq() < 1e-6) {
     ball.spin.set(0, 0);
     if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
-    if (ball.id === 'cue') ball.swervePowerStrength = 0;
+  }
+  return true;
+}
+
+// Adapted from the open-source billiards solver in /billiards to remove swerve,
+// keeping only roll transfer and decay for realistic table-scale spin.
+function applySpinController(ball, stepScale, airborne = false) {
+  if (!ball?.spin || ball.spin.lengthSq() < 1e-6) return false;
+  const { forward, speed } = resolveSpinFrame(ball);
+  const forwardSpin = ball.spin.y || 0;
+  const { tableScale, speedScale } = resolveSpinScale(speed);
+  if (!airborne) {
+    if (Math.abs(forwardSpin) > 1e-6) {
+      const baseAccel =
+        SPIN_ROLL_STRENGTH * tableScale * (0.45 + speedScale * 0.55);
+      let accel = forwardSpin * baseAccel * stepScale;
+      if (forwardSpin < 0 && ball.vel.dot(forward) > 0) {
+        const backspinWeight = Math.min(Math.abs(forwardSpin), 1);
+        const backspinBoost =
+          ball.id === 'cue' && ball.impacted
+            ? THREE.MathUtils.lerp(
+                BACKSPIN_ROLL_BOOST,
+                CUE_BACKSPIN_ROLL_BOOST,
+                backspinWeight
+              )
+            : BACKSPIN_ROLL_BOOST;
+        accel *= backspinBoost;
+      }
+      ball.vel.addScaledVector(forward, accel);
+    }
+    ball.spin.multiplyScalar(Math.pow(SPIN_ROLL_DECAY, stepScale));
+  } else {
+    ball.spin.multiplyScalar(Math.pow(SPIN_AIR_DECAY, stepScale));
+  }
+  if (ball.spin.lengthSq() < 1e-6) {
+    ball.spin.set(0, 0);
+    if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
   }
   return true;
 }
@@ -6333,29 +6372,16 @@ function resolveSwerveSettings(
   forceSwerve = false,
   liftStrength = 0
 ) {
+  void powerStrength;
+  void forceSwerve;
+  void liftStrength;
   const sideSpin = spin?.x ?? 0;
   const magnitude = Math.hypot(spin?.x ?? 0, spin?.y ?? 0);
-  const active =
-    (forceSwerve || magnitude >= SWERVE_THRESHOLD) &&
-    Math.abs(sideSpin) >= 1e-3;
-  if (!active) {
-    return {
-      active: false,
-      sideSpin: 0,
-      magnitude,
-      intensity: 0
-    };
-  }
-  const threshold = Math.max(1 - SWERVE_THRESHOLD, 1e-6);
-  const normalized = clamp((magnitude - SWERVE_THRESHOLD) / threshold, 0, 1);
-  const liftBoost = 0.75 + Math.max(0, liftStrength) * 0.5;
-  const powerBoost = 0.7 + powerStrength * 0.85;
-  const spinBoost = 0.75 + Math.min(Math.abs(sideSpin), 1) * 0.6;
   return {
-    active: true,
+    active: false,
     sideSpin,
     magnitude,
-    intensity: normalized * powerBoost * spinBoost * liftBoost
+    intensity: 0
   };
 }
 
@@ -6365,26 +6391,16 @@ function resolveSpinPreviewSettings(
   forceSwerve = false,
   liftStrength = 0
 ) {
-  const swerve = resolveSwerveSettings(spin, powerStrength, forceSwerve, liftStrength);
-  if (swerve.active) return swerve;
+  void powerStrength;
+  void forceSwerve;
+  void liftStrength;
   const sideSpin = spin?.x ?? 0;
   const magnitude = Math.abs(sideSpin);
-  if (magnitude < 1e-3) {
-    return {
-      active: false,
-      sideSpin: 0,
-      magnitude,
-      intensity: 0
-    };
-  }
-  const powerBoost = 0.55 + powerStrength * 0.35;
-  const liftBoost = 0.8 + Math.max(0, liftStrength) * 0.3;
-  const intensity = Math.min(magnitude, 1) * powerBoost * liftBoost * 0.35;
   return {
     active: false,
     sideSpin,
     magnitude,
-    intensity
+    intensity: 0
   };
 }
 
@@ -6395,31 +6411,13 @@ function resolveSwerveAimDir(
   forceSwerve = false,
   liftStrength = 0
 ) {
+  void spin;
+  void powerStrength;
+  void forceSwerve;
+  void liftStrength;
   if (!aimDir || aimDir.lengthSq() < 1e-8) return aimDir;
   if (SPIN_ENGLISH_DEFLECTION_SCALE <= 0) return aimDir;
-  const swerve = resolveSpinPreviewSettings(
-    spin,
-    powerStrength,
-    forceSwerve,
-    liftStrength
-  );
-  if (swerve.intensity <= 0 || Math.abs(swerve.sideSpin) < 1e-3) return aimDir;
-  const perp = new THREE.Vector2(-aimDir.y, aimDir.x);
-  const curveBase =
-    (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
-  const powerScale = 4 + powerStrength * 6;
-  const swerveScale = 0.6 + swerve.intensity * 0.9;
-  const sideSpin = -swerve.sideSpin;
-  const adjust =
-    sideSpin *
-    swerve.intensity *
-    curveBase *
-    powerScale *
-    AIM_SPIN_PREVIEW_SIDE *
-    swerveScale;
-  const adjusted = aimDir.clone().add(perp.multiplyScalar(adjust));
-  if (adjusted.lengthSq() > 1e-8) adjusted.normalize();
-  return adjusted;
+  return aimDir;
 }
 
 function buildSwerveAimLinePoints(
@@ -6434,6 +6432,13 @@ function buildSwerveAimLinePoints(
   swerveActive,
   liftStrength = 0
 ) {
+  void controlPoint;
+  void dir;
+  void perp;
+  void spin;
+  void powerStrength;
+  void swerveActive;
+  void liftStrength;
   if (!points) return [start, end];
   if (SPIN_ENGLISH_DEFLECTION_SCALE <= 0) {
     points.length = 2;
@@ -6443,55 +6448,11 @@ function buildSwerveAimLinePoints(
     points[1].copy(end);
     return points;
   }
-  const swerve = resolveSpinPreviewSettings(
-    spin,
-    powerStrength,
-    swerveActive,
-    liftStrength
-  );
-  const sideSpin = -swerve.sideSpin;
-  const travel = start.distanceTo(end);
-  if (swerve.intensity <= 0 || Math.abs(sideSpin) < 1e-3 || travel < 1e-4) {
-    points.length = 2;
-    if (!points[0]) points[0] = new THREE.Vector3();
-    if (!points[1]) points[1] = new THREE.Vector3();
-    points[0].copy(start);
-    points[1].copy(end);
-    return points;
-  }
-  const segments = clamp(Math.round(travel / (BALL_R * 1.6)), 6, 14);
-  const curveBase =
-    (SPIN_ROLL_STRENGTH / Math.max(BALL_R, 1e-6)) * SWERVE_PRE_IMPACT_DRIFT;
-  const swerveScale = 0.6 + swerve.intensity * 0.9;
-  const curveScale =
-    curveBase *
-    (4 + powerStrength * 6.5) *
-    AIM_SPIN_PREVIEW_SIDE *
-    swerveScale;
-  const curveAmount = sideSpin * curveScale * travel;
-  controlPoint
-    .copy(start)
-    .addScaledVector(dir, travel * 0.5)
-    .addScaledVector(perp, curveAmount);
-  points.length = segments + 1;
-  const ax = start.x;
-  const ay = start.y;
-  const az = start.z;
-  const bx = controlPoint.x;
-  const by = controlPoint.y;
-  const bz = controlPoint.z;
-  const cx = end.x;
-  const cy = end.y;
-  const cz = end.z;
-  for (let i = 0; i <= segments; i += 1) {
-    const t = i / segments;
-    const inv = 1 - t;
-    const x = inv * inv * ax + 2 * inv * t * bx + t * t * cx;
-    const y = inv * inv * ay + 2 * inv * t * by + t * t * cy;
-    const z = inv * inv * az + 2 * inv * t * bz + t * t * cz;
-    if (!points[i]) points[i] = new THREE.Vector3();
-    points[i].set(x, y, z);
-  }
+  points.length = 2;
+  if (!points[0]) points[0] = new THREE.Vector3();
+  if (!points[1]) points[1] = new THREE.Vector3();
+  points[0].copy(start);
+  points[1].copy(end);
   return points;
 }
 
@@ -19418,8 +19379,7 @@ const powerRef = useRef(hud.power);
           }
           const result = legality.blocked ? { x: 0, y: 0 } : normalized;
           const magnitude = Math.hypot(result.x ?? 0, result.y ?? 0);
-          const mode = magnitude >= SWERVE_THRESHOLD ? 'swerve' : 'standard';
-          spinAppliedRef.current = { ...result, magnitude, mode };
+          spinAppliedRef.current = { ...result, magnitude, mode: 'standard' };
           return result;
         };
         const drag = { on: false, x: 0, y: 0, moved: false };
@@ -21915,14 +21875,7 @@ const powerRef = useRef(hud.power);
         const liftAngle = resolveUserCueLift();
         const liftStrength = normalizeCueLift(liftAngle);
         const physicsSpin = mapSpinForPhysics(appliedSpin);
-        const swerveActive = spinAppliedRef.current?.mode === 'swerve';
-        const guideAimDir2D = resolveSwerveAimDir(
-          aimDir.clone(),
-          physicsSpin,
-          clampedPower,
-          swerveActive,
-          liftStrength
-        );
+        const guideAimDir2D = aimDir.clone();
         const shotAimDir =
           guideAimDir2D && guideAimDir2D.lengthSq() > 1e-8
             ? guideAimDir2D.clone().normalize()
@@ -22114,16 +22067,9 @@ const powerRef = useRef(hud.power);
             cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
           }
           if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode =
-            spinAppliedRef.current?.mode === 'swerve' ? 'swerve' : 'standard';
-          const swerveSettings = resolveSwerveSettings(
-            scaledSpin,
-            clampedPower,
-            cue.spinMode === 'swerve',
-            liftStrength
-          );
-          cue.swerveStrength = cue.spinMode === 'swerve' ? swerveSettings.intensity : 0;
-          cue.swervePowerStrength = cue.spinMode === 'swerve' ? clampedPower : 0;
+          cue.spinMode = 'standard';
+          cue.swerveStrength = 0;
+          cue.swervePowerStrength = 0;
           resetSpinRef.current?.();
           cueLiftRef.current.lift = 0;
           cueLiftRef.current.startLift = 0;
@@ -25107,15 +25053,9 @@ const powerRef = useRef(hud.power);
             0,
             1
           );
-          const swerveActive = spinAppliedRef.current?.mode === 'swerve';
+          const swerveActive = false;
           const aimDir2D = new THREE.Vector2(baseAimDir.x, baseAimDir.z);
-          const guideAimDir2D = resolveSwerveAimDir(
-            aimDir2D,
-            physicsSpin,
-            powerStrength,
-            swerveActive,
-            liftStrength
-          );
+          const guideAimDir2D = aimDir2D;
           const { impact, targetDir, cueDir, targetBall, railNormal } = calcTarget(
             cue,
             guideAimDir2D,
@@ -25426,15 +25366,8 @@ const powerRef = useRef(hud.power);
           if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerStrength = THREE.MathUtils.clamp(remoteAimState?.power ?? 0, 0, 1);
           const remoteSpin = remoteAimState?.spin ?? { x: 0, y: 0 };
-          const remoteSpinMagnitude = Math.hypot(remoteSpin.x ?? 0, remoteSpin.y ?? 0);
-          const remoteSwerveActive = remoteSpinMagnitude >= SWERVE_THRESHOLD;
           const remotePhysicsSpin = mapSpinForPhysics(remoteSpin);
-          const guideAimDir2D = resolveSwerveAimDir(
-            remoteAimDir,
-            remotePhysicsSpin,
-            powerStrength,
-            remoteSwerveActive
-          );
+          const guideAimDir2D = remoteAimDir;
           const { impact, targetDir, cueDir, targetBall, railNormal } = calcTarget(
             cue,
             guideAimDir2D,
@@ -25454,7 +25387,7 @@ const powerRef = useRef(hud.power);
             perp,
             remotePhysicsSpin,
             powerStrength,
-            remoteSwerveActive
+            false
           );
           aimGeom.setFromPoints(aimPoints);
           aim.material.color.set(0x7ce7ff);
@@ -25705,100 +25638,12 @@ const powerRef = useRef(hud.power);
               }
             }
             if (hasSpin) {
-              const swerveTravel = isCue && b.spinMode === 'swerve' && !b.impacted;
-              const swerveStrength = swerveTravel ? Math.max(0, b.swerveStrength ?? 0) : 0;
-              const swervePower = swerveTravel
-                ? Math.max(0, b.swervePowerStrength ?? 0)
-                : 0;
-              const swervePowerScale = swerveStrength > 0 ? 0.85 + swervePower * 0.9 : 0;
-              const swerveScale =
-                swerveStrength > 0 ? (0.6 + swerveStrength * 0.9) * swervePowerScale : 0;
-              const allowRoll =
-                !isCue || b.impacted || swerveTravel || (isCue && b.spin?.lengthSq() > 1e-8);
-              const preImpact = isCue && !b.impacted;
-              if (allowRoll) {
-                const rollMultiplier = swerveTravel
-                  ? SWERVE_TRAVEL_MULTIPLIER * (0.9 + swerveStrength * 0.6)
-                  : 1;
-                const worldSpin = resolveSpinWorldVector(b, TMP_VEC2_SPIN);
-                if (!worldSpin) {
-                  TMP_VEC2_SPIN.set(0, 0);
-                } else {
-                  TMP_VEC2_SPIN.copy(worldSpin);
-                }
-                TMP_VEC2_SPIN.multiplyScalar(
-                  SPIN_ROLL_STRENGTH * rollMultiplier * stepScale
-                );
-                if (b.vel && b.vel.dot(TMP_VEC2_SPIN) < 0) {
-                  const backspinWeight = Math.max(0, -(b.spin?.y ?? 0));
-                  const backspinBoost =
-                    isCue && b.impacted && backspinWeight > 0
-                      ? THREE.MathUtils.lerp(
-                          BACKSPIN_ROLL_BOOST,
-                          CUE_BACKSPIN_ROLL_BOOST,
-                          THREE.MathUtils.clamp(backspinWeight, 0, 1)
-                        )
-                      : BACKSPIN_ROLL_BOOST;
-                  TMP_VEC2_SPIN.multiplyScalar(backspinBoost);
-                }
-                if (preImpact && b.launchDir && b.launchDir.lengthSq() > 1e-8) {
-                  const launchDir = TMP_VEC2_FORWARD.copy(b.launchDir).normalize();
-                  const forwardMag = TMP_VEC2_SPIN.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(forwardMag);
-                  b.vel.add(TMP_VEC2_AXIS);
-                  TMP_VEC2_LATERAL.copy(TMP_VEC2_SPIN).sub(TMP_VEC2_AXIS);
-                  if (b.pendingSpin) {
-                    b.pendingSpin.addScaledVector(
-                      TMP_VEC2_LATERAL,
-                      swerveScale > 0 ? swerveScale : 1
-                    );
-                  }
-                  const alignedSpeed = b.vel.dot(launchDir);
-                  TMP_VEC2_AXIS.copy(launchDir).multiplyScalar(alignedSpeed);
-                  b.vel.copy(TMP_VEC2_AXIS);
-                } else {
-                  b.vel.add(TMP_VEC2_SPIN);
-                  if (
-                    isCue &&
-                    b.pendingSpin &&
-                    b.pendingSpin.lengthSq() > 0
-                  ) {
-                    const driftScale = swerveScale > 0 ? swerveScale : 1;
-                    b.vel.addScaledVector(
-                      b.pendingSpin,
-                      PRE_IMPACT_SPIN_DRIFT * driftScale
-                    );
-                    b.pendingSpin.multiplyScalar(0);
-                  }
-                }
-                const rollDecay = Math.pow(SPIN_ROLL_DECAY, stepScale);
-                b.spin.multiplyScalar(rollDecay);
-                if (isCue && b.swerveStrength > 0) {
-                  b.swerveStrength *= rollDecay;
-                  if (b.swerveStrength < 1e-3) {
-                    b.swerveStrength = 0;
-                    b.swervePowerStrength = 0;
-                  }
-                }
-              } else {
-                const airDecay = Math.pow(SPIN_AIR_DECAY, stepScale);
-                b.spin.multiplyScalar(airDecay);
-                if (isCue && b.swerveStrength > 0) {
-                  b.swerveStrength *= airDecay;
-                  if (b.swerveStrength < 1e-3) {
-                    b.swerveStrength = 0;
-                    b.swervePowerStrength = 0;
-                  }
-                }
-              }
-              if (b.spin.lengthSq() < 1e-6) {
-                b.spin.set(0, 0);
-                if (b.pendingSpin) b.pendingSpin.set(0, 0);
-                if (isCue) {
-                  b.spinMode = 'standard';
-                  b.swerveStrength = 0;
-                  b.swervePowerStrength = 0;
-                }
+              const airborne = (b.lift ?? 0) > 1e-6;
+              applySpinController(b, stepScale, airborne);
+              if (b.spin.lengthSq() < 1e-6 && isCue) {
+                b.spinMode = 'standard';
+                b.swerveStrength = 0;
+                b.swervePowerStrength = 0;
               }
             }
             if (!hasLift) {


### PR DESCRIPTION
### Motivation
- Remove the existing swerve/curving spin behavior and replace it with a simpler, free/open-source style roll-only spin controller so spins only affect forward/back roll and not lateral swerves.
- Make spin transfer feel realistic by scaling it to table size and shot speed while preserving the existing spin direction conventions.

### Description
- Replaced swerve logic and preview curves and disabled swerve-mode by setting `SWERVE_THRESHOLD = 1` and forcing spin mode to `'standard'`, updating aim/preview helpers to produce straight aim lines (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Added `resolveSpinScale`, `applySpinController`, and related constants `SPIN_TABLE_DIAMETER_REF` and `SPIN_SPEED_REF` and simplified `applySpinImpulse` so spin only contributes forward/roll impulses and decays appropriately.
- Applied the new roll-only controller inside the physics update loop and the shot setup (replacing the previous swerve-roll path), and removed pre/post-impact swerve transfers and pending swerve state updates.
- Kept existing rail/spin response where appropriate (e.g. `applyRailSpinResponse`) but now calls into the new roll-only handlers for consistent behavior.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e411009f48329a3f250430ca0f136)