### PR TITLE
Fix store multi-select buy button visibility

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1141,6 +1141,8 @@ export default function Store() {
     () => new Set(selectedPurchasable.map((item) => item.slug)).size,
     [selectedPurchasable]
   );
+  const hasSelection = selectedKeys.length > 0;
+  const hasPurchasableSelection = selectedPurchasable.length > 0;
 
   useEffect(() => {
     if (!selectedPurchasable.length) {
@@ -1406,7 +1408,7 @@ export default function Store() {
   const featuredCount = allMarketplaceItems.length;
   const ownedCount = allMarketplaceItems.filter((item) => item.owned).length;
   const walletLabel = accountId && accountId !== 'guest' ? 'Account linked' : 'Guest mode';
-  const mainPaddingClass = selectedPurchasable.length
+  const mainPaddingClass = hasSelection
     ? 'pb-[calc(10rem+env(safe-area-inset-bottom))]'
     : 'pb-24';
 
@@ -2400,9 +2402,11 @@ export default function Store() {
                     Multi-select checkout
                   </span>
                   <span className="font-semibold text-white">
-                    {selectedPurchasable.length
+                    {hasPurchasableSelection
                       ? `${selectedPurchasable.length} item${selectedPurchasable.length === 1 ? '' : 's'} • ${selectedGameCount || 0} game${selectedGameCount === 1 ? '' : 's'}`
-                      : 'Select items to bundle a purchase'}
+                      : hasSelection
+                        ? 'Selected items are already owned.'
+                        : 'Select items to bundle a purchase'}
                   </span>
                   {selectedOwnedCount > 0 ? (
                     <span className="text-xs text-amber-200">
@@ -2426,7 +2430,7 @@ export default function Store() {
                       setConfirmItems(selectedPurchasable);
                     }}
                     className="rounded-2xl bg-white px-3 py-2 text-xs font-semibold text-zinc-950 hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
-                    disabled={!selectedPurchasable.length || Boolean(processing)}
+                    disabled={!hasPurchasableSelection || Boolean(processing)}
                   >
                     Buy selected ({selectedTotalPrice.toLocaleString()} TPC)
                   </button>
@@ -2582,14 +2586,16 @@ export default function Store() {
         </div>
       </main>
 
-      {selectedPurchasable.length ? (
+      {hasSelection ? (
         <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-zinc-950/90 px-4 py-3 backdrop-blur md:hidden">
           <div className="mx-auto flex w-full max-w-6xl flex-col gap-2">
             <div className="flex items-center justify-between text-xs text-white/70">
               <span>
-                {selectedPurchasable.length} item{selectedPurchasable.length === 1 ? '' : 's'} • {selectedTotalPrice.toLocaleString()} TPC
+                {hasPurchasableSelection
+                  ? `${selectedPurchasable.length} item${selectedPurchasable.length === 1 ? '' : 's'} • ${selectedTotalPrice.toLocaleString()} TPC`
+                  : 'No purchasable items in your selection.'}
               </span>
-              {selectedGameCount ? (
+              {selectedGameCount && hasPurchasableSelection ? (
                 <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5">
                   {selectedGameCount} game{selectedGameCount === 1 ? '' : 's'}
                 </span>
@@ -2610,7 +2616,7 @@ export default function Store() {
                   setConfirmItems(selectedPurchasable);
                 }}
                 className="flex-[2] rounded-2xl bg-white px-3 py-2 text-xs font-semibold text-zinc-950"
-                disabled={!selectedPurchasable.length || Boolean(processing)}
+                disabled={!hasPurchasableSelection || Boolean(processing)}
               >
                 Buy now ({selectedTotalPrice.toLocaleString()} TPC)
               </button>


### PR DESCRIPTION
### Motivation
- The mobile checkout bar and buy CTA were hidden when the user multi-selected items that were already owned, making it unclear why a purchase couldn't proceed; the UI should stay visible and explain the state.

### Description
- Added `hasSelection` and `hasPurchasableSelection` flags and used them to drive UI state in `webapp/src/pages/Store.jsx`.
- Show the mobile checkout bar whenever any selection exists and use `hasPurchasableSelection` to enable/disable buy actions and compute totals.
- Update copy to show a clear message when the selection contains only owned items and keep `Buy` disabled in that case.
- Adjust bottom padding (`mainPaddingClass`) to account for any active selection so the checkout bar does not overlap content.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and validated the Store page UI by capturing a screenshot with a Playwright script, which completed successfully and produced `artifacts/store-multi-select.png`.
- No unit tests were executed for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698087106b0483298820d96f14c98e25)