### PR TITLE
Pool Royale: lock replay camera, restore middle pocket jaws, pull cushions inward, and improve replay cue stroke visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1042,7 +1042,7 @@ const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
 const ENABLE_TABLE_MAPPING_LINES = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
-const LOCK_REPLAY_CAMERA = false;
+const LOCK_REPLAY_CAMERA = true;
 const REPLAY_CUE_STICK_HOLD_MS = 620;
   const TABLE_BASE_SCALE = 1.2;
   const TABLE_WIDTH_SCALE = 1.25;
@@ -1098,7 +1098,7 @@ const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.06; // reduce the outward shift so the rounded cut matches the earlier jaw size
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
-const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 1; // revert middle-jaw side trims so the jaws finish full-width like the earlier build
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
 const POCKET_JAW_MAPPING_RADIUS_SCALE = 1; // keep collision arc true to the jaw outer radius for precise pocket mapping
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
@@ -1617,7 +1617,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.18; // widen the visible air gap so the blue tip never kisses the cue ball
-const CUE_TIP_GAP = BALL_R * 1.02 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
+const CUE_TIP_GAP = BALL_R * 1.08 + CUE_TIP_CLEARANCE; // pull the cue back a touch more from the cue ball while keeping a safe buffer
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -1645,7 +1645,7 @@ const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 7.6;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 16.4;
-const CUE_Y = BALL_CENTER_Y - BALL_R * 0.35; // lower the cue a touch more so the blue tip sits dead-centre on the cue ball
+const CUE_Y = BALL_CENTER_Y - BALL_R * 0.4; // drop the cue front slightly lower so the tip sits just below centre
 const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
 const CUE_BUTT_LIFT = BALL_R * 0.46; // lower the butt slightly while keeping the tip level with the cue-ball centre
@@ -1694,7 +1694,7 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playable face and cushion nose further inward to match the expanded top surface
+const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.16; // pull all cushions further inward toward the table center
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -18854,6 +18854,73 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           };
+          const applyFallbackStroke = (cuePos, cueDir, replayHoldWindow) => {
+            if (!cuePos || !cueDir) return;
+            const fallbackPullback = CUE_PULL_BASE * 0.5;
+            const fallbackForward = CUE_PULL_BASE * 0.25;
+            const pullbackTime = 200;
+            const forwardTime = 240;
+            const settleTime = 140;
+            const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
+            const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
+            const holdWindow = Math.max(replayHoldWindow, totalStroke);
+            const showCue = targetTime <= holdWindow;
+            cueStick.visible = showCue;
+            cueAnimating = showCue;
+            if (!showCue) {
+              syncCueShadow();
+              return;
+            }
+            const idlePos = TMP_VEC3_A.set(
+              cuePos.x - cueDir.x * CUE_TIP_GAP,
+              cuePos.y,
+              cuePos.z - cueDir.z * CUE_TIP_GAP
+            );
+            const pullPos = TMP_VEC3_B.set(
+              cuePos.x - cueDir.x * (CUE_TIP_GAP + fallbackPullback),
+              cuePos.y,
+              cuePos.z - cueDir.z * (CUE_TIP_GAP + fallbackPullback)
+            );
+            const impactPos = TMP_VEC3_C.set(
+              cuePos.x - cueDir.x * Math.max(CUE_TIP_GAP - fallbackForward, 0),
+              cuePos.y,
+              cuePos.z - cueDir.z * Math.max(CUE_TIP_GAP - fallbackForward, 0)
+            );
+            const followPos = tmpReplayCueA.set(
+              cuePos.x - cueDir.x * Math.max(CUE_TIP_GAP - fallbackForward * 0.45, 0),
+              cuePos.y,
+              cuePos.z - cueDir.z * Math.max(CUE_TIP_GAP - fallbackForward * 0.45, 0)
+            );
+            if (targetTime <= pullbackTime && pullbackTime > 0) {
+              const t = THREE.MathUtils.clamp(targetTime / pullbackTime, 0, 1);
+              cueStick.position.lerpVectors(idlePos, pullPos, easeInOutCubic(t));
+            } else if (targetTime <= pullbackTime + forwardTime) {
+              const t = THREE.MathUtils.clamp(
+                (targetTime - pullbackTime) / Math.max(forwardTime, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(pullPos, impactPos, easeOutCubic(t));
+            } else if (targetTime <= pullbackTime + forwardTime + settleTime) {
+              const t = THREE.MathUtils.clamp(
+                (targetTime - pullbackTime - forwardTime) / Math.max(settleTime, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(impactPos, followPos, easeOutCubic(t));
+            } else if (targetTime <= totalStroke) {
+              const t = THREE.MathUtils.clamp(
+                (targetTime - pullbackTime - forwardTime - settleTime) /
+                  Math.max(returnTime, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(followPos, idlePos, easeInOutCubic(t));
+            } else {
+              cueStick.position.copy(idlePos);
+            }
+            syncCueShadow();
+          };
           if (!stroke) {
             const snapshotApplied = applyCueSnapshot();
             const cuePath = playback?.cuePath ?? [];
@@ -18891,68 +18958,7 @@ const powerRef = useRef(hud.power);
             const replayHoldWindow = Number.isFinite(playback?.duration)
               ? playback.duration
               : REPLAY_CUE_STICK_HOLD_MS;
-            const fallbackPullback = CUE_PULL_BASE * 0.35;
-            const fallbackForward = CUE_PULL_BASE * 0.18;
-            const pullbackTime = 160;
-            const forwardTime = 210;
-            const settleTime = 120;
-            const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
-            const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
-            const holdWindow = Math.max(replayHoldWindow, totalStroke);
-            const showCue = targetTime <= holdWindow;
-            cueStick.visible = showCue;
-            cueAnimating = showCue;
-            if (showCue) {
-              const idlePos = TMP_VEC3_A.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * CUE_TIP_GAP,
-                cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * CUE_TIP_GAP
-              );
-              const pullPos = TMP_VEC3_B.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * (CUE_TIP_GAP + fallbackPullback),
-                cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * (CUE_TIP_GAP + fallbackPullback)
-              );
-              const impactPos = TMP_VEC3_C.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * Math.max(CUE_TIP_GAP - fallbackForward, 0),
-                cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * Math.max(CUE_TIP_GAP - fallbackForward, 0)
-              );
-              const followPos = tmpReplayCueA.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * Math.max(CUE_TIP_GAP - fallbackForward * 0.45, 0),
-                cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * Math.max(CUE_TIP_GAP - fallbackForward * 0.45, 0)
-              );
-              if (targetTime <= pullbackTime && pullbackTime > 0) {
-                const t = THREE.MathUtils.clamp(targetTime / pullbackTime, 0, 1);
-                cueStick.position.lerpVectors(idlePos, pullPos, easeInOutCubic(t));
-              } else if (targetTime <= pullbackTime + forwardTime) {
-                const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime) / Math.max(forwardTime, 1e-6),
-                  0,
-                  1
-                );
-                cueStick.position.lerpVectors(pullPos, impactPos, easeOutCubic(t));
-              } else if (targetTime <= pullbackTime + forwardTime + settleTime) {
-                const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime) / Math.max(settleTime, 1e-6),
-                  0,
-                  1
-                );
-                cueStick.position.lerpVectors(impactPos, followPos, easeOutCubic(t));
-              } else if (targetTime <= totalStroke) {
-                const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime - settleTime) /
-                    Math.max(returnTime, 1e-6),
-                  0,
-                  1
-                );
-                cueStick.position.lerpVectors(followPos, idlePos, easeInOutCubic(t));
-              } else {
-                cueStick.position.copy(idlePos);
-              }
-            }
-            syncCueShadow();
+            applyFallbackStroke(cuePos, TMP_VEC3_CUE_DIR, replayHoldWindow);
             return;
           }
           const idleSnap =
@@ -18973,6 +18979,31 @@ const powerRef = useRef(hud.power);
               cueAnimating = false;
               syncCueShadow();
             }
+            return;
+          }
+          tmpReplayCueA.set(idleSnap.x, idleSnap.y, idleSnap.z);
+          tmpReplayCueB.set(pullSnap.x, pullSnap.y, pullSnap.z);
+          TMP_VEC3_A.set(impactSnap.x, impactSnap.y, impactSnap.z);
+          const minimalTravel = BALL_R * 0.08;
+          const totalTravelSq =
+            tmpReplayCueA.distanceToSquared(tmpReplayCueB) +
+            tmpReplayCueB.distanceToSquared(TMP_VEC3_A);
+          if (totalTravelSq < minimalTravel * minimalTravel) {
+            const replayHoldWindow = Number.isFinite(playback?.duration)
+              ? playback.duration
+              : REPLAY_CUE_STICK_HOLD_MS;
+            TMP_VEC3_CUE_DIR.set(
+              Math.sin(cueStick.rotation.y - Math.PI),
+              0,
+              Math.cos(cueStick.rotation.y - Math.PI)
+            );
+            if (TMP_VEC3_CUE_DIR.lengthSq() > 1e-8) {
+              TMP_VEC3_CUE_DIR.normalize();
+            } else {
+              TMP_VEC3_CUE_DIR.set(0, 0, 1);
+            }
+            tmpReplayCueA.set(idleSnap.x, CUE_Y, idleSnap.z);
+            applyFallbackStroke(tmpReplayCueA, TMP_VEC3_CUE_DIR, replayHoldWindow);
             return;
           }
           const replayScale = REPLAY_CUE_STROKE_SLOWDOWN;


### PR DESCRIPTION
### Motivation
- Ensure replay camera remains fixed during replay playback for consistent framing and to match the requested “standing camera stay put” behavior.
- Revert the earlier middle-pocket jaw trimming so the middle jaws read like the previous build and make the jaws by the middle pockets behave as before.
- Pull cushions slightly inward and nudge cue placement so the cue sits a bit farther from the cue ball and the front of the cue is slightly lower, improving visual accuracy and satisfying requested layout tweaks.

### Description
- Set `LOCK_REPLAY_CAMERA = true` to keep replay framing static during playback (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Restored the middle pocket jaw edge to full width by changing `SIDE_POCKET_JAW_EDGE_TRIM_SCALE` from `0.78` to `1` to revert the side-jaw trimming.
- Pulled cushions inward by increasing `CUSHION_FACE_INSET` from `SIDE_RAIL_INNER_THICKNESS * 0.12` to `SIDE_RAIL_INNER_THICKNESS * 0.16` so all cushions move slightly toward the table center.
- Adjusted cue geometry by increasing `CUE_TIP_GAP` (from `BALL_R * 1.02` to `BALL_R * 1.08`) and lowering the cue height `CUE_Y` (from `BALL_CENTER_Y - BALL_R * 0.35` to `BALL_CENTER_Y - BALL_R * 0.4`) so the cue is pulled back a bit and the front side is slightly lower.
- Added a replay fallback stroke implementation (`applyFallbackStroke`) and a minimal-motion detector around the replay cue-stroke application so replays always show a visible pull/release animation when recorded stroke snapshots are too subtle.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev`, and Vite reported ready and accessible locally (dev server started successfully).
- Attempted to capture an in-browser screenshot via Playwright to validate the visual result, but the headless screenshot runs timed out (Playwright attempts timed out after 30s).
- No automated unit tests (e.g., `npm test`) were run for these changes during this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984a3035d9c8329ae1d85e8d9bb3142)