### PR TITLE
Tighten middle-pocket jaws, trim short-rail cushions, shrink balls, and lower standing camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -635,7 +635,7 @@ const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.03; // open the middle rail rounded cuts slightly to match the reference
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 0.98; // tighten the middle rail rounded cuts slightly for a smaller jaw opening
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0; // keep the wood cutouts centered on the middle pocket line
 
 function buildChromePlateGeometry({
@@ -1061,7 +1061,7 @@ const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // push the corner jaws outwa
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.46; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.02; // round the middle jaws slightly more while keeping the corner match
+const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1; // keep middle jaws aligned with corners while trimming their inner lip
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.84; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
@@ -1091,11 +1091,11 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.82; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.42; // trim middle jaw reach slightly while preserving the radius and height
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.36; // trim middle jaw reach slightly while preserving the radius and height
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // keep the middle jaw arc radius aligned with the baseline profile
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.06; // reduce the outward shift so the rounded cut matches the earlier jaw size
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.045; // reduce the outward shift so the rounded cut matches the earlier jaw size
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 1; // restore the full jaw shoulder so the middle pocket trim matches the earlier build
@@ -1152,7 +1152,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.2828; // increase balls another 15% for stronger table presence
+const BALL_SIZE_SCALE = 1.1545; // reduce balls ~10% for a slightly smaller presence
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1190,7 +1190,7 @@ const POCKET_SIDE_MOUTH_SCALE =
   (CORNER_MOUTH_REF / SIDE_MOUTH_REF) *
   POCKET_CORNER_MOUTH_SCALE *
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // keep the middle pocket mouth width identical to the corner pockets
-const SIDE_POCKET_CUT_SCALE = 0.985; // trim the middle cloth/rail cutouts a bit more so the openings follow the tighter pocket radius
+const SIDE_POCKET_CUT_SCALE = 0.97; // trim the middle cloth/rail cutouts a bit more so the openings follow the tighter pocket radius
 const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
@@ -4924,7 +4924,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.86; // lower the standing orbit slightly while keeping a clear top surface view
+const STANDING_VIEW_PHI = 0.88; // lower the standing orbit slightly while keeping a clear top surface view
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -7946,7 +7946,7 @@ export function Table3D(
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.36; // lightly trim short-rail cushions to match the new pocket clearance
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation
- Make the middle-pocket wooden jaw and rounded rail cuts slightly smaller so middle pockets are tighter while keeping existing chrome plate visuals unchanged.
- Reduce ball diameter by ~10% for a slimmer on-table presence and slightly lower the player standing camera for a closer, more natural player view.
- Trim short-rail cushion length so cushion noses do not intrude into pocket perimeters.

### Description
- Adjusted wooden pocket relief and jaw geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx`: `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE` changed to `0.98`, `POCKET_JAW_SIDE_INNER_SCALE` set to `* 1`, `SIDE_POCKET_JAW_LATERAL_EXPANSION` set to `1.36`, and `SIDE_POCKET_JAW_OUTWARD_SHIFT` reduced to `TABLE.THICK * 0.045` to tighten middle jaw/reach while leaving chrome plate constants untouched.
- Reduced ball sizing by changing `BALL_SIZE_SCALE` from `1.2828` to `1.1545` so balls are ~10% smaller and propagated the new radius through ball geometry and related metrics.
- Trimmed middle pocket/cloth cut and short-rail cushions by changing `SIDE_POCKET_CUT_SCALE` from `0.985` to `0.97` and `SHORT_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.28` to `BALL_R * 0.36` to keep cushion edges clear of pocket perimeters.
- Lowered the standing/player camera slightly by updating `STANDING_VIEW_PHI` from `0.86` to `0.88` to produce a marginally lower orbit angle.

### Testing
- Launched the web app dev server using `npm --prefix webapp run dev` and verified Vite reported the local server as ready on port 4173 (succeeded).
- Attempted an automated visual check using Playwright to capture a screenshot, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot was produced (failed).
- No unit/behavioral tests were modified or executed as these are visual/parameter tweaks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69858b9472548329b639694ac7e56500)