### PR TITLE
Restore cue-ball visual height and anchor spin controller in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1675,6 +1675,7 @@ const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 2.6;
 const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
+const CUE_BALL_RENDER_OFFSET_Y = BALL_R * 0.06; // restore cue-ball visual height without moving the cue stick
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
 const SPIN_RING_THICKNESS_PX = 14;
@@ -1682,6 +1683,8 @@ const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
 const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
 const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
+const SPIN_CONTROLLER_BOTTOM_OFFSET_PX = 10;
+const SPIN_CONTROLLER_RIGHT_OFFSET_PX = 10;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets
@@ -25872,7 +25875,12 @@ const powerRef = useRef(hud.power);
               }
             }
             const liftAmount = b.lift ?? 0;
-            b.mesh.position.set(b.pos.x, BALL_CENTER_Y + liftAmount, b.pos.y);
+            const cueBallOffset = b.id === 'cue' ? CUE_BALL_RENDER_OFFSET_Y : 0;
+            b.mesh.position.set(
+              b.pos.x,
+              BALL_CENTER_Y + liftAmount + cueBallOffset,
+              b.pos.y
+            );
             if (scaledSpeed > 0) {
               const axis = new THREE.Vector3(b.vel.y, 0, -b.vel.x).normalize();
               const angle = scaledSpeed / BALL_R;
@@ -28909,9 +28917,10 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-1 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${6 + chromeUiLiftPx}px`,
+            right: `${SPIN_CONTROLLER_RIGHT_OFFSET_PX}px`,
+            bottom: `${SPIN_CONTROLLER_BOTTOM_OFFSET_PX + chromeUiLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,
             transformOrigin: 'bottom right'
           }}


### PR DESCRIPTION
### Motivation
- Restore the cue ball’s visual placement to match the morning 9am appearance while keeping the cue stick behavior unchanged. 
- Ensure the spin controller UI is anchored consistently on-screen rather than relying purely on utility classes so placement matches expected layout across devices.

### Description
- Added a small render-only vertical offset constant `CUE_BALL_RENDER_OFFSET_Y` and applied it when positioning ball meshes so only the cue ball gains the visual lift (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Introduced explicit `SPIN_CONTROLLER_BOTTOM_OFFSET_PX` and `SPIN_CONTROLLER_RIGHT_OFFSET_PX` constants and used them in the spin controller container style, replacing the previous implicit class positioning for more predictable placement (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Kept `chromeUiLiftPx` and `uiScale` behavior intact so the new offsets still account for platform UI differences and scaling (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Started the web developer server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and received a successful Vite ready message indicating the app served at `http://localhost:4173/` (succeeded). 
- Attempted an automated visual check via Playwright to capture `/games/poolroyale`, but the Playwright navigation/screenshot timed out in this environment (failed to capture). 
- Changes were added and committed (`git commit`) to the working branch (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5d32c5848329b5d2caff53f25f68)