### PR TITLE
Update chess piece thumbnails in store assets

### DIFF
--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amberGlow.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#fde68a' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#fde68a' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fde68a' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#fde68a' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/amethyst.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#ddd6fe' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#ddd6fe' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#ddd6fe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#ddd6fe' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/arcticDrift.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#e2e8f0' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#e2e8f0' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#e2e8f0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#e2e8f0' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/cinderBlaze.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#fed7aa' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#fed7aa' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fed7aa' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#fed7aa' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/darkForest.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#86efac' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#86efac' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#86efac' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#86efac' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#86efac' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/marble.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#cbd5f5' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#cbd5f5' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#cbd5f5' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#cbd5f5' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/mintVale.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#bbf7d0' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#bbf7d0' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bbf7d0' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#bbf7d0' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/roseMist.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#fecaca' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#fecaca' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#fecaca' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#fecaca' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>

--- a/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
+++ b/webapp/public/assets/game-art/chess-battle-royal/pieces/royalWave.svg
@@ -1,8 +1,7 @@
-
 <svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
   <defs>
-    <radialGradient id='shine' cx='35%' cy='25%' r='70%'>
-      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.9'/>
+    <radialGradient id='shine' cx='32%' cy='28%' r='70%'>
+      <stop offset='0%' stop-color='#bfdbfe' stop-opacity='0.85'/>
       <stop offset='100%' stop-color='#bfdbfe' stop-opacity='0'/>
     </radialGradient>
     <linearGradient id='body' x1='0' y1='0' x2='1' y2='1'>
@@ -11,9 +10,44 @@
     </linearGradient>
   </defs>
   <rect width='256' height='256' rx='36' fill='#0b1220'/>
-  <circle cx='128' cy='68' r='32' fill='url(#body)' stroke='#bfdbfe' stroke-width='4'/>
-  <path d='M82 200c8-38 18-62 46-62s38 24 46 62' fill='url(#body)'/>
-  <path d='M96 170c4-22 14-38 32-38s28 16 32 38' fill='#1f2937' opacity='0.45'/>
-  <rect x='64' y='196' width='128' height='30' rx='14' fill='#1f2937'/>
-  <circle cx='110' cy='76' r='50' fill='url(#shine)'/>
+  <circle cx='96' cy='78' r='88' fill='url(#shine)'/>
+  <g fill='url(#body)' stroke='#bfdbfe' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'>
+    <g transform='translate(58 70)'>
+      <circle cx='0' cy='-14' r='10'/>
+      <rect x='-9' y='-8' width='18' height='26' rx='6'/>
+      <rect x='-18' y='18' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 70)'>
+      <path d='M-18 20 L18 20 L12 2 L4 -12 L-10 -16 L-20 -6 Z'/>
+      <circle cx='3' cy='-7' r='3' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='20' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 70)'>
+      <circle cx='0' cy='-16' r='9'/>
+      <path d='M-10 -6 C-14 6 -12 22 0 26 C12 22 14 6 10 -6 Z'/>
+      <path d='M0 -10 L0 10' stroke='#0b1220' stroke-width='3'/>
+      <rect x='-16' y='26' width='32' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(58 166)'>
+      <rect x='-14' y='-18' width='28' height='30' rx='4'/>
+      <rect x='-18' y='-26' width='36' height='8' rx='2'/>
+      <rect x='-12' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-3' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='6' y='-26' width='6' height='8' fill='#0b1220' stroke='none'/>
+      <rect x='-18' y='12' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(128 166)'>
+      <circle cx='-10' cy='-18' r='4'/>
+      <circle cx='0' cy='-22' r='4'/>
+      <circle cx='10' cy='-18' r='4'/>
+      <path d='M-18 -14 L18 -14 L10 10 L-10 10 Z'/>
+      <rect x='-18' y='10' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+    <g transform='translate(198 166)'>
+      <rect x='-3' y='-26' width='6' height='16'/>
+      <rect x='-11' y='-20' width='22' height='6'/>
+      <path d='M-14 -12 C-16 4 -12 20 0 24 C12 20 16 4 14 -12 Z'/>
+      <rect x='-18' y='24' width='36' height='8' rx='4' fill='#1f2937' stroke='none'/>
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
### Motivation
- Several Chess Battle Royal piece thumbnails were missing or used legacy placeholders and needed full-set visuals for the store. 
- Thumbnails should match the multi-shape style used by the Snake & Ladder token previews so store and table-menu visuals are consistent.

### Description
- Replaced/regenerated the piece thumbnails in `webapp/public/assets/game-art/chess-battle-royal/pieces` with multi-shape SVG thumbnails showing full sets of chess pieces and consistent lighting/gradients. 
- Files updated include `marble.svg`, `darkForest.svg`, `amberGlow.svg`, `mintVale.svg`, `royalWave.svg`, `roseMist.svg`, `amethyst.svg`, `cinderBlaze.svg`, and `arcticDrift.svg` under the pieces folder. 
- Thumbnails use the same multi-shape composition and color/gradient treatment as the Snake & Ladder token thumbnails and remain referenced by the existing inventory config (no code changes to inventory references). 
- A preview screenshot was generated to validate layout and appearance at `artifacts/chess-piece-thumbnails.png`.

### Testing
- Ran an automated Playwright rendering script to load the new SVG thumbnails into an HTML grid and capture `artifacts/chess-piece-thumbnails.png`, which completed successfully. 
- Committed the asset updates with `git commit`, which completed successfully; no unit or integration tests were applicable for this asset-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698349a6eb6883298fcc5ead082ee60a)