### PR TITLE
Limit Pool Royale spin extremes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -92,9 +92,10 @@ import {
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
-  clampToUnitCircle,
+  clampToMaxOffset,
   computeQuantizedOffsetScaled,
   mapSpinForPhysics,
+  MAX_SPIN_OFFSET,
   normalizeSpinInput,
   smoothDamp,
   SPIN_STUN_RADIUS
@@ -5333,10 +5334,10 @@ const lerpAngle = (start = 0, end = 0, t = 0.5) => {
 // Utilities
 // --------------------------------------------------
 const DEFAULT_SPIN_LIMITS = Object.freeze({
-  minX: -1,
-  maxX: 1,
-  minY: -1,
-  maxY: 1
+  minX: -MAX_SPIN_OFFSET,
+  maxX: MAX_SPIN_OFFSET,
+  minY: -MAX_SPIN_OFFSET,
+  maxY: MAX_SPIN_OFFSET
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
@@ -27140,7 +27141,7 @@ const powerRef = useRef(hud.power);
     };
 
     const clampToPlayable = (nx, ny) => {
-      const raw = clampToUnitCircle(nx, ny);
+      const raw = clampToMaxOffset(nx, ny, MAX_SPIN_OFFSET);
       const limited = clampToLimits(raw.x, raw.y);
       const aimVec = aimDirRef.current;
       const cueBall = cueRef.current;
@@ -27152,7 +27153,7 @@ const powerRef = useRef(hud.power);
         activeCamera
       );
       const reclamped = clampToLimits(viewLimited.x, viewLimited.y);
-      return clampToUnitCircle(reclamped.x, reclamped.y);
+      return clampToMaxOffset(reclamped.x, reclamped.y, MAX_SPIN_OFFSET);
     };
 
     const applySpin = (nx, ny, { updateRequest = true } = {}) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,9 +1,9 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 1;
+export const MAX_SPIN_OFFSET = 0.8;
 export const SPIN_STUN_RADIUS = 0.16;
-export const SPIN_RING1_RADIUS = 0.33;
-export const SPIN_RING2_RADIUS = 0.66;
+export const SPIN_RING1_RADIUS = MAX_SPIN_OFFSET * 0.33;
+export const SPIN_RING2_RADIUS = MAX_SPIN_OFFSET * 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
 export const SPIN_LEVEL0_MAG = 0;
 export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;


### PR DESCRIPTION
### Motivation
- Prevent cue ball instability when users apply very large or edge spin inputs by restricting the maximum spin offset and remapping spin rings to a safer range.

### Description
- Reduced the maximum UI spin offset from `1` to `0.8` (`MAX_SPIN_OFFSET`) in `poolRoyaleSpinUtils.js` and rescaled the spin ring radii to follow the new maximum.
- Added/used `clampToMaxOffset` and imported `MAX_SPIN_OFFSET` into `PoolRoyale.jsx` and replaced instances of `clampToUnitCircle` with `clampToMaxOffset` to ensure controller input is clamped to the reduced range.
- Updated `DEFAULT_SPIN_LIMITS` to use `±MAX_SPIN_OFFSET` so spin limits and UI/physics mapping remain consistent with the new cap.
- Applied these changes to the spin controller workflow (`clampToPlayable`, `applySpin`, snapping/quantization) so UI, preview, and physics receive the clamped values.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f97a173348329b7a4a18f838644ef)