### PR TITLE
Update chess piece store thumbnails

### DIFF
--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f59e0b'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#f59e0b'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#fde68a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#8b5cf6'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#8b5cf6'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#ddd6fe' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#7aa2f7'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#7aa2f7'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#e2e8f0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ff6b35'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#ff6b35'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#fed7aa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#14532d'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#14532d'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#86efac' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f8fafc'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#f8fafc'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#cbd5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#10b981'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#10b981'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#bbf7d0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ef4444'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#ef4444'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#fecaca' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,19 +1,56 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#3b82f6'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='base' x1='0' y1='1' x2='1' y2='0'>
+      <stop offset='0%' stop-color='#0f172a'/>
+      <stop offset='100%' stop-color='#3b82f6'/>
+    </linearGradient>
+    <radialGradient id='shine' cx='35%' cy='22%' r='68%'>
+      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
+      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
+    </radialGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='26' y='22' width='204' height='212' rx='28' fill='#0f172a' opacity='0.6'/>
+  <circle cx='94' cy='70' r='90' fill='url(#shine)'/>
+  <g fill='url(#piece)' stroke='#bfdbfe' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(24 38)'>
+      <circle cx='24' cy='16' r='10'/>
+      <path d='M14 32c3-10 7-16 10-16s7 6 10 16z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(104 34)'>
+      <rect x='12' y='8' width='24' height='10' rx='3'/>
+      <rect x='10' y='18' width='28' height='18' rx='6'/>
+      <rect x='8' y='36' width='32' height='10' rx='4'/>
+      <rect x='14' y='4' width='6' height='6'/>
+      <rect x='24' y='4' width='6' height='6'/>
+    </g>
+    <g transform='translate(184 36)'>
+      <path d='M14 42h28l-4-18-10-10-8 4-6-8-6 6 6 12z'/>
+      <rect x='12' y='42' width='32' height='8' rx='4'/>
+    </g>
+    <g transform='translate(24 128)'>
+      <circle cx='24' cy='14' r='8'/>
+      <path d='M14 24c4-8 16-8 20 0l6 16H8z'/>
+      <rect x='10' y='40' width='28' height='8' rx='4'/>
+    </g>
+    <g transform='translate(104 122)'>
+      <circle cx='12' cy='16' r='5'/>
+      <circle cx='24' cy='12' r='5'/>
+      <circle cx='36' cy='16' r='5'/>
+      <path d='M8 28l6-12 10 10 10-10 6 12z'/>
+      <rect x='10' y='34' width='28' height='10' rx='5'/>
+    </g>
+    <g transform='translate(184 122)'>
+      <rect x='22' y='4' width='4' height='12'/>
+      <rect x='18' y='10' width='12' height='4'/>
+      <rect x='14' y='16' width='20' height='20' rx='6'/>
+      <rect x='10' y='38' width='28' height='8' rx='4'/>
+    </g>
+  </g>
+  <rect x='50' y='210' width='156' height='10' rx='5' fill='url(#base)' opacity='0.75'/>
 </svg>


### PR DESCRIPTION
### Motivation
- Fix missing/placeholder thumbnails for Chess Battle Royal store items and bring piece thumbnails in line with the Snake & Ladder token styling so each thumbnail shows the full set silhouettes across color variants.
- Use cohesive thumbnail shapes and gradients so piece thumbnails match store UI previews and the table menu setup visuals.

### Description
- Replaced/redrew the Chess Battle Royal piece SVG thumbnails under `webapp/public/assets/game-art/chess-battle-royal/pieces/` for the variants: `amberGlow`, `amethyst`, `arcticDrift`, `cinderBlaze`, `darkForest`, `marble`, `mintVale`, `roseMist`, and `royalWave`.
- Thumbnails now render a full-set silhouette composition with updated gradients, background plate, shine, and base strip to match the swatch/shape style used by other games.
- Kept references intact so existing configs (e.g. `webapp/src/config/chessBattleInventoryConfig.js`) continue to point at the updated SVGs.

### Testing
- Ran the webapp dev pipeline via `npm run dev`, which executed asset generation and build steps and produced build metadata in the webapp public folder; the dev server started successfully before the run was cancelled.
- Attempted an automated visual check with Playwright to capture `/store/chess`, but the headless Chromium process crashed with a SIGSEGV in this environment, so no screenshot was produced.
- No failing automated tests were observed related to these asset updates; visual verification is recommended in a full browser environment to confirm rendering on-device.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698349a6eb6883298fcc5ead082ee60a)