### PR TITLE
Guard Domino Royal bootstrap and disable controls until ready

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -5627,6 +5627,14 @@ function makeDomino(a,b,{flat=true, faceUp=true, preserveOrder=false}={}){
 const statusEl = document.getElementById('status');
 const btnDraw = document.getElementById('draw');
 const btnPass = document.getElementById('pass');
+const setControlEnabled = (enabled) => {
+  [btnDraw, btnPass].forEach((btn) => {
+    if (!btn) return;
+    btn.disabled = !enabled;
+    btn.setAttribute('aria-disabled', enabled ? 'false' : 'true');
+  });
+};
+setControlEnabled(false);
 const btnRules = document.getElementById('btnRules');
 const viewToggle = document.getElementById('viewToggle');
 const panelRules = document.getElementById('rules');
@@ -6608,11 +6616,22 @@ btnPass.addEventListener('click',()=>{
 });
 
 async function bootstrapDominoRoyal() {
-  await loadHumanProfileFromApi();
-  startGame();
+  try {
+    await loadHumanProfileFromApi();
+    startGame();
+    setControlEnabled(true);
+  } catch (error) {
+    console.error('Domino Royal failed to start', error);
+    setStatus('Unable to start match. Please reload.');
+    setControlEnabled(false);
+  }
 }
 
-bootstrapDominoRoyal();
+bootstrapDominoRoyal().catch((error) => {
+  console.error('Domino Royal bootstrap failed', error);
+  setStatus('Unable to start match. Please reload.');
+  setControlEnabled(false);
+});
 
 function blockedAndWinner(){
   if(!ends) return null;


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and unexpected user interaction during startup by guarding the Domino arena bootstrap and disabling controls until initialization completes.

### Description
- Added a `setControlEnabled` helper and initially disabled the Draw/Pass buttons to prevent premature input in `webapp/public/domino-royal.html`.
- Wrapped `bootstrapDominoRoyal` in a try/catch and a final `.catch(...)` to surface a friendly status message (`Unable to start match. Please reload.`) and keep controls disabled on failure.
- On successful initialization the UI enables controls and proceeds to `startGame()`.

### Testing
- No automated tests were run for this static HTML/JS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f999c975483298105c0f9e164238a)