### PR TITLE
Limit Pool Royale spin controller extremes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -93,6 +93,7 @@ import {
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
   clampToUnitCircle,
+  clampToMaxOffset,
   computeQuantizedOffsetScaled,
   mapSpinForPhysics,
   normalizeSpinInput,
@@ -1685,6 +1686,7 @@ const SPIN_DECORATION_RADII = [0.18, 0.34, 0.5, 0.66];
 const SPIN_DECORATION_ANGLES = [0, 45, 90, 135, 180, 225, 270, 315];
 const SPIN_DECORATION_DOT_SIZE_PX = 12;
 const SPIN_DECORATION_OFFSET_PERCENT = 58;
+const SPIN_CONTROL_MAX_OFFSET = 0.82;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets
@@ -27141,7 +27143,12 @@ const powerRef = useRef(hud.power);
 
     const clampToPlayable = (nx, ny) => {
       const raw = clampToUnitCircle(nx, ny);
-      const limited = clampToLimits(raw.x, raw.y);
+      const trimmed = clampToMaxOffset(
+        raw.x,
+        raw.y,
+        SPIN_CONTROL_MAX_OFFSET
+      );
+      const limited = clampToLimits(trimmed.x, trimmed.y);
       const aimVec = aimDirRef.current;
       const cueBall = cueRef.current;
       const activeCamera = activeRenderCameraRef.current ?? cameraRef.current;
@@ -27152,7 +27159,12 @@ const powerRef = useRef(hud.power);
         activeCamera
       );
       const reclamped = clampToLimits(viewLimited.x, viewLimited.y);
-      return clampToUnitCircle(reclamped.x, reclamped.y);
+      const capped = clampToMaxOffset(
+        reclamped.x,
+        reclamped.y,
+        SPIN_CONTROL_MAX_OFFSET
+      );
+      return clampToUnitCircle(capped.x, capped.y);
     };
 
     const applySpin = (nx, ny, { updateRequest = true } = {}) => {
@@ -27188,7 +27200,12 @@ const powerRef = useRef(hud.power);
     const applySnapTarget = () => {
       const snapped = computeQuantizedOffsetScaled(
         spinState.target.x,
-        spinState.target.y
+        spinState.target.y,
+        {
+          maxOffset: SPIN_CONTROL_MAX_OFFSET,
+          ring3Radius: SPIN_CONTROL_MAX_OFFSET,
+          level3Mag: SPIN_CONTROL_MAX_OFFSET
+        }
       );
       spinState.target = clampToPlayable(snapped.x, snapped.y);
       spinRequestRef.current = { ...spinState.target };


### PR DESCRIPTION
### Motivation
- Players reported unstable cue-ball behavior when the spin controller allowed extreme top/back/edge inputs, so the spin UI must be constrained to prevent very-fast/edge spins that destabilize physics.

### Description
- Imported `clampToMaxOffset` from `poolRoyaleSpinUtils.js` and added a new UI cap `SPIN_CONTROL_MAX_OFFSET = 0.82` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Trim `clampToPlayable` input with `clampToMaxOffset` before applying spin limits and re-apply the cap after visibility/clamping so the controller cannot select extreme edge offsets.
- Ensure snap behavior respects the reduced range by passing `maxOffset`, `ring3Radius`, and `level3Mag` into `computeQuantizedOffsetScaled` when snapping.
- Change is localized to the Pool Royale spin controller code path in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Launched the dev server with `npm --prefix webapp run dev` and Vite started (server ready), indicating the app builds and serves successfully (succeeded).
- Attempted an automated UI check using Playwright to capture a screenshot of the spin control, but the headless Chromium process crashed/timed out in this environment (failed).
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f97a173348329b7a4a18f838644ef)