### PR TITLE
Adjust store confirmation modal positioning

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1416,7 +1416,7 @@ export default function Store() {
     if (!showListModal) return null;
     const selectedItem = ownedMarketplaceItems.find((item) => item.id === listForm.itemId);
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+      <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-6 pb-24 sm:items-center sm:pt-0 sm:pb-0">
         <div className="flex w-full max-w-xl max-h-[90vh] flex-col overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
@@ -1553,7 +1553,7 @@ export default function Store() {
     if (!confirmItem) return null;
     const gameName = storeMeta[confirmItem.slug]?.name || confirmItem.slug;
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+      <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-6 pb-24 sm:items-center sm:pt-0 sm:pb-0">
         <div className="w-full max-w-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
@@ -1641,7 +1641,7 @@ export default function Store() {
       .join(' • ');
 
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+      <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-6 pb-24 sm:items-center sm:pt-0 sm:pb-0">
         <div className="w-full max-w-2xl max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>


### PR DESCRIPTION
### Motivation
- On small (portrait) screens the purchase confirmation frame sat too low and action buttons could be off-screen, so the modal needs to be shifted upward to keep the confirm/cancel controls visible.

### Description
- Updated modal wrapper classes in `webapp/src/pages/Store.jsx` to use `flex items-start justify-center` and added `pt-6 pb-24 sm:items-center sm:pt-0 sm:pb-0` so modals are pushed up on small screens while preserving centered layout on larger viewports.
- Applied the same positioning change to the list modal, single-item confirm modal, and bulk confirm modal so all store dialogs behave consistently.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and the server reported Vite ready (local and network URLs) indicating the app served successfully. 
- Ran a Playwright script (viewport 412x915) to capture a screenshot of `/store`; the first attempt timed out but a retry completed and produced `artifacts/store-confirm-modal.png`. 
- No unit tests were changed or required for this UI-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69808a5ae42083298e4f4d0c0386ab1d)