### PR TITLE
Update chess piece thumbnails for store

### DIFF
--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f59e0b'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fde68a'/>
+      <stop offset='100%' stop-color='#f59e0b'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#8b5cf6'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#ddd6fe'/>
+      <stop offset='100%' stop-color='#8b5cf6'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#7aa2f7'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#e2e8f0'/>
+      <stop offset='100%' stop-color='#7aa2f7'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ff6b35'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fed7aa'/>
+      <stop offset='100%' stop-color='#ff6b35'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#14532d'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#86efac'/>
+      <stop offset='100%' stop-color='#14532d'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f8fafc'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#cbd5f5'/>
+      <stop offset='100%' stop-color='#f8fafc'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#10b981'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#bbf7d0'/>
+      <stop offset='100%' stop-color='#10b981'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ef4444'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fecaca'/>
+      <stop offset='100%' stop-color='#ef4444'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,19 +1,51 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#3b82f6'/>
       <stop offset='100%' stop-color='#1f2937'/>
     </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#bfdbfe'/>
+      <stop offset='100%' stop-color='#3b82f6'/>
+    </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g transform='translate(20 28)'>
+    <g transform='translate(0 0)'>
+      <circle cx='32' cy='18' r='9' fill='url(#pieceAlt)'/>
+      <rect x='24' y='28' width='16' height='18' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='46' width='28' height='8' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(72 0)'>
+      <path d='M20 48h24c-1-12-6-23-14-28l5-10h-12l-5 12 6 8c-2 4-4 8-4 18z' fill='url(#piece)'/>
+      <rect x='18' y='48' width='28' height='6' rx='3' fill='#1f2937' opacity='0.65'/>
+      <circle cx='36' cy='16' r='4' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(144 0)'>
+      <circle cx='32' cy='16' r='8' fill='url(#pieceAlt)'/>
+      <path d='M24 26c2-6 6-10 8-10s6 4 8 10l-4 12h-8l-4-12z' fill='url(#piece)'/>
+      <rect x='20' y='42' width='24' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='29' y='10' width='6' height='12' transform='rotate(45 32 16)' fill='#1f2937' opacity='0.4'/>
+    </g>
+    <g transform='translate(0 92)'>
+      <rect x='18' y='18' width='28' height='26' rx='4' fill='url(#piece)'/>
+      <rect x='16' y='44' width='32' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+      <rect x='16' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='28' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+      <rect x='40' y='12' width='8' height='6' rx='1' fill='url(#pieceAlt)'/>
+    </g>
+    <g transform='translate(72 92)'>
+      <circle cx='18' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='32' cy='12' r='4' fill='url(#pieceAlt)'/>
+      <circle cx='46' cy='16' r='4' fill='url(#pieceAlt)'/>
+      <path d='M20 22h24l-4 20h-16l-4-20z' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+    <g transform='translate(144 92)'>
+      <rect x='30' y='8' width='4' height='14' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='26' y='12' width='12' height='4' rx='2' fill='url(#pieceAlt)'/>
+      <rect x='24' y='20' width='16' height='22' rx='6' fill='url(#piece)'/>
+      <rect x='18' y='44' width='28' height='10' rx='4' fill='#1f2937' opacity='0.65'/>
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
### Motivation
- Fill missing/insufficient chess piece thumbnails in the store and make chess piece previews show full sets per color variant. 
- Match the thumbnail style used by the Snake & Ladder token previews so chess pieces display consistent shapes and color swatches across the store UI.

### Description
- Replaced/updated the chess piece thumbnail SVGs under `webapp/public/assets/game-art/chess-battle-royal/pieces` to render a full-set layout and two-stop gradients per color (primary + accent). 
- Updated nine color variants: `amberGlow`, `amethyst`, `arcticDrift`, `cinderBlaze`, `darkForest`, `marble`, `mintVale`, `roseMist`, and `royalWave` with the new multi-piece SVG template. 
- The new SVGs use `linearGradient` IDs `piece` and `pieceAlt` and a compact grid of piece silhouettes so store previews show all piece types and color accents. 
- Committed asset changes and verified thumbnails are referenced by the existing store config (`CHESS_BATTLE_STORE_ITEMS`) without code changes to store logic.

### Testing
- Ran a quick node script to scan store item sets for missing `thumbnail` values and observed no missing thumbnails (script completed successfully). 
- Started the webapp dev server using `npm --prefix webapp run dev` and used Playwright to load `/store/chessbattleroyal` and capture a screenshot at `artifacts/store-chess-thumbnails.png`, which completed successfully. 
- No unit tests were required or modified for this asset-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698349a6eb6883298fcc5ead082ee60a)