### PR TITLE
Log store purchases, deliver Snooker unlocks, and make purchase modal scrollable

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -118,6 +118,7 @@ import {
   texasHoldemAccountId
 } from '../utils/texasHoldemInventory.js';
 import { buyBundle, getAccountBalance } from '../utils/api.js';
+import { recordStorePurchase } from '../utils/storeTransactions.js';
 import { DEV_INFO } from '../utils/constants.js';
 
 const TYPE_LABELS = {
@@ -1294,6 +1295,9 @@ export default function Store() {
           if (slug === 'poolroyale') {
             const updated = await addPoolRoyalUnlock(entry.type, entry.optionId, accountId);
             setPoolOwned(updated);
+          } else if (slug === 'snookerroyale') {
+            const updated = await addSnookerRoyalUnlock(entry.type, entry.optionId, accountId);
+            setSnookerOwned(updated);
           } else if (slug === 'airhockey') {
             setAirOwned(addAirHockeyUnlock(entry.type, entry.optionId, accountId));
           } else if (slug === 'chessbattleroyal') {
@@ -1316,8 +1320,23 @@ export default function Store() {
       const groupedCount = groupedEntries.length;
       const successLabel =
         purchasable.length === 1
-          ? `${resolver(purchasable[0])} delivered instantly — now owned in ${storeMeta[purchasable[0].slug]?.name || purchasable[0].slug}.`
-          : `${purchasable.length} cosmetics delivered across ${groupedCount} game${groupedCount === 1 ? '' : 's'}.`;
+          ? `Payment confirmed — ${resolver(purchasable[0])} delivered instantly in ${storeMeta[purchasable[0].slug]?.name || purchasable[0].slug}.`
+          : `Payment confirmed — ${purchasable.length} cosmetics delivered across ${groupedCount} game${groupedCount === 1 ? '' : 's'}.`;
+      const detailLabel =
+        purchasable.length === 1
+          ? `${resolver(purchasable[0])} • ${storeMeta[purchasable[0].slug]?.name || purchasable[0].slug}`
+          : `${purchasable.length} store items across ${groupedCount} game${groupedCount === 1 ? '' : 's'}`;
+      recordStorePurchase(accountId, {
+        totalPrice,
+        detail: detailLabel,
+        items: purchasable.map((item) => ({
+          slug: item.slug,
+          type: item.type,
+          optionId: item.optionId,
+          label: resolver(item),
+          price: item.price
+        }))
+      });
       const purchasedKeys = new Set(purchasable.map((item) => selectionKey(item)));
       setSelectedKeys((prev) => prev.filter((key) => !purchasedKeys.has(key)));
       setPurchaseStatus(successLabel);
@@ -1491,7 +1510,7 @@ export default function Store() {
     const gameName = storeMeta[confirmItem.slug]?.name || confirmItem.slug;
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-lg overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+        <div className="w-full max-w-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">Confirm purchase</p>

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -18,6 +18,7 @@ import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { loadGoogleProfile } from '../utils/google.js';
 import LoginOptions from '../components/LoginOptions.jsx';
+import { mergeStoreTransactions } from '../utils/storeTransactions.js';
 
 const urlParams = new URLSearchParams(window.location.search);
 const DEV_ACCOUNT_ID =
@@ -102,6 +103,15 @@ export default function Wallet({ hideClaim = false }) {
     )
   ).filter(Boolean);
 
+  const refreshTransactions = async (id) => {
+    if (!id) return;
+    const txRes = await getAccountTransactions(id);
+    const list = txRes.transactions || [];
+    const merged = mergeStoreTransactions(list, id);
+    setTransactions(merged);
+    return list;
+  };
+
 
   const loadBalances = async () => {
     const devMode = urlParams.get('dev') || localStorage.getItem('devAccountId');
@@ -138,14 +148,12 @@ export default function Wallet({ hideClaim = false }) {
     if (requiresAuth) return;
     loadBalances().then(async (id) => {
       if (id) {
-        const txRes = await getAccountTransactions(id);
-        const list = txRes.transactions || [];
-        setTransactions(list);
+        const list = await refreshTransactions(id);
         if (DEV_ACCOUNTS.includes(id)) {
-          const gameSum = list
+          const gameSum = (list || [])
             .filter((t) => t.type === 'deposit' && t.game)
             .reduce((s, t) => s + (t.amount || 0), 0);
-          const feeSum = list
+          const feeSum = (list || [])
             .filter((t) => t.type === 'fee')
             .reduce((s, t) => s + (t.amount || 0), 0);
           setDevShare(gameSum);
@@ -198,14 +206,12 @@ export default function Wallet({ hideClaim = false }) {
       setAmount('');
       setNote('');
       const id = await loadBalances();
-      const txRes = await getAccountTransactions(id || accountId);
-      const list = txRes.transactions || [];
-      setTransactions(list);
+      const list = await refreshTransactions(id || accountId);
       if (DEV_ACCOUNTS.includes(id || accountId)) {
-        const gameSum = list
+        const gameSum = (list || [])
           .filter((t) => t.type === 'deposit' && t.game)
           .reduce((s, t) => s + (t.amount || 0), 0);
-        const feeSum = list
+        const feeSum = (list || [])
           .filter((t) => t.type === 'fee')
           .reduce((s, t) => s + (t.amount || 0), 0);
         setDevShare(gameSum);
@@ -231,14 +237,12 @@ export default function Wallet({ hideClaim = false }) {
       }
       setTopupAmount('');
       const id = await loadBalances();
-      const txRes = await getAccountTransactions(id || accountId);
-      const list = txRes.transactions || [];
-      setTransactions(list);
+      const list = await refreshTransactions(id || accountId);
       if (DEV_ACCOUNTS.includes(id || accountId)) {
-        const gameSum = list
+        const gameSum = (list || [])
           .filter((t) => t.type === 'deposit' && t.game)
           .reduce((s, t) => s + (t.amount || 0), 0);
-        const feeSum = list
+        const feeSum = (list || [])
           .filter((t) => t.type === 'fee')
           .reduce((s, t) => s + (t.amount || 0), 0);
         setDevShare(gameSum);

--- a/webapp/src/utils/storeTransactions.js
+++ b/webapp/src/utils/storeTransactions.js
@@ -1,0 +1,82 @@
+const STORAGE_KEY = 'storeTransactionsByAccount';
+const MAX_ENTRIES = 200;
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllTransactions = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read store transactions', err);
+    return {};
+  }
+};
+
+const writeAllTransactions = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeDateKey = (value) => {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return '';
+  return date.toISOString().slice(0, 16);
+};
+
+const buildTransactionKey = (tx) =>
+  `${tx.type}|${tx.amount}|${tx.detail || ''}|${normalizeDateKey(tx.date)}`;
+
+export const readStoreTransactions = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  if (resolvedAccountId === 'guest') return [];
+  const all = readAllTransactions();
+  return Array.isArray(all[resolvedAccountId]) ? all[resolvedAccountId] : [];
+};
+
+export const recordStorePurchase = (accountId, payload = {}) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  if (resolvedAccountId === 'guest') return null;
+  const { totalPrice = 0, detail = 'Store purchase', items = [], status = 'delivered' } = payload;
+  const now = new Date();
+  const tx = {
+    id: `store-${now.getTime()}-${Math.random().toString(16).slice(2, 8)}`,
+    type: 'store',
+    amount: -Math.abs(Number(totalPrice) || 0),
+    date: now.toISOString(),
+    status,
+    token: 'TPC',
+    detail,
+    items
+  };
+  const all = readAllTransactions();
+  const existing = Array.isArray(all[resolvedAccountId]) ? all[resolvedAccountId] : [];
+  const next = [tx, ...existing].slice(0, MAX_ENTRIES);
+  writeAllTransactions({
+    ...all,
+    [resolvedAccountId]: next
+  });
+  return tx;
+};
+
+export const mergeStoreTransactions = (transactions = [], accountId) => {
+  const storeTxs = readStoreTransactions(accountId);
+  if (!storeTxs.length) return transactions;
+  const existingKeys = new Set(transactions.map(buildTransactionKey));
+  const merged = [...transactions];
+  storeTxs.forEach((tx) => {
+    const key = buildTransactionKey(tx);
+    if (!existingKeys.has(key)) {
+      merged.push(tx);
+    }
+  });
+  return merged;
+};


### PR DESCRIPTION
### Motivation
- Users reported bought cosmetics appear as owned but do not show in their transaction history or game-specific inventories, and single-item purchase UI could hide the Pay button on small/portrait screens.

### Description
- Add a lightweight local statement recorder with `recordStorePurchase` and `mergeStoreTransactions` in `webapp/src/utils/storeTransactions.js` to persist and merge store purchases into wallet statements.
- Wire store fulfillment to record receipts and unlock items: `Store.jsx` now records purchases via `recordStorePurchase`, delivers Snooker Royale unlocks (`addSnookerRoyalUnlock`) and updates confirmation copy to indicate payment confirmation and delivery; single-item confirm modal made scrollable (`max-h` + `overflow-y-auto`) so the Pay button is reachable on small screens.
- Merge recorded store transactions into the wallet UI by using `mergeStoreTransactions` and a new `refreshTransactions` helper in `Wallet.jsx` so the transactions list shows store purchases after buys, sends, and top-ups.

### Testing
- Started the dev server (`vite`) and loaded the Store page in a mobile-sized viewport to validate UI changes; the server started successfully and the page was reachable.
- Ran a Playwright script to capture a portrait screenshot of the Store confirmation modal to verify the modal becomes scrollable and the Pay button is visible; screenshot run succeeded and produced an artifact.
- No unit test suite was executed as part of this change (no automated unit tests modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698058f64f148329bd24ce5407721373)