### PR TITLE
Map Pool Royale to BCA 7ft table and align 8-ball/9-ball rules to BCA

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -1,11 +1,46 @@
+const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7]);
+const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15]);
+const GROUP_TOTAL = 7;
+
+const opponent = (player) => (player === 'A' ? 'B' : 'A');
+
+const groupForBall = (id) => {
+  if (SOLIDS.has(id)) return 'solids';
+  if (STRIPES.has(id)) return 'stripes';
+  if (id === 8) return 'eight';
+  return null;
+};
+
+const countGroupRemaining = (ballsOnTable, group) => {
+  if (!group) return 0;
+  let remaining = 0;
+  for (const id of ballsOnTable) {
+    if (groupForBall(id) === group) remaining += 1;
+  }
+  return remaining;
+};
+
+const computeScores = (ballsOnTable, assignments) => {
+  const scores = { A: 0, B: 0 };
+  if (assignments.A) {
+    scores.A = GROUP_TOTAL - countGroupRemaining(ballsOnTable, assignments.A);
+  }
+  if (assignments.B) {
+    scores.B = GROUP_TOTAL - countGroupRemaining(ballsOnTable, assignments.B);
+  }
+  return scores;
+};
+
 export class AmericanBilliards {
   constructor () {
     this.state = {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
+      assignments: { A: null, B: null },
+      isOpenTable: true,
+      breakInProgress: true,
       scores: { A: 0, B: 0 },
       ballInHand: false,
-      foulStreak: { A: 0, B: 0 },
       frameOver: false,
       winner: null
     };
@@ -24,24 +59,41 @@ export class AmericanBilliards {
         nextPlayer: s.currentPlayer,
         ballInHandNext: false,
         frameOver: true,
-        winner: s.winner
+        winner: s.winner,
+        assignments: { ...s.assignments },
+        isOpenTable: s.isOpenTable
       };
     }
     const current = s.currentPlayer;
-    const opp = current === 'A' ? 'B' : 'A';
-    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const opp = opponent(current);
+    const firstContact = contactOrder[0];
+    const pottedBalls = pottedList.filter((id) => id !== 0);
+    const firstGroup = typeof firstContact === 'number' ? groupForBall(firstContact) : null;
+    const assignment = s.assignments[current];
+    const remainingAssigned = countGroupRemaining(s.ballsOnTable, assignment);
+
     let foul = false;
     let reason = '';
 
-    const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!firstContact) {
       foul = true;
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!foul && s.isOpenTable && firstGroup === 'eight') {
       foul = true;
-      reason = 'wrong first contact';
+      reason = '8-ball first contact on open table';
+    }
+
+    if (!foul && !s.isOpenTable && assignment) {
+      if (remainingAssigned > 0 && firstGroup !== assignment) {
+        foul = true;
+        reason = 'wrong first contact';
+      }
+      if (remainingAssigned === 0 && firstGroup !== 'eight') {
+        foul = true;
+        reason = 'must contact 8-ball';
+      }
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -49,43 +101,69 @@ export class AmericanBilliards {
       reason = 'scratch';
     }
 
-    const pottedBalls = pottedList.filter(id => id !== 0);
-    const points = pottedBalls.reduce((a, b) => a + b, 0);
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
-    const targetScore = 61;
 
     if (foul) {
-      const foulPoints = Math.max(1, points);
-      s.scores[opp] += foulPoints;
-      // Balls pocketed on a foul are respotted.
-      nextPlayer = opp;
-      s.currentPlayer = opp;
-      ballInHandNext = true;
-      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
-      s.foulStreak[opp] = 0;
-    } else {
-      for (const id of pottedBalls) s.ballsOnTable.delete(id);
-      s.scores[current] += points;
-      s.foulStreak[current] = 0;
-      s.foulStreak[opp] = 0;
-      if (pottedBalls.length === 0) {
+      if (pottedBalls.includes(8)) {
+        frameOver = true;
+        winner = opp;
+      } else {
+        pottedBalls.forEach((id) => s.ballsOnTable.delete(id));
         nextPlayer = opp;
         s.currentPlayer = opp;
+        ballInHandNext = true;
+      }
+    } else {
+      pottedBalls.forEach((id) => s.ballsOnTable.delete(id));
+      if (s.isOpenTable && pottedBalls.length > 0) {
+        const firstPotted = pottedBalls[0];
+        const group = groupForBall(firstPotted);
+        if (group === 'solids' || group === 'stripes') {
+          s.assignments[current] = group;
+          s.assignments[opp] = group === 'solids' ? 'stripes' : 'solids';
+          s.isOpenTable = false;
+        }
+      }
+
+      const remainingAfter = countGroupRemaining(s.ballsOnTable, s.assignments[current]);
+      if (pottedBalls.includes(8)) {
+        if (s.breakInProgress) {
+          frameOver = true;
+          winner = current;
+        } else if (s.isOpenTable || (s.assignments[current] && remainingAfter > 0)) {
+          frameOver = true;
+          winner = opp;
+        } else {
+          frameOver = true;
+          winner = current;
+        }
+      }
+
+      if (!frameOver) {
+        const pottedOwnGroup =
+          (!s.isOpenTable && s.assignments[current] &&
+            pottedBalls.some((id) => groupForBall(id) === s.assignments[current])) ||
+          (s.isOpenTable && pottedBalls.length > 0);
+        if (!pottedOwnGroup) {
+          nextPlayer = opp;
+          s.currentPlayer = opp;
+        }
       }
     }
 
     s.ballInHand = ballInHandNext;
-    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    s.breakInProgress = false;
+    s.scores = computeScores(s.ballsOnTable, s.assignments);
 
-    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
-      frameOver = true;
-      if (s.scores[current] > s.scores[opp]) winner = current;
-      else if (s.scores[opp] > s.scores[current]) winner = opp;
-      else winner = 'TIE';
+    if (frameOver) {
       s.frameOver = true;
       s.winner = winner;
     }
@@ -97,10 +175,11 @@ export class AmericanBilliards {
       potted: pottedList,
       nextPlayer,
       ballInHandNext,
-      scores: { ...s.scores },
-      currentBall: nextBall,
       frameOver,
-      winner
+      winner,
+      assignments: { ...s.assignments },
+      isOpenTable: s.isOpenTable,
+      scores: { ...s.scores }
     };
   }
 }

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -45,6 +45,11 @@ export class NineBall {
 
     const pottedBalls = pottedList.filter(id => id !== 0);
 
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
+
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1044,16 +1044,31 @@ const ENABLE_TABLE_MAPPING_LINES = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const REPLAY_CUE_STICK_HOLD_MS = 620;
-  const TABLE_BASE_SCALE = 1.2;
-  const TABLE_WIDTH_SCALE = 1.25;
-  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
-  const TABLE_LENGTH_SCALE = 0.8;
-  const TABLE = {
-    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
-    THICK: 1.8 * TABLE_SCALE,
-    WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
-  };
+const TABLE_BASE_SCALE = 1.2;
+const TABLE_WIDTH_SCALE = 1.25;
+const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
+const TABLE_THICKNESS = 1.8 * TABLE_SCALE; // keep the table height identical to the previous build
+// BCA 7ft official references (playing surface 78" × 39", overall 84" × 48", 2.25" balls).
+const WIDTH_REF = 1981.2;
+const HEIGHT_REF = 990.6;
+const TABLE_LENGTH_REF = 2133.6;
+const TABLE_WIDTH_REF = 1219.2;
+const BALL_D_REF = 57.15;
+const BALL_SIZE_SCALE = 1.1545; // lock the previous ball sizing
+const LEGACY_BALL_DIAMETER = 2.5032825703675816; // previous Pool Royale ball diameter (units)
+const MM_TO_UNITS = LEGACY_BALL_DIAMETER / (BALL_D_REF * BALL_SIZE_SCALE);
+const SIDE_RAIL_REF = (TABLE_WIDTH_REF - HEIGHT_REF) / 2;
+const END_RAIL_REF = (TABLE_LENGTH_REF - WIDTH_REF) / 2;
+const SIDE_RAIL_INNER_THICKNESS = SIDE_RAIL_REF * MM_TO_UNITS;
+const END_RAIL_INNER_THICKNESS = END_RAIL_REF * MM_TO_UNITS;
+const PLAY_W = WIDTH_REF * MM_TO_UNITS;
+const PLAY_H = HEIGHT_REF * MM_TO_UNITS;
+const TABLE = {
+  W: PLAY_W + 2 * SIDE_RAIL_INNER_THICKNESS,
+  H: PLAY_H + 2 * END_RAIL_INNER_THICKNESS,
+  THICK: TABLE_THICKNESS,
+  WALL: SIDE_RAIL_INNER_THICKNESS
+};
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
 const RAIL_HEIGHT = TABLE.THICK * 1.38; // raise rails slightly so the cushions sit higher
@@ -1111,31 +1126,14 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
-  const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
-  const D_RADIUS_REF = 292;
-  const PINK_FROM_TOP_REF = 737;
-  const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
-  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
-  const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
-  const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
-  const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
-  // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
-const END_RAIL_INNER_SCALE =
-  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
-  (2 * TABLE.WALL);
-const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
-const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAYFIELD_SHRINK = 0.85; // shrink the playfield footprint by ~15% on all sides while keeping table height intact
-const PLAY_W = (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
-const PLAY_H = (TABLE.H - 2 * END_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
+// BCA 7ft official references (playing surface 78" × 39", 2.25" balls).
+const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
+const D_RADIUS_REF = 292;
+const PINK_FROM_TOP_REF = 737;
+const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
+const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
+const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
+const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
   tableWidth: TABLE.W,
   tableLength: TABLE.H,
@@ -1147,12 +1145,10 @@ export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
 const innerLong = Math.max(PLAY_W, PLAY_H);
 const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
-  console.assert(
-    Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
-  );
-const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
+console.assert(
+  Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
+  'Pool table inner ratio must match the official 2:1 target after scaling.'
+);
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Provide an authentic 7ft pool table footprint (BCA dimensions) scaled for mobile while preserving the existing ball sizing and table height mapping for a consistent visual feel.
- Ensure the American 8‑ball logic follows BCA-style open-table/group assignment and 8‑ball win/loss semantics for accurate gameplay.
- Harden 9‑ball foul detection to include the common BCA “no rail after contact” foul for fair rule enforcement.

### Description
- Rebuilt table geometry in `webapp/src/pages/Games/PoolRoyale.jsx` to use BCA 7ft references (78"×39" playfield) and explicit rail/playfield calculations, preserved legacy ball diameter/scale, and tightened the inner ratio assertion to match the official 2:1 playfield ratio.
- Replaced/rewrote American 8‑ball engine in `lib/americanBilliards.js` to implement BCA-style open table, group assignment on first legal pot, assignment tracking, break-in-progress handling, no-rail fouls, correct 8‑ball win/loss cases, and group-based score computation.
- Updated `src/rules/PoolRoyaleRules.ts` to reflect the new American state shape (assignments, `isOpenTable`, `breakInProgress`), to serialize/apply the new state, to provide `computeAmericanBallOn` helper, and to surface appropriate HUD labels (`open table`, group phases, `8-ball`) and `meta.breakInProgress` propagation.
- Tightened 9‑ball foul logic in `lib/nineBall.js` to treat `noCushionAfterContact` (no rail) as a foul when no object ball is potted.
- Minor messaging/assertion updates and bookkeeping to keep pocket/ball mapping consistent with the new playfield math.

### Testing
- Ran quick numeric sanity checks with inline `node` snippets to verify MM→unit mapping and computed ball diameter values, and confirmed printed results matched expectations (sanity outputs observed during rollout). (succeeded)
- Started the web app dev server with `npm --prefix webapp run dev` and confirmed Vite served the site (server ready and reachable at the reported host/port). (succeeded)
- Attempted an automated Playwright screenshot of the local `PoolRoyale` page to visually validate the table, but Chromium crashed during headless launch causing the screenshot step to fail; server remained running. (failed)
- No unit test suite was executed as part of this change set (`npm test`/`jest` not run). (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d931516c83299807a2c49fc73f92)