### PR TITLE
Fix replay cue alignment and show forward stroke

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12972,7 +12972,8 @@ const powerRef = useRef(hud.power);
     wasInHandRef.current = Boolean(hud.inHand);
     if (enteringInHand) {
       cueBallPlacedFromHandRef.current = false;
-      pendingInHandResetRef.current = true;
+      const cueBall = cueRef.current;
+      pendingInHandResetRef.current = Boolean(cueBall && !cueBall.active);
     }
     if (!hud.inHand || !playerTurn) {
       setInHandPlacementMode(false);
@@ -18823,6 +18824,10 @@ const powerRef = useRef(hud.power);
 
         const applyReplayCueStroke = (playback, targetTime) => {
           const stroke = playback?.cueStroke;
+          const frames = playback?.frames ?? [];
+          const hasCueSnapshots = frames.some(
+            (frame) => Boolean(frame?.cue && frame.cue.position)
+          );
           if (!cueStick) {
             cueAnimating = false;
             return;
@@ -18834,7 +18839,6 @@ const powerRef = useRef(hud.power);
             return;
           }
           const applyCueSnapshot = () => {
-            const frames = playback?.frames ?? [];
             if (!frames.length) return false;
             let frameIndex = 0;
             while (frameIndex < frames.length - 1 && frames[frameIndex + 1].t <= targetTime) {
@@ -18854,16 +18858,22 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           };
+          if (hasCueSnapshots) {
+            return;
+          }
           if (!stroke) {
             const snapshotApplied = applyCueSnapshot();
             const cuePath = playback?.cuePath ?? [];
-            const cueBall = cueRef.current || cue;
-            const cueBallPos = cueBall?.mesh?.position ?? null;
+            const firstFrame = frames[0] ?? null;
+            const cueBallFrame = firstFrame?.balls?.find?.((entry) => entry.id === 'cue') ?? null;
+            const cueBallFramePos =
+              cueBallFrame?.pos && typeof cueBallFrame.pos === 'object'
+                ? TMP_VEC3_A.set(cueBallFrame.pos.x, CUE_Y, cueBallFrame.pos.y)
+                : null;
             const cuePos =
-              cueBallPos
-                ? TMP_VEC3_A.copy(cueBallPos)
-                : cuePath[0]?.pos?.clone?.() ??
-                  (snapshotApplied ? cueStick.position.clone() : null);
+              cuePath[0]?.pos?.clone?.() ??
+              cueBallFramePos ??
+              (snapshotApplied ? cueStick.position.clone() : null);
             if (!cuePos) {
               cueStick.visible = false;
               cueAnimating = false;
@@ -18872,6 +18882,7 @@ const powerRef = useRef(hud.power);
             }
             const first = cuePath[0]?.pos ?? null;
             const second = cuePath[1]?.pos ?? null;
+            const cueBall = cueRef.current || cue;
             if (first && second) {
               TMP_VEC3_CUE_DIR.copy(second).sub(first);
             } else if (cueBall?.vel) {
@@ -21434,6 +21445,11 @@ const powerRef = useRef(hud.power);
         const frameSnapshot = frameRef.current ?? frameState;
         const meta = frameSnapshot?.meta;
         if (!meta || typeof meta !== 'object') return false;
+        const breakInProgress = Boolean(
+          meta.breakInProgress ??
+            (meta.state && typeof meta.state === 'object' ? meta.state.breakInProgress : false)
+        );
+        if (breakInProgress) return true;
         if (meta.variant === 'uk') {
           return Boolean(meta.state?.breakInProgress);
         }
@@ -22441,11 +22457,8 @@ const powerRef = useRef(hud.power);
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          const isAiStroke = aiOpponentEnabled && hudRef.current?.turn === 1;
-          const pullVisibilityBoost = isAiStroke
-            ? AI_CUE_PULL_VISIBILITY_BOOST
-            : PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const pullScale = isAiStroke ? AI_CUE_PULL_SCALE : 1;
+          const pullVisibilityBoost = PLAYER_CUE_PULL_VISIBILITY_BOOST;
+          const pullScale = 1;
           const pullTarget =
             computePullTargetFromPower(clampedPower, maxPull) *
             pullVisibilityBoost *
@@ -22506,16 +22519,12 @@ const powerRef = useRef(hud.power);
           }
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
           const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const forwardDuration = isAiStroke
-            ? AI_CUE_FORWARD_DURATION_MS
-            : THREE.MathUtils.lerp(
-                PLAYER_CUE_FORWARD_MAX_MS,
-                PLAYER_CUE_FORWARD_MIN_MS,
-                forwardBlend
-              );
-          const pullbackDuration = isAiStroke
-            ? AI_CUE_PULLBACK_DURATION_MS
-            : Math.max(120, forwardDuration * 0.65);
+          const forwardDuration = THREE.MathUtils.lerp(
+            PLAYER_CUE_FORWARD_MAX_MS,
+            PLAYER_CUE_FORWARD_MIN_MS,
+            forwardBlend
+          );
+          const pullbackDuration = Math.max(120, forwardDuration * 0.65);
           const startTime = performance.now();
           const followThrough = THREE.MathUtils.lerp(
             CUE_FOLLOW_THROUGH_MIN,
@@ -22523,7 +22532,8 @@ const powerRef = useRef(hud.power);
             powerStrength
           );
           const impactPos = idlePos.clone();
-          const followPos = idlePos.clone();
+          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
+          const followPos = buildCuePosition(-followDistance);
           const followSpeed = THREE.MathUtils.lerp(
             CUE_FOLLOW_SPEED_MIN,
             CUE_FOLLOW_SPEED_MAX,
@@ -22534,7 +22544,7 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_MIN_MS,
             CUE_FOLLOW_MAX_MS
           );
-          const followDurationResolved = isAiStroke ? 120 : followDuration;
+          const followDurationResolved = followDuration;
           const recoverDuration = Math.max(120, followDurationResolved * 0.6);
           const impactTime = startTime + pullbackDuration + forwardDuration;
           const forwardPreviewHold =


### PR DESCRIPTION
### Motivation
- Replays could drift or show the cue in the wrong place because per-frame recorded cue snapshots were being overridden during playback, and forward pushing of the cue was not always visible for player/AI shots.
- AI and player cue strokes used different timing/visibility branches causing inconsistent stroke animation and missing forward motion.
- In-hand entry logic reset the cue ball too aggressively when the cue object did not exist or was active.

### Description
- Stop overriding interpolated per-frame cue snapshots during replay by returning early when `frames` already contain `frame.cue.position`, preserving the recorded pose instead of applying fallback snapshots.  
- Improve replay fallback by using the first replay frame `balls` entry for the cue ball position as a fallback for `cuePos` and ensure direction/velocity resolution prefers `cueRef.current || cue`.  
- Unify cue stroke timing/visibility so player and AI use the same forward/pull calculations by removing AI-specific timing branches and scale overrides and by using the player timing/pull path.  
- Make live cue follow-through visible by computing a `followDistance` and building `followPos` with `buildCuePosition(-followDistance)`, and stop forcing shorter AI follow durations; also set `pendingInHandResetRef.current` only when `cueRef.current` exists but is inactive.

### Testing
- No automated tests were executed for these changes (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698565f5fd088329a261ba9921df5e23)