### PR TITLE
Adjust Pool Royale spin and friction parameters to reduce skating

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1270,20 +1270,20 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 0.6,
-  maxTipOffsetRatio: 0.65
+  airSpinDecay: 4.0,
+  maxTipOffsetRatio: 0.5
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.991;
+const FRICTION = 0.987;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
 const BALL_INERTIA = (2 / 5) * BALL_MASS * BALL_R * BALL_R;
 const SPIN_FIXED_DT = 1 / 120;
 const SPIN_SLIDE_EPS = 0.035;
-const SPIN_KINETIC_FRICTION = 0.26;
-const SPIN_ROLL_DAMPING = 0.14;
-const SPIN_ANGULAR_DAMPING = 0.05;
+const SPIN_KINETIC_FRICTION = 0.32;
+const SPIN_ROLL_DAMPING = 0.2;
+const SPIN_ANGULAR_DAMPING = 0.07;
 const SPIN_GRAVITY = 9.81;
 const BALL_BALL_FRICTION = 0.18;
 const RAIL_FRICTION = 0.19;


### PR DESCRIPTION
### Motivation
- Reduce the unrealistic "skating" feel of balls and cap extreme cue-tip spins while preserving the existing spin controller mapping and UX.
- Make airborne spin decay faster so balls lose air spin sooner and resume natural rolling behavior on contact.

### Description
- Tuned physics constants in `webapp/src/pages/Games/PoolRoyale.jsx` to reduce exaggerated spin and increase damping by changing `PHYSICS_PROFILE.airSpinDecay` from `0.6` to `4.0` and `PHYSICS_PROFILE.maxTipOffsetRatio` from `0.65` to `0.5`.
- Reduced cloth/sliding persistence by updating `FRICTION` from `0.991` to `0.987` to help balls slow more naturally.
- Increased spin-related damping and kinetic friction by updating `SPIN_KINETIC_FRICTION` `0.26 -> 0.32`, `SPIN_ROLL_DAMPING` `0.14 -> 0.2`, and `SPIN_ANGULAR_DAMPING` `0.05 -> 0.07` to reduce sliding/rolling artifacts.
- No input/controller changes were made so spin input and visual controls remain unchanged while the simulation response is softened.

### Testing
- No automated tests were executed for this change; the edit is limited to physics constants and has been committed to the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698034a06cb88329a72c74710ccf39b4)