### PR TITLE
Adjust Pool Royale spin physics: profile, kinetic friction, and angular damping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1270,8 +1270,8 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 1.0,
-  maxTipOffsetRatio: 0.9
+  airSpinDecay: 0.1,
+  maxTipOffsetRatio: 0.22
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.993;
@@ -1281,9 +1281,9 @@ const BALL_MASS = 0.17;
 const BALL_INERTIA = (2 / 5) * BALL_MASS * BALL_R * BALL_R;
 const SPIN_FIXED_DT = 1 / 120;
 const SPIN_SLIDE_EPS = 0.035;
-const SPIN_KINETIC_FRICTION = 0.32;
+const SPIN_KINETIC_FRICTION = 0.24;
 const SPIN_ROLL_DAMPING = 0.2;
-const SPIN_ANGULAR_DAMPING = 0.07;
+const SPIN_ANGULAR_DAMPING = 0.15;
 const SPIN_NEUTRAL_EPS = 1e-4;
 const SPIN_GRAVITY = 9.81;
 const BALL_BALL_FRICTION = 0.18;
@@ -25884,7 +25884,7 @@ const powerRef = useRef(hud.power);
                   );
                 } else {
                   const rollFactor = Math.max(0, 1 - SPIN_ROLL_DAMPING * dt);
-                  const spinFactor = Math.max(0, 1 - SPIN_ANGULAR_DAMPING * dt);
+                  const spinFactor = Math.exp(-SPIN_ANGULAR_DAMPING * dt);
                   TMP_VEC3_A.multiplyScalar(rollFactor);
                   TMP_VEC3_C.multiplyScalar(spinFactor);
                 }
@@ -25892,8 +25892,6 @@ const powerRef = useRef(hud.power);
                 b.vel.y = TMP_VEC3_A.z;
                 b.omega.copy(TMP_VEC3_C);
               }
-              const clothDrag = Math.pow(FRICTION, stepScale);
-              b.vel.multiplyScalar(clothDrag);
             }
             if (
               isCue &&


### PR DESCRIPTION
### Motivation
- Reduce the artificial "fake spin" behavior by tuning spin decay, air spin decay, tip offset, kinetic friction, and angular damping so spin integrates more realistically.
- Remove the extra global linear (cloth) velocity damping that was muting spin effects during the spin integration step.

### Description
- Updated `PHYSICS_PROFILE` in `webapp/src/pages/Games/PoolRoyale.jsx` with `airSpinDecay: 0.1` and `maxTipOffsetRatio: 0.22` while keeping other profile values intact.
- Removed the cloth/global linear damping multiplication (`b.vel.multiplyScalar(Math.pow(FRICTION, stepScale))`) from the spin integration branch so spin settling no longer applies that extra velocity damp.
- Lowered `SPIN_KINETIC_FRICTION` from `0.32` to `0.24` and raised `SPIN_ANGULAR_DAMPING` from `0.07` to `0.15`.
- Applied angular damping as time-correct exponential decay (`omega *= Math.exp(-SPIN_ANGULAR_DAMPING * dt)`) in the spin settle branch instead of a linear factor.

### Testing
- No automated tests were run for this change (no test suite executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ebe7e66c8329b63b58284e0979d7)