### PR TITLE
Reduce slow cushion sliding by damping tangential velocity and spin

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -383,6 +383,7 @@ public class BilliardsSolver
                     double restitution = PhysicsConstants.Restitution;
                     bool hit = false;
                     bool pocket = false;
+                    bool cushionContact = false;
                     Vec2 contactPoint = new Vec2();
 
                     bool allowPocketing = !airborne;
@@ -394,6 +395,7 @@ public class BilliardsSolver
                             normal = e.Normal;
                             restitution = PhysicsConstants.CushionRestitution;
                             hit = true;
+                            cushionContact = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -406,6 +408,7 @@ public class BilliardsSolver
                             normal = e.Normal;
                             restitution = PhysicsConstants.ConnectorRestitution;
                             hit = true;
+                            cushionContact = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -419,6 +422,7 @@ public class BilliardsSolver
                             restitution = allowPocketing ? PhysicsConstants.PocketRestitution : PhysicsConstants.CushionRestitution;
                             hit = true;
                             pocket = allowPocketing;
+                            cushionContact = !allowPocketing;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -457,6 +461,10 @@ public class BilliardsSolver
                             break;
                         }
                         b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        if (cushionContact)
+                        {
+                            ApplyCushionContact(b, normal);
+                        }
                         b.Position = contactPoint + normal * (PhysicsConstants.BallRadius + PhysicsConstants.ContactOffset);
                         remaining = Math.Max(0, remaining - travel);
                         StepVertical(b, travel);
@@ -636,6 +644,27 @@ public class BilliardsSolver
             b.SideSpin *= decay;
             b.ForwardSpin *= decay;
         }
+    }
+
+    private static void ApplyCushionContact(Ball b, Vec2 normal)
+    {
+        var speed = b.Velocity.Length;
+        if (speed < PhysicsConstants.Epsilon)
+            return;
+
+        var tangent = new Vec2(-normal.Y, normal.X);
+        var tangentialSpeed = Vec2.Dot(b.Velocity, tangent);
+        var friction = speed <= PhysicsConstants.CushionSlowSpeed
+            ? PhysicsConstants.CushionSlowFriction
+            : PhysicsConstants.CushionFriction;
+        var tangentialScale = Math.Max(0.0, 1.0 - friction);
+        b.Velocity -= tangent * (tangentialSpeed * (1.0 - tangentialScale));
+
+        var spinDamping = speed <= PhysicsConstants.CushionSlowSpeed
+            ? PhysicsConstants.CushionSlowSpinDamping
+            : PhysicsConstants.CushionSpinDamping;
+        b.SideSpin *= spinDamping;
+        b.ForwardSpin *= spinDamping;
     }
 
     private static void IntegrateCueBall(Ball b, double dt, bool airborne)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -29,6 +29,11 @@ public static class PhysicsConstants
     public const double MasseSwerveBoost = 2.0;        // multiplier for swerve at max masse
     public const double SwerveSpeedCutoff = 2.5;       // m/s after which swerve fades out
     public const double SwerveSpeedFadeRange = 4.0;    // fade distance for swerve cutoff
+    public const double CushionFriction = 0.22;       // tangential velocity loss per cushion impact
+    public const double CushionSlowFriction = 0.5;    // stronger tangential loss for slow cushion hits
+    public const double CushionSpinDamping = 0.6;     // spin retained after cushion impact
+    public const double CushionSlowSpinDamping = 0.25; // extra spin damping on slow cushion hits
+    public const double CushionSlowSpeed = 0.6;       // m/s threshold for slow cushion behavior
     public const double MaxCueElevationDegrees = 85.0; // clamp to UI upper bound
     public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview


### PR DESCRIPTION
### Motivation
- Balls hitting cushions at low speed were sliding/‘air-spinning’ instead of transitioning to rolling, producing unnatural slow motion behavior. 
- The solver should remove excessive tangential velocity and spin on rail impacts to make slow cushion contacts feel more realistic.

### Description
- Added tunable cushion contact constants to `billiards/PhysicsConstants.cs`: `CushionFriction`, `CushionSlowFriction`, `CushionSpinDamping`, `CushionSlowSpinDamping`, and `CushionSlowSpeed` to control tangential and spin damping on cushion hits. 
- Mark cushion/connector/pocket cushion contacts during collision detection in `Step` and apply a new `ApplyCushionContact` routine after the velocity reflection. 
- Implemented `ApplyCushionContact` in `billiards/BilliardsSolver.cs` to reduce tangential velocity (projected onto the cushion tangent) and to damp `SideSpin` and `ForwardSpin`, using stronger damping below the `CushionSlowSpeed` threshold. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f70d26748329a501de922d974d58)