### PR TITLE
Increase airborne spin decay to suppress airborne cue ball spin

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1276,7 +1276,7 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 0.6,
+  airSpinDecay: 6.0,
   maxTipOffsetRatio: 0.9
 });
 const FRICTION = 0.993;


### PR DESCRIPTION
### Motivation
- Suppress undesirable airborne cue-ball spin during jumps/bounces while preserving normal on-table spin behaviour by increasing airborne spin damping.

### Description
- Updated `PHYSICS_PROFILE.airSpinDecay` from `0.6` to `6.0` in `webapp/src/pages/Games/SnookerRoyal.jsx` to make airborne spin decay much faster.

### Testing
- No automated tests were run for this physics-only tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f530546988329b0b8b2fe5e5ebda8)