### PR TITLE
Prevent cue ball spin from affecting trajectory before first impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6337,12 +6337,12 @@ function decaySpin(ball, stepScale, airborne = false) {
 
 function applySpinController(ball, stepScale, airborne = false) {
   if (!ball?.spin || ball.spin.lengthSq() < 1e-6) return false;
+  if (ball.id === 'cue' && !ball.impacted) {
+    return decaySpin(ball, stepScale, airborne);
+  }
   const { forward, lateral, speed } = resolveSpinFrame(ball);
   let forwardSpin = ball.spin.y || 0;
   const sideSpin = ball.spin.x || 0;
-  if (ball.id === 'cue' && !ball.impacted && forwardSpin < 0) {
-    forwardSpin = 0;
-  }
   if (Math.abs(forwardSpin) > 1e-8) {
     const powerScale = resolveSpinPowerScale(speed);
     const restScale = speed > 1e-6 ? 1 : SPIN_REST_ACCEL_SCALE;


### PR DESCRIPTION
### Motivation
- Ensure the cue ball follows the visible aim line and the object ball follows the target line by preventing pre-impact spin-induced deflections while keeping spin available for post-impact effects.

### Description
- In `applySpinController` (webapp/src/pages/Games/PoolRoyale.jsx) early-return for the cue ball when it has not yet impacted so spin is only decayed pre-impact and does not modify velocity or cause swerve before first contact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a80e6e348329906db8a23042e56b)