### PR TITLE
Add ball‑in‑hand hand icon for cue‑ball placement (press & drag)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5289,6 +5289,7 @@ const TMP_VEC3_E = new THREE.Vector3();
 const TMP_VEC3_F = new THREE.Vector3();
 const TMP_VEC3_G = new THREE.Vector3();
 const TMP_VEC3_H = new THREE.Vector3();
+const TMP_VEC3_IN_HAND_ICON = new THREE.Vector3();
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CUE_TIP_OFFSET = new THREE.Vector3();
 const TMP_VEC3_CUE_BUTT_OFFSET = new THREE.Vector3();
@@ -12878,6 +12879,9 @@ function PoolRoyaleGame({
     []
   );
   const inHandPlacementModeRef = useRef(inHandPlacementMode);
+  const inHandIconRef = useRef(null);
+  const inHandDragRef = useRef({ active: false, pointerId: null, lastPos: null });
+  const inHandPlacementApiRef = useRef({ begin: null, move: null, end: null });
   const gameOverHandledRef = useRef(false);
   const userSuggestionRef = useRef(null);
   const startAiThinkingRef = useRef(() => {});
@@ -21492,11 +21496,7 @@ const powerRef = useRef(hud.power);
         clampInHandPosition(
           new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
         );
-      const inHandDrag = {
-        active: false,
-        pointerId: null,
-        lastPos: null
-      };
+      const inHandDrag = inHandDragRef.current;
       const updateCuePlacement = (pos) => {
         if (!cue || !pos) return;
         cue.mesh.visible = true;
@@ -21768,6 +21768,51 @@ const powerRef = useRef(hud.power);
           autoAimRequestRef.current = true;
         }
         e.preventDefault?.();
+      };
+      inHandPlacementApiRef.current = {
+        begin: (e) => {
+          const currentHud = hudRef.current;
+          if (!(currentHud?.inHand)) return false;
+          if (!inHandPlacementModeRef.current) return false;
+          if (shooting) return false;
+          const p = project(e);
+          if (!p) return false;
+          if (!tryUpdatePlacement(p, false)) return false;
+          inHandDrag.active = true;
+          inHandDrag.pointerId = e.pointerId ?? 'icon';
+          return true;
+        },
+        move: (e) => {
+          if (!inHandDrag.active) return false;
+          if (
+            inHandDrag.pointerId != null &&
+            e.pointerId != null &&
+            e.pointerId !== inHandDrag.pointerId
+          ) {
+            return false;
+          }
+          const p = project(e);
+          if (p) tryUpdatePlacement(p, false);
+          return true;
+        },
+        end: (e) => {
+          if (!inHandDrag.active) return false;
+          if (
+            inHandDrag.pointerId != null &&
+            e.pointerId != null &&
+            e.pointerId !== inHandDrag.pointerId
+          ) {
+            return false;
+          }
+          inHandDrag.active = false;
+          const pos = inHandDrag.lastPos;
+          if (pos) {
+            tryUpdatePlacement(pos, true);
+            setInHandPlacementMode(false);
+            autoAimRequestRef.current = true;
+          }
+          return true;
+        }
       };
       dom.addEventListener('pointerdown', handleInHandDown);
       dom.addEventListener('pointermove', handleInHandMove);
@@ -26838,6 +26883,44 @@ const powerRef = useRef(hud.power);
           }
           syncCueShadow();
           const frameCamera = updateCamera();
+          const handIconEl = inHandIconRef.current;
+          if (handIconEl) {
+            const currentHud = hudRef.current;
+            const shouldShow =
+              Boolean(currentHud?.inHand) &&
+              currentHud?.turn === 0 &&
+              cue?.mesh &&
+              cue?.active &&
+              !replayPlaybackRef.current;
+            if (!shouldShow) {
+              handIconEl.style.opacity = '0';
+              handIconEl.style.pointerEvents = 'none';
+            } else {
+              const rect = renderer.domElement.getBoundingClientRect();
+              cue.mesh.getWorldPosition(TMP_VEC3_IN_HAND_ICON);
+              const cameraForUi = frameCamera ?? camera;
+              TMP_VEC3_IN_HAND_ICON.project(cameraForUi);
+              const screenX =
+                (TMP_VEC3_IN_HAND_ICON.x * 0.5 + 0.5) * rect.width + rect.left;
+              const screenY =
+                (-TMP_VEC3_IN_HAND_ICON.y * 0.5 + 0.5) * rect.height + rect.top;
+              const offsetX = 30;
+              const offsetY = -28;
+              const clampedX = clamp(
+                screenX + offsetX,
+                rect.left + 16,
+                rect.right - 16
+              );
+              const clampedY = clamp(
+                screenY + offsetY,
+                rect.top + 16,
+                rect.bottom - 16
+              );
+              handIconEl.style.opacity = '1';
+              handIconEl.style.pointerEvents = 'auto';
+              handIconEl.style.transform = `translate(${clampedX}px, ${clampedY}px) translate(-50%, -50%)`;
+            }
+          }
           renderer.render(scene, frameCamera ?? camera);
           const shouldStreamAim =
             isOnlineMatch &&
@@ -27189,6 +27272,36 @@ const powerRef = useRef(hud.power);
     setHud((prev) => ({ ...prev, inHand: true }));
     setInHandPlacementMode(true);
   }, [canRepositionCueBall]);
+  const canUseInHandIcon = showPlayerControls && hud.inHand;
+  const handleInHandIconPointerDown = useCallback(
+    (event) => {
+      if (!canUseInHandIcon || shootingRef.current) return;
+      cueBallPlacedFromHandRef.current = false;
+      inHandPlacementModeRef.current = true;
+      setInHandPlacementMode(true);
+      inHandPlacementApiRef.current?.begin?.(event);
+      if (event.pointerId != null) {
+        try {
+          event.currentTarget?.setPointerCapture?.(event.pointerId);
+        } catch {}
+      }
+      event.preventDefault?.();
+    },
+    [canUseInHandIcon]
+  );
+  const handleInHandIconPointerMove = useCallback((event) => {
+    inHandPlacementApiRef.current?.move?.(event);
+    event.preventDefault?.();
+  }, []);
+  const handleInHandIconPointerUp = useCallback((event) => {
+    inHandPlacementApiRef.current?.end?.(event);
+    if (event.pointerId != null) {
+      try {
+        event.currentTarget?.releasePointerCapture?.(event.pointerId);
+      } catch {}
+    }
+    event.preventDefault?.();
+  }, []);
   const spinRingLabels = useMemo(
     () => {
       const radius = 72;
@@ -29019,6 +29132,22 @@ const powerRef = useRef(hud.power);
             Tap to place · drag to fine-tune · release to lock
           </span>
         </div>
+      )}
+      {canUseInHandIcon && (
+        <button
+          ref={inHandIconRef}
+          type="button"
+          aria-label="Hold and drag to place the cue ball"
+          title="Hold and drag to place the cue ball"
+          onPointerDown={handleInHandIconPointerDown}
+          onPointerMove={handleInHandIconPointerMove}
+          onPointerUp={handleInHandIconPointerUp}
+          onPointerCancel={handleInHandIconPointerUp}
+          className="fixed z-40 flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-xl text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition"
+          style={{ opacity: 0, pointerEvents: 'none', transform: 'translate(-9999px, -9999px)' }}
+        >
+          <span aria-hidden="true">✋️</span>
+        </button>
       )}
       {/* Power Slider */}
       {showPowerSlider && !replayActive && (


### PR DESCRIPTION
### Motivation
- Provide a clear, responsive affordance for ball‑in‑hand so players can click‑and‑hold to reposition the cue ball in real time. 
- Keep input handling and placement logic unified with existing in‑hand flow so the icon is a thin UI layer rather than a separate placement system.

### Description
- Added a new DOM button (✋️) anchored to the cue ball during ball‑in‑hand by adding `inHandIconRef` and rendering a fixed button when `hud.inHand` is true. 
- Exposed an `inHandPlacementApiRef` and `inHandDragRef` to reuse the existing placement logic (`tryUpdatePlacement`, `resolveInHandPlacement`) for begin/move/end pointer interactions from the icon. 
- Updated the render loop to project the cue ball world position to screen space using `TMP_VEC3_IN_HAND_ICON` and keep the hand icon positioned and interactive in real time. 
- Minor housekeeping: added the `TMP_VEC3_IN_HAND_ICON` temporary vector and wired pointer handlers `handleInHandIconPointerDown/Move/Up` so capture/release integrate with pointer capture when available.
- File changed: `webapp/src/pages/Games/PoolRoyale.jsx` (UI + input + render loop integration). 

### Testing
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready serving the app (succeeded). 
- Attempted an automated Playwright screenshot to validate the icon on the `/games/poolroyale` page but the browser screenshot attempts timed out (failed). 
- No unit tests (`npm test` / `jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819f8ba0888329b92df1a123dcebc8)