### PR TITLE
Handle storefront item bundle purchases in store route

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import authenticate from '../middleware/auth.js';
 import User from '../models/User.js';
-import { ensureTransactionArray } from '../utils/userUtils.js';
+import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { withProxy } from '../utils/proxyAgent.js';
 import TonWeb from 'tonweb';
 
@@ -60,11 +60,51 @@ router.post('/purchase', authenticate, async (req, res) => {
   if (!accountId) {
     return res.status(400).json({ error: 'accountId required' });
   }
-  let pack = BUNDLES[bundle];
+  const isItemBundle =
+    bundle &&
+    typeof bundle === 'object' &&
+    !Array.isArray(bundle) &&
+    Array.isArray(bundle.items);
+  let pack = !isItemBundle ? BUNDLES[bundle] : null;
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
   if (authId && user.telegramId && authId !== user.telegramId) {
     return res.status(403).json({ error: 'forbidden' });
+  }
+
+  if (isItemBundle) {
+    const rawItems = bundle.items.filter(Boolean);
+    if (!rawItems.length) {
+      return res.status(400).json({ error: 'items required' });
+    }
+    const items = rawItems.map((item) => ({
+      slug: item.slug,
+      type: item.type,
+      optionId: item.optionId,
+      price: Number(item.price) || 0
+    }));
+    const totalPrice = items.reduce((sum, item) => sum + (Number(item.price) || 0), 0);
+    if (!Number.isFinite(totalPrice) || totalPrice <= 0) {
+      return res.status(400).json({ error: 'invalid bundle total' });
+    }
+    ensureTransactionArray(user);
+    const balance = calculateBalance(user);
+    if (balance < totalPrice) {
+      return res.status(400).json({ error: 'insufficient balance' });
+    }
+    const txDate = new Date();
+    user.transactions.push({
+      amount: -totalPrice,
+      type: 'storefront',
+      token: 'TPC',
+      status: 'delivered',
+      date: txDate,
+      detail: 'Storefront purchase',
+      items
+    });
+    user.balance = balance - totalPrice;
+    await user.save();
+    return res.json({ balance: user.balance, date: txDate });
   }
 
   if (txHash) {


### PR DESCRIPTION
### Motivation
- The store purchase endpoint rejected requests that supplied a storefront `bundle` object of items with an "bundle required" error, preventing in-app storefront checkouts that debit the user's off-chain TPC balance. 

### Description
- Detects a storefront item bundle when the request `bundle` is an object containing an `items` array and treats it separately from predefined `BUNDLES`. 
- Validates `items`, computes `totalPrice`, and returns `400` for empty items, invalid totals, or insufficient balance. 
- Debits the user by creating a transaction entry with `type: 'storefront'` and the item list, updates `user.balance` and saves the user, then responds with the new balance and date. 
- Adds `calculateBalance` import from `userUtils` and keeps the existing `txHash` / bundle-by-key flow intact for on-chain bundle purchases. 

### Testing
- No automated tests were run for this change. 
- The change is limited to `bot/routes/store.js` and returns clear `400` error responses for invalid storefront bundles, and `200` with `{ balance, date }` on successful storefront purchases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698076fbda008329afaaa58f3f341c5e)