### PR TITLE
Improve Web Speech unlock for Telegram mobile and Murlan commentary

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2127,16 +2127,25 @@ export default function MurlanRoyaleArena({ search }) {
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     window.addEventListener('pointerdown', unlockCommentary);
+    window.addEventListener('pointerup', unlockCommentary);
     window.addEventListener('click', unlockCommentary);
     window.addEventListener('touchstart', unlockCommentary);
+    window.addEventListener('touchend', unlockCommentary);
     window.addEventListener('keydown', unlockCommentary);
     return () => {
       window.removeEventListener('pointerdown', unlockCommentary);
+      window.removeEventListener('pointerup', unlockCommentary);
       window.removeEventListener('click', unlockCommentary);
       window.removeEventListener('touchstart', unlockCommentary);
+      window.removeEventListener('touchend', unlockCommentary);
       window.removeEventListener('keydown', unlockCommentary);
     };
   }, [unlockCommentary]);
+
+  useEffect(() => {
+    if (!configOpen) return;
+    unlockCommentary();
+  }, [configOpen, unlockCommentary]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return undefined;

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -18,6 +18,7 @@ let speechSupportListenerAttached = false;
 let speechSupportState = false;
 
 const SPEECH_SUPPORT_EVENT = 'tonplaygram:speech-support';
+const TELEGRAM_EVENT_OPTIONS = { passive: true };
 
 const getSpeechUtteranceClass = () => {
   if (typeof SpeechSynthesisUtterance !== 'undefined') return SpeechSynthesisUtterance;
@@ -124,18 +125,22 @@ export const installSpeechSynthesisUnlock = () => {
   const isTelegram = typeof window !== 'undefined' && Boolean(window.Telegram?.WebApp);
   const options = { once: !isTelegram, passive: true };
   window.addEventListener('pointerdown', handler, options);
+  window.addEventListener('pointerup', handler, options);
   window.addEventListener('touchstart', handler, options);
   window.addEventListener('touchend', handler, options);
   window.addEventListener('click', handler, options);
   window.addEventListener('keydown', handler, options);
+  if (typeof document !== 'undefined') {
+    document.addEventListener('touchend', handler, options);
+  }
   if (isTelegram) {
     speechUnlockVisibilityHandler = () => {
       if (document.visibilityState === 'visible') {
         handler();
       }
     };
-    window.addEventListener('focus', handler, { passive: true });
-    document.addEventListener('visibilitychange', speechUnlockVisibilityHandler, { passive: true });
+    window.addEventListener('focus', handler, TELEGRAM_EVENT_OPTIONS);
+    document.addEventListener('visibilitychange', speechUnlockVisibilityHandler, TELEGRAM_EVENT_OPTIONS);
   }
 };
 


### PR DESCRIPTION
### Motivation
- Telegram WebApp on mobile sometimes prevents Web Speech from initializing from common gestures, which causes voice commentary to remain unavailable for mobile/Telegram users.
- Make the in-game commentary more reliable by broadening the user interactions that trigger speech unlock and by unlocking when opening commentary/settings.

### Description
- Add a `TELEGRAM_EVENT_OPTIONS` constant and use it for Telegram-specific `focus`/`visibilitychange` handlers in `webapp/src/utils/textToSpeech.js` to ensure passive event handling in the WebApp environment.
- Register additional gesture events (`pointerup`, `touchend`) and a `document.touchend` fallback in `installSpeechSynthesisUnlock` to better capture Telegram/mobile interactions and call the speech-unlock handler.
- In `webapp/src/pages/Games/MurlanRoyaleArena.jsx` add `pointerup`/`touchend` listeners alongside existing gesture listeners and call `unlockCommentary` when the commentary/settings panel (`configOpen`) is opened so pending commentary can start immediately.
- Changes touch/gesture handling only; no commentary text or assets were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5356c87c832985976c83b2ba12e0)