### PR TITLE
Relax Pool Royale spin visibility threshold

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5335,7 +5335,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_VIEW_BLOCK_THRESHOLD = 0;
+const SPIN_VIEW_BLOCK_THRESHOLD = -0.2;
 
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;


### PR DESCRIPTION
### Motivation
- Make it easier to apply cue-ball spin when the strike point remains visually available by relaxing the visibility blocking rule for spin.

### Description
- Change `SPIN_VIEW_BLOCK_THRESHOLD` from `0` to `-0.2` in `webapp/src/pages/Games/PoolRoyale.jsx` so spin points that are slightly out of direct view are still allowed when other checks pass.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f348707ac83298e32397eb9c28867)