### PR TITLE
Reduce Pool Royale spin edge strength

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1683,7 +1683,7 @@ const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
-const SPIN_UI_MAX_OFFSET = 0.82;
+const SPIN_UI_MAX_OFFSET = 0.75;
 // angle for cushion cuts guiding balls into corner pockets
 const DEFAULT_CUSHION_CUT_ANGLE = 32;
 // match the corner-cushion cut angle on both sides of the corner pockets

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,6 +1,6 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 1;
+export const MAX_SPIN_OFFSET = 0.75;
 export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
@@ -11,7 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
-export const SPIN_EDGE_AXIS_LOCK_MAG = 0.85;
+export const SPIN_EDGE_AXIS_LOCK_MAG = 0.7;
 export const SPIN_EDGE_AXIS_LOCK_RATIO = 0.3;
 
 export const SPIN_DIRECTIONS = [


### PR DESCRIPTION
### Motivation
- Reduce extreme spin input at the UI edge to prevent odd cue-ball behaviour and soften edge-case spin effects.

### Description
- Lowered the spin controller maximum input range by changing `MAX_SPIN_OFFSET` from `1` to `0.75` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Reduced the axis-lock threshold by changing `SPIN_EDGE_AXIS_LOCK_MAG` from `0.85` to `0.7` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to match the new range.
- Updated the UI clamp `SPIN_UI_MAX_OFFSET` from `0.82` to `0.75` in `webapp/src/pages/Games/PoolRoyale.jsx` so the playable controller matches the new limits.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980889a314c8329906b91380410bbad)