### PR TITLE
Add Murlan table finishes to Ludo Battle Royal

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -4,12 +4,14 @@ import {
   TOKEN_STYLE_OPTIONS
 } from './ludoBattleOptions.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   stools: [MURLAN_STOOL_THEMES[0]?.id],
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   tokenPalette: [TOKEN_PALETTE_OPTIONS[0]?.id],
@@ -25,6 +27,7 @@ const reduceLabels = (options) =>
 
 export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   tables: Object.freeze(reduceLabels(MURLAN_TABLE_THEMES)),
+  tableFinish: Object.freeze(reduceLabels(MURLAN_TABLE_FINISHES)),
   stools: Object.freeze(reduceLabels(MURLAN_STOOL_THEMES)),
   environmentHdri: Object.freeze(
     reduceLabels(
@@ -42,6 +45,17 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
 });
 
 export const LUDO_BATTLE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `ludo-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
   ...MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `ludo-table-${theme.id}`,
     type: 'tables',
@@ -102,6 +116,11 @@ export const LUDO_BATTLE_STORE_ITEMS = [
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },
+  {
+    type: 'tableFinish',
+    optionId: MURLAN_TABLE_FINISHES[0]?.id,
+    label: MURLAN_TABLE_FINISHES[0]?.label
+  },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0]?.id, label: MURLAN_STOOL_THEMES[0]?.label },
   {
     type: 'environmentHdri',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -164,6 +164,7 @@ const BLACKJACK_TYPE_LABELS = {
 
 const LUDO_TYPE_LABELS = {
   tables: 'Table Models',
+  tableFinish: 'Table Finish',
   stools: 'Stools & Chairs',
   environmentHdri: 'HDR Environments',
   tokenPalette: 'Token Palette',


### PR DESCRIPTION
### Motivation
- Make the full set of Murlan table finishes available for Ludo Battle Royal so tables, chairs and tokens can match the Murlan/Murlan Royale graphics and be purchased/unlocked from the store.
- Ensure procedural Ludo tables use the selected Murlan finish (wood grain/etc.) so appearance matches other Royale games and can be stored in the Ludo inventory/loadout.

### Description
- Added import and usage of `MURLAN_TABLE_FINISHES` in `webapp/src/config/ludoBattleInventoryConfig.js` and exposed finishes in `LUDO_BATTLE_DEFAULT_UNLOCKS`, `LUDO_BATTLE_OPTION_LABELS`, `LUDO_BATTLE_STORE_ITEMS`, and `LUDO_BATTLE_DEFAULT_LOADOUT` so finishes appear in inventory and store.
- Added `tableFinish` handling to `webapp/src/pages/Games/LudoBattleRoyal.jsx` including new `TABLE_FINISH_OPTIONS`, `DEFAULT_TABLE_FINISH`, default appearance entry, customization section, and normalization/ensure logic for `tableFinish` options.
- Updated the Ludo table build flow to accept a `tableFinish` parameter and apply its `woodOption` when creating or reapplying materials to the procedural table using `applyTableMaterials` so the procedural table respects the chosen finish.
- Labeled the new type in the store UI by adding `tableFinish: 'Table Finish'` to `LUDO_TYPE_LABELS` in `webapp/src/pages/Store.jsx` to surface finishes in the Store UI.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready, indicating the front-end served successfully.
- Captured a store UI screenshot for Ludo (`/store/ludobattleroyal`) using Playwright; the run completed and produced `artifacts/ludo-store-table-finish.png`, validating the new store items are rendered.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9a6bd2108329820112f87ae95620)