### PR TITLE
Show live lineup info as popup above thumbnails

### DIFF
--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -415,19 +415,23 @@ export default function ProjectAchievementsCard() {
                 <div className="absolute right-1 top-1">
                   <InfoIcon infoType="game" infoKey={game.name} label={game.name} />
                 </div>
-                <img
-                  src={thumbnail || game.image}
-                  alt={game.name}
-                  className="h-10 w-10 rounded-md object-cover"
-                  loading="lazy"
-                  onError={(event) => {
-                    event.currentTarget.src = game.image;
-                  }}
-                />
+                <div className="relative flex flex-col items-center">
+                  {expandedInfo.type === 'game' && expandedInfo.key === game.name && (
+                    <div className="absolute bottom-full left-1/2 z-10 mb-1 w-40 -translate-x-1/2 rounded-md border border-border/60 bg-surface/95 p-2 text-[9px] leading-relaxed text-foreground shadow-lg">
+                      {gameInfo}
+                    </div>
+                  )}
+                  <img
+                    src={thumbnail || game.image}
+                    alt={game.name}
+                    className="h-10 w-10 rounded-md object-cover"
+                    loading="lazy"
+                    onError={(event) => {
+                      event.currentTarget.src = game.image;
+                    }}
+                  />
+                </div>
                 <span className="text-[9px] font-semibold text-muted">{game.name}</span>
-                {expandedInfo.type === 'game' && expandedInfo.key === game.name && (
-                  <p className="text-[9px] leading-relaxed text-muted/80">{gameInfo}</p>
-                )}
               </div>
             );
           })}


### PR DESCRIPTION
### Motivation
- The Live Game Lineup needs the info content to appear as a popup anchored above each game thumbnail, while keeping achievement/info behavior for other sections unchanged.

### Description
- Wrap each game thumbnail in a relative container and render a positioned popup above the thumbnail when `expandedInfo.type === 'game'` and `expandedInfo.key === game.name`.
- Use a small tooltip-like element with Tailwind classes (`absolute bottom-full left-1/2 z-10 mb-1 w-40 -translate-x-1/2 rounded-md border bg-surface/95 p-2 shadow-lg`) to display `gameInfo` and remove the previous inline text under the thumbnail.
- Keep the existing `InfoIcon` button and `handleToggleInfo` behavior so only the Live Game Lineup displays the new popup treatment.

### Testing
- Started the web frontend with `npm --prefix webapp run dev` (Vite) and it served successfully on `http://localhost:4173/`.
- Ran a Playwright UI script that opened the page at mobile viewport `430x932`, clicked the lineup info icon, and produced a screenshot artifact `artifacts/live-game-lineup-info.png`, which shows the popup above the thumbnail (script succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983310e36b083299243429b22864620)