### PR TITLE
Pull Pool Royale cushions inward and shorten table bases by 20%

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1585,7 +1585,9 @@ const TABLE_HEIGHT_SCALE = 1.56;
 const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE;
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
-const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;
+const BASE_HEIGHT_REDUCTION = 0.8; // shorten base/leg stack by 20%
+const BASE_LEG_HEIGHT =
+  TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER * BASE_HEIGHT_REDUCTION;
 const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
 const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension to lower the playfield
@@ -1610,11 +1612,11 @@ const SKIRT_RAIL_GAP_FILL = TABLE.THICK * 0.095; // raise the apron further so i
 const BASE_HEIGHT_FILL = 1; // grow bases upward so the stance stays consistent with the shorter skirt
 // adjust overall table position so the shorter legs bring the playfield closer to floor level
 const BASE_TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H + TABLE_LIFT - TABLE_DROP;
-const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.18; // lower the full table assembly by 18%
+const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.2; // lower the full table assembly to match shorter bases
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA - TABLE_HEIGHT_DROP;
 const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
-const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
+const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.02;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.18; // widen the visible air gap so the blue tip never kisses the cue ball
 const CUE_TIP_GAP = BALL_R * 1.08 + CUE_TIP_CLEARANCE; // pull the blue tip into the cue-ball centre line while leaving a safe buffer
@@ -7940,14 +7942,14 @@ export function Table3D(
     mesh.material.needsUpdate = true;
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
-  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.085; // push the cushions slightly farther outward to match the Snooker Royal rail edge
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
+  const CUSHION_RAIL_FLUSH = TABLE.THICK * 0.03; // pull the cushions inward toward the table center to avoid rail overlap
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.02; // pull the short-rail cushions inward so noses clear the wood rails
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.018; // add a slightly deeper setback along the long rails
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
   const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match Snooker Royal pocket clearance
-  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
+  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.01; // reduce the side cushion reach so they sit just inside the rails
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const railsGroup = new THREE.Group();


### PR DESCRIPTION
### Motivation
- Cushions were visually overlapping the wooden rails and needed to be pulled slightly inward to clear the rails. 
- The table base/leg stack should be 20% shorter and the table/camera lowered to match the new stance for correct visual framing.

### Description
- Adjusted cushion positioning constants to pull cushions inward and reduce their rail reach by changing `CUSHION_RAIL_FLUSH`, `CUSHION_SHORT_RAIL_CENTER_NUDGE`, `CUSHION_LONG_RAIL_CENTER_NUDGE`, and `SIDE_CUSHION_RAIL_REACH` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Introduced `BASE_HEIGHT_REDUCTION = 0.8` and applied it to `BASE_LEG_HEIGHT` to shorten base/leg stack by 20%.
- Increased `TABLE_HEIGHT_DROP` to `0.2` and nudged `ORBIT_FOCUS_BASE_Y` to keep camera framing aligned with the new table height.
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` which reported Vite ready and served the app (success).
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate renders, but the Playwright run timed out and the screenshot step failed (timeout).
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d0b6b3b08329b7c1d6919256732f)