### PR TITLE
Add pocket jaw damping to reduce artificial edge rolling

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -383,6 +383,7 @@ public class BilliardsSolver
                     double restitution = PhysicsConstants.Restitution;
                     bool hit = false;
                     bool pocket = false;
+                    bool pocketJawHit = false;
                     Vec2 contactPoint = new Vec2();
 
                     bool allowPocketing = !airborne;
@@ -419,6 +420,7 @@ public class BilliardsSolver
                             restitution = allowPocketing ? PhysicsConstants.PocketRestitution : PhysicsConstants.CushionRestitution;
                             hit = true;
                             pocket = allowPocketing;
+                            pocketJawHit = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -457,6 +459,12 @@ public class BilliardsSolver
                             break;
                         }
                         b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        if (pocketJawHit)
+                        {
+                            b.Velocity = ApplyPocketJawFriction(b.Velocity, normal);
+                            b.SideSpin *= PhysicsConstants.PocketJawSpinDamping;
+                            b.ForwardSpin *= PhysicsConstants.PocketJawSpinDamping;
+                        }
                         b.Position = contactPoint + normal * (PhysicsConstants.BallRadius + PhysicsConstants.ContactOffset);
                         remaining = Math.Max(0, remaining - travel);
                         StepVertical(b, travel);
@@ -638,6 +646,16 @@ public class BilliardsSolver
         }
     }
 
+    private static Vec2 ApplyPocketJawFriction(Vec2 velocity, Vec2 normal)
+    {
+        if (velocity.Length <= PhysicsConstants.Epsilon)
+            return velocity;
+        var n = normal.Normalized();
+        var normalComponent = n * Vec2.Dot(velocity, n);
+        var tangential = velocity - normalComponent;
+        return normalComponent + tangential * PhysicsConstants.PocketJawTangentDamping;
+    }
+
     private static void IntegrateCueBall(Ball b, double dt, bool airborne)
     {
         b.Position += b.Velocity * dt;
@@ -728,6 +746,10 @@ public class BilliardsSolver
                 cue.Position += cue.Velocity * te;
                 var restitution = airborne ? PhysicsConstants.CushionRestitution : PhysicsConstants.PocketRestitution;
                 var post = Collision.Reflect(cue.Velocity, e.Normal, restitution);
+                if (!airborne)
+                {
+                    post = ApplyPocketJawFriction(post, e.Normal);
+                }
                 impact = new Impact { Point = cue.Position, CueVelocity = post };
                 return true;
             }

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -10,6 +10,8 @@ public static class PhysicsConstants
     public const double ConnectorRestitution = CushionRestitution * 0.25;
     // pocket edges fully absorb balls (no bounce)
     public const double PocketRestitution = 0.0;
+    public const double PocketJawTangentDamping = 0.35; // tangential speed retained on pocket jaw hits
+    public const double PocketJawSpinDamping = 0.2;     // spin retained on pocket jaw hits
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double Gravity = 9.81;                // m/s^2
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)


### PR DESCRIPTION
### Motivation
- Balls were exhibiting unnatural sliding/edge-rolling and retaining artificial spin when contacting pocket jaws, so pocket-edge impacts need extra tangential and spin damping to produce more realistic rolling.

### Description
- Added `PocketJawTangentDamping` and `PocketJawSpinDamping` constants to `billiards/PhysicsConstants.cs` to expose tunable damping for pocket jaw interactions.
- Implemented `ApplyPocketJawFriction(Vec2, Vec2)` in `billiards/BilliardsSolver.cs` which attenuates the tangential component of velocity on jaw hits.
- Applied pocket-jaw friction and spin damping in the main `Step` integrator so pocket-edge collisions reduce tangential speed and spin before the ball settles or pockets.
- Applied the same pocket-jaw friction in the CCD preview path (`TryFindImpact`) so previews reflect the updated runtime behavior.

### Testing
- No automated tests were executed for this change.
- The change is limited to physics constants and the solver path for pocket-edge impacts and should be covered by existing physics tests if run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7e556abc8329adad83115d9da3b2)