### PR TITLE
Restore Polyhaven cloth pattern mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3049,7 +3049,7 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = 0.62; // emphasize Poly Haven cloth patterns for clearer weave detail
+const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 7;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
@@ -3058,9 +3058,7 @@ const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(1.7, 1.7);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
-const CLOTH_PATTERN_OVERRIDES = Object.freeze({
-  polar_fleece: { repeatScale: 0.94 } // 10% larger pattern to emphasize the fleece nap
-});
+const CLOTH_PATTERN_OVERRIDES = Object.freeze({});
 
 const CLOTH_TEXTURE_KEYS_BY_SOURCE = CLOTH_LIBRARY.reduce((acc, cloth) => {
   if (!cloth?.sourceId) return acc;
@@ -7117,7 +7115,9 @@ export function Table3D(
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 12; // base density before global scaling adjustments
-  const clothPatternUpscale = (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
+  const clothPatternUpscale = isPolyHavenCloth
+    ? 1
+    : (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
   const patternOverride =
     clothMapSource === 'polyhaven'
       ? null

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -3053,7 +3053,7 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.76; // tighten the pattern footprint so the scan resolves more clearly
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = (1 / 3) / 1.2;
+const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 4.4;
 const POLYHAVEN_TEXTURE_RESOLUTION = '4k';
 const CLOTH_NORMAL_SCALE = new THREE.Vector2(1.9, 0.9);
@@ -3061,10 +3061,7 @@ const POLYHAVEN_NORMAL_SCALE = new THREE.Vector2(3.05, 1.7);
 const CLOTH_ROUGHNESS_BASE = 0.82;
 const CLOTH_ROUGHNESS_TARGET = 0.78;
 const CLOTH_BRIGHTNESS_LERP = 0.05;
-const CLOTH_PATTERN_OVERRIDES = Object.freeze({
-  polar_fleece: { repeatScale: 0.94 }, // 10% larger pattern to emphasize the fleece nap
-  terry_cloth: { repeatScale: 3 } // counter Polyhaven repeat scale so terry cloth matches the standard thread density
-});
+const CLOTH_PATTERN_OVERRIDES = Object.freeze({});
 
 const CLOTH_TEXTURE_KEYS_BY_SOURCE = CLOTH_LIBRARY.reduce((acc, cloth) => {
   if (!cloth?.sourceId) return acc;
@@ -7010,7 +7007,9 @@ function Table3D(
   const ballDiameter = BALL_R * 2;
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 12; // base density before global scaling adjustments
-  const clothPatternUpscale = (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
+  const clothPatternUpscale = isPolyHavenCloth
+    ? 1
+    : (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
   const patternOverride = resolveClothPatternOverride(clothTextureKey);
   const clothTextureScale =
     0.032 * 1.35 * 1.56 * 1.12 * clothPatternUpscale; // stretch the weave while keeping the cloth visibly taut


### PR DESCRIPTION
### Motivation
- Preserve the original texture mapping and visible pattern detail for Polyhaven-sourced cloths so store items show their authentic Polyhaven appearance.
- Remove previously-applied Polyhaven-specific repeat scaling and per-texture overrides that distorted the source patterns.
- Ensure consistent cloth pattern handling across Pool and Snooker tables so Polyhaven assets are not upscaled or altered by procedural heuristics.

### Description
- Set `POLYHAVEN_PATTERN_REPEAT_SCALE` to `1` in `SnookerRoyal.jsx` and `PoolRoyale.jsx` to avoid modifying Polyhaven texture repeat by default.
- Clear `CLOTH_PATTERN_OVERRIDES` to an empty object so no built-in overrides (e.g. `terry_cloth`) alter Polyhaven mappings.
- Skip the non-Polyhaven procedural pattern upscaling by making `clothPatternUpscale` conditional: `isPolyHavenCloth ? 1 : <previous-upscale-formula>` in both `SnookerRoyal.jsx` and `PoolRoyale.jsx`.
- Files changed: `webapp/src/pages/Games/SnookerRoyal.jsx` and `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- No automated tests were executed for this change in this rollout.
- Code modifications were verified by static inspection and repository commit (`Restore polyhaven cloth texture mapping`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803b57151c8329ba83b8e94ecb23ac)