### PR TITLE
Tweak cushion spin response and spin input scaling

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -383,6 +383,7 @@ public class BilliardsSolver
                     double restitution = PhysicsConstants.Restitution;
                     bool hit = false;
                     bool pocket = false;
+                    bool cushionContact = false;
                     Vec2 contactPoint = new Vec2();
 
                     bool allowPocketing = !airborne;
@@ -394,6 +395,7 @@ public class BilliardsSolver
                             normal = e.Normal;
                             restitution = PhysicsConstants.CushionRestitution;
                             hit = true;
+                            cushionContact = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -406,6 +408,7 @@ public class BilliardsSolver
                             normal = e.Normal;
                             restitution = PhysicsConstants.ConnectorRestitution;
                             hit = true;
+                            cushionContact = true;
                             contactPoint = (b.Position + b.Velocity * tEdge) - normal * PhysicsConstants.BallRadius;
                         }
                     }
@@ -457,6 +460,10 @@ public class BilliardsSolver
                             break;
                         }
                         b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        if (cushionContact && !airborne)
+                        {
+                            ApplyCushionResponse(b, normal);
+                        }
                         b.Position = contactPoint + normal * (PhysicsConstants.BallRadius + PhysicsConstants.ContactOffset);
                         remaining = Math.Max(0, remaining - travel);
                         StepVertical(b, travel);
@@ -673,6 +680,27 @@ public class BilliardsSolver
                 b.ForwardSpin *= PhysicsConstants.LandingSpinDamping;
             }
         }
+    }
+
+    private static void ApplyCushionResponse(Ball b, Vec2 normal)
+    {
+        var n = normal.Normalized();
+        var tangent = new Vec2(-n.Y, n.X);
+        double normalSpeed = Vec2.Dot(b.Velocity, n);
+        double tangentialSpeed = Vec2.Dot(b.Velocity, tangent);
+        double spinImpulse = b.SideSpin * PhysicsConstants.CushionSpinInfluence;
+        double adjustedTangential = tangentialSpeed * (1.0 - PhysicsConstants.CushionTangentialLoss) + spinImpulse;
+
+        if (Math.Abs(adjustedTangential) < PhysicsConstants.CushionStopSpeed &&
+            Math.Abs(normalSpeed) < PhysicsConstants.CushionStopSpeed)
+        {
+            b.Velocity = new Vec2(0, 0);
+        }
+        else
+        {
+            b.Velocity = n * normalSpeed + tangent * adjustedTangential;
+        }
+        b.SideSpin *= PhysicsConstants.CushionSpinDamping;
     }
 
     private static double LinearDrag(bool airborne)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -17,6 +17,10 @@ public static class PhysicsConstants
     public const double AirSpinDecay = 0.6;            // per-second decay while airborne
     public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
     public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
+    public const double CushionTangentialLoss = 0.35;  // tangential speed lost on cushion contact
+    public const double CushionSpinInfluence = 0.45;   // tangential m/s per unit side spin on cushion
+    public const double CushionSpinDamping = 0.65;     // side spin retained after cushion contact
+    public const double CushionStopSpeed = 0.08;       // m/s threshold to stop on cushion
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
     public const double JumpStopVelocity = 0.2;        // m/s below which vertical motion stops
     public const double AirborneHeightThreshold = BallRadius * 0.25; // height before ignoring cushions/balls

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -198,10 +198,17 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  const tuned = {
+    x: quantized.x,
+    y:
+      quantized.y > 0
+        ? clamp(quantized.y * 1.25, -1, 1)
+        : clamp(quantized.y * 0.4, -1, 1)
+  };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
-    quantized.y,
+    -tuned.x,
+    tuned.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Make cushion contacts respond to cue-ball side spin so balls roll along rails or stop when spin/power is low.
- Adjust spin-to-physics mapping so the lower/higher halves of the spin controller produce the requested sensitivity changes.

### Description
- Added new tuning constants in `billiards/PhysicsConstants.cs`: `CushionTangentialLoss`, `CushionSpinInfluence`, `CushionSpinDamping`, and `CushionStopSpeed` to expose cushion behavior knobs.
- In `billiards/BilliardsSolver.cs` detect cushion/connector contacts and call `ApplyCushionResponse`, which transfers `SideSpin` into tangential rail velocity, applies tangential loss, enforces a stop threshold for low-power slides, and damps side spin after the contact.
- Updated `webapp/src/pages/Games/poolRoyaleSpinUtils.js` in `mapSpinForPhysics` to apply asymmetric scaling to the quantized Y spin (one half scaled by `1.25`, the other attenuated to `0.4`) to match the requested lower/high spin sensitivity changes.
- Preserved existing collision reflection and pocket handling logic.

### Testing
- No automated tests were executed for this change.
- The change set was committed and includes edits to `billiards/BilliardsSolver.cs`, `billiards/PhysicsConstants.cs`, and `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fe6c5a8c8329b847f84c4c0e538e)