### PR TITLE
Match Chess Battle Royal thumbnails to Snake & Ladder token lineup

### DIFF
--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#f59e0b'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fde68a'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fde68a'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fde68a'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fde68a'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fde68a'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#fde68a'/>
+      <circle cx='10' cy='5' r='3' fill='#fde68a'/>
+      <circle cx='15' cy='7' r='3' fill='#fde68a'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#fde68a'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#fde68a'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#fde68a'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#fde68a'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fde68a'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fde68a'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fde68a'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fde68a'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fde68a'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fde68a'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f59e0b'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f59e0b'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f59e0b'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#8b5cf6'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#ddd6fe'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#ddd6fe'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#ddd6fe'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#ddd6fe'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#ddd6fe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#ddd6fe'/>
+      <circle cx='10' cy='5' r='3' fill='#ddd6fe'/>
+      <circle cx='15' cy='7' r='3' fill='#ddd6fe'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#ddd6fe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#ddd6fe'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#ddd6fe'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#ddd6fe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#ddd6fe'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#ddd6fe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#ddd6fe'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#ddd6fe'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#ddd6fe'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#ddd6fe'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#8b5cf6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#8b5cf6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#8b5cf6'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#7aa2f7'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#e2e8f0'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#e2e8f0'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#e2e8f0'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#e2e8f0'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#e2e8f0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#e2e8f0'/>
+      <circle cx='10' cy='5' r='3' fill='#e2e8f0'/>
+      <circle cx='15' cy='7' r='3' fill='#e2e8f0'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#e2e8f0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#e2e8f0'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#e2e8f0'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#e2e8f0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#e2e8f0'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#e2e8f0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#e2e8f0'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#e2e8f0'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#e2e8f0'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#e2e8f0'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#7aa2f7'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#7aa2f7'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#7aa2f7'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#ff6b35'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fed7aa'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fed7aa'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fed7aa'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fed7aa'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fed7aa'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#fed7aa'/>
+      <circle cx='10' cy='5' r='3' fill='#fed7aa'/>
+      <circle cx='15' cy='7' r='3' fill='#fed7aa'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#fed7aa'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#fed7aa'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#fed7aa'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#fed7aa'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fed7aa'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fed7aa'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fed7aa'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fed7aa'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fed7aa'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fed7aa'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ff6b35'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ff6b35'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ff6b35'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#14532d'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#86efac'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#86efac'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#86efac'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#86efac'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#86efac'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#86efac'/>
+      <circle cx='10' cy='5' r='3' fill='#86efac'/>
+      <circle cx='15' cy='7' r='3' fill='#86efac'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#86efac'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#86efac'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#86efac'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#86efac'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#86efac'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#86efac'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#86efac'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#86efac'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#86efac'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#86efac'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#14532d'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#14532d'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#14532d'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#f8fafc'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#cbd5f5'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#cbd5f5'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#cbd5f5'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#cbd5f5'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#cbd5f5'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#cbd5f5'/>
+      <circle cx='10' cy='5' r='3' fill='#cbd5f5'/>
+      <circle cx='15' cy='7' r='3' fill='#cbd5f5'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#cbd5f5'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#cbd5f5'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#cbd5f5'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#cbd5f5'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#cbd5f5'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#cbd5f5'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#cbd5f5'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#cbd5f5'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#cbd5f5'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#cbd5f5'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#f8fafc'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#f8fafc'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#f8fafc'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#10b981'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#bbf7d0'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#bbf7d0'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#bbf7d0'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#bbf7d0'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#bbf7d0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#bbf7d0'/>
+      <circle cx='10' cy='5' r='3' fill='#bbf7d0'/>
+      <circle cx='15' cy='7' r='3' fill='#bbf7d0'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#bbf7d0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#bbf7d0'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#bbf7d0'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#bbf7d0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#bbf7d0'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#bbf7d0'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#bbf7d0'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#bbf7d0'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#bbf7d0'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#bbf7d0'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#10b981'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#10b981'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#10b981'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#ef4444'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fecaca'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fecaca'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fecaca'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fecaca'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fecaca'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#fecaca'/>
+      <circle cx='10' cy='5' r='3' fill='#fecaca'/>
+      <circle cx='15' cy='7' r='3' fill='#fecaca'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#fecaca'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#fecaca'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#fecaca'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#fecaca'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#fecaca'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#fecaca'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#fecaca'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#fecaca'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#fecaca'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#fecaca'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#ef4444'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#ef4444'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#ef4444'/>
+    </g>
+    
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,19 +1,118 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
-  <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
-      <stop offset='0%' stop-color='#3b82f6'/>
-      <stop offset='100%' stop-color='#1f2937'/>
-    </linearGradient>
-  </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <g>
+
+    <g transform='translate(24 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#bfdbfe'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#bfdbfe'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(50 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#bfdbfe'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(76 64)'>
+      <circle cx='10' cy='7' r='4' fill='#bfdbfe'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#bfdbfe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(102 64)'>
+      <circle cx='5' cy='7' r='3' fill='#bfdbfe'/>
+      <circle cx='10' cy='5' r='3' fill='#bfdbfe'/>
+      <circle cx='15' cy='7' r='3' fill='#bfdbfe'/>
+      <path d='M5 10h10l-2 10h-6l-2-10z' fill='#bfdbfe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(128 64)'>
+      <rect x='9' y='2' width='2' height='6' rx='1' fill='#bfdbfe'/>
+      <rect x='6' y='4' width='8' height='2' rx='1' fill='#bfdbfe'/>
+      <rect x='6' y='8' width='8' height='12' rx='3' fill='#bfdbfe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(154 64)'>
+      <circle cx='10' cy='7' r='4' fill='#bfdbfe'/>
+      <path d='M6 12c1-3 3-5 4-5s3 2 4 5l-2 8h-4l-2-8z' fill='#bfdbfe'/>
+      <rect x='4' y='20' width='12' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(180 64)'>
+      <path d='M4 22h12c-1-6-4-10-8-12l2-6h-6l-2 6 4 4c-1 2-2 4-2 8z' fill='#bfdbfe'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(206 64)'>
+      <rect x='4' y='4' width='12' height='6' rx='1' fill='#bfdbfe'/>
+      <rect x='3' y='10' width='14' height='12' rx='2' fill='#bfdbfe'/>
+      <rect x='2' y='22' width='16' height='4' rx='2' fill='#bfdbfe'/>
+    </g>
+    
+
+    <g transform='translate(24 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(50 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(76 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(102 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(128 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(154 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(180 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+
+    <g transform='translate(206 110)'>
+      <circle cx='10' cy='7' r='5' fill='#3b82f6'/>
+      <rect x='6' y='12' width='8' height='10' rx='3' fill='#3b82f6'/>
+      <rect x='3' y='22' width='14' height='4' rx='2' fill='#3b82f6'/>
+    </g>
+    
+  </g>
 </svg>


### PR DESCRIPTION
### Motivation
- Ensure visual consistency between Chess Battle Royal store previews and the Snake & Ladder token thumbnails by using the same shape/style for piece thumbnails.
- Make store and menu previews show the full starting lineup (back rank + pawns) so each color variant communicates the complete set at a glance.
- Simplify and standardize thumbnail art so color palettes map clearly to primary/accent fills used on the board start positions.

### Description
- Rewrote the thumbnail SVG assets for nine color variants under `webapp/public/assets/game-art/chess-battle-royal/pieces` (`amberGlow`, `amethyst`, `arcticDrift`, `cinderBlaze`, `darkForest`, `marble`, `mintVale`, `roseMist`, `royalWave`) to render a full back rank above a pawn row laid out like the Snake & Ladder token setup.
- Replaced previous gradient/defs-based artwork with compact silhouette/grouped shapes painted using each palette's primary and accent colors so thumbnails match the token visual language.
- Unified canvas/background to the same rounded-square style used by token thumbnails and arranged pieces in the same left-to-right board-order lineup.
- This change is asset-only and does not modify store logic, configs, or runtime code that references these thumbnails.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and the server came up successfully.
- Ran a Playwright script to load `/store/chessbattleroyal` and captured a screenshot saved to `artifacts/store-chess-thumbnails.png`, which completed successfully.
- No unit tests were changed as this is an asset-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698349a6eb6883298fcc5ead082ee60a)