### PR TITLE
Fix TonConnect manifest base URL selection

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -58,7 +58,12 @@ export default function App() {
   useReferralClaim();
   useNativePushNotifications();
 
-  const baseUrl = `${window.location.origin}${import.meta.env.BASE_URL}`;
+  const publicOrigin = (() => {
+    const origin = window.location.origin;
+    if (origin.startsWith('http')) return origin;
+    return import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram.com';
+  })();
+  const baseUrl = `${publicOrigin}${import.meta.env.BASE_URL}`;
   const manifestUrl = new URL('tonconnect-manifest.json', baseUrl).toString();
   const walletsListSource = new URL('tonconnect-wallets.json', baseUrl).toString();
   const returnUrl = window.location.href;


### PR DESCRIPTION
### Motivation
- Ensure TonConnect manifest and wallets list URLs resolve correctly in native/webview environments where `window.location.origin` may not be an HTTP(S) URL by falling back to a configurable public origin.

### Description
- Update `webapp/src/App.jsx` to compute `baseUrl` using a `publicOrigin` that returns `window.location.origin` when it starts with `http`, otherwise falls back to `import.meta.env.VITE_PUBLIC_APP_URL` or `https://tonplaygram.com`, and use that `baseUrl` to construct `manifestUrl` and `walletsListSource`.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite emitted chunk-size warnings but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817da080488329ac7629cb265ee523)