### PR TITLE
Restore Pool Royale spin controller and cue stick logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1616,7 +1616,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.18; // widen the visible air gap so the blue tip never kisses the cue ball
-const CUE_TIP_GAP = BALL_R * 1.02 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
+const CUE_TIP_GAP = BALL_R * 1.12 + CUE_TIP_CLEARANCE; // pull the blue tip farther back so it stays visible
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -1629,8 +1629,8 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_PULL_RETURN_PUSH = 0.78; // push the cue forward to its start point more decisively after a pull
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.7; // ensure the forward push is visible even on short strokes
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 3.2; // cap the forward travel so the cue never overshoots the ball too far
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.4; // ensure the forward push is visible even on short strokes
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 2.6; // cap the forward travel so the cue never overshoots the ball too far
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -1644,12 +1644,12 @@ const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 7.6;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 16.4;
-const CUE_Y = BALL_CENTER_Y - BALL_R * 0.35; // lower the cue a touch more so the blue tip sits dead-centre on the cue ball
+const CUE_Y = BALL_CENTER_Y - BALL_R * 0.085; // rest the cue a touch lower so the tip lines up with the cue-ball centre on portrait screens
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
-const CUE_BUTT_LIFT = BALL_R * 0.46; // lower the butt slightly while keeping the tip level with the cue-ball centre
-const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.08; // keep a tighter gap so the cue butt clears the cushion top surface
-const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly as cushions rise so it never touches
+const CUE_BUTT_LIFT = BALL_R * 0.52; // keep the butt elevated for clearance while keeping the tip level with the cue-ball centre
+const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.11; // keep the cue butt from dipping below the cushion top surface
+const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.08; // lift the cue slightly more as cushions rise so it never touches
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
@@ -5340,7 +5340,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_VIEW_BLOCK_THRESHOLD = 0;
+const SPIN_VIEW_BLOCK_THRESHOLD = -0.18;
 
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
@@ -5370,37 +5370,6 @@ const computeCueViewVector = (cueBall, camera) => {
   TMP_VEC2_VIEW.set(cx, cz);
   if (TMP_VEC2_VIEW.lengthSq() < 1e-8) return null;
   return TMP_VEC2_VIEW.clone().normalize();
-};
-
-const clampSpinToVisibleHemisphere = (spinInput, aimDir, cueBall, camera) => {
-  if (!spinInput || !aimDir || !cueBall || !camera) return spinInput;
-  const viewVec = computeCueViewVector(cueBall, camera);
-  if (!viewVec) return spinInput;
-  const axes = prepareSpinAxes(aimDir);
-  TMP_VEC2_SPIN.set(0, 0);
-  TMP_VEC2_SPIN.addScaledVector(axes.perp, spinInput.x ?? 0);
-  TMP_VEC2_SPIN.addScaledVector(axes.axis, spinInput.y ?? 0);
-  if (TMP_VEC2_SPIN.lengthSq() < 1e-8) return spinInput;
-  TMP_VEC2_VIEW.set(viewVec.x, viewVec.y).normalize();
-  const viewDot = TMP_VEC2_SPIN.dot(TMP_VEC2_VIEW);
-  if (viewDot >= 0) return spinInput;
-  const dx = camera.position.x - cueBall.pos.x;
-  const dz = camera.position.z - cueBall.pos.y;
-  const planarDistance = Math.hypot(dx, dz);
-  const elevation = Math.atan2(camera.position.y ?? 0, Math.max(planarDistance, 1e-6));
-  const relax =
-    elevation <= 0
-      ? 0
-      : THREE.MathUtils.clamp(
-          (elevation - 0.35) / (0.75 - 0.35),
-          0,
-          1
-        );
-  TMP_VEC2_SPIN.addScaledVector(TMP_VEC2_VIEW, -viewDot * (1 - relax));
-  return {
-    x: TMP_VEC2_SPIN.dot(axes.perp),
-    y: TMP_VEC2_SPIN.dot(axes.axis)
-  };
 };
 
 const resolveCameraBasis = (camera) => {
@@ -18636,7 +18605,7 @@ const powerRef = useRef(hud.power);
             ? {
                 position: serializeVector3Snapshot(cueStick.position),
                 rotation: serializeQuaternionSnapshot(cueStick.quaternion),
-                visible: cueStick.visible ?? true
+                visible: cueStick.visible
               }
             : null;
           shotRecording.frames.push({
@@ -18758,7 +18727,9 @@ const powerRef = useRef(hud.power);
               cueStick.quaternion.set(quatA.x, quatA.y, quatA.z, quatA.w);
             }
             const visible = cueStateB?.visible ?? cueStateA?.visible;
-            cueStick.visible = visible == null ? true : Boolean(visible);
+            if (visible != null) {
+              cueStick.visible = Boolean(visible);
+            }
             cueAnimating = cueStick.visible;
             syncCueShadow();
             return true;
@@ -19497,19 +19468,7 @@ const powerRef = useRef(hud.power);
               x: 0,
               y: 0
             };
-            const viewClamped = clampSpinToVisibleHemisphere(
-              requested,
-              aimVec,
-              cueBall,
-              activeCamera
-            );
-            if (
-              viewClamped.x !== requested.x ||
-              viewClamped.y !== requested.y
-            ) {
-              spinRequestRef.current = { ...viewClamped };
-            }
-            legality = checkSpinLegality2D(cueBall, viewClamped, ballsList, {
+            legality = checkSpinLegality2D(cueBall, requested, ballsList, {
               axes,
               view: viewVec
                 ? { x: viewVec.x, y: viewVec.y }
@@ -27142,17 +27101,7 @@ const powerRef = useRef(hud.power);
     const clampToPlayable = (nx, ny) => {
       const raw = clampToUnitCircle(nx, ny);
       const limited = clampToLimits(raw.x, raw.y);
-      const aimVec = aimDirRef.current;
-      const cueBall = cueRef.current;
-      const activeCamera = activeRenderCameraRef.current ?? cameraRef.current;
-      const viewLimited = clampSpinToVisibleHemisphere(
-        limited,
-        aimVec,
-        cueBall,
-        activeCamera
-      );
-      const reclamped = clampToLimits(viewLimited.x, viewLimited.y);
-      return clampToUnitCircle(reclamped.x, reclamped.y);
+      return clampToUnitCircle(limited.x, limited.y);
     };
 
     const applySpin = (nx, ny, { updateRequest = true } = {}) => {


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale spin controller and cue-stick behavior to the earlier 05:00 baseline so spin input, cue visuals, and replay cue handling match the previous gameplay tuning.
- Undo recent view-hemisphere clamping and visibility changes that altered spin legality and replay cue visibility.

### Description
- Restored cue tuning constants in `webapp/src/pages/Games/PoolRoyale.jsx` including `CUE_TIP_GAP`, `CUE_FOLLOW_THROUGH_MIN`, `CUE_FOLLOW_THROUGH_MAX`, `CUE_Y`, `CUE_BUTT_LIFT`, `CUE_BUTT_CUSHION_CLEARANCE`, and `CUE_CUSHION_LIFT_BIAS` to the prior values.
- Reverted spin visibility threshold to `SPIN_VIEW_BLOCK_THRESHOLD = -0.18` and removed the `clampSpinToVisibleHemisphere` helper and its usages so spin legality is evaluated against the requested spin vector again.
- Restored prior replay cue visibility behavior by removing the unconditional default-to-visible fallback and only setting `cueStick.visible` when the snapshot explicitly provides a value.

### Testing
- No automated tests were run as part of this change (unit/CI not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa0c4d0248329953c5c4291c80d59)