### PR TITLE
Align FINAL_TILE with board and fix roll/movement mapping

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -100,7 +100,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT + 1;
+export const FINAL_TILE = BOARD_CELL_COUNT;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2525,9 +2525,7 @@ export default function SnakeAndLadder() {
     let preview = pos;
     if (preview === 0) {
       if (rolledSix) preview = 1;
-    } else if (preview === 100 && diceCount === 1) {
-      if (value === 1) preview = FINAL_TILE;
-    } else if (preview !== 100 || diceCount !== 2) {
+    } else {
       if (preview + value <= FINAL_TILE) preview = preview + value;
     }
     if (snakes[preview] != null) preview = Math.max(0, snakes[preview]);
@@ -2558,40 +2556,7 @@ export default function SnakeAndLadder() {
       let current = pos;
       let target = current;
 
-      if (current === 100 && diceCount === 2) {
-        if (rolledSix) {
-          setDiceCount(1);
-          setPlayerDiceCounts((arr) => {
-            const copy = [...arr];
-            copy[currentTurn] = 1;
-            return copy;
-          });
-          setMessage("Six rolled! One die removed.");
-        } else {
-          setMessage("");
-          enqueueSnakeCommentaryEvent('needSix', { player: playerLabel });
-        }
-        setTurnMessage("Your turn");
-        setDiceVisible(true);
-        setMoving(false);
-        return;
-      } else if (current === 100 && diceCount === 1) {
-        if (value === 1) {
-          target = FINAL_TILE;
-        } else {
-          setMessage("Need a 1 to win!");
-          enqueueSnakeCommentaryEvent('exactNeeded', { player: playerLabel, need: 1 });
-          setTurnMessage("");
-          setDiceVisible(false);
-          const next = getPreviousTurn(currentTurn);
-          setTimeout(() => {
-            setCurrentTurn(next);
-            setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
-          return;
-        }
-      } else if (current === 0) {
+      if (current === 0) {
         if (rolledSix) {
           target = 1;
           if (!muted) cheerSoundRef.current?.play().catch(() => {});
@@ -2792,8 +2757,6 @@ export default function SnakeAndLadder() {
     let preview = aiPositions[index - 1];
     if (preview === 0) {
       if (rolledSix) preview = 1;
-    } else if (preview === 100) {
-      if (value === 1) preview = FINAL_TILE;
     } else if (preview + value <= FINAL_TILE) {
       preview = preview + value;
     }
@@ -2828,44 +2791,6 @@ export default function SnakeAndLadder() {
         if (!muted) cheerSoundRef.current?.play().catch(() => {});
       } else {
         enqueueSnakeCommentaryEvent('startBlocked', { player: playerLabel });
-      }
-    } else if (current === 100 && playerDiceCounts[index] === 2) {
-      if (rolledSix) {
-        setPlayerDiceCounts(arr => {
-          const copy = [...arr];
-          copy[index] = 1;
-          return copy;
-        });
-        if (currentTurn === index) setDiceCount(1);
-        setTurnMessage(`${getPlayerName(index)}'s turn`);
-        setDiceVisible(true);
-        setMoving(false);
-        return;
-      } else {
-        setTurnMessage(`${getPlayerName(index)} needs a 6`);
-        enqueueSnakeCommentaryEvent('needSix', { player: playerLabel });
-        setDiceVisible(false);
-        const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
-      }
-    } else if (current === 100 && playerDiceCounts[index] === 1) {
-      if (value === 1) target = FINAL_TILE;
-      else {
-        enqueueSnakeCommentaryEvent('exactNeeded', { player: playerLabel, need: 1 });
-        setTurnMessage('');
-        setDiceVisible(false);
-        const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
       }
     } else if (current + value <= FINAL_TILE) {
       target = current + value;


### PR DESCRIPTION
### Motivation
- The board layout used `BOARD_CELL_COUNT` as the number of playable tiles but the game logic treated the final tile inconsistently, causing dice/commentary and token movement to be out of sync with actual board cells. 
- Simplify and correct end-of-board special-case handling so preview/target calculations and commentary reliably match dice results.

### Description
- Set the exported `FINAL_TILE` to match the board cell count by changing `export const FINAL_TILE = BOARD_CELL_COUNT;` in `webapp/src/components/SnakeBoard.jsx` to remove the off-by-one mismatch. 
- Remove the previous special-case end-tile handling and simplify preview calculation so that player preview advances by the rolled value when applicable in `webapp/src/pages/Games/SnakeAndLadder.jsx`. 
- Remove the extra branches that attempted to manage a phantom end tile (and dice-count split logic) for both player and AI roll paths so movement, effects (snakes/ladders), and commentary use the same `FINAL_TILE` semantics.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f95c27bc8329910a7df432c02499)