### PR TITLE
Add pocket mouth guards to prevent ball escape

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -73,6 +73,7 @@ public class BilliardsSolver
         double sideJawInset = PhysicsConstants.SideJawInset;
         double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8) * PhysicsConstants.SideJawDepthScale;
         double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
+        double mouthGuardInset = Math.Max(0.0, PhysicsConstants.PocketMouthGuardInset);
 
         // Straight cushion spans (long rails)
         AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
@@ -163,6 +164,48 @@ public class BilliardsSolver
             new Vec2(width, height / 2 + sideCut),
             new Vec2(width - sideJawInset, height / 2 + sideCut),
             new Vec2(-1, 0));
+
+        AddPocketMouthGuard(
+            new Vec2(cornerCut, 0),
+            new Vec2(0, cornerCut),
+            new Vec2(1, 1),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width - cornerCut, 0),
+            new Vec2(width, cornerCut),
+            new Vec2(-1, 1),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width, height - cornerCut),
+            new Vec2(width - cornerCut, height),
+            new Vec2(-1, -1),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(0, height - cornerCut),
+            new Vec2(cornerCut, height),
+            new Vec2(1, -1),
+            mouthGuardInset);
+
+        AddPocketMouthGuard(
+            new Vec2(width / 2 - sideCut, 0),
+            new Vec2(width / 2 + sideCut, 0),
+            new Vec2(0, 1),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width / 2 - sideCut, height),
+            new Vec2(width / 2 + sideCut, height),
+            new Vec2(0, -1),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(0, height / 2 - sideCut),
+            new Vec2(0, height / 2 + sideCut),
+            new Vec2(1, 0),
+            mouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width, height / 2 - sideCut),
+            new Vec2(width, height / 2 + sideCut),
+            new Vec2(-1, 0),
+            mouthGuardInset);
 
         double capture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
         Pockets.Add(new Pocket { Center = new Vec2(0, 0), Radius = capture });
@@ -274,6 +317,25 @@ public class BilliardsSolver
         if (Vec2.Dot(normal, interiorHint) < 0)
             normal = -normal;
         ConnectorEdges.Add(new Edge { A = a, B = b, Normal = normal.Normalized() });
+    }
+
+    private void AddPocketMouthGuard(Vec2 a, Vec2 b, Vec2 interiorHint, double inset)
+    {
+        if ((b - a).Length < PhysicsConstants.Epsilon)
+            return;
+        Vec2 dir = (b - a).Normalized();
+        Vec2 normal = new Vec2(-dir.Y, dir.X);
+        if (Vec2.Dot(normal, interiorHint) < 0)
+            normal = -normal;
+        if (normal.Length > PhysicsConstants.Epsilon)
+            normal = normal.Normalized();
+        if (inset > PhysicsConstants.Epsilon)
+        {
+            Vec2 offset = -normal * inset;
+            a += offset;
+            b += offset;
+        }
+        PocketEdges.Add(new Edge { A = a, B = b, Normal = normal });
     }
 
     private static Vec2 PointOnCircle(Vec2 center, double radius, double angle)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -51,6 +51,8 @@ public static class PhysicsConstants
     public const double SideJawDepthScale = 1.08;
     // Shift the pocket capture center outward for the chrome plate cut.
     public const double SidePocketOutset = 0.006;
+    // Offset pocket mouth guards to stop balls slipping between jaws and cushions.
+    public const double PocketMouthGuardInset = BallRadius * 0.35;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
### Motivation
- Prevent balls from slipping through the small gaps between pocket jaws and cushions by adding thin helper geometry at pocket mouths. 
- Use a tunable inset sized relative to `BallRadius` so the guard scales with ball geometry and can be calibrated.

### Description
- Add `PocketMouthGuardInset` constant to `billiards/PhysicsConstants.cs` (default `BallRadius * 0.35`) to control guard offset. 
- Add `AddPocketMouthGuard(Vec2 a, Vec2 b, Vec2 interiorHint, double inset)` to `billiards/BilliardsSolver.cs` to create a pocket-mouth edge, optionally offset inward by the inset. 
- Call `AddPocketMouthGuard` from `InitStandardTable()` to place guards around corner and side pocket mouths so those segments are included in `PocketEdges` and stop balls escaping between jaws and cushions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6e0e3c188329befd3cd9b42c3298)