### PR TITLE
Improve cushion spin response and rebalance spin scaling for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -13,6 +13,8 @@ export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
 export const SPIN_EDGE_AXIS_LOCK_MAG = 0.7;
 export const SPIN_EDGE_AXIS_LOCK_RATIO = 0.3;
+export const SPIN_TOP_HALF_SCALE = 0.4;
+export const SPIN_BOTTOM_HALF_SCALE = 1.25;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -198,10 +200,18 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  let scaledY = quantized.y;
+  if (scaledY > 0) {
+    scaledY *= SPIN_TOP_HALF_SCALE;
+  } else if (scaledY < 0) {
+    scaledY *= SPIN_BOTTOM_HALF_SCALE;
+  }
+  scaledY = clamp(scaledY, -1, 1);
+  const scaled = { x: quantized.x, y: scaledY };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
-    quantized.y,
+    -scaled.x,
+    scaled.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Cushion contacts currently allow slow balls to slide along rails instead of rolling when spin is present, and spin mapping felt asymmetric between top/back halves. 
- The change aims to make spinning balls interact with cushions more naturally (spin can drive roll along the rail) and to rebalance player-facing spin controls so backspin is stronger and topspin is reduced.

### Description
- Updated `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to introduce `SPIN_TOP_HALF_SCALE` and `SPIN_BOTTOM_HALF_SCALE` and scale the quantized spin Y component so top-half (topspin) is reduced and bottom-half (backspin) is amplified before mapping to cue-frame. 
- Added rail/cushion contact tuning constants `RAIL_SPIN_ROLL_ACCELERATION`, `RAIL_CONTACT_SLIDE_DAMPING`, and `RAIL_CONTACT_SPIN_DAMPING` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Implemented `applyRailContactRoll(ball, impact, stepScale)` in `webapp/src/pages/Games/PoolRoyale.jsx` to damp slide along the tangent and convert spin into tangential roll acceleration at cushion contacts, including spin damping while in contact. 
- Hooked the new contact handler into the physics loop by calling `applyRailContactRoll(b, railImpact, stepScale)` immediately after `applyRailImpulse`/`applyRailSpinResponse` on rail impacts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fe6c5a8c8329b847f84c4c0e538e)