### PR TITLE
Add ball-in-hand hand icon and icon-initiated drag for cue ball

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12925,6 +12925,10 @@ const handleSkipReplayClick = useCallback(() => {
   const [hudInsets, setHudInsets] = useState({ left: '0px', right: '0px' });
   const [bottomHudOffset, setBottomHudOffset] = useState(0);
   const inHandTopViewRef = useRef(false);
+  const inHandIconRef = useRef(null);
+  const startInHandDragRef = useRef(null);
+  const endInHandDragRef = useRef(null);
+  const inHandIconFrameRef = useRef(null);
 const leftControlsRef = useRef(null);
 const spinBoxRef = useRef(null);
 const showRuleToast = useCallback((message) => {
@@ -12959,6 +12963,64 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     hudRef.current = hud;
   }, [hud]);
+  useEffect(() => {
+    const icon = inHandIconRef.current;
+    if (!icon) return undefined;
+    let disposed = false;
+    const tmp = new THREE.Vector3();
+    const update = () => {
+      if (disposed) return;
+      const currentHud = hudRef.current;
+      if (!currentHud?.inHand) {
+        icon.style.opacity = '0';
+        icon.style.pointerEvents = 'none';
+        inHandIconFrameRef.current = requestAnimationFrame(update);
+        return;
+      }
+      const cueBall = cueRef.current;
+      const camera = activeRenderCameraRef.current ?? cameraRef.current;
+      const dom = rendererRef.current?.domElement;
+      if (!cueBall || !camera || !dom) {
+        icon.style.opacity = '0';
+        icon.style.pointerEvents = 'none';
+        inHandIconFrameRef.current = requestAnimationFrame(update);
+        return;
+      }
+      if (cueBall.mesh?.position) {
+        tmp.copy(cueBall.mesh.position);
+      } else if (cueBall.pos) {
+        tmp.set(cueBall.pos.x, BALL_CENTER_Y, cueBall.pos.y);
+      } else {
+        icon.style.opacity = '0';
+        icon.style.pointerEvents = 'none';
+        inHandIconFrameRef.current = requestAnimationFrame(update);
+        return;
+      }
+      tmp.project(camera);
+      if (tmp.z < 0 || tmp.z > 1) {
+        icon.style.opacity = '0';
+        icon.style.pointerEvents = 'none';
+        inHandIconFrameRef.current = requestAnimationFrame(update);
+        return;
+      }
+      const rect = dom.getBoundingClientRect();
+      const screenX = rect.left + (tmp.x * 0.5 + 0.5) * rect.width;
+      const screenY = rect.top + (-tmp.y * 0.5 + 0.5) * rect.height;
+      const offset = 28 * uiScale;
+      const scale = Math.max(0.85, Math.min(1.2, uiScale));
+      icon.style.opacity = '1';
+      icon.style.pointerEvents = 'auto';
+      icon.style.transform = `translate3d(${screenX + offset}px, ${screenY - offset}px, 0) scale(${scale})`;
+      inHandIconFrameRef.current = requestAnimationFrame(update);
+    };
+    inHandIconFrameRef.current = requestAnimationFrame(update);
+    return () => {
+      disposed = true;
+      if (inHandIconFrameRef.current) {
+        cancelAnimationFrame(inHandIconFrameRef.current);
+      }
+    };
+  }, [uiScale]);
   useEffect(
     () => () => {
       if (ruleToastTimeoutRef.current) {
@@ -21495,7 +21557,8 @@ const powerRef = useRef(hud.power);
       const inHandDrag = {
         active: false,
         pointerId: null,
-        lastPos: null
+        lastPos: null,
+        captureTarget: null
       };
       const updateCuePlacement = (pos) => {
         if (!cue || !pos) return;
@@ -21715,7 +21778,7 @@ const powerRef = useRef(hud.power);
         setHud((prev) => ({ ...prev, inHand: false }));
         return true;
       };
-      const handleInHandDown = (e) => {
+      const beginInHandDrag = (e, captureTarget = dom) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand)) return;
         if (!inHandPlacementModeRef.current) return;
@@ -21726,12 +21789,16 @@ const powerRef = useRef(hud.power);
         if (!tryUpdatePlacement(p, false)) return;
         inHandDrag.active = true;
         inHandDrag.pointerId = e.pointerId ?? 'mouse';
-        if (e.pointerId != null && dom.setPointerCapture) {
+        inHandDrag.captureTarget = captureTarget ?? dom;
+        if (e.pointerId != null && inHandDrag.captureTarget?.setPointerCapture) {
           try {
-            dom.setPointerCapture(e.pointerId);
+            inHandDrag.captureTarget.setPointerCapture(e.pointerId);
           } catch {}
         }
         e.preventDefault?.();
+      };
+      const handleInHandDown = (e) => {
+        beginInHandDrag(e, dom);
       };
       const handleInHandMove = (e) => {
         if (!inHandDrag.active) return;
@@ -21755,12 +21822,13 @@ const powerRef = useRef(hud.power);
         ) {
           return;
         }
-        if (e.pointerId != null && dom.releasePointerCapture) {
+        if (e.pointerId != null && inHandDrag.captureTarget?.releasePointerCapture) {
           try {
-            dom.releasePointerCapture(e.pointerId);
+            inHandDrag.captureTarget.releasePointerCapture(e.pointerId);
           } catch {}
         }
         inHandDrag.active = false;
+        inHandDrag.captureTarget = null;
         const pos = inHandDrag.lastPos;
         if (pos) {
           tryUpdatePlacement(pos, true);
@@ -21769,8 +21837,11 @@ const powerRef = useRef(hud.power);
         }
         e.preventDefault?.();
       };
+      startInHandDragRef.current = beginInHandDrag;
+      endInHandDragRef.current = endInHandDrag;
       dom.addEventListener('pointerdown', handleInHandDown);
       dom.addEventListener('pointermove', handleInHandMove);
+      window.addEventListener('pointermove', handleInHandMove);
       window.addEventListener('pointerup', endInHandDrag);
       dom.addEventListener('pointercancel', endInHandDrag);
       window.addEventListener('pointercancel', endInHandDrag);
@@ -26977,9 +27048,12 @@ const powerRef = useRef(hud.power);
         window.removeEventListener('keydown', keyRot);
         dom.removeEventListener('pointerdown', handleInHandDown);
         dom.removeEventListener('pointermove', handleInHandMove);
+        window.removeEventListener('pointermove', handleInHandMove);
         window.removeEventListener('pointerup', endInHandDrag);
         dom.removeEventListener('pointercancel', endInHandDrag);
         window.removeEventListener('pointercancel', endInHandDrag);
+        startInHandDragRef.current = null;
+        endInHandDragRef.current = null;
         applyBaseRef.current = () => {};
         applyFinishRef.current = () => {};
         applyTableSlotRef.current = () => {};
@@ -27189,6 +27263,16 @@ const powerRef = useRef(hud.power);
     setHud((prev) => ({ ...prev, inHand: true }));
     setInHandPlacementMode(true);
   }, [canRepositionCueBall]);
+  const handleInHandIconPointerDown = useCallback((event) => {
+    if (!hudRef.current?.inHand) return;
+    event.preventDefault?.();
+    setInHandPlacementMode(true);
+    startInHandDragRef.current?.(event, event.currentTarget);
+  }, []);
+  const handleInHandIconPointerUp = useCallback((event) => {
+    event.preventDefault?.();
+    endInHandDragRef.current?.(event);
+  }, []);
   const spinRingLabels = useMemo(
     () => {
       const radius = 72;
@@ -29008,6 +29092,21 @@ const powerRef = useRef(hud.power);
         </div>
       )}
       {hud?.inHand && (
+        <button
+          ref={inHandIconRef}
+          type="button"
+          onPointerDown={handleInHandIconPointerDown}
+          onPointerUp={handleInHandIconPointerUp}
+          onPointerCancel={handleInHandIconPointerUp}
+          aria-label="Drag cue ball"
+          title="Hold to drag the cue ball"
+          className="pointer-events-auto absolute left-0 top-0 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-white/50 bg-slate-900/80 text-lg shadow-[0_10px_22px_rgba(0,0,0,0.45)] backdrop-blur-sm"
+          style={{ transform: 'translate3d(-9999px, -9999px, 0)', touchAction: 'none' }}
+        >
+          <span aria-hidden="true">✋️</span>
+        </button>
+      )}
+      {hud?.inHand && (
         <div className="pointer-events-none absolute left-1/2 top-4 z-40 flex -translate-x-1/2 flex-col items-center gap-2 px-3 text-center text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.55)]">
           <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-semibold text-gray-900 shadow-lg ring-1 ring-white/60">
             <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">BIH</span>
@@ -29016,7 +29115,7 @@ const powerRef = useRef(hud.power);
             </span>
           </div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/85">
-            Tap to place · drag to fine-tune · release to lock
+            Hold the hand icon · drag to fine-tune · release to lock
           </span>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Provide a clear affordance when the player has ball-in-hand by showing a hand icon adjacent to the cue ball and let the player hold-and-drag to position the cue ball for a responsive placement experience.

### Description
- Add UI and refs for an in-hand hand icon (`inHandIconRef`, `inHandIconFrameRef`, `startInHandDragRef`, `endInHandDragRef`) and render the icon while `hud.inHand` is true in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Introduce an animation/update loop that projects the cue ball world position to screen space and repositions the hand icon so it tracks the cue ball in real time.
- Extend the existing in-hand placement drag flow to support icon-initiated pointer capture by adding `beginInHandDrag(captureTarget)` and storing `inHandDrag.captureTarget`, and bind pointer move handling on `window` to improve responsiveness while dragging.
- Wire the icon `onPointerDown`/`onPointerUp` to start/stop the placement drag and update the HUD copy to instruct players to "Hold the hand icon · drag to fine-tune · release to lock".
- Ensure proper cleanup of event listeners and animation frames on teardown.

### Testing
- Launched the web dev server (`npm --prefix webapp run dev`) in the environment to exercise the UI (server started in background; no unit tests were executed).
- Attempted an automated visual check using Playwright to capture a screenshot, but the headless browser failed to launch/crashed (SIGSEGV/TargetClosedError), so no screenshot was produced.
- No unit tests (`npm test`) or snapshot tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819f8ba0888329b92df1a123dcebc8)