### PR TITLE
Match Pool Royale rolling/power to Snooker Royal and increase shot power by 33%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1274,7 +1274,7 @@ const PHYSICS_PROFILE = Object.freeze({
   maxTipOffsetRatio: 0.5
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.987;
+const FRICTION = 0.993;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1542,10 +1542,10 @@ const RAIL_SPIN_THROW_SCALE = BALL_R * 0.36; // let cushion contacts inherit not
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // invert spin along the impact normal to keep the cue ball rolling after rebounds
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligned with the aim line
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
-// Apply a +50% boost to the current baseline so Pool Royale shots travel farther with the same slider input.
-const SHOT_POWER_REDUCTION = 1.05;
-const SHOT_POWER_BOOST = 1.5;
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while matching Snooker Royal pacing.
+// Increase overall Pool Royale power by 33% on top of the Snooker Royal baseline.
+const SHOT_POWER_REDUCTION = 0.425;
+const SHOT_POWER_BOOST = 1.995;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Make Pool Royale ball motion and shot feel consistent with the Snooker Royal physics while increasing overall shot strength per request.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` set `FRICTION` to `0.993` to match the Snooker Royal rolling pace and preserve existing spin tuning.
- Retune shot power constants by changing `SHOT_POWER_REDUCTION` to `0.425` and `SHOT_POWER_BOOST` to `1.995` and update the inline comment to reflect the new Snooker baseline +33% power intent.

### Testing
- No automated tests were run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980424e6dbc83299bde6642f033492f)