### PR TITLE
Harden API auth, CORS, Socket.IO auth, and tests

### DIFF
--- a/bot/middleware/auth.js
+++ b/bot/middleware/auth.js
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-function verifyTelegramInitData(initData) {
+export function verifyTelegramInitData(initData) {
   try {
     const params = new URLSearchParams(initData);
     const hash = params.get('hash');

--- a/bot/package.json
+++ b/bot/package.json
@@ -14,6 +14,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.5.1",
     "geoip-lite": "^1.4.10",
+    "helmet": "^7.2.0",
     "https-proxy-agent": "^7.0.2",
     "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.6.0",

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -27,8 +27,13 @@ import {
 
 const router = Router();
 
+function ensureAccountOwner(req, user) {
+  if (!user?.telegramId) return true;
+  return req.auth?.telegramId === user.telegramId;
+}
+
 // Create or fetch account for a user
-router.post('/create', async (req, res) => {
+router.post('/create', authenticate, async (req, res) => {
   const {
     telegramId,
     accountId,
@@ -38,6 +43,9 @@ router.post('/create', async (req, res) => {
     lastName,
     photo
   } = req.body;
+  if (telegramId && req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   const useMemoryStore = shouldUseMemoryUserStore();
 
   try {
@@ -223,12 +231,15 @@ router.post('/create', async (req, res) => {
 });
 
 // Get balance by account id
-router.post('/balance', async (req, res) => {
+router.post('/balance', authenticate, async (req, res) => {
   const { accountId } = req.body;
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!ensureAccountOwner(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   const balance = calculateBalance(user);
   if (user.balance !== balance) {
     user.balance = balance;
@@ -242,12 +253,15 @@ router.post('/balance', async (req, res) => {
 });
 
 // Get full account info including gifts and transactions
-router.post('/info', async (req, res) => {
+router.post('/info', authenticate, async (req, res) => {
   const { accountId } = req.body;
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!ensureAccountOwner(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
 
   ensureTransactionArray(user);
   if (!Array.isArray(user.gifts)) user.gifts = [];
@@ -276,7 +290,7 @@ router.post('/info', async (req, res) => {
 });
 
 // Send TPC between accounts
-router.post('/send', async (req, res) => {
+router.post('/send', authenticate, async (req, res) => {
   const { fromAccount, toAccount, amount, note } = req.body;
   if (!fromAccount || !toAccount || typeof amount !== 'number') {
     return res
@@ -288,6 +302,9 @@ router.post('/send', async (req, res) => {
 
   const sender = await User.findOne({ accountId: fromAccount });
   if (!sender) return res.status(404).json({ error: 'sender not found' });
+  if (!ensureAccountOwner(req, sender)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   const feeSender = Math.round(amount * 0.02);
   const feeReceiver = Math.round(amount * 0.01);
   if (sender.balance < amount + feeSender) {
@@ -422,7 +439,7 @@ router.post('/send', async (req, res) => {
 });
 
 // Send a gift using account ids
-router.post('/gift', async (req, res) => {
+router.post('/gift', authenticate, async (req, res) => {
   const { fromAccount, toAccount, gift } = req.body;
   if (!fromAccount || !toAccount || !gift) {
     return res
@@ -436,6 +453,9 @@ router.post('/gift', async (req, res) => {
   const sender = await User.findOne({ accountId: fromAccount });
   if (!sender || sender.balance < g.price) {
     return res.status(400).json({ error: 'insufficient balance' });
+  }
+  if (!ensureAccountOwner(req, sender)) {
+    return res.status(403).json({ error: 'forbidden' });
   }
 
   let receiver = await User.findOne({ accountId: toAccount });
@@ -515,7 +535,7 @@ router.post('/gift', async (req, res) => {
 });
 
 // Convert received gifts to TPC
-router.post('/convert-gifts', async (req, res) => {
+router.post('/convert-gifts', authenticate, async (req, res) => {
   const { accountId, giftIds, action = 'burn', toAccount } = req.body;
   if (!accountId || !Array.isArray(giftIds)) {
     return res.status(400).json({ error: 'accountId and giftIds required' });
@@ -523,6 +543,9 @@ router.post('/convert-gifts', async (req, res) => {
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!ensureAccountOwner(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
 
   ensureTransactionArray(user);
   if (!Array.isArray(user.gifts)) user.gifts = [];
@@ -642,11 +665,14 @@ router.post('/convert-gifts', async (req, res) => {
 });
 
 // List transactions by account id
-router.post('/transactions', async (req, res) => {
+router.post('/transactions', authenticate, async (req, res) => {
   const { accountId } = req.body;
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!ensureAccountOwner(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   ensureTransactionArray(user);
   res.json({ transactions: user.transactions });
 });

--- a/bot/routes/poolRoyale.js
+++ b/bot/routes/poolRoyale.js
@@ -55,10 +55,11 @@ async function handleInventoryGet(accountId, res) {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   let user;
+  let inMemoryStore = false;
   try {
-    if (shouldUseMemoryUserStore()) {
-      user = findMemoryUser({ accountId });
-    } else {
+    user = findMemoryUser({ accountId });
+    inMemoryStore = !!user;
+    if (!user && !shouldUseMemoryUserStore()) {
       user = await User.findOne({ accountId });
     }
   } catch (err) {
@@ -71,7 +72,7 @@ async function handleInventoryGet(accountId, res) {
   if (!areInventoriesEqual(user.poolRoyalInventory, normalized)) {
     user.poolRoyalInventory = normalized;
     try {
-      if (shouldUseMemoryUserStore()) {
+      if (shouldUseMemoryUserStore() || inMemoryStore) {
         saveMemoryUser(user);
       } else {
         await user.save();
@@ -87,10 +88,11 @@ async function handleInventorySet(accountId, inventory, res) {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   let user;
+  let inMemoryStore = false;
   try {
-    if (shouldUseMemoryUserStore()) {
-      user = findMemoryUser({ accountId });
-    } else {
+    user = findMemoryUser({ accountId });
+    inMemoryStore = !!user;
+    if (!user && !shouldUseMemoryUserStore()) {
       user = await User.findOne({ accountId });
     }
   } catch (err) {
@@ -102,7 +104,7 @@ async function handleInventorySet(accountId, inventory, res) {
   const merged = mergeInventories(user.poolRoyalInventory, inventory);
   user.poolRoyalInventory = merged;
   try {
-    if (shouldUseMemoryUserStore()) {
+    if (shouldUseMemoryUserStore() || inMemoryStore) {
       saveMemoryUser(user);
     } else {
       await user.save();

--- a/bot/routes/snookerRoyal.js
+++ b/bot/routes/snookerRoyal.js
@@ -55,10 +55,11 @@ async function handleInventoryGet(accountId, res) {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   let user;
+  let inMemoryStore = false;
   try {
-    if (shouldUseMemoryUserStore()) {
-      user = findMemoryUser({ accountId });
-    } else {
+    user = findMemoryUser({ accountId });
+    inMemoryStore = !!user;
+    if (!user && !shouldUseMemoryUserStore()) {
       user = await User.findOne({ accountId });
     }
   } catch (err) {
@@ -71,7 +72,7 @@ async function handleInventoryGet(accountId, res) {
   if (!areInventoriesEqual(user.snookerRoyalInventory, normalized)) {
     user.snookerRoyalInventory = normalized;
     try {
-      if (shouldUseMemoryUserStore()) {
+      if (shouldUseMemoryUserStore() || inMemoryStore) {
         saveMemoryUser(user);
       } else {
         await user.save();
@@ -87,10 +88,11 @@ async function handleInventorySet(accountId, inventory, res) {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
 
   let user;
+  let inMemoryStore = false;
   try {
-    if (shouldUseMemoryUserStore()) {
-      user = findMemoryUser({ accountId });
-    } else {
+    user = findMemoryUser({ accountId });
+    inMemoryStore = !!user;
+    if (!user && !shouldUseMemoryUserStore()) {
       user = await User.findOne({ accountId });
     }
   } catch (err) {
@@ -102,7 +104,7 @@ async function handleInventorySet(accountId, inventory, res) {
   const merged = mergeInventories(user.snookerRoyalInventory, inventory);
   user.snookerRoyalInventory = merged;
   try {
-    if (shouldUseMemoryUserStore()) {
+    if (shouldUseMemoryUserStore() || inMemoryStore) {
       saveMemoryUser(user);
     } else {
       await user.save();

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -8,6 +8,7 @@ import PostRecord from '../models/PostRecord.js';
 import { similarityRatio, normalizeText } from '../utils/textSimilarity.js';
 import { withProxy } from '../utils/proxyAgent.js';
 import CustomTask from '../models/CustomTask.js';
+import authenticate from '../middleware/auth.js';
 
 const router = Router();
 const twitterClient = process.env.TWITTER_BEARER_TOKEN
@@ -59,9 +60,12 @@ function parseTelegramLink(link) {
   };
 }
 
-router.post('/list', async (req, res) => {
+router.post('/list', authenticate, async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
 
   const TWELVE_HOURS = 12 * 60 * 60 * 1000;
   const baseTasks = await Promise.all(
@@ -101,9 +105,12 @@ router.post('/list', async (req, res) => {
   res.json({ version: TASKS_VERSION, tasks: [...baseTasks, ...customTasks] });
 });
 
-router.post('/complete', async (req, res) => {
+router.post('/complete', authenticate, async (req, res) => {
   const { telegramId, taskId } = req.body;
   if (!telegramId || !taskId) return res.status(400).json({ error: 'telegramId and taskId required' });
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
 
   let config = TASKS.find(t => t.id === taskId);
   if (!config && taskId.startsWith('custom_')) {
@@ -129,6 +136,8 @@ router.post('/complete', async (req, res) => {
         console.error('telegram reaction verify failed:', err.message);
         return res.status(500).json({ error: 'verification failed' });
       }
+    } else if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
     } else {
       console.warn('BOT_TOKEN not configured; skipping Telegram reaction check');
     }
@@ -149,6 +158,8 @@ router.post('/complete', async (req, res) => {
         console.error('engage tweet verify failed:', err.message);
         return res.status(500).json({ error: 'verification failed' });
       }
+    } else if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
     } else {
       console.warn('TWITTER_BEARER_TOKEN not configured; skipping X engagement check');
     }
@@ -176,10 +187,16 @@ router.post('/complete', async (req, res) => {
   res.json({ message: 'completed', reward: config.reward });
 });
 
-router.post('/verify-telegram-reaction', async (req, res) => {
+router.post('/verify-telegram-reaction', authenticate, async (req, res) => {
   const { telegramId, messageId, threadId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   if (!process.env.BOT_TOKEN) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
+    }
     console.warn('BOT_TOKEN not configured; skipping Telegram reaction verification');
     return res.json({ reacted: false });
   }
@@ -227,12 +244,18 @@ async function didReply(telegramId, tweetId) {
   return Array.isArray(search?.data?.data) && search.data.data.length > 0;
 }
 
-router.post('/verify-like', async (req, res) => {
+router.post('/verify-like', authenticate, async (req, res) => {
   const { telegramId, tweetUrl } = req.body;
   if (!telegramId || !tweetUrl) {
     return res.status(400).json({ error: 'telegramId and tweetUrl required' });
   }
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   if (!twitterClient) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
+    }
     console.warn('TWITTER_BEARER_TOKEN not configured; skipping like verification');
     return res.json({ liked: false });
   }
@@ -247,12 +270,18 @@ router.post('/verify-like', async (req, res) => {
   }
 });
 
-router.post('/verify-retweet', async (req, res) => {
+router.post('/verify-retweet', authenticate, async (req, res) => {
   const { telegramId, tweetUrl } = req.body;
   if (!telegramId || !tweetUrl) {
     return res.status(400).json({ error: 'telegramId and tweetUrl required' });
   }
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   if (!twitterClient) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
+    }
     console.warn('TWITTER_BEARER_TOKEN not configured; skipping retweet verification');
     return res.json({ retweeted: false });
   }
@@ -267,12 +296,18 @@ router.post('/verify-retweet', async (req, res) => {
   }
 });
 
-router.post('/verify-reply', async (req, res) => {
+router.post('/verify-reply', authenticate, async (req, res) => {
   const { telegramId, tweetUrl } = req.body;
   if (!telegramId || !tweetUrl) {
     return res.status(400).json({ error: 'telegramId and tweetUrl required' });
   }
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
   if (!twitterClient) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
+    }
     console.warn('TWITTER_BEARER_TOKEN not configured; skipping reply verification');
     return res.json({ replied: false });
   }
@@ -287,10 +322,13 @@ router.post('/verify-reply', async (req, res) => {
   }
 });
 
-router.post('/verify-post', async (req, res) => {
+router.post('/verify-post', authenticate, async (req, res) => {
   const { telegramId, tweetUrl } = req.body;
   if (!telegramId || !tweetUrl) {
     return res.status(400).json({ error: 'telegramId and tweetUrl required' });
+  }
+  if (req.auth?.telegramId !== Number(telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
   }
 
   const config = TASKS.find((t) => t.id === 'post_tweet');
@@ -303,6 +341,9 @@ router.post('/verify-post', async (req, res) => {
   }
 
   if (!twitterClient) {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'verification unavailable' });
+    }
     console.warn('TWITTER_BEARER_TOKEN not configured; skipping post verification');
     await PostRecord.create({ telegramId, tweetId: 'unknown' });
     const user = await User.findOneAndUpdate(

--- a/bot/utils/memoryUserStore.js
+++ b/bot/utils/memoryUserStore.js
@@ -10,7 +10,8 @@ const defaultUserFields = () => ({
   referralCode: null,
   walletAddress: null,
   walletPublicKey: null,
-  poolRoyalInventory: undefined
+  poolRoyalInventory: undefined,
+  snookerRoyalInventory: undefined
 });
 
 const findByKey = (key, value) => {

--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -59,10 +59,10 @@ export class AmericanBilliards {
     const targetScore = 61;
 
     if (foul) {
+      const foulPenalty = first || lowest || 1;
       s.scores[current] = Math.max(0, s.scores[current] - 1);
-      s.scores[opp] += 1;
-      // Balls pocketed on a foul stay down, but the turn still passes.
-      for (const id of pottedBalls) s.ballsOnTable.delete(id);
+      s.scores[opp] += foulPenalty;
+      // Balls pocketed on a foul stay on the table.
       nextPlayer = opp;
       s.currentPlayer = opp;
       ballInHandNext = true;

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -188,6 +188,33 @@ function aimPointForCandidate (candidate, state, cueBall) {
   if (candidate.bankAnchor) {
     return { x: candidate.bankAnchor.x, y: candidate.bankAnchor.y }
   }
+  if (
+    candidate.actionType === 'safety' &&
+    candidate.targetBall &&
+    cueBall &&
+    pathBlocked(cueBall, candidate.targetBall, state.balls, [cueBall.id, candidate.targetBall.id], state.ballRadius)
+  ) {
+    const cueDistances = {
+      left: cueBall.x,
+      right: state.width - cueBall.x,
+      top: cueBall.y,
+      bottom: state.height - cueBall.y
+    }
+    const rail = Object.entries(cueDistances).sort((a, b) => a[1] - b[1])[0]?.[0] || 'left'
+    const mirrored = mirrorPoint(candidate.targetBall, state.width, state.height, rail)
+    const anchor = intersectionWithRail(cueBall, mirrored, rail, state.width, state.height)
+    if (anchor) {
+      return { x: anchor.x, y: anchor.y }
+    }
+  }
+  if (
+    candidate.actionType === 'pot' &&
+    candidate.targetBall &&
+    typeof candidate.angle === 'number' &&
+    candidate.angle <= STRAIGHT_SHOT_THRESHOLD
+  ) {
+    return { x: candidate.targetBall.x, y: candidate.targetBall.y }
+  }
   const ghost = contactPointTowardsPocket(
     candidate.targetBall,
     candidate.pocket,

--- a/test/jestNodeTestShim.js
+++ b/test/jestNodeTestShim.js
@@ -8,7 +8,19 @@ import {
   test as jestTest
 } from '@jest/globals';
 
-const test = (...args) => jestTest(...args);
+const wrapJestTest = (fn) => (name, optionsOrFn, maybeFn) => {
+  if (typeof optionsOrFn === 'function') {
+    return fn(name, optionsOrFn, maybeFn);
+  }
+  if (optionsOrFn && typeof maybeFn === 'function') {
+    return fn(name, maybeFn, optionsOrFn.timeout);
+  }
+  return fn(name, optionsOrFn);
+};
+
+const test = wrapJestTest(jestTest);
+test.skip = wrapJestTest(jestTest.skip);
+test.only = wrapJestTest(jestTest.only);
 
 export default test;
 export {

--- a/test/joinSeatCleanup.test.js
+++ b/test/joinSeatCleanup.test.js
@@ -31,6 +31,7 @@ test('joinRoom clears lobby seat', { concurrency: false, timeout: 20000 }, async
     PORT: '3204',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: 'test-token',
     SKIP_WEBAPP_BUILD: '1',
     SKIP_BOT_LAUNCH: '1'
   };
@@ -47,7 +48,9 @@ test('joinRoom clears lobby seat', { concurrency: false, timeout: 20000 }, async
     let lobby = lobbies.find(l => l.id === 'snake-2');
     assert.equal(lobby.players, 1);
 
-    const s1 = io('http://localhost:3204');
+    const s1 = io('http://localhost:3204', {
+      extraHeaders: { Authorization: 'Bearer test-token' }
+    });
     await new Promise((resolve) => s1.on('connect', resolve));
     s1.emit('joinRoom', { roomId: 'snake-2-100', accountId: 'p1', name: 'A' });
     await delay(500);

--- a/test/lobbyWait.test.js
+++ b/test/lobbyWait.test.js
@@ -31,6 +31,7 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
     PORT: '3203',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: 'test-token',
     SKIP_WEBAPP_BUILD: '1',
     SKIP_BOT_LAUNCH: '1'
   };
@@ -42,7 +43,9 @@ test('joinRoom waits until table full', { concurrency: false, timeout: 20000 }, 
       body: JSON.stringify({ tableId: 'snake-2-100', accountId: 'p1', name: 'A', confirmed: true })
     });
 
-    const s1 = io('http://localhost:3203');
+    const s1 = io('http://localhost:3203', {
+      extraHeaders: { Authorization: 'Bearer test-token' }
+    });
     const errors = [];
     await new Promise((resolve) => s1.on('connect', resolve));
     s1.on('error', (e) => errors.push(e));

--- a/test/onlineRoutes.test.js
+++ b/test/onlineRoutes.test.js
@@ -52,7 +52,8 @@ test('online routes reflect pinged users', { concurrency: false }, async () => {
     const listRes = await fetch('http://localhost:3205/api/online/list');
     assert.equal(listRes.status, 200);
     const list = await listRes.json();
-    assert.deepEqual(list.users, [{ id: 'player1', status: 'online' }]);
+    const normalized = JSON.parse(JSON.stringify(list.users));
+    assert.deepEqual(normalized, [{ id: 'player1', status: 'online' }]);
   } finally {
     server.kill();
   }

--- a/test/poolRoyalInventoryRoutes.test.js
+++ b/test/poolRoyalInventoryRoutes.test.js
@@ -3,8 +3,27 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import { spawn } from 'child_process';
 import path from 'node:path';
+import crypto from 'crypto';
 
 const distDir = path.resolve(process.cwd(), 'webapp', 'dist');
+
+function createInitData(id, token) {
+  const params = new URLSearchParams();
+  params.set('user', JSON.stringify({ id }));
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+  const secret = crypto
+    .createHmac('sha256', 'WebAppData')
+    .update(token)
+    .digest();
+  const hash = crypto.createHmac('sha256', secret)
+    .update(dataCheckString)
+    .digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -25,7 +44,10 @@ async function startServer(env) {
 async function createAccount(port, telegramId) {
   const res = await fetch(`http://localhost:${port}/api/account/create`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'x-telegram-init-data': createInitData(telegramId, 'dummy')
+    },
     body: JSON.stringify({ telegramId })
   });
   assert.equal(res.status, 200);

--- a/test/referralRoutes.test.js
+++ b/test/referralRoutes.test.js
@@ -2,8 +2,27 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
 import { spawn } from 'child_process';
+import crypto from 'crypto';
 
 const distDir = new URL('../webapp/dist/', import.meta.url);
+
+function createInitData(id, token) {
+  const params = new URLSearchParams();
+  params.set('user', JSON.stringify({ id }));
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+  const secret = crypto
+    .createHmac('sha256', 'WebAppData')
+    .update(token)
+    .digest();
+  const hash = crypto.createHmac('sha256', secret)
+    .update(dataCheckString)
+    .digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -23,7 +42,7 @@ async function startServer(env) {
   return server;
 }
 
-test('claiming a referral updates inviter stats', { concurrency: false }, async () => {
+test('claiming a referral updates inviter stats', { concurrency: false, timeout: 20000 }, async () => {
   fs.mkdirSync(new URL('assets', distDir), { recursive: true });
   fs.writeFileSync(new URL('index.html', distDir), '');
 
@@ -73,14 +92,20 @@ test('claiming a referral updates inviter stats', { concurrency: false }, async 
 
     const inviterAccRes = await fetch('http://localhost:3210/api/account/create', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(inviterId, 'dummy')
+      },
       body: JSON.stringify({ telegramId: inviterId })
     });
     const inviterAcc = await inviterAccRes.json();
     assert.ok(inviterAcc.walletAddress);
     const inviterInfoRes = await fetch('http://localhost:3210/api/account/info', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(inviterId, 'dummy')
+      },
       body: JSON.stringify({ accountId: inviterAcc.accountId })
     });
     const inviterAccount = await inviterInfoRes.json();
@@ -90,14 +115,20 @@ test('claiming a referral updates inviter stats', { concurrency: false }, async 
 
     const userAccRes = await fetch('http://localhost:3210/api/account/create', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(userId, 'dummy')
+      },
       body: JSON.stringify({ telegramId: userId })
     });
     const userAcc = await userAccRes.json();
     assert.ok(userAcc.walletAddress);
     const userInfoRes = await fetch('http://localhost:3210/api/account/info', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(userId, 'dummy')
+      },
       body: JSON.stringify({ accountId: userAcc.accountId })
     });
     const userAccount = await userInfoRes.json();

--- a/test/snakeSeat.test.js
+++ b/test/snakeSeat.test.js
@@ -54,10 +54,18 @@ test('seat and unseat endpoints update lobby', { concurrency: false, timeout: 20
     });
     assert.equal(res.status, 200);
 
-    res = await fetch('http://localhost:3206/api/snake/lobby/snake-2');
-    assert.equal(res.status, 200);
-    lobby = await res.json();
-    assert.ok(!lobby.players.some(p => p.id === 'p100'));
+    let removed = false;
+    const deadline = Date.now() + 2000;
+    while (!removed && Date.now() < deadline) {
+      res = await fetch('http://localhost:3206/api/snake/lobby/snake-2');
+      assert.equal(res.status, 200);
+      lobby = await res.json();
+      removed = !lobby.players.some(p => p.id === 'p100');
+      if (!removed) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+    assert.ok(removed);
   } finally {
     server.kill();
   }

--- a/test/snookerRoyalInventoryRoutes.test.js
+++ b/test/snookerRoyalInventoryRoutes.test.js
@@ -3,8 +3,27 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import { spawn } from 'child_process';
 import path from 'node:path';
+import crypto from 'crypto';
 
 const distDir = path.resolve(process.cwd(), 'webapp', 'dist');
+
+function createInitData(id, token) {
+  const params = new URLSearchParams();
+  params.set('user', JSON.stringify({ id }));
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+  const secret = crypto
+    .createHmac('sha256', 'WebAppData')
+    .update(token)
+    .digest();
+  const hash = crypto.createHmac('sha256', secret)
+    .update(dataCheckString)
+    .digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -25,7 +44,10 @@ async function startServer(env) {
 async function createAccount(port, telegramId) {
   const res = await fetch(`http://localhost:${port}/api/account/create`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'x-telegram-init-data': createInitData(telegramId, 'dummy')
+    },
     body: JSON.stringify({ telegramId })
   });
   assert.equal(res.status, 200);

--- a/test/socialSearchFilterSelf.test.js
+++ b/test/socialSearchFilterSelf.test.js
@@ -2,8 +2,27 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
 import { spawn } from 'child_process';
+import crypto from 'crypto';
 
 const distDir = new URL('../webapp/dist/', import.meta.url);
+
+function createInitData(id, token) {
+  const params = new URLSearchParams();
+  params.set('user', JSON.stringify({ id }));
+  const dataCheckString = [...params.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join('\n');
+  const secret = crypto
+    .createHmac('sha256', 'WebAppData')
+    .update(token)
+    .digest();
+  const hash = crypto.createHmac('sha256', secret)
+    .update(dataCheckString)
+    .digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
 
 async function startServer(env) {
   const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
@@ -36,17 +55,26 @@ test('search excludes requesting user', { concurrency: false }, async () => {
   try {
     await fetch('http://localhost:3208/api/profile/update', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(1, 'dummy')
+      },
       body: JSON.stringify({ telegramId: 1, firstName: 'Alice' })
     });
     await fetch('http://localhost:3208/api/profile/update', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(2, 'dummy')
+      },
       body: JSON.stringify({ telegramId: 2, firstName: 'Alicia' })
     });
     const res = await fetch('http://localhost:3208/api/social/search', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-telegram-init-data': createInitData(1, 'dummy')
+      },
       body: JSON.stringify({ query: 'Ali', telegramId: 1 })
     });
     assert.equal(res.status, 200);

--- a/test/walletRoutes.test.js
+++ b/test/walletRoutes.test.js
@@ -62,6 +62,7 @@ test('withdraw route reverts balance on claim failure', { concurrency: false }, 
     PORT: '3211',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
+    WITHDRAW_ENABLED: 'true',
     SKIP_WEBAPP_BUILD: '1',
     SKIP_BOT_LAUNCH: '1',
   };
@@ -104,6 +105,7 @@ test('claim-external route reverts balance on claim failure', { concurrency: fal
     PORT: '3212',
     MONGO_URI: 'memory',
     BOT_TOKEN: 'dummy',
+    WITHDRAW_ENABLED: 'true',
     SKIP_WEBAPP_BUILD: '1',
     SKIP_BOT_LAUNCH: '1',
   };

--- a/webapp/src/utils/lobby.js
+++ b/webapp/src/utils/lobby.js
@@ -1,4 +1,5 @@
 export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
+  if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && table?.id === 'single') {
     return aiCount > 0;
   }
@@ -8,7 +9,6 @@ export function canStartGame(game, table, stake, aiCount = 0, players = 0) {
     if (players < capacity) return false;
     if (players > capacity) return false;
   }
-  if (!stake || !stake.token || !stake.amount) return false;
   if (game === 'snake' && !table) return false;
   return true;
 }


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated/unauthorized operations on profile, tasks, social and account endpoints by enforcing identity checks and limiting exposed profile data.
- Reduce attack surface by replacing wildcard CORS with an allowlist and adding Socket.IO authentication for real-time endpoints.
- Add defenses (Helmet/CSP, per-user rate-limiting) and harden dev-only endpoints (calibration) to avoid accidental exposure in production.
- Make tests reflect the new auth flows and ensure the whole suite passes before merging.

### Description
- Authentication and identity checks: exported `verifyTelegramInitData` and updated `authenticate` usage across routes; added explicit `authenticate` middleware and `telegramId` ownership checks for `/api/profile` (including returning public fields when unauthorized), `/api/tasks`, `/api/social/*`, `/api/account` endpoints, and many profile/account actions (`update`, `updateBalance`, `addTransaction`, `link-*`).
- Socket and CORS: replaced wildcard CORS with allowlist support via `ALLOWED_ORIGINS`, added Socket.IO middleware to accept either a bearer `API_AUTH_TOKEN` or signed Telegram init data (`x-telegram-init-data`) and reject unauthorized socket connections.
- Defense-in-depth: added `helmet` with a restrictive Content Security Policy, introduced a per-user `userLimiter` rate limiter (keyed by `telegramId`/`accountId` or IP), and enforced authentication on goal-rush calibration (dev-only access validated by account membership).
- Inventory & memory store: extended the in-memory user store to include `snookerRoyalInventory`, and updated `pool-royale`/`snooker-royale` handlers to use and persist memory-backed users when `MONGO_URI=memory`.
- Gameplay & AI fixes: adjusted lobby/stake checks (`canStartGame`), improved `poolUkAdvancedAi` aim logic for safeties and straight pot prioritization, and refined foul scoring in `AmericanBilliards`.
- Tests & tooling: updated `bot/package.json` to add `helmet`, adjusted many integration tests to send `x-telegram-init-data` or socket `Authorization` headers, enhanced the Jest shim to support the test option signatures and added several test timeouts/robustness fixes.

### Testing
- Ran the full automated suite with `npm test` after changes and dependency install; result: all test suites passed: `32 passed, 32 total` (tests: `111 passed`, `1 skipped`).
- Verified Socket auth and new CORS/Helmet behavior implicitly via updated integration tests that exercise socket joins and API calls using `x-telegram-init-data` and `API_AUTH_TOKEN`.
- No manual changes beyond the repo edits; CI-ready test artifacts were produced and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4223a3a08329a076012865eb6f08)