### PR TITLE
Fix PolyHaven store thumbnails and Polar Fleece cloth mappings

### DIFF
--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -303,7 +303,7 @@ const TABLE_BASE_THUMBNAILS = Object.freeze({
   openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
   coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
   gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
-  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+  woodenTable02Alt: polyHavenThumb('wooden_table_02')
 });
 
 const FIELD_THUMBNAILS = Object.freeze({

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -1,4 +1,4 @@
-import { swatchThumbnail } from './storeThumbnails.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const MURLAN_OUTFIT_THEMES = [
   {
@@ -50,8 +50,6 @@ export const MURLAN_OUTFIT_THEMES = [
     thumbnail: swatchThumbnail(['#1f2937', '#090b10', '#9ca3af'])
   }
 ];
-
-const POLYHAVEN_THUMB = (id) => `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;
 
 const BASE_STOOL_THEMES = [
   {
@@ -134,7 +132,7 @@ const POLYHAVEN_CHAIR_THEMES = [
   { id: 'wheelchair_01', label: 'Wheelchair 01', source: 'polyhaven', assetId: 'wheelchair_01' }
 ].map((option, index) => ({
   ...option,
-  thumbnail: POLYHAVEN_THUMB(option.assetId),
+  thumbnail: polyHavenThumb(option.assetId),
   price: 520 + index * 35,
   description: `${option.label} with preserved original materials.`,
   preserveMaterials: true
@@ -158,7 +156,7 @@ const POLYHAVEN_TABLE_THEMES = [
   ...option,
   assetId: option.id,
   source: 'polyhaven',
-  thumbnail: POLYHAVEN_THUMB(option.id),
+  thumbnail: polyHavenThumb(option.id),
   price: 980 + index * 40,
   preserveMaterials: true,
   description: option.description || `${option.label} with preserved Poly Haven materials.`
@@ -170,7 +168,7 @@ export const MURLAN_TABLE_THEMES = [
     label: 'Murlan Default Table',
     source: 'procedural',
     price: 0,
-    thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+    thumbnail: polyHavenThumb('CoffeeTable_01'),
     description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
   },
   ...POLYHAVEN_TABLE_THEMES

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -324,7 +324,7 @@ const BASE_VARIANT_THUMBNAILS = Object.freeze({
   openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
   coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
   gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
-  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+  woodenTable02Alt: polyHavenThumb('wooden_table_02')
 });
 
 export const POOL_ROYALE_HDRI_VARIANT_MAP = Object.freeze(

--- a/webapp/src/config/snookerRoyalClothPresets.js
+++ b/webapp/src/config/snookerRoyalClothPresets.js
@@ -72,7 +72,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleece',
     label: 'Polar Fleece',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 640,
     priceStep: 10,
     bluePremium: 20,
@@ -91,7 +91,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleecePlush',
     label: 'Polar Fleece Plush',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 700,
     priceStep: 10,
     bluePremium: 20,
@@ -110,7 +110,7 @@ const MATERIAL_SERIES = [
   {
     prefix: 'polarFleeceNatureOcean',
     label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'caban',
+    sourceId: 'polar_fleece',
     basePrice: 660,
     priceStep: 10,
     bluePremium: 20,

--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -323,7 +323,7 @@ const BASE_VARIANT_THUMBNAILS = Object.freeze({
   openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
   coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
   gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
-  woodenTable02Alt: polyHavenThumb('WoodenTable_02')
+  woodenTable02Alt: polyHavenThumb('wooden_table_02')
 });
 
 export const SNOOKER_ROYALE_HDRI_VARIANT_MAP = Object.freeze(

--- a/webapp/src/config/storeThumbnails.js
+++ b/webapp/src/config/storeThumbnails.js
@@ -1,6 +1,17 @@
 const POLYHAVEN_THUMB_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs';
 const POLYHAVEN_ASSET_ALIASES = {
-  rosewood_veneer_01: 'rosewood_veneer1'
+  rosewood_veneer_01: 'rosewood_veneer1',
+  WoodenTable_02: 'wooden_table_02',
+  polar_fleece_ocean_crest: 'polar_fleece',
+  polar_fleece_ocean_current: 'polar_fleece',
+  polar_fleece_ocean_lagoon: 'polar_fleece',
+  polar_fleece_ocean_reef: 'polar_fleece',
+  polar_fleece_ocean_abyss: 'polar_fleece',
+  polar_fleece_nature_fern: 'polar_fleece',
+  polar_fleece_nature_grove: 'polar_fleece',
+  polar_fleece_nature_canopy: 'polar_fleece',
+  polar_fleece_nature_meadow: 'polar_fleece',
+  polar_fleece_nature_wildwood: 'polar_fleece'
 };
 
 const resolvePolyHavenId = (id) => POLYHAVEN_ASSET_ALIASES[id] ?? id;


### PR DESCRIPTION
### Motivation
- Several store items used incorrect PolyHaven IDs (mixed-case or variant IDs) causing thumbnails to not match the actual PolyHaven assets. 
- Polar Fleece cloth presets referenced the wrong `sourceId`, so generated thumbnails and descriptions could point to the wrong asset. 
- Ensure all table/chair/table-finish thumbnails use the shared thumbnail resolver so store UI shows the correct images.

### Description
- Added aliases to `POLYHAVEN_ASSET_ALIASES` in `webapp/src/config/storeThumbnails.js` to map variant names (including Polar Fleece variants and `WoodenTable_02`) to the correct PolyHaven base IDs. 
- Updated `webapp/src/config/snookerRoyalClothPresets.js` to set the Polar Fleece presets' `sourceId` to `polar_fleece` so thumbnails and descriptions resolve correctly. 
- Replaced `WoodenTable_02` usages with the aliased `wooden_table_02` in `poolRoyaleInventoryConfig.js`, `snookerRoyalInventoryConfig.js`, and `airHockeyInventoryConfig.js` so base variant thumbnails are consistent. 
- Standardized `murlanThemes.js` to import and use the shared `polyHavenThumb` resolver for PolyHaven thumbnails instead of an inline helper.

### Testing
- Ran a small `node` script to print generated `polyHavenThumb` URLs for `POLY_HAVEN_CLOTHS` to verify mapping logic, and the script produced the expected URLs. (succeeded)
- Performed HTTPS probes (simple GET/HEAD) against the CDN thumbnails to validate reachability, but requests to the PolyHaven CDN failed in this environment and returned errors. (failed in CI environment)
- Started the webapp dev server with `npm --prefix webapp run dev` to ensure Vite boots and the config changes don't break startup, and the server reported ready. (succeeded)
- Attempted an automated Playwright screenshot of `/store/all` for visual verification, but Chromium crashed (SIGSEGV) in this environment so visual validation could not be completed. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980976846e08329baae82c358041053)