### PR TITLE
Pool Royale: keep balls inside rails and lower cue tip to center

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1639,7 +1639,7 @@ const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 7.6;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 16.4;
-const CUE_Y = BALL_CENTER_Y - BALL_R * 0.2; // rest the cue lower so the tip centers on the cue-ball in portrait
+const CUE_Y = BALL_CENTER_Y - BALL_R * 0.28; // lower the cue a touch more so the blue tip sits dead-centre on the cue ball
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
 const CUE_BUTT_LIFT = BALL_R * 0.46; // lower the butt slightly while keeping the tip level with the cue-ball centre
@@ -6103,6 +6103,38 @@ function reflectRails(ball) {
         type: 'jaw',
         normal: TMP_VEC2_A.clone(),
         tangent: new THREE.Vector2(-TMP_VEC2_A.y, TMP_VEC2_A.x),
+        preImpactVel
+      };
+    }
+    const outsideRails =
+      ball.pos.x < -railLimitX ||
+      ball.pos.x > railLimitX ||
+      ball.pos.y < -railLimitY ||
+      ball.pos.y > railLimitY;
+    if (outsideRails && nearestPocketDist >= nearestCaptureRadius) {
+      preImpactVel = ball.vel.clone();
+      const clampedX = THREE.MathUtils.clamp(ball.pos.x, -railLimitX, railLimitX);
+      const clampedY = THREE.MathUtils.clamp(ball.pos.y, -railLimitY, railLimitY);
+      const delta = TMP_VEC2_A.set(ball.pos.x - clampedX, ball.pos.y - clampedY);
+      if (delta.lengthSq() > 1e-8) {
+        delta.normalize();
+      } else {
+        delta.set(
+          ball.pos.x < 0 ? -1 : 1,
+          ball.pos.y < 0 ? -1 : 1
+        );
+      }
+      ball.pos.set(clampedX, clampedY);
+      const stamp =
+        typeof performance !== 'undefined' && performance.now
+          ? performance.now()
+          : Date.now();
+      ball.lastRailHitAt = stamp;
+      ball.lastRailHitType = 'rail';
+      return {
+        type: 'rail',
+        normal: delta.clone(),
+        tangent: new THREE.Vector2(-delta.y, delta.x),
         preImpactVel
       };
     }


### PR DESCRIPTION
### Motivation
- Prevent cue/balls from escaping the playfield when strong topspin or jump interactions push them beyond rail bounds.  
- Visually align the cue tip with the cue ball in portrait so the blue tip appears centred on the ball.

### Description
- Lowered the cue anchor height by adjusting `CUE_Y` in `webapp/src/pages/Games/PoolRoyale.jsx` from `BALL_CENTER_Y - BALL_R * 0.2` to `BALL_CENTER_Y - BALL_R * 0.28` so the tip sits more centrally over the cue ball.  
- Added a hard clamp fallback inside `reflectRails(ball)` (in `webapp/src/pages/Games/PoolRoyale.jsx`) that detects when a ball is outside the rail limits and not inside a pocket capture radius, clamps its position back to the rail limits, records a rail hit, and returns a synthetic rail impact (with `type: 'rail'`, `normal`, `tangent`, and `preImpactVel`) to prevent it from leaving the playfield.  
- The fallback only triggers when cushion segments are active and the ball is outside rail limits while not within a nearby pocket capture region, preserving normal pocket/jaw handling.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the dev server started successfully (Vite ready).  
- Ran a Playwright-based screenshot script against `http://127.0.0.1:4173/` with a mobile portrait viewport (`720x1280`) which completed and produced `artifacts/pool-royale-root.png`.  
- No automated unit tests were modified and no test failures were observed during these manual/automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2661a74c83299771f21a5fed2311)