### PR TITLE
Improve replay cue animation, show fouls in replay, and relax UK 8-ball black-pot rule

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -166,6 +166,15 @@ export class UkPool {
         reason = 'potted black early';
       }
     }
+    if (foul && blackPotted) {
+      const ownSet = ownGroup ? s.ballsOnTable[ownGroup] : null;
+      const ownCleared = ownSet && ownSet.size === 0;
+      const remainingColors = s.ballsOnTable.blue.size + s.ballsOnTable.red.size;
+      if (!scratched && (ownCleared || remainingColors === 0) && reason === 'potted black early') {
+        foul = false;
+        reason = '';
+      }
+    }
 
     // apply pot removals
     if (!foul) {


### PR DESCRIPTION
### Motivation
- Replays currently sometimes hide the cue stick or show no forward stroke when the recorded `cueStroke` is missing, and fouls were not surfaced to the replay UI.
- UK 8-ball rule handling flagged some legal black pots as fouls when the shooter had already cleared their colours or the table had no colours left.
- In-hand camera behavior should match other pool variants (full-table top view) when ball-in-hand is allowed so players see the same overview during placement.

### Description
- Added a fallback cue-stick stroke animation for replays when `cueStroke` is not recorded that simulates pullback/impact/settle/return and extends the replay hold window; implemented in `webapp/src/pages/Games/PoolRoyale.jsx` inside `applyReplayCueStroke`/cue path logic and related helpers.
- Capture and propagate fouls into replay metadata by writing `shotRecording.replayFoul` when a shot resolves (local and remote), and surface that state as an on-screen badge during replay (`replayFoul` state + overlay in the replay header). Changes in `PoolRoyale.jsx` include setting `replayFoul` on `startShotReplay` and clearing it on `finishReplayPlayback` and storing `replayFoul` for incoming remote recordings.
- Make in-hand placement enter a full-table top view for supported variants (UK and non-break American/9-ball) so ball-in-hand shows the same overhead framing; added `inHandTopViewRef` logic to enter/exit `topView` when `hud.inHand` changes.
- Adjust UK 8-ball rule logic in `lib/poolUk8Ball.js` to avoid marking a pot of the black as a foul when the shooter has already cleared their assigned colour (or when no coloured balls remain) and the cue was not scratched; this relaxes the `potted black early` branch to prevent erroneous fouls.

### Testing
- No automated tests were executed as part of this change set.
- The changes were committed and the modified files are `webapp/src/pages/Games/PoolRoyale.jsx` and `lib/poolUk8Ball.js` (no unit/CI runs were performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e663c148883298f9bd852b4e19748)