### PR TITLE
Reduce Pool Royale max spin (halve maxTipOffsetRatio)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1271,7 +1271,7 @@ const PHYSICS_PROFILE = Object.freeze({
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 4.0,
-  maxTipOffsetRatio: 0.42
+  maxTipOffsetRatio: 0.21
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.993;


### PR DESCRIPTION
### Motivation
- Reduce the maximum cue-tip offset (and therefore max spin) in Pool Royale by at least 50% to tone down extreme spinning behavior.

### Description
- Change `PHYSICS_PROFILE.maxTipOffsetRatio` in `webapp/src/pages/Games/PoolRoyale.jsx` from `0.42` to `0.21` to halve the effective maximum spin.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809152cd9883299aa83cd1c0750f7a)