### PR TITLE
Adjust store confirmation modal position

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1553,8 +1553,8 @@ export default function Store() {
     if (!confirmItem) return null;
     const gameName = storeMeta[confirmItem.slug]?.name || confirmItem.slug;
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+      <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pb-4 pt-8 sm:pt-12">
+        <div className="w-full max-w-lg max-h-[calc(100vh-6rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">Confirm purchase</p>
@@ -1641,8 +1641,8 @@ export default function Store() {
       .join(' • ');
 
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
-        <div className="w-full max-w-2xl max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
+      <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pb-4 pt-8 sm:pt-12">
+        <div className="w-full max-w-2xl max-h-[calc(100vh-6rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">Confirm bulk purchase</p>


### PR DESCRIPTION
### Motivation
- Keep the single-item and bulk purchase confirmation modals higher on small (portrait) screens so the action buttons remain visible and usable.

### Description
- Move modal containers from `flex items-center justify-center` to `flex items-start justify-center`, add `pb-4 pt-8 sm:pt-12` padding on the wrapper, and reduce modal max height from `max-h-[calc(100vh-2rem)]` to `max-h-[calc(100vh-6rem)]` in `webapp/src/pages/Store.jsx` for both single and bulk confirm modals.

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and verified the store page loaded, then ran a Playwright script which successfully captured `artifacts/store-confirm-modal.png` showing the updated modal positioning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69808a5ae42083298e4f4d0c0386ab1d)