### PR TITLE
Prevent ball mesh rotation while airborne in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25873,7 +25873,7 @@ const powerRef = useRef(hud.power);
             }
             const liftAmount = b.lift ?? 0;
             b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
-            if (scaledSpeed > 0) {
+            if (scaledSpeed > 0 && !hasLift) {
               const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
               const angle = scaledSpeed / BALL_R;
               b.mesh.rotateOnWorldAxis(axis, angle);


### PR DESCRIPTION
### Motivation
- Remove visible mid-air rolling/spinning of the cue ball (and other balls) while preserving normal on-table roll and spin behavior to match gameplay intent.

### Description
- Add a guard to the per-step physics rendering so the mesh rotation is applied only when a ball is on the table (changed in `webapp/src/pages/Games/PoolRoyale.jsx` to `if (scaledSpeed > 0 && !hasLift)` to skip rotation when airborne).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f530546988329b0b8b2fe5e5ebda8)