### PR TITLE
Restore Domino Royal to Feb 1 baseline: commentary init & chair timeout/fallback

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -769,23 +769,15 @@ const COMMENTARY_LINES = {
   ]
 };
 
-let speechSynth = null;
-let speechSynthResolved = false;
-let commentarySpeechInitialized = false;
-function getSpeechSynth() {
-  if (speechSynthResolved) return speechSynth;
-  speechSynthResolved = true;
+const speechSynth = (() => {
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) return null;
   try {
-    speechSynth = window.speechSynthesis;
+    return window.speechSynthesis;
   } catch (error) {
     console.warn('Speech synthesis unavailable', error);
-    speechSynth = null;
+    return null;
   }
-  return speechSynth;
-}
-const speechUtteranceCtor =
-  typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null;
+})();
 let commentaryVoices = [];
 let commentaryPresetId = COMMENTARY_PRESETS[0]?.id || 'atlas';
 let commentaryMuted = false;
@@ -836,10 +828,9 @@ function persistCommentaryPrefs() {
 }
 
 function refreshCommentaryVoices() {
-  const synth = getSpeechSynth();
-  if (!synth) return;
+  if (!speechSynth) return;
   try {
-    commentaryVoices = synth.getVoices() || [];
+    commentaryVoices = speechSynth.getVoices() || [];
     commentaryReady = true;
   } catch (error) {
     commentaryVoices = [];
@@ -898,9 +889,8 @@ function getVoiceProfileForKind(kind) {
 function clearCommentaryQueue() {
   commentaryQueue = [];
   commentarySpeaking = false;
-  const synth = getSpeechSynth();
-  if (synth) {
-    synth.cancel();
+  if (speechSynth) {
+    speechSynth.cancel();
   }
 }
 
@@ -971,18 +961,16 @@ function buildCommentaryLine(kind, context = {}) {
 }
 
 function ensureSpeechUnlocked() {
-  const synth = getSpeechSynth();
-  if (!synth) return;
+  if (!speechSynth) return;
   try {
-    synth.resume();
+    speechSynth.resume();
   } catch (error) {
     console.warn('Failed to resume speech synthesis', error);
   }
 }
 
 function scheduleCommentaryVoicesRetry() {
-  const synth = getSpeechSynth();
-  if (!synth || commentaryVoicesRetryTimer) return;
+  if (!speechSynth || commentaryVoicesRetryTimer) return;
   commentaryVoicesRetryTimer = window.setTimeout(() => {
     commentaryVoicesRetryTimer = null;
     refreshCommentaryVoices();
@@ -993,8 +981,7 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  const synth = getSpeechSynth();
-  if (!synth || !speechUtteranceCtor || commentaryMuted || !text) return;
+  if (!speechSynth || commentaryMuted || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
@@ -1011,7 +998,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   if (!priority && now - commentaryLastEventAt < COMMENTARY_MIN_INTERVAL_MS) return;
   if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
   const profile = getVoiceProfileForKind(kind);
-  const utterance = new speechUtteranceCtor(text);
+  const utterance = new SpeechSynthesisUtterance(text);
   const primaryVoice = resolveCommentaryVoice(profile);
   const secondaryVoice = resolveCommentaryVoice(
     getCommentaryVoiceProfiles().find((voiceProfile) => voiceProfile !== profile),
@@ -1036,9 +1023,9 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
     }
   };
   commentaryLastEventAt = now;
-  if (synth.speaking || commentarySpeaking) {
+  if (speechSynth.speaking || commentarySpeaking) {
     if (interrupt) {
-      synth.cancel();
+      speechSynth.cancel();
     } else {
       commentaryQueue.push({ text, options: { interrupt, priority, kind } });
       return;
@@ -1046,7 +1033,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   }
   commentarySpeaking = true;
   try {
-    synth.speak(utterance);
+    speechSynth.speak(utterance);
   } catch (error) {
     commentarySpeaking = false;
     console.warn('Commentary failed to speak', error);
@@ -1054,29 +1041,23 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  const synth = getSpeechSynth();
-  if (commentaryMuted || !synth || !speechUtteranceCtor) return;
+  if (commentaryMuted || !speechSynth) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
 }
 
-function initCommentarySpeech() {
-  if (commentarySpeechInitialized) return getSpeechSynth();
-  const synth = getSpeechSynth();
-  if (!synth || !speechUtteranceCtor) return null;
-  commentarySpeechInitialized = true;
+if (speechSynth) {
+  readCommentaryPrefs();
   refreshCommentaryVoices();
-  synth.onvoiceschanged = () => refreshCommentaryVoices();
+  speechSynth.onvoiceschanged = () => refreshCommentaryVoices();
   scheduleCommentaryVoicesRetry();
-  return synth;
+} else {
+  readCommentaryPrefs();
 }
-
-readCommentaryPrefs();
 
 function unlockInteractiveAudio() {
   ensureAudioContext();
-  initCommentarySpeech();
   ensureSpeechUnlocked();
   if (!commentaryUnlocked) {
     commentaryUnlocked = true;
@@ -5135,7 +5116,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(getSpeechSynth() && speechUtteranceCtor);
+  const commentarySupported = Boolean(speechSynth);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';
@@ -5407,6 +5388,8 @@ function disposeChairResources(root) {
   });
 }
 
+const CHAIR_MODEL_TIMEOUT_MS = 2500;
+
 function placeChairsWithOption(option, chairData, token) {
   if (token !== chairBuildToken) return;
 
@@ -5420,12 +5403,32 @@ function placeChairsWithOption(option, chairData, token) {
     disposeChairResources(chair);
   }
 
-  if (!chairData) return;
-
   const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
-  const seatBottomOffset = -chairTemplateBounds.min.y;
-  const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
-  const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
+  const seatBottomOffset = chairData
+    ? -chairTemplateBounds.min.y
+    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight;
+  const labelHeight = chairData
+    ? seatBottomOffset + chairTemplateBounds.max.y + 0.12
+    : CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness + 0.72;
+  const labelDepth = chairData
+    ? -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35
+    : -CHAIR_DIMENSIONS.seatDepth * 0.35;
+
+  const sharedMaterials = chairData
+    ? null
+    : {
+        fabric: createChairFabricMaterial(option, renderer),
+        leg: new THREE.MeshStandardMaterial({
+          color: new THREE.Color(option.legColor ?? "#1f1f1f"),
+          metalness: 0.6,
+          roughness: 0.35
+        }),
+        accent: new THREE.MeshStandardMaterial({
+          color: new THREE.Color(adjustHexColor(option.legColor ?? "#1f1f1f", 0.15)),
+          metalness: 0.75,
+          roughness: 0.32
+        })
+      };
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
@@ -5436,7 +5439,9 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.position.set(basis.position.x, CHAIR_BASE_HEIGHT, basis.position.z);
     wrapper.lookAt(lookTarget);
 
-    const chair = cloneChairWithTheme(chairData, option);
+    const chair = chairData
+      ? cloneChairWithTheme(chairData, option)
+      : createDominoChair(option, renderer, sharedMaterials);
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 
@@ -5457,13 +5462,24 @@ function placeChairsWithOption(option, chairData, token) {
 
 async function buildChairs(option = CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME) {
   const token = ++chairBuildToken;
-  let chairData = null;
-  try {
-    chairData = await ensureChairTemplateForTheme(option);
-  } catch (error) {
-    console.warn("Failed to load Domino chair glTF", error);
-  }
+  const chairDataPromise = ensureChairTemplateForTheme(option).catch((error) => {
+    console.warn("Falling back to procedural chair for Domino", error);
+    return null;
+  });
+
+  const chairData = await Promise.race([
+    chairDataPromise,
+    new Promise((resolve) => setTimeout(() => resolve(null), CHAIR_MODEL_TIMEOUT_MS))
+  ]);
+
   placeChairsWithOption(option, chairData, token);
+
+  if (!chairData) {
+    chairDataPromise.then((resolved) => {
+      if (!resolved || token !== chairBuildToken) return;
+      placeChairsWithOption(option, resolved, token);
+    });
+  }
 }
 
 /* ---------- Tile Helpers (ensure defined before use) ---------- */


### PR DESCRIPTION
### Motivation
- Revert recent Domino Royal regressions that broke commentary/speech initialization and chair GLTF loading, restoring the stable morning baseline behavior.
- Ensure commentary uses a direct `speechSynthesis` flow with voice refresh/retry and queue handling, and add a timed fallback for chair models so procedural chairs appear if GLTF loading is slow or fails.

### Description
- Restored static `speechSynth` initialization and removed the indirection around `getSpeechSynth` and `speechUtteranceCtor`, and updated commentary functions (`refreshCommentaryVoices`, `ensureSpeechUnlocked`, `scheduleCommentaryVoicesRetry`, `speakCommentary`, `announceCommentary`, UI gating) to use `speechSynth` directly.
- Reinstated commentary prefs loading and voice change handling with `speechSynth.onvoiceschanged` and voice retry scheduling.
- Added `CHAIR_MODEL_TIMEOUT_MS = 2500`, changed `buildChairs` to `Promise.race` between the chair GLTF promise and a timeout, and updated `placeChairsWithOption` to support both GLTF-based and procedural chair creation (and to re-place chairs if the GLTF resolves later).
- Miscellaneous guard and resource-disposal adjustments around chair placement, materials, and label offsets to match the earlier baseline.

### Testing
- Ran an automated Playwright smoke check that started a local `http.server`, loaded `domino-royal.html` at `http://127.0.0.1:4173/domino-royal.html`, verified a `canvas` was present, and saved a screenshot, and the script completed successfully.
- No unit tests or CI jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982382eca3c8329b60ad4b9e588f785)