### PR TITLE
Raise Pool Royale rails/cushions and preserve in-hand respot flag

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1056,7 +1056,7 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
-const RAIL_HEIGHT = TABLE.THICK * 1.33; // raise rails slightly so the cushions sit higher
+const RAIL_HEIGHT = TABLE.THICK * 1.36; // raise rails slightly so the cushions sit higher
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1351,8 +1351,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.35; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = -TABLE.THICK * 0.01; // lift the cushion base slightly so the lip sits higher above the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.12; // trim the cushion tops a touch less so they sit higher than before
+const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.008; // lift the cushion base slightly so the lip sits higher above the cloth
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.1; // trim the cushion tops a touch less so they sit higher than before
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -12959,7 +12959,8 @@ const powerRef = useRef(hud.power);
     if (enteringInHand) {
       cueBallPlacedFromHandRef.current = false;
       const cueBall = cueRef.current;
-      pendingInHandResetRef.current = Boolean(cueBall && !cueBall.active);
+      pendingInHandResetRef.current =
+        pendingInHandResetRef.current || Boolean(cueBall && !cueBall.active);
     }
     if (!hud.inHand || !playerTurn) {
       setInHandPlacementMode(false);


### PR DESCRIPTION
### Motivation
- Match the visual lift of the pocket jaws by raising the wooden rails and nudging the cushion geometry, and ensure cue-ball-in-hand is correctly respotted instead of remaining stuck in a pocket.

### Description
- Tuned table geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx`: increased `RAIL_HEIGHT` and adjusted `CUSHION_EXTRA_LIFT` and `CUSHION_HEIGHT_DROP` so rails/cushions sit slightly higher relative to pocket jaws.
- Kept the pending in-hand respot state when entering in-hand mode by changing the in-hand reset assignment to preserve an existing `pendingInHandResetRef.current` flag so a queued cue-ball respot is not lost.

### Testing
- Started the web dev server with `npm --prefix webapp run dev` and verified Vite served the app (local dev server started). 
- Attempted an automated headless capture using Playwright to validate the visual change, but the Chromium instance crashed in this environment so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c7002dd48329baa55edd5a0a21bc)