### PR TITLE
Increase snooker table scale for larger playfield and balls

### DIFF
--- a/webapp/src/config/snookerClubTables.js
+++ b/webapp/src/config/snookerClubTables.js
@@ -1,6 +1,6 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
+const BASE_TABLE_SCALE = 1.58;
+const BASE_TABLE_MOBILE_SCALE = 1.66;
+const BASE_TABLE_COMPACT_SCALE = 1.5;
 const BASE_PLAYFIELD_WIDTH_MM = 3569; // official 12ft snooker playfield width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
@@ -17,9 +17,9 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     sideCushionCutAngleDeg: 45,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
-      scale: 1.56,
-      mobileScale: 1.68,
-      compactScale: 1.48
+      scale: 1.68,
+      mobileScale: 1.82,
+      compactScale: 1.6
     })
   },
   '10ft': {

--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,6 +1,6 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
+const BASE_TABLE_SCALE = 1.58;
+const BASE_TABLE_MOBILE_SCALE = 1.66;
+const BASE_TABLE_COMPACT_SCALE = 1.5;
 const BASE_PLAYFIELD_WIDTH_MM = 3569; // official 12ft snooker playfield width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
@@ -17,9 +17,9 @@ const TABLE_PHYSICAL_SPECS = Object.freeze({
     sideCushionCutAngleDeg: 27,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
-      scale: 1.56,
-      mobileScale: 1.68,
-      compactScale: 1.48
+      scale: 1.68,
+      mobileScale: 1.82,
+      compactScale: 1.6
     })
   },
   '10ft': {


### PR DESCRIPTION
### Motivation
- Visuals for Snooker Royal need to match the pool Royal ball radius by enlarging the table and ball rendering while preserving the existing layout and proportions. 
- Keep Snooker Club sizing consistent with Snooker Royal so both snooker variants present the same enlarged visuals.

### Description
- Increased base scale constants in `webapp/src/config/snookerRoyalTables.js` from `1.46/1.52/1.36` to `1.58/1.66/1.5`. 
- Applied the same base scale changes to `webapp/src/config/snookerClubTables.js` for consistency. 
- Updated `scaleOverrides` for the 12ft spec to `scale: 1.68`, `mobileScale: 1.82`, and `compactScale: 1.6` to produce a larger rendered playfield and ball sizes.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, indicating configuration loads without syntax errors. 
- Attempted automated visual verification using Playwright to capture a screenshot, but the headless Chromium/WebKit runs timed out or crashed in the container, so no screenshot could be produced. 
- No unit test suite was run as this is a configuration/tuning change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698042d5084883298732b2a72907704a)