### PR TITLE
Fix Pool Royale rail spin response and edge spin lock

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6374,7 +6374,6 @@ function applyRailSpinResponse(ball, impact) {
   const normal = impact.normal.clone().normalize();
   const tangent = impact.tangent?.clone() ?? new THREE.Vector2(-normal.y, normal.x);
   const speed = Math.max(ball.vel.length(), 0);
-  const preImpactSpin = ball.spin.clone();
   const worldSpin = resolveSpinWorldVector(ball, TMP_VEC2_LIMIT);
   if (!worldSpin) return;
   const throwFactor = Math.max(
@@ -6386,7 +6385,16 @@ function applyRailSpinResponse(ball, impact) {
     const throwStrength = spinAlongTangent * RAIL_SPIN_THROW_SCALE * (0.35 + throwFactor);
     ball.vel.addScaledVector(tangent, throwStrength);
   }
-  ball.spin.copy(preImpactSpin);
+  const spinAlongNormal = worldSpin.dot(normal);
+  TMP_VEC2_A
+    .copy(tangent)
+    .multiplyScalar(spinAlongTangent)
+    .addScaledVector(normal, -spinAlongNormal * RAIL_SPIN_NORMAL_FLIP);
+  const spinFrame = resolveSpinFrame(ball);
+  ball.spin.set(
+    TMP_VEC2_A.dot(spinFrame.lateral),
+    TMP_VEC2_A.dot(spinFrame.forward)
+  );
   decaySpin(ball, 0.6, false);
 }
 

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,6 +11,8 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
+export const SPIN_EDGE_AXIS_LOCK_MAG = 0.85;
+export const SPIN_EDGE_AXIS_LOCK_RATIO = 0.3;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -144,7 +146,19 @@ export const normalizeSpinInput = (spin) => {
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const edgeMagnitude = Math.hypot(clamped.x, clamped.y);
+  if (edgeMagnitude >= SPIN_EDGE_AXIS_LOCK_MAG) {
+    const absX = Math.abs(clamped.x);
+    const absY = Math.abs(clamped.y);
+    if (absX <= absY * SPIN_EDGE_AXIS_LOCK_RATIO) {
+      return { x: 0, y: clamped.y };
+    }
+    if (absY <= absX * SPIN_EDGE_AXIS_LOCK_RATIO) {
+      return { x: clamped.x, y: 0 };
+    }
+  }
+  return clamped;
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Players observed the cue ball keeping an unrealistic "air spin" after cushion impacts and odd lateral swerve / pocket-edge spin when applying extreme topspin/power. 
- The spin controller also allowed unintended diagonal spin at extreme UI offsets producing surprising behaviour on rebounds and pocket edges.

### Description
- Reproject cushion-contact spin into the rail frame and update the cue-ball spin vector after a rail hit so spin is aligned with the impact tangent/normal before decay, implemented in `applyRailSpinResponse` in `PoolRoyale.jsx`.
- Add an edge-axis locking rule to the spin normalization so extreme inputs snap more cleanly to a primary axis and reduce accidental diagonal spin, implemented with new constants `SPIN_EDGE_AXIS_LOCK_MAG` and `SPIN_EDGE_AXIS_LOCK_RATIO` and logic in `normalizeSpinInput` in `poolRoyaleSpinUtils.js`.
- Modified files: `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698051afc2a48329a8028fd1b84435e4)