### PR TITLE
Prevent topspin from boosting cue launch speed in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6313,7 +6313,7 @@ function applySpinController(ball, stepScale, airborne = false) {
   const { forward, speed } = resolveSpinFrame(ball);
   if (!airborne && speed > 1e-6) {
     let forwardSpin = ball.spin.y || 0;
-    if (ball.id === 'cue' && !ball.impacted && forwardSpin < 0) {
+    if (ball.id === 'cue' && !ball.impacted) {
       forwardSpin = 0;
     }
     const powerScale = resolveSpinPowerScale(speed);


### PR DESCRIPTION
### Motivation
- Fix a bug where applying top spin caused the cue ball to gain extra forward velocity at launch so shot power changed when spin was applied.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` updated `applySpinController` to zero the forward spin for the cue ball before the first impact by changing the condition to `if (ball.id === 'cue' && !ball.impacted) forwardSpin = 0;`, preventing topspin/backspin from altering initial launch velocity.

### Testing
- No automated tests were run for this change (manual verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982db50e4c88329981be5519f3ffb93)