### PR TITLE
Lower HDRI resolution defaults for Ludo Battle Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -279,12 +279,13 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['4k', '2k']);
+const HDRI_RESOLUTION_STACK = Object.freeze(['2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
     preferredResolutions: HDRI_RESOLUTION_STACK,
+    fallbackResolution: HDRI_RESOLUTION_STACK[0],
     thumbnail: polyHavenThumb(variant.assetId),
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -369,7 +369,7 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.04 * MODEL_SCALE;
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['2k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
@@ -1404,7 +1404,7 @@ async function resolvePolyHavenHdriUrl(config = {}) {
     Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
       ? config.preferredResolutions
       : DEFAULT_HDRI_RESOLUTIONS;
-  const fallbackRes = config?.fallbackResolution || preferred[0] || '4k';
+  const fallbackRes = config?.fallbackResolution || preferred[0] || '2k';
   const fallbackUrl =
     config?.fallbackUrl ||
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;


### PR DESCRIPTION
### Motivation
- Reduce HDRI download and setup time for Ludo Battle Royale by preferring lower-resolution HDRIs for environment lighting.
- Ensure Pool Royale HDRI variants and Ludo default selection align to a faster-loading resolution to improve perceived load performance.

### Description
- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` to set `HDRI_RESOLUTION_STACK` to `['2k']` and assign `fallbackResolution` to `HDRI_RESOLUTION_STACK[0]` for each `POOL_ROYALE_HDRI_VARIANTS` entry.
- Updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` to change `DEFAULT_HDRI_RESOLUTIONS` from `['4k']` to `['2k']` and to use `'2k'` as the final fallback resolution in `resolvePolyHavenHdriUrl`.
- These changes make `2k` the preferred and fallback HDRI resolution for Pool/Ludo environments to reduce load times.

### Testing
- No automated tests were executed as part of this change.
- Changes were committed and staged files are `webapp/src/config/poolRoyaleInventoryConfig.js` and `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5393abe48329b11e085c081e557d)