### PR TITLE
Fix snake multiplayer dice roll mapping and commentary sync

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -343,6 +343,21 @@ const FALLBACK_SEAT_POSITIONS = [
 
 const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
 
+const mapDiceTotalToValues = (total, count) => {
+  const safeCount = Math.max(1, Number.isFinite(count) ? count : 1);
+  const minTotal = safeCount;
+  const maxTotal = safeCount * 6;
+  const sanitizedTotal = clampValue(Math.round(total || minTotal), minTotal, maxTotal);
+  const values = Array(safeCount).fill(1);
+  let remaining = sanitizedTotal - safeCount;
+  for (let i = 0; i < safeCount && remaining > 0; i += 1) {
+    const add = Math.min(5, remaining);
+    values[i] += add;
+    remaining -= add;
+  }
+  return values;
+};
+
 function parseHexColor(hex) {
   if (typeof hex !== 'string') return null;
   const trimmed = hex.trim();
@@ -1419,6 +1434,7 @@ export default function SnakeAndLadder() {
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
   const diceRollIdRef = useRef(0);
+  const diceRollStartRef = useRef({ id: null, seatIndex: null });
   const [diceBoardEvent, setDiceBoardEvent] = useState(null);
   const [seatAnchors, setSeatAnchors] = useState([]);
   const [diceAnchor, setDiceAnchor] = useState(null);
@@ -1485,6 +1501,37 @@ export default function SnakeAndLadder() {
   const startDiceBoardAnimation = useCallback((phase) => {
     setDiceBoardEvent(phase);
   }, []);
+
+  const finalizeDiceBoardRoll = useCallback(
+    ({ total, values, seatIndex, count }) => {
+      const resolvedCount = Math.max(1, count ?? diceCount + bonusDice);
+      const resolvedValues = Array.isArray(values) && values.length
+        ? values
+        : mapDiceTotalToValues(total, resolvedCount);
+      let rollId = diceRollIdRef.current;
+      const started =
+        diceRollStartRef.current.id === rollId &&
+        diceRollStartRef.current.seatIndex === seatIndex;
+      if (!started) {
+        rollId += 1;
+        diceRollIdRef.current = rollId;
+        startDiceBoardAnimation({
+          id: rollId,
+          phase: 'start',
+          count: resolvedCount,
+          seatIndex
+        });
+      }
+      startDiceBoardAnimation({
+        id: rollId,
+        phase: 'end',
+        values: resolvedValues,
+        seatIndex
+      });
+      diceRollStartRef.current = { id: rollId, seatIndex };
+    },
+    [bonusDice, diceCount, startDiceBoardAnimation]
+  );
 
 
   // Preload token and avatar images so board icons and AI photos display
@@ -2174,9 +2221,29 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value }) => {
-      setRollResult(value);
+    const onRolled = ({ value, values, seatIndex, playerId }) => {
+      const total = Array.isArray(values)
+        ? values.reduce((sum, val) => sum + Number(val || 0), 0)
+        : Number(value ?? 0);
+      setRollResult(total);
       setTimeout(() => setRollResult(null), 2000);
+      if (!isMultiplayer) return;
+      const resolvedSeatIndex = Number.isInteger(seatIndex)
+        ? seatIndex
+        : Number.isInteger(playerId)
+        ? playerId
+        : currentTurn;
+      const count = diceCount + bonusDice;
+      finalizeDiceBoardRoll({
+        total,
+        values,
+        seatIndex: resolvedSeatIndex,
+        count
+      });
+      const playerLabel = getPlayerName(resolvedSeatIndex);
+      if (playerLabel) {
+        enqueueSnakeCommentaryEvent('roll', { player: playerLabel, roll: total });
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);


### PR DESCRIPTION
### Motivation
- Ensure dice board animations and spoken commentary reflect the actual dice totals received from the server in multiplayer games.  

### Description
- Added `mapDiceTotalToValues(total, count)` to deterministically split a reported dice total into per-die face values for animation.  
- Added `diceRollStartRef` and `finalizeDiceBoardRoll(...)` to coordinate dice-board `start`/`end` animation phases and ensure the board receives consistent per-die values.  
- Updated the multiplayer `diceRolled` handler (`onRolled`) to compute the total from `values` or `value`, call `finalizeDiceBoardRoll(...)` for multiplayer sessions, set `rollResult` to the resolved total, and enqueue the commentary event so spoken lines match the visible roll.  
- All changes are contained in `webapp/src/pages/Games/SnakeAndLadder.jsx` (insertion of `mapDiceTotalToValues`, `diceRollStartRef`, `finalizeDiceBoardRoll`, and `onRolled` updates).  

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, confirming the app builds/serves locally.  
- Attempted an end-to-end screenshot with Playwright to validate the board visually, but the Chromium process crashed (SIGSEGV) so the visual check did not complete.  
- No unit tests were added or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f95c27bc8329910a7df432c02499)