### PR TITLE
Update Pool Royale to 7ft table scaling, preserve ball size, and add BCA-style American 8‑ball + AI updates

### DIFF
--- a/lib/american8Ball.js
+++ b/lib/american8Ball.js
@@ -1,0 +1,174 @@
+function opponent (p) {
+  return p === 'A' ? 'B' : 'A'
+}
+
+function groupForBall (id) {
+  if (id >= 1 && id <= 7) return 'SOLIDS'
+  if (id >= 9 && id <= 15) return 'STRIPES'
+  if (id === 8) return 'EIGHT'
+  return null
+}
+
+function remainingCount (ballsOnTable, group) {
+  if (group === 'SOLIDS') {
+    return [...ballsOnTable].filter((id) => id >= 1 && id <= 7).length
+  }
+  if (group === 'STRIPES') {
+    return [...ballsOnTable].filter((id) => id >= 9 && id <= 15).length
+  }
+  return 0
+}
+
+export class AmericanEightBall {
+  constructor () {
+    this.state = {
+      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      assignments: { A: null, B: null },
+      currentPlayer: 'A',
+      ballInHand: true,
+      isOpenTable: true,
+      breakInProgress: true,
+      frameOver: false,
+      winner: null
+    }
+  }
+
+  shotTaken (shot = {}) {
+    const s = this.state
+    if (s.frameOver) {
+      return {
+        legal: false,
+        foul: true,
+        reason: 'frame over',
+        potted: [],
+        nextPlayer: s.currentPlayer,
+        ballInHandNext: false,
+        frameOver: true,
+        winner: s.winner
+      }
+    }
+    const current = s.currentPlayer
+    const opp = opponent(current)
+    const contactOrder = Array.isArray(shot.contactOrder) ? shot.contactOrder : []
+    const pottedList = Array.isArray(shot.potted) ? shot.potted : []
+    const first = contactOrder[0]
+    const pottedBalls = pottedList.filter((id) => id !== 0)
+    const scratch = pottedList.includes(0) || shot.cueOffTable
+    const solidsPotted = pottedBalls.filter((id) => id >= 1 && id <= 7)
+    const stripesPotted = pottedBalls.filter((id) => id >= 9 && id <= 15)
+    const eightPotted = pottedBalls.includes(8)
+    let foul = false
+    let reason = ''
+
+    if (!first) {
+      foul = true
+      reason = 'no contact'
+    }
+
+    if (!foul && scratch) {
+      foul = true
+      reason = 'scratch'
+    }
+
+    const ownGroup = s.assignments[current]
+    const ownRemaining = ownGroup ? remainingCount(s.ballsOnTable, ownGroup) : 0
+    if (!foul && ownGroup) {
+      if (ownRemaining > 0) {
+        if (groupForBall(first) !== ownGroup) {
+          foul = true
+          reason = 'wrong first contact'
+        }
+      } else if (first !== 8) {
+        foul = true
+        reason = 'must hit 8'
+      }
+    }
+
+    if (!foul && pottedBalls.length === 0 && shot.noCushionAfterContact) {
+      foul = true
+      reason = 'no cushion'
+    }
+
+    let nextPlayer = current
+    let ballInHandNext = false
+    let frameOver = false
+    let winner = null
+
+    if (eightPotted) {
+      if (foul) {
+        frameOver = true
+        winner = opp
+      } else if (s.isOpenTable && s.breakInProgress) {
+        frameOver = true
+        winner = current
+      } else if (s.isOpenTable) {
+        frameOver = true
+        winner = opp
+      } else if (ownGroup && ownRemaining > 0) {
+        frameOver = true
+        winner = opp
+      } else {
+        frameOver = true
+        winner = current
+      }
+    }
+
+    if (!frameOver) {
+      for (const id of pottedBalls) {
+        if (id !== 8) s.ballsOnTable.delete(id)
+      }
+    }
+
+    if (foul) {
+      nextPlayer = opp
+      s.currentPlayer = opp
+      ballInHandNext = true
+    } else {
+      if (s.isOpenTable) {
+        if (solidsPotted.length && !stripesPotted.length) {
+          s.assignments[current] = 'SOLIDS'
+          s.assignments[opp] = 'STRIPES'
+          s.isOpenTable = false
+        } else if (stripesPotted.length && !solidsPotted.length) {
+          s.assignments[current] = 'STRIPES'
+          s.assignments[opp] = 'SOLIDS'
+          s.isOpenTable = false
+        }
+      }
+
+      const groupAfter = s.assignments[current]
+      const pottedOwn =
+        s.isOpenTable
+          ? solidsPotted.length > 0 || stripesPotted.length > 0
+          : groupAfter === 'SOLIDS'
+            ? solidsPotted.length > 0
+            : groupAfter === 'STRIPES'
+              ? stripesPotted.length > 0
+              : false
+      if (!pottedOwn && !eightPotted) {
+        nextPlayer = opp
+        s.currentPlayer = opp
+      }
+    }
+
+    if (frameOver) {
+      s.frameOver = true
+      s.winner = winner
+    }
+    s.ballInHand = ballInHandNext
+    s.breakInProgress = false
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: pottedList,
+      nextPlayer,
+      ballInHandNext,
+      frameOver,
+      winner: frameOver ? winner : undefined
+    }
+  }
+}
+
+export default AmericanEightBall

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -44,6 +44,10 @@ export class NineBall {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
+    if (!foul && pottedBalls.length === 0 && shot.noCushionAfterContact) {
+      foul = true;
+      reason = 'no cushion';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -1,6 +1,6 @@
 import { FrameState, Player, ShotContext, ShotEvent } from '../types';
 import { UkPool } from '../../lib/poolUk8Ball.js';
-import { AmericanBilliards } from '../../lib/americanBilliards.js';
+import { AmericanEightBall } from '../../lib/american8Ball.js';
 import { NineBall } from '../../lib/nineBall.js';
 
 type PoolVariantId = 'american' | 'uk' | '9ball';
@@ -32,12 +32,13 @@ type UkSerializedState = {
 
 type AmericanSerializedState = {
   ballsOnTable: number[];
+  assignments: { A: 'SOLIDS' | 'STRIPES' | null; B: 'SOLIDS' | 'STRIPES' | null };
   currentPlayer: 'A' | 'B';
-  scores: { A: number; B: number };
   ballInHand: boolean;
-  foulStreak: { A: number; B: number };
+  isOpenTable: boolean;
+  breakInProgress: boolean;
   frameOver: boolean;
-  winner: 'A' | 'B' | 'TIE' | null;
+  winner: 'A' | 'B' | null;
 };
 
 type NineSerializedState = {
@@ -124,25 +125,27 @@ function applyUkState(game: UkPool, snapshot: UkSerializedState) {
   };
 }
 
-function serializeAmericanState(state: AmericanBilliards['state']): AmericanSerializedState {
+function serializeAmericanState(state: AmericanEightBall['state']): AmericanSerializedState {
   return {
     ballsOnTable: Array.from(state.ballsOnTable.values()),
+    assignments: { ...state.assignments },
     currentPlayer: state.currentPlayer,
-    scores: { ...state.scores },
     ballInHand: state.ballInHand,
-    foulStreak: { ...state.foulStreak },
+    isOpenTable: state.isOpenTable,
+    breakInProgress: state.breakInProgress,
     frameOver: state.frameOver,
     winner: state.winner
   };
 }
 
-function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerializedState) {
+function applyAmericanState(game: AmericanEightBall, snapshot: AmericanSerializedState) {
   game.state = {
     ballsOnTable: new Set(snapshot.ballsOnTable),
+    assignments: { ...snapshot.assignments },
     currentPlayer: snapshot.currentPlayer,
-    scores: { ...snapshot.scores },
     ballInHand: snapshot.ballInHand,
-    foulStreak: { ...snapshot.foulStreak },
+    isOpenTable: snapshot.isOpenTable,
+    breakInProgress: snapshot.breakInProgress,
     frameOver: snapshot.frameOver,
     winner: snapshot.winner
   };
@@ -287,10 +290,8 @@ export class PoolRoyaleRules {
         return base;
       }
       default: {
-        const game = new AmericanBilliards();
-        game.state.ballInHand = true;
+        const game = new AmericanEightBall();
         const snapshot = serializeAmericanState(game.state);
-        const lowest = lowestBall(snapshot.ballsOnTable) ?? 1;
         const base: FrameState = {
           balls: [],
           activePlayer: 'A',
@@ -298,12 +299,12 @@ export class PoolRoyaleRules {
           currentBreak: 0,
           phase: 'REDS_AND_COLORS',
           redsRemaining: snapshot.ballsOnTable.length,
-          ballOn: [`BALL_${lowest}`],
+          ballOn: ['SOLIDS', 'STRIPES'],
           frameOver: false
         };
         const hud: HudInfo = {
-          next: `ball ${lowest}`,
-          phase: 'rotation',
+          next: 'open table',
+          phase: 'open',
           scores: { A: 0, B: 0 }
         };
         base.meta = {
@@ -442,11 +443,9 @@ export class PoolRoyaleRules {
   private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
     const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
-    const game = new AmericanBilliards();
+    const game = new AmericanEightBall();
     if (previous) {
       applyAmericanState(game, previous.state);
-    } else {
-      game.state.ballInHand = true;
     }
     const contactOrder: number[] = [];
     for (const ev of events) {
@@ -473,43 +472,26 @@ export class PoolRoyaleRules {
     });
     const pottedCount = potted.filter((id) => id !== 0).length;
     const snapshot = serializeAmericanState(game.state);
-    const lowest = lowestBall(snapshot.ballsOnTable);
-    const tableClear = snapshot.ballsOnTable.length === 0;
-    const frameOver = snapshot.frameOver || tableClear;
+    const { ballOn, scores, phase } = this.computeAmericanTargets(snapshot);
     const hud: HudInfo = {
-      next:
-        frameOver && snapshot.winner
-          ? 'frame over'
-          : lowest != null
-            ? `ball ${lowest}`
-            : tableClear
-              ? 'frame over'
-              : 'rack clear',
-      phase: frameOver ? 'complete' : 'rotation',
-      scores: { ...snapshot.scores }
+      next: ballOn.length ? ballOn.map((entry) => entry.toLowerCase()).join(' / ') : 'frame over',
+      phase,
+      scores
     };
-    let winner: FrameState['winner'];
-    if (frameOver) {
-      if (snapshot.winner === 'A' || snapshot.winner === 'B' || snapshot.winner === 'TIE') {
-        winner = snapshot.winner;
-      } else if (snapshot.scores.A > snapshot.scores.B) winner = 'A';
-      else if (snapshot.scores.B > snapshot.scores.A) winner = 'B';
-      else winner = 'TIE';
-    }
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
       players: {
-        A: { ...state.players.A, score: snapshot.scores.A },
-        B: { ...state.players.B, score: snapshot.scores.B }
+        A: { ...state.players.A, score: scores.A },
+        B: { ...state.players.B, score: scores.B }
       },
       currentBreak:
         !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
           ? (state.currentBreak ?? 0) + pottedCount
           : 0,
-      ballOn: lowest != null && !frameOver ? [`BALL_${lowest}`] : [],
-      frameOver,
-      winner,
+      ballOn,
+      frameOver: snapshot.frameOver,
+      winner: snapshot.winner ?? undefined,
       foul: result.foul
         ? {
             points: 0,
@@ -520,10 +502,53 @@ export class PoolRoyaleRules {
         variant: 'american',
         state: snapshot,
         hud,
-        breakInProgress: false
+        breakInProgress: snapshot.breakInProgress
       } satisfies PoolMeta
     };
     return nextState;
+  }
+
+  private computeAmericanTargets(state: AmericanSerializedState): {
+    ballOn: string[];
+    scores: { A: number; B: number };
+    phase: string;
+  } {
+    const remainingSolids = state.ballsOnTable.filter((id) => id >= 1 && id <= 7).length;
+    const remainingStripes = state.ballsOnTable.filter((id) => id >= 9 && id <= 15).length;
+    const totals = { solids: 7, stripes: 7 };
+    const scores = {
+      A:
+        state.assignments.A === 'SOLIDS'
+          ? totals.solids - remainingSolids
+          : state.assignments.A === 'STRIPES'
+            ? totals.stripes - remainingStripes
+            : 0,
+      B:
+        state.assignments.B === 'SOLIDS'
+          ? totals.solids - remainingSolids
+          : state.assignments.B === 'STRIPES'
+            ? totals.stripes - remainingStripes
+            : 0
+    };
+    if (state.frameOver) {
+      return { ballOn: [], scores, phase: 'complete' };
+    }
+    if (state.isOpenTable) {
+      const available: string[] = [];
+      if (remainingSolids > 0) available.push('SOLIDS');
+      if (remainingStripes > 0) available.push('STRIPES');
+      if (available.length === 0) available.push('8');
+      return { ballOn: available, scores, phase: 'open' };
+    }
+    const current = state.currentPlayer;
+    const assignment = state.assignments[current];
+    if (assignment === 'SOLIDS' && remainingSolids > 0) {
+      return { ballOn: ['SOLIDS'], scores, phase: 'groups' };
+    }
+    if (assignment === 'STRIPES' && remainingStripes > 0) {
+      return { ballOn: ['STRIPES'], scores, phase: 'groups' };
+    }
+    return { ballOn: ['8'], scores, phase: '8-ball' };
   }
 
   private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -2,9 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { planShot, estimateCueAfterShot } from '../lib/poolAi.js';
 
-test('planShot targets lowest numbered ball', () => {
+test('planShot targets lowest numbered ball on an open table', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 300, y: 250, vx: 0, vy: 0, pocketed: false },
@@ -30,9 +30,9 @@ test('planShot targets lowest numbered ball', () => {
   assert(decision.rationale.length > 0);
 });
 
-test('eight ball is treated as normal', () => {
+test('eight ball becomes the target when it is the only object ball', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 100, y: 100, vx: 0, vy: 0, pocketed: false },
@@ -56,7 +56,7 @@ test('eight ball is treated as normal', () => {
 
 test('ball in hand aims for straight shot', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 0, y: 0, vx: 0, vy: 0, pocketed: false },
@@ -88,7 +88,7 @@ test('ball in hand aims for straight shot', () => {
 
 test('avoids pocket with blocking ball at entrance', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 50, y: 100, vx: 0, vy: 0, pocketed: false },
@@ -162,7 +162,7 @@ test('UNASSIGNED group defers to ballOn value', () => {
 
 test('prefers target with smallest cut angle', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 100, y: 250, vx: 0, vy: 0, pocketed: false },
@@ -218,7 +218,7 @@ test('straight shots stay on line regardless of power', () => {
 
 test('avoids unnecessary spin when natural position is good', () => {
   const req = {
-    game: 'AMERICAN_BILLIARDS',
+    game: 'AMERICAN_8BALL',
     state: {
       balls: [
         { id: 0, x: 200, y: 250, vx: 0, vy: 0, pocketed: false },

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -44,7 +44,7 @@ describe('PoolRoyaleRules', () => {
     expect(foulState.ballOn).toContain('YELLOW');
   });
 
-  test('American variant handles break transition, fouls, and ball-in-hand', () => {
+  test('American 8-ball handles break transition, fouls, and ball-in-hand', () => {
     const rules = new PoolRoyaleRules('american');
     const initialFrame = rules.getInitialFrame('Breaker', 'Opponent');
     const initialMeta = initialFrame.meta as any;
@@ -52,7 +52,7 @@ describe('PoolRoyaleRules', () => {
     expect(initialMeta?.variant).toBe('american');
     expect(initialMeta?.breakInProgress).toBe(true);
     expect(initialMeta?.state?.ballInHand).toBe(true);
-    expect(initialMeta?.hud?.next).toBe('ball 1');
+    expect(initialMeta?.hud?.next).toBe('open table');
 
     const breakEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 1, ballId: 1 },
@@ -68,12 +68,12 @@ describe('PoolRoyaleRules', () => {
 
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
-    expect(cleared.ballOn).toEqual(['BALL_3']);
-    expect(clearedMeta?.hud?.next).toBe('ball 3');
-    expect(cleared.players.A.score).toBe(3);
+    expect(cleared.ballOn).toEqual(['SOLIDS']);
+    expect(clearedMeta?.hud?.next).toBe('solids');
+    expect(cleared.players.A.score).toBe(2);
 
     const scratchEvents: ShotEvent[] = [
-      { type: 'HIT', firstContact: 3, ballId: 3 },
+      { type: 'HIT', firstContact: 9, ballId: 9 },
       { type: 'POTTED', ball: 0, pocket: 'TR', ballId: 'cue' }
     ];
     const scratchContext: ShotContext = { cueBallPotted: true, contactMade: true };
@@ -83,8 +83,8 @@ describe('PoolRoyaleRules', () => {
     expect(scratch.foul?.reason).toBe('scratch');
     expect(scratchMeta?.state?.ballInHand).toBe(true);
     expect(scratch.activePlayer).toBe('B');
-    expect(scratch.ballOn).toEqual(['BALL_3']);
-    expect(scratchMeta?.hud?.phase).toBe('rotation');
+    expect(scratch.ballOn).toEqual(['STRIPES']);
+    expect(scratchMeta?.hud?.phase).toBe('groups');
   });
 
   test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {

--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -1,9 +1,22 @@
 const BASE_TABLE_SCALE = 1.44;
 const BASE_TABLE_MOBILE_SCALE = 1.44;
 const BASE_TABLE_COMPACT_SCALE = 1.44;
-const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
+const BASE_PLAYFIELD_WIDTH_MM = 1981; // WPA 7 ft playing surface width (78")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '7ft': {
+    id: '7ft',
+    label: '7 ft (Bar Box)',
+    playfield: Object.freeze({ widthMm: 1981, heightMm: 991 }), // 78" × 39"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
   '9ft': {
     id: '9ft',
     label: '9 ft (Tournament)',
@@ -75,7 +88,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '9ft';
+export const DEFAULT_TABLE_SIZE_ID = '7ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -913,8 +913,8 @@ function addPocketCuts(
 // Config
 // --------------------------------------------------
 // separate scales for table and balls
-// Dimensions tuned for an official 9ft pool table footprint while globally reduced
-// to fit comfortably inside the existing mobile arena presentation.
+// Dimensions tuned for an official 7ft pool table footprint while keeping the
+// current ball size/height so the mobile presentation stays familiar.
 const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
 const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while keeping the table height unchanged
@@ -1047,10 +1047,10 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
   const TABLE_BASE_SCALE = 1.2;
   const TABLE_WIDTH_SCALE = 1.25;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
-  const TABLE_LENGTH_SCALE = 0.8;
+  const TABLE_LENGTH_SCALE = 1;
   const TABLE = {
-    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
+    W: 59 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
+    H: 118 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
     THICK: 1.8 * TABLE_SCALE,
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
   };
@@ -1112,9 +1112,9 @@ const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; 
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
+  // (WPA 7ft reference: 78" × 39", 2.25" balls)
+  const WIDTH_REF = 1981;
+  const HEIGHT_REF = 991;
   const BALL_D_REF = 57.15;
   const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
   const D_RADIUS_REF = 292;
@@ -1127,7 +1127,7 @@ const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
   // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
   // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
+  const TARGET_RATIO = 2;
 const END_RAIL_INNER_SCALE =
   (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
   (2 * TABLE.WALL);
@@ -1152,8 +1152,8 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
-const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
+const BALL_SIZE_SCALE = 1.1545; // preserve the existing ball size scaling
+const BALL_DIAMETER = 2.5032825703675816; // keep the current ball size/height unchanged
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const ENABLE_BALL_FLOOR_SHADOWS = true;
@@ -4906,7 +4906,7 @@ function applySnookerScaling({
     }
   }
   if (Array.isArray(balls)) {
-    const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5;
+    const expectedRadius = BALL_R;
     balls.forEach((ball) => {
       if (!ball) return;
       ball.colliderRadius = expectedRadius;
@@ -23834,6 +23834,7 @@ const powerRef = useRef(hud.power);
             return null;
           }
           const metaState = frameSnapshot?.meta?.state ?? null;
+          const currentSeat = frameSnapshot?.activePlayer === 'B' ? 'B' : 'A';
           const aiState = {
             balls: aiBalls,
             pockets,
@@ -23841,10 +23842,12 @@ const powerRef = useRef(hud.power);
             height,
             ballRadius: BALL_R,
             friction: FRICTION,
-            ballInHand: Boolean(metaState?.ballInHand)
+            ballInHand: Boolean(metaState?.ballInHand),
+            myGroup: metaState?.assignments?.[currentSeat] ?? null,
+            ballOn: Array.isArray(frameSnapshot?.ballOn) ? frameSnapshot.ballOn[0] : undefined
           };
           const decision = planShot({
-            game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
+            game: variantId === 'american' ? 'AMERICAN_8BALL' : 'NINE_BALL',
             state: aiState,
             timeBudgetMs: Math.min(AI_THINKING_BUDGET_MS, 320)
           });


### PR DESCRIPTION
### Motivation

- Ship an accurate mobile-friendly Pool table using official 7 ft (78"×39") proportions while keeping the current ball height/visual scale for consistent mobile presentation. 
- Align the internal rules and AI to BCA-style 8‑ball and 9‑ball behaviour so game logic, fouls and ball-in-hand handling match tournament expectations.

### Description

- Replace 9ft defaults with a new 7ft table option and make `7ft` the default table size in `webapp/src/config/poolRoyaleTables.js` and adjust `webapp/src/pages/Games/PoolRoyale.jsx` table dimensions and playfield mapping to match 7ft measurements while preserving the current ball diameter/height constants. 
- Preserve the existing ball visual/physics radius by keeping the previous ball diameter value and applying it directly when computing colliders and mesh scaling in `PoolRoyale.jsx`. 
- Add a new American 8‑ball rule engine in `lib/american8Ball.js` and wire it into the rules wrapper (`src/rules/PoolRoyaleRules.ts`) replacing the prior American flow with the BCA-style 8‑ball handling (assignments, open-table handling, eight-ball outcomes and no-cushion checks). 
- Tighten 9‑ball foul logic to include a no-cushion foul case and update AI/planner integrations to support `AMERICAN_8BALL` (lib/public and webapp copies of `poolAi.js`), plus adapt the Pool Royale UI AI bridge to pass group assignments (`myGroup`) and `ballOn` into the planner. 
- Update game tests to reflect the new 8‑ball variant naming and expectations (`test/poolAi.test.js`, `test/poolRoyaleRules.test.ts`) and update serialization/metadata types to carry the new American 8‑ball state shape. 

### Testing

- Unit test suites were not executed in this rollout; tests were modified (`test/poolAi.test.js`, `test/poolRoyaleRules.test.ts`) but not run. 
- A Playwright-based screenshot attempt of the running dev site was performed but failed due to a Chromium crash (`TargetClosedError`); Vite did start (dev server reported ready), but the headless browser process terminated before the capture. 
- Changes were committed after manual local validation of diffs; recommend running `npm test` and spinning a local dev build (`npm --prefix webapp run dev`) plus full CI to validate runtime and rule transitions across variants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ece92b108329893564bffd616882)