### PR TITLE
Adjust Pool Royale cameras and ball/cloth heights

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1240,7 +1240,7 @@ const CLOTH_LIFT = (() => {
   return Math.max(0, RAIL_HEIGHT - ballR - eps);
 })();
 const ACTION_CAMERA_START_BLEND = 1;
-const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
+const CLOTH_DROP = BALL_R * 0.2; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth apertures to the now-wider interior pocket diameter at the rim
@@ -4936,7 +4936,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.82; // lift the standing orbit slightly higher for a clearer top surface view
+const STANDING_VIEW_PHI = 0.79; // lift the standing orbit slightly higher for a clearer top surface view
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -4952,7 +4952,8 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.54; // pull the standing camera slightly closer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.52; // pull the standing camera slightly closer while keeping the angle unchanged
+const REPLAY_STANDING_HEIGHT_BOOST = BALL_R * 0.35; // lift the replay standing camera a touch for a steeper downward angle
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5021,9 +5022,9 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.04; // raise the camera a touch to ensure full end-rail coverage
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // raise the camera a touch to ensure full end-rail coverage
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.04; // lower the 2D top view slightly to keep framing consistent after the table shrink
+const TOP_VIEW_RADIUS_SCALE = 1.06; // raise the 2D top view slightly to keep framing consistent after the table shrink
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
@@ -19348,6 +19349,9 @@ const powerRef = useRef(hud.power);
           }
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
+          }
+          if (storedPosition) {
+            storedPosition.y += REPLAY_STANDING_HEIGHT_BOOST * scale;
           }
           replayCameraRef.current = {
             position: storedPosition,


### PR DESCRIPTION
### Motivation
- Tweak camera framing and ball placement so standing/replay/top/2D views better match portrait-screen visual goals and prevent balls appearing to float above the cloth.

### Description
- Lowered the standing orbit phi from `0.82` to `0.79` and tightened the standing distance by changing `STANDING_VIEW_DISTANCE_SCALE` from `0.54` to `0.52` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added `REPLAY_STANDING_HEIGHT_BOOST = BALL_R * 0.35` and apply it to stored replay camera positions so replay standing cameras sit slightly higher for a steeper look-down angle.
- Raised top/2D view distance by increasing `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` from `1.04` to `1.06` to lift the 2D framing.
- Lowered ball resting height on the cloth by increasing `CLOTH_DROP` from `BALL_R * 0.18` to `BALL_R * 0.2` so balls sit closer to the cloth surface.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and Vite reported ready at the local and network URLs, which succeeded.
- Attempted an automated visual check with Playwright to capture a Pool Royale screenshot, but the Playwright screenshot timed out (capture failed).
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69841c93f56083298b0e966f72c4fe20)