### PR TITLE
Fix domino commentary crash on unsupported speech APIs

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -778,6 +778,8 @@ const speechSynth = (() => {
     return null;
   }
 })();
+const speechUtteranceCtor =
+  typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null;
 let commentaryVoices = [];
 let commentaryPresetId = COMMENTARY_PRESETS[0]?.id || 'atlas';
 let commentaryMuted = false;
@@ -981,7 +983,7 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  if (!speechSynth || commentaryMuted || !text) return;
+  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
@@ -998,7 +1000,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   if (!priority && now - commentaryLastEventAt < COMMENTARY_MIN_INTERVAL_MS) return;
   if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
   const profile = getVoiceProfileForKind(kind);
-  const utterance = new SpeechSynthesisUtterance(text);
+  const utterance = new speechUtteranceCtor(text);
   const primaryVoice = resolveCommentaryVoice(profile);
   const secondaryVoice = resolveCommentaryVoice(
     getCommentaryVoiceProfiles().find((voiceProfile) => voiceProfile !== profile),
@@ -1041,7 +1043,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  if (commentaryMuted || !speechSynth) return;
+  if (commentaryMuted || !speechSynth || !speechUtteranceCtor) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
@@ -5116,7 +5118,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(speechSynth);
+  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when an environment exposes `speechSynthesis` but lacks the `SpeechSynthesisUtterance` constructor, which caused the Domino Royal announcer code to fail and left commentary controls in an invalid state.

### Description
- Add a `speechUtteranceCtor` guard and require it in `speakCommentary`/`announceCommentary`, and disable commentary UI when the utterance constructor is unavailable by updating `webapp/public/domino-royal.html`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f999c975483298105c0f9e164238a)