### PR TITLE
Add cushion tangential friction and spin damping to improve rail collisions

### DIFF
--- a/billiards/Collision.cs
+++ b/billiards/Collision.cs
@@ -13,6 +13,18 @@ public static class Collision
         return v - n * (1 + restitution) * dot;
     }
 
+    /// <summary>Reflect velocity with tangential damping to simulate cushion grip.</summary>
+    public static Vec2 ReflectWithFriction(Vec2 v, Vec2 normal, double restitution, double friction)
+    {
+        var n = normal.Normalized();
+        var alongNormal = Vec2.Dot(v, n);
+        var tangent = v - n * alongNormal;
+        var clampedFriction = Math.Clamp(friction, 0.0, 0.95);
+        var dampedTangent = tangent * (1.0 - clampedFriction);
+        var reflectedNormal = n * (-alongNormal * restitution);
+        return dampedTangent + reflectedNormal;
+    }
+
     /// <summary>Reflect velocity on a surface with default table restitution.</summary>
     public static Vec2 Reflect(Vec2 v, Vec2 normal)
     {

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -14,7 +14,7 @@ public static class PhysicsConstants
     public const double Gravity = 9.81;                // m/s^2
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
     public const double SpinDecay = 2.0;               // per-second decay for on-table spin
-    public const double AirSpinDecay = 0.6;            // per-second decay while airborne
+    public const double AirSpinDecay = 3.5;            // per-second decay while airborne
     public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
     public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
@@ -53,6 +53,12 @@ public static class PhysicsConstants
     public const double SidePocketOutset = 0.006;
     // Offset pocket mouth guards to stop balls slipping between jaws and cushions.
     public const double PocketMouthGuardInset = BallRadius * 0.35;
+
+    // Cushion response tuning to reduce slow sliding and improve grip.
+    public const double CushionFriction = 0.22;        // tangential damping on cushion contact
+    public const double CushionFrictionLowSpeedBoost = 0.28; // extra damping for slow impacts
+    public const double CushionFrictionSpeedThreshold = 1.1; // m/s threshold for low-speed boost
+    public const double CushionSpinLoss = 0.35;        // spin retained after cushion contact
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 32;


### PR DESCRIPTION
### Motivation
- Slow balls were unrealistically sliding along cushions and entering pockets instead of exhibiting natural roll/impact behavior, so cushion interactions and spin response need more realistic handling.
- The change aims to reduce artificial sliding at low speeds and make post-impact rolling and spin loss feel natural and consistent with shot power and spin.

### Description
- Add `Collision.ReflectWithFriction` to apply tangential damping on cushion/rail impacts and simulate cushion grip.
- Replace direct `Collision.Reflect` calls in `BilliardsSolver.cs` (connector, cushion and pocket edge handling and preview impact paths) with `ReflectWithFriction`, and damp `SideSpin` and `ForwardSpin` after cushion contacts.
- Introduce new tuning constants in `PhysicsConstants.cs`: `CushionFriction`, `CushionFrictionLowSpeedBoost`, `CushionFrictionSpeedThreshold`, and `CushionSpinLoss`, and increase `AirSpinDecay` to better match airborne spin behavior.
- Add `CushionFrictionForSpeed` helper to scale tangential damping by impact speed so low-speed impacts get stronger grip.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981909249988329a0150c289c689364)