### PR TITLE
Tune Pool Royale pocket geometry, in‑hand camera, cue stroke and shot power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -628,7 +628,7 @@ const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia 
 const CHROME_SIDE_PLATE_OUTER_TRIM_EXTRA_SCALE = 0.56; // trim the opposite side of the middle pocket chrome so it ends flush past the rounded cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.14; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.2; // open the rounded chrome cut sizing a touch more
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // restore the rounded chrome cut size to the earlier 9am scale
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
@@ -1090,7 +1090,7 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.82; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.4; // pull the middle jaw reach back to the earlier rounded cut size
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // restore middle jaw reach so the pocket cut matches the earlier 9am sizing
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // keep the middle jaw arc radius aligned with the baseline profile
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
@@ -1545,9 +1545,9 @@ const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // align spin inversion with Snooker Royal rebound behavior
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligned with the aim line
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power softer than before.
-// Apply a 20% reduction to soften every strike and keep mobile play comfortable.
+// Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
-const SHOT_POWER_REDUCTION = 0.8;
+const SHOT_POWER_REDUCTION = 0.64;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_FORCE_BOOST =
   1.5 *
@@ -1627,9 +1627,9 @@ const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while 
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
-const CUE_PULL_RETURN_PUSH = 0.78; // push the cue forward to its start point more decisively after a pull
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 1.1; // ensure the forward push is clearly visible even on short strokes
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 4.2; // cap the forward travel so the cue never overshoots the ball too far
+const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 1.45; // ensure the forward push is clearly visible even on short strokes
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 4.8; // cap the forward travel so the cue never overshoots the ball too far
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -5094,8 +5094,8 @@ const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
 const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
-const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.38; // pull the orbit back while the cue ball is in-hand for a wider placement view
-const IN_HAND_DRAG_SPEED = 1; // match air-hockey style 1:1 drag movement
+const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.32; // restore the 9pm in-hand orbit framing for cue-ball placement
+const IN_HAND_DRAG_SPEED = 0.92; // restore the 9pm in-hand drag pace for cue-ball placement
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;


### PR DESCRIPTION
### Motivation
- Restore Pool Royale side-pocket appearance and chrome cut sizing to the earlier (9am) visual reference so middle pockets and chrome plates match the prior build.
- Restore the cue-ball "ball in hand" placement feel to the prior (9pm) framing and drag pace for precise placement.
- Fix the cue stick visual push-forward so the stick doesn't appear stuck pulled back and follow-through reads more clearly.
- Reduce overall shot power by 20% to soften strikes and match mobile pacing.

### Description
- Updated pocket geometry and chrome cut scale in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `SIDE_POCKET_JAW_LATERAL_EXPANSION` from `1.4` to `1.5` and `CHROME_SIDE_POCKET_CUT_SCALE` from `1.2` to `1.06` to restore the earlier middle-pocket jaw / chrome cut sizing.
- Restored in‑hand placement feel by changing `IN_HAND_CAMERA_RADIUS_MULTIPLIER` from `1.38` to `1.32` and `IN_HAND_DRAG_SPEED` from `1` to `0.92` for the cue‑ball in‑hand orbit framing and drag responsiveness.
- Increased cue stroke forward clarity by raising `CUE_PULL_RETURN_PUSH` from `0.78` to `0.92` and expanding follow‑through travel via `CUE_FOLLOW_THROUGH_MIN` and `CUE_FOLLOW_THROUGH_MAX` (from `BALL_R * 1.1`/`4.2` to `BALL_R * 1.45`/`4.8`).
- Applied an additional 20% shot power reduction by setting `SHOT_POWER_REDUCTION` from `0.8` to `0.64` so overall shot force is softer across the game.
- Changes were committed to the repository (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were executed as part of this change; only source edits and a commit were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a408c5888329a29ba7f355e4b65d)