### PR TITLE
Improve pocket capture and guard tuning for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1310,18 +1310,17 @@ const POCKET_INTERIOR_CAPTURE_R =
   POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // match capture radius directly to the pocket bowl opening
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
-const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the true bowl opening
-const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.16; // give middle pockets a touch more capture so shots don't hang in the jaws
-const POCKET_GUARD_RADIUS = Math.max(0, POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.04); // align the rail guard to the playable capture bowl instead of the visual rim
-const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.18); // shrink the safety margin so angled cushion cuts register sooner
+const CAPTURE_R =
+  POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.12; // expand capture slightly so balls drop reliably once they clear the mouth
+const SIDE_CAPTURE_R =
+  SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.22; // give middle pockets a touch more capture so shots don't hang in the jaws
+const POCKET_GUARD_RADIUS = Math.max(0, CAPTURE_R - BALL_R * 0.02); // align the rail guard to the playable capture bowl instead of the visual rim
+const POCKET_GUARD_CLEARANCE = Math.max(0, CAPTURE_R - BALL_R * 0.08); // keep the guard active deeper into the capture zone
 const CORNER_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.58 * POCKET_VISUAL_EXPANSION; // clamp corner reflections to the actual pocket depth
 const SIDE_POCKET_GUARD_RADIUS =
-  SIDE_CAPTURE_R - BALL_R * 0.1; // use the middle-pocket bowl to gate reflections with a tighter inset
-const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
-  0,
-  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
-);
+  Math.max(0, SIDE_CAPTURE_R - BALL_R * 0.04); // use the middle-pocket bowl to gate reflections with a tighter inset
+const SIDE_POCKET_GUARD_CLEARANCE = Math.max(0, SIDE_CAPTURE_R - BALL_R * 0.1);
 const CUSHION_CUT_RESTITUTION_SCALE = 0.76; // damp angled-cushion rebounds so they feel less punchy than straight rails
 const CUSHION_CUT_FRICTION_SCALE = 1.2; // add a touch more grab on angled cuts to prevent over-bouncy jaw rebounds
 const SIDE_POCKET_DEPTH_LIMIT =


### PR DESCRIPTION
### Motivation
- Increase potting reliability by expanding pocket capture zones and aligning pocket guard radii/clearance so balls that clear the mouth are classified and handled as pocketed.

### Description
- Adjusted capture and guard constants in `webapp/src/pages/Games/PoolRoyale.jsx`: `CAPTURE_R` was increased by `BALL_R * 0.12`, `SIDE_CAPTURE_R` by `BALL_R * 0.22`, and `POCKET_GUARD_RADIUS` / `POCKET_GUARD_CLEARANCE` and the side-pocket guard values were updated to derive from the new capture radii.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e1365ba48329b34ede863282942d)