### PR TITLE
Clickable info popups for achievements, roadmap, and live games

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -1,7 +1,20 @@
+import { useState } from 'react';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
 
 export default function ProjectAchievementsCard() {
+  const [activeInfo, setActiveInfo] = useState(null);
+  const InfoIcon = ({ info, label }) => (
+    <button
+      type="button"
+      onClick={() => setActiveInfo({ title: label, description: info })}
+      className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border/70 bg-surface/80 text-[10px] font-bold text-muted shadow-sm transition hover:text-foreground"
+      aria-label={`Open info about ${label}`}
+    >
+      i
+    </button>
+  );
+
   const completionThreshold = 90;
   const calculateAverageProgress = (items) => {
     if (!items.length) {
@@ -15,34 +28,133 @@ export default function ProjectAchievementsCard() {
     return Math.round(totalProgress / items.length);
   };
   const deliveredAchievements = [
-    { label: '🧾 Wallet transaction history works', progress: 100 },
-    { label: '💬 In-chat TPC transfers enabled', progress: 100 },
-    { label: '🧑‍🤝‍🤝 Friends and inbox chat', progress: 100 },
-    { label: '🎰 Roulette spin live', progress: 100 },
+    {
+      label: '🧾 Wallet transaction history works',
+      progress: 100,
+      info:
+        'Users can view a complete, chronological ledger of wallet activity including deposits, withdrawals, rewards, and gameplay transfers with timestamps for auditability.',
+    },
+    {
+      label: '💬 In-chat TPC transfers enabled',
+      progress: 100,
+      info:
+        'TPC can be sent directly inside chats, allowing frictionless peer-to-peer transfers with confirmations and balance updates in real time.',
+    },
+    {
+      label: '🧑‍🤝‍🤝 Friends and inbox chat',
+      progress: 100,
+      info:
+        'Friend lists, direct messages, and notifications are active so players can connect, coordinate matches, and receive system updates.',
+    },
+    {
+      label: '🎰 Roulette spin live',
+      progress: 100,
+      info:
+        'The roulette minigame is deployed with live spin animations, prize resolution, and reward payout tracking.',
+    },
     {
       label:
         '🤝 Game invites for 1v1 or group play with Telegram notifications (Android/iOS push notifications after migration)',
       progress: 100,
+      info:
+        'Players can invite friends to 1v1 or group sessions; Telegram alerts already work and mobile push notifications are planned post-migration.',
     },
-    { label: '💬 In-game chat enabled', progress: 100 },
-    { label: '🕹️ Telegram bot and web app integration', progress: 100 },
-    { label: '🔄 Daily Check-In rewards', progress: 100 },
-    { label: '⛏️ Mining system active', progress: 100 },
-    { label: '📺 Ad watch rewards', progress: 100 },
-    { label: '🎯 Social tasks for X, Telegram, TikTok', progress: 100 },
-    { label: '📹 Intro video view rewards', progress: 100 },
-    { label: '🎡 Spin & Win wheel', progress: 100 },
-    { label: '🍀 Lucky Card prizes', progress: 100 },
-    { label: '🎁 NFT gifts', progress: 100 },
+    {
+      label: '💬 In-game chat enabled',
+      progress: 100,
+      info:
+        'Live chat works inside gameplay sessions so teams can coordinate and players can share quick updates without leaving the game.',
+    },
+    {
+      label: '🕹️ Telegram bot and web app integration',
+      progress: 100,
+      info:
+        'The Telegram bot is connected to the web app, enabling seamless login, deep links, and shared account state.',
+    },
+    {
+      label: '🔄 Daily Check-In rewards',
+      progress: 100,
+      info:
+        'Daily streak check-ins deliver rewards with tracking for consecutive days and instant balance updates.',
+    },
+    {
+      label: '⛏️ Mining system active',
+      progress: 100,
+      info:
+        'Mining mechanics are live with accrual timers and claim flows so users can generate rewards over time.',
+    },
+    {
+      label: '📺 Ad watch rewards',
+      progress: 100,
+      info:
+        'Users can watch rewarded ads to earn TPC, with completion verification and crediting.',
+    },
+    {
+      label: '🎯 Social tasks for X, Telegram, TikTok',
+      progress: 100,
+      info:
+        'Social engagement quests are active across X, Telegram, and TikTok with task completion tracking and reward payouts.',
+    },
+    {
+      label: '📹 Intro video view rewards',
+      progress: 100,
+      info:
+        'Intro video rewards are enabled to educate new users and pay out incentives for completion.',
+    },
+    {
+      label: '🎡 Spin & Win wheel',
+      progress: 100,
+      info:
+        'Spin & Win is live with randomized prize selection, animations, and prize delivery.',
+    },
+    {
+      label: '🍀 Lucky Card prizes',
+      progress: 100,
+      info:
+        'Lucky Card reward draws are deployed with revealed prizes and automatic wallet crediting.',
+    },
+    {
+      label: '🎁 NFT gifts',
+      progress: 100,
+      info:
+        'NFT gift distribution is supported for campaigns, rewards, and partner drops.',
+    },
     {
       label: '🚀 Referral boost: invite more friends to earn more TPC',
       progress: 100,
+      info:
+        'Referral boosts multiply rewards based on invited friends, tracking conversions and issuing bonus TPC.',
     },
-    { label: '🛒 NFT marketplace for user listings', progress: 100 },
-    { label: '🏆 Game tournaments live', progress: 100 },
-    { label: '🎁 Tournament winner gifts', progress: 100 },
-    { label: '🏦 Game transactions are public', progress: 100 },
-    { label: '⛏️ Mining transactions are public', progress: 100 },
+    {
+      label: '🛒 NFT marketplace for user listings',
+      progress: 100,
+      info:
+        'The NFT marketplace allows user listings, browsing, and purchases with transparent ownership updates.',
+    },
+    {
+      label: '🏆 Game tournaments live',
+      progress: 100,
+      info:
+        'Tournament brackets and matchmaking are available, allowing competitive play with leaderboard updates.',
+    },
+    {
+      label: '🎁 Tournament winner gifts',
+      progress: 100,
+      info:
+        'Winners receive automated gifts and rewards upon tournament completion.',
+    },
+    {
+      label: '🏦 Game transactions are public',
+      progress: 100,
+      info:
+        'Game-related transactions are visible in the public ledger for transparency and verification.',
+    },
+    {
+      label: '⛏️ Mining transactions are public',
+      progress: 100,
+      info:
+        'Mining activity is recorded on the public ledger so rewards and claims are auditable.',
+    },
   ];
 
   const roadmapSteps = [
@@ -51,43 +163,59 @@ export default function ProjectAchievementsCard() {
       description:
         'Fixing the online connection is almost done, partly completed with a bit left to finalize.',
       progress: 85,
+      info:
+        'Networking reliability fixes are nearing completion; remaining work focuses on edge cases, reconnection flow, and final QA.',
     },
     {
       title: 'Store Item Photos',
       description: 'Upload all necessary photos for the store items.',
       progress: 55,
+      info:
+        'Asset photography is being uploaded for every store listing, including thumbnails and high-res previews.',
     },
     {
       title: 'Mobile Launch',
       description:
         'Release the Playgram app on Android and iOS with the current 3D game lineup.',
       progress: 70,
+      info:
+        'Mobile builds are being finalized for Android and iOS with the existing 3D titles and onboarding flow.',
     },
     {
       title: 'Growth & Community',
       description:
         'Gather Telegram group feedback to identify glitches, errors, and malfunctions, then take new feature requests to community votes so every voice is heard.',
       progress: 40,
+      info:
+        'Community feedback loops are active, with issue triage and feature voting planned to prioritize the roadmap.',
     },
     {
       title: 'TPC Tokenization',
       description:
         'Mint the official TPC token and finalize token utility across the ecosystem.',
+      info:
+        'Token minting and utility alignment are in planning to define issuance, rewards, and in-app use cases.',
     },
     {
       title: 'Exchange Readiness',
       description:
         'Begin CEX outreach and prepare DEX liquidity provisioning.',
+      info:
+        'Exchange preparation includes outreach, compliance readiness, and DEX liquidity planning.',
     },
     {
       title: 'CEX + DEX Listings',
       description:
         'List on decentralized exchanges and finalize listings on major CEX partners.',
+      info:
+        'Listing execution covers final DEX deployment and CEX partnerships once readiness milestones are met.',
     },
     {
       title: 'Next Phases',
       description:
         'Post-listing initiatives are in progress and will be announced after CEX/DEX milestones.',
+      info:
+        'Future initiatives are queued for announcement after exchange milestones, including new game features and partnerships.',
     },
   ];
   const normalizedRoadmapSteps = roadmapSteps.map((step) => ({
@@ -99,6 +227,7 @@ export default function ProjectAchievementsCard() {
     .map((step) => ({
       label: `✅ ${step.title}`,
       progress: step.progress,
+      info: `${step.info ?? step.description} Current progress: ${step.progress}%.`,
     }));
   const achievements = [...deliveredAchievements, ...promotedRoadmapAchievements];
   const roadmap = normalizedRoadmapSteps.filter(
@@ -126,6 +255,35 @@ export default function ProjectAchievementsCard() {
     ...gamesCatalog.filter((game) => game.slug !== 'poolroyale'),
     ...poolVariants,
   ];
+  const liveGameDetails = {
+    'Snakes & Ladders': {
+      info:
+        'Classic board game mode is live with turn-based rolls, animated pieces, and rewards tied to match outcomes.',
+    },
+    Roulette: {
+      info:
+        'Roulette is fully playable with real-time spin results, payout resolution, and reward delivery.',
+    },
+    'Pool Royale': {
+      info:
+        'Pool Royale is in progress with core physics and visuals delivered; multiplayer matchmaking and ranked progression are the next gaps to close.',
+    },
+    'UK 8 Pool': {
+      info:
+        'UK 8 Ball ruleset is live with polished ball physics, AI opponents, and shot timers. Online PvP is next.',
+    },
+    '9 Ball': {
+      info:
+        '9 Ball mode is live with accurate rack rules, foul detection, and AI play. Competitive online lobbies remain in progress.',
+    },
+    'American Billiards': {
+      info:
+        'American Billiards is available with table physics tuned for the ruleset; ranked matchmaking and tournaments are still planned.',
+    },
+  };
+  const getGameInfo = (game) =>
+    liveGameDetails[game.name]?.info
+    ?? 'Core gameplay is delivered and playable. Missing pieces are the next multiplayer, progression, and competitive layers.';
 
   return (
     <div className="relative rounded-2xl border border-border/70 bg-gradient-to-br from-surface/95 via-surface/90 to-surface/80 p-5 shadow-xl shadow-black/5 space-y-6 overflow-hidden wide-card">
@@ -163,7 +321,10 @@ export default function ProjectAchievementsCard() {
               key={item.label}
               className="flex items-center justify-between gap-3 rounded-lg border border-border/40 bg-surface/90 px-3 py-2"
             >
-              <span>{item.label}</span>
+              <div className="flex items-center gap-2">
+                <span>{item.label}</span>
+                <InfoIcon info={item.info} label={item.label} />
+              </div>
               <span className="text-[10px] font-semibold text-emerald-400">{item.progress}%</span>
             </li>
           ))}
@@ -187,8 +348,11 @@ export default function ProjectAchievementsCard() {
             return (
               <div
                 key={game.name}
-                className="flex flex-col items-center gap-1 rounded-lg border border-border/50 bg-surface/90 p-2 text-center"
+                className="relative flex flex-col items-center gap-1 rounded-lg border border-border/50 bg-surface/90 p-2 text-center"
               >
+                <div className="absolute right-1 top-1">
+                  <InfoIcon info={getGameInfo(game)} label={game.name} />
+                </div>
                 <img
                   src={thumbnail || game.image}
                   alt={game.name}
@@ -241,12 +405,46 @@ export default function ProjectAchievementsCard() {
                   {step.progress}% complete ✔️
                 </div>
               </div>
-              <p className="mt-1 text-sm font-semibold text-foreground">{step.title}</p>
+              <div className="mt-1 flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-foreground">{step.title}</p>
+                <InfoIcon
+                  info={`${step.info ?? step.description} Current progress: ${step.progress}%.`}
+                  label={step.title}
+                />
+              </div>
               <p className="text-xs text-muted">{step.description}</p>
             </li>
           ))}
         </ol>
       </div>
+      {activeInfo && (
+        <div
+          className="absolute inset-0 z-20 flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setActiveInfo(null)}
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl border border-border/70 bg-surface/95 p-4 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-foreground">{activeInfo.title}</p>
+                <p className="mt-2 text-xs text-muted">{activeInfo.description}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setActiveInfo(null)}
+                className="rounded-full border border-border/60 px-2 py-1 text-[10px] font-semibold text-muted transition hover:text-foreground"
+                aria-label="Close info dialog"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make info affordances interactive so users can tap the info icon to read full details about achievements, roadmap items, and live game thumbnails without leaving the card.

### Description
- Add `useState`-backed `activeInfo` and replace passive info spans with a clickable `InfoIcon` button that sets the active info payload. 
- Introduce a modal-like overlay dialog (accessible via `role="dialog"` and `aria-modal="true"`) that shows the selected `title` and `description` and supports background click and close button to dismiss. 
- Wire `info` text into delivered achievements and roadmap steps and include the `info` when promoting roadmap steps to achievements. 
- Add `liveGameDetails` and `getGameInfo` and render an `InfoIcon` on each Live Game Lineup thumbnail so game-specific status and missing pieces can be inspected.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready. 
- Ran a Playwright script that opened a mobile (390×844) viewport, clicked the first info button, and produced the screenshot `artifacts/achievements-roadmap-popup.png`, and the script completed successfully. 
- No unit tests were changed because this is a UI-only enhancement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818035cd8083298f94ca00059207f6)