### PR TITLE
Increase store price range to 100–5000 TPC, make bulk checkout scrollable, and add missing thumbnails

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -15,7 +15,8 @@ const BASE_CHAIR_OPTIONS = [
     primary: '#8b1538',
     accent: '#5c0f26',
     highlight: '#d35a7a',
-    legColor: '#1f1f1f'
+    legColor: '#1f1f1f',
+    thumbnail: swatchThumbnail(['#8b1538', '#5c0f26', '#d35a7a'])
   },
   {
     id: 'midnightNavy',
@@ -23,7 +24,8 @@ const BASE_CHAIR_OPTIONS = [
     primary: '#153a8b',
     accent: '#0c214f',
     highlight: '#4d74d8',
-    legColor: '#10131c'
+    legColor: '#10131c',
+    thumbnail: swatchThumbnail(['#153a8b', '#0c214f', '#4d74d8'])
   },
   {
     id: 'emeraldWave',
@@ -31,7 +33,8 @@ const BASE_CHAIR_OPTIONS = [
     primary: '#0f6a2f',
     accent: '#063d1b',
     highlight: '#48b26a',
-    legColor: '#142318'
+    legColor: '#142318',
+    thumbnail: swatchThumbnail(['#0f6a2f', '#063d1b', '#48b26a'])
   },
   {
     id: 'onyxShadow',
@@ -39,7 +42,8 @@ const BASE_CHAIR_OPTIONS = [
     primary: '#202020',
     accent: '#101010',
     highlight: '#6f6f6f',
-    legColor: '#080808'
+    legColor: '#080808',
+    thumbnail: swatchThumbnail(['#202020', '#101010', '#6f6f6f'])
   },
   {
     id: 'royalPlum',
@@ -47,7 +51,8 @@ const BASE_CHAIR_OPTIONS = [
     primary: '#3f1f5b',
     accent: '#2c1340',
     highlight: '#7c4ae0',
-    legColor: '#140a24'
+    legColor: '#140a24',
+    thumbnail: swatchThumbnail(['#3f1f5b', '#2c1340', '#7c4ae0'])
   }
 ];
 

--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -71,7 +71,8 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     optionId: theme.id,
     name: theme.label,
     price: theme.price ?? 300 + idx * 20,
-    description: theme.description || `Premium ${theme.label} seating with original finish.`
+    description: theme.description || `Premium ${theme.label} seating with original finish.`,
+    thumbnail: theme.thumbnail
   })),
   ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
     id: `ludo-hdri-${variant.id}`,

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -121,7 +121,8 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     optionId: theme.id,
     name: theme.label,
     price: theme.price ?? 300 + idx * 20,
-    description: theme.description || `Premium ${theme.label} seating with original finish.`
+    description: theme.description || `Premium ${theme.label} seating with original finish.`,
+    thumbnail: theme.thumbnail
   })),
   POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
     id: `hdri-${variant.id}`,

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -54,13 +54,69 @@ export const MURLAN_OUTFIT_THEMES = [
 const POLYHAVEN_THUMB = (id) => `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;
 
 const BASE_STOOL_THEMES = [
-  { id: 'ruby', label: 'Ruby', seatColor: '#8b0000', legColor: '#1f1f1f', price: 0, description: 'Default ruby cushions with noir legs.' },
-  { id: 'slate', label: 'Slate', seatColor: '#374151', legColor: '#0f172a', price: 210, description: 'Slate seats with midnight legs.' },
-  { id: 'teal', label: 'Teal', seatColor: '#0f766e', legColor: '#082f2a', price: 230, description: 'Teal cushions with deep green support.' },
-  { id: 'amber', label: 'Amber', seatColor: '#b45309', legColor: '#2f2410', price: 250, description: 'Amber seats with rich brown legs.' },
-  { id: 'violet', label: 'Violet', seatColor: '#7c3aed', legColor: '#2b1059', price: 270, description: 'Violet cushions with twilight framing.' },
-  { id: 'frost', label: 'Ice', seatColor: '#1f2937', legColor: '#0f172a', price: 290, description: 'Frosted charcoal seats with dark legs.' },
-  { id: 'leather', label: 'Leather', seatColor: '#6a4a32', legColor: '#1a1410', price: 320, description: 'Leather-wrapped seats with dark studio legs.' }
+  {
+    id: 'ruby',
+    label: 'Ruby',
+    seatColor: '#8b0000',
+    legColor: '#1f1f1f',
+    price: 0,
+    description: 'Default ruby cushions with noir legs.',
+    thumbnail: swatchThumbnail(['#8b0000', '#1f1f1f', '#f8fafc'])
+  },
+  {
+    id: 'slate',
+    label: 'Slate',
+    seatColor: '#374151',
+    legColor: '#0f172a',
+    price: 210,
+    description: 'Slate seats with midnight legs.',
+    thumbnail: swatchThumbnail(['#374151', '#0f172a', '#e2e8f0'])
+  },
+  {
+    id: 'teal',
+    label: 'Teal',
+    seatColor: '#0f766e',
+    legColor: '#082f2a',
+    price: 230,
+    description: 'Teal cushions with deep green support.',
+    thumbnail: swatchThumbnail(['#0f766e', '#082f2a', '#5eead4'])
+  },
+  {
+    id: 'amber',
+    label: 'Amber',
+    seatColor: '#b45309',
+    legColor: '#2f2410',
+    price: 250,
+    description: 'Amber seats with rich brown legs.',
+    thumbnail: swatchThumbnail(['#b45309', '#2f2410', '#fde68a'])
+  },
+  {
+    id: 'violet',
+    label: 'Violet',
+    seatColor: '#7c3aed',
+    legColor: '#2b1059',
+    price: 270,
+    description: 'Violet cushions with twilight framing.',
+    thumbnail: swatchThumbnail(['#7c3aed', '#2b1059', '#ddd6fe'])
+  },
+  {
+    id: 'frost',
+    label: 'Ice',
+    seatColor: '#1f2937',
+    legColor: '#0f172a',
+    price: 290,
+    description: 'Frosted charcoal seats with dark legs.',
+    thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#e2e8f0'])
+  },
+  {
+    id: 'leather',
+    label: 'Leather',
+    seatColor: '#6a4a32',
+    legColor: '#1a1410',
+    price: 320,
+    description: 'Leather-wrapped seats with dark studio legs.',
+    thumbnail: swatchThumbnail(['#6a4a32', '#1a1410', '#fcd34d'])
+  }
 ];
 
 const POLYHAVEN_CHAIR_THEMES = [

--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -168,7 +168,8 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price ?? 340 + idx * 30,
-    description: option.description || 'Unlock a premium lounge chair model from Murlan Royale.'
+    description: option.description || 'Unlock a premium lounge chair model from Murlan Royale.',
+    thumbnail: option.thumbnail
   })),
   ...TEXAS_TABLE_THEME_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-table-${option.id}`,

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -225,8 +225,8 @@ const TEXAS_TYPE_LABELS = {
 };
 
 const TON_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TON_PRICE_MIN = 0.1;
-const TON_PRICE_MAX = 5;
+const TON_PRICE_MIN = 100;
+const TON_PRICE_MAX = 5000;
 const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const SNOOKER_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNOOKER_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
@@ -1579,7 +1579,7 @@ export default function Store() {
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-2xl overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+        <div className="w-full max-w-2xl max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">Confirm bulk purchase</p>


### PR DESCRIPTION
### Motivation
- Store prices were clamped to an unrealistically low TPC range and need to start at `100` up to `5000` TPC.
- The bulk/multi-item confirmation modal did not allow scrolling which prevented paying when many items were selected.
- Several stool/chair store items lacked thumbnails and should show thumbnails pulled from the original source or generated swatches so cards render consistently.

### Description
- Raised price clamp constants by changing `TON_PRICE_MIN` to `100` and `TON_PRICE_MAX` to `5000` in `webapp/src/pages/Store.jsx` to scale displayed/priced values.  
- Made the bulk confirm modal scrollable by adding `max-h-[calc(100vh-2rem)] overflow-y-auto` to the modal container in `webapp/src/pages/Store.jsx`.  
- Added `thumbnail` swatch entries to the base stool themes in `webapp/src/config/murlanThemes.js` so default stool options render thumbnails.  
- Added `thumbnail` swatches for base chess chair options in `webapp/src/config/chessBattleInventoryConfig.js` and propagated `thumbnail: theme.thumbnail` / `thumbnail: option.thumbnail` for stool/chair items in `webapp/src/config/ludoBattleInventoryConfig.js`, `webapp/src/config/murlanInventoryConfig.js`, and `webapp/src/config/texasHoldemInventoryConfig.js` so previously missing thumbnails are filled.

### Testing
- Ran a small Node script to enumerate store items missing `thumbnail` before/after the change; previously it reported missing stools/chairs and after changes the script returned no missing thumbnails (success).  
- Started the webapp dev server via Vite (`npm --prefix webapp run dev`) and the server reported ready (Vite started successfully).  
- Attempted an automated Playwright screenshot of `/store` to visually validate the modal and thumbnails but the Playwright run timed out (failure); no screenshot could be captured.  
- No unit test suite (`jest`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69805338a5048329a3618e40bb87d84d)