### PR TITLE
Use GLTF tokens for Ludo Battle Royal and align HDRI/token visuals with Murlan

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -86,8 +86,9 @@ export const TOKEN_STYLE_OPTIONS = Object.freeze([
   {
     id: 'towerRooks',
     label: 'Minimal Rook Set',
-    description: 'Swap every pawn with sleek rooks for a clean read.',
-    typeSequence: ['r']
+    description: 'Swap every pawn with sleek GLTF rooks for a clean read.',
+    typeSequence: ['r'],
+    prefersAbg: true
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Make Ludo Battle Royal visuals consistent with Murlan Royale by using the same GLTF token assets and HDRI naming/configuration.
- Remove procedural token meshes so tokens are a single source of truth (GLTF) and easier to tint/style.
- Ensure AI pieces use the same chess-piece GLTF look as human players but follow the per-side palette/colors.

### Description
- Force use of GLTF ABG assets for Ludo tokens by enabling ABG usage in `buildLudoBoard` and removing fallback to procedural mesh generation. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Tint GLTF token prototypes with the player palette so AI and human tokens share the same model but different colors. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Simplified/removed procedural token helpers and measurement usage (e.g. `measureProceduralTokenHeight`, procedural token material/texture/rook factory and head preset application were removed or stubbed out). (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Updated Ludo token style options to mark GLTF-preferring styles and clarified descriptions in `TOKEN_STYLE_OPTIONS`. (modified `webapp/src/config/ludoBattleOptions.js`)
- Align Ludo HDRI option presentation with Murlan-style entries by adding `label` fields derived from `POOL_ROYALE_HDRI_VARIANTS`. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Adjusted `buildLudoBoard` call sites and signature to remove the now-unused head preset/AI index parameters. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Removed an untracked empty Gradle wrapper JAR from the tree to keep the working tree clean. (working-tree cleanup)

### Testing
- Started the local dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (dev server reported ready and host/port URLs). — succeeded.
- Attempted an automated Playwright screenshot of the Ludo Battle Royal page to validate visuals, but the headless Chromium process crashed (SIGSEGV) in this environment and the screenshot run failed. — failed due to environment/browser crash.
- No unit test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f422536448329bd385f96d73b50e4)