### PR TITLE
Fix TonConnect modal closing after wallet connect

### DIFF
--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -1,18 +1,27 @@
 import { useEffect } from 'react';
-import { useTonConnectUI } from '@tonconnect/ui-react';
+import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 
 export default function TonConnectSync() {
   const [tonConnectUI] = useTonConnectUI();
+  const tonAddress = useTonAddress(true);
+
+  const syncWalletAddress = (address) => {
+    if (address) {
+      localStorage.setItem('walletAddress', address);
+      tonConnectUI.closeModal();
+    } else {
+      localStorage.removeItem('walletAddress');
+    }
+  };
+
+  useEffect(() => {
+    syncWalletAddress(tonAddress || '');
+  }, [tonAddress]);
 
   useEffect(() => {
     const unsubscribe = tonConnectUI.onStatusChange((wallet) => {
       const address = wallet?.account?.address || '';
-      if (address) {
-        localStorage.setItem('walletAddress', address);
-        tonConnectUI.closeModal();
-      } else {
-        localStorage.removeItem('walletAddress');
-      }
+      syncWalletAddress(address);
     });
 
     return () => unsubscribe();


### PR DESCRIPTION
### Motivation
- The TonConnect modal could remain visible after a wallet was connected because the app only reacted to status change events and not to the resolved address provided by the hook, causing the UI and localStorage to get out of sync.

### Description
- Import `useTonAddress` and use it to observe the resolved wallet address in addition to `onStatusChange` events.
- Add a `syncWalletAddress` helper that updates `localStorage` and calls `tonConnectUI.closeModal()` when an address is present.
- Add an effect to call `syncWalletAddress` when the hook-provided `tonAddress` changes.
- Replace inline address handling in the `onStatusChange` handler with the new `syncWalletAddress` to centralize logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f1b096a6c832982ed04c0c264866a)