### PR TITLE
Pool Royale: tighten cushions & pocket jaws, unify ball‑in‑hand, improve replay pocket/cue capture

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1061,7 +1061,7 @@ const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // push the corner jaws outwa
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.46; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 0.965; // tighten the middle jaw inner lip for a smaller rounded cut
+const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.02; // round the middle jaws slightly more while keeping the corner match
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.84; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
@@ -1091,16 +1091,16 @@ const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the m
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.82; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
-const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.3; // trim middle jaw reach slightly while preserving the radius and height
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // keep the middle jaw arc radius aligned with the baseline profile
-const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // add a hint of extra depth so the enlarged jaws stay balanced
+const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // push the middle jaw reach a touch wider so the openings read larger
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
+const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.035; // reduce the outward shift so the rounded cut matches the earlier jaw size
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.085; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
-const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 1; // restore the full jaw shoulder so the middle pocket trim matches the earlier build
+const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.78; // taper the middle jaw edges sooner so they finish where the rails stop
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1; // keep collision arc true to the jaw outer radius for precise pocket mapping
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 0.97; // tighten the collision arc so the jaw meets the cushion cut and seals the pocket gap
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1694,7 +1694,7 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.12; // push the playable face and cushion nose further inward to match the expanded top surface
+const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.14; // push the playable face and cushion nose further inward to match the expanded top surface
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -1905,7 +1905,7 @@ function deriveInHandFromFrame(frame) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === 'uk' && meta.state) {
-    return Boolean(meta.state.mustPlayFromBaulk);
+    return Boolean(meta.state.ballInHand ?? meta.state.mustPlayFromBaulk);
   }
   return false;
 }
@@ -18631,6 +18631,79 @@ const powerRef = useRef(hud.power);
           return snapshot;
         };
         captureReplayCameraSnapshotRef.current = captureReplayCameraSnapshot;
+        const buildReplayPocketSnapshot = ({
+          pocketId,
+          pocketCenter,
+          ballPos,
+          approachDir
+        }) => {
+          if (!pocketCenter) return null;
+          const anchorType = pocketId === 'TM' || pocketId === 'BM' ? 'side' : 'short';
+          const anchorId =
+            resolvePocketCameraAnchor(pocketId, pocketCenter, approachDir, ballPos) ??
+            pocketId;
+          const outward =
+            getPocketCameraOutward(anchorId) ??
+            pocketCenter.clone().normalize();
+          if (outward.lengthSq() < 1e-6) {
+            outward.set(
+              anchorType === 'side' ? signed(pocketCenter.x, 1) : 0,
+              anchorType === 'side' ? 0 : signed(pocketCenter.y, 1)
+            );
+          }
+          outward.normalize();
+          const approach =
+            approachDir?.clone?.() ?? pocketCenter.clone();
+          if (approach.lengthSq() < 1e-6) {
+            approach.set(
+              0,
+              anchorType === 'side' ? signed(pocketCenter.x, 1) : -signed(pocketCenter.y, 1)
+            );
+          }
+          approach.normalize();
+          const focusPoint2D = ballPos?.clone?.() ?? pocketCenter.clone();
+          const baseHeightOffset = POCKET_CAM.heightOffset;
+          const shortPocketHeightMultiplier =
+            POCKET_CAM.heightOffsetShortMultiplier ?? 1;
+          const heightOffset =
+            anchorType === 'side'
+              ? baseHeightOffset * 0.92
+              : baseHeightOffset * shortPocketHeightMultiplier;
+          const heightScale = POCKET_CAM.heightScale ?? 1;
+          const baseDistance =
+            anchorType === 'short'
+              ? POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside
+              : POCKET_CAM.minOutside;
+          const outwardOffsetMagnitude =
+            anchorType === 'short'
+              ? POCKET_CAM.outwardOffsetShort ?? POCKET_CAM.outwardOffset
+              : POCKET_CAM.outwardOffset;
+          const distanceScale = POCKET_CAM.distanceScale ?? 1;
+          const cameraDistance =
+            (baseDistance + Math.max(0, outwardOffsetMagnitude ?? 0)) * distanceScale;
+          const sideEdgeShift =
+            anchorType === 'side'
+              ? POCKET_CAM_SIDE_EDGE_SHIFT *
+                signed(focusPoint2D.y - pocketCenter.y, approach.y || 1)
+              : 0;
+          const resolvedPosition = new THREE.Vector3(
+            (pocketCenter.x + outward.x * cameraDistance) * worldScaleFactor,
+            (TABLE_Y + TABLE.THICK + heightOffset * heightScale) * worldScaleFactor,
+            (pocketCenter.y + outward.y * cameraDistance + sideEdgeShift) * worldScaleFactor
+          );
+          const focusHeightLocal = BALL_CENTER_Y + BALL_R * 0.6;
+          const resolvedTarget = new THREE.Vector3(
+            focusPoint2D.x * worldScaleFactor,
+            focusHeightLocal,
+            focusPoint2D.y * worldScaleFactor
+          );
+          return {
+            position: resolvedPosition,
+            target: resolvedTarget,
+            fov: Number.isFinite(camera?.fov) ? camera.fov : CAMERA.fov,
+            key: `pocket:${anchorId ?? pocketId ?? 'replay'}:replay`
+          };
+        };
 
         const applyBallSnapshot = (snapshot) => {
           if (!Array.isArray(snapshot)) return;
@@ -18679,7 +18752,7 @@ const powerRef = useRef(hud.power);
           pendingLayoutRef.current = null;
         }
 
-        const recordReplayFrame = (timestamp) => {
+        const recordReplayFrame = (timestamp, cameraOverride = null) => {
           if (!shotRecording) return;
           const start = shotRecording.startTime ?? timestamp;
           if (shotRecording.startTime == null) {
@@ -18687,7 +18760,7 @@ const powerRef = useRef(hud.power);
           }
           const relative = Math.max(0, timestamp - start);
           const snapshot = captureBallSnapshot();
-          const cameraSnapshot = captureReplayCameraSnapshot();
+          const cameraSnapshot = cameraOverride ?? captureReplayCameraSnapshot();
           const cueSnapshot = cueStick
             ? {
                 position: serializeVector3Snapshot(cueStick.position),
@@ -18858,7 +18931,8 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           };
-          if (hasCueSnapshots) {
+          if (!stroke && hasCueSnapshots) {
+            applyCueSnapshot();
             return;
           }
           if (!stroke) {
@@ -21450,9 +21524,6 @@ const powerRef = useRef(hud.power);
             (meta.state && typeof meta.state === 'object' ? meta.state.breakInProgress : false)
         );
         if (breakInProgress) return true;
-        if (meta.variant === 'uk') {
-          return Boolean(meta.state?.breakInProgress);
-        }
         return false;
       };
 
@@ -25015,7 +25086,7 @@ const powerRef = useRef(hud.power);
                   cueBallPotted || Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === 'uk' && nextMeta.state) {
                 nextInHand =
-                  cueBallPotted || Boolean(nextMeta.state.mustPlayFromBaulk);
+                  cueBallPotted || Boolean(nextMeta.state.ballInHand ?? nextMeta.state.mustPlayFromBaulk);
               }
             }
           }
@@ -26618,12 +26689,15 @@ const powerRef = useRef(hud.power);
             const c = captureCenters[pocketIndex];
             const captureRadius = captureRadii[pocketIndex] ?? CAPTURE_R;
             if (b.pos.distanceTo(c) < captureRadius) {
+              const entryVel = b.vel.clone();
               const entrySpeed = b.vel.length();
               const pocketVolume = THREE.MathUtils.clamp(
                 entrySpeed / POCKET_DROP_SPEED_REFERENCE,
                 0,
                 1
               );
+              const fromX = b.pos.x;
+              const fromZ = b.pos.y;
               const shouldForceCornerPocketView =
                 !suppressPocketCameras &&
                 !topViewRef.current &&
@@ -26667,8 +26741,19 @@ const powerRef = useRef(hud.power);
                   }
                 }
               }
+              const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               if (shotRecording) {
-                recordReplayFrame(performance.now());
+                const shouldForceReplayPocket =
+                  !pocketCameraStateRef.current || activeShotView?.mode !== 'pocket';
+                const replayPocketSnapshot = shouldForceReplayPocket
+                  ? buildReplayPocketSnapshot({
+                      pocketId,
+                      pocketCenter: c,
+                      ballPos: new THREE.Vector2(fromX, fromZ),
+                      approachDir: entryVel
+                    })
+                  : null;
+                recordReplayFrame(performance.now(), replayPocketSnapshot);
               }
               playPocket(pocketVolume);
               b.active = false;
@@ -26710,10 +26795,7 @@ const powerRef = useRef(hud.power);
                   });
                 }
               }
-              const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               const dropStart = performance.now();
-              const fromX = b.pos.x;
-              const fromZ = b.pos.y;
               const holderDir = resolvePocketHolderDirection(c, pocketId);
               const pocketRestIndex =
                 pocketRestIndexRef.current.get(pocketId) ?? 0;


### PR DESCRIPTION
### Motivation
- Bring Pool Royale pocket geometry and cushions visually/physically closer to the Snooker Royal reference so middle pocket jaws and cushion faces match the intended layout.
- Make ball‑in‑hand handling consistent between 8‑ball (UK) and 9‑ball variants so placement rules use the same `ballInHand` state where appropriate.
- Ensure missed or potted balls during live broadcast are represented in replays with an appropriate pocket camera snapshot, and make the cue‑stick replay animation reflect the broadcast (pull + push) reliably.

### Description
- Tuned pocket / jaw / cushion constants in `webapp/src/pages/Games/PoolRoyale.jsx` (eg. `POCKET_JAW_SIDE_INNER_SCALE`, `SIDE_POCKET_JAW_LATERAL_EXPANSION`, `SIDE_POCKET_JAW_RADIUS_EXPANSION`, `SIDE_POCKET_JAW_DEPTH_EXPANSION`, `SIDE_POCKET_JAW_OUTWARD_SHIFT`, `SIDE_POCKET_JAW_EDGE_TRIM_SCALE`, `POCKET_JAW_MAPPING_RADIUS_SCALE`, `CUSHION_FACE_INSET`) to pull cushions inward and match middle pocket jaws to Snooker Royal metrics. 
- Unified in‑hand derivation and post‑shot next‑in‑hand logic to consult `state.ballInHand` for UK/8Ball as well as American/9Ball by updating `deriveInHandFromFrame` and next‑in‑hand extraction after shot resolution. 
- Added replay improvements: `recordReplayFrame` now accepts an optional `cameraOverride`, a new `buildReplayPocketSnapshot` helper constructs a pocket camera snapshot, and pocket capture code will force a replay pocket snapshot when appropriate so missed/potted balls publish a pocket camera frame into the recording. 
- Improved cue stroke replay behavior by preferring to apply cue snapshots when present and ensuring cue stroke animation remains active and synchronized during replay playback so pullback and forward follow‑through are visible.

### Testing
- No automated tests were added or executed for this change; only code changes in `webapp/src/pages/Games/PoolRoyale.jsx` were applied and committed. 
- Manual runtime verification was not performed in this patch (no app run / smoke test reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985a2aec5e883298b9a5ec228edfac3)