### PR TITLE
Increase Snooker Royal table & ball scale to better match Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -962,13 +962,13 @@ function addPocketCuts(
 // --------------------------------------------------
 // separate scales for table and balls
 // Dimensions tuned for the Pool Royale footprint for identical table sizing and layout.
-const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
-const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
-const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while keeping the table height unchanged
-const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
-const SIZE_REDUCTION = 0.7;
+const TABLE_SIZE_SHRINK = 0.9; // tighten the table footprint slightly while keeping the layout aligned
+const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the lighter shrink so the arena stays compact without distorting proportions
+const TABLE_FOOTPRINT_SCALE = 0.88; // reduce the table footprint ~12% while keeping the table height unchanged
+const BASE_FOOTPRINT_SHRINK = 0.88; // shrink the table base footprint by 12% without changing overall height
+const SIZE_REDUCTION = 0.78; // enlarge the playfield/balls to better match Pool Royale sizing
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 1.06; // shrink the table footprint slightly less so the playfield reads larger
+const TABLE_DISPLAY_SCALE = 1.06; // keep the playfield slightly enlarged without altering layout proportions
 const CAMERA_DISPLAY_SCALE = 0.712; // pull cameras closer to match Pool Royale ball size on the larger snooker table
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal playfield and balls slightly larger while preserving the existing table layout so the ball radius reads like the Pool Royale mode.

### Description
- Adjusted snooker sizing constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to increase table and ball scale while keeping proportions intact.
- Changed `TABLE_SIZE_SHRINK` from `0.85` to `0.9`, `TABLE_FOOTPRINT_SCALE` and `BASE_FOOTPRINT_SHRINK` from `0.82` to `0.88`, and `SIZE_REDUCTION` from `0.7` to `0.78` so the playfield and balls render larger but maintain layout alignment.
- Kept `TABLE_DISPLAY_SCALE` and camera/clipping settings unchanged to preserve visual composition and gameplay behavior.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev` and Vite reported as ready, indicating the change loads in the dev environment.
- Attempted an automated visual validation using Playwright to capture a screenshot, but the screenshot run timed out and did not complete.
- No unit tests or CI builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698042d5084883298732b2a72907704a)