### PR TITLE
Broaden Telegram web speech support detection

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -19,6 +19,22 @@ let speechSupportState = false;
 
 const SPEECH_SUPPORT_EVENT = 'tonplaygram:speech-support';
 
+const getSpeechUtteranceClass = () => {
+  if (typeof SpeechSynthesisUtterance !== 'undefined') return SpeechSynthesisUtterance;
+  if (typeof window !== 'undefined') {
+    if (window.SpeechSynthesisUtterance) {
+      return window.SpeechSynthesisUtterance;
+    }
+    if (window.webkitSpeechSynthesisUtterance) {
+      return window.webkitSpeechSynthesisUtterance;
+    }
+  }
+  if (typeof webkitSpeechSynthesisUtterance !== 'undefined') {
+    return webkitSpeechSynthesisUtterance;
+  }
+  return null;
+};
+
 const emitSpeechSupport = (supported) => {
   if (typeof window === 'undefined') return;
   if (speechSupportState === supported) return;
@@ -82,7 +98,8 @@ const createSpeechUnlockHandler = () => {
 
 const evaluateSpeechSupport = () => {
   const synth = getSpeechSynthesis();
-  const supported = Boolean(synth && typeof SpeechSynthesisUtterance !== 'undefined');
+  const isTelegram = typeof window !== 'undefined' && Boolean(window.Telegram?.WebApp);
+  const supported = Boolean(synth && (getSpeechUtteranceClass() || isTelegram));
   if (supported && !speechSupportListenerAttached) {
     speechSupportListenerAttached = true;
     const handler = () => evaluateSpeechSupport();
@@ -148,7 +165,9 @@ export const getSpeechSynthesis = () => {
 
 export const getSpeechSupport = () => {
   if (speechSupportState) return true;
-  return Boolean(getSpeechSynthesis() && typeof SpeechSynthesisUtterance !== 'undefined');
+  const synth = getSpeechSynthesis();
+  const isTelegram = typeof window !== 'undefined' && Boolean(window.Telegram?.WebApp);
+  return Boolean(synth && (getSpeechUtteranceClass() || isTelegram));
 };
 
 export const onSpeechSupportChange = (callback) => {
@@ -181,9 +200,10 @@ const ensureSpeechUnlocked = (synth) => {
 
 export const primeSpeechSynthesis = () => {
   const synth = getSpeechSynthesis();
-  if (!synth || synth.speaking || synth.pending || typeof SpeechSynthesisUtterance === 'undefined') return;
+  const UtteranceClass = getSpeechUtteranceClass();
+  if (!synth || synth.speaking || synth.pending || !UtteranceClass) return;
   ensureSpeechUnlocked(synth);
-  const utterance = new SpeechSynthesisUtterance('.');
+  const utterance = new UtteranceClass('.');
   utterance.volume = 0.01;
   utterance.rate = 1;
   utterance.pitch = 1;
@@ -289,7 +309,8 @@ export const speakCommentaryLines = async (
   { speakerSettings = DEFAULT_SPEAKER_SETTINGS, voiceHints = DEFAULT_VOICE_HINTS } = {}
 ) => {
   const synth = getSpeechSynthesis();
-  if (!synth || !Array.isArray(lines) || lines.length === 0) return;
+  const UtteranceClass = getSpeechUtteranceClass();
+  if (!synth || !UtteranceClass || !Array.isArray(lines) || lines.length === 0) return;
 
   const voices = await loadVoices(synth);
   const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Mason'))];
@@ -308,7 +329,7 @@ export const speakCommentaryLines = async (
   for (const line of lines) {
     const speaker = line.speaker || 'Mason';
     const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
-    const utterance = new SpeechSynthesisUtterance(line.text);
+    const utterance = new UtteranceClass(line.text);
     const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
     const fallbackLang = resolveHintedLanguage(voiceHints[speaker] || voiceHints.Mason);
 


### PR DESCRIPTION
### Motivation
- Fix false negatives for Web Speech support detection in Telegram in-app webviews where the utterance constructor may be non-standard or provided on `window`/WebKit shims. 
- Ensure voice commentary UI is not blocked incorrectly and avoid runtime errors when the utterance constructor is absent. 
- Improve robustness of priming and speaking logic so the app only attempts TTS when both synthesis and an utterance class are available.

### Description
- Add a `getSpeechUtteranceClass` helper that resolves the utterance constructor from the global scope, `window`, or WebKit shims (`webkitSpeechSynthesisUtterance`).
- Use the helper in `evaluateSpeechSupport`, `getSpeechSupport`, `primeSpeechSynthesis`, and `speakCommentaryLines` so support checks and utterance creation are consistent and tolerant of WebKit/Telegram variants.
- Treat the presence of `window.Telegram?.WebApp` together with an available `speechSynthesis` as an indication of possible speech capability to avoid incorrectly hiding commentary controls in Telegram webviews.
- Add guards to skip priming and speaking when there is no synthesis instance or no resolved utterance class to prevent exceptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f3db74aa883299ca68c2a1afaada2)