### PR TITLE
Restore Pool Royale spin controller baseline (restore Feb 1 spin direction & magnitude)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -92,7 +92,6 @@ import {
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
-  clampToMaxOffset,
   clampToUnitCircle,
   computeQuantizedOffsetScaled,
   mapSpinForPhysics,
@@ -1524,7 +1523,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 420;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 220;
 const POCKET_VIEW_POST_POT_HOLD_MS = 80;
 const POCKET_VIEW_MAX_HOLD_MS = 1400;
-const SPIN_GLOBAL_SCALE = 0.35; // reduce overall spin impact by 65%
+const SPIN_GLOBAL_SCALE = 0.6; // reduce overall spin impact by 25%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1670,9 +1669,9 @@ const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so 
 const SPIN_RING_RATIO = 1;
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
 const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.15;
-const SIDE_SPIN_MULTIPLIER = 1.15;
+const SIDE_SPIN_MULTIPLIER = 1.5;
 const BACKSPIN_MULTIPLIER = 2.6;
-const TOPSPIN_MULTIPLIER = 1.15;
+const TOPSPIN_MULTIPLIER = 1.5;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -27188,7 +27187,17 @@ const powerRef = useRef(hud.power);
     const clampToPlayable = (nx, ny) => {
       const raw = clampToUnitCircle(nx, ny);
       const limited = clampToLimits(raw.x, raw.y);
-      return clampToUnitCircle(limited.x, limited.y);
+      const aimVec = aimDirRef.current;
+      const cueBall = cueRef.current;
+      const activeCamera = activeRenderCameraRef.current ?? cameraRef.current;
+      const viewLimited = clampSpinToVisibleHemisphere(
+        limited,
+        aimVec,
+        cueBall,
+        activeCamera
+      );
+      const reclamped = clampToLimits(viewLimited.x, viewLimited.y);
+      return clampToUnitCircle(reclamped.x, reclamped.y);
     };
 
     const applySpin = (nx, ny, { updateRequest = true } = {}) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,6 +1,6 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 0.75;
+export const MAX_SPIN_OFFSET = 1;
 export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
@@ -11,10 +11,6 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = 0;
-export const SPIN_EDGE_AXIS_LOCK_MAG = 0.7;
-export const SPIN_EDGE_AXIS_LOCK_RATIO = 0.3;
-export const SPIN_TOP_HALF_SCALE = 0.4;
-export const SPIN_BOTTOM_HALF_SCALE = 1.25;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -148,19 +144,7 @@ export const normalizeSpinInput = (spin) => {
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     return { x: 0, y: STUN_TOPSPIN_BIAS };
   }
-  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
-  const edgeMagnitude = Math.hypot(clamped.x, clamped.y);
-  if (edgeMagnitude >= SPIN_EDGE_AXIS_LOCK_MAG) {
-    const absX = Math.abs(clamped.x);
-    const absY = Math.abs(clamped.y);
-    if (absX <= absY * SPIN_EDGE_AXIS_LOCK_RATIO) {
-      return { x: 0, y: clamped.y };
-    }
-    if (absY <= absX * SPIN_EDGE_AXIS_LOCK_RATIO) {
-      return { x: clamped.x, y: 0 };
-    }
-  }
-  return clamped;
+  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };
 
 export const mapUiOffsetToCueFrame = (
@@ -200,18 +184,10 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
-  let scaledY = quantized.y;
-  if (scaledY > 0) {
-    scaledY *= SPIN_TOP_HALF_SCALE;
-  } else if (scaledY < 0) {
-    scaledY *= SPIN_BOTTOM_HALF_SCALE;
-  }
-  scaledY = clamp(scaledY, -1, 1);
-  const scaled = { x: quantized.x, y: scaledY };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -scaled.x,
-    scaled.y,
+    -quantized.x,
+    quantized.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale spin controller to the prior baseline so spin direction and magnitude match the Feb 1 behavior. 
- The recent tuning changed spin scale, top/side multipliers and removed the visible-hemisphere clamp causing different spin feel and inconsistent rail responses. 
- Only the spin controller and mapping were targeted to preserve prior gameplay feel without touching unrelated physics elsewhere.

### Description
- Reverted spin UI/physics mapping in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by setting `MAX_SPIN_OFFSET = 1`, removing the axis-lock and top/bottom half-scaling logic, and mapping `quantized` spin directly in `mapSpinForPhysics` so UI offsets translate to physics as before. 
- Restored spin controller settings in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `SPIN_GLOBAL_SCALE = 0.6` and resetting `SIDE_SPIN_MULTIPLIER` and `TOPSPIN_MULTIPLIER` back to `1.5`. 
- Reintroduced the visible-hemisphere clamp in the spin input pipeline by calling `clampSpinToVisibleHemisphere` inside `clampToPlayable` so strike points that are not visible are blocked as before. 
- Tidied imports to use the shared `poolRoyaleSpinUtils.js` utilities and removed the now-unused partial clamp variations from the page file.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982187ddb80832980627a62aa841fb7)