### PR TITLE
Fix dice face mapping for 3 and 4 in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2248,8 +2248,8 @@ function setDiceOrientation(dice, val) {
   const eulers = {
     1: new THREE.Euler(0, 0, 0),
     2: new THREE.Euler(-Math.PI / 2, 0, 0),
-    3: new THREE.Euler(0, 0, -Math.PI / 2),
-    4: new THREE.Euler(0, 0, Math.PI / 2),
+    3: new THREE.Euler(0, 0, Math.PI / 2),
+    4: new THREE.Euler(0, 0, -Math.PI / 2),
     5: new THREE.Euler(Math.PI / 2, 0, 0),
     6: new THREE.Euler(Math.PI, 0, 0)
   };


### PR DESCRIPTION
### Motivation
- Correct a visual mismatch where rolls of `3` and `4` showed on the wrong dice faces so commentary and token movement align with the displayed result.

### Description
- Swapped the Euler rotations for face values `3` and `4` in `setDiceOrientation` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx` so the dice displays the correct face for those rolls.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ee9e7dec8329a1af28d0e3d74585)