### PR TITLE
Align Pool Royale physics with Snooker Royal and refine UK 8‑ball break/black handling

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -37,6 +37,7 @@ export class UkPool {
 
   startBreak () {
     this.state.lastEvent = 'BREAK_START';
+    this.state.mustPlayFromBaulk = true;
   }
 
   /**
@@ -70,6 +71,7 @@ export class UkPool {
     let foul = false;
     let reason = '';
     const scratched = shot.potted.includes('cue') || shot.cueOffTable;
+    const blackPotted = shot.potted.includes('black');
 
     const first = shot.contactOrder && shot.contactOrder[0];
     const isBreak = s.lastEvent === 'BREAK_START' || s.lastEvent === null;
@@ -149,31 +151,43 @@ export class UkPool {
     }
 
     // potting black
-    let blackPotted = shot.potted.includes('black');
-    if (!foul && blackPotted) {
-      // can only pot black if own group cleared
-      const ownSet = ownGroup ? s.ballsOnTable[ownGroup] : null;
-      const hasOwn = ownSet && ownSet.size > 0;
-      // On an open table, potting the black is only a foul if both
-      // colours remain. If one set is already cleared we implicitly
-      // treat the remaining colour as the player's group.
-      const openIllegal =
-        s.isOpenTable &&
-        s.ballsOnTable.blue.size > 0 &&
-        s.ballsOnTable.red.size > 0;
-      if (hasOwn || openIllegal) {
-        foul = true;
-        reason = 'potted black early';
-      }
+    const remainingColors = s.ballsOnTable.blue.size + s.ballsOnTable.red.size;
+    const ownSet = ownGroup ? s.ballsOnTable[ownGroup] : null;
+    const ownCleared = Boolean(ownSet && ownSet.size === 0);
+    const blackLegal =
+      (!s.isOpenTable && ownGroup && ownCleared) ||
+      (s.isOpenTable && remainingColors === 0);
+    if (!foul && blackPotted && !blackLegal) {
+      foul = true;
+      reason = 'potted black early';
     }
-    if (foul && blackPotted) {
-      const ownSet = ownGroup ? s.ballsOnTable[ownGroup] : null;
-      const ownCleared = ownSet && ownSet.size === 0;
-      const remainingColors = s.ballsOnTable.blue.size + s.ballsOnTable.red.size;
-      if (!scratched && (ownCleared || remainingColors === 0) && reason === 'potted black early') {
-        foul = false;
-        reason = '';
-      }
+    if (
+      isBreak &&
+      blackPotted &&
+      reason === 'potted black early' &&
+      this.rules.blackOnBreak === 're-rack' &&
+      !scratched
+    ) {
+      s.ballsOnTable = initialBalls();
+      s.assignments = { A: null, B: null };
+      s.currentPlayer = current;
+      s.shotsRemaining = 1;
+      s.isOpenTable = true;
+      s.lastEvent = 'BREAK_RERACK';
+      s.frameOver = false;
+      s.winner = null;
+      s.mustPlayFromBaulk = true;
+      return {
+        legal: true,
+        foul: false,
+        potted: [],
+        nextPlayer: current,
+        shotsRemainingNext: 1,
+        choiceRequired: false,
+        frameOver: false,
+        winner: null,
+        rerack: true
+      };
     }
 
     // apply pot removals

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -355,7 +355,7 @@ export class PoolRoyaleRules {
       noCushionAfterContact: Boolean(context.noCushionAfterContact),
       placedFromHand: Boolean(context.placedFromHand)
     });
-    const pottedCount = potted.filter((colour) => colour !== 'cue').length;
+    const pottedCount = shotResult?.rerack ? 0 : potted.filter((colour) => colour !== 'cue').length;
     const snapshot = serializeUkState(game.state);
     const totals = previous ? previous.totals : { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR };
     const playerScores = this.computeUkScores(snapshot, totals);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1270,7 +1270,7 @@ const PHYSICS_PROFILE = Object.freeze({
   restitution: 0.985,
   mu: 0.421,
   spinDecay: 2.0,
-  airSpinDecay: 1.0,
+  airSpinDecay: 6.0,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
@@ -1528,7 +1528,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 420;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 220;
 const POCKET_VIEW_POST_POT_HOLD_MS = 80;
 const POCKET_VIEW_MAX_HOLD_MS = 1400;
-const SPIN_GLOBAL_SCALE = 0.35; // reduce overall spin impact by 65%
+const SPIN_GLOBAL_SCALE = 0.66; // match Snooker Royal spin strength for identical roll response
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1552,11 +1552,13 @@ const AIR_SPIN_ROLL_SCALE = 0; // disable forward/back spin acceleration while a
 const AIR_SPIN_SWERVE_SCALE = 0; // disable Magnus-style drift for airborne side spin
 const BALL_SPIN_THROW_SCALE = BALL_R * 0.34; // small tangential throw from ball-to-ball spin contact
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligned with the aim line
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while matching Snooker Royal pacing.
-// Increase overall Pool Royale power by 33% on top of the Snooker Royal baseline.
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power 25% softer than before.
+// Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
+// Snooker Royal feedback: increase standard shots by 30% and amplify the break by 50% to open racks faster.
+// Snooker Royal power pass: lift overall shot strength by another 25%.
 const SHOT_POWER_REDUCTION = 0.425;
-const SHOT_POWER_BOOST = 1.995;
 const SHOT_POWER_MULTIPLIER = 2.109375;
+const SHOT_POWER_INCREASE = 1.5;
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1566,7 +1568,7 @@ const SHOT_FORCE_BOOST =
   0.85 *
   SHOT_POWER_REDUCTION *
   SHOT_POWER_MULTIPLIER *
-  SHOT_POWER_BOOST;
+  SHOT_POWER_INCREASE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;


### PR DESCRIPTION
### Motivation
- Make Pool Royale ball motion and roll behavior match Snooker Royal so balls feel identical across modes for consistent play experience.
- Ensure UK 8‑ball break behavior follows correct ball‑in‑hand/baulk semantics and handle black‑on‑break scenarios without producing false fouls.
- Prevent re‑racked breaks from incorrectly counting toward the current break total or producing inconsistent state across rule layers.

### Description
- Set break placement for UK 8‑ball by enabling `mustPlayFromBaulk` on `UkPool.startBreak()` in `lib/poolUk8Ball.js` so breaks begin with ball‑in‑hand semantics.
- Add black‑on‑break handling in `lib/poolUk8Ball.js` to detect black potted on the break and perform a re‑rack (reset `ballsOnTable`, `assignments`, `mustPlayFromBaulk`, and return a `rerack` flag) when `this.rules.blackOnBreak === 're-rack'` and no scratch occurred.
- Prevent re‑rack results from inflating current break totals by making `src/rules/PoolRoyaleRules.ts` treat `shotResult.rerack` as zero potted balls when computing `currentBreak`.
- Align physics tuning in `webapp/src/pages/Games/PoolRoyale.jsx` with the Snooker Royal baseline by changing `PHYSICS_PROFILE.airSpinDecay` (1.0 → 6.0), increasing `SPIN_GLOBAL_SCALE` (0.35 → 0.66), and adjusting the shot power constants (`SHOT_POWER_*` variables and `SHOT_FORCE_BOOST`) to produce matching roll, spin, and break response.

### Testing
- No automated tests were executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817bd4ce5483299f6cef7e2a96e055)