### PR TITLE
Align Snake & Ladder movement with 3D board FINAL_TILE

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -96,6 +96,7 @@ const PYRAMID_LEVELS = [11, 9, 6, 3];
 const LEVEL_TILE_COUNTS = PYRAMID_LEVELS.map((size) => (size <= 1 ? 1 : size * 4 - 4));
 const BASE_LEVEL_TILES = PYRAMID_LEVELS[0];
 const TOTAL_BOARD_TILES = LEVEL_TILE_COUNTS.reduce((sum, count) => sum + count, 0);
+export const FINAL_TILE = TOTAL_BOARD_TILES;
 const RAW_BOARD_SIZE = 1.125;
 const BOARD_SCALE = 2.7 * 0.68 * 1.15 * 0.8; // shrink board footprint by 20%
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
-import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
-import { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
+import SnakeBoard3D, { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard3D.jsx";
 import {
   dropSound,
   snakeSound,
@@ -1178,7 +1177,7 @@ export default function SnakeAndLadder() {
   const [diceVisible, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const [myName, setMyName] = useState('You');
-  const [pot, setPot] = useState(101);
+  const [pot, setPot] = useState(BOARD_FINAL_TILE);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
@@ -2525,10 +2524,8 @@ export default function SnakeAndLadder() {
     let preview = pos;
     if (preview === 0) {
       if (rolledSix) preview = 1;
-    } else if (preview === 100 && diceCount === 1) {
-      if (value === 1) preview = FINAL_TILE;
-    } else if (preview !== 100 || diceCount !== 2) {
-      if (preview + value <= FINAL_TILE) preview = preview + value;
+    } else if (preview + value <= FINAL_TILE) {
+      preview = preview + value;
     }
     if (snakes[preview] != null) preview = Math.max(0, snakes[preview]);
     else if (ladders[preview] != null) {
@@ -2558,40 +2555,7 @@ export default function SnakeAndLadder() {
       let current = pos;
       let target = current;
 
-      if (current === 100 && diceCount === 2) {
-        if (rolledSix) {
-          setDiceCount(1);
-          setPlayerDiceCounts((arr) => {
-            const copy = [...arr];
-            copy[currentTurn] = 1;
-            return copy;
-          });
-          setMessage("Six rolled! One die removed.");
-        } else {
-          setMessage("");
-          enqueueSnakeCommentaryEvent('needSix', { player: playerLabel });
-        }
-        setTurnMessage("Your turn");
-        setDiceVisible(true);
-        setMoving(false);
-        return;
-      } else if (current === 100 && diceCount === 1) {
-        if (value === 1) {
-          target = FINAL_TILE;
-        } else {
-          setMessage("Need a 1 to win!");
-          enqueueSnakeCommentaryEvent('exactNeeded', { player: playerLabel, need: 1 });
-          setTurnMessage("");
-          setDiceVisible(false);
-          const next = getPreviousTurn(currentTurn);
-          setTimeout(() => {
-            setCurrentTurn(next);
-            setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
-          return;
-        }
-      } else if (current === 0) {
+      if (current === 0) {
         if (rolledSix) {
           target = 1;
           if (!muted) cheerSoundRef.current?.play().catch(() => {});
@@ -2792,8 +2756,6 @@ export default function SnakeAndLadder() {
     let preview = aiPositions[index - 1];
     if (preview === 0) {
       if (rolledSix) preview = 1;
-    } else if (preview === 100) {
-      if (value === 1) preview = FINAL_TILE;
     } else if (preview + value <= FINAL_TILE) {
       preview = preview + value;
     }
@@ -2828,44 +2790,6 @@ export default function SnakeAndLadder() {
         if (!muted) cheerSoundRef.current?.play().catch(() => {});
       } else {
         enqueueSnakeCommentaryEvent('startBlocked', { player: playerLabel });
-      }
-    } else if (current === 100 && playerDiceCounts[index] === 2) {
-      if (rolledSix) {
-        setPlayerDiceCounts(arr => {
-          const copy = [...arr];
-          copy[index] = 1;
-          return copy;
-        });
-        if (currentTurn === index) setDiceCount(1);
-        setTurnMessage(`${getPlayerName(index)}'s turn`);
-        setDiceVisible(true);
-        setMoving(false);
-        return;
-      } else {
-        setTurnMessage(`${getPlayerName(index)} needs a 6`);
-        enqueueSnakeCommentaryEvent('needSix', { player: playerLabel });
-        setDiceVisible(false);
-        const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
-      }
-    } else if (current === 100 && playerDiceCounts[index] === 1) {
-      if (value === 1) target = FINAL_TILE;
-      else {
-        enqueueSnakeCommentaryEvent('exactNeeded', { player: playerLabel, need: 1 });
-        setTurnMessage('');
-        setDiceVisible(false);
-        const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
-        return;
       }
     } else if (current + value <= FINAL_TILE) {
       target = current + value;


### PR DESCRIPTION
### Motivation
- The game logic and commentary were using a different final-tile interpretation than the 3D board, causing dice results, movement and spoken commentary to mismatch. 
- Ensure movement, pot target and dice preview all reference the same board tile count to make behavior deterministic and precise.

### Description
- Export `FINAL_TILE` from `webapp/src/components/SnakeBoard3D.jsx` and reuse it in the game logic by importing it as `BOARD_FINAL_TILE`. 
- Use `BOARD_FINAL_TILE` as the pot default (`pot` state) so the pot / finish target matches the rendered board. 
- Simplify and align movement/preview logic in `webapp/src/pages/Games/SnakeAndLadder.jsx` by removing the previous out-of-sync special-case checks and ensuring both player and AI preview/move calculations use `FINAL_TILE` consistently. 
- Updated imports in `SnakeAndLadder.jsx` to consume the exported `FINAL_TILE` from the 3D board component.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f95c27bc8329910a7df432c02499)