### PR TITLE
Redirect Domino Royal to standalone on mobile/Telegram to avoid iframe issues

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -1,11 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { isTelegramWebView } from '../../utils/telegram.js';
 
 export default function DominoRoyalArena({ search }) {
   const [src, setSrc] = useState(() => `/domino-royal.html${search || ''}`);
+  const shouldUseStandalone = useMemo(() => {
+    if (typeof navigator === 'undefined' || typeof window === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    const isMobileUA = /Android|iPhone|iPad|iPod|Mobile/i.test(ua);
+    const isCoarsePointer =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(pointer: coarse)').matches;
+    return isTelegramWebView() || isMobileUA || isCoarsePointer;
+  }, []);
 
   useEffect(() => {
     setSrc(`/domino-royal.html${search || ''}`);
   }, [search]);
+
+  useEffect(() => {
+    if (!shouldUseStandalone || typeof window === 'undefined') return;
+    if (window.location.pathname === '/domino-royal.html') return;
+    window.location.assign(src);
+  }, [shouldUseStandalone, src]);
+
+  if (shouldUseStandalone) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-black text-sm text-white/70">
+        Opening Domino Royal…
+      </div>
+    );
+  }
 
   return (
     <div className="relative w-full h-full bg-black">


### PR DESCRIPTION
### Motivation
- Mobile and Telegram in-app browsers can block or mis-handle heavy WebGL/iframe game pages; embedding `domino-royal.html` in an iframe caused access problems on those clients. 
- The page should open directly on constrained clients to ensure WebGL, audio and device features initialize correctly and provide a stable mobile experience.

### Description
- Added Telegram / mobile / coarse-pointer detection in `webapp/src/pages/Games/DominoRoyalArena.jsx` using `isTelegramWebView()` and UA/matchMedia checks. 
- When a mobile-like or Telegram WebView is detected, the app now navigates the top window to the standalone `/domino-royal.html` instead of rendering it inside an `<iframe>`. 
- Shows a brief loading placeholder (`Opening Domino Royal…`) while the redirect is performed to provide user feedback. 
- Keeps the previous iframe embedding behavior for desktop/non-mobile clients to preserve the original experience.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982540e50288329ab640ef879218f97)