### PR TITLE
Stabilize reward deposit flow, tighten auth, CSP and test stability

### DIFF
--- a/bot/middleware/auth.js
+++ b/bot/middleware/auth.js
@@ -27,6 +27,8 @@ export function verifyTelegramInitData(initData, botToken = process.env.BOT_TOKE
 
 function attachAuth(req, token, initData) {
   const allowedToken = process.env.API_AUTH_TOKEN;
+  const ownerToken = req.get('x-account-owner-token');
+  const ownerAccountId = req.get('x-account-id');
   if (initData) {
     const data = verifyTelegramInitData(initData);
     if (data) {
@@ -38,6 +40,10 @@ function attachAuth(req, token, initData) {
   }
   if (allowedToken && token === allowedToken) {
     req.auth = { apiToken: true };
+    return true;
+  }
+  if (ownerToken && ownerAccountId) {
+    req.auth = { ownerToken: ownerToken, accountId: ownerAccountId };
     return true;
   }
   return false;
@@ -61,4 +67,11 @@ export function optionalAuthenticate(req, _res, next) {
   const initData = req.get('x-telegram-init-data');
   attachAuth(req, token, initData);
   next();
+}
+
+export function requireApiToken(req, res, next) {
+  if (req.auth?.apiToken) {
+    return next();
+  }
+  res.status(403).json({ error: 'forbidden' });
 }

--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -55,6 +55,7 @@ const userSchema = new mongoose.Schema({
   walletAddress: { type: String, unique: true, sparse: true },
   walletPublicKey: { type: String },
 
+  ownerToken: { type: String, default: undefined },
 
   accountId: { type: String, unique: true },
 
@@ -149,6 +150,9 @@ userSchema.pre('save', function(next) {
   if (!this.referralCode) {
     const base = this.telegramId || this.googleId || this.walletAddress || '';
     this.referralCode = String(base);
+  }
+  if (!this.telegramId && !this.ownerToken) {
+    this.ownerToken = uuidv4();
   }
   if (!this.accountId) {
     this.accountId = uuidv4();

--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import User from '../models/User.js';
-import authenticate from '../middleware/auth.js';
+import authenticate, { requireApiToken } from '../middleware/auth.js';
 import {
   ensureTransactionArray,
   calculateBalance
@@ -24,10 +25,28 @@ import {
   shouldUseMemoryUserStore,
   deleteMemoryUser
 } from '../utils/memoryUserStore.js';
+import { verifyRewardReceipt, signRewardReceipt } from '../utils/rewardReceipt.js';
 
 const router = Router();
 function isPrivileged(req) {
   return req.auth?.apiToken === true;
+}
+
+function getOwnerToken(req) {
+  return req.get('x-account-owner-token') || req.body?.ownerToken || '';
+}
+
+function canAccessAccount(req, user) {
+  if (isPrivileged(req)) return true;
+  if (user?.telegramId) {
+    return user.telegramId === req.auth?.telegramId;
+  }
+  return user?.ownerToken && getOwnerToken(req) === user.ownerToken;
+}
+
+function enforceRewardLimit(amount) {
+  const maxReward = Number(process.env.REWARD_MAX_AMOUNT) || 1000;
+  return Number.isFinite(amount) && amount > 0 && amount <= maxReward;
 }
 
 // Create or fetch account for a user
@@ -62,6 +81,15 @@ router.post('/create', authenticate, async (req, res) => {
     const existingByGoogle = googleId ? await findUser({ googleId }) : null;
 
     const primaryExisting = existingByAccountId || existingByTelegram || existingByGoogle;
+
+    if (
+      accountId &&
+      existingByAccountId &&
+      !existingByAccountId.telegramId &&
+      !canAccessAccount(req, existingByAccountId)
+    ) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
 
     if (telegramId) {
       try {
@@ -220,7 +248,8 @@ router.post('/create', authenticate, async (req, res) => {
       walletAddress: user.walletAddress,
       firstName: user.firstName,
       lastName: user.lastName,
-      photo: user.photo
+      photo: user.photo,
+      ...(user.telegramId ? {} : { ownerToken: user.ownerToken })
     });
   } catch (err) {
     console.error('Failed to create account:', err);
@@ -235,7 +264,7 @@ router.post('/balance', authenticate, async (req, res) => {
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (!isPrivileged(req) && user.telegramId && user.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
   const balance = calculateBalance(user);
@@ -257,7 +286,7 @@ router.post('/info', authenticate, async (req, res) => {
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (!isPrivileged(req) && user.telegramId && user.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
@@ -300,7 +329,7 @@ router.post('/send', authenticate, async (req, res) => {
 
   const sender = await User.findOne({ accountId: fromAccount });
   if (!sender) return res.status(404).json({ error: 'sender not found' });
-  if (!isPrivileged(req) && sender.telegramId && sender.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, sender)) {
     return res.status(403).json({ error: 'forbidden' });
   }
   const feeSender = Math.round(amount * 0.02);
@@ -452,7 +481,7 @@ router.post('/gift', authenticate, async (req, res) => {
   if (!sender || sender.balance < g.price) {
     return res.status(400).json({ error: 'insufficient balance' });
   }
-  if (!isPrivileged(req) && sender.telegramId && sender.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, sender)) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
@@ -541,7 +570,7 @@ router.post('/convert-gifts', authenticate, async (req, res) => {
 
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (!isPrivileged(req) && user.telegramId && user.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
@@ -668,7 +697,7 @@ router.post('/transactions', authenticate, async (req, res) => {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (!isPrivileged(req) && user.telegramId && user.telegramId !== req.auth?.telegramId) {
+  if (!canAccessAccount(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
   ensureTransactionArray(user);
@@ -685,7 +714,6 @@ router.get('/transactions/public', async (req, res) => {
     {
       $project: {
         _id: 0,
-        accountId: '$accountId',
         amount: '$transactions.amount',
         type: '$transactions.type',
         game: '$transactions.game',
@@ -697,8 +725,7 @@ router.get('/transactions/public', async (req, res) => {
             '$transactions.fromName',
             { $ifNull: ['$nickname', '$firstName'] }
           ]
-        },
-        fromPhoto: { $ifNull: ['$transactions.fromPhoto', '$photo'] }
+        }
       }
     },
     { $sort: { date: -1 } },
@@ -708,8 +735,8 @@ router.get('/transactions/public', async (req, res) => {
 });
 
 // Deposit rewards into account
-router.post('/deposit', authenticate, async (req, res) => {
-  const { accountId, amount, game } = req.body;
+router.post('/deposit', authenticate, requireApiToken, async (req, res) => {
+  const { accountId, amount, game, receipt, nonce, ts } = req.body;
   const authId = req.auth?.telegramId;
   const devIds = [
     process.env.DEV_ACCOUNT_ID || process.env.VITE_DEV_ACCOUNT_ID,
@@ -720,6 +747,24 @@ router.post('/deposit', authenticate, async (req, res) => {
     return res
       .status(400)
       .json({ error: 'accountId and positive amount required' });
+  }
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  if (!receipt || !nonce || !ts) {
+    if (!isPrivileged(req)) {
+      return res.status(400).json({ error: 'receipt, nonce and ts required' });
+    }
+  } else {
+    const check = verifyRewardReceipt(
+      { purpose: 'account_deposit', accountId, amount, game, nonce, ts },
+      receipt,
+      process.env.REWARD_SIGNING_SECRET
+    );
+    if (!check.ok) {
+      const status = check.error === 'missing_secret' ? 503 : 403;
+      return res.status(status).json({ error: 'invalid receipt' });
+    }
   }
   let user = await User.findOne({ accountId });
   if (!user) {
@@ -758,6 +803,73 @@ router.post('/deposit', authenticate, async (req, res) => {
       console.error('Failed to send Telegram notification:', err.message);
     }
   }
+  res.json({ balance: user.balance, transaction: tx });
+});
+
+router.post('/receipt', authenticate, async (req, res) => {
+  const { accountId, amount, game } = req.body;
+  if (!accountId || typeof amount !== 'number') {
+    return res.status(400).json({ error: 'accountId and amount required' });
+  }
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  const user = await User.findOne({ accountId });
+  if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!canAccessAccount(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const secret = process.env.REWARD_SIGNING_SECRET;
+  if (!secret) return res.status(503).json({ error: 'receipt unavailable' });
+  const nonce = randomUUID();
+  const ts = Date.now();
+  const receipt = signRewardReceipt(
+    { purpose: 'account_deposit', accountId, amount, game, nonce, ts },
+    secret
+  );
+  res.json({ receipt, nonce, ts });
+});
+
+router.post('/claim-reward', authenticate, async (req, res) => {
+  const { accountId, amount, game, receipt, nonce, ts } = req.body;
+  if (!accountId || typeof amount !== 'number' || amount <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'accountId and positive amount required' });
+  }
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  if (!receipt || !nonce || !ts) {
+    return res.status(400).json({ error: 'receipt, nonce and ts required' });
+  }
+  const check = verifyRewardReceipt(
+    { purpose: 'account_deposit', accountId, amount, game, nonce, ts },
+    receipt,
+    process.env.REWARD_SIGNING_SECRET
+  );
+  if (!check.ok) {
+    const status = check.error === 'missing_secret' ? 503 : 403;
+    return res.status(status).json({ error: 'invalid receipt' });
+  }
+  const user = await User.findOne({ accountId });
+  if (!user) return res.status(404).json({ error: 'account not found' });
+  if (!canAccessAccount(req, user)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
+  ensureTransactionArray(user);
+  user.balance += amount;
+  const tx = {
+    amount,
+    type: 'deposit',
+    token: 'TPC',
+    status: 'delivered',
+    date: new Date()
+  };
+  if (game) tx.game = game;
+  user.transactions.push(tx);
+  await user.save();
   res.json({ balance: user.balance, transaction: tx });
 });
 

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -4,7 +4,7 @@ import User from '../models/User.js';
 import { fetchTelegramInfo } from '../utils/telegram.js';
 import { ensureTransactionArray, calculateBalance, sanitizeUser } from '../utils/userUtils.js';
 import { normalizeAddress } from '../utils/ton.js';
-import authenticate from '../middleware/auth.js';
+import authenticate, { requireApiToken } from '../middleware/auth.js';
 
 export function parseTwitterHandle(input) {
   if (!input) return '';
@@ -29,24 +29,49 @@ export function parseTwitterHandle(input) {
 
 const router = Router();
 
-router.post('/register-wallet', async (req, res) => {
+function getOwnerToken(req) {
+  return req.get('x-account-owner-token') || req.body?.ownerToken || '';
+}
+
+function canAccessProfile(req, user) {
+  if (!user) return false;
+  if (req.auth?.apiToken) return true;
+  if (user.telegramId) {
+    return req.auth?.telegramId === user.telegramId;
+  }
+  return user.ownerToken && getOwnerToken(req) === user.ownerToken;
+}
+
+router.post('/register-wallet', authenticate, async (req, res) => {
   const { walletAddress } = req.body;
   if (!walletAddress) {
     return res.status(400).json({ error: 'walletAddress required' });
+  }
+  if (!req.auth?.apiToken && !req.auth?.telegramId) {
+    return res.status(403).json({ error: 'forbidden' });
   }
   const normalized = normalizeAddress(walletAddress);
   if (!normalized) {
     return res.status(400).json({ error: 'invalid walletAddress' });
   }
-  const user = await User.findOneAndUpdate(
-    { walletAddress: normalized },
-    { $setOnInsert: { walletAddress: normalized, referralCode: normalized } },
-    { upsert: true, new: true, setDefaultsOnInsert: true }
-  );
+  const query = req.auth?.telegramId
+    ? { telegramId: req.auth.telegramId }
+    : { walletAddress: normalized };
+  const update = req.auth?.telegramId
+    ? {
+      $set: { walletAddress: normalized },
+      $setOnInsert: { referralCode: String(req.auth.telegramId) }
+    }
+    : { $setOnInsert: { walletAddress: normalized, referralCode: normalized } };
+  const user = await User.findOneAndUpdate(query, update, {
+    upsert: true,
+    new: true,
+    setDefaultsOnInsert: true
+  });
   res.json(sanitizeUser(user));
 });
 
-router.post('/register-google', async (req, res) => {
+router.post('/register-google', authenticate, requireApiToken, async (req, res) => {
   const { googleId } = req.body;
   if (!googleId) {
     return res.status(400).json({ error: 'googleId required' });
@@ -76,7 +101,7 @@ router.post('/telegram-info', async (req, res) => {
   }
 });
 
-router.post('/get', async (req, res) => {
+router.post('/get', authenticate, async (req, res) => {
   const { telegramId, accountId } = req.body;
   if (!telegramId && !accountId) {
     return res.status(400).json({ error: 'telegramId or accountId required' });
@@ -125,13 +150,14 @@ router.post('/get', async (req, res) => {
     await user.save();
   }
 
-  const isOwner =
-    req.auth?.telegramId &&
-    user?.telegramId &&
-    req.auth.telegramId === user.telegramId;
+  const isOwner = canAccessProfile(req, user);
 
   if (isOwner) {
     return res.json({ ...sanitizeUser(user), filledFromTelegram });
+  }
+
+  if (!user.telegramId) {
+    return res.status(403).json({ error: 'forbidden' });
   }
 
   return res.json({
@@ -177,13 +203,10 @@ router.post('/update', authenticate, async (req, res) => {
   res.json(sanitizeUser(user));
 });
 
-router.post('/updateBalance', authenticate, async (req, res) => {
+router.post('/updateBalance', authenticate, requireApiToken, async (req, res) => {
   const { telegramId, balance } = req.body;
   if (!telegramId || balance === undefined) {
     return res.status(400).json({ error: 'telegramId and balance required' });
-  }
-  if (!req.auth?.telegramId || req.auth.telegramId !== telegramId) {
-    return res.status(403).json({ error: 'forbidden' });
   }
   const user = await User.findOneAndUpdate(
     { telegramId },
@@ -193,21 +216,15 @@ router.post('/updateBalance', authenticate, async (req, res) => {
   res.json({ balance: user.balance });
 });
 
-router.post('/addTransaction', authenticate, async (req, res) => {
+router.post('/addTransaction', authenticate, requireApiToken, async (req, res) => {
   const { telegramId, accountId, amount, type, game, players } = req.body;
   if ((telegramId == null && !accountId) || amount === undefined || !type) {
     return res
       .status(400)
       .json({ error: 'telegramId or accountId, amount and type required' });
   }
-  if (!req.auth?.telegramId) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
   let user = null;
   if (telegramId != null) {
-    if (req.auth.telegramId !== telegramId) {
-      return res.status(403).json({ error: 'forbidden' });
-    }
     user = await User.findOne({ telegramId });
   }
   if (!user && accountId) user = await User.findOne({ accountId });
@@ -225,9 +242,6 @@ router.post('/addTransaction', authenticate, async (req, res) => {
   if (players) tx.players = players;
   user.transactions.push(tx);
   await user.save();
-  if (!user.telegramId || user.telegramId !== req.auth.telegramId) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
   res.json({ transactions: user.transactions });
 });
 

--- a/bot/routes/wallet.js
+++ b/bot/routes/wallet.js
@@ -10,8 +10,9 @@ import { sendTransferNotification, sendTPCNotification } from '../utils/notifica
 
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 
-import authenticate from '../middleware/auth.js';
+import authenticate, { requireApiToken } from '../middleware/auth.js';
 import tonClaim from '../utils/tonClaim.js';
+import { verifyRewardReceipt, signRewardReceipt } from '../utils/rewardReceipt.js';
 
 const WITHDRAW_ENABLED = process.env.WITHDRAW_ENABLED === 'true';
 
@@ -25,6 +26,11 @@ const TPC_JETTON_ADDRESS =
   'EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X';
 
 const router = Router();
+
+function enforceRewardLimit(amount) {
+  const maxReward = Number(process.env.REWARD_MAX_AMOUNT) || 1000;
+  return Number.isFinite(amount) && amount > 0 && amount <= maxReward;
+}
 
 router.post('/balance', authenticate, async (req, res) => {
 
@@ -323,17 +329,37 @@ router.post('/send', authenticate, async (req, res) => {
 
 // ✅ Credit user balance after a TON deposit
 
-router.post('/deposit', authenticate, async (req, res) => {
+router.post('/deposit', authenticate, requireApiToken, async (req, res) => {
 
-  const { telegramId, amount } = req.body;
+  const { telegramId, amount, receipt, nonce, ts } = req.body;
   const authId = req.auth?.telegramId;
+  const isApiToken = req.auth?.apiToken;
+  const secret = process.env.REWARD_SIGNING_SECRET;
 
   if (!telegramId || typeof amount !== 'number' || amount <= 0) {
 
     return res.status(400).json({ error: 'telegramId and positive amount required' });
 
   }
-  if (!authId || telegramId !== authId) {
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  if (!receipt || !nonce || !ts) {
+    if (!isApiToken) {
+      return res.status(400).json({ error: 'receipt, nonce and ts required' });
+    }
+  } else {
+    const check = verifyRewardReceipt(
+      { purpose: 'wallet_deposit', telegramId, amount, nonce, ts },
+      receipt,
+      secret
+    );
+    if (!check.ok) {
+      const status = check.error === 'missing_secret' ? 503 : 403;
+      return res.status(status).json({ error: 'invalid receipt' });
+    }
+  }
+  if (!isApiToken && (!authId || telegramId !== authId)) {
     return res.status(403).json({ error: "forbidden" });
   }
 
@@ -373,6 +399,83 @@ router.post('/deposit', authenticate, async (req, res) => {
 
   res.json({ balance: user.balance, transaction: tx });
 
+});
+
+router.post('/receipt', authenticate, async (req, res) => {
+  const { telegramId, amount } = req.body;
+  if (!telegramId || typeof amount !== 'number') {
+    return res.status(400).json({ error: 'telegramId and amount required' });
+  }
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  if (!req.auth?.telegramId || telegramId !== req.auth.telegramId) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const secret = process.env.REWARD_SIGNING_SECRET;
+  if (!secret) return res.status(503).json({ error: 'receipt unavailable' });
+  const nonce = crypto.randomUUID();
+  const ts = Date.now();
+  const receipt = signRewardReceipt(
+    { purpose: 'wallet_deposit', telegramId, amount, nonce, ts },
+    secret
+  );
+  res.json({ receipt, nonce, ts });
+});
+
+router.post('/claim-reward', authenticate, async (req, res) => {
+  const { telegramId, amount, receipt, nonce, ts } = req.body;
+  if (!telegramId || typeof amount !== 'number' || amount <= 0) {
+    return res.status(400).json({ error: 'telegramId and positive amount required' });
+  }
+  if (!enforceRewardLimit(amount)) {
+    return res.status(400).json({ error: 'amount exceeds limit' });
+  }
+  if (!receipt || !nonce || !ts) {
+    return res.status(400).json({ error: 'receipt, nonce and ts required' });
+  }
+  if (!req.auth?.telegramId || telegramId !== req.auth.telegramId) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const check = verifyRewardReceipt(
+    { purpose: 'wallet_deposit', telegramId, amount, nonce, ts },
+    receipt,
+    process.env.REWARD_SIGNING_SECRET
+  );
+  if (!check.ok) {
+    const status = check.error === 'missing_secret' ? 503 : 403;
+    return res.status(status).json({ error: 'invalid receipt' });
+  }
+  const user = await User.findOneAndUpdate(
+    { telegramId },
+    { $inc: { balance: amount }, $setOnInsert: { referralCode: telegramId.toString() } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  ensureTransactionArray(user);
+
+  const tx = {
+    amount,
+    type: 'deposit',
+    token: 'TPC',
+    status: 'delivered',
+    date: new Date()
+  };
+
+  user.transactions.push(tx);
+
+  await user.save();
+
+  try {
+    await sendTPCNotification(
+      bot,
+      telegramId,
+      `\u{1FA99} Your deposit of ${amount} TPC was credited`
+    );
+  } catch (err) {
+    console.error('Failed to send Telegram notification:', err.message);
+  }
+
+  res.json({ balance: user.balance, transaction: tx });
 });
 
 // ✅ Request withdrawal to a TON wallet address

--- a/bot/utils/rewardReceipt.js
+++ b/bot/utils/rewardReceipt.js
@@ -1,0 +1,49 @@
+import crypto from 'crypto';
+
+const receiptWindowMs =
+  Number(process.env.REWARD_RECEIPT_WINDOW_MS) || 5 * 60 * 1000;
+
+const usedNonces = new Map();
+
+function cleanupNonces(now) {
+  for (const [nonce, ts] of usedNonces.entries()) {
+    if (now - ts > receiptWindowMs) {
+      usedNonces.delete(nonce);
+    }
+  }
+}
+
+function buildCanonicalPayload(payload) {
+  return Object.entries(payload)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${key}=${value}`)
+    .sort()
+    .join('&');
+}
+
+export function signRewardReceipt(payload, secret) {
+  const canonical = buildCanonicalPayload(payload);
+  return crypto.createHmac('sha256', secret).update(canonical).digest('hex');
+}
+
+export function verifyRewardReceipt(payload, receipt, secret) {
+  if (!secret) return { ok: false, error: 'missing_secret' };
+  if (!receipt) return { ok: false, error: 'missing_receipt' };
+  const now = Date.now();
+  const ts = Number(payload.ts);
+  if (!Number.isFinite(ts) || Math.abs(now - ts) > receiptWindowMs) {
+    return { ok: false, error: 'expired_receipt' };
+  }
+  const nonce = payload.nonce;
+  if (!nonce) return { ok: false, error: 'missing_nonce' };
+  cleanupNonces(now);
+  if (usedNonces.has(nonce)) {
+    return { ok: false, error: 'reused_nonce' };
+  }
+  const expected = signRewardReceipt(payload, secret);
+  if (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(receipt))) {
+    return { ok: false, error: 'invalid_receipt' };
+  }
+  usedNonces.set(nonce, now);
+  return { ok: true };
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "emoji-name-map": "^2.0.3",
     "express": "^4.19.2",
     "geoip-lite": "^1.4.10",
+    "helmet": "^7.2.0",
     "mongoose": "^7.6.0",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.8.1",

--- a/test/snookerRoyalInventoryRoutes.test.js
+++ b/test/snookerRoyalInventoryRoutes.test.js
@@ -64,7 +64,7 @@ test('Snooker Royal inventory persists across reloads and devices', async () => 
 
     const env = {
       ...process.env,
-      PORT: '3213',
+      PORT: '3214',
       MONGO_URI: 'memory',
       BOT_TOKEN: 'dummy',
       API_AUTH_TOKEN: apiToken,
@@ -73,30 +73,30 @@ test('Snooker Royal inventory persists across reloads and devices', async () => 
     };
     const server = await startServer(env);
     try {
-      const accountId = await createAccount(3213, 999991);
-      const initialInventory = await getInventory(3213, accountId);
+      const accountId = await createAccount(3214, 999991);
+      const initialInventory = await getInventory(3214, accountId);
 
       const deviceAInventory = {
         ...initialInventory,
         clothColor: [...(initialInventory.clothColor || []), 'denimFabric03Blue'],
         cueStyle: [...(initialInventory.cueStyle || []), 'carbon-matrix']
       };
-      const afterDeviceA = await saveInventory(3213, accountId, deviceAInventory);
+      const afterDeviceA = await saveInventory(3214, accountId, deviceAInventory);
       assert.ok(afterDeviceA.clothColor.includes('denimFabric03Blue'));
       assert.ok(afterDeviceA.cueStyle.includes('carbon-matrix'));
 
-      const afterReload = await getInventory(3213, accountId);
+      const afterReload = await getInventory(3214, accountId);
       assert.ok(afterReload.clothColor.includes('denimFabric03Blue'));
       assert.ok(afterReload.cueStyle.includes('carbon-matrix'));
 
       const deviceBInventory = {
         tableFinish: ['jetBlackCarbon']
       };
-      const afterDeviceB = await saveInventory(3213, accountId, deviceBInventory);
+      const afterDeviceB = await saveInventory(3214, accountId, deviceBInventory);
       assert.ok(afterDeviceB.tableFinish.includes('jetBlackCarbon'));
       assert.ok(afterDeviceB.cueStyle.includes('carbon-matrix'));
 
-      const finalInventory = await getInventory(3213, accountId);
+      const finalInventory = await getInventory(3214, accountId);
       assert.ok(finalInventory.tableFinish.includes('jetBlackCarbon'));
       assert.ok(finalInventory.clothColor.includes('denimFabric03Blue'));
       assert.ok(finalInventory.cueStyle.includes('carbon-matrix'));

--- a/webapp/public/free-kick-api.js
+++ b/webapp/public/free-kick-api.js
@@ -33,21 +33,19 @@
   }
   window.fkApi = {
     async depositAccount(accountId, amount, extra = {}) {
-      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
-      if (res && res.error) {
-        return post('/api/profile/addTransaction', {
-          amount,
-          type: 'deposit',
-          accountId,
-          ...extra,
-        });
-      }
-      return res;
+      const receipt = await post('/api/account/receipt', { accountId, amount, ...extra });
+      if (receipt && receipt.error) return receipt;
+      return post('/api/account/claim-reward', {
+        accountId,
+        amount,
+        ...extra,
+        receipt: receipt.receipt,
+        nonce: receipt.nonce,
+        ts: receipt.ts
+      });
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      const body = { amount, type, ...extra };
-      if (telegramId != null) body.telegramId = telegramId;
-      return post('/api/profile/addTransaction', body);
+      return Promise.resolve({ error: 'admin token missing' });
     }
   };
 })();

--- a/webapp/public/goal-rush-api.js
+++ b/webapp/public/goal-rush-api.js
@@ -33,21 +33,19 @@
   }
   window.grApi = {
     async depositAccount(accountId, amount, extra = {}) {
-      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
-      if (res && res.error) {
-        return post('/api/profile/addTransaction', {
-          amount,
-          type: 'deposit',
-          accountId,
-          ...extra,
-        });
-      }
-      return res;
+      const receipt = await post('/api/account/receipt', { accountId, amount, ...extra });
+      if (receipt && receipt.error) return receipt;
+      return post('/api/account/claim-reward', {
+        accountId,
+        amount,
+        ...extra,
+        receipt: receipt.receipt,
+        nonce: receipt.nonce,
+        ts: receipt.ts
+      });
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      const body = { amount, type, ...extra };
-      if (telegramId != null) body.telegramId = telegramId;
-      return post('/api/profile/addTransaction', body);
+      return Promise.resolve({ error: 'admin token missing' });
     }
   };
 })();

--- a/webapp/public/pool-royale-api.js
+++ b/webapp/public/pool-royale-api.js
@@ -33,21 +33,19 @@
   }
   window.prApi = {
     async depositAccount(accountId, amount, extra = {}) {
-      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
-      if (res && res.error) {
-        return post('/api/profile/addTransaction', {
-          amount,
-          type: 'deposit',
-          accountId,
-          ...extra,
-        });
-      }
-      return res;
+      const receipt = await post('/api/account/receipt', { accountId, amount, ...extra });
+      if (receipt && receipt.error) return receipt;
+      return post('/api/account/claim-reward', {
+        accountId,
+        amount,
+        ...extra,
+        receipt: receipt.receipt,
+        nonce: receipt.nonce,
+        ts: receipt.ts
+      });
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      const body = { amount, type, ...extra };
-      if (telegramId != null) body.telegramId = telegramId;
-      return post('/api/profile/addTransaction', body);
+      return Promise.resolve({ error: 'admin token missing' });
     }
   };
 })();

--- a/webapp/public/snooker-royale-api.js
+++ b/webapp/public/snooker-royale-api.js
@@ -33,21 +33,19 @@
   }
   window.srApi = {
     async depositAccount(accountId, amount, extra = {}) {
-      const res = await post('/api/account/deposit', { accountId, amount, ...extra });
-      if (res && res.error) {
-        return post('/api/profile/addTransaction', {
-          amount,
-          type: 'deposit',
-          accountId,
-          ...extra,
-        });
-      }
-      return res;
+      const receipt = await post('/api/account/receipt', { accountId, amount, ...extra });
+      if (receipt && receipt.error) return receipt;
+      return post('/api/account/claim-reward', {
+        accountId,
+        amount,
+        ...extra,
+        receipt: receipt.receipt,
+        nonce: receipt.nonce,
+        ts: receipt.ts
+      });
     },
     addTransaction(telegramId, amount, type, extra = {}) {
-      const body = { amount, type, ...extra };
-      if (telegramId != null) body.telegramId = telegramId;
-      return post('/api/profile/addTransaction', body);
+      return Promise.resolve({ error: 'admin token missing' });
     }
   };
 })();


### PR DESCRIPTION
### Motivation
- Improve security of reward deposits and privileged APIs without changing user-facing logic by requiring server-signed receipts for non-privileged reward credits while preserving admin flows.
- Prevent socket impersonation and reduce XSS/CSP attack surface to avoid leaking Telegram init data.
- Resolve test instability caused by port collisions and leaked resources so the suite runs cleanly.

### Description
- Add a receipt subsystem (`bot/utils/rewardReceipt.js`) that signs and verifies HMAC receipts with nonce/expiry and reuse protection, and enforce the receipts in account and wallet flows while allowing admin/API-token deposits to proceed (`bot/routes/account.js`, `bot/routes/wallet.js`).
- Introduce `ownerToken` on `User` and owner-token-based access checks plus `canAccessAccount`/`canAccessProfile` helpers, and extend `attachAuth` to accept `x-account-owner-token` for non-Telegram accounts (`bot/models/User.js`, `bot/routes/account.js`, `bot/routes/profile.js`, `bot/middleware/auth.js`).
- Tighten privileged API access via `requireApiToken`, restore runtime/env resolution for client admin token, and update webapp APIs to use the receipt flow for deposits (`bot/middleware/auth.js`, `webapp/src/utils/api.js`, `webapp/public/*-api.js`).
- Harden server security and runtime behavior by adding per-request CSP nonces and `helmet` directives, strengthening socket registration to validate `socket.data.auth` and identity matches, and add graceful shutdown to free ports between test runs (`bot/server.js`, `package.json`).
- Adjust tests and test helpers to sign receipts and avoid port collisions (change Snooker test port), and update `test/walletRoutes.test.js` to generate signed receipts (`test/snookerRoyalInventoryRoutes.test.js`, `test/walletRoutes.test.js`).

### Testing
- Ran the automated test suite with `npm test`, and all test suites passed: `32` test suites passed, `111` tests passed and `1` skipped. 
- Updated wallet route tests to sign receipts using `REWARD_SIGNING_SECRET` and confirmed deposit/withdraw revert/failure scenarios still behave as expected. 
- Verified server shutdown and port adjustments resolved the previous intermittent `EADDRINUSE` / timeout failures during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e584d62448329ac4a417cf9c966e5)