### PR TITLE
Detect Web Speech at runtime and make commentary reactive for Telegram

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -12,7 +12,13 @@ import { AiOutlineInfoCircle, AiOutlineMessage } from 'react-icons/ai';
 import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 import { buildAirHockeyCommentaryLine, AIR_HOCKEY_SPEAKERS } from '../utils/airHockeyCommentary.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../utils/textToSpeech.js';
 import { applyWoodTextures, WOOD_GRAIN_OPTIONS_BY_ID } from '../utils/woodMaterials.js';
 import { AIR_HOCKEY_CUSTOMIZATION } from '../config/airHockeyInventoryConfig.js';
 import {
@@ -562,7 +568,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       AIR_HOCKEY_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const initialProfile = useMemo(() => selectPerformanceProfile(activeGraphicsOption), [activeGraphicsOption]);
   const targetRef = useRef(Number(target) || 3);
   const gameOverRef = useRef(false);
@@ -692,6 +698,15 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     const options = AIR_HOCKEY_CUSTOMIZATION[key] || [];
     return options.find((option) => option.id === optionId) || options[0];
   };
+
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     setAirInventory(getAirHockeyInventory(resolvedAccountId));

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -29,7 +29,13 @@ import {
   CHESS_BATTLE_SPEAKERS,
   createChessMatchCommentaryScript
 } from '../../utils/chessBattleCommentary.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../../utils/textToSpeech.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import { TABLE_WOOD_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_BASE_OPTIONS } from '../../utils/tableCustomizationOptions.js';
 import {
@@ -6011,7 +6017,7 @@ function Chess3D({
   });
   const [isMuted, setIsMuted] = useState(() => isGameMuted());
   const effectiveSoundEnabled = soundEnabled && !isMuted;
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentaryMutedRef = useRef(commentaryMuted);
   const commentaryReadyRef = useRef(false);
   const commentaryQueueRef = useRef([]);
@@ -6065,6 +6071,15 @@ function Chess3D({
       CHESS_BATTLE_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   useEffect(() => {
     uiRef.current = ui;
   }, [ui]);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -63,7 +63,13 @@ import {
   buildCommentaryLine,
   createMatchCommentaryScript
 } from '../../utils/ludoBattleRoyaleCommentary.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../../utils/textToSpeech.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
@@ -2784,7 +2790,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const activeCommentaryPreset = useMemo(
     () =>
       LUDO_BATTLE_COMMENTARY_PRESETS.find((preset) => preset.id === commentaryPresetId) ??
@@ -2816,6 +2822,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     };
   }, [activeFrameRateOption]);
   const frameQualityRef = useRef(frameQualityProfile);
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
   }, [frameQualityProfile]);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -47,7 +47,13 @@ import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { getAvatarUrl } from '../../utils/avatarUtils.js';
 import { getGameVolume, isGameMuted } from '../../utils/sound.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../../utils/textToSpeech.js';
 import {
   buildMurlanCommentaryLine,
   MURLAN_ROYALE_SPEAKERS,
@@ -1897,7 +1903,7 @@ export default function MurlanRoyaleArena({ search }) {
       MURLAN_ROYALE_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentarySpeakers = useMemo(() => {
     const base = [
       MURLAN_ROYALE_SPEAKERS.lead,
@@ -1919,6 +1925,15 @@ export default function MurlanRoyaleArena({ search }) {
     commentarySpeakerIndexRef.current = index + 1;
     return commentarySpeakers[index % commentarySpeakers.length] || MURLAN_ROYALE_SPEAKERS.analyst;
   }, [activeCommentaryPreset?.id, commentarySpeakers]);
+
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     commentaryMutedRef.current = commentaryMuted;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -38,7 +38,13 @@ import {
   buildCommentaryLine,
   POOL_ROYALE_SPEAKERS
 } from '../../utils/poolRoyaleCommentary.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../../utils/textToSpeech.js';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -11675,7 +11681,7 @@ function PoolRoyaleGame({
       POOL_ROYALE_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const availableTableFinishes = useMemo(
     () =>
       TABLE_FINISH_OPTIONS.filter((option) =>
@@ -11795,6 +11801,15 @@ function PoolRoyaleGame({
       POCKET_LINER_OPTIONS[0],
     [availablePocketLiners, pocketLinerId]
   );
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   useEffect(() => {
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -101,7 +101,13 @@ import {
   createSnakeMatchCommentaryScript,
   SNAKE_LADDER_SPEAKERS
 } from "../../utils/snakeAndLadderCommentary.js";
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from "../../utils/textToSpeech.js";
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from "../../utils/textToSpeech.js";
 
 const TOKEN_COLOR_OPTIONS = Object.freeze(
   SNAKE_TOKEN_COLOR_OPTIONS.map((option) => ({
@@ -1279,7 +1285,7 @@ export default function SnakeAndLadder() {
       SNAKE_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentaryMutedRef = useRef(commentaryMuted);
   const commentaryReadyRef = useRef(false);
   const commentaryQueueRef = useRef([]);
@@ -1290,6 +1296,15 @@ export default function SnakeAndLadder() {
   const commentaryIntroPlayedRef = useRef(false);
   const commentaryOutroPlayedRef = useRef(false);
   const pendingCommentaryLinesRef = useRef(null);
+
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     setAppearance((prev) => {

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -36,7 +36,7 @@ import {
   buildSnookerCommentaryLine,
   createSnookerMatchCommentaryScript
 } from '../../utils/snookerRoyalCommentary.js';
-import { getSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import { getSpeechSupport, getSpeechSynthesis, onSpeechSupportChange, speakCommentaryLines } from '../../utils/textToSpeech.js';
 import {
   createBallPreviewDataUrl,
   getBallMaterial as getBilliardBallMaterial
@@ -11417,7 +11417,7 @@ function SnookerRoyalGame({
       SNOOKER_ROYAL_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const availableTableFinishes = useMemo(
     () =>
       TABLE_FINISH_OPTIONS.filter((option) =>
@@ -11535,6 +11535,15 @@ function SnookerRoyalGame({
       POCKET_LINER_OPTIONS[0],
     [availablePocketLiners, pocketLinerId]
   );
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   useEffect(() => {
     if (!isSnookerOptionUnlocked('tableFinish', tableFinishId, snookerInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -39,7 +39,13 @@ import {
   buildTexasHoldemCommentaryLine,
   TEXAS_HOLDEM_SPEAKERS
 } from '../../utils/texasHoldemCommentary.js';
-import { getSpeechSynthesis, primeSpeechSynthesis, speakCommentaryLines } from '../../utils/textToSpeech.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../../utils/textToSpeech.js';
 import { TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID } from '../../config/poolRoyaleInventoryConfig.js';
 import { chatBeep } from '../../assets/soundData.js';
@@ -2856,7 +2862,7 @@ function TexasHoldemArena({ search }) {
       TEXAS_HOLDEM_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const commentarySupported = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentarySpeakers = useMemo(
     () => [TEXAS_HOLDEM_SPEAKERS.lead, TEXAS_HOLDEM_SPEAKERS.analyst],
     []
@@ -2866,6 +2872,15 @@ function TexasHoldemArena({ search }) {
     commentarySpeakerIndexRef.current = index + 1;
     return commentarySpeakers[index % commentarySpeakers.length] || TEXAS_HOLDEM_SPEAKERS.analyst;
   }, [commentarySpeakers]);
+
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     commentaryMutedRef.current = commentaryMuted;


### PR DESCRIPTION
### Motivation
- Telegram's in-app browser can expose the Web Speech API late or under vendor-prefixed names, causing commentary UI to remain disabled or previous unlock logic to fail.
- The previous change was reverted because availability detection was brittle and speech calls could throw, breaking gameplay flows.

### Description
- Added a speech support monitor and event API in `webapp/src/utils/textToSpeech.js` (`emitSpeechSupport`, `installSpeechSupportMonitor`, `getSpeechSupport`, `onSpeechSupportChange`) to detect when `speechSynthesis` / `SpeechSynthesisUtterance` become available at runtime and to notify listeners. 
- Made `getSpeechSynthesis` resilient to vendor-prefixed implementations (`window.speechSynthesis` then `window.webkitSpeechSynthesis`) and guarded `primeSpeechSynthesis`/`speak` calls with checks for `SpeechSynthesisUtterance` plus `try/catch` to avoid thrown exceptions and to cancel safely on error. 
- Kept speech-unlock listeners installed even when no synth exists initially (removed the early-return) and added focus/visibility hooks to re-evaluate support (helpful for Telegram). 
- Updated commentary components across games to track support reactively: replaced one-time `useMemo(Boolean(getSpeechSynthesis()))` snapshots with stateful `getSpeechSupport()` + `onSpeechSupportChange` subscriptions in the following files: `AirHockey3D.jsx`, `SnakeAndLadder.jsx`, `TexasHoldemArena.jsx`, `LudoBattleRoyal.jsx`, `ChessBattleRoyal.jsx`, `MurlanRoyaleArena.jsx`, `SnookerRoyal.jsx`, `PoolRoyale.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (Vite build finished; existing chunk-size warnings reported but unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e3f463620832981599f323c57b69f)