### PR TITLE
Tighten Snooker Royal broadcast framing to match Pool Royale

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -163,10 +163,14 @@ public class CueCamera : MonoBehaviour
     public float standingCameraDistance = 0.82f;
     // Height offset above the table focus, captured on start.
     public float standingCameraHeight = 0.48f;
+    // Pull the standing camera inward so the framing matches the Pool Royale view.
+    public float standingCameraDistanceInset = 0.08f;
+    // Additional height offset applied after caching the standing camera pose.
+    public float standingCameraHeightOffset = -0.04f;
 
     [Header("Pocket camera framing")]
     // Pull the pocket camera slightly inward for tighter pocket coverage.
-    public float pocketCameraDistanceInset = 0.08f;
+    public float pocketCameraDistanceInset = 0.14f;
     // Nudge the pocket camera look target downward for a slightly steeper angle.
     public float pocketCameraLookDownOffset = 0.03f;
 
@@ -756,7 +760,7 @@ public class CueCamera : MonoBehaviour
         float heightOffset = baseHeight;
         if (useStandingCameraForBroadcast && cachedStandingCamera)
         {
-            heightOffset = Mathf.Max(standingCameraHeight, minimumHeightAboveFocus);
+            heightOffset = Mathf.Max(standingCameraHeight + standingCameraHeightOffset, minimumHeightAboveFocus);
         }
         float heightPadding = useStandingCameraForBroadcast && cachedStandingCamera ? 0f : Mathf.Max(0f, broadcastHeightPadding);
         float height = Mathf.Max(heightOffset + heightPadding, minRailHeight);
@@ -769,7 +773,7 @@ public class CueCamera : MonoBehaviour
         focus.z = broadcastBounds.center.z;
 
         float distance = useStandingCameraForBroadcast && cachedStandingCamera
-            ? standingCameraDistance
+            ? Mathf.Max(standingCameraDistance - Mathf.Max(0f, standingCameraDistanceInset), broadcastMinDistance)
             : ComputeBroadcastDistance(focus, height, forward, cam, broadcastBounds);
         if (isPocketCamera)
         {


### PR DESCRIPTION
### Motivation
- Align Snooker Royal broadcast framing with Pool Royale so standing camera framing, pocket framing and apparent ball size/margins match the Pool Royale view.
- Pull pocket cameras slightly inward and allow a small standing-camera inward/height tune so broadcast shots and pocket closeups have the same exaframing as Pool Royale.

### Description
- Added two public tuning fields: `standingCameraDistanceInset` and `standingCameraHeightOffset` to allow configurable inward shift and height adjustment for the cached standing camera pose.
- Apply the standing-camera inset and height offset when `useStandingCameraForBroadcast && cachedStandingCamera` is used, clamping the distance to `broadcastMinDistance` and applying the height offset to the height calculation.
- Increased the pocket camera inset by raising `pocketCameraDistanceInset` from `0.08f` to `0.14f` so pocket cameras produce tighter framing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981995934a08329a51916e0ee912842)