### PR TITLE
Improve Telegram speech unlock for Murlan commentary

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2127,13 +2127,17 @@ export default function MurlanRoyaleArena({ search }) {
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     window.addEventListener('pointerdown', unlockCommentary);
+    window.addEventListener('pointerup', unlockCommentary);
     window.addEventListener('click', unlockCommentary);
     window.addEventListener('touchstart', unlockCommentary);
+    window.addEventListener('touchend', unlockCommentary);
     window.addEventListener('keydown', unlockCommentary);
     return () => {
       window.removeEventListener('pointerdown', unlockCommentary);
+      window.removeEventListener('pointerup', unlockCommentary);
       window.removeEventListener('click', unlockCommentary);
       window.removeEventListener('touchstart', unlockCommentary);
+      window.removeEventListener('touchend', unlockCommentary);
       window.removeEventListener('keydown', unlockCommentary);
     };
   }, [unlockCommentary]);


### PR DESCRIPTION
### Motivation
- Telegram mobile in-app webviews often block or delay Web Speech initialization causing commentary not to be heard; the change aims to make unlocking and voice loading more reliable in that environment. 
- Commentary UX should activate on additional pointer/touch gestures common on mobile (e.g., `pointerup` / `touchend`) so users don't have to repeat interactions. 
- Slow voice enumeration in some webviews requires longer retries and explicit priming to surface available voices.

### Description
- Added an `isTelegramWebApp` helper and Telegram-aware logic in `webapp/src/utils/textToSpeech.js` to detect Telegram WebApp context. 
- Listen for `pointerup` events in `installSpeechSynthesisUnlock` and in the Murlan commentary page by adding `pointerup`/`touchend` handlers to improve unlock coverage on mobile (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`). 
- When running inside Telegram, call `primeSpeechSynthesis()` earlier and increase the voice load timeout (effective timeout bumped to at least 6000ms) in `loadVoices` to give the WebView more time to populate voices. 
- Kept existing unlock and resume behavior (`ensureSpeechUnlocked`, `synth.resume()`, `synth.getVoices()`) while improving the event coverage and retry window for voice loading.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5356c87c832985976c83b2ba12e0)