### PR TITLE
Refresh chess battle thumbnails and add chess-battle-royal art assets

### DIFF
--- a/webapp/public/assets/game-art/.gitignore
+++ b/webapp/public/assets/game-art/.gitignore
@@ -7,3 +7,5 @@
 !variants/
 !variants/pool-royale/
 !variants/pool-royale/*.svg
+!chess-battle-royal/
+!chess-battle-royal/**

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/chrome.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/chrome.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#6e6e6e'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#b0b0b0'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#b0b0b0' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/classic.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/classic.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#2b2f36'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#eee8d5'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#eee8d5' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/forest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/forest.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#065f46'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#a7f3d0'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#a7f3d0' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/ivorySlate.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/ivorySlate.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#111827'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#e5e7eb'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#e5e7eb' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/nebulaGlass.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/nebulaGlass.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#0b1024'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#e0f2fe'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#e0f2fe' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/ocean.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/ocean.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#1e3a5f'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#a4c8e1'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#a4c8e1' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/sand.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/sand.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#6b4f3a'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#ddd0b8'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#ddd0b8' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/boards/violet.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/boards/violet.svg
@@ -1,0 +1,38 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='#3b2a6e'/>
+  <rect x='26.00' y='26.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='77.00' y='26.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='128.00' y='26.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='179.00' y='26.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='51.50' y='51.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='102.50' y='51.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='153.50' y='51.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='204.50' y='51.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='26.00' y='77.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='77.00' y='77.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='128.00' y='77.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='179.00' y='77.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='51.50' y='102.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='102.50' y='102.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='153.50' y='102.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='204.50' y='102.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='26.00' y='128.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='77.00' y='128.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='128.00' y='128.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='179.00' y='128.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='51.50' y='153.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='102.50' y='153.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='153.50' y='153.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='204.50' y='153.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='26.00' y='179.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='77.00' y='179.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='128.00' y='179.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='179.00' y='179.00' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='51.50' y='204.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='102.50' y='204.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='153.50' y='204.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='204.50' y='204.50' width='25.50' height='25.50' fill='#ddd6fe'/>
+  <rect x='26' y='26' width='204' height='204' rx='18' fill='none' stroke='#ddd6fe' stroke-width='4' opacity='0.6'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/heads/current.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/heads/current.svg
@@ -1,0 +1,18 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='glow' cx='40%' cy='30%' r='70%'>
+      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='glass' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#94a3b8' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#1f2937' stop-opacity='1'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='90' r='54' fill='url(#glass)' stroke='#e2e8f0' stroke-width='4'/>
+  <rect x='86' y='150' width='84' height='30' rx='14' fill='#1f2937'/>
+  <rect x='72' y='182' width='112' height='34' rx='16' fill='#1f2937' opacity='0.9'/>
+  <circle cx='108' cy='74' r='48' fill='url(#glow)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/heads/headChrome.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/heads/headChrome.svg
@@ -1,0 +1,18 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='glow' cx='40%' cy='30%' r='70%'>
+      <stop offset='0%' stop-color='#f8fafc' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#f8fafc' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='glass' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#94a3b8' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#1f2937' stop-opacity='1'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='90' r='54' fill='url(#glass)' stroke='#f8fafc' stroke-width='4'/>
+  <rect x='86' y='150' width='84' height='30' rx='14' fill='#1f2937'/>
+  <rect x='72' y='182' width='112' height='34' rx='16' fill='#1f2937' opacity='0.9'/>
+  <circle cx='108' cy='74' r='48' fill='url(#glow)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/heads/headGold.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/heads/headGold.svg
@@ -1,0 +1,18 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='glow' cx='40%' cy='30%' r='70%'>
+      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='glass' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#f59e0b' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#1f2937' stop-opacity='1'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='90' r='54' fill='url(#glass)' stroke='#fde68a' stroke-width='4'/>
+  <rect x='86' y='150' width='84' height='30' rx='14' fill='#1f2937'/>
+  <rect x='72' y='182' width='112' height='34' rx='16' fill='#1f2937' opacity='0.9'/>
+  <circle cx='108' cy='74' r='48' fill='url(#glow)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/heads/headRuby.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/heads/headRuby.svg
@@ -1,0 +1,18 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='glow' cx='40%' cy='30%' r='70%'>
+      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='glass' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#b91c1c' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#1f2937' stop-opacity='1'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='90' r='54' fill='url(#glass)' stroke='#fecaca' stroke-width='4'/>
+  <rect x='86' y='150' width='84' height='30' rx='14' fill='#1f2937'/>
+  <rect x='72' y='182' width='112' height='34' rx='16' fill='#1f2937' opacity='0.9'/>
+  <circle cx='108' cy='74' r='48' fill='url(#glow)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/heads/headSapphire.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/heads/headSapphire.svg
@@ -1,0 +1,18 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='glow' cx='40%' cy='30%' r='70%'>
+      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='glass' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2563eb' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#1f2937' stop-opacity='1'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='90' r='54' fill='url(#glass)' stroke='#bfdbfe' stroke-width='4'/>
+  <rect x='86' y='150' width='84' height='30' rx='14' fill='#1f2937'/>
+  <rect x='72' y='182' width='112' height='34' rx='16' fill='#1f2937' opacity='0.9'/>
+  <circle cx='108' cy='74' r='48' fill='url(#glow)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#f59e0b'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#8b5cf6'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#7aa2f7'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#ff6b35'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#14532d'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#f8fafc'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#10b981'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#ef4444'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,0 +1,19 @@
+
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <defs>
+    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
+      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
+    </radialGradient>
+    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#3b82f6'/>
+      <stop offset='100%' stop-color='#1f2937'/>
+    </linearGradient>
+  </defs>
+  <rect width='256' height='256' rx='36' fill='#0b1220'/>
+  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
+  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
+  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
+  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
+  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+</svg>

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -138,32 +138,32 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
 
 export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
   sideColor: Object.freeze({
-    marble: swatchThumbnail(['#f8fafc', '#e2e8f0', '#cbd5f5']),
-    darkForest: swatchThumbnail(['#14532d', '#0f3d23', '#86efac']),
-    amberGlow: swatchThumbnail(['#fbbf24', '#b45309', '#fde68a']),
-    mintVale: swatchThumbnail(['#10b981', '#065f46', '#bbf7d0']),
-    royalWave: swatchThumbnail(['#3b82f6', '#1d4ed8', '#bfdbfe']),
-    roseMist: swatchThumbnail(['#ef4444', '#be123c', '#fecaca']),
-    amethyst: swatchThumbnail(['#8b5cf6', '#6d28d9', '#ddd6fe']),
-    cinderBlaze: swatchThumbnail(['#ff6b35', '#7f1d1d', '#fed7aa']),
-    arcticDrift: swatchThumbnail(['#bcd7ff', '#7aa2f7', '#e2e8f0'])
+    marble: '/assets/game-art/chess-battle-royal/pieces/marble.svg',
+    darkForest: '/assets/game-art/chess-battle-royal/pieces/darkForest.svg',
+    amberGlow: '/assets/game-art/chess-battle-royal/pieces/amberGlow.svg',
+    mintVale: '/assets/game-art/chess-battle-royal/pieces/mintVale.svg',
+    royalWave: '/assets/game-art/chess-battle-royal/pieces/royalWave.svg',
+    roseMist: '/assets/game-art/chess-battle-royal/pieces/roseMist.svg',
+    amethyst: '/assets/game-art/chess-battle-royal/pieces/amethyst.svg',
+    cinderBlaze: '/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg',
+    arcticDrift: '/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg'
   }),
   boardTheme: Object.freeze({
-    classic: swatchThumbnail(['#e7e2d3', '#2b2f36', '#f1f5f9']),
-    ivorySlate: swatchThumbnail(['#f8fafc', '#64748b', '#e2e8f0']),
-    forest: swatchThumbnail(['#065f46', '#134e4a', '#bbf7d0']),
-    sand: swatchThumbnail(['#d6c7a1', '#8b6b4f', '#fef3c7']),
-    ocean: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe']),
-    violet: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe']),
-    chrome: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc']),
-    nebulaGlass: swatchThumbnail(['#312e81', '#111827', '#a855f7'])
+    classic: '/assets/game-art/chess-battle-royal/boards/classic.svg',
+    ivorySlate: '/assets/game-art/chess-battle-royal/boards/ivorySlate.svg',
+    forest: '/assets/game-art/chess-battle-royal/boards/forest.svg',
+    sand: '/assets/game-art/chess-battle-royal/boards/sand.svg',
+    ocean: '/assets/game-art/chess-battle-royal/boards/ocean.svg',
+    violet: '/assets/game-art/chess-battle-royal/boards/violet.svg',
+    chrome: '/assets/game-art/chess-battle-royal/boards/chrome.svg',
+    nebulaGlass: '/assets/game-art/chess-battle-royal/boards/nebulaGlass.svg'
   }),
   headStyle: Object.freeze({
-    current: swatchThumbnail(['#94a3b8', '#475569', '#e2e8f0']),
-    headRuby: swatchThumbnail(['#b91c1c', '#7f1d1d', '#fecaca']),
-    headSapphire: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe']),
-    headChrome: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc']),
-    headGold: swatchThumbnail(['#f59e0b', '#b45309', '#fde68a'])
+    current: '/assets/game-art/chess-battle-royal/heads/current.svg',
+    headRuby: '/assets/game-art/chess-battle-royal/heads/headRuby.svg',
+    headSapphire: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg',
+    headChrome: '/assets/game-art/chess-battle-royal/heads/headChrome.svg',
+    headGold: '/assets/game-art/chess-battle-royal/heads/headGold.svg'
   })
 });
 
@@ -208,7 +208,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Marble Pieces',
     price: 1400,
     description: 'Premium marble-inspired pieces for either side.',
-    thumbnail: swatchThumbnail(['#f8fafc', '#e2e8f0', '#cbd5f5'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.marble
   },
   {
     id: 'chess-side-forest',
@@ -217,7 +217,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Dark Forest Pieces',
     price: 1300,
     description: 'Deep forest hue pieces with luxe accents.',
-    thumbnail: swatchThumbnail(['#14532d', '#0f3d23', '#86efac'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.darkForest
   },
   {
     id: 'chess-side-royal',
@@ -226,7 +226,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Royal Wave Pieces',
     price: 420,
     description: 'Royal blue quick-select palette.',
-    thumbnail: swatchThumbnail(['#3b82f6', '#1d4ed8', '#bfdbfe'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.royalWave
   },
   {
     id: 'chess-side-rose',
@@ -235,7 +235,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Rose Mist Pieces',
     price: 420,
     description: 'Rosy quick-select palette with soft glow.',
-    thumbnail: swatchThumbnail(['#ef4444', '#be123c', '#fecaca'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.roseMist
   },
   {
     id: 'chess-side-amethyst',
@@ -244,7 +244,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Amethyst Pieces',
     price: 460,
     description: 'Amethyst quick-select palette with sheen.',
-    thumbnail: swatchThumbnail(['#8b5cf6', '#6d28d9', '#ddd6fe'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.amethyst
   },
   {
     id: 'chess-side-cinder',
@@ -253,7 +253,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Cinder Blaze Pieces',
     price: 480,
     description: 'Molten orange-on-charcoal palette for fiery showdowns.',
-    thumbnail: swatchThumbnail(['#ff6b35', '#7f1d1d', '#fed7aa'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.cinderBlaze
   },
   {
     id: 'chess-side-arctic',
@@ -262,7 +262,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Arctic Drift Pieces',
     price: 520,
     description: 'Icy stone palette with frosted metallic hints.',
-    thumbnail: swatchThumbnail(['#bcd7ff', '#7aa2f7', '#e2e8f0'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor.arcticDrift
   },
   {
     id: 'chess-board-ivorySlate',
@@ -271,7 +271,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Ivory/Slate Board',
     price: 380,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#f8fafc', '#64748b', '#e2e8f0'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.ivorySlate
   },
   {
     id: 'chess-board-forest',
@@ -280,7 +280,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Forest Board',
     price: 410,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#065f46', '#134e4a', '#bbf7d0'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.forest
   },
   {
     id: 'chess-board-sand',
@@ -289,7 +289,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Sand/Brown Board',
     price: 440,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#d6c7a1', '#8b6b4f', '#fef3c7'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.sand
   },
   {
     id: 'chess-board-ocean',
@@ -298,7 +298,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Ocean Board',
     price: 470,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.ocean
   },
   {
     id: 'chess-board-violet',
@@ -307,7 +307,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Violet Board',
     price: 500,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#7c3aed', '#5b21b6', '#ddd6fe'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.violet
   },
   {
     id: 'chess-board-chrome',
@@ -316,7 +316,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Chrome Board',
     price: 540,
     description: 'Alternate board palette for fast swaps.',
-    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.chrome
   },
   {
     id: 'chess-board-nebula',
@@ -325,7 +325,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Nebula Glass Board',
     price: 580,
     description: 'Cosmic glass palette with deep-space contrasts.',
-    thumbnail: swatchThumbnail(['#312e81', '#111827', '#a855f7'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.boardTheme.nebulaGlass
   },
   {
     id: 'chess-head-ruby',
@@ -334,7 +334,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Ruby Pawn Heads',
     price: 310,
     description: 'Unlocks an additional pawn head glass preset.',
-    thumbnail: swatchThumbnail(['#b91c1c', '#7f1d1d', '#fecaca'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headRuby
   },
   {
     id: 'chess-head-sapphire',
@@ -343,7 +343,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Sapphire Pawn Heads',
     price: 335,
     description: 'Unlocks an additional pawn head glass preset.',
-    thumbnail: swatchThumbnail(['#2563eb', '#1d4ed8', '#bfdbfe'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headSapphire
   },
   {
     id: 'chess-head-chrome',
@@ -352,7 +352,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Chrome Pawn Heads',
     price: 360,
     description: 'Unlocks an additional pawn head glass preset.',
-    thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headChrome
   },
   {
     id: 'chess-head-gold',
@@ -361,7 +361,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     name: 'Gold Pawn Heads',
     price: 385,
     description: 'Unlocks an additional pawn head glass preset.',
-    thumbnail: swatchThumbnail(['#f59e0b', '#b45309', '#fde68a'])
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
   ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
     id: `chess-hdri-${variant.id}`,


### PR DESCRIPTION
### Motivation
- Replace generic swatch thumbnails with photographer-style thumbnails for Chess Battle Royal pieces, pawn heads and board themes to improve store and menu visuals.
- Include the actual thumbnails as tracked assets so the UI can load dedicated SVG previews instead of generated swatches.

### Description
- Repointed thumbnail references in `webapp/src/config/chessBattleInventoryConfig.js` to the new assets under `/assets/game-art/chess-battle-royal` for `sideColor`, `boardTheme` and `headStyle` entries.
- Added a set of SVG thumbnails for pieces, heads and boards in `webapp/public/assets/game-art/chess-battle-royal/{pieces,heads,boards}` and enabled the folder in `webapp/public/assets/game-art/.gitignore`.
- Generated the SVG thumbnails with a small script (creates consistent 256×256 previews) and wired the new paths into existing store and customization UI code so `option.thumbnail` points to the new assets.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served the pages (Vite reported ready and HMR updates for changed files). 
- Ran the asset-generation Python script to emit the SVGs under `webapp/public/assets/game-art/chess-battle-royal` and verified the files exist and are referenced by the config. 
- Attempted an automated Playwright screenshot to capture the running Chess page, but the headless browser crashed / timed out (SIGSEGV / timeout) so no in-game screenshots were produced; the visual assets and config wiring remain in place for manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831d9ee13483298713c25f3bb3f48e)