### PR TITLE
Reduce Pool Royale global spin scale by 30%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1526,7 +1526,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 420;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 220;
 const POCKET_VIEW_POST_POT_HOLD_MS = 80;
 const POCKET_VIEW_MAX_HOLD_MS = 1400;
-const SPIN_GLOBAL_SCALE = 0.5; // reduce overall spin impact by 50%
+const SPIN_GLOBAL_SCALE = 0.35; // reduce overall spin impact by 65%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;


### PR DESCRIPTION
### Motivation
- Reduce the amount of cue/ball spin in the Pool Royale game so shots feel less exaggerated and match the requested 30% reduction in spinning.

### Description
- Updated `SPIN_GLOBAL_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx` from `0.5` to `0.35` to reduce overall spin influence across the Pool Royale physics code.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f2908b988329b0a8966b66b03f2e)