### PR TITLE
Fix Telegram mobile commentary unlock for Murlan Royale

### DIFF
--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -319,6 +319,7 @@ export const speakCommentaryLines = async (
   ensureSpeechUnlocked(synth);
 
   for (const line of lines) {
+    ensureSpeechUnlocked(synth);
     const speaker = line.speaker || 'Mason';
     const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
     const utterance = new UtteranceClass(line.text);


### PR DESCRIPTION
### Motivation

- Users reported that voice commentary often fails to play in mobile in-app browsers (Telegram WebApp), so commentary must be reliably unlocked and played on the first user gesture.
- The goal is to satisfy mobile WebView autoplay / audio context restrictions and avoid stalled speech synthesis during commentary playback.

### Description

- Play pending commentary immediately on first user gesture by adding `playImmediateCommentary` and invoking it from `unlockCommentary` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the queued intro/pending lines are spoken right away and the queued flow resumes afterwards.
- Re-apply speech unlock logic before each spoken line by calling `ensureSpeechUnlocked(synth)` inside `speakCommentaryLines` in `webapp/src/utils/textToSpeech.js` to reduce the chance of the synthesis getting stuck in mobile WebViews.
- Ensure commentary state/bookkeeping is updated after immediate playback by updating `commentarySpeakingRef` and `commentaryLastEventAtRef` when the immediate play finishes, and adjust hook dependencies accordingly.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f4986299083298b80054950f013a0)