### PR TITLE
8Ball: rename variant, switch UK rules to ball-in-hand, and add cue-ball reposition UI

### DIFF
--- a/docs/3d-billiards-variants.md
+++ b/docs/3d-billiards-variants.md
@@ -1,6 +1,6 @@
 # 3D Billiards Mode Specifications
 
-These notes capture the shared expectations for the upcoming 3D billiards experiences so every build of the table (mobile portrait first) stays aligned. The same baseline applies whether we ship Pool Royal, UK 8 Ball, 9 Ball, or American Billiards.
+These notes capture the shared expectations for the upcoming 3D billiards experiences so every build of the table (mobile portrait first) stays aligned. The same baseline applies whether we ship Pool Royal, 8Ball, 9 Ball, or American Billiards.
 
 ## Shared 3D Table Requirements
 
@@ -22,7 +22,7 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 - Match the skirt underlay: melamine and wooden rails must share the same grain direction, pattern scale, and plank widths as the skirts beneath them so the table reads as one uniform shell and stops cleanly above the legs.
 - Pocket jaws and rims must match the chrome plate cutouts **100%**—never size them from the wooden rail arches.
 
-### 3D UK 8 Ball
+### 3D 8Ball
 - 7 ft pub-style table with rounded corners and smaller pockets.
 - Use red/yellow object balls plus the black. Update ball material presets accordingly.
 
@@ -42,4 +42,4 @@ Exactly **four** chalk blocks are visible at all times—one centred on each woo
 - ✅ Rule-card UI snippets for each mode.
 - ✅ QA pass ensuring the chalk objects never clip through cue animations or player avatars.
 
-These guidelines ensure every 3D billiards variant feels consistent while still highlighting the differences players expect between Pool Royal, UK 8 Ball, 9 Ball, and American Billiards.
+These guidelines ensure every 3D billiards variant feels consistent while still highlighting the differences players expect between Pool Royal, 8Ball, 9 Ball, and American Billiards.

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -151,7 +151,7 @@ function currentGroup (state) {
   }
   if (!g) return undefined
   const norm = g.toString().toUpperCase()
-  // In UK 8-ball, balls 1-7 are red (solids) and 9-15 are blue (stripes).
+  // In 8Ball, balls 1-7 are red (solids) and 9-15 are blue (stripes).
   // Map the textual colour assignment to the corresponding group.
   if (norm === 'RED') return 'SOLIDS'
   if (norm === 'BLUE') return 'STRIPES'

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -37,6 +37,7 @@ export class UkPool {
 
   startBreak () {
     this.state.lastEvent = 'BREAK_START';
+    this.state.mustPlayFromBaulk = true;
   }
 
   /**
@@ -216,10 +217,10 @@ export class UkPool {
 
     if (foul) {
       nextPlayer = opp;
-      shotsNext = 2;
+      shotsNext = 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = scratched;
+      s.mustPlayFromBaulk = true;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -1,4 +1,4 @@
-// Advanced UK 8-Ball Pool AI planner
+// Advanced 8Ball pool AI planner
 // Generates candidate shots, evaluates probabilities and positional play,
 // and returns the best plan according to expected value heuristics.
 

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -4,18 +4,20 @@ import { UkPool } from '../lib/poolUk8Ball.js';
 import { selectShot, recordShotOutcome, __resetShotMemory } from '../lib/poolUkAdvancedAi.js';
 import planShot from '../lib/poolAi.js';
 
-test('scratch on break gives opponent two visits without free ball', () => {
+test('scratch on break gives opponent ball in hand', () => {
   const game = new UkPool();
+  game.startBreak();
   const res = game.shotTaken({
     contactOrder: ['red'],
     potted: ['cue'],
     cueOffTable: false,
     noCushionAfterContact: false,
-    placedFromHand: false
+    placedFromHand: true
   });
   assert.equal(res.foul, true);
   assert.equal(res.nextPlayer, 'B');
-  assert.equal(res.shotsRemainingNext, 2);
+  assert.equal(res.shotsRemainingNext, 1);
+  assert.equal(game.state.mustPlayFromBaulk, true);
 });
 
 test('after foul player must hit a valid colour first', () => {
@@ -90,9 +92,9 @@ test('potting 8-ball before clearing group loses the frame', () => {
   assert.equal(res.winner, 'B');
 });
 
-test('two visits behaviour', () => {
+test('foul grants ball in hand without extra visits', () => {
   const game = new UkPool();
-  // foul to give B two visits
+  // foul gives ball in hand for B with a single visit
   game.shotTaken({
     contactOrder: ['blue'],
     potted: ['cue'],
@@ -126,7 +128,7 @@ test('two visits behaviour', () => {
     placedFromHand: true
   });
   assert.equal(res2.nextPlayer, 'B');
-  assert.equal(res2.shotsRemainingNext, 2);
+  assert.equal(res2.shotsRemainingNext, 1);
 });
 
 test('potting both colours on break requires choice', () => {

--- a/webapp/public/assets/game-art/variants/pool-royale/8-pool-uk-rack.svg
+++ b/webapp/public/assets/game-art/variants/pool-royale/8-pool-uk-rack.svg
@@ -27,5 +27,5 @@
     <circle cx="150" cy="120" r="12" fill="#d12c2c"/>
     <circle cx="180" cy="120" r="12" fill="#ffd200"/>
   </g>
-  <text x="120" y="152" font-family="'Inter', Arial, sans-serif" font-size="14" fill="#cbd5f5" text-anchor="middle">8 Pool UK</text>
+  <text x="120" y="152" font-family="'Inter', Arial, sans-serif" font-size="14" fill="#cbd5f5" text-anchor="middle">8Ball</text>
 </svg>

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -151,7 +151,7 @@ function currentGroup (state) {
   }
   if (!g) return undefined
   const norm = g.toString().toUpperCase()
-  // In UK 8-ball, balls 1-7 are red (solids) and 9-15 are blue (stripes).
+  // In 8Ball, balls 1-7 are red (solids) and 9-15 are blue (stripes).
   // Map the textual colour assignment to the corresponding group.
   if (norm === 'RED') return 'SOLIDS'
   if (norm === 'BLUE') return 'STRIPES'

--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -238,7 +238,7 @@ export default function ProjectAchievementsCard() {
 
   const poolVariants = [
     {
-      name: 'UK 8 Pool',
+      name: '8Ball',
       image: '/assets/icons/8ballrack.png',
     },
     {
@@ -268,9 +268,9 @@ export default function ProjectAchievementsCard() {
       info:
         'Pool Royale is in progress with core physics and visuals delivered; multiplayer matchmaking and ranked progression are the next gaps to close.',
     },
-    'UK 8 Pool': {
+    '8Ball': {
       info:
-        'UK 8 Ball ruleset is live with polished ball physics, AI opponents, and shot timers. Online PvP is next.',
+        '8Ball ruleset is live with polished ball physics, AI opponents, and shot timers. Online PvP is next.',
     },
     '9 Ball': {
       info:
@@ -339,7 +339,7 @@ export default function ProjectAchievementsCard() {
           </span>
         </div>
         <p className="text-xs text-muted">
-          Pool Royale includes UK 8 Ball, 9 Ball, and American Billiards. All games are fully
+          Pool Royale includes 8Ball, 9 Ball, and American Billiards. All games are fully
           playable (currently local vs AI only).
         </p>
         <div className="grid grid-cols-4 gap-2">

--- a/webapp/src/config/poolRoyaleTraining.js
+++ b/webapp/src/config/poolRoyaleTraining.js
@@ -12,7 +12,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Side pocket control',
-    discipline: 'UK 8-Ball',
+    discipline: '8Ball',
     objective: 'Slide the ball into the side pocket while keeping the cue ball out of the scratch lanes.',
     cue: { x: -0.48, z: -0.32 },
     balls: [{ rackIndex: 2, x: -0.02, z: 0.24 }],
@@ -30,7 +30,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Back-cut to corner',
-    discipline: 'UK 8-Ball',
+    discipline: '8Ball',
     objective: 'Cut the ball back to the near corner and check the cue ball off the short rail.',
     cue: { x: -0.58, z: -0.12 },
     balls: [{ rackIndex: 4, x: 0.54, z: 0.18 }],
@@ -75,7 +75,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Ladder drill',
-    discipline: 'UK 8-Ball',
+    discipline: '8Ball',
     objective: 'Work up the long rail through three balls without losing angle.',
     cue: { x: -0.28, z: -0.48 },
     balls: [
@@ -115,7 +115,7 @@ const TRAINING_BLUEPRINTS = [
 const clamp = (value) => Math.max(-0.94, Math.min(0.94, value));
 
 const DISCIPLINE_TO_VARIANT = {
-  'UK 8-Ball': 'uk',
+  '8Ball': 'uk',
   '9-Ball': '9ball',
   'American Billiards': 'american'
 };

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1721,7 +1721,7 @@ const UK_POOL_BLACK = 0x000000;
 const POOL_VARIANT_COLOR_SETS = Object.freeze({
   uk: {
     id: 'uk',
-    label: '8-Ball UK',
+    label: '8Ball',
     cueColor: 0xffffff,
     rackLayout: 'triangle',
     disableSnookerMarkings: true,
@@ -11366,7 +11366,7 @@ function PoolRoyaleGame({
   );
   const infoText = useMemo(() => {
     if (activeVariant?.id === 'uk') {
-      return 'Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent two shots.';
+      return 'Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent ball in hand.';
     }
     return 'Pocket your assigned group, then sink the 8-ball to win. Fouls give your opponent ball in hand.';
   }, [activeVariant]);
@@ -21409,7 +21409,7 @@ const powerRef = useRef(hud.power);
 
       const allowFullTableInHand = () => {
         const id = variantId();
-        if (id === 'uk') return true;
+        if (id === 'uk') return false;
         if (id === 'american' || id === '9ball') {
           return !isBreakRestrictedInHand();
         }
@@ -27179,6 +27179,16 @@ const powerRef = useRef(hud.power);
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
   const showSpinController =
     !hud.over && !replayActive && (isPlayerTurn || aiTakingShot);
+  const canRepositionCueBall = useMemo(
+    () => showPlayerControls && deriveInHandFromFrame(frameState),
+    [frameState, showPlayerControls]
+  );
+  const handleCueBallReposition = useCallback(() => {
+    if (!canRepositionCueBall || shootingRef.current) return;
+    cueBallPlacedFromHandRef.current = false;
+    setHud((prev) => ({ ...prev, inHand: true }));
+    setInHandPlacementMode(true);
+  }, [canRepositionCueBall]);
   const spinRingLabels = useMemo(
     () => {
       const radius = 72;
@@ -29002,7 +29012,7 @@ const powerRef = useRef(hud.power);
           <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
             <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
             <span className="text-left leading-tight">
-              Place the cue ball {['american', '9ball'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle'}
+              Place the cue ball {['american', '9ball'].includes(variantKey) ? 'anywhere on the table' : 'inside the baulk semicircle behind the white line'}
             </span>
           </div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
@@ -29058,6 +29068,20 @@ const powerRef = useRef(hud.power);
               }}
             ></div>
           </div>
+          {canRepositionCueBall && (
+            <button
+              type="button"
+              onClick={handleCueBallReposition}
+              disabled={hud.inHand}
+              aria-label="Reposition cue ball"
+              title="Reposition cue ball"
+              className={`absolute -left-11 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-white/50 bg-slate-900/80 text-lg shadow-lg transition ${
+                hud.inHand ? 'cursor-not-allowed opacity-60' : 'hover:scale-105'
+              }`}
+            >
+              <span aria-hidden="true">✋️</span>
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -486,7 +486,7 @@ export default function PoolRoyaleLobby() {
           </div>
           <div className="grid grid-cols-3 gap-3">
             {[
-              { id: 'uk', label: '8 Pool UK' },
+              { id: 'uk', label: '8Ball' },
               { id: 'american', label: 'American' },
               { id: '9ball', label: '9-Ball' }
             ].map(({ id, label }) => {
@@ -526,7 +526,7 @@ export default function PoolRoyaleLobby() {
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Visuals</span>
             </div>
             <p className="text-xs text-white/60">
-              Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8 Pool UK rules.
+              Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8Ball rules.
             </p>
             <div className="grid grid-cols-3 gap-3">
               {[

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1705,7 +1705,7 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
   },
   uk: {
     id: 'uk',
-    label: '8-Ball UK',
+    label: '8Ball',
     cueColor: 0xffffff,
     rackLayout: 'triangle',
     disableSnookerMarkings: true,

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { applySRGBColorSpace } from './colorSpace.js';
 
 // Pool Royale generates up to 15 numbered + striped textures when players pick the
-// Solids & Stripes skin for UK 8-ball. At 4096px this was exhausting mobile GPUs
+// Solids & Stripes skin for 8Ball. At 4096px this was exhausting mobile GPUs
 // and crashing the session, so dial the texture size back to keep memory in check.
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -275,16 +275,16 @@ const ENGLISH_TEMPLATES = Object.freeze({
     ]
   },
   eightBallUk: {
-    variantName: '8-ball UK',
+    variantName: '8Ball',
     groupCall: [
       'Open table between {groupPrimary} and {groupSecondary}; {player} will claim a set soon.',
-      '{groupPrimary} versus {groupSecondary} in UK rules; the first clean pot sets the route.',
-      'UK rules in play. {groupPrimary} and {groupSecondary} are both available.'
+      '{groupPrimary} versus {groupSecondary} in 8Ball; the first clean pot sets the route.',
+      '8Ball rules in play. {groupPrimary} and {groupSecondary} are both available.'
     ],
     freeBall: [
-      'Foul gives {player} a free ball—huge advantage in UK rules.',
-      'That is a free ball for {player}; they can use it tactically.',
-      'UK rules apply: free ball and two visits for {player}.'
+      'Foul gives {player} ball in hand—huge advantage in 8Ball.',
+      'Ball in hand for {player}; they can use it tactically.',
+      '8Ball rules apply: ball in hand for {player}.'
     ],
     blackBall: [
       'The black is in play now. This is the money ball.',
@@ -453,16 +453,16 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ]
     },
     eightBallUk: {
-      variantName: '8 palle UK',
+      variantName: '8Ball',
       groupCall: [
-        'Regole UK: {groupPrimary} e {groupSecondary} sono aperte.',
+        'Regole 8Ball: {groupPrimary} e {groupSecondary} sono aperte.',
         '{player} deve scegliere tra {groupPrimary} e {groupSecondary}.',
-        'Tavolo aperto in UK 8-ball.'
+        'Tavolo aperto in 8Ball.'
       ],
       freeBall: [
-        'Fallo: {player} ha free ball e due visite.',
-        'Free ball per {player}; grande vantaggio.',
-        '{player} ha free ball: può impostare tattica.'
+        'Fallo: {player} ha palla in mano.',
+        'Palla in mano per {player}; grande vantaggio.',
+        '{player} con palla in mano: può impostare la tattica.'
       ],
       blackBall: [
         'Ora la nera è in gioco.',
@@ -558,9 +558,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       eightBall: ['现在进入8号球阶段，走位决定胜负。']
     },
     eightBallUk: {
-      variantName: '英式8球',
-      groupCall: ['英式规则，{groupPrimary}与{groupSecondary}等待归属。'],
-      freeBall: ['{player}获得自由球与两次击球机会。'],
+      variantName: '8Ball',
+      groupCall: ['8Ball规则，{groupPrimary}与{groupSecondary}等待归属。'],
+      freeBall: ['{player}获得自由球，拥有球权优势。'],
       blackBall: ['黑球上台，角度要求很高。']
     }
   },
@@ -651,9 +651,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       eightBall: ['अब 8-बॉल का खेल, पोजिशन निर्णायक है।']
     },
     eightBallUk: {
-      variantName: 'यूके 8-बॉल',
-      groupCall: ['यूके नियमों में {groupPrimary} और {groupSecondary} खुले हैं।'],
-      freeBall: ['{player} को फ्री बॉल और दो विज़िट मिलती हैं।'],
+      variantName: '8Ball',
+      groupCall: ['8Ball नियमों में {groupPrimary} और {groupSecondary} खुले हैं।'],
+      freeBall: ['{player} को बॉल इन हैंड मिलती है।'],
       blackBall: ['ब्लैक बॉल आ गई, एंगल बहुत जरूरी है।']
     }
   },
@@ -744,9 +744,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       eightBall: ['Ahora la 8 está en juego; la posición manda.']
     },
     eightBallUk: {
-      variantName: '8 bolas británico',
-      groupCall: ['Reglas UK: {groupPrimary} y {groupSecondary} aún abiertos.'],
-      freeBall: ['{player} tiene bola libre y dos visitas.'],
+      variantName: '8Ball',
+      groupCall: ['Reglas 8Ball: {groupPrimary} y {groupSecondary} aún abiertos.'],
+      freeBall: ['{player} tiene bola en mano.'],
       blackBall: ['La negra está en juego; el ángulo es clave.']
     }
   },
@@ -837,9 +837,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       eightBall: ['La 8 est en jeu; la position est cruciale.']
     },
     eightBallUk: {
-      variantName: '8-ball UK',
-      groupCall: ['Règles UK: {groupPrimary} et {groupSecondary} sont ouverts.'],
-      freeBall: ['{player} a une bille libre et deux visites.'],
+      variantName: '8Ball',
+      groupCall: ['Règles 8Ball: {groupPrimary} et {groupSecondary} sont ouverts.'],
+      freeBall: ['{player} a une bille en main.'],
       blackBall: ['La noire est en jeu; l’angle compte.']
     }
   },
@@ -930,9 +930,9 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       eightBall: ['الآن الكرة 8 في اللعب؛ الوضعية هي الفاصل.']
     },
     eightBallUk: {
-      variantName: '8 بول بريطاني',
-      groupCall: ['قواعد UK: {groupPrimary} و{groupSecondary} مفتوحة.'],
-      freeBall: ['{player} يحصل على كرة حرة وزيارتين.'],
+      variantName: '8Ball',
+      groupCall: ['قواعد 8Ball: {groupPrimary} و{groupSecondary} مفتوحة.'],
+      freeBall: ['{player} يحصل على كرة في اليد.'],
       blackBall: ['الكرة السوداء في اللعب؛ الزاوية مهمة جدًا.']
     }
   },
@@ -1102,16 +1102,16 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ]
     },
     eightBallUk: {
-      variantName: '8-boll britanik',
+      variantName: '8Ball',
       groupCall: [
-        'Rregullat UK: {groupPrimary} dhe {groupSecondary} janë të hapura.',
-        'Rregullat UK—grupet janë të lira për momentin.',
+        'Rregullat 8Ball: {groupPrimary} dhe {groupSecondary} janë të hapura.',
+        'Rregullat 8Ball—grupet janë të lira për momentin.',
         '{groupPrimary} ose {groupSecondary}; poti i parë e vendos.'
       ],
       freeBall: [
-        'Top i lirë dhe dy vizita për {player}.',
-        '{player} merr top të lirë—avantazh i madh.',
-        'Dy vizita në UK; {player} ka shans të artë.'
+        'Top në dorë për {player}.',
+        '{player} merr top në dorë—avantazh i madh.',
+        'Top në dorë; {player} ka shans të artë.'
       ],
       blackBall: [
         'Topi i zi në lojë; kërkohet kënd i përsosur.',


### PR DESCRIPTION
### Motivation
- Align the UK 8-ball variant with official 8-ball rules by removing the "two visits" free-ball flow and using ball-in-hand (baulk) on fouls and break scratches. 
- Provide a clear UX for cue-ball placement on break/fouls by restricting placement to the baulk area and adding an explicit reposition control. 
- Rename copy/assets from “UK 8 Ball” / “8 Pool UK” to `8Ball` for consistent product naming across UI, docs and training content. 

### Description
- Rules: updated `UkPool` behavior in `lib/poolUk8Ball.js` so `startBreak()` sets `mustPlayFromBaulk = true`, fouls set `shotsNext = 1` and `mustPlayFromBaulk = true` (remove two-visit flow), and shot result fields adjusted accordingly. 
- UI/game: restricted full-table in-hand placement for the UK variant by changing `allowFullTableInHand()` in `webapp/src/pages/Games/PoolRoyale.jsx`, clarified in-hand HUD text to mention the white line, and added a cue-ball reposition button (✋️) with handler `handleCueBallReposition` and `canRepositionCueBall` so players can re-enter in-hand placement. 
- Text/assets: renamed UX labels and assets from UK names to `8Ball` across lobby, lobby thumbnails, training config, commentary templates, docs and a rack SVG; updated comments in AI code and material factory to reflect the new name. 
- Tests: updated `test/poolUk8Ball.test.js` to reflect the new ball-in-hand behavior (added `game.startBreak()` where appropriate and expect `shotsRemainingNext === 1` and `mustPlayFromBaulk === true`). 

Files changed (high level): `lib/poolUk8Ball.js`, `webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/PoolRoyaleLobby.jsx`, `webapp/src/config/poolRoyaleTraining.js`, `webapp/src/utils/poolRoyaleCommentary.js`, `webapp/src/components/ProjectAchievementsCard.jsx`, `webapp/src/utils/ballMaterialFactory.js`, `docs/3d-billiards-variants.md`, `webapp/public/assets/game-art/variants/pool-royale/8-pool-uk-rack.svg`, `lib/poolUkAdvancedAi.js`, `lib/poolAi.js`, `test/poolUk8Ball.test.js`. 

### Testing
- Started the web dev server with `npm --prefix webapp run dev` which launched Vite successfully and served the app (local URL printed). 
- Attempted an automated headless screenshot via Playwright to validate the lobby/game UI, but the Playwright run timed out and did not complete. 
- Updated unit tests under `test/poolUk8Ball.test.js` to match the new rules, but automated unit tests (`jest`) were not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698186fe1db08329a4b627b6d4e96b37)