### PR TITLE
Revert Pool Royale pocket capture tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1310,17 +1310,18 @@ const POCKET_INTERIOR_CAPTURE_R =
   POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // match capture radius directly to the pocket bowl opening
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
-const CAPTURE_R =
-  POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.12; // expand capture slightly so balls drop reliably once they clear the mouth
-const SIDE_CAPTURE_R =
-  SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.22; // give middle pockets a touch more capture so shots don't hang in the jaws
-const POCKET_GUARD_RADIUS = Math.max(0, CAPTURE_R - BALL_R * 0.02); // align the rail guard to the playable capture bowl instead of the visual rim
-const POCKET_GUARD_CLEARANCE = Math.max(0, CAPTURE_R - BALL_R * 0.08); // keep the guard active deeper into the capture zone
+const CAPTURE_R = POCKET_INTERIOR_CAPTURE_R; // pocket capture radius aligned to the true bowl opening
+const SIDE_CAPTURE_R = SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.16; // give middle pockets a touch more capture so shots don't hang in the jaws
+const POCKET_GUARD_RADIUS = Math.max(0, POCKET_INTERIOR_CAPTURE_R - BALL_R * 0.04); // align the rail guard to the playable capture bowl instead of the visual rim
+const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.18); // shrink the safety margin so angled cushion cuts register sooner
 const CORNER_POCKET_DEPTH_LIMIT =
   POCKET_VIS_R * 1.58 * POCKET_VISUAL_EXPANSION; // clamp corner reflections to the actual pocket depth
 const SIDE_POCKET_GUARD_RADIUS =
-  Math.max(0, SIDE_CAPTURE_R - BALL_R * 0.04); // use the middle-pocket bowl to gate reflections with a tighter inset
-const SIDE_POCKET_GUARD_CLEARANCE = Math.max(0, SIDE_CAPTURE_R - BALL_R * 0.1);
+  SIDE_CAPTURE_R - BALL_R * 0.1; // use the middle-pocket bowl to gate reflections with a tighter inset
+const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
+  0,
+  SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
+);
 const CUSHION_CUT_RESTITUTION_SCALE = 0.76; // damp angled-cushion rebounds so they feel less punchy than straight rails
 const CUSHION_CUT_FRICTION_SCALE = 1.2; // add a touch more grab on angled cuts to prevent over-bouncy jaw rebounds
 const SIDE_POCKET_DEPTH_LIMIT =


### PR DESCRIPTION
### Motivation
- Restore previous pocket capture behaviour by reverting recent tuning to match the prior playable geometry and guard offsets. 
- This ensures ball capture radii and pocket guard logic align with the existing physics assumptions used elsewhere in the project.

### Description
- Reverted pocket capture constants in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `CAPTURE_R` back to `POCKET_INTERIOR_CAPTURE_R`. 
- Restored `SIDE_CAPTURE_R` to use `BALL_R * 0.16` and adjusted `POCKET_GUARD_RADIUS`/`POCKET_GUARD_CLEARANCE` back to their previous offsets computed from `POCKET_INTERIOR_CAPTURE_R`. 
- Restored `SIDE_POCKET_GUARD_RADIUS` to `SIDE_CAPTURE_R - BALL_R * 0.1` and `SIDE_POCKET_GUARD_CLEARANCE` to `Math.max(0, SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04)`. 
- Formatting and small expression changes were applied in the same block to match the previous tuned values.

### Testing
- No automated tests were executed as part of this change. 
- The change is a deterministic constant revert limited to `webapp/src/pages/Games/PoolRoyale.jsx` and should be validated in-play to confirm capture behaviour matches the previous build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ed81465c8329bae73509e0d85dd8)