### PR TITLE
Add remote domino-style thumbnail support

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -2635,10 +2635,27 @@ const HIGHLIGHT_STYLE_OPTIONS = Object.freeze([
   }
 ]);
 
+const DOMINO_STYLE_THUMB_BASE = (() => {
+  if (typeof window === 'undefined') return '';
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('dominoThumbBase') || window.DOMINO_STYLE_THUMBNAIL_BASE || '';
+  } catch (error) {
+    return window.DOMINO_STYLE_THUMBNAIL_BASE || '';
+  }
+})();
+
+const resolveDominoStyleThumbnail = (id) => {
+  if (!DOMINO_STYLE_THUMB_BASE) return '';
+  const trimmed = DOMINO_STYLE_THUMB_BASE.replace(/\/+$/, '');
+  return `${trimmed}/domino-style-${id}.png`;
+};
+
 const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'imperialIvory',
     label: 'Imperial Ivory',
+    thumbnail: resolveDominoStyleThumbnail('imperialIvory'),
     preview: ['#f7f1e4', '#d8af37'],
     body: {
       color: '#f7f1e4',
@@ -2674,6 +2691,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'obsidianPlatinum',
     label: 'Obsidian Platinum',
+    thumbnail: resolveDominoStyleThumbnail('obsidianPlatinum'),
     preview: ['#090909', '#c5ccd9'],
     body: {
       color: '#0b0c10',
@@ -2709,6 +2727,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'midnightRose',
     label: 'Midnight Rose',
+    thumbnail: resolveDominoStyleThumbnail('midnightRose'),
     preview: ['#0d1533', '#c27c6a'],
     body: {
       color: '#101b38',
@@ -2744,6 +2763,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'auroraJade',
     label: 'Aurora Jade',
+    thumbnail: resolveDominoStyleThumbnail('auroraJade'),
     preview: ['#0e3b2c', '#d0b58f'],
     body: {
       color: '#0e3b2c',
@@ -2779,6 +2799,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'frostedOpal',
     label: 'Frosted Opal',
+    thumbnail: resolveDominoStyleThumbnail('frostedOpal'),
     preview: ['#e8eef4', '#7a93d2'],
     body: {
       color: '#e8eef4',
@@ -2814,6 +2835,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'carbonVolt',
     label: 'Carbon Volt',
+    thumbnail: resolveDominoStyleThumbnail('carbonVolt'),
     preview: ['#0b1020', '#22d3ee'],
     body: {
       color: '#0c1428',
@@ -2849,6 +2871,7 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
   {
     id: 'sandstoneAurora',
     label: 'Sandstone Aurora',
+    thumbnail: resolveDominoStyleThumbnail('sandstoneAurora'),
     preview: ['#f1d8b0', '#f97316'],
     body: {
       color: '#f1d8b0',
@@ -5045,7 +5068,11 @@ function createOptionPreview(key, option) {
     case 'dominoStyle':
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';
-      {
+      if (option?.thumbnail) {
+        swatch.style.backgroundImage = `url(${option.thumbnail})`;
+        swatch.style.backgroundSize = 'cover';
+        swatch.style.backgroundPosition = 'center';
+      } else {
         const [topColor, bottomColor] = Array.isArray(option.preview) && option.preview.length >= 2
           ? option.preview
           : ['#1f2937', '#0f172a'];

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,6 +1,6 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { polyHavenThumb, remoteThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: [
@@ -85,6 +85,11 @@ const DOMINO_STYLE_THUMBNAILS = Object.freeze({
   sandstoneAurora: swatchThumbnail(['#d6c7a1', '#7c2d12', '#fcd34d'])
 });
 
+const DOMINO_STYLE_THUMB_BASE = import.meta.env.VITE_DOMINO_STYLE_THUMBNAIL_BASE || '';
+
+const resolveDominoStyleThumbnail = (id) =>
+  remoteThumb(DOMINO_STYLE_THUMB_BASE, `domino-style-${id}.png`) || DOMINO_STYLE_THUMBNAILS[id];
+
 const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
   marksmanAmber: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a']),
   iceTracer: swatchThumbnail(['#e0f2fe', '#0ea5e9', '#bae6fd']),
@@ -163,7 +168,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     name: option.label,
     price: 820 + idx * 40,
     description: 'Premium domino material set for tiles and pips.',
-    thumbnail: DOMINO_STYLE_THUMBNAILS[option.id]
+    thumbnail: resolveDominoStyleThumbnail(option.id)
   })),
   ...DOMINO_ROYAL_OPTION_SETS.highlightStyle.slice(1).map((option, idx) => ({
     id: `domino-highlight-${option.id}`,

--- a/webapp/src/config/storeThumbnails.js
+++ b/webapp/src/config/storeThumbnails.js
@@ -21,6 +21,14 @@ const encodeSvg = (svg) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 export const polyHavenThumb = (id) =>
   `${POLYHAVEN_THUMB_BASE}/${resolvePolyHavenId(id)}.png?width=256&height=256`;
 
+export const remoteThumb = (base, assetPath) => {
+  if (!base) return '';
+  const trimmed = base.replace(/\/+$/, '');
+  const nextPath = String(assetPath || '').replace(/^\/+/, '');
+  if (!trimmed || !nextPath) return '';
+  return `${trimmed}/${nextPath}`;
+};
+
 export const khronosThumb = (modelId) =>
   `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/${modelId}/screenshot/screenshot.jpg`;
 


### PR DESCRIPTION
### Motivation
- Provide higher-resolution domino piece thumbnails without committing binary assets to the repository.
- Allow the store and in-game menu to show CDN-hosted domino-style images while falling back to existing SVG swatches.

### Description
- Added `remoteThumb` helper to `webapp/src/config/storeThumbnails.js` to build CDN-style thumbnail URLs from a base and asset path.
- Wired a new `VITE_DOMINO_STYLE_THUMBNAIL_BASE` env hook in `webapp/src/config/dominoRoyalInventoryConfig.js` and a `resolveDominoStyleThumbnail` helper to prefer remote `domino-style-<id>.png` URLs with SVG swatch fallbacks.
- Added runtime `DOMINO_STYLE_THUMB_BASE` / `resolveDominoStyleThumbnail` and per-style `thumbnail` fields in `webapp/public/domino-royal.html` and updated the UI preview to use `option.thumbnail` (background image) when present.
- Ensures no binary files are added to the PR; images can be uploaded to external storage and referenced via `VITE_DOMINO_STYLE_THUMBNAIL_BASE` or `?dominoThumbBase=` query param.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served at `http://localhost:4173/`.
- Ran Playwright screenshot automation that opened `domino-royal.html?uhd=1` and produced `artifacts/domino-piece-zoomed-*-<style>.png` for all seven styles, verifying zoomed, higher-resolution captures (screenshots generated successfully despite an earlier transient Chromium crash during some headless attempts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dcded3248329957d709e6a2165e0)