### PR TITLE
Fix wall feed reaction crash

### DIFF
--- a/webapp/src/pages/Trending.jsx
+++ b/webapp/src/pages/Trending.jsx
@@ -56,6 +56,8 @@ export default function Trending() {
   const [isPosting, setIsPosting] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
+  const toPostList = (data) => (Array.isArray(data) ? data : []);
+
   useEffect(() => {
     let active = true;
     setIsLoading(true);
@@ -65,7 +67,7 @@ export default function Trending() {
         : listWallFeed(telegramId);
     request
       .then((data) => {
-        if (active) setPosts(data || []);
+        if (active) setPosts(toPostList(data));
       })
       .catch(() => {
         if (active) setPosts([]);
@@ -101,7 +103,7 @@ export default function Trending() {
       activeTab === 'trending'
         ? await listTrendingPosts()
         : await listWallFeed(telegramId);
-    setPosts(data || []);
+    setPosts(toPostList(data));
   }
 
   async function handlePostSubmit() {
@@ -140,8 +142,10 @@ export default function Trending() {
   }
 
   async function handleReact(id, emoji) {
-    await reactWallPost(id, telegramId, emoji);
-    refresh();
+    const res = await reactWallPost(id, telegramId, emoji);
+    if (!res?.error) {
+      refresh();
+    }
   }
 
   function shareOn(platform, post) {


### PR DESCRIPTION
### Motivation
- Prevent the Wall feed UI from breaking when the backend returns a non-array response and avoid refreshing the feed after a failed reaction request.

### Description
- Add a defensive helper `toPostList` and use it when setting posts in the initial feed load and `refresh()` to ensure `posts` is always an array.
- Modify `handleReact` to check the API response and only call `refresh()` when `reactWallPost` did not return an error.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842d04fce483299c50ac6b13cbd3f0)