### PR TITLE
Fix Pool Royale rail clamp to keep balls on table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6023,6 +6023,58 @@ function reflectRails(ball) {
   const guardClearance = POCKET_GUARD_CLEARANCE;
   const cornerDepthLimit = CORNER_POCKET_DEPTH_LIMIT;
   let preImpactVel = null;
+  const resolveRailLimitClamp = () => {
+    const nearPocketRadius =
+      Math.max(CAPTURE_R, SIDE_CAPTURE_R) + BALL_R * 0.22;
+    const nearPocket = pocketCenters().some(
+      (c) => ball.pos.distanceTo(c) < nearPocketRadius
+    );
+    if (nearPocket) return null;
+    let collided = null;
+    let collisionNormal = null;
+    if (ball.pos.x < -railLimitX) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = -railLimitX - ball.pos.x;
+      ball.pos.x = -railLimitX + overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(1, 0);
+    }
+    if (ball.pos.x > railLimitX) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = ball.pos.x - railLimitX;
+      ball.pos.x = railLimitX - overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(-1, 0);
+    }
+    if (ball.pos.y < -railLimitY) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = -railLimitY - ball.pos.y;
+      ball.pos.y = -railLimitY + overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(0, 1);
+    }
+    if (ball.pos.y > railLimitY) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = ball.pos.y - railLimitY;
+      ball.pos.y = railLimitY - overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(0, -1);
+    }
+    if (collided) {
+      const stamp =
+        typeof performance !== 'undefined' && performance.now
+          ? performance.now()
+          : Date.now();
+      ball.lastRailHitAt = stamp;
+      ball.lastRailHitType = collided;
+    }
+    if (collided) {
+      const normal = collisionNormal ?? new THREE.Vector2(0, 1);
+      const tangent = new THREE.Vector2(-normal.y, normal.x);
+      return { type: collided, normal, tangent, preImpactVel };
+    }
+    return null;
+  };
   const hasCushionSegments =
     Array.isArray(CUSHION_SEGMENTS) && CUSHION_SEGMENTS.length > 0;
   if (hasCushionSegments) {
@@ -6120,6 +6172,8 @@ function reflectRails(ball) {
         preImpactVel
       };
     }
+    const fallbackImpact = resolveRailLimitClamp();
+    if (fallbackImpact) return fallbackImpact;
   }
   if (!hasCushionSegments) {
     for (const { sx, sy } of CORNER_SIGNS) {
@@ -6191,55 +6245,8 @@ function reflectRails(ball) {
       }
     }
 
-    const nearPocketRadius =
-      Math.max(CAPTURE_R, SIDE_CAPTURE_R) + BALL_R * 0.22;
-    const nearPocket = pocketCenters().some(
-      (c) => ball.pos.distanceTo(c) < nearPocketRadius
-    );
-    if (nearPocket) return null;
-    let collided = null;
-    let collisionNormal = null;
-    if (ball.pos.x < -railLimitX && ball.vel.x < 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = -railLimitX - ball.pos.x;
-      ball.pos.x = -railLimitX + overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(1, 0);
-    }
-    if (ball.pos.x > railLimitX && ball.vel.x > 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = ball.pos.x - railLimitX;
-      ball.pos.x = railLimitX - overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(-1, 0);
-    }
-    if (ball.pos.y < -railLimitY && ball.vel.y < 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = -railLimitY - ball.pos.y;
-      ball.pos.y = -railLimitY + overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(0, 1);
-    }
-    if (ball.pos.y > railLimitY && ball.vel.y > 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = ball.pos.y - railLimitY;
-      ball.pos.y = railLimitY - overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(0, -1);
-    }
-    if (collided) {
-      const stamp =
-        typeof performance !== 'undefined' && performance.now
-          ? performance.now()
-          : Date.now();
-      ball.lastRailHitAt = stamp;
-      ball.lastRailHitType = collided;
-    }
-    if (collided) {
-      const normal = collisionNormal ?? new THREE.Vector2(0, 1);
-      const tangent = new THREE.Vector2(-normal.y, normal.x);
-      return { type: collided, normal, tangent, preImpactVel };
-    }
+    const fallbackImpact = resolveRailLimitClamp();
+    if (fallbackImpact) return fallbackImpact;
   }
   return null;
 }


### PR DESCRIPTION
### Motivation
- Players reported the cue ball (and occasionally other balls) leaving the table or behaving like it's airborne when rail collision segments failed to register a contact. This change prevents balls from escaping the cushion perimeter by clamping them back into play.

### Description
- Added a reusable `resolveRailLimitClamp` helper inside `reflectRails` in `webapp/src/pages/Games/PoolRoyale.jsx` that detects out-of-bounds balls (excluding near-pocket captures) and moves them back inside the computed `railLimitX`/`railLimitY` with a synthetic rail impact result. 
- The helper records `preImpactVel`, sets `ball.lastRailHitAt` and `ball.lastRailHitType`, and returns an impact object with `type`, `normal`, `tangent`, and `preImpactVel` to match existing impact-handling logic. 
- Invoked the clamp fallback from both the segmented-cushion branch and the legacy (non-segmented) branch so either path uses the same safety clamp when cushion geometry misses collisions. 
- Kept existing pocket-capture/guard checks so balls still get captured by pockets and are not forcibly clamped when legitimately near pocket zones.

### Testing
- Automated tests: none were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698253a6ff208329877b07630ec623d7)