### PR TITLE
Promote zoom preview & fallback to original images for store thumbnails

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -141,9 +141,9 @@ export default function ProjectAchievementsCard() {
     },
     {
       label: '🖼️ Store catalog photo set finalized',
-      progress: 100,
+      progress: 85,
       info:
-        'Completed: finished the remaining product catalog photo set with consistent thumbnail sizing, unified metadata, and high-res zoom previews that match lighting setups. Next: seasonal drops and limited-run studio captures.',
+        'In progress: most catalog photos are aligned, but some thumbnails still fall back to placeholders (notably chess pieces and other legacy items). Next: locate original captures for every remaining item, refresh the missing thumbnails, and re-verify lighting parity for the zoom previews.',
     },
     {
       label: '🏆 Game tournaments live',
@@ -188,13 +188,13 @@ export default function ProjectAchievementsCard() {
     {
       title: 'Store Item Photos',
       description: 'Finalize the full store catalog photo set and keep image metadata aligned.',
-      progress: 100,
+      progress: 85,
       info:
-        'Completed: full catalog photos uploaded with validated thumbnail sizing and metadata consistency. High-res zoom previews now use matched lighting for accurate material checks.',
+        'In progress: the photo set is mostly complete, but several thumbnails are still missing originals (chess pieces and other legacy items). We need to locate the source images, update thumbnails, and re-check lighting match across zoom previews.',
       nextActions: [
-        'Schedule seasonal photo refreshes for new drops.',
-        'Capture limited-edition highlight reels.',
-        'Maintain lighting parity across future releases.',
+        'Locate original renders for chess pieces and other missing thumbnails.',
+        'Regenerate thumbnails from the original captures and verify metadata.',
+        'Confirm lighting parity between the zoom preview and store thumbnails.',
       ],
     },
     {


### PR DESCRIPTION
### Motivation
- Ensure the high-res zoom preview appears prominently at the top of the store item detail so it replaces the small thumbnail as the primary product view. 
- Improve thumbnail fidelity by falling back to original/full-size images when autogenerated thumbnails or missing thumbnail fields are detected. 
- Update project achievements to reflect that the store photo set is still in progress while some original thumbnails (e.g., chess pieces) are located and fixed.

### Description
- Added `resolveOriginalImage` and updated `resolveItemThumbnail` in `webapp/src/pages/Store.jsx` to prefer original images when thumbnails are missing or are generated swatches, and to normalize PolyHaven sizes with `normalizePolyHavenImage` for consistent sizing. 
- Adjusted `resolveItemMedia` to include the original image as a zoom candidate so zoom previews use best-quality sources when available. 
- Promoted the zoom image to a hero position in the item detail view (top of the modal) with a tappable hero that opens the zoom modal, and moved the store thumbnail into its own panel for quick reference (UI changes in `Store.jsx`). 
- Updated messaging and the `Store Item Photos` / `Store catalog photo set finalized` achievement entries in `webapp/src/components/ProjectAchievementsCard.jsx` to show reduced progress and next steps for missing thumbnails.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and confirmed Vite served the app (local dev server ready at port 4173). — success. 
- Ran a Playwright script that navigated to a store item page (`/store/poolroyale`) and captured a screenshot of the updated detail view to validate the zoom hero and thumbnail panel visually; the script produced a screenshot artifact. — success. 
- No unit tests were changed or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d269500483298d688ca15a463488)