### PR TITLE
Add Ludo table finish inventory and quality-based texture scaling

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -6,12 +6,14 @@ import {
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
   stools: [MURLAN_STOOL_THEMES[0]?.id],
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   tokenPalette: [TOKEN_PALETTE_OPTIONS[0]?.id],
   tokenStyle: [TOKEN_STYLE_OPTIONS[0]?.id],
   tokenPiece: [TOKEN_PIECE_OPTIONS[0]?.id]
@@ -34,6 +36,7 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
       }))
     )
   ),
+  tableFinish: Object.freeze(reduceLabels(MURLAN_TABLE_FINISHES)),
   tokenPalette: Object.freeze(reduceLabels(TOKEN_PALETTE_OPTIONS)),
   tokenStyle: Object.freeze(reduceLabels(TOKEN_STYLE_OPTIONS)),
   tokenPiece: Object.freeze(reduceLabels(TOKEN_PIECE_OPTIONS)),
@@ -42,6 +45,17 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
 });
 
 export const LUDO_BATTLE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `ludo-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
   ...MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `ludo-table-${theme.id}`,
     type: 'tables',
@@ -107,6 +121,11 @@ export const LUDO_BATTLE_DEFAULT_LOADOUT = [
     type: 'environmentHdri',
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
     label: LUDO_BATTLE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID] || 'HDR Environment'
+  },
+  {
+    type: 'tableFinish',
+    optionId: MURLAN_TABLE_FINISHES[0]?.id,
+    label: MURLAN_TABLE_FINISHES[0]?.label
   },
   { type: 'tokenPalette', optionId: TOKEN_PALETTE_OPTIONS[0]?.id, label: `${TOKEN_PALETTE_OPTIONS[0]?.label} Palette` },
   { type: 'tokenStyle', optionId: TOKEN_STYLE_OPTIONS[0]?.id, label: TOKEN_STYLE_OPTIONS[0]?.label },

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -166,6 +166,7 @@ const LUDO_TYPE_LABELS = {
   tables: 'Table Models',
   stools: 'Stools & Chairs',
   environmentHdri: 'HDR Environments',
+  tableFinish: 'Table Finish',
   tokenPalette: 'Token Palette',
   tokenStyle: 'Token Style',
   tokenPiece: 'Token Piece',


### PR DESCRIPTION
### Motivation
- Expose the Murlan Royale table finishes and chair stools as purchasable/unlockable options for the Ludo Battle Royal arena so table visuals can match Murlan quality presets. 
- Ensure table/chair materials and PolyHaven texture resolution follow selected graphics quality to improve perceived clarity on high-end devices and reduce runtime cost on low-end profiles.

### Description
- Added imports and wiring for `MURLAN_TABLE_FINISHES` into Ludo inventory: default unlocks, `LUDO_BATTLE_STORE_ITEMS`, `LUDO_BATTLE_OPTION_LABELS`, and default loadout (`webapp/src/config/ludoBattleInventoryConfig.js`).
- Added `tableFinish` appearance state and customization section and rendered its preview in the Ludo customization UI (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Applied chosen table finish by resolving `tableFinish.woodOption` into table material application and by passing finish-driven `woodOption` into `rebuildTable` and initial arena setup, and applied finish-only material updates when finish changes (avoids full rebuild when unnecessary).
- Added quality → preferred PolyHaven texture size mapping (`TEXTURE_SIZE_BY_QUALITY`) and threaded `preferredTextureSizes` through `frameQualityProfile` → `frameQualityRef` → `loadPolyhavenTextureSet` / `createPolyhavenInstance` so model texture resolutions match selected frame-quality profile.
- Reworked `rebuildTable`/`rebuildChairs` to accept resolved material options and quality-driven texture preferences; added a small effect to reload table/chair assets when graphics quality changes.
- Added a store label for `tableFinish` in the store UI (`webapp/src/pages/Store.jsx`).

### Testing
- Smoke-tested by starting the web app dev server with `npm --prefix webapp run dev` and loading `/#/games/ludobattleroyal`, then programmatically opening the customization panel and capturing a screenshot via a Playwright script; the script completed and produced `browser:/tmp/codex_browser_invocations/880853f75d84e9db/artifacts/artifacts/ludo-table-finish.png` indicating the new UI entry renders correctly. (Dev server and Playwright smoke test succeeded.)
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9a6bd2108329820112f87ae95620)