### PR TITLE
Align Pool Royale table sizing and BCA 8/9-ball rules

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -3,9 +3,10 @@ export class AmericanBilliards {
     this.state = {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
-      scores: { A: 0, B: 0 },
       ballInHand: false,
-      foulStreak: { A: 0, B: 0 },
+      isOpenTable: true,
+      assignments: { A: null, B: null },
+      breakInProgress: true,
       frameOver: false,
       winner: null
     };
@@ -29,7 +30,6 @@ export class AmericanBilliards {
     }
     const current = s.currentPlayer;
     const opp = current === 'A' ? 'B' : 'A';
-    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
     let foul = false;
     let reason = '';
 
@@ -39,9 +39,29 @@ export class AmericanBilliards {
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
-      foul = true;
-      reason = 'wrong first contact';
+    const solids = new Set([1, 2, 3, 4, 5, 6, 7]);
+    const stripes = new Set([9, 10, 11, 12, 13, 14, 15]);
+    const isSolid = (id) => solids.has(id);
+    const isStripe = (id) => stripes.has(id);
+    const isEight = (id) => id === 8;
+    const remainingSolids = Array.from(s.ballsOnTable).filter(isSolid).length;
+    const remainingStripes = Array.from(s.ballsOnTable).filter(isStripe).length;
+    const assigned = s.assignments[current];
+    const needsEight = assigned && (assigned === 'SOLIDS' ? remainingSolids === 0 : remainingStripes === 0);
+
+    if (!foul && assigned) {
+      if (needsEight) {
+        if (first !== 8) {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      } else if (assigned === 'SOLIDS' && !isSolid(first)) {
+        foul = true;
+        reason = 'wrong first contact';
+      } else if (assigned === 'STRIPES' && !isStripe(first)) {
+        foul = true;
+        reason = 'wrong first contact';
+      }
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -50,45 +70,63 @@ export class AmericanBilliards {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    const points = pottedBalls.reduce((a, b) => a + b, 0);
+
+    if (!foul && !pottedBalls.length && shot.noCushionAfterContact) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
-    const targetScore = 61;
 
-    if (foul) {
-      const foulPoints = Math.max(1, points);
-      s.scores[opp] += foulPoints;
-      // Balls pocketed on a foul are respotted.
-      nextPlayer = opp;
-      s.currentPlayer = opp;
-      ballInHandNext = true;
-      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
-      s.foulStreak[opp] = 0;
-    } else {
-      for (const id of pottedBalls) s.ballsOnTable.delete(id);
-      s.scores[current] += points;
-      s.foulStreak[current] = 0;
-      s.foulStreak[opp] = 0;
-      if (pottedBalls.length === 0) {
+    const eightPotted = pottedBalls.includes(8);
+    const solidPotted = pottedBalls.find(isSolid);
+    const stripePotted = pottedBalls.find(isStripe);
+    const firstGroupPotted = pottedBalls.find((id) => isSolid(id) || isStripe(id)) ?? null;
+
+    if (foul && eightPotted) {
+      frameOver = true;
+      winner = opp;
+      s.frameOver = true;
+      s.winner = winner;
+    } else if (!foul && eightPotted) {
+      frameOver = true;
+      if (s.breakInProgress) {
+        winner = current;
+      } else if (s.isOpenTable) {
+        winner = opp;
+      } else if (!needsEight) {
+        winner = opp;
+      } else {
+        winner = current;
+      }
+      s.frameOver = true;
+      s.winner = winner;
+    }
+
+    if (!frameOver) {
+      if (foul) {
         nextPlayer = opp;
         s.currentPlayer = opp;
+        ballInHandNext = true;
+      } else {
+        for (const id of pottedBalls) s.ballsOnTable.delete(id);
+        if (s.isOpenTable && firstGroupPotted) {
+          s.isOpenTable = false;
+          s.assignments[current] = isSolid(firstGroupPotted) ? 'SOLIDS' : 'STRIPES';
+          s.assignments[opp] = isSolid(firstGroupPotted) ? 'STRIPES' : 'SOLIDS';
+        }
+        if (pottedBalls.length === 0) {
+          nextPlayer = opp;
+          s.currentPlayer = opp;
+        }
       }
     }
 
     s.ballInHand = ballInHandNext;
-    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
-
-    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
-      frameOver = true;
-      if (s.scores[current] > s.scores[opp]) winner = current;
-      else if (s.scores[opp] > s.scores[current]) winner = opp;
-      else winner = 'TIE';
-      s.frameOver = true;
-      s.winner = winner;
-    }
+    s.breakInProgress = false;
 
     return {
       legal: !foul,
@@ -97,8 +135,6 @@ export class AmericanBilliards {
       potted: pottedList,
       nextPlayer,
       ballInHandNext,
-      scores: { ...s.scores },
-      currentBall: nextBall,
       frameOver,
       winner
     };

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -44,6 +44,10 @@ export class NineBall {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
+    if (!foul && !pottedBalls.length && shot.noCushionAfterContact) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1111,10 +1111,9 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
+  // Official 7ft bar table playing surface reference: 78" × 39" (1981.2mm × 990.6mm), 2.25" balls.
+  const WIDTH_REF = 1981.2;
+  const HEIGHT_REF = 990.6;
   const BALL_D_REF = 57.15;
   const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
   const D_RADIUS_REF = 292;
@@ -1125,9 +1124,8 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
-  // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
+  // Match the official 7ft (bar) table playing surface ratio (78" × 39").
+  const TARGET_RATIO = 2;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1149,10 +1147,12 @@ const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   console.assert(
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
+    'Pool table inner ratio must match the official 7ft 2:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
+const LEGACY_WIDTH_REF = 2540;
+const LEGACY_BALL_SCALE = 1.1545;
+const BALL_SIZE_SCALE = LEGACY_BALL_SCALE * (LEGACY_WIDTH_REF / WIDTH_REF);
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table and ball mapping match an authentic 7ft (78"×39") playing surface scaled for mobile while keeping the visual ball sizing consistent with the existing build. 
- Align the 8-ball and 9-ball game logic with standard BCA-style rules (group assignment on open table, eight-ball win/loss/forfeiture conditions, and rail/cushion fouls) so gameplay follows expected officiating.

### Description
- Updated table geometry and mapping constants in `webapp/src/pages/Games/PoolRoyale.jsx` to use a 7ft playing surface reference (`WIDTH_REF = 1981.2`, `HEIGHT_REF = 990.6`) and set the inner target ratio to `2:1`, while adjusting ball scaling to preserve prior visual feel. 
- Implemented BCA-style 8-ball state and flow in `lib/americanBilliards.js` including `isOpenTable`, `assignments`, `breakInProgress`, group assignment on first legal pot, eight-ball win/loss handling (including break eight rule), and added a rail-after-contact foul. 
- Added `no-rail-after-contact` foul handling for 9-ball in `lib/nineBall.js` and propagated the updated state shape into the higher-level rules bridge in `src/rules/PoolRoyaleRules.ts`, including serialization/deserialization adjustments and HUD `ballOn`/`next` text changes to reflect open/table/group/8-ball states. 
- Updated unit tests in `test/americanBilliards.test.js` to exercise the new 8-ball behaviors (open-table assignment, break eight win, early eight loss, wrong-first-contact fouls, and clearing-then-potting-eight). 

### Testing
- Ran the American billiards unit tests with `node --test test/americanBilliards.test.js`, and all tests passed (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ece92b108329893564bffd616882)