### PR TITLE
Adjust topspin scaling and improve ball-in-hand touch controls (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5328,8 +5328,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_POWER_SOFT_CAP = 0.8;
-const TOPSPIN_POWER_MAX_SCALE = 0.7;
+const TOPSPIN_POWER_SOFT_CAP = 0.9;
+const TOPSPIN_POWER_MAX_SCALE = 0.955;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
 const SPIN_VIEW_BLOCK_THRESHOLD = 0;
@@ -12746,7 +12746,12 @@ function PoolRoyaleGame({
   );
   const inHandPlacementModeRef = useRef(inHandPlacementMode);
   const inHandIconRef = useRef(null);
-  const inHandDragRef = useRef({ active: false, pointerId: null, lastPos: null });
+  const inHandDragRef = useRef({
+    active: false,
+    pointerId: null,
+    lastPos: null,
+    deferred: false
+  });
   const inHandPlacementApiRef = useRef({ begin: null, move: null, end: null });
   const gameOverHandledRef = useRef(false);
   const userSuggestionRef = useRef(null);
@@ -14634,21 +14639,18 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     if (replayActive) return;
     const controls = topViewControlsRef.current;
-    const meta = frameState?.meta;
-    const variant = meta?.variant ?? activeVariantRef.current?.id ?? null;
-    const allowFullTable =
-      variant === 'uk' ||
-      ((variant === 'american' || variant === '9ball') && !meta?.breakInProgress);
-    if (hud.inHand && allowFullTable && controls?.enter) {
-      controls.enter(true, { variant: 'top' });
-      inHandTopViewRef.current = true;
+    if (hud.inHand) {
+      if (controls?.exit && (inHandTopViewRef.current || topViewRef.current)) {
+        controls.exit(true);
+      }
+      inHandTopViewRef.current = false;
       return;
     }
     if (!hud.inHand && inHandTopViewRef.current && controls?.exit) {
       controls.exit(true);
       inHandTopViewRef.current = false;
     }
-  }, [frameState, hud.inHand, replayActive]);
+  }, [hud.inHand, replayActive]);
 
   useEffect(() => {
     const host = mountRef.current;
@@ -21593,6 +21595,7 @@ const powerRef = useRef(hud.power);
         if (!tryUpdatePlacement(p, false)) return;
         inHandDrag.active = true;
         inHandDrag.pointerId = e.pointerId ?? 'mouse';
+        inHandDrag.deferred = false;
         if (e.pointerId != null && dom.setPointerCapture) {
           try {
             dom.setPointerCapture(e.pointerId);
@@ -21628,6 +21631,7 @@ const powerRef = useRef(hud.power);
           } catch {}
         }
         inHandDrag.active = false;
+        inHandDrag.deferred = false;
         const pos = inHandDrag.lastPos;
         if (pos) {
           tryUpdatePlacement(pos, true);
@@ -21637,16 +21641,21 @@ const powerRef = useRef(hud.power);
         e.preventDefault?.();
       };
       inHandPlacementApiRef.current = {
-        begin: (e) => {
+        begin: (e, options = {}) => {
           const currentHud = hudRef.current;
           if (!(currentHud?.inHand)) return false;
           if (!inHandPlacementModeRef.current) return false;
           if (shooting) return false;
           const p = project(e);
           if (!p) return false;
-          if (!tryUpdatePlacement(p, false)) return false;
+          const deferredPlacement = Boolean(options?.deferPlacement);
+          if (!deferredPlacement && !tryUpdatePlacement(p, false)) return false;
           inHandDrag.active = true;
           inHandDrag.pointerId = e.pointerId ?? 'icon';
+          inHandDrag.deferred = deferredPlacement;
+          if (deferredPlacement) {
+            inHandDrag.lastPos = p;
+          }
           return true;
         },
         move: (e) => {
@@ -21659,7 +21668,13 @@ const powerRef = useRef(hud.power);
             return false;
           }
           const p = project(e);
-          if (p) tryUpdatePlacement(p, false);
+          if (p) {
+            if (inHandDrag.deferred) {
+              inHandDrag.lastPos = p;
+            } else {
+              tryUpdatePlacement(p, false);
+            }
+          }
           return true;
         },
         end: (e) => {
@@ -21672,6 +21687,7 @@ const powerRef = useRef(hud.power);
             return false;
           }
           inHandDrag.active = false;
+          inHandDrag.deferred = false;
           const pos = inHandDrag.lastPos;
           if (pos) {
             tryUpdatePlacement(pos, true);
@@ -22209,6 +22225,9 @@ const powerRef = useRef(hud.power);
             spinTop *= BACKSPIN_MULTIPLIER;
           } else if (scaledSpin.y > 0) {
             spinTop *= TOPSPIN_MULTIPLIER * topspinPowerScale;
+            if (clampedPower > TOPSPIN_POWER_SOFT_CAP) {
+              spinSide *= topspinPowerScale;
+            }
           }
           cue.vel.copy(base);
           if (cue.spin) {
@@ -27104,7 +27123,7 @@ const powerRef = useRef(hud.power);
       cueBallPlacedFromHandRef.current = false;
       inHandPlacementModeRef.current = true;
       setInHandPlacementMode(true);
-      inHandPlacementApiRef.current?.begin?.(event);
+      inHandPlacementApiRef.current?.begin?.(event, { deferPlacement: true });
       if (event.pointerId != null) {
         try {
           event.currentTarget?.setPointerCapture?.(event.pointerId);
@@ -28948,15 +28967,59 @@ const powerRef = useRef(hud.power);
         <button
           ref={inHandIconRef}
           type="button"
-          aria-label="Hold and drag to place the cue ball"
-          title="Hold and drag to place the cue ball"
+          aria-label="Hold and drag, release to place the cue ball"
+          title="Hold and drag, release to place the cue ball"
           onPointerDown={handleInHandIconPointerDown}
           onPointerMove={handleInHandIconPointerMove}
           onPointerUp={handleInHandIconPointerUp}
           onPointerCancel={handleInHandIconPointerUp}
-          className="fixed z-40 flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-xl text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition"
+          className="fixed z-40 flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-xl text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition relative"
           style={{ opacity: 0, pointerEvents: 'none', transform: 'translate(-9999px, -9999px)' }}
         >
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-3 left-1/2 -translate-x-1/2"
+            style={{
+              width: 0,
+              height: 0,
+              borderLeft: '6px solid transparent',
+              borderRight: '6px solid transparent',
+              borderBottom: '8px solid rgba(255,255,255,0.85)'
+            }}
+          />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-3 left-1/2 -translate-x-1/2"
+            style={{
+              width: 0,
+              height: 0,
+              borderLeft: '6px solid transparent',
+              borderRight: '6px solid transparent',
+              borderTop: '8px solid rgba(255,255,255,0.85)'
+            }}
+          />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -left-3 top-1/2 -translate-y-1/2"
+            style={{
+              width: 0,
+              height: 0,
+              borderTop: '6px solid transparent',
+              borderBottom: '6px solid transparent',
+              borderRight: '8px solid rgba(255,255,255,0.85)'
+            }}
+          />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -right-3 top-1/2 -translate-y-1/2"
+            style={{
+              width: 0,
+              height: 0,
+              borderTop: '6px solid transparent',
+              borderBottom: '6px solid transparent',
+              borderLeft: '8px solid rgba(255,255,255,0.85)'
+            }}
+          />
           <span aria-hidden="true">✋️</span>
         </button>
       )}


### PR DESCRIPTION
### Motivation
- Make max-power topspin/top-side-spin behave like ~90% power to avoid excessive spin at full pull. 
- Keep ball-in-hand placement in the 3D camera flow and make mobile placement easier by deferring placement until the user releases the hand icon. 
- Improve affordance by adding four directional triangles around the hand icon and clarifying the tooltip.

### Description
- Tuned topspin scaling constants (`TOPSPIN_POWER_SOFT_CAP`, `TOPSPIN_POWER_MAX_SCALE`) and applied the topspin power scale to lateral spin when `clampedPower` exceeds the soft cap so max-power spin matches ~90% behavior (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added `deferred` state to `inHandDragRef` and extended `inHandPlacementApiRef` with a `deferPlacement` option so hand-icon drags can update a stored position while delaying commit until pointer release.
- Changed `handleInHandIconPointerDown` to begin placement with `deferPlacement: true` so the cue ball is only placed when the finger is released, improving mobile hold+drag behavior.
- Kept ball-in-hand workflow in the live 3D/orbit camera (avoid switching to 2D/top view) by adjusting the in-hand top-view logic to preserve the 3D view while placing.
- Added four small CSS triangle spans around the hand icon button to indicate 4-direction movement and updated the button `aria-label`/`title` to "Hold and drag, release to place the cue ball".

### Testing
- Started the web app dev server with `npm --prefix webapp run dev` and Vite reported ready on the configured port (server start succeeded). 
- Attempted an automated Playwright screenshot to validate the UI, but the screenshot timed out due to the heavy WebGL page load (timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982273db5a08329a8e30d182a023d76)