### PR TITLE
Albanian commentary: eSpeak voice hints and text tweaks; pool AI & UK 8-ball fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,3 +424,7 @@ Run `npm run reset-db` to drop the existing MongoDB database and start with a cl
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Third-party licenses
+
+See [docs/third-party-licenses.md](docs/third-party-licenses.md) for third-party license notices.

--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -1,0 +1,6 @@
+# Third-party licenses
+
+This project uses optional text-to-speech voice selection hints that reference the
+open-source eSpeak project for Albanian commentary support. eSpeak is licensed under
+the GNU General Public License. For the full license text and details, see:
+https://espeak.sourceforge.net/license.html

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -523,10 +523,36 @@ function safetyShot (req) {
   }
 }
 
+function pickBallInHandPlacement (req, target, entry) {
+  const r = req.state.ballRadius
+  const dir = { x: target.x - entry.x, y: target.y - entry.y }
+  const len = Math.hypot(dir.x, dir.y) || 1
+  const unit = { x: dir.x / len, y: dir.y / len }
+  const distances = [6, 8, 10, 12].map(m => m * r)
+  for (const d of distances) {
+    const cand = { x: target.x + unit.x * d, y: target.y + unit.y * d }
+    if (cand.x < r || cand.x > req.state.width - r || cand.y < r || cand.y > req.state.height - r) {
+      continue
+    }
+    if (
+      req.state.mustPlayFromBaulk &&
+      typeof req.state.baulkLineY === 'number' &&
+      cand.y < req.state.baulkLineY
+    ) {
+      continue
+    }
+    const overlap = req.state.balls.some(
+      b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+    )
+    if (overlap) continue
+    return cand
+  }
+  return null
+}
+
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
   const targets = chooseTargets(req)
-  if (!cue || targets.length === 0) return null
+  if (targets.length === 0) return null
 
   let best = null
   for (const target of targets) {
@@ -541,6 +567,8 @@ function fallbackAimAtTarget (req) {
     }
     if (!bestPocket) continue
     const entry = pocketEntry(bestPocket, req.state.ballRadius, req.state.width, req.state.height, target)
+    const cue = req.state.ballInHand ? pickBallInHandPlacement(req, target, entry) : req.state.balls.find(b => b.id === 0)
+    if (!cue) continue
     const ghost = {
       x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
       y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
@@ -562,7 +590,8 @@ function fallbackAimAtTarget (req) {
       targetPocket: bestPocket,
       aimPoint: ghost,
       quality: 0,
-      rationale: 'fallback-aim'
+      rationale: 'fallback-aim',
+      cueBallPosition: req.state.ballInHand ? cue : undefined
     }
     if (!best || bestAlign > best.align) {
       best = { ...candidate, align: bestAlign }

--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -251,8 +251,12 @@ export class UkPool {
       const hasOpenTablePot =
         s.isOpenTable && shot.potted.some(col => col === 'blue' || col === 'red');
       const potOwn = (groupAfter && shot.potted.includes(groupAfter)) || hasOpenTablePot;
+      const recoveryShot = mustBaulk && shot.placedFromHand;
       if (!potOwn) {
         shotsNext = s.shotsRemaining - 1;
+        if (recoveryShot) {
+          shotsNext = Math.max(shotsNext, 1);
+        }
       }
       if (shotsNext <= 0) {
         nextPlayer = opp;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1007,11 +1007,33 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'albanian-booth',
     label: 'Albanian Booth',
-    description: 'Shqip commentary with native cadence',
+    description: 'Shqip commentary with eSpeak-supported voices',
     language: 'sq-AL',
     voiceHints: {
-      [POOL_ROYALE_SPEAKERS.lead]: ['sq-AL', 'Albanian', 'male', 'Arben', 'Besnik', 'Luan'],
-      [POOL_ROYALE_SPEAKERS.analyst]: ['sq-AL', 'Albanian', 'female', 'Elira', 'Arta', 'Besa']
+      [POOL_ROYALE_SPEAKERS.lead]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'eSpeak',
+        'eSpeak NG',
+        'Albanian (eSpeak NG)',
+        'male',
+        'Arben',
+        'Besnik',
+        'Luan'
+      ],
+      [POOL_ROYALE_SPEAKERS.analyst]: [
+        'sq-AL',
+        'sq',
+        'Albanian',
+        'eSpeak',
+        'eSpeak NG',
+        'Albanian (eSpeak NG)',
+        'female',
+        'Elira',
+        'Arta',
+        'Besa'
+      ]
     },
     speakerSettings: {
       [POOL_ROYALE_SPEAKERS.lead]: { rate: 1.02, pitch: 0.98, volume: 1 },

--- a/webapp/src/utils/poolRoyaleCommentary.js
+++ b/webapp/src/utils/poolRoyaleCommentary.js
@@ -942,7 +942,7 @@ const LOCALIZED_TEMPLATES = Object.freeze({
         'Mirë se vini në {arena}. {speaker} me ju për {variantName}.',
         'Përshëndetje nga {arena}—{speaker} në komentim.',
         'Tungjatjeta, {arena} është gati për {player} kundër {opponent}.',
-        'Mirëmbrëma nga {arena}. Sot {player} kundër {opponent}.'
+        'Mirëmbrëma nga {arena}. Sonte {player} kundër {opponent}.'
       ],
       intro: [
         'Mirë se vini në {arena}. {speaker} me ju. {player} përballë {opponent}; {scoreline} në {variantName}.',
@@ -951,11 +951,11 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       ],
       introReply: [
         'Faleminderit, {speaker}. Kontrolli i topit të bardhë dhe pozicionimi vendosin gjithçka.',
-        'Kënaqësi të jem këtu, {speaker}. Fiton ai që menaxhon këndet.',
-        'Saktë, {speaker}. Qetësia dhe ritmi janë vendimtarë.'
+        'Kënaqësi të jem këtu, {speaker}. Fiton ai që menaxhon këndet dhe ritmin.',
+        'Saktë, {speaker}. Qetësia dhe rrjedha e lojës janë vendimtare.'
       ],
       breakShot: [
-        '{player} gati për thyerjen; shpërndarje e pastër dhe top i bardhë i qetë.',
+        '{player} gati për thyerjen; shpërndarje e pastër dhe top i bardhë i kontrolluar.',
         '{player} hyn për thyerje—shpejtësia dhe kontrolli janë kyç.',
         'Ja thyerja nga {player}; të shohim si hapen topat.'
       ],
@@ -973,17 +973,17 @@ const LOCALIZED_TEMPLATES = Object.freeze({
       safety: [
         'Siguri e mençur; {player} fsheh topin e bardhë.',
         'Zgjedhje taktike, e lë {opponent} në pozicion të vështirë.',
-        'S’më bind plotësisht kjo siguri—ka rrezik të mbetet hapur.',
+        'Nuk më bind plotësisht kjo siguri—ka rrezik të mbetet hapur.',
         'Siguri e pastër; i prish ritmin kundërshtarit.'
       ],
       pressure: [
         'Moment me presion; {player} duhet të jetë i saktë.',
         'Goditje e madhe—mënyra si e prek topin vendos gjithçka.',
         'Tension i lartë; një gabim këtu kushton.',
-        'Kjo është goditje që ndan fituesin.'
+        'Kjo është goditja që ndan fituesin.'
       ],
       pot: [
-        'Çfarë goditje! {player} fut {targetBall} në {pocket}.',
+        'Çfarë goditjeje! {player} fut {targetBall} në {pocket}.',
         'E pabesueshme—{player} e fut dhe mban pozicion.',
         '{player} fut {targetBall} në {pocket}, topi i bardhë qëndron bukur.',
         'Goditje e pastër; {player} lë kënd të mirë për tjetrin.',


### PR DESCRIPTION
### Motivation

- Provide clearer, more natural Albanian commentary and ensure the app can select/advertise eSpeak-compatible voices for Albanian TTS while documenting the eSpeak license. 
- Improve AI behavior for ball-in-hand fallback aiming and ensure UK 8-ball foul recovery produces the expected single-visit ball-in-hand behavior observed by tests. 

### Description

- Update Albanian commentary phrasing and translations in `webapp/src/utils/poolRoyaleCommentary.js` to improve wording and flow. 
- Expand the Pool Royale Albanian booth preset in `webapp/src/pages/Games/PoolRoyale.jsx` to prefer eSpeak/eSpeak NG voice hints and update its description. 
- Add `docs/third-party-licenses.md` and link it from `README.md` to note eSpeak licensing (https://espeak.sourceforge.net/license.html). 
- Add `pickBallInHandPlacement` and wire ball-in-hand fallback placement into `lib/poolAi.js` so fallback aims return a sensible `cueBallPosition` for ball-in-hand situations. 
- Adjust UK 8-ball shot resolution in `lib/poolUk8Ball.js` so a recovery `placedFromHand` (after a foul / must play from baulk) does not incorrectly remove the single extra visit. 

### Testing

- Ran the full test suite with `npm test -- --runInBand`. 
- Iterated on failing tests and re-ran `npm test -- --runInBand` until all suites passed. 
- Final automated test result: all test suites passed (`32 passed`), with `111` tests passing and `1` skipped (112 total), and no remaining failing suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dd52e2948329b1f95a9f2c704837)