### PR TITLE
Fix Chess Battle Royal 2D camera framing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1673,11 +1673,11 @@ const CAMERA_DEFAULT_PHI = clamp(
 const cameraPhiHardMax = Math.min(cameraPhiMax, Math.PI - 0.45);
 const CAMERA_SAFE_MAX_RADIUS = CAMERA_BASE_RADIUS * 2.2;
 const CAMERA_TOPDOWN_MIN_RADIUS = CAMERA_BASE_RADIUS * 1.05;
-const CAMERA_TOPDOWN_MAX_RADIUS = CAMERA_BASE_RADIUS * 1.65;
+const CAMERA_TOPDOWN_MAX_RADIUS = CAMERA_BASE_RADIUS * 1.9;
 const CAMERA_3D_MIN_RADIUS = CAMERA_SAFE_MAX_RADIUS * 0.65;
 const CAMERA_3D_MAX_RADIUS = CAMERA_SAFE_MAX_RADIUS * 1.35;
-const CAMERA_2D_MIN_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS * 0.75;
-const CAMERA_2D_MAX_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS * 1.15;
+const CAMERA_2D_MIN_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS;
+const CAMERA_2D_MAX_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS;
 const CAM = {
   fov: ARENA_CAMERA_DEFAULTS.fov,
   near: ARENA_CAMERA_DEFAULTS.near,
@@ -7600,6 +7600,8 @@ function Chess3D({
       if (mode === '2d') {
         cameraMemory.last3d = current;
         controls.enableRotate = false;
+        controls.enablePan = false;
+        controls.enableZoom = false;
         controls.minPolarAngle = CAMERA_TOPDOWN_LOCK;
         controls.maxPolarAngle = CAMERA_TOPDOWN_LOCK;
         controls.minDistance = CAMERA_2D_MIN_RADIUS;
@@ -7609,6 +7611,8 @@ function Chess3D({
         animateCameraTo(target, 360);
       } else {
         controls.enableRotate = true;
+        controls.enablePan = true;
+        controls.enableZoom = true;
         controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
         controls.maxPolarAngle = CAM.phiMax;
         controls.minDistance = CAMERA_3D_MIN_RADIUS;


### PR DESCRIPTION
### Motivation
- The 2D/top-down view was starting too zoomed-in and allowed pan/zoom, which causes the board to shift out of center in portrait mobile; the goal is a fixed, centered 2D framing that does not move or zoom.

### Description
- Increased the top-down camera radius by changing `CAMERA_TOPDOWN_MAX_RADIUS` multiplier from `1.65` to `1.9` to start the 2D view more zoomed out.
- Locked the 2D radius by setting `CAMERA_2D_MIN_RADIUS` and `CAMERA_2D_MAX_RADIUS` to `CAMERA_TOPDOWN_MAX_RADIUS` so the distance cannot change in 2D mode.
- Disabled orbit controls pan and zoom in 2D by setting `controls.enablePan = false` and `controls.enableZoom = false` when mode is `'2d'`, and restored them when returning to 3D.
- Modified file `webapp/src/pages/Games/ChessBattleRoyal.jsx` to implement these changes.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported the site available at `http://localhost:4173/`, which succeeded.
- Ran a Playwright script that opened `http://127.0.0.1:4173/games/chessbattleroyal` in a 430x932 viewport and saved a screenshot to `artifacts/chess-battle-2d-camera.png`, which completed successfully.
- No unit test changes were made and no failing automated tests were observed during this validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f605e614832988fcd7d7fb1fd28b)