### PR TITLE
Lower Ludo Battle Royale HDRI defaults to 2k/1k to speed loading

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -369,7 +369,8 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.04 * MODEL_SCALE;
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['2k', '1k']);
+const DEFAULT_HDRI_RESOLUTIONS = HDRI_RESOLUTION_STACK;
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
@@ -379,6 +380,8 @@ const HDRI_UNITS_PER_METER = 1;
 const LUDO_HDRI_OPTIONS = Object.freeze(
   POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
+    preferredResolutions: HDRI_RESOLUTION_STACK,
+    fallbackResolution: HDRI_RESOLUTION_STACK[0],
     label: `${variant.name} HDRI`
   }))
 );
@@ -1404,7 +1407,7 @@ async function resolvePolyHavenHdriUrl(config = {}) {
     Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
       ? config.preferredResolutions
       : DEFAULT_HDRI_RESOLUTIONS;
-  const fallbackRes = config?.fallbackResolution || preferred[0] || '4k';
+  const fallbackRes = config?.fallbackResolution || preferred[0] || '2k';
   const fallbackUrl =
     config?.fallbackUrl ||
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;


### PR DESCRIPTION
### Motivation
- HDRI assets were defaulting to `4k`, causing slow downloads and long load times for the Ludo Battle Royale arena; lowering defaults reduces bandwidth and speeds startup.
- Ensure HDRI variants explicitly advertise lower preferred resolutions and a suitable fallback so runtime resolution resolution selection prefers smaller files.

### Description
- Introduced `HDRI_RESOLUTION_STACK = Object.freeze(['2k','1k'])` and set `DEFAULT_HDRI_RESOLUTIONS` to that stack in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Updated `LUDO_HDRI_OPTIONS` to include `preferredResolutions: HDRI_RESOLUTION_STACK` and `fallbackResolution: HDRI_RESOLUTION_STACK[0]` for each HDRI variant.
- Changed the default PolyHaven fallback resolution in `resolvePolyHavenHdriUrl` from `'4k'` to `'2k'` so generated fallback URLs use `2k` HDRIs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5393abe48329b11e085c081e557d)