### PR TITLE
Adjust Pool Royale ball scale and resting height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1164,7 +1164,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = BASE_INNER_LONG / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1; // increase balls 10% to match the new visual scale
+const BALL_SIZE_SCALE = 1.21; // increase balls 10% from the current size to match the new visual scale
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1242,7 +1242,7 @@ const CLOTH_LIFT = (() => {
 const ACTION_CAMERA_START_BLEND = 1;
 const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
-const BALL_REST_SINK = 0; // keep ball bottoms touching the cloth surface
+const BALL_REST_SINK = BALL_R * 0.02; // sink balls slightly lower into the cloth for a subtler drop
 const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth apertures to the now-wider interior pocket diameter at the rim
 const CLOTH_REFLECTION_LIMITS = Object.freeze({


### PR DESCRIPTION
### Motivation
- Tweak Pool Royale ball visuals so balls sit slightly lower on the cloth and appear 10% larger than the current in-game size to match the requested visual adjustments.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to change `BALL_SIZE_SCALE` from `1.1` to `1.21` and set `BALL_REST_SINK` from `0` to `BALL_R * 0.02` to lower ball resting height.

### Testing
- Started the local dev server with `npm --prefix webapp run dev` (Vite reported ready), attempted an automated Playwright screenshot of `/games/poolroyale` but the page did not finish loading before the timeout, and no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698461b71878832991c36250afa0ab17)