### PR TITLE
Pool Royale: refine chrome & pocket holders, improve in-hand placement and replay, fix UK 8‑ball parsing

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -220,7 +220,7 @@ export class UkPool {
       shotsNext = 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = true;
+      s.mustPlayFromBaulk = Boolean(isBreak);
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -171,13 +171,22 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
 }
 
 function parseUkColour(value: unknown): UkColour | null {
+  if (typeof value === 'number') {
+    if (value === 8) return 'black';
+    return null;
+  }
   if (typeof value !== 'string') return null;
   const lower = value.toLowerCase();
+  if (lower === 'cue') return 'cue';
+  if (lower.startsWith('ball_')) {
+    const numeric = Number.parseInt(lower.replace('ball_', ''), 10);
+    if (numeric === 8) return 'black';
+  }
+  if (lower === '8') return 'black';
   if (lower.startsWith('yellow')) return 'blue';
   if (lower.startsWith('blue')) return 'blue';
   if (lower.startsWith('red')) return 'red';
   if (lower.startsWith('black')) return 'black';
-  if (lower === 'cue') return 'cue';
   return null;
 }
 


### PR DESCRIPTION
### Motivation
- Make the table finishing match the photo by trimming the middle-pocket chrome plates and adjusting holder geometry so potted balls settle against the leather strap without overlap.
- Improve player experience when holding the cue ball by making in-hand placement faster and screen-direction mapping more accurate across variants.
- Make replays reliable and informative by recording static camera snapshots (including pocket cams), showing cue stick animation, and surfacing fouls during replay. 
- Fix UK 8‑ball parsing and baulk logic so the 8-ball and must-play-from-baulk rules behave correctly.

### Description
- Visual/mesh tweaks: reduced side chrome plate span and width scales (`CHROME_SIDE_PLATE_POCKET_SPAN_SCALE`, `CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE`) and reduced pocket guide drop; adjusted pocket holder rest spacing and pullback to keep potted balls flush with the leather strap (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- In-hand placement: added a screen-delta based placement helper so dragging maps more responsively to table coordinates, introduced `IN_HAND_DRAG_SPEED`, tracked last screen sample to compute deltas, and allowed full-table in-hand placement when not break-restricted for UK/American/9‑ball (JS changes and pointer projection refactors in `PoolRoyale.jsx`).
- Replay & cameras: capture and cache static replay camera snapshots keyed by camera type (overhead vs pocket) so replay playback can hold a camera without continuously moving; ensure cue stick snapshots are recorded and always visible during replay frames; mark replay frames with camera keys and force a frame cut when the camera key changes so pocket cameras can be shown cleanly (changes in `PoolRoyale.jsx`).
- Replay foul visibility: when a shot resolves to a foul, tag the replay decision to force a replay and show a foul banner in the replay UI (logic in `PoolRoyale.jsx`).
- Rules/8‑ball fixes: enhance UK colour parsing to recognize numeric and `BALL_8` identifiers and prevent false 8-ball detection errors (`src/rules/PoolRoyaleRules.ts`), and only set `mustPlayFromBaulk` after fouls during the break to avoid inappropriate baulk restrictions (`lib/poolUk8Ball.js`).

### Testing
- Manual code inspection and `git` commit were performed locally; no automated unit or integration tests were executed as part of this change. 
- Changes are limited to UI/UX, replay recording, and rules parsing code paths; recommend running game smoke checks and playing brief matches in the three variants (UK/9ball/American) to validate: chrome/pocket visuals, in-hand placement behavior before/after break, replay camera switching (including pocket cams) and foul display, and correct 8-ball win/foul handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832f9f539c8329a3bb4a13058aba5f)