### PR TITLE
Reduce low-speed spin steering in billiards physics

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -610,9 +610,13 @@ public class BilliardsSolver
         if (!airborne)
         {
             Vec2 dir = b.Velocity.Normalized();
+            double spinEffectScale = Smoothstep(
+                PhysicsConstants.SpinEffectSpeedThreshold,
+                PhysicsConstants.SpinEffectSpeedThreshold + PhysicsConstants.SpinEffectSpeedFadeRange,
+                speed);
             if (b.ForwardSpin > 0)
             {
-                var forwardAccel = PhysicsConstants.RollAcceleration * b.ForwardSpin;
+                var forwardAccel = PhysicsConstants.RollAcceleration * b.ForwardSpin * spinEffectScale;
                 b.Velocity += dir * forwardAccel * dt;
             }
 
@@ -623,7 +627,7 @@ public class BilliardsSolver
                 double excess = speed - PhysicsConstants.SwerveSpeedCutoff;
                 speedFactor = Math.Max(0.0, 1.0 - excess / PhysicsConstants.SwerveSpeedFadeRange);
             }
-            var swerveAccel = PhysicsConstants.SwerveCoefficient * b.SideSpin * speed * b.MasseFactor * speedFactor;
+            var swerveAccel = PhysicsConstants.SwerveCoefficient * b.SideSpin * speed * b.MasseFactor * speedFactor * spinEffectScale;
             b.Velocity += lateral * swerveAccel * dt;
 
             double decay = Math.Exp(-PhysicsConstants.SpinDecay * dt);

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -17,6 +17,8 @@ public static class PhysicsConstants
     public const double AirSpinDecay = 0.6;            // per-second decay while airborne
     public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
     public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
+    public const double SpinEffectSpeedThreshold = 0.3; // m/s below which spin has no steering/roll effect
+    public const double SpinEffectSpeedFadeRange = 0.4; // m/s range to fade in spin effects
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
     public const double JumpStopVelocity = 0.2;        // m/s below which vertical motion stops
     public const double AirborneHeightThreshold = BallRadius * 0.25; // height before ignoring cushions/balls


### PR DESCRIPTION
### Motivation

- Balls near pocket edges exhibited unrealistic spin-driven drift and apparent sliding instead of natural rolling, so spin-related steering/roll forces should be suppressed at very low speeds to avoid artificial motion.
- Preserve existing spin behavior at normal shot speeds while removing exaggerated low-speed effects that pull balls into pockets.

### Description

- Add two tunable constants `SpinEffectSpeedThreshold` and `SpinEffectSpeedFadeRange` to `billiards/PhysicsConstants.cs` to define the low-speed cutoff and fade-in range for spin effects.
- Compute a `spinEffectScale` using the existing `Smoothstep` function inside `ApplySpinForces` in `billiards/BilliardsSolver.cs` to smoothly interpolate spin influence based on current ball speed.
- Multiply forward roll acceleration and lateral swerve (`RollAcceleration` and `SwerveCoefficient` contributions) by `spinEffectScale` so spin has no steering/roll effect below the threshold and fades in over the configured range.
- Changes touch `billiards/PhysicsConstants.cs` and `billiards/BilliardsSolver.cs` and are intended to reduce artificial pocket-edge rolling while keeping high-speed spin behavior intact.

### Testing

- No automated tests were run for this change.
- The change was committed and staged for PR; manual playtesting is recommended to tune the new constants and verify reduced low-speed spin artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7e556abc8329adad83115d9da3b2)