### PR TITLE
Adjust Pool Royale ball rest height and standing camera distance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1242,6 +1242,7 @@ const CLOTH_LIFT = (() => {
 const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
+const BALL_REST_SINK = BALL_R * 0.02; // nudge resting balls slightly lower so they sit closer to the cloth
 const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth apertures to the now-wider interior pocket diameter at the rim
 const CLOTH_REFLECTION_LIMITS = Object.freeze({
@@ -1253,7 +1254,7 @@ const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
 const BALL_CENTER_Y =
-  CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP; // rest balls directly on the lowered cloth plane
+  CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP - BALL_REST_SINK; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
 const BALL_SEGMENTS = Object.freeze({ width: 80, height: 60 });
 const BALL_GEOMETRY = new THREE.SphereGeometry(
@@ -4952,7 +4953,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.54; // pull the standing camera slightly closer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.5; // pull the standing camera slightly closer while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads


### PR DESCRIPTION
### Motivation
- Improve visual contact between balls and cloth by lowering the resting ball center so balls sit slightly closer to the felt.
- Match the requested portrait-screen framing by pulling the standing player camera a bit closer to the table for tighter composition.

### Description
- Introduced `BALL_REST_SINK = BALL_R * 0.02` and subtracted it from `BALL_CENTER_Y` in `webapp/src/pages/Games/PoolRoyale.jsx` so resting balls sit marginally lower.
- Reduced `STANDING_VIEW_DISTANCE_SCALE` from `0.54` to `0.5` in `webapp/src/pages/Games/PoolRoyale.jsx` to tighten the standing orbit camera distance.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported the site ready at `http://localhost:4173/`.
- Attempted to capture a visual smoke screenshot with Playwright, but the headless run timed out so no screenshot was produced and no visual confirmation was captured; no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698425cd7f108329901be8611a549245)