### PR TITLE
Use remote CDN thumbnails for Domino style previews and store items

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2635,11 +2635,16 @@ const HIGHLIGHT_STYLE_OPTIONS = Object.freeze([
   }
 ]);
 
+const DOMINO_STYLE_THUMB_BASE = window?.DOMINO_STYLE_THUMB_BASE || '';
+const buildDominoStyleThumb = (name) =>
+  DOMINO_STYLE_THUMB_BASE ? `${DOMINO_STYLE_THUMB_BASE.replace(/\\/$/, '')}/${name}` : '';
+
 const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'imperialIvory',
     label: 'Imperial Ivory',
     preview: ['#f7f1e4', '#d8af37'],
+    thumbnail: buildDominoStyleThumb('domino-style-imperial-ivory.png'),
     body: {
       color: '#f7f1e4',
       roughness: 0.16,
@@ -2675,6 +2680,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'obsidianPlatinum',
     label: 'Obsidian Platinum',
     preview: ['#090909', '#c5ccd9'],
+    thumbnail: buildDominoStyleThumb('domino-style-obsidian-platinum.png'),
     body: {
       color: '#0b0c10',
       roughness: 0.24,
@@ -2710,6 +2716,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'midnightRose',
     label: 'Midnight Rose',
     preview: ['#0d1533', '#c27c6a'],
+    thumbnail: buildDominoStyleThumb('domino-style-midnight-rose.png'),
     body: {
       color: '#101b38',
       roughness: 0.2,
@@ -2745,6 +2752,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'auroraJade',
     label: 'Aurora Jade',
     preview: ['#0e3b2c', '#d0b58f'],
+    thumbnail: buildDominoStyleThumb('domino-style-aurora-jade.png'),
     body: {
       color: '#0e3b2c',
       roughness: 0.22,
@@ -2780,6 +2788,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'frostedOpal',
     label: 'Frosted Opal',
     preview: ['#e8eef4', '#7a93d2'],
+    thumbnail: buildDominoStyleThumb('domino-style-frosted-opal.png'),
     body: {
       color: '#e8eef4',
       roughness: 0.18,
@@ -2815,6 +2824,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'carbonVolt',
     label: 'Carbon Volt',
     preview: ['#0b1020', '#22d3ee'],
+    thumbnail: buildDominoStyleThumb('domino-style-carbon-volt.png'),
     body: {
       color: '#0c1428',
       roughness: 0.28,
@@ -2850,6 +2860,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     id: 'sandstoneAurora',
     label: 'Sandstone Aurora',
     preview: ['#f1d8b0', '#f97316'],
+    thumbnail: buildDominoStyleThumb('domino-style-sandstone-aurora.png'),
     body: {
       color: '#f1d8b0',
       roughness: 0.34,
@@ -5045,13 +5056,15 @@ function createOptionPreview(key, option) {
     case 'dominoStyle':
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';
-      {
+      if (option?.thumbnail) {
+        swatch.style.backgroundImage = `url('${option.thumbnail}')`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      } else {
         const [topColor, bottomColor] = Array.isArray(option.preview) && option.preview.length >= 2
           ? option.preview
           : ['#1f2937', '#0f172a'];
         swatch.style.background = `linear-gradient(135deg, ${topColor}, ${bottomColor})`;
-      }
-      {
         const pip = document.createElement('div');
         pip.style.position = 'absolute';
         pip.style.width = '0.58rem';
@@ -5064,8 +5077,6 @@ function createOptionPreview(key, option) {
         pip.style.opacity = '0.95';
         pip.style.pointerEvents = 'none';
         swatch.appendChild(pip);
-      }
-      {
         const inset = document.createElement('div');
         inset.style.position = 'absolute';
         inset.style.inset = 'auto 0.4rem 0.3rem 0.4rem';

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,6 +1,8 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { polyHavenThumb, remoteThumbnail, swatchThumbnail } from './storeThumbnails.js';
+
+const DOMINO_STYLE_THUMBNAIL_BASE = import.meta.env.VITE_DOMINO_STYLE_THUMBNAIL_BASE || '';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: [
@@ -76,13 +78,27 @@ const DOMINO_TABLE_BASE_THUMBNAILS = Object.freeze({
 });
 
 const DOMINO_STYLE_THUMBNAILS = Object.freeze({
-  imperialIvory: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0']),
-  obsidianPlatinum: swatchThumbnail(['#1f2937', '#6b7280', '#e5e7eb']),
-  midnightRose: swatchThumbnail(['#881337', '#1f2937', '#fecdd3']),
-  auroraJade: swatchThumbnail(['#047857', '#0f172a', '#86efac']),
-  frostedOpal: swatchThumbnail(['#f8fafc', '#c7d2fe', '#e2e8f0']),
-  carbonVolt: swatchThumbnail(['#0f172a', '#111827', '#fde047']),
-  sandstoneAurora: swatchThumbnail(['#d6c7a1', '#7c2d12', '#fcd34d'])
+  imperialIvory:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-imperial-ivory.png') ||
+    swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0']),
+  obsidianPlatinum:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-obsidian-platinum.png') ||
+    swatchThumbnail(['#1f2937', '#6b7280', '#e5e7eb']),
+  midnightRose:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-midnight-rose.png') ||
+    swatchThumbnail(['#881337', '#1f2937', '#fecdd3']),
+  auroraJade:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-aurora-jade.png') ||
+    swatchThumbnail(['#047857', '#0f172a', '#86efac']),
+  frostedOpal:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-frosted-opal.png') ||
+    swatchThumbnail(['#f8fafc', '#c7d2fe', '#e2e8f0']),
+  carbonVolt:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-carbon-volt.png') ||
+    swatchThumbnail(['#0f172a', '#111827', '#fde047']),
+  sandstoneAurora:
+    remoteThumbnail(DOMINO_STYLE_THUMBNAIL_BASE, 'domino-style-sandstone-aurora.png') ||
+    swatchThumbnail(['#d6c7a1', '#7c2d12', '#fcd34d'])
 });
 
 const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({

--- a/webapp/src/config/storeThumbnails.js
+++ b/webapp/src/config/storeThumbnails.js
@@ -24,6 +24,12 @@ export const polyHavenThumb = (id) =>
 export const khronosThumb = (modelId) =>
   `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/${modelId}/screenshot/screenshot.jpg`;
 
+export const remoteThumbnail = (baseUrl, filename) => {
+  if (!baseUrl || !filename) return '';
+  const trimmedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  return `${trimmedBase}/${filename}`;
+};
+
 export const swatchThumbnail = (colors = []) => {
   const [primary = '#1f2937', secondary = '#0f172a', accent = '#ffffff'] = colors;
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">


### PR DESCRIPTION
### Motivation
- Improve visual fidelity of domino style thumbnails by allowing high-resolution images hosted on a CDN instead of embedding binaries in the repo.
- Make store cards and the Domino Royal setup menu show zoomed/photographic thumbnails when available while keeping a fallback vector swatch.
- Avoid committing binary image assets to the repository by exposing a configurable base URL for remote thumbnails.

### Description
- Added `remoteThumbnail(baseUrl, filename)` to `webapp/src/config/storeThumbnails.js` to build trimmed CDN URLs and kept `swatchThumbnail` as a fallback. 
- Wired a new `VITE_DOMINO_STYLE_THUMBNAIL_BASE` environment variable in `webapp/src/config/dominoRoyalInventoryConfig.js` and used `remoteThumbnail(...) || swatchThumbnail(...)` for each domino style thumbnail. 
- Added `DOMINO_STYLE_THUMB_BASE` + `buildDominoStyleThumb(name)` to `webapp/public/domino-royal.html`, inserted `thumbnail` URLs into `DOMINO_STYLE_OPTIONS`, and updated `createOptionPreview` to render the remote image when provided or fall back to the original swatch/pip rendering.
- No binary image files were added to the repository; thumbnails are expected to be uploaded to a CDN and referenced via the env var or `window.DOMINO_STYLE_THUMB_BASE`.

### Testing
- No automated tests were added or executed because the change is configuration/UI rendering focused and does not include runtime logic changes to core systems. 
- Manual smoke: menu preview code path now supports `option.thumbnail` and will set `backgroundImage`, and store config resolves thumbnails from `VITE_DOMINO_STYLE_THUMBNAIL_BASE` with a swatch fallback (no failures observed in static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dcded3248329957d709e6a2165e0)