### PR TITLE
Align table customization menus and thumbnails across games

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -32,6 +32,16 @@
   #configPanel.active{display:flex;}
   #configPanel h3{margin:0;font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.75);}
   #configSections{display:flex;flex-direction:column;gap:.55rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
+  .config-card{border:1px solid rgba(148,197,255,.18);border-radius:1rem;padding:.75rem;background:rgba(15,23,42,.45);box-shadow:0 10px 24px rgba(0,0,0,.35);}
+  .config-card-title{margin:0;font-size:.7rem;letter-spacing:.34em;text-transform:uppercase;color:rgba(226,232,240,.8);}
+  .config-card-subtitle{margin:.35rem 0 0 0;font-size:.7rem;color:rgba(226,232,240,.6);}
+  .config-tabs{display:flex;gap:.4rem;overflow-x:auto;padding:.2rem .15rem .35rem;margin:0 -.15rem;}
+  .config-tab{border:1px solid rgba(148,197,255,.2);border-radius:999px;padding:.4rem .75rem;background:rgba(255,255,255,.05);color:rgba(226,232,240,.7);font-size:.7rem;font-weight:700;white-space:nowrap;transition:.2s ease;}
+  .config-tab.active{border-color:rgba(125,211,252,.8);color:#fff;background:rgba(56,189,248,.12);box-shadow:0 0 12px rgba(56,189,248,.25);}
+  .config-list{display:flex;flex-direction:column;gap:.4rem;max-height:14rem;overflow-y:auto;padding-right:.2rem;}
+  .config-row{display:flex;align-items:center;justify-content:space-between;gap:.6rem;border:1px solid rgba(148,197,255,.18);border-radius:.9rem;padding:.5rem .6rem;background:rgba(255,255,255,.05);font-size:.72rem;font-weight:700;color:rgba(226,232,240,.9);text-align:left;transition:.2s ease;}
+  .config-row.active{border-color:rgba(56,189,248,.7);background:rgba(56,189,248,.12);box-shadow:0 0 12px rgba(56,189,248,.2);}
+  .config-preview-wrap{width:6rem;flex-shrink:0;}
   #configSections::-webkit-scrollbar{width:.35rem;}
   #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
   #configSections::-webkit-scrollbar-track{background:transparent;}
@@ -2893,6 +2903,7 @@ const TABLE_SETUP_SECTIONS = [
   { key: "highlightStyle", label: "Highlights", options: HIGHLIGHT_STYLE_OPTIONS },
   { key: "chairTheme", label: "Stolat", options: CHAIR_THEME_OPTIONS }
 ];
+let activeTableSetupKey = TABLE_SETUP_SECTIONS[0]?.key;
 
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   environmentHdri: ENVIRONMENT_HDRI_OPTIONS,
@@ -4965,7 +4976,7 @@ window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
 function createOptionPreview(key, option) {
   const swatch = document.createElement('div');
   swatch.style.width = '100%';
-  swatch.style.height = '1.5rem';
+  swatch.style.height = '3.5rem';
   swatch.style.borderRadius = '0.75rem';
   swatch.style.border = '1px solid rgba(255,255,255,0.12)';
   switch (key) {
@@ -5176,38 +5187,74 @@ function refreshConfigUI() {
     commentaryWrapper.appendChild(commentaryNote);
   }
   configSectionsEl.appendChild(commentaryWrapper);
+  const personalizeWrapper = document.createElement('div');
+  personalizeWrapper.className = 'config-card';
+  const personalizeTitle = document.createElement('p');
+  personalizeTitle.className = 'config-card-title';
+  personalizeTitle.textContent = 'Personalize Arena';
+  personalizeWrapper.appendChild(personalizeTitle);
+  const personalizeSubtitle = document.createElement('p');
+  personalizeSubtitle.className = 'config-card-subtitle';
+  personalizeSubtitle.textContent = 'Table details, domino skins, and room styling.';
+  personalizeWrapper.appendChild(personalizeSubtitle);
+  const tabsRow = document.createElement('div');
+  tabsRow.className = 'config-tabs';
+  if (!TABLE_SETUP_SECTIONS.some((section) => section.key === activeTableSetupKey)) {
+    activeTableSetupKey = TABLE_SETUP_SECTIONS[0]?.key;
+  }
   TABLE_SETUP_SECTIONS.forEach((section) => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'config-section';
-    const label = document.createElement('h4');
-    label.textContent = section.label;
-    wrapper.appendChild(label);
-    const optionsGrid = document.createElement('div');
-    optionsGrid.className = 'config-options';
-    const availableOptions = getUnlockedOptions(section.key, dominoInventory);
+    const tab = document.createElement('button');
+    tab.type = 'button';
+    tab.className = 'config-tab';
+    if (section.key === activeTableSetupKey) {
+      tab.classList.add('active');
+    }
+    tab.textContent = section.label;
+    tab.addEventListener('click', () => {
+      activeTableSetupKey = section.key;
+      refreshConfigUI();
+    });
+    tabsRow.appendChild(tab);
+  });
+  personalizeWrapper.appendChild(tabsRow);
+  const activeSection =
+    TABLE_SETUP_SECTIONS.find((section) => section.key === activeTableSetupKey) ||
+    TABLE_SETUP_SECTIONS[0];
+  if (activeSection) {
+    const activeLabel = document.createElement('p');
+    activeLabel.className = 'config-card-subtitle';
+    activeLabel.style.marginTop = '0.35rem';
+    activeLabel.textContent = activeSection.label;
+    personalizeWrapper.appendChild(activeLabel);
+    const optionsList = document.createElement('div');
+    optionsList.className = 'config-list';
+    const availableOptions = getUnlockedOptions(activeSection.key, dominoInventory);
     availableOptions.forEach((option) => {
-      const idx = findDominoOptionIndex(section.key, option.id);
+      const idx = findDominoOptionIndex(activeSection.key, option.id);
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'config-option';
-      if (appearance[section.key] === idx) {
+      button.className = 'config-row';
+      if (appearance[activeSection.key] === idx) {
         button.classList.add('active');
       }
-      button.appendChild(createOptionPreview(section.key, option));
       const name = document.createElement('span');
       name.textContent = option.label ?? option.id;
       button.appendChild(name);
+      const previewWrap = document.createElement('span');
+      previewWrap.className = 'config-preview-wrap';
+      previewWrap.appendChild(createOptionPreview(activeSection.key, option));
+      button.appendChild(previewWrap);
       button.addEventListener('click', () => {
-        if (appearance[section.key] === idx) return;
-        appearance[section.key] = idx;
+        if (appearance[activeSection.key] === idx) return;
+        appearance[activeSection.key] = idx;
         applyAppearanceChange({ refresh: false });
         refreshConfigUI();
       });
-      optionsGrid.appendChild(button);
+      optionsList.appendChild(button);
     });
-    wrapper.appendChild(optionsGrid);
-    configSectionsEl.appendChild(wrapper);
-  });
+    personalizeWrapper.appendChild(optionsList);
+  }
+  configSectionsEl.appendChild(personalizeWrapper);
 
   const feedbackWrapper = document.createElement('div');
   feedbackWrapper.className = 'config-section';

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2411,48 +2411,70 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     }
   }, [selections]);
 
-  const renderOptionRow = (label, key) => {
-    const options = (AIR_HOCKEY_CUSTOMIZATION[key] || []).filter((option) =>
-      isAirHockeyOptionUnlocked(key, option.id, airInventory)
-    );
-    if (!options.length) return null;
-    return (
-      <div className="space-y-1">
-        <div className="text-[11px] uppercase tracking-wide text-white/70">{label}</div>
-        <div className="grid grid-cols-2 gap-2">
-          {options.map((option, idx) => {
-            const swatch =
-              option.surface ||
-              option.wood ||
-              option.color ||
-              option.base ||
-              option.swatches?.[0];
-            const active = selections[key] === option.id;
-            return (
-              <button
-                key={`${key}-${option.name}`}
-                onClick={() =>
-                  setSelections((prev) => ({
-                    ...prev,
-                    [key]: option.id
-                  }))
-                }
-                className={`flex items-center justify-between rounded px-2 py-1 text-left text-[11px] font-semibold transition ${
-                  active ? 'bg-white/20 text-white' : 'bg-white/5 text-white/80 hover:bg-white/10'
-                }`}
-              >
-                <span className="truncate">{option.name}</span>
-                <span
-                  className="ml-2 w-5 h-5 rounded-full border border-white/30"
-                  style={{ background: swatch }}
-                />
-              </button>
-            );
-          })}
+  const customizationSections = useMemo(
+    () =>
+      [
+        { key: 'field', label: 'Field Surface', options: AIR_HOCKEY_CUSTOMIZATION.field },
+        { key: 'cushionCloth', label: 'Cushion Cloth', options: AIR_HOCKEY_CUSTOMIZATION.cushionCloth },
+        { key: 'table', label: 'Table Finish', options: AIR_HOCKEY_CUSTOMIZATION.table },
+        { key: 'tableBase', label: 'Table Base', options: AIR_HOCKEY_CUSTOMIZATION.tableBase },
+        { key: 'environmentHdri', label: 'HDRI Environment', options: AIR_HOCKEY_CUSTOMIZATION.environmentHdri },
+        { key: 'puck', label: 'Puck', options: AIR_HOCKEY_CUSTOMIZATION.puck },
+        { key: 'mallet', label: 'Mallets', options: AIR_HOCKEY_CUSTOMIZATION.mallet },
+        { key: 'goals', label: 'Goals', options: AIR_HOCKEY_CUSTOMIZATION.goals }
+      ]
+        .map((section) => ({
+          ...section,
+          options: (section.options || []).filter((option) =>
+            isAirHockeyOptionUnlocked(section.key, option.id, airInventory)
+          )
+        }))
+        .filter((section) => section.options.length > 0),
+    [airInventory]
+  );
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    customizationSections[0]?.key ?? 'field'
+  );
+  useEffect(() => {
+    if (!customizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(customizationSections[0]?.key ?? 'field');
+    }
+  }, [activeCustomizationKey, customizationSections]);
+  const activeCustomizationSection =
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
+
+  const renderOptionPreview = useCallback((key, option) => {
+    const thumb = option?.thumbnail;
+    if (thumb) {
+      return (
+        <div className="relative h-14 w-full overflow-hidden rounded-xl border border-white/10 bg-slate-950/40">
+          <img src={thumb} alt={option?.name || option?.label || key} className="h-full w-full object-cover" loading="lazy" />
+          <div className="absolute inset-0 bg-gradient-to-tr from-white/10 via-transparent to-black/40" />
         </div>
+      );
+    }
+    const swatches = option?.swatches;
+    const base =
+      option?.surface ||
+      option?.wood ||
+      option?.color ||
+      option?.base ||
+      option?.rim ||
+      option?.emissive ||
+      swatches?.[0] ||
+      '#1f2937';
+    const accent = Array.isArray(swatches) && swatches.length > 1 ? swatches[1] : undefined;
+    return (
+      <div
+        className="relative h-14 w-full overflow-hidden rounded-xl border border-white/10 bg-slate-950/40"
+        style={{
+          background: accent ? `linear-gradient(135deg, ${base}, ${accent})` : base
+        }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-tr from-white/10 via-transparent to-black/40" />
       </div>
     );
-  };
+  }, []);
 
   return (
     <div
@@ -2695,14 +2717,70 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
                 </p>
               )}
             </div>
-            {renderOptionRow('Field Surface', 'field')}
-            {renderOptionRow('Cushion Cloth', 'cushionCloth')}
-            {renderOptionRow('Table Finish', 'table')}
-            {renderOptionRow('Table Base', 'tableBase')}
-            {renderOptionRow('HDRI Environment', 'environmentHdri')}
-            {renderOptionRow('Puck', 'puck')}
-            {renderOptionRow('Mallets', 'mallet')}
-            {renderOptionRow('Goals', 'goals')}
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, arena details, and equipment.</p>
+              </div>
+              <div className="mt-3 max-h-72 space-y-3">
+                <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                  {customizationSections.map(({ key, label }) => {
+                    const selectedSection = key === activeCustomizationKey;
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => setActiveCustomizationKey(key)}
+                        className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                          selectedSection
+                            ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                            : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+                {activeCustomizationSection && (
+                  <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                    <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                      {activeCustomizationSection.label}
+                    </p>
+                    <div className="space-y-1.5">
+                      {activeCustomizationSection.options.map((option) => {
+                        const selected = selections[activeCustomizationSection.key] === option.id;
+                        return (
+                          <button
+                            key={`${activeCustomizationSection.key}-${option.id}`}
+                            type="button"
+                            onClick={() =>
+                              setSelections((prev) => ({
+                                ...prev,
+                                [activeCustomizationSection.key]: option.id
+                              }))
+                            }
+                            aria-pressed={selected}
+                            className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                              selected
+                                ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                : 'border-white/10 bg-white/5 hover:border-white/20'
+                            }`}
+                          >
+                            <span className="text-[0.7rem] font-semibold text-gray-100">
+                              {option.name || option.label}
+                            </span>
+                            <span className="w-24 shrink-0">
+                              {renderOptionPreview(activeCustomizationSection.key, option)}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -6337,12 +6337,23 @@ function Chess3D({
       if (option.thumbnail) {
         return (
           <span
-            className={`${swatchClass} bg-cover bg-center`}
-            style={{ backgroundImage: `url(${option.thumbnail})` }}
-          />
+            className="relative h-14 w-24 overflow-hidden rounded-xl border border-white/15 bg-white/10"
+          >
+            <span
+              className="absolute inset-0 bg-cover bg-center"
+              style={{ backgroundImage: `url(${option.thumbnail})` }}
+            />
+            <span className="absolute inset-0 bg-gradient-to-tr from-white/10 via-transparent to-black/40" />
+          </span>
         );
       }
-      return <span className={swatchClass} style={{ background: '#4b5563' }} />;
+      return (
+        <span className="relative h-14 w-24 overflow-hidden rounded-xl border border-white/15 bg-slate-800/70">
+          <span className="absolute inset-0 flex items-center justify-center text-[0.6rem] font-semibold uppercase tracking-[0.2em] text-white/80">
+            {option?.label || 'Table'}
+          </span>
+        </span>
+      );
     }
     if (key === 'tableFinish') {
       const swatches = Array.isArray(option.swatches) && option.swatches.length >= 2

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2744,6 +2744,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       })).filter((section) => section.options.length > 0),
     [ludoInventory]
   );
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    CUSTOMIZATION_SECTIONS[0]?.key ?? 'tables'
+  );
+  useEffect(() => {
+    if (!customizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(customizationSections[0]?.key ?? 'tables');
+    }
+  }, [activeCustomizationKey, customizationSections]);
+  const activeCustomizationSection =
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
   const arenaRef = useRef(null);
   const [seatAnchors, setSeatAnchors] = useState([]);
   const seatPositionsRef = useRef([]);
@@ -5313,36 +5323,70 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 </button>
               </div>
               <div className="mt-4 flex-1 space-y-4 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
-                {customizationSections.map(({ key, label, options }) => (
-                  <div key={key} className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-2 gap-2">
-                      {options.map((option) => {
-                        const selected = appearance[key] === option.idx;
-                        const disabled = false;
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                    <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                  </div>
+                  <div className="mt-3 max-h-72 space-y-3">
+                    <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                      {customizationSections.map(({ key, label }) => {
+                        const selectedSection = key === activeCustomizationKey;
                         return (
                           <button
-                            key={option.id ?? option.idx}
+                            key={key}
                             type="button"
-                            onClick={() => setAppearance((prev) => ({ ...prev, [key]: option.idx }))}
-                            aria-pressed={selected}
-                            disabled={disabled}
-                            className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              selected
-                                ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
-                                : 'border-white/10 bg-white/5 hover:border-white/20'
-                            } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
+                            onClick={() => setActiveCustomizationKey(key)}
+                            className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                              selectedSection
+                                ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+                            }`}
                           >
-                            {renderPreview(key, option)}
-                            <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">
-                              {option.label}
-                            </span>
+                            {label}
                           </button>
                         );
                       })}
                     </div>
+                    {activeCustomizationSection && (
+                      <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                        <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                          {activeCustomizationSection.label}
+                        </p>
+                        <div className="space-y-1.5">
+                          {activeCustomizationSection.options.map((option) => {
+                            const selected = appearance[activeCustomizationSection.key] === option.idx;
+                            return (
+                              <button
+                                key={option.id ?? option.idx}
+                                type="button"
+                                onClick={() =>
+                                  setAppearance((prev) =>
+                                    normalizeAppearance({
+                                      ...prev,
+                                      [activeCustomizationSection.key]: option.idx
+                                    })
+                                  )
+                                }
+                                aria-pressed={selected}
+                                className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                  selected
+                                    ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                                }`}
+                              >
+                                <span className="text-[0.7rem] font-semibold text-gray-100">{option.label}</span>
+                                <span className="w-24 shrink-0">
+                                  {renderPreview(activeCustomizationSection.key, option)}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                ))}
+                </div>
                 <div className="space-y-4">
                   <div>
                     <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1770,6 +1770,16 @@ export default function MurlanRoyaleArena({ search }) {
         section.key === 'tableFinish' || section.key === 'tableCloth' ? allowTableFinish : true
       );
   }, [appearance.tables, murlanInventory]);
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    CUSTOMIZATION_SECTIONS[0]?.key ?? 'tables'
+  );
+  useEffect(() => {
+    if (!customizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(customizationSections[0]?.key ?? 'tables');
+    }
+  }, [activeCustomizationKey, customizationSections]);
+  const activeCustomizationSection =
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
@@ -3863,32 +3873,65 @@ export default function MurlanRoyaleArena({ search }) {
                   </button>
                 </div>
                 <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-                  {customizationSections.map(({ key, label, options }) => (
-                    <div key={key} className="space-y-2">
-                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                      <div className="grid grid-cols-2 gap-2">
-                        {options.map((option, idx) => {
-                          const selected = appearance[key] === idx;
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                    <div>
+                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                      <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                    </div>
+                    <div className="mt-3 max-h-72 space-y-3">
+                      <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                        {customizationSections.map(({ key, label }) => {
+                          const selectedSection = key === activeCustomizationKey;
                           return (
                             <button
-                              key={option.id}
+                              key={key}
                               type="button"
-                              onClick={() => setAppearance((prev) => ({ ...prev, [key]: idx }))}
-                              aria-pressed={selected}
-                              className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                                selected
-                                  ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
-                                  : 'border-white/10 bg-white/5 hover:border-white/20'
+                              onClick={() => setActiveCustomizationKey(key)}
+                              className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                selectedSection
+                                  ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                  : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
                               }`}
                             >
-                              {renderPreview(key, option)}
-                              <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
+                              {label}
                             </button>
                           );
                         })}
                       </div>
+                      {activeCustomizationSection && (
+                        <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                          <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                            {activeCustomizationSection.label}
+                          </p>
+                          <div className="space-y-1.5">
+                            {activeCustomizationSection.options.map((option) => {
+                              const selected = appearance[activeCustomizationSection.key] === option.idx;
+                              return (
+                                <button
+                                  key={option.id}
+                                  type="button"
+                                  onClick={() =>
+                                    setAppearance((prev) => ({ ...prev, [activeCustomizationSection.key]: option.idx }))
+                                  }
+                                  aria-pressed={selected}
+                                  className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                    selected
+                                      ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                      : 'border-white/10 bg-white/5 hover:border-white/20'
+                                  }`}
+                                >
+                                  <span className="text-[0.7rem] font-semibold text-gray-100">{option.label}</span>
+                                  <span className="w-24 shrink-0">
+                                    {renderPreview(activeCustomizationSection.key, option)}
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  ))}
+                  </div>
                   <div className="space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Graphics</p>
                     <div className="grid gap-2">

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1274,6 +1274,26 @@ export default function SnakeAndLadder() {
   const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
+  const customizationSections = useMemo(
+    () =>
+      SNAKE_CUSTOMIZATION_SECTIONS.map((section) => ({
+        ...section,
+        options: section.options
+          .map((option, idx) => ({ ...option, idx }))
+          .filter(({ id }) => isSnakeOptionUnlocked(section.key, id, snakeInventory))
+      })).filter((section) => section.options.length > 0),
+    [snakeInventory]
+  );
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    SNAKE_CUSTOMIZATION_SECTIONS[0]?.key ?? 'tableFinish'
+  );
+  useEffect(() => {
+    if (!customizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(customizationSections[0]?.key ?? 'tableFinish');
+    }
+  }, [activeCustomizationKey, customizationSections]);
+  const activeCustomizationSection =
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
@@ -3536,38 +3556,67 @@ export default function SnakeAndLadder() {
                 </button>
               </div>
               <div className="mt-4 space-y-4 pr-1">
-                {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
-                  <div key={key} className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-2 gap-2">
-                      {options.map((option, idx) => {
-                        const unlocked = isSnakeOptionUnlocked(key, option.id, snakeInventory);
-                        if (!unlocked) return null;
-                        const selected = normalizedAppearance[key] === idx;
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                    <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and board details.</p>
+                  </div>
+                  <div className="mt-3 max-h-72 space-y-3">
+                    <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                      {customizationSections.map(({ key, label }) => {
+                        const selectedSection = key === activeCustomizationKey;
                         return (
                           <button
-                            key={option.id ?? idx}
+                            key={key}
                             type="button"
-                            onClick={() =>
-                              setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
-                            }
-                            aria-pressed={selected}
-                            className={`flex flex-col items-center gap-1.5 rounded-xl border px-2 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              selected
-                                ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
-                                : 'border-white/10 bg-white/5 hover:border-white/20'
+                            onClick={() => setActiveCustomizationKey(key)}
+                            className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                              selectedSection
+                                ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
                             }`}
                           >
-                            {renderPreview(key, option)}
-                            <span className="block w-full text-center text-[0.6rem] font-semibold text-gray-200">
-                              {option.label}
-                            </span>
+                            {label}
                           </button>
                         );
                       })}
                     </div>
+                    {activeCustomizationSection && (
+                      <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                        <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                          {activeCustomizationSection.label}
+                        </p>
+                        <div className="space-y-1.5">
+                          {activeCustomizationSection.options.map((option) => {
+                            const selected = normalizedAppearance[activeCustomizationSection.key] === option.idx;
+                            return (
+                              <button
+                                key={option.id ?? option.idx}
+                                type="button"
+                                onClick={() =>
+                                  setAppearance((prev) =>
+                                    normalizeAppearance({ ...prev, [activeCustomizationSection.key]: option.idx })
+                                  )
+                                }
+                                aria-pressed={selected}
+                                className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                  selected
+                                    ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
+                                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                                }`}
+                              >
+                                <span className="text-[0.7rem] font-semibold text-gray-100">{option.label}</span>
+                                <span className="w-24 shrink-0">
+                                  {renderPreview(activeCustomizationSection.key, option)}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                ))}
+                </div>
               </div>
               <div className="mt-4 space-y-3">
                 <label className="flex items-center justify-between text-[0.7rem] text-gray-200">

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -11450,6 +11450,24 @@ function SnookerRoyalGame({
       ),
     [snookerInventory]
   );
+  const tableCustomizationSections = useMemo(
+    () => [
+      { key: 'tableFinish', label: 'Table Finish', options: availableTableFinishes },
+      { key: 'tableBase', label: 'Table Base', options: availableTableBases }
+    ],
+    [availableTableBases, availableTableFinishes]
+  );
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    tableCustomizationSections[0]?.key ?? 'tableFinish'
+  );
+  useEffect(() => {
+    if (!tableCustomizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(tableCustomizationSections[0]?.key ?? 'tableFinish');
+    }
+  }, [activeCustomizationKey, tableCustomizationSections]);
+  const activeCustomizationSection =
+    tableCustomizationSections.find(({ key }) => key === activeCustomizationKey) ??
+    tableCustomizationSections[0];
   const availableChromeOptions = useMemo(
     () =>
       CHROME_COLOR_OPTIONS.filter((option) =>
@@ -26774,82 +26792,92 @@ const powerRef = useRef(hud.power);
                   </p>
                 )}
               </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Finish
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableTableFinishes.map((option) => {
-                    const active = option.id === tableFinishId;
-                    const thumb = option.thumbnail;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setTableFinishId(option.id)}
-                        aria-pressed={active}
-                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                            : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="truncate">{option.label}</span>
-                        {thumb ? (
-                          <img
-                            src={thumb}
-                            alt={option.label}
-                            className="h-6 w-10 rounded-lg border border-white/20 object-cover"
-                            loading="lazy"
-                          />
-                        ) : null}
-                      </button>
-                    );
-                  })}
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <div>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Personalize Arena
+                  </p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">
+                    Table finish and base details.
+                  </p>
                 </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Base
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableTableBases.map((option) => {
-                    const active = option.id === tableBaseId;
-                    const swatchA = option.swatches?.[0] ?? '#0f172a';
-                    const swatchB = option.swatches?.[1] ?? '#1f2937';
-                    const thumb = option.thumbnail;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setTableBaseId(option.id)}
-                        aria-pressed={active}
-                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                            : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="truncate">{option.name}</span>
-                        {thumb ? (
-                          <img
-                            src={thumb}
-                            alt={option.name}
-                            className="h-6 w-10 rounded-lg border border-white/25 object-cover"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <span
-                            className="h-5 w-8 rounded-lg border border-white/25"
-                            aria-hidden="true"
-                            style={{
-                              background: `linear-gradient(135deg, ${swatchA}, ${swatchB})`
-                            }}
-                          />
-                        )}
-                      </button>
-                    );
-                  })}
+                <div className="mt-3 max-h-72 space-y-3">
+                  <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                    {tableCustomizationSections.map(({ key, label }) => {
+                      const selectedSection = key === activeCustomizationKey;
+                      return (
+                        <button
+                          key={key}
+                          type="button"
+                          onClick={() => setActiveCustomizationKey(key)}
+                          className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            selectedSection
+                              ? 'border-emerald-300/80 bg-emerald-300/15 text-white shadow-[0_0_12px_rgba(16,185,129,0.35)]'
+                              : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+                          }`}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  {activeCustomizationSection && (
+                    <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                      <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                        {activeCustomizationSection.label}
+                      </p>
+                      <div className="space-y-1.5">
+                        {activeCustomizationSection.options.map((option) => {
+                          const isFinish = activeCustomizationSection.key === 'tableFinish';
+                          const selected = isFinish
+                            ? option.id === tableFinishId
+                            : option.id === tableBaseId;
+                          const swatchA = option.swatches?.[0] ?? '#0f172a';
+                          const swatchB = option.swatches?.[1] ?? '#1f2937';
+                          const thumb = option.thumbnail;
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              onClick={() =>
+                                isFinish ? setTableFinishId(option.id) : setTableBaseId(option.id)
+                              }
+                              aria-pressed={selected}
+                              className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                                selected
+                                  ? 'border-emerald-300 bg-emerald-300/20 text-white shadow-[0_0_12px_rgba(16,185,129,0.35)]'
+                                  : 'border-white/10 bg-white/5 text-white/80 hover:border-white/20'
+                              }`}
+                            >
+                              <span className="text-[0.7rem] font-semibold text-gray-100">
+                                {option.label || option.name}
+                              </span>
+                              <span className="w-24 shrink-0">
+                                {thumb ? (
+                                  <span className="relative h-14 w-full overflow-hidden rounded-xl border border-white/15 bg-white/10">
+                                    <img
+                                      src={thumb}
+                                      alt={option.label || option.name}
+                                      className="absolute inset-0 h-full w-full object-cover"
+                                      loading="lazy"
+                                    />
+                                    <span className="absolute inset-0 bg-gradient-to-tr from-white/10 via-transparent to-black/40" />
+                                  </span>
+                                ) : (
+                                  <span
+                                    className="block h-14 w-full rounded-xl border border-white/15"
+                                    style={{
+                                      background: `linear-gradient(135deg, ${swatchA}, ${swatchB})`
+                                    }}
+                                  />
+                                )}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
               <div>

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2749,6 +2749,16 @@ function TexasHoldemArena({ search }) {
         }),
     [appearance.tableTheme, texasInventory]
   );
+  const [activeCustomizationKey, setActiveCustomizationKey] = useState(
+    CUSTOMIZATION_SECTIONS[0]?.key ?? 'tableTheme'
+  );
+  useEffect(() => {
+    if (!customizationSections.some((section) => section.key === activeCustomizationKey)) {
+      setActiveCustomizationKey(customizationSections[0]?.key ?? 'tableTheme');
+    }
+  }, [activeCustomizationKey, customizationSections]);
+  const activeCustomizationSection =
+    customizationSections.find(({ key }) => key === activeCustomizationKey) ?? customizationSections[0];
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
@@ -5206,36 +5216,69 @@ function TexasHoldemArena({ search }) {
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              {customizationSections.map(({ key, label, options }) => (
-                <div key={key} className="space-y-2">
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                  <div className="grid grid-cols-2 gap-2">
-                    {options.map((option) => {
-                      const selected = appearance[key] === option.idx;
-                      const disabled =
-                        key === 'tableShape' && option.id === DIAMOND_SHAPE_ID && effectivePlayerCount > 4;
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <div>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                </div>
+                <div className="mt-3 max-h-72 space-y-3">
+                  <div className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1">
+                    {customizationSections.map(({ key, label }) => {
+                      const selectedSection = key === activeCustomizationKey;
                       return (
                         <button
-                          key={option.id}
+                          key={key}
                           type="button"
-                          onClick={() => {
-                            if (disabled) return;
-                            setAppearance((prev) => ({ ...prev, [key]: option.idx }));
-                          }}
-                          aria-pressed={selected}
-                          disabled={disabled}
-                          className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                            selected ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]' : 'border-white/10 bg-white/5 hover:border-white/20'
-                          } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
+                          onClick={() => setActiveCustomizationKey(key)}
+                          className={`whitespace-nowrap rounded-full border px-3 py-2 text-[0.7rem] font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            selectedSection
+                              ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                              : 'border-white/10 bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+                          }`}
                         >
-                          {renderPreview(key, option)}
-                          <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
+                          {label}
                         </button>
                       );
                     })}
                   </div>
+                  {activeCustomizationSection && (
+                    <div className="max-h-60 space-y-1.5 overflow-y-auto pr-1">
+                      <p className="text-[10px] uppercase tracking-[0.3em] text-white/60">
+                        {activeCustomizationSection.label}
+                      </p>
+                      <div className="space-y-1.5">
+                        {activeCustomizationSection.options.map((option) => {
+                          const selected = appearance[activeCustomizationSection.key] === option.idx;
+                          const disabled =
+                            activeCustomizationSection.key === 'tableShape' &&
+                            option.id === DIAMOND_SHAPE_ID &&
+                            effectivePlayerCount > 4;
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              onClick={() => {
+                                if (disabled) return;
+                                setAppearance((prev) => ({ ...prev, [activeCustomizationSection.key]: option.idx }));
+                              }}
+                              aria-pressed={selected}
+                              disabled={disabled}
+                              className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                selected
+                                  ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                  : 'border-white/10 bg-white/5 hover:border-white/20'
+                              } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
+                            >
+                              <span className="text-[0.7rem] font-semibold text-gray-100">{option.label}</span>
+                              <span className="w-24 shrink-0">{renderPreview(activeCustomizationSection.key, option)}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              ))}
+              </div>
               <div className="space-y-2">
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</p>
                 <div className="grid gap-2">


### PR DESCRIPTION
### Motivation
- Standardize the table/table-setup UI across multiple games so the in-game table menu matches the `Chess Battle Royal` table setup layout and uses the same thumbnail sizing used by the `Ludo Battle Royal` table setup.

### Description
- Added a tabbed "Personalize Arena" UI pattern and per-screen active tab state (`activeCustomizationKey` / `activeCustomizationSection`) to pages: `webapp/src/pages/Games/TexasHoldemArena.jsx`, `LudoBattleRoyal.jsx`, `MurlanRoyaleArena.jsx`, `SnakeAndLadder.jsx`, and `SnookerRoyal.jsx` so customization sections show as tabs and list previews like the chess menu.
- Converted the Air Hockey customizer to the same layout by introducing `customizationSections`, an `activeCustomizationKey` state and a `renderOptionPreview` helper in `webapp/src/components/AirHockey3D.jsx` (replacing the old `renderOptionRow`).
- Updated Domino Royal 3D UI (`webapp/public/domino-royal.html`) with CSS for tabbed cards, increased preview thumbnail height (`createOptionPreview` height increased) and rewired `refreshConfigUI` to render a compact tab + list preview panel driven by an `activeTableSetupKey` variable.
- Increased Chess table thumbnail preview size in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to match the Ludo/Lobby proportions and adjusted preview markup to use the same rounded thumbnail card style.

### Testing
- Ran a visual smoke test by serving `webapp/public` via `python -m http.server` and executed a Playwright script which opened `http://127.0.0.1:4173/domino-royal.html`, opened the config panel and saved a screenshot to `artifacts/domino-table-menu.png`; the script completed successfully and produced the screenshot.
- Performed a local commit of the changes with `git commit` which succeeded; no automated unit tests were modified or run as these are UI/UX changes only.
- No test failures observed from the visual smoke run; further cross-device/manual QA is recommended for final verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dc29c6ec832989aa2ee348024b1e)