### PR TITLE
Restore Domino Royal commentary guards

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -778,6 +778,8 @@ const speechSynth = (() => {
     return null;
   }
 })();
+const speechUtteranceCtor =
+  typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null;
 let commentaryVoices = [];
 let commentaryPresetId = COMMENTARY_PRESETS[0]?.id || 'atlas';
 let commentaryMuted = false;
@@ -981,7 +983,7 @@ function scheduleCommentaryVoicesRetry() {
 }
 
 function speakCommentary(text, { interrupt = false, priority = false, kind = '' } = {}) {
-  if (!speechSynth || commentaryMuted || !text) return;
+  if (!speechSynth || !speechUtteranceCtor || commentaryMuted || !text) return;
   if (!commentaryReady) {
     refreshCommentaryVoices();
   }
@@ -998,7 +1000,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
   if (!priority && now - commentaryLastEventAt < COMMENTARY_MIN_INTERVAL_MS) return;
   if (!priority && commentaryQueue.length >= COMMENTARY_QUEUE_LIMIT) return;
   const profile = getVoiceProfileForKind(kind);
-  const utterance = new SpeechSynthesisUtterance(text);
+  const utterance = new speechUtteranceCtor(text);
   const primaryVoice = resolveCommentaryVoice(profile);
   const secondaryVoice = resolveCommentaryVoice(
     getCommentaryVoiceProfiles().find((voiceProfile) => voiceProfile !== profile),
@@ -1041,7 +1043,7 @@ function speakCommentary(text, { interrupt = false, priority = false, kind = '' 
 }
 
 function announceCommentary(kind, context = {}, options = {}) {
-  if (commentaryMuted || !speechSynth) return;
+  if (commentaryMuted || !speechSynth || !speechUtteranceCtor) return;
   const line = buildCommentaryLine(kind, context);
   if (!line) return;
   speakCommentary(line, { ...options, kind });
@@ -5116,7 +5118,7 @@ function refreshConfigUI() {
   commentaryWrapper.appendChild(commentaryLabel);
   const commentaryGrid = document.createElement('div');
   commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(speechSynth);
+  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
   COMMENTARY_PRESETS.forEach((preset) => {
     const presetButton = document.createElement('button');
     presetButton.type = 'button';


### PR DESCRIPTION
### Motivation
- Ensure Domino Royal only attempts voice playback when the browser environment provides both `speechSynthesis` and a usable `SpeechSynthesisUtterance` constructor to avoid runtime errors on platforms with partial Web Speech support.

### Description
- Reintroduced a guarded `speechUtteranceCtor` variable set to `typeof SpeechSynthesisUtterance === 'function' ? SpeechSynthesisUtterance : null` in `webapp/public/domino-royal.html`.
- Updated `speakCommentary` to bail out when `!speechUtteranceCtor` and to instantiate utterances with `new speechUtteranceCtor(text)` instead of directly calling `SpeechSynthesisUtterance`.
- Tightened `announceCommentary` and the commentary options UI to require both `speechSynth` and `speechUtteranceCtor` before enabling or queuing voice commentary.

### Testing
- Performed a local smoke render by serving the app and running a Playwright script that opened `webapp/public/domino-royal.html` at `390x844` and captured a screenshot; the page loaded and the screenshot was produced (`artifacts/domino-royal.png`), indicating no fatal JS errors on load.
- Basic runtime checks (voice gating and UI disabled state) were validated by observing that commentary-related functions return early when the utterance constructor is missing; the automated page load succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830caddeb48329890a829f581cc250)