### PR TITLE
Add webkit SpeechSynthesisUtterance fallback for Telegram webviews

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -19,6 +19,17 @@ let speechSupportState = false;
 
 const SPEECH_SUPPORT_EVENT = 'tonplaygram:speech-support';
 
+const getSpeechUtteranceClass = () => {
+  if (typeof SpeechSynthesisUtterance !== 'undefined') return SpeechSynthesisUtterance;
+  if (typeof window !== 'undefined' && window.SpeechSynthesisUtterance) {
+    return window.SpeechSynthesisUtterance;
+  }
+  if (typeof window !== 'undefined' && window.webkitSpeechSynthesisUtterance) {
+    return window.webkitSpeechSynthesisUtterance;
+  }
+  return null;
+};
+
 const emitSpeechSupport = (supported) => {
   if (typeof window === 'undefined') return;
   if (speechSupportState === supported) return;
@@ -82,7 +93,7 @@ const createSpeechUnlockHandler = () => {
 
 const evaluateSpeechSupport = () => {
   const synth = getSpeechSynthesis();
-  const supported = Boolean(synth && typeof SpeechSynthesisUtterance !== 'undefined');
+  const supported = Boolean(synth && getSpeechUtteranceClass());
   if (supported && !speechSupportListenerAttached) {
     speechSupportListenerAttached = true;
     const handler = () => evaluateSpeechSupport();
@@ -148,7 +159,7 @@ export const getSpeechSynthesis = () => {
 
 export const getSpeechSupport = () => {
   if (speechSupportState) return true;
-  return Boolean(getSpeechSynthesis() && typeof SpeechSynthesisUtterance !== 'undefined');
+  return Boolean(getSpeechSynthesis() && getSpeechUtteranceClass());
 };
 
 export const onSpeechSupportChange = (callback) => {
@@ -181,9 +192,10 @@ const ensureSpeechUnlocked = (synth) => {
 
 export const primeSpeechSynthesis = () => {
   const synth = getSpeechSynthesis();
-  if (!synth || synth.speaking || synth.pending || typeof SpeechSynthesisUtterance === 'undefined') return;
+  const UtteranceClass = getSpeechUtteranceClass();
+  if (!synth || synth.speaking || synth.pending || !UtteranceClass) return;
   ensureSpeechUnlocked(synth);
-  const utterance = new SpeechSynthesisUtterance('.');
+  const utterance = new UtteranceClass('.');
   utterance.volume = 0.01;
   utterance.rate = 1;
   utterance.pitch = 1;
@@ -289,7 +301,8 @@ export const speakCommentaryLines = async (
   { speakerSettings = DEFAULT_SPEAKER_SETTINGS, voiceHints = DEFAULT_VOICE_HINTS } = {}
 ) => {
   const synth = getSpeechSynthesis();
-  if (!synth || !Array.isArray(lines) || lines.length === 0) return;
+  const UtteranceClass = getSpeechUtteranceClass();
+  if (!synth || !UtteranceClass || !Array.isArray(lines) || lines.length === 0) return;
 
   const voices = await loadVoices(synth);
   const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Mason'))];
@@ -308,7 +321,7 @@ export const speakCommentaryLines = async (
   for (const line of lines) {
     const speaker = line.speaker || 'Mason';
     const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
-    const utterance = new SpeechSynthesisUtterance(line.text);
+    const utterance = new UtteranceClass(line.text);
     const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
     const fallbackLang = resolveHintedLanguage(voiceHints[speaker] || voiceHints.Mason);
 


### PR DESCRIPTION
### Motivation
- Some in-app browsers (notably Telegram webviews) expose a Web Speech utterance constructor under vendor-prefixed names, causing false negatives when checking for speech support. 
- Ensure voice commentary detection and utterance creation are robust across environments so commentary can play when Web Speech is available via vendor prefixes.

### Description
- Added a `getSpeechUtteranceClass` helper in `webapp/src/utils/textToSpeech.js` that returns `SpeechSynthesisUtterance`, `window.SpeechSynthesisUtterance`, or `window.webkitSpeechSynthesisUtterance` where available. 
- Replaced direct checks for `SpeechSynthesisUtterance` with `getSpeechUtteranceClass()` in `evaluateSpeechSupport`, `getSpeechSupport`, and used the returned class to instantiate utterances in `primeSpeechSynthesis` and `speakCommentaryLines` to avoid false negatives and unsafe construction. 
- Added guards to skip priming or speaking when no utterance class or synthesis backend is present, preserving previous safety behavior.

### Testing
- No automated tests were run for this change. 
- The change was limited to `webapp/src/utils/textToSpeech.js` and validated by inspecting the updated file to ensure the helper is used consistently where utterance detection/creation occurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f3db74aa883299ca68c2a1afaada2)