### PR TITLE
Align chess piece thumbnails with Snake & Ladder token lineup

### DIFF
--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f59e0b'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fde68a'/>
+      <stop offset='100%' stop-color='#f59e0b'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#8b5cf6'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#ddd6fe'/>
+      <stop offset='100%' stop-color='#8b5cf6'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#7aa2f7'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#e2e8f0'/>
+      <stop offset='100%' stop-color='#7aa2f7'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ff6b35'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fed7aa'/>
+      <stop offset='100%' stop-color='#ff6b35'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#14532d'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#86efac'/>
+      <stop offset='100%' stop-color='#14532d'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#f8fafc'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#cbd5f5'/>
+      <stop offset='100%' stop-color='#f8fafc'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#10b981'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#bbf7d0'/>
+      <stop offset='100%' stop-color='#10b981'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#ef4444'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#fecaca'/>
+      <stop offset='100%' stop-color='#ef4444'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,19 +1,32 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
-      <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
-    </radialGradient>
-    <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
+    <linearGradient id='piece' x1='0' y1='0' x2='1' y2='1'>
       <stop offset='0%' stop-color='#3b82f6'/>
-      <stop offset='100%' stop-color='#1f2937'/>
+      <stop offset='100%' stop-color='#111827'/>
+    </linearGradient>
+    <linearGradient id='pieceAlt' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#bfdbfe'/>
+      <stop offset='100%' stop-color='#3b82f6'/>
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <rect x='18' y='52' width='220' height='152' rx='24' fill='#0f172a' opacity='0.65'/>
+  <g font-family="'DejaVu Sans','Segoe UI Symbol','Noto Sans Symbols2','Apple Symbols',sans-serif" font-size='26' font-weight='700' text-anchor='middle'>
+    <text x='30' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='58' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='86' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='114' y='108' fill='url(#pieceAlt)'>♛</text>
+    <text x='142' y='108' fill='url(#pieceAlt)'>♚</text>
+    <text x='170' y='108' fill='url(#pieceAlt)'>♝</text>
+    <text x='198' y='108' fill='url(#pieceAlt)'>♞</text>
+    <text x='226' y='108' fill='url(#pieceAlt)'>♜</text>
+    <text x='30' y='156' fill='url(#piece)'>♟</text>
+    <text x='58' y='156' fill='url(#piece)'>♟</text>
+    <text x='86' y='156' fill='url(#piece)'>♟</text>
+    <text x='114' y='156' fill='url(#piece)'>♟</text>
+    <text x='142' y='156' fill='url(#piece)'>♟</text>
+    <text x='170' y='156' fill='url(#piece)'>♟</text>
+    <text x='198' y='156' fill='url(#piece)'>♟</text>
+    <text x='226' y='156' fill='url(#piece)'>♟</text>
+  </g>
 </svg>


### PR DESCRIPTION
### Motivation
- Make Chess Battle Royal side-color thumbnails match the Snake & Ladder token thumbnails and display the full starting lineup as in the official board setup. 

### Description
- Replaced the chess-piece thumbnails for nine color variants under `webapp/public/assets/game-art/chess-battle-royal/pieces` (`amberGlow`, `amethyst`, `arcticDrift`, `cinderBlaze`, `darkForest`, `marble`, `mintVale`, `roseMist`, `royalWave`) with a two-rank lineup (back rank + pawns) sized and arranged to match the token preview style. 
- New SVGs use two gradients (`piece` and `pieceAlt`), a dark inset panel background and Unicode chess glyphs arranged across fixed `x`/`y` positions so previews mirror the table-start arrangement. 
- Implemented a small generation script to produce consistent SVG templates and palette-specific gradient stops for each variant.

### Testing
- Generated the SVG assets and started the dev server with `npm --prefix webapp run dev`, and the server reported ready. 
- Ran a Playwright script that loaded `/store/chessbattleroyal` at a mobile viewport and saved a screenshot to `artifacts/store-chess-thumbnails.png`, which completed successfully. 
- No unit tests were modified as this is an asset-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698349a6eb6883298fcc5ead082ee60a)