### PR TITLE
Restore Domino Royal morning baseline: commentary init & chair loading fallback

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -769,21 +769,15 @@ const COMMENTARY_LINES = {
   ]
 };
 
-let speechSynth = null;
-let speechSynthResolved = false;
-let commentarySpeechInitialized = false;
-function getSpeechSynth() {
-  if (speechSynthResolved) return speechSynth;
-  speechSynthResolved = true;
+const speechSynth = (() => {
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) return null;
   try {
-    speechSynth = window.speechSynthesis;
+    return window.speechSynthesis;
   } catch (error) {
     console.warn('Speech synthesis unavailable', error);
-    speechSynth = null;
+    return null;
   }
-  return speechSynth;
-}
+})();
 const speechUtteranceCtor =
   typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null;
 let commentaryVoices = [];
@@ -798,6 +792,9 @@ let lastAnnouncedTurn = null;
 let commentaryVoiceCycleIndex = 0;
 let commentaryUnlocked = false;
 let commentaryVoicesRetryTimer = null;
+let commentaryVoiceAttempts = 0;
+let commentaryDisabled = false;
+const COMMENTARY_MAX_VOICE_ATTEMPTS = 6;
 const lastCommentaryLineByKind = new Map();
 const COMMENTARY_VOICE_BY_KIND = {
   greeting: 'color',
@@ -836,14 +833,26 @@ function persistCommentaryPrefs() {
 }
 
 function refreshCommentaryVoices() {
-  const synth = getSpeechSynth();
-  if (!synth) return;
+  if (!speechSynth || commentaryDisabled) return;
   try {
-    commentaryVoices = synth.getVoices() || [];
-    commentaryReady = true;
+    commentaryVoices = speechSynth.getVoices() || [];
+    if (commentaryVoices.length) {
+      commentaryReady = true;
+      commentaryVoiceAttempts = 0;
+    } else {
+      commentaryReady = false;
+      commentaryVoiceAttempts += 1;
+      if (commentaryVoiceAttempts >= COMMENTARY_MAX_VOICE_ATTEMPTS) {
+        disableCommentary('No speech synthesis voices available.');
+      }
+    }
   } catch (error) {
     commentaryVoices = [];
     commentaryReady = false;
+    commentaryVoiceAttempts += 1;
+    if (commentaryVoiceAttempts >= COMMENTARY_MAX_VOICE_ATTEMPTS) {
+      disableCommentary('Speech synthesis failed to load voices.');
+    }
     console.warn('Failed to refresh commentary voices', error);
   }
 }
@@ -898,10 +907,18 @@ function getVoiceProfileForKind(kind) {
 function clearCommentaryQueue() {
   commentaryQueue = [];
   commentarySpeaking = false;
-  const synth = getSpeechSynth();
-  if (synth) {
-    synth.cancel();
+  if (speechSynth) {
+    speechSynth.cancel();
   }
+}
+
+function disableCommentary(reason) {
+  if (commentaryDisabled) return;
+  commentaryDisabled = true;
+  commentaryMuted = true;
+  clearCommentaryQueue();
+  persistCommentaryPrefs();
+  console.warn('Commentary disabled', reason);
 }
 
 function setCommentaryMuted(next) {
@@ -971,18 +988,16 @@ function buildCommentaryLine(kind, context = {}) {
 }
 
 function ensureSpeechUnlocked() {
-  const synth = getSpeechSynth();
-  if (!synth) return;
+  if (!speechSynth) return;
   try {
-    synth.resume();
+    speechSynth.resume();
   } catch (error) {
     console.warn('Failed to resume speech synthesis', error);
   }
 }
 
 function scheduleCommentaryVoicesRetry() {
-  const synth = getSpeechSynth();
-  if (!synth || commentaryVoicesRetryTimer) return;
+  if (!speechSynth || commentaryVoicesRetryTimer || commentaryDisabled) return;
   commentaryVoicesRetryTimer = window.setTimeout(() => {
     commentaryVoicesRetryTimer = null;
     refreshCommentaryVoices();
@@ -993,13 +1008,13 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  const synth = getSpeechSynth();
-  if (!synth || !speechUtteranceCtor || commentaryMuted || !text) return;
+  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || commentaryDisabled || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
   if (!commentaryVoices.length) {
     scheduleCommentaryVoicesRetry();
+    return;
   }
   if (!commentaryUnlocked) {
     if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
@@ -1036,9 +1051,9 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
     }
   };
   commentaryLastEventAt = now;
-  if (synth.speaking || commentarySpeaking) {
+  if (speechSynth.speaking || commentarySpeaking) {
     if (interrupt) {
-      synth.cancel();
+      speechSynth.cancel();
     } else {
       commentaryQueue.push({ text, options: { interrupt, priority, kind } });
       return;
@@ -1046,37 +1061,32 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   }
   commentarySpeaking = true;
   try {
-    synth.speak(utterance);
+    speechSynth.speak(utterance);
   } catch (error) {
     commentarySpeaking = false;
+    disableCommentary(error?.message || 'Speech synthesis crashed.');
     console.warn('Commentary failed to speak', error);
   }
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  const synth = getSpeechSynth();
-  if (commentaryMuted || !synth || !speechUtteranceCtor) return;
+  if (commentaryMuted || commentaryDisabled || !speechSynth || !speechUtteranceCtor) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
 }
 
-function initCommentarySpeech() {
-  if (commentarySpeechInitialized) return getSpeechSynth();
-  const synth = getSpeechSynth();
-  if (!synth || !speechUtteranceCtor) return null;
-  commentarySpeechInitialized = true;
+if (speechSynth) {
+  readCommentaryPrefs();
   refreshCommentaryVoices();
-  synth.onvoiceschanged = () => refreshCommentaryVoices();
+  speechSynth.onvoiceschanged = () => refreshCommentaryVoices();
   scheduleCommentaryVoicesRetry();
-  return synth;
+} else {
+  readCommentaryPrefs();
 }
-
-readCommentaryPrefs();
 
 function unlockInteractiveAudio() {
   ensureAudioContext();
-  initCommentarySpeech();
   ensureSpeechUnlocked();
   if (!commentaryUnlocked) {
     commentaryUnlocked = true;
@@ -5135,7 +5145,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(getSpeechSynth() && speechUtteranceCtor);
+  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor && !commentaryDisabled);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';
@@ -5407,8 +5417,10 @@ function disposeChairResources(root) {
   });
 }
 
+const CHAIR_MODEL_TIMEOUT_MS = 2500;
+
 function placeChairsWithOption(option, chairData, token) {
-  if (token !== chairBuildToken) return;
+  if (token !== chairBuildToken || !chairData) return;
 
   disposeSeatLabel({ persistPreference: false });
   disposeSeatAvatars();
@@ -5419,8 +5431,6 @@ function placeChairsWithOption(option, chairData, token) {
     chair.parent?.remove(chair);
     disposeChairResources(chair);
   }
-
-  if (!chairData) return;
 
   const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
   const seatBottomOffset = -chairTemplateBounds.min.y;
@@ -5457,13 +5467,25 @@ function placeChairsWithOption(option, chairData, token) {
 
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
   const token = ++chairBuildToken;
-  let chairData = null;
-  try {
-    chairData = await ensureChairTemplateForTheme(option);
-  } catch (error) {
-    console.warn("Failed to load Domino chair glTF", error);
+  const chairDataPromise = ensureChairTemplateForTheme(option).catch((error) => {
+    console.warn("Failed to load chair GLTF for Domino", error);
+    return null;
+  });
+
+  const chairData = await Promise.race([
+    chairDataPromise,
+    new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
+  ]);
+
+  if (chairData) {
+    placeChairsWithOption(option, chairData, token);
+    return;
   }
-  placeChairsWithOption(option, chairData, token);
+
+  chairDataPromise.then((resolved) => {
+    if (!resolved || token !== chairBuildToken) return;
+    placeChairsWithOption(option, resolved, token);
+  });
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */


### PR DESCRIPTION
### Motivation
- Revert recent regressions in Domino Royal that broke speech/commentary initialization and chair model loading, restoring the stable behavior from this morning.
- Ensure commentary voice retry/disable handling and chair GLTF timeout/fallback are robust to missing browser features or slow asset loads.

### Description
- Restored speech synthesis initialization and lifecycle to use the original `speechSynth` flow, reintroducing voice retry counting and a `disableCommentary` path when voices fail to load.
- Rewrote commentary functions to use the restored `speechSynth` instance for `refreshCommentaryVoices`, `ensureSpeechUnlocked`, `scheduleCommentaryVoicesRetry`, `speakCommentary`, and `announceCommentary`, and updated config UI to reflect `commentaryDisabled` state.
- Reinstated chair loading timeout behavior by adding `CHAIR_MODEL_TIMEOUT_MS` and switching `buildChairs` to `Promise.race` between the chair load and a timeout, with a fallback `then` handler that places chairs if/when the model becomes available.
- Minor restorations and cleanup around commentary queue handling, error logging, and chair placement guards to match the morning baseline.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982382eca3c8329b60ad4b9e588f785)