### PR TITLE
Align Pool Royale physics: increase airSpinDecay and maxTipOffsetRatio

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1270,8 +1270,8 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 4.0,
-  maxTipOffsetRatio: 0.21
+  airSpinDecay: 6.0,
+  maxTipOffsetRatio: 0.8
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.993;


### PR DESCRIPTION
### Motivation
- Adjust Pool Royale ball spin behavior to the requested physics parameters so spin decay and tip-offset handling match the intended gameplay feel.

### Description
- Update `PHYSICS_PROFILE` in `webapp/src/pages/Games/PoolRoyale.jsx` to set `airSpinDecay: 6.0` and `maxTipOffsetRatio: 0.8` (previously `4.0` and `0.21`).

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e61fae3083299d90960175725abd)