### PR TITLE
Match Snooker Royal table/base height to Pool Royale and tighten pocket camera framing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1410,7 +1410,7 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
-const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
+const POCKET_CAM_INWARD_SCALE = 0.65; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -1561,7 +1561,7 @@ const POCKET_SOUND_TAIL = 1;
 const LEG_SCALE = 6.2;
 const LEG_HEIGHT_FACTOR = 4;
 const LEG_HEIGHT_MULTIPLIER = 4.5;
-const BASE_TABLE_LIFT = 4.0;
+const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 0.82;
 const TABLE_HEIGHT_SCALE = 1.56;


### PR DESCRIPTION
### Motivation
- Make Snooker Royal table stance match Pool Royale height for visual consistency and bring pocket cameras closer for tighter pocket framing.

### Description
- Update `BASE_TABLE_LIFT` in `webapp/src/pages/Games/SnookerRoyal.jsx` from `4.0` to `3.6` to lower the table assembly.
- Update `POCKET_CAM_INWARD_SCALE` in `webapp/src/pages/Games/SnookerRoyal.jsx` from `0.82` to `0.65` to pull pocket cameras further inward.
- Changes were staged and committed to the repository.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported as ready (local server started successfully).
- Attempted an automated visual check using Playwright to capture a screenshot, but the screenshot run timed out in the tooling environment.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f341b939c8329a108d12a3c3eb019)