### PR TITLE
Fix dice face mapping for Snake & Ladder (swap faces 3 and 4)

### DIFF
--- a/webapp/src/components/LuxuryDice.jsx
+++ b/webapp/src/components/LuxuryDice.jsx
@@ -22,8 +22,8 @@ const orientationMap = (() => {
   const map = {};
   map[1] = new THREE.Quaternion();
   map[2] = new THREE.Quaternion().setFromEuler(new THREE.Euler(-Math.PI / 2, 0, 0));
-  map[3] = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, -Math.PI / 2));
-  map[4] = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, Math.PI / 2));
+  map[3] = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, Math.PI / 2));
+  map[4] = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, -Math.PI / 2));
   map[5] = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
   map[6] = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI, 0, 0));
   return map;

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1583,8 +1583,8 @@ function getDiceOrientationQuaternion(val) {
   const orientations = {
     1: new THREE.Euler(0, 0, 0),
     2: new THREE.Euler(-Math.PI / 2, 0, 0),
-    3: new THREE.Euler(0, 0, -Math.PI / 2),
-    4: new THREE.Euler(0, 0, Math.PI / 2),
+    3: new THREE.Euler(0, 0, Math.PI / 2),
+    4: new THREE.Euler(0, 0, -Math.PI / 2),
     5: new THREE.Euler(Math.PI / 2, 0, 0),
     6: new THREE.Euler(Math.PI, 0, 0)
   };


### PR DESCRIPTION
### Motivation
- The dice visual orientation for faces 3 and 4 was inverted causing a roll of `3` to display as `4` (and vice‑versa), which made movement and commentary inconsistent with the shown face.

### Description
- Swap the Euler rotations for values `3` and `4` in the 3D/visual dice logic by updating `webapp/src/components/LuxuryDice.jsx` and `webapp/src/components/SnakeBoard3D.jsx` so displayed faces match rolled values.

### Testing
- Launched the dev site with `npm --prefix webapp run dev` and captured a mobile viewport screenshot using a Playwright script which completed and produced `artifacts/snake-dice.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983197b4c7083298fd3211f273d0e34)