### PR TITLE
Pool Royale: pocket chrome/holders visual tweaks, replay foul & cue fixes, in-hand input smoothing, and American 8‑ball rules overhaul

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -1,11 +1,30 @@
+const SOLID_SET = new Set([1, 2, 3, 4, 5, 6, 7]);
+const STRIPE_SET = new Set([9, 10, 11, 12, 13, 14, 15]);
+
+function groupForBall (id) {
+  if (id === 8) return 'black';
+  if (SOLID_SET.has(id)) return 'solid';
+  if (STRIPE_SET.has(id)) return 'stripe';
+  return null;
+}
+
+function opponent (player) {
+  return player === 'A' ? 'B' : 'A';
+}
+
 export class AmericanBilliards {
   constructor () {
     this.state = {
-      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      ballsOnTable: {
+        solids: new Set(SOLID_SET),
+        stripes: new Set(STRIPE_SET),
+        black8: true,
+        cueInPocket: false
+      },
+      assignments: { A: null, B: null },
       currentPlayer: 'A',
-      scores: { A: 0, B: 0 },
       ballInHand: false,
-      foulStreak: { A: 0, B: 0 },
+      isOpenTable: true,
       frameOver: false,
       winner: null
     };
@@ -27,67 +46,113 @@ export class AmericanBilliards {
         winner: s.winner
       };
     }
+
     const current = s.currentPlayer;
-    const opp = current === 'A' ? 'B' : 'A';
-    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const opp = opponent(current);
+    const ownGroup = s.assignments[current];
+    const firstContact = contactOrder[0] ?? null;
+    const firstGroup = typeof firstContact === 'number' ? groupForBall(firstContact) : null;
+    const scratched = pottedList.includes(0) || shot.cueOffTable;
+    const solidsRemaining = s.ballsOnTable.solids.size;
+    const stripesRemaining = s.ballsOnTable.stripes.size;
+    const ownGroupRemaining =
+      ownGroup === 'solid'
+        ? solidsRemaining
+        : ownGroup === 'stripe'
+          ? stripesRemaining
+          : null;
+    const nonBlackRemaining = solidsRemaining + stripesRemaining;
+
     let foul = false;
     let reason = '';
-
-    const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!foul && !firstContact) {
       foul = true;
       reason = 'no contact';
     }
-
-    if (!foul && first !== lowest) {
-      foul = true;
-      reason = 'wrong first contact';
-    }
-
-    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!foul && scratched) {
       foul = true;
       reason = 'scratch';
     }
-
-    const pottedBalls = pottedList.filter(id => id !== 0);
-    const points = pottedBalls.reduce((a, b) => a + b, 0);
-
-    let nextPlayer = current;
-    let ballInHandNext = false;
-    let frameOver = false;
-    let winner = null;
-    const targetScore = 61;
-
-    if (foul) {
-      const foulPoints = Math.max(1, points);
-      s.scores[opp] += foulPoints;
-      // Balls pocketed on a foul are respotted.
-      nextPlayer = opp;
-      s.currentPlayer = opp;
-      ballInHandNext = true;
-      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
-      s.foulStreak[opp] = 0;
-    } else {
-      for (const id of pottedBalls) s.ballsOnTable.delete(id);
-      s.scores[current] += points;
-      s.foulStreak[current] = 0;
-      s.foulStreak[opp] = 0;
-      if (pottedBalls.length === 0) {
-        nextPlayer = opp;
-        s.currentPlayer = opp;
+    if (!foul) {
+      if (s.isOpenTable || !ownGroup) {
+        if (firstGroup === 'black' && nonBlackRemaining > 0) {
+          foul = true;
+          reason = 'contacted black early';
+        }
+      } else if (ownGroupRemaining != null && ownGroupRemaining > 0) {
+        if (firstGroup !== ownGroup) {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      } else if (firstGroup !== 'black') {
+        foul = true;
+        reason = 'must hit 8 ball';
       }
     }
 
-    s.ballInHand = ballInHandNext;
-    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const pottedSolids = pottedList.filter((id) => SOLID_SET.has(id));
+    const pottedStripes = pottedList.filter((id) => STRIPE_SET.has(id));
+    const blackPotted = pottedList.includes(8);
+    const ownClearedBefore =
+      ownGroupRemaining != null ? ownGroupRemaining === 0 : false;
 
-    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
+    if (!foul && blackPotted && !ownClearedBefore) {
+      foul = true;
+      reason = 'potted black early';
+    }
+
+    let frameOver = false;
+    let winner = null;
+    if (blackPotted) {
       frameOver = true;
-      if (s.scores[current] > s.scores[opp]) winner = current;
-      else if (s.scores[opp] > s.scores[current]) winner = opp;
-      else winner = 'TIE';
+      winner = foul ? opp : current;
       s.frameOver = true;
       s.winner = winner;
+    }
+
+    if (!foul) {
+      pottedSolids.forEach((id) => s.ballsOnTable.solids.delete(id));
+      pottedStripes.forEach((id) => s.ballsOnTable.stripes.delete(id));
+      if (blackPotted) s.ballsOnTable.black8 = false;
+      if (pottedList.includes(0)) s.ballsOnTable.cueInPocket = true;
+    }
+
+    if (!foul && s.isOpenTable) {
+      let assigned = null;
+      if (firstGroup === 'solid' && pottedSolids.length > 0) assigned = 'solid';
+      if (firstGroup === 'stripe' && pottedStripes.length > 0) assigned = 'stripe';
+      if (!assigned && pottedSolids.length > 0 && pottedStripes.length === 0) {
+        assigned = 'solid';
+      }
+      if (!assigned && pottedStripes.length > 0 && pottedSolids.length === 0) {
+        assigned = 'stripe';
+      }
+      if (assigned) {
+        s.assignments[current] = assigned;
+        s.assignments[opp] = assigned === 'solid' ? 'stripe' : 'solid';
+        s.isOpenTable = false;
+      }
+    }
+
+    let nextPlayer = current;
+    if (foul) {
+      nextPlayer = opp;
+      s.currentPlayer = opp;
+      s.ballInHand = true;
+    } else if (!frameOver) {
+      const pottedOwn =
+        s.isOpenTable
+          ? pottedSolids.length > 0 || pottedStripes.length > 0
+          : ownGroup === 'solid'
+            ? pottedSolids.length > 0
+            : ownGroup === 'stripe'
+              ? pottedStripes.length > 0
+              : false;
+      if (!pottedOwn) {
+        nextPlayer = opp;
+        s.currentPlayer = opp;
+      }
+      s.ballInHand = false;
     }
 
     return {
@@ -96,9 +161,7 @@ export class AmericanBilliards {
       reason: foul ? reason : undefined,
       potted: pottedList,
       nextPlayer,
-      ballInHandNext,
-      scores: { ...s.scores },
-      currentBall: nextBall,
+      ballInHandNext: s.ballInHand,
       frameOver,
       winner
     };

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -618,8 +618,8 @@ const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually ab
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.52; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.01; // trim the outer fascia extension so the outside edge tucks in slightly
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.35; // trim fascia span so the middle plates finish at the side rail edge
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.92; // trim the outer fascia extension so the outside edge tucks in slightly
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 0.96; // extend the plate ends slightly toward the corner pockets
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.975; // expand the middle fascia slightly so both flanks gain a touch more presence
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.12; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
@@ -1361,7 +1361,7 @@ const POCKET_DROP_ENTRY_VELOCITY = -0.6; // initial downward impulse before grav
 const POCKET_DROP_REST_HOLD_MS = 360; // keep the ball visible on the strap briefly before hiding it
 const POCKET_DROP_SPEED_REFERENCE = 1.4;
 const POCKET_HOLDER_SLIDE = BALL_R * 1.2; // horizontal drift as the ball rolls toward the leather strap
-const POCKET_HOLDER_TILT_RAD = THREE.MathUtils.degToRad(9); // slight angle so potted balls settle against the strap
+const POCKET_HOLDER_TILT_RAD = THREE.MathUtils.degToRad(6.5); // slight angle so potted balls settle against the strap
 const POCKET_LEATHER_TEXTURE_ID = 'fabric_leather_02';
 const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({
   x: (0.08 / 27) * 0.7 / 2,
@@ -1398,8 +1398,8 @@ const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form t
 const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.02; // lift the chrome holder rails so the short L segments meet the ring
 const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
-const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.02; // tighter spacing so potted balls touch on the holder rails
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.78; // keep the ball rest point unchanged while the chrome guides extend
+const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.0; // tighter spacing so potted balls touch on the holder rails
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.3; // keep the ball rest point unchanged while the chrome guides extend
 const POCKET_HOLDER_REST_DROP = BALL_R * 1.98; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
@@ -1409,7 +1409,7 @@ const POCKET_EDGE_STOP_EXTRA_DROP = TABLE.THICK * 0.14; // push the cloth sleeve
 const POCKET_HOLDER_L_LEG = BALL_DIAMETER * 0.92; // extend the short L section so it reaches the ring and guides balls like the reference trays
 const POCKET_HOLDER_L_SPAN = Math.max(POCKET_GUIDE_LENGTH * 0.42, BALL_DIAMETER * 5.2); // longer tray section that actually holds the balls
 const POCKET_HOLDER_L_THICKNESS = POCKET_GUIDE_RADIUS * 3; // thickness shared by both L segments for a sturdy chrome look
-const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.34; // lift the leather strap so it meets the raised holder rails
+const POCKET_STRAP_VERTICAL_LIFT = BALL_R * 0.42; // lift the leather strap so it meets the raised holder rails
 const POCKET_BOARD_TOUCH_OFFSET = -CLOTH_EXTENDED_DEPTH + MICRO_EPS * 2; // raise the pocket bowls until they meet the cloth underside without leaving a gap
 const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve around the pocket cuts
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
@@ -5134,6 +5134,7 @@ const REPLAY_BANNER_VARIANTS = {
   multi: ['Double pot!', 'Two for one!', 'What a combo!'],
   power: ['Power drive!', 'Thunder break!', 'Crushed it!'],
   spin: ['Swerve magic!', 'Spin control!', 'Curved in!'],
+  foul: ['Foul!', 'That’s a foul!', 'Costly foul!'],
   final: ['Final ball!', 'Closing shot!', 'Match winner!'],
   default: ['Good shot!', 'Nice pot!', 'Great touch!']
 };
@@ -18643,7 +18644,7 @@ const powerRef = useRef(hud.power);
             ? {
                 position: serializeVector3Snapshot(cueStick.position),
                 rotation: serializeQuaternionSnapshot(cueStick.quaternion),
-                visible: cueStick.visible ?? true
+                visible: true
               }
             : null;
           shotRecording.frames.push({
@@ -21652,8 +21653,17 @@ const powerRef = useRef(hud.power);
         ) {
           return;
         }
-        const p = project(e);
-        if (p) tryUpdatePlacement(p, false);
+        const coalesced =
+          typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : null;
+        if (coalesced && coalesced.length > 0) {
+          coalesced.forEach((evt) => {
+            const p = project(evt);
+            if (p) tryUpdatePlacement(p, false);
+          });
+        } else {
+          const p = project(e);
+          if (p) tryUpdatePlacement(p, false);
+        }
         e.preventDefault?.();
       };
       const endInHandDrag = (e) => {
@@ -21709,15 +21719,20 @@ const powerRef = useRef(hud.power);
           ) {
             return false;
           }
-          const p = project(e);
-          if (p) {
-            if (inHandDrag.deferred) {
-              inHandDrag.lastPos = p;
-              tryUpdatePlacement(p, false);
-            } else {
-              tryUpdatePlacement(p, false);
+          const coalesced =
+            typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : null;
+          const events = coalesced && coalesced.length > 0 ? coalesced : [e];
+          events.forEach((evt) => {
+            const p = project(evt);
+            if (p) {
+              if (inHandDrag.deferred) {
+                inHandDrag.lastPos = p;
+                tryUpdatePlacement(p, false);
+              } else {
+                tryUpdatePlacement(p, false);
+              }
             }
-          }
+          });
           return true;
         },
         end: (e) => {
@@ -24464,6 +24479,32 @@ const powerRef = useRef(hud.power);
             ? { ...safeState.foul }
             : null;
         }
+        const shotWasFoul = Boolean(safeState?.foul);
+        if (shotWasFoul) {
+          if (replayDecision) {
+            const replayTags = new Set(replayDecision.tags ?? []);
+            replayTags.add('foul');
+            replayDecision = {
+              ...replayDecision,
+              tags: Array.from(replayTags),
+              shouldReplay: true,
+              primaryTag: replayDecision.primaryTag ?? 'foul'
+            };
+          } else {
+            replayDecision = {
+              shouldReplay: true,
+              banner: selectReplayBanner('foul'),
+              zoomOnly: false,
+              tags: ['foul'],
+              primaryTag: 'foul'
+            };
+          }
+          replayBannerText = replayDecision.banner ?? selectReplayBanner('foul');
+          replayAccent = replayDecision.primaryTag ?? 'foul';
+          shouldStartReplay =
+            !skipAllReplaysRef.current &&
+            Boolean(shotRecording?.frames?.length);
+        }
         const isFinalShot =
           Boolean(safeState?.frameOver) && (shotRecording?.frames?.length ?? 0) > 1;
         if (isFinalShot) {
@@ -24531,7 +24572,6 @@ const powerRef = useRef(hud.power);
         if (safeState?.foul) {
           showRuleToast('Foul');
         }
-        const shotWasFoul = Boolean(safeState?.foul);
         const potCount = potted.filter((entry) => entry.id !== 'cue').length;
         if (potted.length) {
           potted.forEach((entry) => {


### PR DESCRIPTION
### Motivation
- Align Pool Royale table visuals to reference: trim middle chrome plates to finish at the side rail and adjust pocket holder geometry so potted balls rest cleanly against the leather strap.  
- Improve user experience for ball-in-hand placement by making drag input more responsive and consistent.  
- Ensure replay captures fouls and always shows the cue stick, and mark foul shots as replay-worthy so replays clearly show the foul and cue.  
- Fix American (8-ball US) rule handling so solids/stripes assignment, 8-ball logic, and HUD/ball-on state are correct and consistent.

### Description
- Adjusted chrome/pocket constants to trim chrome plates and tune side-plate reach: `CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE` and `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Tuned pocket-holder geometry for potted ball behaviour: reduced `POCKET_HOLDER_TILT_RAD`, tightened `POCKET_HOLDER_REST_SPACING`/`POCKET_HOLDER_REST_PULLBACK`, and raised `POCKET_STRAP_VERTICAL_LIFT` in `webapp/src/pages/Games/PoolRoyale.jsx`.  
- Replay and cue visibility changes: added a `foul` replay banner variant and tag, force foul shots to be replay-candidate, and always capture cue snapshot as visible in recorded frames (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Input responsiveness for ball-in-hand: use `getCoalescedEvents()` where available and iterate coalesced pointer events in in-hand handlers and `inHandPlacementApi` to improve placement smoothing (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Rewrote American 8-ball rules engine to solids/stripes model: replaced and added `lib/americanBilliards.js` implementing solids/stripes assignment, fouls, black (8) handling, ball-in-hand, and next-player logic.  
- Updated rule serialization/deserialization and game-state handling for the american variant in `src/rules/PoolRoyaleRules.ts`, including new `AmericanSerializedState` shape, `serialize/applyAmericanState`, `computeAmericanBallOn`, and adjusted initial frame metadata for the american variant.  
- Misc: updated places that compute `ballOn`/HUD and ensured the american apply-shot pipeline uses the new state shape and ball-on computation.

Files changed (high-level): `webapp/src/pages/Games/PoolRoyale.jsx`, `lib/americanBilliards.js`, `src/rules/PoolRoyaleRules.ts`.

### Testing
- No automated tests were executed as part of this change; changes were implemented and committed locally and require runtime validation in the app to verify visual alignment, in-hand responsiveness, replay behaviour, and rule correctness.  
- Manual validation recommended: run the Pool Royale scene, verify chrome plates finish at side rails, middle-pocket holder/strap stops balls correctly without overlap, ball-in-hand placement is smoother (try rapid pointer moves / touch), fouls trigger and display replays with the cue stick visible, and play through American 8-ball scenarios focusing on last-8 behaviour (potting 8-ball conditions, fouls on 8) to confirm rule correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832f9f539c8329a3bb4a13058aba5f)