### PR TITLE
Reduce Pool Royale cue ball max spin

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1271,7 +1271,7 @@ const PHYSICS_PROFILE = Object.freeze({
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
-  maxTipOffsetRatio: 0.9
+  maxTipOffsetRatio: 0.65
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.991;


### PR DESCRIPTION
### Motivation
- Reduce maximum cue ball spin in Pool Royale by lowering the cue-tip offset cap so extreme spins are less likely.

### Description
- Update `PHYSICS_PROFILE.maxTipOffsetRatio` from `0.9` to `0.65` in `webapp/src/pages/Games/PoolRoyale.jsx` to limit the maximum spin applied via the cue tip.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fbc4daa3c83299998307115cd1a33)