### PR TITLE
Adjust Pool Royale pocket chrome, pocket-holder geometry, in-hand responsiveness, and replay cue fallback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -615,11 +615,11 @@ const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so 
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0; // keep fascia placement identical to snooker
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.38; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.26; // trim the side fascia reach so the middle chrome ends cleanly at the side rail edge
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.22; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1.01; // trim the outer fascia extension so the outside edge tucks in slightly
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.14; // trim fascia span so the middle plates finish at the side rail edge
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.96; // reduce outside reach so the chrome ends flush with the side rail
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 0.96; // extend the plate ends slightly toward the corner pockets
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.975; // expand the middle fascia slightly so both flanks gain a touch more presence
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.12; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
@@ -1388,18 +1388,19 @@ const POCKET_NET_VERTICAL_LIFT = BALL_R * 0.16; // match Snooker Royal pocket ne
 const POCKET_NET_HEX_REPEAT = 3;
 const POCKET_NET_HEX_RADIUS_RATIO = 0.085;
 const POCKET_GUIDE_RADIUS = BALL_R * 0.075; // slimmer chrome rails so potted balls visibly ride the three thin holders
-const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.35, BALL_DIAMETER * 7.6); // stretch the holder run so it comfortably fits 7 balls
+const POCKET_GUIDE_LENGTH = Math.max(POCKET_NET_DEPTH * 1.28, BALL_DIAMETER * 7.2); // pull the holder run slightly inward toward the pocket
 const POCKET_GUIDE_DROP = BALL_R * 0.06;
 const POCKET_GUIDE_SPREAD = BALL_R * 0.48;
 const POCKET_GUIDE_RING_CLEARANCE = BALL_R * 0.08; // start the chrome rails just outside the ring to keep the mouth open
 const POCKET_GUIDE_RING_OVERLAP = POCKET_NET_RING_TUBE_RADIUS * 1.05; // allow the L-arms to peek past the ring without blocking the pocket mouth
 const POCKET_GUIDE_STEM_DEPTH = BALL_DIAMETER * 1.18; // lengthen the elbow so each rail meets the ring with a ball-length guide
 const POCKET_GUIDE_FLOOR_DROP = BALL_R * 0.14; // drop the centre rail to form the floor of the holder
-const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.02; // lift the chrome holder rails so the short L segments meet the ring
+const POCKET_GUIDE_VERTICAL_DROP = BALL_R * 0.01; // lift the chrome holder rails so the short L segments sit higher near the ring
 const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments toward the leather strap
+const POCKET_SIDE_GUIDE_STRAP_PULL = BALL_R * 0.08; // push only the side rails toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.04; // keep balls flush without overlap as they settle against the strap
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.3; // pull the resting spot closer to the leather strap
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.05; // pull the resting spot inward toward the pocket and strap
 const POCKET_HOLDER_REST_DROP = BALL_R * 1.98; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
@@ -5093,7 +5094,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.38; // pull the orbit back while the cue ball is in-hand for a wider placement view
-const IN_HAND_DRAG_SPEED = 1.35; // boost in-hand drag responsiveness so screen movement maps cleanly to table placement
+const IN_HAND_DRAG_SPEED = 2.2; // boost in-hand drag responsiveness for faster, 60fps-feel placement response
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;
@@ -7803,10 +7804,12 @@ export function Table3D(
       const middleSway = isMiddlePocket ? POCKET_MIDDLE_HOLDER_SWAY * (pocketId === 'TM' ? -1 : 1) : 0;
       const lateralOffset = (i - 1) * POCKET_GUIDE_SPREAD + middleSway * (i - 1);
       const isCenterGuide = i === 1;
+      const strapSidePull = isCenterGuide ? 0 : POCKET_SIDE_GUIDE_STRAP_PULL;
       const start = ringAnchor
         .clone()
         .addScaledVector(outwardDir, railStartOffset)
         .addScaledVector(sideDir, lateralOffset)
+        .addScaledVector(strapDir, strapSidePull)
         .add(
           new THREE.Vector3(
             0,
@@ -18834,11 +18837,15 @@ const powerRef = useRef(hud.power);
             return true;
           };
           if (!stroke) {
-            if (applyCueSnapshot()) return;
+            const snapshotApplied = applyCueSnapshot();
             const cuePath = playback?.cuePath ?? [];
             const cueBall = cueRef.current || cue;
             const cueBallPos = cueBall?.mesh?.position ?? null;
-            const cuePos = cueBallPos ? TMP_VEC3_A.copy(cueBallPos) : cuePath[0]?.pos?.clone?.() ?? null;
+            const cuePos =
+              cueBallPos
+                ? TMP_VEC3_A.copy(cueBallPos)
+                : cuePath[0]?.pos?.clone?.() ??
+                  (snapshotApplied ? cueStick.position.clone() : null);
             if (!cuePos) {
               cueStick.visible = false;
               cueAnimating = false;
@@ -21441,10 +21448,12 @@ const powerRef = useRef(hud.power);
         }
         return best;
       };
-      const defaultInHandPosition = () =>
-        clampInHandPosition(
-          new THREE.Vector2(0, allowFullTableInHand() ? 0 : baulkZ)
+      const defaultInHandPosition = ({ forceBaulk = false } = {}) => {
+        const restrictToBaulk = forceBaulk || !allowFullTableInHand();
+        return clampInHandPosition(
+          new THREE.Vector2(0, restrictToBaulk ? baulkZ : 0)
         );
+      };
       const inHandDrag = inHandDragRef.current;
       const updateCuePlacement = (pos) => {
         if (!cue || !pos) return;
@@ -21804,8 +21813,11 @@ const powerRef = useRef(hud.power);
       dom.addEventListener('pointercancel', endInHandDrag);
       window.addEventListener('pointercancel', endInHandDrag);
       if (hudRef.current?.inHand) {
-        const startPos = defaultInHandPosition();
-        if (startPos) {
+        const shouldResetCue = !cue?.active || isBreakRestrictedInHand();
+        const startPos = shouldResetCue
+          ? defaultInHandPosition({ forceBaulk: isBreakRestrictedInHand() })
+          : null;
+        if (startPos && cue) {
           cue.active = false;
           updateCuePlacement(startPos);
           cue.active = true;
@@ -24768,7 +24780,7 @@ const powerRef = useRef(hud.power);
             if (cueBallPotted) {
               cue.active = false;
               removePocketDropEntry(cue.id);
-              const fallback = defaultInHandPosition();
+              const fallback = defaultInHandPosition({ forceBaulk: true });
               if (fallback) {
                 updateCuePlacement(fallback);
               } else {


### PR DESCRIPTION
### Motivation
- Match photographed table: trim middle-pocket chrome plates so the side chrome finishes at the side-rail edge and nudge pocket-holder rails/strap slightly inward for a tighter fit. 
- Make replay cue visible and animate pulling-back/forward when replay data is sparse so the cue movement reads correctly. 
- Fix ball-in-hand flow: when a foul occurs but the cue ball was not potted leave the cue ball where it is and let the player move it, and when the cue ball is potted place it in the baulk/white-line area but allow free placement afterwards. 
- Improve responsiveness of in-hand drag so the placement UI better matches finger movement (target ~60fps feel).

### Description
- Updated chrome fascia constants to reduce middle-plate span and outer extension by changing `CHROME_SIDE_PLATE_POCKET_SPAN_SCALE`, `CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE`, and `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` in `PoolRoyale.jsx`. 
- Pulled pocket-holder geometry inward and adjusted holder params by reducing `POCKET_GUIDE_LENGTH`, lowering `POCKET_GUIDE_VERTICAL_DROP`, nudging `POCKET_HOLDER_REST_PULLBACK`, and adding `POCKET_SIDE_GUIDE_STRAP_PULL`; applied a per-guide `strapSidePull` so only the side rails shift. 
- Increased in-hand drag responsiveness by raising `IN_HAND_DRAG_SPEED` to `2.2` and revised in-hand placement logic by replacing `defaultInHandPosition()` with `defaultInHandPosition({ forceBaulk = false })` and only resetting the cue placement at in-hand start when necessary (e.g. break/baulk restrictions). 
- Ensured replay cue stroke uses fallback cue snapshots when stroke frames are missing by applying `applyCueSnapshot()` and using its position as a fallback for `cuePos` so the cue stick still animates during replay playback. 
- Minor tidy-ups around pocket/strap placement math to keep center guide unchanged while shifting side guides inward; all edits are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Dev server launched with `npm --prefix webapp run dev` and Vite reported the site as ready, validating the app builds and serves locally. 
- Attempted a visual smoke check by running a Playwright script to capture `/games/poolroyale`, but the Playwright run timed out (no screenshot produced). 
- No unit test suite was executed against these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698340127bc88329b50797b2a8b74120)