### PR TITLE
Relax Pool Royale spin visibility clamp

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5335,7 +5335,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_VIEW_BLOCK_THRESHOLD = 0;
+const SPIN_VIEW_BLOCK_THRESHOLD = -0.15;
 
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
@@ -5378,7 +5378,7 @@ const clampSpinToVisibleHemisphere = (spinInput, aimDir, cueBall, camera) => {
   if (TMP_VEC2_SPIN.lengthSq() < 1e-8) return spinInput;
   TMP_VEC2_VIEW.set(viewVec.x, viewVec.y).normalize();
   const viewDot = TMP_VEC2_SPIN.dot(TMP_VEC2_VIEW);
-  if (viewDot >= 0) return spinInput;
+  if (viewDot >= SPIN_VIEW_BLOCK_THRESHOLD) return spinInput;
   TMP_VEC2_SPIN.addScaledVector(TMP_VEC2_VIEW, -viewDot);
   return {
     x: TMP_VEC2_SPIN.dot(axes.perp),


### PR DESCRIPTION
### Motivation
- Prevent the spin controller from prematurely blocking playable spin input when the cue-tip contact point is still visually visible so players can apply spin more accurately.

### Description
- Lowered the visibility threshold by replacing `SPIN_VIEW_BLOCK_THRESHOLD = 0` with `SPIN_VIEW_BLOCK_THRESHOLD = -0.15` and use that constant in `clampSpinToVisibleHemisphere` so view-dot checks allow a small negative margin before clamping.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f348707ac83298e32397eb9c28867)