### PR TITLE
Set Pool Royale airSpinDecay to 1.0 and maxTipOffsetRatio to 0.9

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1270,8 +1270,8 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 4.0,
-  maxTipOffsetRatio: 0.21
+  airSpinDecay: 1.0,
+  maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.993;


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale physics parameters to the requested gameplay values so spin decay and tip-offset handling match the intended feel.

### Description
- Update `PHYSICS_PROFILE` in `webapp/src/pages/Games/PoolRoyale.jsx` to set `airSpinDecay: 1.0` and `maxTipOffsetRatio: 0.9`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e61fae3083299d90960175725abd)