### PR TITLE
Disable airborne spin effects in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1548,8 +1548,8 @@ const RAIL_SPIN_ROLL_ACCELERATION = SPIN_ROLL_ACCELERATION * 0.45;
 const RAIL_CONTACT_SLIDE_DAMPING = 0.55;
 const RAIL_CONTACT_SPIN_DAMPING = 0.35;
 const SPIN_REST_ACCEL_SCALE = 0.45; // prevent stationary spin from stalling without over-accelerating
-const AIR_SPIN_ROLL_SCALE = 0.22; // reduce forward/back spin acceleration while airborne
-const AIR_SPIN_SWERVE_SCALE = BALL_R * 0.55; // gentle Magnus-style drift for airborne side spin
+const AIR_SPIN_ROLL_SCALE = 0; // disable forward/back spin acceleration while airborne
+const AIR_SPIN_SWERVE_SCALE = 0; // disable Magnus-style drift for airborne side spin
 const BALL_SPIN_THROW_SCALE = BALL_R * 0.34; // small tangential throw from ball-to-ball spin contact
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligned with the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while matching Snooker Royal pacing.


### PR DESCRIPTION
### Motivation
- The Pool Royale airborne spin behavior should be disabled by setting air spin effects to zero so airborne balls do not receive roll or Magnus-style swerve.

### Description
- Set `AIR_SPIN_ROLL_SCALE` and `AIR_SPIN_SWERVE_SCALE` to `0` in `webapp/src/pages/Games/PoolRoyale.jsx` to remove forward/back roll acceleration and airborne side-spin drift.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810968e6748329afaeff5326422259)