### PR TITLE
Defer Domino commentary init and require glTF chairs to avoid crashes

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -769,15 +769,21 @@ const COMMENTARY_LINES = {
   ]
 };
 
-const speechSynth = (() => {
+let speechSynth = null;
+let speechSynthResolved = false;
+let commentarySpeechInitialized = false;
+function getSpeechSynth() {
+  if (speechSynthResolved) return speechSynth;
+  speechSynthResolved = true;
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) return null;
   try {
-    return window.speechSynthesis;
+    speechSynth = window.speechSynthesis;
   } catch (error) {
     console.warn('Speech synthesis unavailable', error);
-    return null;
+    speechSynth = null;
   }
-})();
+  return speechSynth;
+}
 const speechUtteranceCtor =
   typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null;
 let commentaryVoices = [];
@@ -830,9 +836,10 @@ function persistCommentaryPrefs() {
 }
 
 function refreshCommentaryVoices() {
-  if (!speechSynth) return;
+  const synth = getSpeechSynth();
+  if (!synth) return;
   try {
-    commentaryVoices = speechSynth.getVoices() || [];
+    commentaryVoices = synth.getVoices() || [];
     commentaryReady = true;
   } catch (error) {
     commentaryVoices = [];
@@ -891,8 +898,9 @@ function getVoiceProfileForKind(kind) {
 function clearCommentaryQueue() {
   commentaryQueue = [];
   commentarySpeaking = false;
-  if (speechSynth) {
-    speechSynth.cancel();
+  const synth = getSpeechSynth();
+  if (synth) {
+    synth.cancel();
   }
 }
 
@@ -963,16 +971,18 @@ function buildCommentaryLine(kind, context = {}) {
 }
 
 function ensureSpeechUnlocked() {
-  if (!speechSynth) return;
+  const synth = getSpeechSynth();
+  if (!synth) return;
   try {
-    speechSynth.resume();
+    synth.resume();
   } catch (error) {
     console.warn('Failed to resume speech synthesis', error);
   }
 }
 
 function scheduleCommentaryVoicesRetry() {
-  if (!speechSynth || commentaryVoicesRetryTimer) return;
+  const synth = getSpeechSynth();
+  if (!synth || commentaryVoicesRetryTimer) return;
   commentaryVoicesRetryTimer = window.setTimeout(() => {
     commentaryVoicesRetryTimer = null;
     refreshCommentaryVoices();
@@ -983,7 +993,8 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || !text) return;
+  const synth = getSpeechSynth();
+  if (!synth || !speechUtteranceCtor || commentaryMuted || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
@@ -1025,9 +1036,9 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
     }
   };
   commentaryLastEventAt = now;
-  if (speechSynth.speaking || commentarySpeaking) {
+  if (synth.speaking || commentarySpeaking) {
     if (interrupt) {
-      speechSynth.cancel();
+      synth.cancel();
     } else {
       commentaryQueue.push({ text, options: { interrupt, priority, kind } });
       return;
@@ -1035,7 +1046,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   }
   commentarySpeaking = true;
   try {
-    speechSynth.speak(utterance);
+    synth.speak(utterance);
   } catch (error) {
     commentarySpeaking = false;
     console.warn('Commentary failed to speak', error);
@@ -1043,23 +1054,29 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  if (commentaryMuted || !speechSynth || !speechUtteranceCtor) return;
+  const synth = getSpeechSynth();
+  if (commentaryMuted || !synth || !speechUtteranceCtor) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
 }
 
-if (speechSynth) {
-  readCommentaryPrefs();
+function initCommentarySpeech() {
+  if (commentarySpeechInitialized) return getSpeechSynth();
+  const synth = getSpeechSynth();
+  if (!synth || !speechUtteranceCtor) return null;
+  commentarySpeechInitialized = true;
   refreshCommentaryVoices();
-  speechSynth.onvoiceschanged = () => refreshCommentaryVoices();
+  synth.onvoiceschanged = () => refreshCommentaryVoices();
   scheduleCommentaryVoicesRetry();
-} else {
-  readCommentaryPrefs();
+  return synth;
 }
+
+readCommentaryPrefs();
 
 function unlockInteractiveAudio() {
   ensureAudioContext();
+  initCommentarySpeech();
   ensureSpeechUnlocked();
   if (!commentaryUnlocked) {
     commentaryUnlocked = true;
@@ -5118,7 +5135,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
+  const commentarySupported = Boolean(getSpeechSynth() && speechUtteranceCtor);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';
@@ -5390,8 +5407,6 @@ function disposeChairResources(root) {
   });
 }
 
-const CHAIR_MODEL_TIMEOUT_MS = 2500;
-
 function placeChairsWithOption(option, chairData, token) {
   if (token !== chairBuildToken) return;
 
@@ -5405,32 +5420,12 @@ function placeChairsWithOption(option, chairData, token) {
     disposeChairResources(chair);
   }
 
-  const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
-  const seatBottomOffset = chairData
-    ? -chairTemplateBounds.min.y
-    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight;
-  const labelHeight = chairData
-    ? seatBottomOffset + chairTemplateBounds.max.y + 0.12
-    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness + 0.72;
-  const labelDepth = chairData
-    ? -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35
-    : -CHAIR_DIMENSIONS.seatDepth * 0.35;
+  if (!chairData) return;
 
-  const sharedMaterials = chairData
-    ? null
-    : {
-        fabric: createChairFabricMaterial(option, renderer),
-        leg: new THREE.MeshStandardMaterial({
-          color: new THREE.Color(option.legColor ?? "#1f1f1f"),
-          metalness: 0.6,
-          roughness: 0.35
-        }),
-        accent: new THREE.MeshStandardMaterial({
-          color: new THREE.Color(adjustHexColor(option.legColor ?? "#1f1f1f", 0.15)),
-          metalness: 0.75,
-          roughness: 0.32
-        })
-      };
+  const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
+  const seatBottomOffset = -chairTemplateBounds.min.y;
+  const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
+  const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
@@ -5441,9 +5436,7 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
 
-    const chair = chairData
-      ? cloneChairWithTheme(chairData, option)
-      : createDominoChair(option, renderer, sharedMaterials);
+    const chair = cloneChairWithTheme(chairData, option);
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 
@@ -5464,24 +5457,13 @@ function placeChairsWithOption(option, chairData, token) {
 
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
   const token = ++chairBuildToken;
-  const chairDataPromise = ensureChairTemplateForTheme(option).catch((error) => {
-    console.warn("Falling back to procedural chair for Domino", error);
-    return null;
-  });
-
-  const chairData = await Promise.race([
-    chairDataPromise,
-    new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
-  ]);
-
-  placeChairsWithOption(option, chairData, token);
-
-  if (!chairData) {
-    chairDataPromise.then((resolved) => {
-      if (!resolved || token !== chairBuildToken) return;
-      placeChairsWithOption(option, resolved, token);
-    });
+  let chairData = null;
+  try {
+    chairData = await ensureChairTemplateForTheme(option);
+  } catch (error) {
+    console.warn("Failed to load Domino chair glTF", error);
   }
+  placeChairsWithOption(option, chairData, token);
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */


### PR DESCRIPTION
### Motivation

- The Domino Royal page could crash or misbehave when speech synthesis is accessed eagerly in environments without Web Speech support or with restricted APIs, so initialization must be deferred until user interaction. 
- Procedural chair construction is used as a fallback but introduced complexity and mismatches; the chairs should rely on the authored glTF assets and skip the procedural fallback to avoid runtime errors.

### Description

- Added a safe accessor `getSpeechSynth()` and `initCommentarySpeech()` to defer and centralize `speechSynthesis` handling and replaced direct uses of `speechSynth` with calls to `getSpeechSynth()` across commentary functions. 
- Deferred commentary voice refreshing and `onvoiceschanged` wiring until `unlockInteractiveAudio()` is invoked so speech setup only happens after an interactive gesture. 
- Updated commentary support detection to use `getSpeechSynth()` so the UI reflects actual availability after initialization. 
- Removed the procedural chair fallback by returning early when `chairData` (the glTF) is missing and updated `buildChairs()` to await `ensureChairTemplateForTheme()` and log a warning instead of falling back to a runtime procedural build.

### Testing

- Performed an automated browser smoke test by serving `webapp/public` with `python -m http.server` and launching a Playwright script to load `/domino-royal.html` and capture a screenshot (`artifacts/domino-royal.png`), which completed successfully. 
- No unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698205070ff0832999a166ccee5881db)