### PR TITLE
Restore Pool Royale spin controller and ball physics to Feb 1 baseline

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,6 +1,6 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.75;
+export const MAX_SPIN_OFFSET = 1;
 export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
@@ -11,10 +11,6 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
-export const SPIN_EDGE_AXIS_LOCK_MAG = 0.7;
-export const SPIN_EDGE_AXIS_LOCK_RATIO = 0.3;
-export const SPIN_TOP_HALF_SCALE = 0.4;
-export const SPIN_BOTTOM_HALF_SCALE = 1.25;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -148,19 +144,7 @@ export const normalizeSpinInput = (spin) => {
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
-  const edgeMagnitude = Math.hypot(clamped.x, clamped.y);
-  if (edgeMagnitude >= SPIN_EDGE_AXIS_LOCK_MAG) {
-    const absX = Math.abs(clamped.x);
-    const absY = Math.abs(clamped.y);
-    if (absX <= absY * SPIN_EDGE_AXIS_LOCK_RATIO) {
-      return { x: 0, y: clamped.y };
-    }
-    if (absY <= absX * SPIN_EDGE_AXIS_LOCK_RATIO) {
-      return { x: clamped.x, y: 0 };
-    }
-  }
-  return clamped;
+  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };
 
 export const mapUiOffsetToCueFrame = (
@@ -200,18 +184,10 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
-  let scaledY = quantized.y;
-  if (scaledY > 0) {
-    scaledY *= SPIN_TOP_HALF_SCALE;
-  } else if (scaledY < 0) {
-    scaledY *= SPIN_BOTTOM_HALF_SCALE;
-  }
-  scaledY = clamp(scaledY, -1, 1);
-  const scaled = { x: quantized.x, y: scaledY };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -scaled.x,
-    scaled.y,
+    -quantized.x,
+    quantized.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Revert recent spin/physics experiments and restore the Pool Royale spin controller, input mapping and ball physics tuning to the Feb 1 baseline so gameplay (spin feel, cushion response and shot pacing) matches the previous validated behaviour.

### Description
- Reinstated legacy spin normalization and mapping in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` (e.g. `MAX_SPIN_OFFSET`, `normalizeSpinInput`, and `mapSpinForPhysics`) so UI offsets map to the original physics frame and quantization rules. 
- Restored Pool Royale physics/profile constants and spin tuning in `webapp/src/pages/Games/PoolRoyale.jsx` including `PHYSICS_PROFILE.airSpinDecay`, `SPIN_*` constants, spin roll/kinetic friction and rail friction, and reset `SPIN_GLOBAL_SCALE` to the prior value used on Feb 1. 
- Reverted the experimental rail/slow-spin and airborne-spin handling and helper functions added by the intervening changes (removed/disabled the additional slow-rail damping, contact-roll/ball-spin-throw logic and the align-omega helper), returning to the prior rail impact spin behaviour. 
- Restored the spin controller UI presentation and behavior (spin ring visuals, decoration points and dot handling) and the spin input clamping used by the previous implementation, plus small related UX bits for cue-ball-in-hand handling in the same files. 
- Files changed: `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- Started the web dev server with `npm --prefix webapp run dev`, and Vite reported the app ready and serving (server startup succeeded). 
- Attempted a Playwright browser snapshot of `/games/poolroyale`, but the headless Chromium process crashed and the screenshot step failed, so end-to-end rendering verification did not complete. 
- No automated unit tests were executed as part of this change; the patch was committed locally (`git commit`) after manual validation steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981eb591ff0832998bdfea7853f1c1f)