### PR TITLE
Align Snake & Ladder tokens with Ludo Battle Royal size & placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -182,6 +182,7 @@ const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
 const TOKEN_SCALE = 1.19;
 const TOKEN_RADIUS = TILE_SIZE * 0.3 * TOKEN_SCALE;
 const TOKEN_HEIGHT = TILE_SIZE * 0.48 * TOKEN_SCALE;
+const LUDO_TOKEN_HEIGHT = 0.09;
 const CHESS_TOKEN_HEIGHT_SCALE = 2;
 const TOKEN_ACCENT_TARGET = new THREE.Color('#f8fafc');
 const TILE_LABEL_OFFSET = TILE_SIZE * 0.0004;
@@ -191,10 +192,12 @@ const TILE_EDGE_INSET = TILE_SIZE * 0.22;
 const BASE_PLATFORM_EXTRA_MULTIPLIER = 1.72;
 const FIRST_LEVEL_PLATFORM_EXTRA = TILE_SIZE * 0.9;
 const HOME_TOKEN_FORWARD_LIFT = TILE_SIZE * 1.05;
-const HOME_TOKEN_OUTWARD_EXTRA = TILE_SIZE * 0.9;
-// Extra distance so side-seat tokens rest closer to their players than the board edge.
-const SIDE_HOME_EXTRA_DISTANCE = TILE_SIZE * 2.4;
-const BACK_HOME_EXTRA_DISTANCE = TILE_SIZE * 2.8;
+const HOME_TOKEN_OUTWARD_EXTRA = TILE_SIZE * 1.2;
+const TOKEN_TABLE_EDGE_INSET = TILE_SIZE * 0.45;
+const TABLE_RADIUS_LOCAL = TABLE_RADIUS / BOARD_SCALE;
+// Subtle distance so side-seat tokens rest closer to their players than the board edge.
+const SIDE_HOME_EXTRA_DISTANCE = TILE_SIZE * 0.5;
+const BACK_HOME_EXTRA_DISTANCE = TILE_SIZE * 0.7;
 const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_SCALE;
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
@@ -3102,6 +3105,7 @@ function updateTokens(
     const baseY = Number.isFinite(baseLevelTop) ? baseLevelTop : 0;
     const center = new THREE.Vector3(0, baseY, 0);
     const forwardLift = HOME_TOKEN_FORWARD_LIFT + HOME_TOKEN_OUTWARD_EXTRA;
+    const tableEdgeDistance = TABLE_RADIUS_LOCAL - TOKEN_TABLE_EDGE_INSET;
     seatAnchors.forEach((anchor, index) => {
       if (!anchor) {
         seatHomes[index] = null;
@@ -3122,7 +3126,8 @@ function updateTokens(
       let seatBonus = 0;
       if (index === 1 || index === 3) seatBonus = SIDE_HOME_EXTRA_DISTANCE;
       else if (index === 2) seatBonus = BACK_HOME_EXTRA_DISTANCE;
-      const distanceFromBoard = boardHalf + BOARD_EDGE_BUFFER + forwardLift + seatBonus;
+      const minimumDistance = boardHalf + BOARD_EDGE_BUFFER + forwardLift;
+      const distanceFromBoard = Math.max(minimumDistance, tableEdgeDistance) + seatBonus;
       const target = center.clone().addScaledVector(direction, distanceFromBoard);
       target.y = baseY + TOKEN_HEIGHT * 0.02;
       seatHomes[index] = { position: target, direction };
@@ -3182,7 +3187,11 @@ function updateTokens(
       let pieceMaterials = null;
       if (piecePrototype) {
         const piece = piecePrototype.clone(true);
-        scaleChessPieceToToken(piece, TOKEN_HEIGHT * CHESS_TOKEN_HEIGHT_SCALE);
+        const targetHeight =
+          playerShape?.source === 'ludoBattleRoyal'
+            ? LUDO_TOKEN_HEIGHT
+            : TOKEN_HEIGHT * CHESS_TOKEN_HEIGHT_SCALE;
+        scaleChessPieceToToken(piece, targetHeight);
         pieceMaterials = [];
         piece.traverse((child) => {
           if (child.isMesh) {
@@ -3762,7 +3771,9 @@ export default function SnakeBoard3D({
 
   useEffect(() => {
     let active = true;
-    if (!tokenShape || tokenShape.source !== 'chessBattleRoyal') {
+    const usesChessPrototypes =
+      tokenShape?.source === 'chessBattleRoyal' || tokenShape?.source === 'ludoBattleRoyal';
+    if (!usesChessPrototypes) {
       if (boardRef.current) {
         boardRef.current.tokenPrototypes = null;
       }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -806,12 +806,12 @@ const WALL_TEXTURE_OPTIONS = Object.freeze([
 ]);
 
 const TOKEN_SHAPE_OPTIONS = Object.freeze([
-  { id: 'pawn', label: 'Pawn', pieceType: 'pawn', source: 'chessBattleRoyal' },
-  { id: 'knight', label: 'Knight', pieceType: 'knight', source: 'chessBattleRoyal' },
-  { id: 'bishop', label: 'Bishop', pieceType: 'bishop', source: 'chessBattleRoyal' },
-  { id: 'rook', label: 'Rook', pieceType: 'rook', source: 'chessBattleRoyal' },
-  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'chessBattleRoyal' },
-  { id: 'king', label: 'King', pieceType: 'king', source: 'chessBattleRoyal' }
+  { id: 'pawn', label: 'Pawn', pieceType: 'pawn', source: 'ludoBattleRoyal' },
+  { id: 'knight', label: 'Knight', pieceType: 'knight', source: 'ludoBattleRoyal' },
+  { id: 'bishop', label: 'Bishop', pieceType: 'bishop', source: 'ludoBattleRoyal' },
+  { id: 'rook', label: 'Rook', pieceType: 'rook', source: 'ludoBattleRoyal' },
+  { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'ludoBattleRoyal' },
+  { id: 'king', label: 'King', pieceType: 'king', source: 'ludoBattleRoyal' }
 ]);
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder tokens match the Ludo Battle Royal presentation by moving them slightly outward toward the table edge and using the same token shapes/sizing so the visual language is consistent across games.

### Description
- Added `LUDO_TOKEN_HEIGHT`, `TOKEN_TABLE_EDGE_INSET`, and `TABLE_RADIUS_LOCAL` and adjusted `HOME_TOKEN_OUTWARD_EXTRA`, `SIDE_HOME_EXTRA_DISTANCE`, and `BACK_HOME_EXTRA_DISTANCE` to bias home token placement outward toward the table edge. 
- In `updateTokens` the seat home distance now takes `TABLE_RADIUS_LOCAL - TOKEN_TABLE_EDGE_INSET` into account so side-seat tokens rest closer to players and match the Ludo rails layout. 
- Scale chess-piece prototypes differently when the `tokenShape.source` is `ludoBattleRoyal` by using `LUDO_TOKEN_HEIGHT` in `scaleChessPieceToToken`. 
- Allow token prototype loading when `tokenShape.source` is either `chessBattleRoyal` or `ludoBattleRoyal` so Snake can reuse the Ludo/Chess piece prototypes. 
- Change `TOKEN_SHAPE_OPTIONS` in `SnakeAndLadder.jsx` to reference the `ludoBattleRoyal` source so the Snake game uses the Ludo Battle Royal token shapes.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed Vite reported a ready server (succeeded). 
- Launched a headless browser and captured screenshots of the Snake lobby and game routes using Playwright; some navigations initially timed out but I successfully produced lobby screenshots (artifacts saved during the run). 
- No unit tests were modified or executed (visual/UI-only changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831ef8acec832991710a2ae221f8cc)