### PR TITLE
Exclude start/GO tiles from safe tiles in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1647,7 +1647,9 @@ const START_KEY_TO_PLAYER = new Map(
   })
 );
 const SAFE_TRACK_INDEXES = new Set(
-  PLAYER_START_INDEX.flatMap((index) => [index, (index + 8) % RING_STEPS])
+  PLAYER_START_INDEX
+    .map((index) => (index + 8) % RING_STEPS)
+    .filter((index) => !PLAYER_START_INDEX.includes(index))
 );
 const SAFE_TRACK_KEY_SET = new Set(
   [...SAFE_TRACK_INDEXES].map((index) => {


### PR DESCRIPTION
### Motivation
- Start/GO track squares were being treated as safe because they were included in the safe-index set, preventing tokens from being captured when landing on those tiles.
- The intent is to make start/GO tiles behave like regular track tiles so captures can occur there for all players.

### Description
- Update initialization of `SAFE_TRACK_INDEXES` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to compute `(index + 8) % RING_STEPS` and then filter out any indexes that are in `PLAYER_START_INDEX` so start tiles are never considered safe.
- This replaces the previous inclusion of start indexes and ensures only genuine safe positions remain protected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f59cee4c832993a0813d95d40e44)