### PR TITLE
Match Snooker roll behavior and increase Pool Royale shot power by 33%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1274,7 +1274,7 @@ const PHYSICS_PROFILE = Object.freeze({
   maxTipOffsetRatio: 0.5
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.987;
+const FRICTION = 0.993;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1544,8 +1544,9 @@ const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to ke
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligned with the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
 // Apply a +50% boost to the current baseline so Pool Royale shots travel farther with the same slider input.
+// Increase overall shot strength by an additional 33% for a stronger feel.
 const SHOT_POWER_REDUCTION = 1.05;
-const SHOT_POWER_BOOST = 1.5;
+const SHOT_POWER_BOOST = 1.5 * 1.33;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Align Pool Royale ball rolling behavior with the Snooker Royal build so balls move and roll consistently across modes.
- Give Pool Royale a stronger feel by increasing shot power to better match requested gameplay pacing.

### Description
- Increased the cloth friction constant from `0.987` to `0.993` in `webapp/src/pages/Games/PoolRoyale.jsx` to match Snooker Royal roll behavior.
- Increased the shot power baseline by multiplying `SHOT_POWER_BOOST` by `1.33` (effective +33%) and added an explanatory comment next to the change in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Kept existing spin and related physics constants unchanged so spin behavior remains consistent with current tuning.

### Testing
- No automated tests were run for this change.
- Changes were committed to the branch and prepared as a PR (file modified: `webapp/src/pages/Games/PoolRoyale.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980424e6dbc83299bde6642f033492f)