### PR TITLE
Harden Domino Royal commentary and enforce GLTF-only chairs

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -792,6 +792,9 @@ let lastAnnouncedTurn = null;
 let commentaryVoiceCycleIndex = 0;
 let commentaryUnlocked = false;
 let commentaryVoicesRetryTimer = null;
+let commentaryVoiceAttempts = 0;
+let commentaryDisabled = false;
+const COMMENTARY_MAX_VOICE_ATTEMPTS = 6;
 const lastCommentaryLineByKind = new Map();
 const COMMENTARY_VOICE_BY_KIND = {
   greeting: 'color',
@@ -830,13 +833,26 @@ function persistCommentaryPrefs() {
 }
 
 function refreshCommentaryVoices() {
-  if (!speechSynth) return;
+  if (!speechSynth || commentaryDisabled) return;
   try {
     commentaryVoices = speechSynth.getVoices() || [];
-    commentaryReady = true;
+    if (commentaryVoices.length) {
+      commentaryReady = true;
+      commentaryVoiceAttempts = 0;
+    } else {
+      commentaryReady = false;
+      commentaryVoiceAttempts += 1;
+      if (commentaryVoiceAttempts >= COMMENTARY_MAX_VOICE_ATTEMPTS) {
+        disableCommentary('No speech synthesis voices available.');
+      }
+    }
   } catch (error) {
     commentaryVoices = [];
     commentaryReady = false;
+    commentaryVoiceAttempts += 1;
+    if (commentaryVoiceAttempts >= COMMENTARY_MAX_VOICE_ATTEMPTS) {
+      disableCommentary('Speech synthesis failed to load voices.');
+    }
     console.warn('Failed to refresh commentary voices', error);
   }
 }
@@ -894,6 +910,15 @@ function clearCommentaryQueue() {
   if (speechSynth) {
     speechSynth.cancel();
   }
+}
+
+function disableCommentary(reason) {
+  if (commentaryDisabled) return;
+  commentaryDisabled = true;
+  commentaryMuted = true;
+  clearCommentaryQueue();
+  persistCommentaryPrefs();
+  console.warn('Commentary disabled', reason);
 }
 
 function setCommentaryMuted(next) {
@@ -972,7 +997,7 @@ function ensureSpeechUnlocked() {
 }
 
 function scheduleCommentaryVoicesRetry() {
-  if (!speechSynth || commentaryVoicesRetryTimer) return;
+  if (!speechSynth || commentaryVoicesRetryTimer || commentaryDisabled) return;
   commentaryVoicesRetryTimer = window.setTimeout(() => {
     commentaryVoicesRetryTimer = null;
     refreshCommentaryVoices();
@@ -983,12 +1008,13 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || !text) return;
+  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || commentaryDisabled || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
   if (!commentaryVoices.length) {
     scheduleCommentaryVoicesRetry();
+    return;
   }
   if (!commentaryUnlocked) {
     if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
@@ -1038,12 +1064,13 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
     speechSynth.speak(utterance);
   } catch (error) {
     commentarySpeaking = false;
+    disableCommentary(error?.message || 'Speech synthesis crashed.');
     console.warn('Commentary failed to speak', error);
   }
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  if (commentaryMuted || !speechSynth || !speechUtteranceCtor) return;
+  if (commentaryMuted || commentaryDisabled || !speechSynth || !speechUtteranceCtor) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
@@ -5118,7 +5145,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
+  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor && !commentaryDisabled);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';
@@ -5393,7 +5420,7 @@ function disposeChairResources(root) {
 const CHAIR_MODEL_TIMEOUT_MS = 2500;
 
 function placeChairsWithOption(option, chairData, token) {
-  if (token !== chairBuildToken) return;
+  if (token !== chairBuildToken || !chairData) return;
 
   disposeSeatLabel({ persistPreference: false });
   disposeSeatAvatars();
@@ -5406,31 +5433,9 @@ function placeChairsWithOption(option, chairData, token) {
   }
 
   const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
-  const seatBottomOffset = chairData
-    ? -chairTemplateBounds.min.y
-    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight;
-  const labelHeight = chairData
-    ? seatBottomOffset + chairTemplateBounds.max.y + 0.12
-    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness + 0.72;
-  const labelDepth = chairData
-    ? -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35
-    : -CHAIR_DIMENSIONS.seatDepth * 0.35;
-
-  const sharedMaterials = chairData
-    ? null
-    : {
-        fabric: createChairFabricMaterial(option, renderer),
-        leg: new THREE.MeshStandardMaterial({
-          color: new THREE.Color(option.legColor ?? "#1f1f1f"),
-          metalness: 0.6,
-          roughness: 0.35
-        }),
-        accent: new THREE.MeshStandardMaterial({
-          color: new THREE.Color(adjustHexColor(option.legColor ?? "#1f1f1f", 0.15)),
-          metalness: 0.75,
-          roughness: 0.32
-        })
-      };
+  const seatBottomOffset = -chairTemplateBounds.min.y;
+  const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
+  const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
@@ -5441,9 +5446,7 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
 
-    const chair = chairData
-      ? cloneChairWithTheme(chairData, option)
-      : createDominoChair(option, renderer, sharedMaterials);
+    const chair = cloneChairWithTheme(chairData, option);
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 
@@ -5465,7 +5468,7 @@ function placeChairsWithOption(option, chairData, token) {
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
   const token = ++chairBuildToken;
   const chairDataPromise = ensureChairTemplateForTheme(option).catch((error) => {
-    console.warn("Falling back to procedural chair for Domino", error);
+    console.warn("Failed to load chair GLTF for Domino", error);
     return null;
   });
 
@@ -5474,14 +5477,15 @@ async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?
     new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
   ]);
 
-  placeChairsWithOption(option, chairData, token);
-
-  if (!chairData) {
-    chairDataPromise.then((resolved) => {
-      if (!resolved || token !== chairBuildToken) return;
-      placeChairsWithOption(option, resolved, token);
-    });
+  if (chairData) {
+    placeChairsWithOption(option, chairData, token);
+    return;
   }
+
+  chairDataPromise.then((resolved) => {
+    if (!resolved || token !== chairBuildToken) return;
+    placeChairsWithOption(option, resolved, token);
+  });
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */


### PR DESCRIPTION
### Motivation
- Prevent crashes originating from Web Speech commentary in the Domino Royal game by detecting repeated voice-load failures and safely disabling commentary when unreliable. 
- Remove the procedural chair fallback so the Domino arena uses only the GLTF chair assets to avoid rendering/fit mismatches and simplify resource handling.

### Description
- Added commentary resilience: introduced `commentaryVoiceAttempts`, `commentaryDisabled`, `COMMENTARY_MAX_VOICE_ATTEMPTS`, and `disableCommentary()` to auto-disable speech after repeated failures and to persist mute state; updated `refreshCommentaryVoices()` to count attempts and call `disableCommentary()` when necessary. 
- Guarded speech paths: added checks for `commentaryDisabled` in `refreshCommentaryVoices()`, `scheduleCommentaryVoicesRetry()`, `speakCommentary()` and `announceCommentary()` so no unsafe speech calls occur once disabled, and `speakCommentary()` now returns early if voices are unavailable. 
- UI integration: updated commentary UI availability check to honor `commentaryDisabled` so commentary controls are disabled when speech is not usable (`const commentarySupported = Boolean(speechSynth && speechUtteranceCtor && !commentaryDisabled)`). 
- Enforced GLTF-only chairs: changed `placeChairsWithOption()` to require `chairData` and removed use of the procedural `createDominoChair()` fallback, adjusted seat offsets to use `chairTemplateBounds`, and updated `buildChairs()` to only place chairs immediately when GLTF data is available while still applying the template once the async load resolves. 
- Minor log change: replaced the earlier fallback console message with a clearer failure message when GLTF chair loading fails.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698205070ff0832999a166ccee5881db)