### PR TITLE
Shrink Pool Royale playfield and tweak middle-pocket chrome plates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -616,11 +616,11 @@ const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so 
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0; // keep fascia placement identical to snooker
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
-const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.26; // trim the side fascia reach so the middle chrome ends cleanly at the side rail edge
+const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.22; // trim the side fascia reach so the middle chrome ends cleanly at the side rail edge
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0; // keep the middle fascia centred on the pocket without carving extra relief
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.25; // expand the middle fascia slightly toward the diamonds on both ends
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.96; // reduce outside reach so the chrome ends flush with the side rail
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.94; // reduce outside reach so the chrome ends flush with the side rail
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.18; // extend the plate ends further toward the corner pockets (toward the chalks)
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.975; // expand the middle fascia slightly so both flanks gain a touch more presence
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.16; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
@@ -629,7 +629,7 @@ const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia 
 const CHROME_SIDE_PLATE_OUTER_TRIM_EXTRA_SCALE = 0.56; // trim the opposite side of the middle pocket chrome so it ends flush past the rounded cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.14; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // restore the rounded chrome cut size to the earlier 9am scale
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.1; // open the rounded chrome cut size slightly more for the middle pocket fascias
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
@@ -1124,17 +1124,21 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
-  const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
+  const BASE_SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
   // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
   // and preserving pocket proportions from the previous build.
   const TARGET_RATIO = 1.83;
-const END_RAIL_INNER_SCALE =
-  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
+const BASE_END_RAIL_INNER_SCALE =
+  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * BASE_SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
-const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
-const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAY_W = TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS;
-const PLAY_H = TABLE.H - 2 * END_RAIL_INNER_THICKNESS;
+const BASE_END_RAIL_INNER_THICKNESS = TABLE.WALL * BASE_END_RAIL_INNER_SCALE;
+const BASE_PLAY_W = TABLE.W - 2 * BASE_SIDE_RAIL_INNER_THICKNESS;
+const BASE_PLAY_H = TABLE.H - 2 * BASE_END_RAIL_INNER_THICKNESS;
+const PLAYFIELD_SHRINK = 0.85; // shrink the playable field ~15% on all sides while keeping table height unchanged
+const PLAY_W = BASE_PLAY_W * PLAYFIELD_SHRINK;
+const PLAY_H = BASE_PLAY_H * PLAYFIELD_SHRINK;
+const SIDE_RAIL_INNER_THICKNESS = (TABLE.W - PLAY_W) / 2;
+const END_RAIL_INNER_THICKNESS = (TABLE.H - PLAY_H) / 2;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
   tableWidth: TABLE.W,
   tableLength: TABLE.H,
@@ -1143,12 +1147,18 @@ export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
   playfieldWidth: PLAY_W,
   playfieldHeight: PLAY_H
 });
-const innerLong = Math.max(PLAY_W, PLAY_H);
-const innerShort = Math.min(PLAY_W, PLAY_H);
+const innerLong = Math.max(BASE_PLAY_W, BASE_PLAY_H);
+const innerShort = Math.min(BASE_PLAY_W, BASE_PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
+const playfieldLong = Math.max(PLAY_W, PLAY_H);
+const playfieldShort = Math.min(PLAY_W, PLAY_H);
   console.assert(
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
+  );
+  console.assert(
+    Math.abs(playfieldLong / Math.max(1e-6, playfieldShort) - TARGET_RATIO) < 1e-4,
+    'Pool table playfield ratio must match the widened 1.83:1 target after shrink.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
 const BALL_SIZE_SCALE = 1.1155; // increase balls 15% from the previous tuned size for stronger table presence


### PR DESCRIPTION
### Motivation

- Reduce the playable field footprint by ~15% on all sides while keeping table height, ball sizes and pocket alignment unchanged to preserve the existing look and physics.
- Reduce the chrome fascia around the middle (side) pockets slightly and increase the rounded cut of those chrome plates for the requested visual adjustment.

### Description

- Introduced `PLAYFIELD_SHRINK = 0.85` and compute `PLAY_W`/`PLAY_H` from `BASE_PLAY_W`/`BASE_PLAY_H` so the playable area is shrunk ~15% while the table geometry (height/thickness) remains unchanged.
- Renamed and factored rail/playfield derivation into `BASE_*` values (e.g. `BASE_SIDE_RAIL_INNER_THICKNESS`, `BASE_PLAY_W`, `BASE_PLAY_H`) and computed `SIDE_RAIL_INNER_THICKNESS`/`END_RAIL_INNER_THICKNESS` from the new playfield size.
- Updated chrome fascia constants to trim the middle-pocket chrome and open the rounded cut: changed `CHROME_SIDE_PLATE_POCKET_SPAN_SCALE` from `1.26` to `1.22`, `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` from `0.96` to `0.94`, and `CHROME_SIDE_POCKET_CUT_SCALE` from `1.06` to `1.1`.
- Kept ball size and pocket mouth calculations tied to the Pool Royale references and preserved assertions; added a second assertion to validate the playfield ratio after the shrink step and preserved `POOL_ROYALE_TABLE_DIMENSIONS` to export the new playfield width/height.

### Testing

- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, Vite started and served the site successfully.
- Attempted an automated visual capture using Playwright to confirm the scene, but the Playwright screenshot timed out (failed to capture within the allotted timeout).
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848dd5f510832985a2ca1770fee3fb)