### PR TITLE
Fix Domino Royal module CDN for mobile WebViews

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -194,13 +194,13 @@
 </div>
 
 <script type="module">
-import * as THREE from "https://esm.sh/three@0.160.0";
-import { OrbitControls } from "https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js";
-import { RoomEnvironment } from "https://esm.sh/three@0.160.0/examples/jsm/environments/RoomEnvironment.js";
-import { RoundedBoxGeometry } from "https://esm.sh/three@0.160.0/examples/jsm/geometries/RoundedBoxGeometry.js";
-import { GLTFLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js";
-import { RGBELoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/RGBELoader.js";
-import { DRACOLoader } from "https://esm.sh/three@0.160.0/examples/jsm/loaders/DRACOLoader.js";
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js";
+import { OrbitControls } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js";
+import { RoomEnvironment } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/environments/RoomEnvironment.js";
+import { RoundedBoxGeometry } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/geometries/RoundedBoxGeometry.js";
+import { GLTFLoader } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js";
+import { RGBELoader } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/RGBELoader.js";
+import { DRACOLoader } from "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/DRACOLoader.js";
 import "./flag-emojis.js";
 
 const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
### Motivation
- Mobile browsers and Telegram WebView can fail to load some ESM proxy hosts; switching the Three.js imports to a more compatible CDN helps the Domino Battle Royal page load in those environments.

### Description
- Replaced module imports in `webapp/public/domino-royal.html` from `https://esm.sh/three@0.160.0` to jsDelivr ESM endpoints such as `https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js` and matching `examples/jsm/*` entries.

### Testing
- No automated tests were run for this static HTML change; the patch is limited to swapping import URLs in `webapp/public/domino-royal.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982540e50288329ab640ef879218f97)