### PR TITLE
Unify table setup menu layout and thumbnail sizing across games

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5298,9 +5298,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             )}
           </div>
           {configOpen && (
-            <div className="pointer-events-auto mt-2 flex max-h-[80vh] w-72 max-w-[80vw] flex-col rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
+            <div className="pointer-events-auto mt-2 flex max-h-[80vh] w-72 max-w-[80vw] flex-col overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur pr-1">
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</span>
+                <div>
+                  <span className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</span>
+                  <p className="mt-1 text-[0.7rem] text-white/70">
+                    Personalize the board, tokens, and arena staging.
+                  </p>
+                </div>
                 <button
                   type="button"
                   onClick={() => setConfigOpen(false)}
@@ -5312,172 +5317,176 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   </svg>
                 </button>
               </div>
-              <div className="mt-4 flex-1 space-y-4 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
-                {customizationSections.map(({ key, label, options }) => (
-                  <div key={key} className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-2 gap-2">
-                      {options.map((option) => {
-                        const selected = appearance[key] === option.idx;
-                        const disabled = false;
-                        return (
-                          <button
-                            key={option.id ?? option.idx}
-                            type="button"
-                            onClick={() => setAppearance((prev) => ({ ...prev, [key]: option.idx }))}
-                            aria-pressed={selected}
-                            disabled={disabled}
-                            className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              selected
-                                ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
-                                : 'border-white/10 bg-white/5 hover:border-white/20'
-                            } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
-                          >
-                            {renderPreview(key, option)}
-                            <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">
-                              {option.label}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))}
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">
-                      Graphics
-                    </h3>
-                    <div className="mt-2 grid gap-2">
-                      {FRAME_RATE_OPTIONS.map((option) => {
-                        const active = option.id === frameRateId;
-                        return (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => setFrameRateId(option.id)}
-                            aria-pressed={active}
-                            className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              active
-                                ? 'border-sky-300 bg-sky-300/90 text-black shadow-[0_0_16px_rgba(125,211,252,0.45)]'
-                                : 'border-white/15 bg-white/5 text-white/80 hover:bg-white/10'
-                            }`}
-                          >
-                            <span className="flex items-center justify-between gap-2">
-                              <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                                {option.label}
-                              </span>
-                              <span className="text-xs font-semibold tracking-wide">
-                                {option.resolution
-                                  ? `${option.resolution} • ${option.fps} FPS`
-                                  : `${option.fps} FPS`}
-                              </span>
-                            </span>
-                            {option.description ? (
-                              <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                                {option.description}
-                              </span>
-                            ) : null}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                  <div className="space-y-3">
-                    <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                      <span>Sound effects</span>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
-                        checked={soundEnabled}
-                        onChange={(event) => {
-                          const next = event.target.checked;
-                          setSoundEnabled(next);
-                          setGameMuted(!next);
-                        }}
-                      />
-                    </label>
-                    <div>
-                      <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">
-                        Commentary
-                      </h3>
-                      <div className="mt-2 grid gap-2">
-                        {LUDO_BATTLE_COMMENTARY_PRESETS.map((preset) => {
-                          const active = preset.id === commentaryPresetId;
-                          return (
-                            <button
-                              key={preset.id}
-                              type="button"
-                              onClick={() => setCommentaryPresetId(preset.id)}
-                              aria-pressed={active}
-                              disabled={!commentarySupported}
-                              className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                                active
-                                  ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                                  : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                              } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                            >
-                              <span className="flex items-center justify-between gap-2">
-                                <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                                {active && (
-                                  <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
-                                    Active
-                                  </span>
-                                )}
-                              </span>
-                              <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                                {preset.description}
-                              </span>
-                            </button>
-                          );
-                        })}
+              <div className="mt-4 flex-1 space-y-3 touch-pan-y overscroll-contain">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">Table surfaces, tokens, and seating.</p>
+                  <div className="mt-3 space-y-4">
+                    {customizationSections.map(({ key, label, options }) => (
+                      <div key={key} className="space-y-2">
+                        <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
+                        <div className="grid grid-cols-2 gap-2">
+                          {options.map((option) => {
+                            const selected = appearance[key] === option.idx;
+                            const disabled = false;
+                            return (
+                              <button
+                                key={option.id ?? option.idx}
+                                type="button"
+                                onClick={() => setAppearance((prev) => ({ ...prev, [key]: option.idx }))}
+                                aria-pressed={selected}
+                                disabled={disabled}
+                                className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                  selected
+                                    ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                                } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
+                              >
+                                {renderPreview(key, option)}
+                                <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">
+                                  {option.label}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => setCommentaryMuted((prev) => !prev)}
-                        aria-pressed={commentaryMuted}
-                        disabled={!commentarySupported}
-                        className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                          commentaryMuted
-                            ? 'bg-sky-300 text-black shadow-[0_0_18px_rgba(56,189,248,0.65)]'
-                            : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span>Mute commentary</span>
-                        <span
-                          className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                            commentaryMuted
-                              ? 'border-black/30 text-black/70'
-                              : 'border-white/30 text-white/70'
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">
+                    Graphics
+                  </h3>
+                  <div className="mt-2 grid gap-2">
+                    {FRAME_RATE_OPTIONS.map((option) => {
+                      const active = option.id === frameRateId;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setFrameRateId(option.id)}
+                          aria-pressed={active}
+                          className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            active
+                              ? 'border-sky-300 bg-sky-300/90 text-black shadow-[0_0_16px_rgba(125,211,252,0.45)]'
+                              : 'border-white/15 bg-white/5 text-white/80 hover:bg-white/10'
                           }`}
                         >
-                          {commentaryMuted ? 'On' : 'Off'}
-                        </span>
-                      </button>
-                      {!commentarySupported && (
-                        <p className="mt-2 text-[10px] uppercase tracking-[0.2em] text-white/60">
-                          Voice commentary needs Web Speech support.
-                        </p>
-                      )}
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                              {option.label}
+                            </span>
+                            <span className="text-xs font-semibold tracking-wide">
+                              {option.resolution
+                                ? `${option.resolution} • ${option.fps} FPS`
+                                : `${option.fps} FPS`}
+                            </span>
+                          </span>
+                          {option.description ? (
+                            <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                              {option.description}
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-3">
+                  <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
+                    <span>Sound effects</span>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
+                      checked={soundEnabled}
+                      onChange={(event) => {
+                        const next = event.target.checked;
+                        setSoundEnabled(next);
+                        setGameMuted(!next);
+                      }}
+                    />
+                  </label>
+                  <div>
+                    <h3 className="text-[10px] uppercase tracking-[0.35em] text-sky-100/80">
+                      Commentary
+                    </h3>
+                    <div className="mt-2 grid gap-2">
+                      {LUDO_BATTLE_COMMENTARY_PRESETS.map((preset) => {
+                        const active = preset.id === commentaryPresetId;
+                        return (
+                          <button
+                            key={preset.id}
+                            type="button"
+                            onClick={() => setCommentaryPresetId(preset.id)}
+                            aria-pressed={active}
+                            disabled={!commentarySupported}
+                            className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                              active
+                                ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                                : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                            } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                          >
+                            <span className="flex items-center justify-between gap-2">
+                              <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
+                              {active && (
+                                <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
+                                  Active
+                                </span>
+                              )}
+                            </span>
+                            <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                              {preset.description}
+                            </span>
+                          </button>
+                        );
+                      })}
                     </div>
                     <button
                       type="button"
-                      onClick={() => {
-                        fitRef.current?.();
-                        setConfigOpen(false);
-                      }}
-                      className="w-full rounded-lg bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
+                      onClick={() => setCommentaryMuted((prev) => !prev)}
+                      aria-pressed={commentaryMuted}
+                      disabled={!commentarySupported}
+                      className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        commentaryMuted
+                          ? 'bg-sky-300 text-black shadow-[0_0_18px_rgba(56,189,248,0.65)]'
+                          : 'bg-white/10 text-white/80 hover:bg-white/20'
+                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
                     >
-                      Center camera
+                      <span>Mute commentary</span>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                          commentaryMuted
+                            ? 'border-black/30 text-black/70'
+                            : 'border-white/30 text-white/70'
+                        }`}
+                      >
+                        {commentaryMuted ? 'On' : 'Off'}
+                      </span>
                     </button>
-                    <button
-                      type="button"
-                      onClick={() => window.location.reload()}
-                      className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
-                    >
-                      Restart game
-                    </button>
+                    {!commentarySupported && (
+                      <p className="mt-2 text-[10px] uppercase tracking-[0.2em] text-white/60">
+                        Voice commentary needs Web Speech support.
+                      </p>
+                    )}
                   </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      fitRef.current?.();
+                      setConfigOpen(false);
+                    }}
+                    className="w-full rounded-lg bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
+                  >
+                    Center camera
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => window.location.reload()}
+                    className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
+                  >
+                    Restart game
+                  </button>
                 </div>
               </div>
             </div>

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2968,14 +2968,14 @@ export default function MurlanRoyaleArena({ search }) {
         return (
           <div className="flex items-center justify-center gap-2">
             <div
-              className="h-12 w-8 rounded-md border"
+              className="h-14 w-9 rounded-md border"
               style={{
                 background: option.frontBackground,
                 borderColor: option.frontBorder || '#e5e7eb'
               }}
             />
             <div
-              className="h-12 w-8 rounded-md border border-white/10"
+              className="h-14 w-9 rounded-md border border-white/10"
               style={{
                 backgroundImage: `linear-gradient(135deg, ${
                   option.backGradient?.[0] ?? option.backColor
@@ -2987,7 +2987,7 @@ export default function MurlanRoyaleArena({ search }) {
         );
       case 'stools':
         return (
-          <div className="relative flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-950/50 overflow-hidden">
+          <div className="relative flex h-14 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-950/50 overflow-hidden">
             {option.thumbnail ? (
               <img
                 src={option.thumbnail}
@@ -3028,8 +3028,8 @@ export default function MurlanRoyaleArena({ search }) {
       case 'outfit':
       default:
         return (
-          <div className="relative flex h-12 w-full items-center justify-center">
-            <div className="relative h-12 w-12 rounded-full" style={{ background: option.baseColor }}>
+          <div className="relative flex h-14 w-full items-center justify-center">
+            <div className="relative h-14 w-14 rounded-full" style={{ background: option.baseColor }}>
               <div
                 className="absolute inset-1 rounded-full border-2"
                 style={{ borderColor: option.accentColor }}
@@ -3841,9 +3841,14 @@ export default function MurlanRoyaleArena({ search }) {
               <span className="sr-only">Open table customization</span>
             </button>
             {configOpen && (
-              <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
+              <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur pr-1">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</span>
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</p>
+                    <p className="mt-1 text-[0.7rem] text-white/70">
+                      Personalize the Murlan Royale table, chairs, and cards.
+                    </p>
+                  </div>
                   <button
                     type="button"
                     onClick={() => setConfigOpen(false)}
@@ -3862,35 +3867,43 @@ export default function MurlanRoyaleArena({ search }) {
                     </svg>
                   </button>
                 </div>
-                <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-                  {customizationSections.map(({ key, label, options }) => (
-                    <div key={key} className="space-y-2">
-                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                      <div className="grid grid-cols-2 gap-2">
-                        {options.map((option, idx) => {
-                          const selected = appearance[key] === idx;
-                          return (
-                            <button
-                              key={option.id}
-                              type="button"
-                              onClick={() => setAppearance((prev) => ({ ...prev, [key]: idx }))}
-                              aria-pressed={selected}
-                              className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                                selected
-                                  ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
-                                  : 'border-white/10 bg-white/5 hover:border-white/20'
-                              }`}
-                            >
-                              {renderPreview(key, option)}
-                              <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
+                <div className="mt-4 space-y-3">
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                    <div>
+                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                      <p className="mt-1 text-[0.7rem] text-white/60">Table surface, chairs, and cards.</p>
                     </div>
-                  ))}
-                  <div className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Graphics</p>
+                    <div className="mt-3 space-y-4">
+                      {customizationSections.map(({ key, label, options }) => (
+                        <div key={key} className="space-y-2">
+                          <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
+                          <div className="grid grid-cols-2 gap-2">
+                            {options.map((option, idx) => {
+                              const selected = appearance[key] === idx;
+                              return (
+                                <button
+                                  key={option.id}
+                                  type="button"
+                                  onClick={() => setAppearance((prev) => ({ ...prev, [key]: idx }))}
+                                  aria-pressed={selected}
+                                  className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                    selected
+                                      ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]'
+                                      : 'border-white/10 bg-white/5 hover:border-white/20'
+                                  }`}
+                                >
+                                  {renderPreview(key, option)}
+                                  <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                     <div className="grid gap-2">
                       {FRAME_RATE_OPTIONS.map((option) => {
                         const active = option.id === frameRateId;
@@ -3922,8 +3935,8 @@ export default function MurlanRoyaleArena({ search }) {
                       })}
                     </div>
                   </div>
-                  <div className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</p>
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
                     <div className="grid gap-2">
                       {MURLAN_ROYALE_COMMENTARY_PRESETS.map((preset) => {
                         const active = preset.id === commentaryPresetId;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3285,9 +3285,9 @@ export default function SnakeAndLadder() {
         const pip = option.pip ?? '#111827';
         const rim = option.rim ?? '#fbbf24';
         return (
-          <div className="w-full h-12 flex items-center justify-center">
+          <div className="w-full h-14 flex items-center justify-center">
             <div
-              className="relative w-9 h-9 rounded-xl shadow-[0_8px_20px_rgba(15,23,42,0.55)]"
+              className="relative h-10 w-10 rounded-xl shadow-[0_8px_20px_rgba(15,23,42,0.55)]"
               style={{ background: body, boxShadow: `0 6px 16px ${rim}44` }}
             >
               <span
@@ -3307,7 +3307,7 @@ export default function SnakeAndLadder() {
         const woodLight = option.woodLight ?? '#d6b68c';
         const woodDark = option.woodDark ?? '#8b5e34';
         return (
-          <div className="w-full h-12 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
+          <div className="w-full h-14 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
             <div
               className="h-2 rounded-full"
               style={{ background: `linear-gradient(90deg, ${metal}, ${lightenHex(metal, 0.2)})` }}
@@ -3326,9 +3326,9 @@ export default function SnakeAndLadder() {
       case 'tokenFinish': {
         const accent = option.accentTarget ?? '#f8fafc';
         return (
-          <div className="w-full h-12 flex items-center justify-center">
+          <div className="w-full h-14 flex items-center justify-center">
             <div
-              className="relative h-10 w-10 rounded-full"
+              className="relative h-11 w-11 rounded-full"
               style={{
                 background: `radial-gradient(circle at 30% 30%, ${accent}, ${darkenHex(accent, 0.65)})`,
                 boxShadow: `0 10px 25px ${accent}33`
@@ -3344,7 +3344,7 @@ export default function SnakeAndLadder() {
       }
       case 'tokenShape': {
         return (
-          <div className="flex h-12 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-base text-white/80">
+          <div className="flex h-14 w-full items-center justify-center rounded-xl border border-white/10 bg-slate-900/70 text-base text-white/80">
             ♟️
           </div>
         );
@@ -3353,9 +3353,9 @@ export default function SnakeAndLadder() {
         const color = option.preset?.color ?? '#e2e8f0';
         const accent = option.preset?.color ? lightenHex(option.preset.color, 0.2) : '#f8fafc';
         return (
-          <div className="flex h-12 w-full items-center justify-center">
+          <div className="flex h-14 w-full items-center justify-center">
             <div
-              className="relative h-10 w-10 rounded-full border border-white/10"
+              className="relative h-11 w-11 rounded-full border border-white/10"
               style={{
                 background: `radial-gradient(circle at 30% 30%, ${accent}, ${color})`,
                 boxShadow: `0 10px 20px ${color}44`
@@ -3368,7 +3368,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#cbd5f5', '#475569'];
         return (
           <div
-            className="w-full h-12 rounded-xl border border-white/10"
+            className="w-full h-14 rounded-xl border border-white/10"
             style={{
               backgroundImage: option.thumbnail
                 ? `url(${option.thumbnail})`
@@ -3405,7 +3405,7 @@ export default function SnakeAndLadder() {
         const seat = option.seatColor || option.primary || '#7c3aed';
         const legs = option.legColor || '#111827';
         return (
-          <div className="w-full h-12 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-2">
+          <div className="w-full h-14 rounded-xl border border-white/10 bg-gradient-to-br from-slate-900/80 to-slate-800/60 p-2">
             <div className="flex h-full items-end gap-3">
               <div
                 className="h-3 w-full rounded-full"
@@ -3427,7 +3427,7 @@ export default function SnakeAndLadder() {
         const swatches = option.swatches || ['#94a3b8', '#1f2937'];
         return (
           <div
-            className="w-full h-12 rounded-xl border border-white/10"
+            className="w-full h-14 rounded-xl border border-white/10"
             style={{
               backgroundImage: option.thumbnail
                 ? `url(${option.thumbnail})`
@@ -3445,7 +3445,7 @@ export default function SnakeAndLadder() {
           : ['#0ea5e9', '#312e81'];
         return (
           <div
-            className="w-full h-12 rounded-xl border border-white/10"
+            className="w-full h-14 rounded-xl border border-white/10"
             style={{
               backgroundImage: option.thumbnail
                 ? `url(${option.thumbnail})`
@@ -3523,9 +3523,14 @@ export default function SnakeAndLadder() {
           {showConfig && (
             <div className="absolute left-0 mt-2 w-[min(22rem,80vw)] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/85 p-4 text-xs text-gray-100 shadow-[0_20px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl">
               <div className="flex items-center justify-between">
-                <span className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-sky-200/80">
-                  Table Setup
-                </span>
+                <div>
+                  <span className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-sky-200/80">
+                    Table Setup
+                  </span>
+                  <p className="mt-1 text-[0.7rem] text-white/70">
+                    Customize the Snake &amp; Ladder arena layout and visuals.
+                  </p>
+                </div>
                 <button
                   type="button"
                   aria-label="Mbyll konfigurimet"
@@ -3535,180 +3540,187 @@ export default function SnakeAndLadder() {
                   ✕
                 </button>
               </div>
-              <div className="mt-4 space-y-4 pr-1">
-                {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
-                  <div key={key} className="space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                    <div className="grid grid-cols-2 gap-2">
-                      {options.map((option, idx) => {
-                        const unlocked = isSnakeOptionUnlocked(key, option.id, snakeInventory);
-                        if (!unlocked) return null;
-                        const selected = normalizedAppearance[key] === idx;
-                        return (
-                          <button
-                            key={option.id ?? idx}
-                            type="button"
-                            onClick={() =>
-                              setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
-                            }
-                            aria-pressed={selected}
-                            className={`flex flex-col items-center gap-1.5 rounded-xl border px-2 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              selected
-                                ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
-                                : 'border-white/10 bg-white/5 hover:border-white/20'
-                            }`}
-                          >
-                            {renderPreview(key, option)}
-                            <span className="block w-full text-center text-[0.6rem] font-semibold text-gray-200">
+              <div className="mt-4 space-y-3 pr-1">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">Boards, tokens, and table themes.</p>
+                  <div className="mt-3 space-y-4">
+                    {SNAKE_CUSTOMIZATION_SECTIONS.map(({ key, label, options }) => (
+                      <div key={key} className="space-y-2">
+                        <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
+                        <div className="grid grid-cols-2 gap-2">
+                          {options.map((option, idx) => {
+                            const unlocked = isSnakeOptionUnlocked(key, option.id, snakeInventory);
+                            if (!unlocked) return null;
+                            const selected = normalizedAppearance[key] === idx;
+                            return (
+                              <button
+                                key={option.id ?? idx}
+                                type="button"
+                                onClick={() =>
+                                  setAppearance((prev) => normalizeAppearance({ ...prev, [key]: idx }))
+                                }
+                                aria-pressed={selected}
+                                className={`flex flex-col items-center gap-1.5 rounded-xl border px-2 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                  selected
+                                    ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_18px_rgba(56,189,248,0.45)]'
+                                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                                }`}
+                              >
+                                {renderPreview(key, option)}
+                                <span className="block w-full text-center text-[0.6rem] font-semibold text-gray-200">
+                                  {option.label}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-3">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Settings</p>
+                  <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
+                    <span>Ndalo tingujt</span>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
+                      checked={muted}
+                      onChange={(event) => {
+                        const next = event.target.checked;
+                        setMuted(next);
+                        setGameMuted(next);
+                      }}
+                    />
+                  </label>
+                  <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
+                    <span>Show movement trail</span>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
+                      checked={showTrailEnabled}
+                      onChange={(event) => setShowTrailEnabled(event.target.checked)}
+                    />
+                  </label>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</h3>
+                  <div className="grid gap-2">
+                    {SNAKE_COMMENTARY_PRESETS.map((preset) => {
+                      const active = preset.id === commentaryPresetId;
+                      return (
+                        <button
+                          key={preset.id}
+                          type="button"
+                          onClick={() => setCommentaryPresetId(preset.id)}
+                          aria-pressed={active}
+                          disabled={!commentarySupported}
+                          className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
+                              : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                          } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                        >
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
+                            {active && (
+                              <span className="rounded-full border border-emerald-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-emerald-100">
+                                Active
+                              </span>
+                            )}
+                          </span>
+                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                            {preset.description}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setCommentaryMuted((prev) => !prev)}
+                    aria-pressed={commentaryMuted}
+                    disabled={!commentarySupported}
+                    className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                      commentaryMuted
+                        ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
+                        : 'bg-white/10 text-white/80 hover:bg-white/20'
+                    } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                  >
+                    <span>Mute commentary</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                        commentaryMuted
+                          ? 'border-black/30 text-black/70'
+                          : 'border-white/30 text-white/70'
+                      }`}
+                    >
+                      {commentaryMuted ? 'On' : 'Off'}
+                    </span>
+                  </button>
+                  {!commentarySupported && (
+                    <p className="text-[10px] text-white/50">
+                      Voice commentary requires a browser with Web Speech support.
+                    </p>
+                  )}
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</h3>
+                  <div className="grid gap-2">
+                    {FRAME_RATE_OPTIONS.map((option) => {
+                      const active = option.id === frameRateId;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setFrameRateId(option.id)}
+                          aria-pressed={active}
+                          className={`w-full rounded-2xl border px-4 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
                               {option.label}
                             </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4 space-y-3">
-                <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Ndalo tingujt</span>
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
-                    checked={muted}
-                    onChange={(event) => {
-                      const next = event.target.checked;
-                      setMuted(next);
-                      setGameMuted(next);
-                    }}
-                  />
-                </label>
-                <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
-                  <span>Show movement trail</span>
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
-                    checked={showTrailEnabled}
-                    onChange={(event) => setShowTrailEnabled(event.target.checked)}
-                  />
-                </label>
-              </div>
-              <div className="mt-4 space-y-2">
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</h3>
-                <div className="grid gap-2">
-                  {SNAKE_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => setCommentaryPresetId(preset.id)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
-                            : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                          {active && (
-                            <span className="rounded-full border border-emerald-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-emerald-100">
-                              Active
+                            <span className="text-xs font-semibold tracking-wide">
+                              {option.resolution
+                                ? `${option.resolution} • ${option.fps} FPS`
+                                : `${option.fps} FPS`}
                             </span>
-                          )}
-                        </span>
-                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
+                          </span>
+                          {option.description ? (
+                            <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                              {option.description}
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setCommentaryMuted((prev) => !prev)}
-                  aria-pressed={commentaryMuted}
-                  disabled={!commentarySupported}
-                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    commentaryMuted
-                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                      : 'bg-white/10 text-white/80 hover:bg-white/20'
-                  } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                >
-                  <span>Mute commentary</span>
-                  <span
-                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                      commentaryMuted
-                        ? 'border-black/30 text-black/70'
-                        : 'border-white/30 text-white/70'
-                    }`}
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAppearance({ ...DEFAULT_APPEARANCE });
+                      setFrameRateId(DEFAULT_FRAME_RATE_ID);
+                    }}
+                    className="w-full rounded-lg border border-white/10 bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
                   >
-                    {commentaryMuted ? 'On' : 'Off'}
-                  </span>
-                </button>
-                {!commentarySupported && (
-                  <p className="text-[10px] text-white/50">
-                    Voice commentary requires a browser with Web Speech support.
-                  </p>
-                )}
-              </div>
-              <div className="mt-4 space-y-2">
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/60">Graphics</h3>
-                <div className="grid gap-2">
-                  {FRAME_RATE_OPTIONS.map((option) => {
-                    const active = option.id === frameRateId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setFrameRateId(option.id)}
-                        aria-pressed={active}
-                        className={`w-full rounded-2xl border px-4 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                            {option.label}
-                          </span>
-                          <span className="text-xs font-semibold tracking-wide">
-                            {option.resolution
-                              ? `${option.resolution} • ${option.fps} FPS`
-                              : `${option.fps} FPS`}
-                          </span>
-                        </span>
-                        {option.description ? (
-                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                            {option.description}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
+                    Reseto personalizimin
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => window.location.reload()}
+                    className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
+                  >
+                    Restart game
+                  </button>
                 </div>
-              </div>
-              <div className="mt-4 space-y-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAppearance({ ...DEFAULT_APPEARANCE });
-                    setFrameRateId(DEFAULT_FRAME_RATE_ID);
-                  }}
-                  className="w-full rounded-lg border border-white/10 bg-white/10 py-2 text-center text-[0.7rem] font-semibold text-white transition hover:bg-white/20"
-                >
-                  Reseto personalizimin
-                </button>
-                <button
-                  type="button"
-                  onClick={() => window.location.reload()}
-                  className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
-                >
-                  Restart game
-                </button>
               </div>
             </div>
           )}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26660,12 +26660,17 @@ const powerRef = useRef(hud.power);
           <div
             id="snooker-config-panel"
             ref={configPanelRef}
-            className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur"
+            className="pointer-events-auto mt-2 w-72 max-w-[80vw] max-h-[80vh] overflow-y-auto rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur pr-1"
           >
             <div className="flex items-center justify-between gap-4">
-              <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">
-                Table Setup
-              </span>
+              <div>
+                <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">
+                  Table Setup
+                </span>
+                <p className="mt-1 text-[0.7rem] text-white/70">
+                  Match the Snooker Royal table finish and arena mood.
+                </p>
+              </div>
               <button
                 type="button"
                 onClick={() => setConfigOpen(false)}
@@ -26684,8 +26689,8 @@ const powerRef = useRef(hud.power);
                 </svg>
               </button>
             </div>
-            <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              <div>
+            <div className="mt-4 space-y-3">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Replays
                 </h3>
@@ -26711,7 +26716,7 @@ const powerRef = useRef(hud.power);
                   </span>
                 </button>
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Commentary
                 </h3>
@@ -26774,7 +26779,7 @@ const powerRef = useRef(hud.power);
                   </p>
                 )}
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish
                 </h3>
@@ -26788,7 +26793,7 @@ const powerRef = useRef(hud.power);
                         type="button"
                         onClick={() => setTableFinishId(option.id)}
                         aria-pressed={active}
-                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-2xl px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                           active
                             ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
                             : 'bg-white/10 text-white/80 hover:bg-white/20'
@@ -26799,7 +26804,7 @@ const powerRef = useRef(hud.power);
                           <img
                             src={thumb}
                             alt={option.label}
-                            className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                            className="h-14 w-20 rounded-xl border border-white/20 object-cover"
                             loading="lazy"
                           />
                         ) : null}
@@ -26808,7 +26813,7 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Base
                 </h3>
@@ -26824,7 +26829,7 @@ const powerRef = useRef(hud.power);
                         type="button"
                         onClick={() => setTableBaseId(option.id)}
                         aria-pressed={active}
-                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-2xl px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                           active
                             ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
                             : 'bg-white/10 text-white/80 hover:bg-white/20'
@@ -26835,12 +26840,12 @@ const powerRef = useRef(hud.power);
                           <img
                             src={thumb}
                             alt={option.name}
-                            className="h-6 w-10 rounded-lg border border-white/25 object-cover"
+                            className="h-14 w-20 rounded-xl border border-white/25 object-cover"
                             loading="lazy"
                           />
                         ) : (
                           <span
-                            className="h-5 w-8 rounded-lg border border-white/25"
+                            className="h-14 w-20 rounded-xl border border-white/25"
                             aria-hidden="true"
                             style={{
                               background: `linear-gradient(135deg, ${swatchA}, ${swatchB})`
@@ -26852,7 +26857,7 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   HDR Environment
                 </h3>
@@ -26879,12 +26884,12 @@ const powerRef = useRef(hud.power);
                           <img
                             src={thumb}
                             alt={`${variant.name} HDRI`}
-                            className="h-6 w-10 rounded-lg border border-white/30 object-cover"
+                            className="h-14 w-20 rounded-xl border border-white/30 object-cover"
                             loading="lazy"
                           />
                         ) : (
                           <span
-                            className="h-6 w-10 rounded-lg border border-white/30"
+                            className="h-14 w-20 rounded-xl border border-white/30"
                             aria-hidden="true"
                             style={{
                               background: `linear-gradient(135deg, ${swatchA}, ${swatchB})`
@@ -26896,7 +26901,7 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Chrome Plates
                 </h3>
@@ -26928,7 +26933,7 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              <div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Cue Styles
                 </h3>
@@ -26952,7 +26957,7 @@ const powerRef = useRef(hud.power);
                           <img
                             src={thumb}
                             alt={preset.label}
-                            className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                            className="h-14 w-20 rounded-xl border border-white/20 object-cover"
                             loading="lazy"
                           />
                         ) : null}
@@ -26995,7 +27000,7 @@ const powerRef = useRef(hud.power);
                             <img
                               src={thumb}
                               alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                              className="h-14 w-20 rounded-xl border border-white/20 object-cover"
                               loading="lazy"
                             />
                           ) : null}
@@ -27065,7 +27070,7 @@ const powerRef = useRef(hud.power);
                             <img
                               src={thumb}
                               alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                              className="h-14 w-20 rounded-xl border border-white/20 object-cover"
                               loading="lazy"
                             />
                           ) : null}

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -5191,151 +5191,166 @@ function TexasHoldemArena({ search }) {
           </button>
         </div>
       {configOpen && (
-        <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</span>
+        <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur pr-1">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</p>
+              <p className="mt-1 text-[0.7rem] text-white/70">
+                Tune the felt, rails, and chair finishes.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setConfigOpen(false)}
+              className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+              aria-label="Mbyll personalizimin"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+              </svg>
+            </button>
+          </div>
+          <div className="mt-4 space-y-3">
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
+                <p className="mt-1 text-[0.7rem] text-white/60">Table finishes, cloth, and chair styling.</p>
+              </div>
+              <div className="mt-3 space-y-4">
+                {customizationSections.map(({ key, label, options }) => (
+                  <div key={key} className="space-y-2">
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      {options.map((option) => {
+                        const selected = appearance[key] === option.idx;
+                        const disabled =
+                          key === 'tableShape' && option.id === DIAMOND_SHAPE_ID && effectivePlayerCount > 4;
+                        return (
+                          <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => {
+                              if (disabled) return;
+                              setAppearance((prev) => ({ ...prev, [key]: option.idx }));
+                            }}
+                            aria-pressed={selected}
+                            disabled={disabled}
+                            className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                              selected ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]' : 'border-white/10 bg-white/5 hover:border-white/20'
+                            } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
+                          >
+                            {renderPreview(key, option)}
+                            <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+              <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
+              <div className="grid gap-2">
+                {TEXAS_HOLDEM_COMMENTARY_PRESETS.map((preset) => {
+                  const active = preset.id === commentaryPresetId;
+                  return (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => setCommentaryPresetId(preset.id)}
+                      aria-pressed={active}
+                      disabled={!commentarySupported}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        active
+                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
+                        {active && (
+                          <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
+                            Active
+                          </span>
+                        )}
+                      </span>
+                      <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                        {preset.description}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
               <button
                 type="button"
-                onClick={() => setConfigOpen(false)}
-                className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                aria-label="Mbyll personalizimin"
+                onClick={() => setCommentaryMuted((prev) => !prev)}
+                aria-pressed={commentaryMuted}
+                disabled={!commentarySupported}
+                className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                  commentaryMuted
+                    ? 'bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                    : 'bg-white/10 text-white/80 hover:bg-white/20'
+                } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
-                </svg>
-              </button>
-            </div>
-            <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              {customizationSections.map(({ key, label, options }) => (
-                <div key={key} className="space-y-2">
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">{label}</p>
-                  <div className="grid grid-cols-2 gap-2">
-                    {options.map((option) => {
-                      const selected = appearance[key] === option.idx;
-                      const disabled =
-                        key === 'tableShape' && option.id === DIAMOND_SHAPE_ID && effectivePlayerCount > 4;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => {
-                            if (disabled) return;
-                            setAppearance((prev) => ({ ...prev, [key]: option.idx }));
-                          }}
-                          aria-pressed={selected}
-                          disabled={disabled}
-                          className={`flex flex-col items-center rounded-2xl border p-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                            selected ? 'border-sky-400/80 bg-sky-400/10 shadow-[0_0_12px_rgba(56,189,248,0.35)]' : 'border-white/10 bg-white/5 hover:border-white/20'
-                          } ${disabled ? 'cursor-not-allowed opacity-50 hover:border-white/10' : ''}`}
-                        >
-                          {renderPreview(key, option)}
-                          <span className="mt-2 text-center text-[0.65rem] font-semibold text-gray-200">{option.label}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Commentary</p>
-                <div className="grid gap-2">
-                  {TEXAS_HOLDEM_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => setCommentaryPresetId(preset.id)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                          active
-                            ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                          {active && (
-                            <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
-                              Active
-                            </span>
-                          )}
-                        </span>
-                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setCommentaryMuted((prev) => !prev)}
-                  aria-pressed={commentaryMuted}
-                  disabled={!commentarySupported}
-                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                <span>Mute commentary</span>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
                     commentaryMuted
-                      ? 'bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                      : 'bg-white/10 text-white/80 hover:bg-white/20'
-                  } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                      ? 'border-black/30 text-black/70'
+                      : 'border-white/30 text-white/70'
+                  }`}
                 >
-                  <span>Mute commentary</span>
-                  <span
-                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                      commentaryMuted
-                        ? 'border-black/30 text-black/70'
-                        : 'border-white/30 text-white/70'
-                    }`}
-                  >
-                    {commentaryMuted ? 'On' : 'Off'}
-                  </span>
-                </button>
-                {!commentarySupported && (
-                  <p className="text-[0.65rem] text-white/50">
-                    Voice commentary needs Web Speech support.
-                  </p>
-                )}
-              </div>
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.35em] text-white/60">Graphics</p>
+                  {commentaryMuted ? 'On' : 'Off'}
+                </span>
+              </button>
+              {!commentarySupported && (
+                <p className="text-[0.65rem] text-white/50">
+                  Voice commentary needs Web Speech support.
+                </p>
+              )}
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
                   Match the Murlan Royale presets for identical FPS and clarity options.
                 </p>
-                <div className="grid gap-2">
-                  {FRAME_RATE_OPTIONS.map((option) => {
-                    const active = option.id === frameRateId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setFrameRateId(option.id)}
-                        aria-pressed={active}
-                        className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                          active
-                            ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                        }`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{option.label}</span>
-                          <span className="text-[11px] font-semibold tracking-wide text-sky-100">
-                            {option.resolution ? `${option.resolution} • ${option.fps} FPS` : `${option.fps} FPS`}
-                          </span>
+              </div>
+              <div className="grid gap-2">
+                {FRAME_RATE_OPTIONS.map((option) => {
+                  const active = option.id === frameRateId;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => setFrameRateId(option.id)}
+                      aria-pressed={active}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        active
+                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                      }`}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{option.label}</span>
+                        <span className="text-[11px] font-semibold tracking-wide text-sky-100">
+                          {option.resolution ? `${option.resolution} • ${option.fps} FPS` : `${option.fps} FPS`}
                         </span>
-                        {option.description ? (
-                          <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                            {option.description}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
+                      </span>
+                      {option.description ? (
+                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           </div>
-        )}
+        </div>
+      )}
       </div>
       <div className="absolute inset-0 pointer-events-none">
         {seatAnchors.map((anchor, index) => (


### PR DESCRIPTION
### Motivation
- Provide a consistent table customization UX by matching non-chess games to the Chess Battle Royal table-setup layout and the Ludo Battle Royal preview sizing. 
- Make thumbnails and preview tiles uniform across arenas so players see consistent thumbnail proportions when personalizing tables. 
- Group and clarify customization sections (graphics, commentary, appearance, settings) into repeatable card blocks for better discoverability.

### Description
- Reworked table setup panels to a card-based layout with descriptive headers and consistent spacing across these files: `webapp/src/pages/Games/TexasHoldemArena.jsx`, `LudoBattleRoyal.jsx`, `MurlanRoyaleArena.jsx`, `SnakeAndLadder.jsx`, and `SnookerRoyal.jsx`.
- Added constrained panel sizing and scrolling via `max-h-[80vh]` + `overflow-y-auto` and `pr-1` to keep menus usable on mobile/portrait screens and match the Chess menu behavior.
- Resized many customization preview thumbnails and tiles (e.g. changed preview classes to `h-14 w-20`, `h-14`, `h-11`, `h-10` etc.) so thumbnails match the Ludo Battle Royal proportions used on table setup screens.
- Reorganized sections into consistent `rounded-xl` card groups for "Personalize Arena", "Commentary", "Graphics", and "Settings" and adjusted button/label styles for visual parity.

### Testing
- Launched the dev server with `npm --prefix webapp run dev` and verified the site came up successfully (Vite reported ready); this succeeded.
- Ran a Playwright script that opened `/games/ludobattleroyal`, opened the table customization menu, and saved a screenshot to `artifacts/ludo-table-menu.png`, which completed successfully and confirms the new menu layout renders as intended.
- No unit tests were modified or run since these are UI/CSS adjustments only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dc29c6ec832989aa2ee348024b1e)