### PR TITLE
Improve cushion collisions: add friction and spin damping

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -456,7 +456,13 @@ public class BilliardsSolver
                             b.Pocketed = true;
                             break;
                         }
-                        b.Velocity = Collision.Reflect(b.Velocity, normal, restitution);
+                        var incoming = b.Velocity;
+                        var reflected = Collision.Reflect(incoming, normal, restitution);
+                        if (restitution > 0)
+                        {
+                            reflected = ApplyCushionFriction(b, incoming, reflected, normal);
+                        }
+                        b.Velocity = reflected;
                         b.Position = contactPoint + normal * (PhysicsConstants.BallRadius + PhysicsConstants.ContactOffset);
                         remaining = Math.Max(0, remaining - travel);
                         StepVertical(b, travel);
@@ -704,7 +710,12 @@ public class BilliardsSolver
             if (Ccd.CircleSegment(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te) && te <= dt)
             {
                 cue.Position += cue.Velocity * te;
-                var post = Collision.Reflect(cue.Velocity, e.Normal, PhysicsConstants.ConnectorRestitution);
+                var incoming = cue.Velocity;
+                var post = Collision.Reflect(incoming, e.Normal, PhysicsConstants.ConnectorRestitution);
+                if (PhysicsConstants.ConnectorRestitution > 0)
+                {
+                    post = ApplyCushionFriction(cue, incoming, post, e.Normal);
+                }
                 impact = new Impact { Point = cue.Position, CueVelocity = post };
                 return true;
             }
@@ -715,7 +726,12 @@ public class BilliardsSolver
             if (Ccd.CircleSegment(cue.Position, cue.Velocity, PhysicsConstants.BallRadius, e.A, e.B, e.Normal, out double te) && te <= dt)
             {
                 cue.Position += cue.Velocity * te;
-                var post = Collision.Reflect(cue.Velocity, e.Normal, PhysicsConstants.CushionRestitution);
+                var incoming = cue.Velocity;
+                var post = Collision.Reflect(incoming, e.Normal, PhysicsConstants.CushionRestitution);
+                if (PhysicsConstants.CushionRestitution > 0)
+                {
+                    post = ApplyCushionFriction(cue, incoming, post, e.Normal);
+                }
                 impact = new Impact { Point = cue.Position, CueVelocity = post };
                 return true;
             }
@@ -727,7 +743,12 @@ public class BilliardsSolver
             {
                 cue.Position += cue.Velocity * te;
                 var restitution = airborne ? PhysicsConstants.CushionRestitution : PhysicsConstants.PocketRestitution;
-                var post = Collision.Reflect(cue.Velocity, e.Normal, restitution);
+                var incoming = cue.Velocity;
+                var post = Collision.Reflect(incoming, e.Normal, restitution);
+                if (restitution > 0)
+                {
+                    post = ApplyCushionFriction(cue, incoming, post, e.Normal);
+                }
                 impact = new Impact { Point = cue.Position, CueVelocity = post };
                 return true;
             }
@@ -768,5 +789,27 @@ public class BilliardsSolver
             return x >= edge1 ? 1.0 : 0.0;
         double t = Math.Clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
         return t * t * (3.0 - 2.0 * t);
+    }
+
+    private static Vec2 ApplyCushionFriction(Ball ball, Vec2 incoming, Vec2 reflected, Vec2 normal)
+    {
+        var tangent = new Vec2(-normal.Y, normal.X);
+        double tangentSpeed = Vec2.Dot(incoming, tangent);
+        double speedAbs = Math.Abs(tangentSpeed);
+        double lowSpeedBlend = 1.0 - Smoothstep(0.0, PhysicsConstants.CushionLowSpeed, speedAbs);
+        double friction = Lerp(PhysicsConstants.CushionFriction, PhysicsConstants.CushionLowSpeedFriction, lowSpeedBlend);
+        friction = Math.Clamp(friction, 0.0, 1.0);
+        reflected -= tangent * (tangentSpeed * friction);
+
+        double spinDamping = Lerp(PhysicsConstants.CushionSpinDamping, PhysicsConstants.CushionLowSpeedSpinDamping, lowSpeedBlend);
+        spinDamping = Math.Clamp(spinDamping, 0.0, 1.0);
+        ball.SideSpin *= 1.0 - spinDamping;
+        ball.ForwardSpin *= 1.0 - spinDamping * PhysicsConstants.CushionForwardSpinDamping;
+        return reflected;
+    }
+
+    private static double Lerp(double a, double b, double t)
+    {
+        return a + (b - a) * Math.Clamp(t, 0.0, 1.0);
     }
 }

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -14,7 +14,7 @@ public static class PhysicsConstants
     public const double Gravity = 9.81;                // m/s^2
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
     public const double SpinDecay = 2.0;               // per-second decay for on-table spin
-    public const double AirSpinDecay = 0.6;            // per-second decay while airborne
+    public const double AirSpinDecay = 3.0;            // per-second decay while airborne
     public const double SwerveCoefficient = 2.4;       // lateral accel per unit side spin * speed
     public const double RollAcceleration = 1.2;        // forward accel per unit top/back spin
     public const double JumpRestitution = 0.1;         // vertical energy retained on landing
@@ -40,6 +40,12 @@ public static class PhysicsConstants
     public const double MinCollisionTime = 1e-4;       // guard to prevent zero-time loops
     public const double ContactOffset = 1e-5;          // small push to keep balls off geometry
     public const int MaxSubSteps = 64;                 // hard cap per integration step
+    public const double CushionFriction = 0.18;        // base tangential damping at cushion contact
+    public const double CushionLowSpeedFriction = 0.7; // extra damping when sliding slowly
+    public const double CushionLowSpeed = 0.35;        // m/s below which cushion grip increases
+    public const double CushionSpinDamping = 0.25;     // spin lost on cushion contact
+    public const double CushionLowSpeedSpinDamping = 0.45; // extra spin loss for slow hits
+    public const double CushionForwardSpinDamping = 0.6;   // forward spin fraction vs side spin
 
     // Pocket geometry derived from WPA spec (metres)
     public const double CornerPocketMouth = 0.1014984; // scaled with table reduction


### PR DESCRIPTION
### Motivation
- Cushion/rail impacts were producing unrealistic sliding and excessive airborne spin, so the contact model needed to be tuned to give natural rolling, grip on slow rail hits, and correct spin loss on impacts.

### Description
- Added tunable constants in `PhysicsConstants.cs` (`CushionFriction`, `CushionLowSpeedFriction`, `CushionLowSpeed`, `CushionSpinDamping`, `CushionLowSpeedSpinDamping`, `CushionForwardSpinDamping`) and increased `AirSpinDecay` to reduce unrealistic airspin. 
- Implemented `ApplyCushionFriction` in `BilliardsSolver.cs` to remove tangential velocity at cushion contact and damp side/forward spin using a speed-dependent blend. 
- Applied the cushion friction/spin damping in the live simulation reflection path and in the CCD preview/impact code (`Step` and `TryFindImpact`) for consistent behavior. 
- Added small helpers (`Lerp`) and used `Smoothstep` blending to transition to higher friction/spin loss at low tangential speeds.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981909249988329a0150c289c689364)