### PR TITLE
Clamp cue ball speed when applying spin

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -16,6 +16,7 @@ public class BilliardsSolver
         public double Height;
         public double VerticalVelocity;
         public double MasseFactor = 1.0;
+        public double MaxSpeed;
     }
 
     public struct ShotSpin
@@ -581,7 +582,8 @@ public class BilliardsSolver
             VerticalVelocity = verticalSpeed,
             SideSpin = clamped.Side,
             ForwardSpin = forwardSpin,
-            MasseFactor = masseFactor
+            MasseFactor = masseFactor,
+            MaxSpeed = planarSpeed
         };
     }
 
@@ -625,6 +627,15 @@ public class BilliardsSolver
             }
             var swerveAccel = PhysicsConstants.SwerveCoefficient * b.SideSpin * speed * b.MasseFactor * speedFactor;
             b.Velocity += lateral * swerveAccel * dt;
+
+            if (b.MaxSpeed > PhysicsConstants.Epsilon)
+            {
+                var cappedSpeed = b.Velocity.Length;
+                if (cappedSpeed > b.MaxSpeed)
+                {
+                    b.Velocity = b.Velocity.Normalized() * b.MaxSpeed;
+                }
+            }
 
             double decay = Math.Exp(-PhysicsConstants.SpinDecay * dt);
             b.SideSpin *= decay;


### PR DESCRIPTION
### Motivation

- Prevent applying topspin/backspin/side spin from unintentionally increasing the shot's effective power so shot `Speed` remains consistent whether spin is applied or not.

### Description

- Added a `MaxSpeed` field to `Ball` and set it to the initial planar speed in `CreateCueBall` so the cue ball remembers its shot power.
- After applying spin accelerations in `ApplySpinForces` the cue ball velocity is clamped to `MaxSpeed` to prohibit spin from boosting overall speed.
- Change contained in `billiards/BilliardsSolver.cs` and is limited to spin/speed handling during the preview/simulation path.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982db50e4c88329981be5519f3ffb93)