### PR TITLE
Pool Royale: add pocket jaw mapping overlay and adjust mapping colors

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -10600,9 +10600,9 @@ export function Table3D(
     const mappingGroup = new THREE.Group();
     mappingGroup.name = 'tableMappingOverlay';
     const fieldLineMaterial = new THREE.LineBasicMaterial({
-      color: 0xf5d547,
+      color: 0xffffff,
       transparent: true,
-      opacity: 0.9,
+      opacity: 0.45,
       depthTest: false,
       depthWrite: false
     });
@@ -10614,6 +10614,13 @@ export function Table3D(
       depthWrite: false
     });
     const pocketLineMaterial = new THREE.LineBasicMaterial({
+      color: 0xf5d547,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false,
+      depthWrite: false
+    });
+    const jawLineMaterial = new THREE.LineBasicMaterial({
       color: 0x2f7bff,
       transparent: true,
       opacity: 0.9,
@@ -10700,6 +10707,30 @@ export function Table3D(
       }
       registerMappingLine(makeLine(points, pocketLineMaterial, true));
     });
+    if (Array.isArray(table.userData?.pocketJaws)) {
+      table.userData.pocketJaws.forEach((jaw) => {
+        if (!(jaw?.center instanceof THREE.Vector2)) return;
+        if (!Number.isFinite(jaw?.outerRadius) || jaw.outerRadius <= MICRO_EPS) return;
+        if (!Number.isFinite(jaw?.jawAngle) || jaw.jawAngle <= MICRO_EPS) return;
+        if (!Number.isFinite(jaw?.orientationAngle)) return;
+        const steps = Math.max(18, Math.ceil((jaw.jawAngle / Math.PI) * 48));
+        const startAngle = jaw.orientationAngle - jaw.jawAngle / 2;
+        const endAngle = jaw.orientationAngle + jaw.jawAngle / 2;
+        const points = [];
+        for (let i = 0; i <= steps; i += 1) {
+          const t = i / steps;
+          const theta = THREE.MathUtils.lerp(startAngle, endAngle, t);
+          points.push(
+            new THREE.Vector3(
+              jaw.center.x + Math.cos(theta) * jaw.outerRadius,
+              mappingLineY,
+              jaw.center.y + Math.sin(theta) * jaw.outerRadius
+            )
+          );
+        }
+        registerMappingLine(makeLine(points, jawLineMaterial));
+      });
+    }
     table.add(mappingGroup);
   }
 


### PR DESCRIPTION
### Motivation

- Provide a clearer visual mapping overlay for the Pool Royale table so cushions, pockets and pocket jaws can be inspected during layout/debugging, using thin lines and distinct colors (cushions red, pockets yellow, jaws blue, field outline subdued).

### Description

- Adjusted the table mapping line materials in `webapp/src/pages/Games/PoolRoyale.jsx` to use a lower-opacity white for the field outline and keep cushions as red via the existing material.
- Recolored pocket outlines to yellow (`0xf5d547`) and added a new jaw outline material in blue (`0x2f7bff`) with matching line settings and render order for overlay clarity.
- Rendered pocket jaw arcs from `table.userData.pocketJaws` by sampling the jaw arc (computed from `jaw.outerRadius`, `jaw.jawAngle`, and `jaw.orientationAngle`) into a line strip and registering it in the `tableMappingOverlay` group when `ENABLE_TABLE_MAPPING_LINES` is active.

### Testing

- Started the web dev server with `npm --prefix webapp run dev` which launched Vite successfully and served the app (dev server started).
- Attempted an automated visual check via Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot call timed out and did not complete.
- No unit tests were run for this visual change; the change is purely rendering/visual and should be verified visually in the running dev server by enabling `ENABLE_TABLE_MAPPING_LINES` and inspecting the overlay in-game.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697edb2bc16883299f78c770f485586f)