### PR TITLE
Remove 50 Hz graphics option in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -101,7 +101,7 @@ function detectLowRefreshDisplay() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
     return false;
   }
-  const queries = ['(max-refresh-rate: 59hz)', '(max-refresh-rate: 50hz)', '(prefers-reduced-motion: reduce)'];
+  const queries = ['(max-refresh-rate: 59hz)', '(prefers-reduced-motion: reduce)'];
   for (const query of queries) {
     try {
       if (window.matchMedia(query).matches) {
@@ -237,12 +237,12 @@ function detectPreferredFrameRateId() {
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
-    return 'hd50';
+    return 'fhd60';
   }
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'hd50';
+      return 'fhd60';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
@@ -498,15 +498,6 @@ const DEFAULT_COMMENTARY_PRESET_ID = LUDO_BATTLE_COMMENTARY_PRESETS[0]?.id || 'e
 
 const FRAME_RATE_STORAGE_KEY = 'ludoFrameRate';
 const FRAME_RATE_OPTIONS = Object.freeze([
-  {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
-    renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: 'HD render • DPR 1.4 cap',
-    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
-  },
   {
     id: 'fhd60',
     label: 'Full HD (60 Hz)',
@@ -2575,7 +2566,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
       const legacyMap = {
-        mobile50: 'hd50',
+        mobile50: 'fhd60',
         balanced60: 'fhd60',
         smooth90: 'qhd90',
         fast120: 'uhd120',


### PR DESCRIPTION
### Motivation
- The Ludo Battle Royal graphics presets included a 50 Hz (hd50) battery-saver option that should be removed to simplify profiles and avoid targeting a deprecated refresh-rate preset.

### Description
- Removed the 50 Hz preset from `FRAME_RATE_OPTIONS` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so only 60/90/120 Hz profiles remain.
- Dropped the explicit `(max-refresh-rate: 50hz)` query from `detectLowRefreshDisplay()` so low-refresh detection no longer prefers 50 Hz.
- Updated `detectPreferredFrameRateId()` and the legacy mapping so low-refresh/legacy `mobile50` selections map to the 60 Hz (`fhd60`) profile instead of the removed `hd50`.
- Updated the initial frame-rate selection logic to use the new set of options and preserved existing 60/90/120 behavior.

### Testing
- Ran `rg` to scan `LudoBattleRoyal.jsx` for `hd50|50 Hz|50hz` and found no remaining 50 Hz option references (no matches).
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported the server as ready.
- Automated browser capture via Playwright navigated to `/games/ludobattleroyal`, opened the settings panel and saved a screenshot showing the Graphics panel with the 50 Hz option removed, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5a9789b48329a33280c370f03e4b)