### PR TITLE
Reduce max Pool Royale topspin and dampen topspin at high power

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,6 +1,6 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
-export const MAX_SPIN_OFFSET = 1;
+export const MAX_SPIN_OFFSET = 0.75;
 export const SPIN_STUN_RADIUS = 0.16;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;


### PR DESCRIPTION
### Motivation
- Players reported unstable cueball behavior when applying full topspin at max power, and the spin UI range needed to be reduced to match intended magnitude.

### Description
- Lowered the UI and quantized spin maximum by setting `MAX_SPIN_OFFSET` to `0.75` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Added a configurable topspin dampening window with `MAX_POWER_TOPSPIN_DAMPEN_START`, `MAX_POWER_TOPSPIN_DAMPEN_END`, and `MAX_POWER_TOPSPIN_DAMPEN_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Implemented `resolveTopspinPowerDampen(power)` to smoothly reduce applied topspin when `power` is in the high range, and applied this dampening to the `spinTop` calculation so full-strength shots produce less extreme topspin.

### Testing
- No automated tests were run for this change (no test execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821fa861308329b9a1f08e3e80b01b)