### PR TITLE
Adjust Snooker Royal pocket cameras, cushions, and shot physics

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1408,7 +1408,7 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
-const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
+const POCKET_CAM_INWARD_SCALE = 0.72; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -1507,7 +1507,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 560;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 300;
 const POCKET_VIEW_POST_POT_HOLD_MS = 160;
 const POCKET_VIEW_MAX_HOLD_MS = 3200;
-const SPIN_GLOBAL_SCALE = 0.6; // reduce overall spin impact by 25%
+const SPIN_GLOBAL_SCALE = 0.66; // increase overall spin impact by 10%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1530,6 +1530,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligne
 // Snooker Royal power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.425; // reduce shot power by 50% to match the requested pacing
 const SHOT_POWER_MULTIPLIER = 2.109375;
+const SHOT_POWER_INCREASE = 1.25; // boost overall shot strength by 25%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1538,7 +1539,8 @@ const SHOT_FORCE_BOOST =
   1.3 *
   0.85 *
   SHOT_POWER_REDUCTION *
-  SHOT_POWER_MULTIPLIER;
+  SHOT_POWER_MULTIPLIER *
+  SHOT_POWER_INCREASE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
@@ -7731,8 +7733,10 @@ function Table3D(
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.085; // push the cushions slightly farther outward to match the physical rail edge
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
-  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.26; // shorten the corner cushions more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK *0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
@@ -7778,7 +7782,7 @@ function Table3D(
   );
   const horizontalCushionLength = Math.max(
     MICRO_EPS,
-    PLAY_W - 2 * cornerCushionClearance
+    PLAY_W - 2 * cornerCushionClearance - LONG_RAIL_CUSHION_LENGTH_TRIM
   );
   const sideLineX =
     halfW - CUSHION_RAIL_FLUSH - CUSHION_LONG_RAIL_CENTER_NUDGE + SIDE_CUSHION_RAIL_REACH;
@@ -7792,7 +7796,10 @@ function Table3D(
   );
   const verticalCushionLength = Math.max(
     MICRO_EPS,
-    Math.max(0, cornerIntersectionZ - adjustedSidePocketReach)
+    Math.max(
+      0,
+      cornerIntersectionZ - adjustedSidePocketReach - SHORT_RAIL_CUSHION_LENGTH_TRIM
+    )
   );
   const verticalCushionCenter =
     adjustedSidePocketReach +


### PR DESCRIPTION
### Motivation
- Pull pocket cameras visually closer for tighter pocket framing to match Pool Royale framing. 
- Make cushion extents match Pool Royale pocket spacing so pocket-to-cushion distances align between modes. 
- Increase shot power and spin to reach the requested gameplay feel (+25% power, +10% spin).

### Description
- Change `POCKET_CAM_INWARD_SCALE` from `0.82` to `0.72` to pull pocket cameras closer. 
- Increase `SPIN_GLOBAL_SCALE` from `0.6` to `0.66` to raise overall spin impact by ~10%. 
- Add `SHOT_POWER_INCREASE = 1.25` and include it in `SHOT_FORCE_BOOST` so overall shot strength is boosted by 25%. 
- Adjust cushion geometry by increasing `CUSHION_CORNER_CLEARANCE_REDUCTION`, adding `LONG_RAIL_CUSHION_LENGTH_TRIM` and `SHORT_RAIL_CUSHION_LENGTH_TRIM`, and subtracting those trims from `horizontalCushionLength` and `verticalCushionLength` calculations in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- No automated tests were executed for this change (`npm test`/`jest` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f1f9eb3348329ad9e38a645af656c)