### PR TITLE
Use official Ton Connect wallets list

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -60,7 +60,7 @@ export default function App() {
 
   const baseUrl = `${window.location.origin}${import.meta.env.BASE_URL}`;
   const manifestUrl = new URL('tonconnect-manifest.json', baseUrl).toString();
-  const walletsListSource = new URL('tonconnect-wallets.json', baseUrl).toString();
+  const walletsListSource = 'https://raw.githubusercontent.com/ton-connect/wallets-list/main/wallets.json';
   const returnUrl = window.location.href;
   const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
   const actionsConfiguration = {


### PR DESCRIPTION
### Motivation
- Ensure Ton Connect loads an up-to-date, authoritative wallets list from the upstream `ton-connect/wallets-list` so wallet metadata/bridge endpoints are accurate and wallet connection issues caused by stale local config are avoided.

### Description
- Replace the local manifest-derived wallets list source with the official upstream raw URL by changing `walletsListSource` to `'https://raw.githubusercontent.com/ton-connect/wallets-list/main/wallets.json'` in `webapp/src/App.jsx` and keep the Ton Connect UI provider and button layout unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efe74a57c83298afffc2ffa92927a)