### PR TITLE
Adjust cue-ball spin response on cushions and add spin deadzone

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -384,6 +384,7 @@ public class BilliardsSolver
                     bool hit = false;
                     bool pocket = false;
                     Vec2 contactPoint = new Vec2();
+                    bool cushionResponse = false;
 
                     bool allowPocketing = !airborne;
                     foreach (var e in CushionEdges)
@@ -395,6 +396,7 @@ public class BilliardsSolver
                             restitution = PhysicsConstants.CushionRestitution;
                             hit = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
+                            cushionResponse = true;
                         }
                     }
 
@@ -407,6 +409,7 @@ public class BilliardsSolver
                             restitution = PhysicsConstants.ConnectorRestitution;
                             hit = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
+                            cushionResponse = true;
                         }
                     }
 
@@ -420,6 +423,7 @@ public class BilliardsSolver
                             hit = true;
                             pocket = allowPocketing;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
+                            cushionResponse = !pocket;
                         }
                     }
 
@@ -451,12 +455,17 @@ public class BilliardsSolver
                         var speed = b.Velocity.Length;
                         var newSpeed = Math.Max(0, speed - LinearDrag(airborne) * travel);
                         b.Velocity = newSpeed > 0 ? b.Velocity.Normalized() * newSpeed : new Vec2(0, 0);
+                        var preImpactVelocity = b.Velocity;
                         if (pocket)
                         {
                             b.Pocketed = true;
                             break;
                         }
                         b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        if (cushionResponse && !airborne)
+                        {
+                            ApplyCushionSpinResponse(b, normal, preImpactVelocity);
+                        }
                         b.Position = contactPoint + normal * (PhysicsConstants.BallRadius + PhysicsConstants.ContactOffset);
                         remaining = Math.Max(0, remaining - travel);
                         StepVertical(b, travel);
@@ -590,6 +599,9 @@ public class BilliardsSolver
         double side = Math.Clamp(spin.Side, -PhysicsConstants.MaxTipOffsetRatio, PhysicsConstants.MaxTipOffsetRatio);
         double top = Math.Clamp(spin.Top, 0, PhysicsConstants.MaxTipOffsetRatio);
         double back = Math.Clamp(spin.Back, 0, PhysicsConstants.MaxTipOffsetRatio);
+        double deadzone = PhysicsConstants.SpinDeadzoneRatio * PhysicsConstants.MaxTipOffsetRatio;
+        if (Math.Abs(side) < deadzone)
+            side = 0;
         double magnitude = Math.Max(Math.Abs(side), Math.Abs(top - back));
         if (magnitude > PhysicsConstants.MaxTipOffsetRatio && magnitude > PhysicsConstants.Epsilon)
         {
@@ -636,6 +648,23 @@ public class BilliardsSolver
             b.SideSpin *= decay;
             b.ForwardSpin *= decay;
         }
+    }
+
+    private static void ApplyCushionSpinResponse(Ball b, Vec2 normal, Vec2 incomingVelocity)
+    {
+        if (incomingVelocity.Length < PhysicsConstants.Epsilon)
+            return;
+
+        var tangent = new Vec2(-normal.Y, normal.X);
+        double tangentialSpeed = Vec2.Dot(incomingVelocity, tangent);
+        double tangentialFactor = Math.Clamp(Math.Abs(tangentialSpeed) / incomingVelocity.Length, 0.0, 1.0);
+        double retention = PhysicsConstants.CushionSpinRetention * (0.5 + 0.5 * tangentialFactor);
+        b.SideSpin = -b.SideSpin * retention;
+        b.ForwardSpin *= PhysicsConstants.CushionForwardSpinRetention;
+
+        double deadzone = PhysicsConstants.SpinDeadzoneRatio * PhysicsConstants.MaxTipOffsetRatio;
+        if (Math.Abs(b.SideSpin) < deadzone)
+            b.SideSpin = 0;
     }
 
     private static void IntegrateCueBall(Ball b, double dt, bool airborne)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -15,6 +15,7 @@ public static class PhysicsConstants
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
     public const double SpinDecay = 2.0;               // per-second decay for on-table spin
     public const double AirSpinDecay = 0.6;            // per-second decay while airborne
+    public const double SpinDeadzoneRatio = 0.03;      // fraction of max tip offset to ignore tiny spin
     public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
     public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
@@ -31,6 +32,8 @@ public static class PhysicsConstants
     public const double SwerveSpeedFadeRange = 4.0;    // fade distance for swerve cutoff
     public const double MaxCueElevationDegrees = 85.0; // clamp to UI upper bound
     public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
+    public const double CushionSpinRetention = 0.65;   // portion of side spin retained after cushion hit
+    public const double CushionForwardSpinRetention = 0.7; // portion of top/back spin retained after cushion hit
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
     public const double TableHeight = 1.07707;


### PR DESCRIPTION
### Motivation
- Fix unrealistic cue-ball behaviour where spin remained as "air spin" after contacting cushions and produced unnatural trajectories off rails.
- Prevent extreme tip inputs at the controller edges from producing unintended swerve toward pockets by ignoring very small side-spin values.

### Description
- Added tunable constants `SpinDeadzoneRatio`, `CushionSpinRetention`, and `CushionForwardSpinRetention` in `billiards/PhysicsConstants.cs` to control deadzone and spin retention on rail impacts. 
- Implemented a side-spin deadzone in `ClampSpin` to zero out tiny side spin before simulation in `billiards/BilliardsSolver.cs`.
- Detect cushion/connector/pocket-edge collisions and set a `cushionResponse` flag in the main `Step` loop, capture pre-impact velocity, and call the new `ApplyCushionSpinResponse` after cushion reflections to flip/dampen `SideSpin` and attenuate `ForwardSpin`.
- Kept pocketing logic unchanged and applied a final deadzone test after cushion response to avoid tiny residual swerve.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698051afc2a48329a8028fd1b84435e4)