### PR TITLE
Pool Royale: adopt BCA 7ft table dimensions and update 8‑ball/9‑ball rules

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -1,13 +1,55 @@
+const TOTALS = Object.freeze({ SOLID: 7, STRIPE: 7 });
+
+function opponent (seat) {
+  return seat === 'A' ? 'B' : 'A';
+}
+
+function ballGroup (id) {
+  if (id === 8) return 'EIGHT';
+  if (id >= 1 && id <= 7) return 'SOLID';
+  if (id >= 9 && id <= 15) return 'STRIPE';
+  return null;
+}
+
+function remainingGroup (ballsOnTable, group) {
+  if (!group) return 0;
+  let count = 0;
+  for (const id of ballsOnTable) {
+    if (ballGroup(id) === group) count += 1;
+  }
+  return count;
+}
+
+function computeScores (state) {
+  const remainingSolids = remainingGroup(state.ballsOnTable, 'SOLID');
+  const remainingStripes = remainingGroup(state.ballsOnTable, 'STRIPE');
+  return {
+    A: state.assignments.A === 'SOLID'
+      ? TOTALS.SOLID - remainingSolids
+      : state.assignments.A === 'STRIPE'
+        ? TOTALS.STRIPE - remainingStripes
+        : 0,
+    B: state.assignments.B === 'SOLID'
+      ? TOTALS.SOLID - remainingSolids
+      : state.assignments.B === 'STRIPE'
+        ? TOTALS.STRIPE - remainingStripes
+        : 0
+  };
+}
+
 export class AmericanBilliards {
   constructor () {
     this.state = {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
+      assignments: { A: null, B: null },
+      isOpenTable: true,
       scores: { A: 0, B: 0 },
       ballInHand: false,
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
-      winner: null
+      winner: null,
+      breakInProgress: true
     };
   }
 
@@ -28,8 +70,7 @@ export class AmericanBilliards {
       };
     }
     const current = s.currentPlayer;
-    const opp = current === 'A' ? 'B' : 'A';
-    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const opp = opponent(current);
     let foul = false;
     let reason = '';
 
@@ -39,9 +80,30 @@ export class AmericanBilliards {
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
-      foul = true;
-      reason = 'wrong first contact';
+    const firstGroup = ballGroup(first);
+    if (!foul) {
+      if (s.isOpenTable) {
+        if (firstGroup === 'EIGHT') {
+          foul = true;
+          reason = '8-ball contacted first on open table';
+        }
+      } else {
+        const assignment = s.assignments[current];
+        const remaining = remainingGroup(s.ballsOnTable, assignment);
+        const onEight = remaining === 0;
+        if (onEight) {
+          if (first !== 8) {
+            foul = true;
+            reason = 'must contact 8-ball first';
+          }
+        } else if (assignment === 'SOLID' && firstGroup !== 'SOLID') {
+          foul = true;
+          reason = 'wrong first contact';
+        } else if (assignment === 'STRIPE' && firstGroup !== 'STRIPE') {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      }
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -50,18 +112,31 @@ export class AmericanBilliards {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    const points = pottedBalls.reduce((a, b) => a + b, 0);
+    const eightPotted = pottedBalls.includes(8);
+
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
-    const targetScore = 61;
+    const wasBreak = Boolean(s.breakInProgress);
 
     if (foul) {
-      const foulPoints = Math.max(1, points);
-      s.scores[opp] += foulPoints;
-      // Balls pocketed on a foul are respotted.
+      for (const id of pottedBalls) {
+        if (id !== 8) s.ballsOnTable.delete(id);
+      }
+      if (eightPotted && !wasBreak) {
+        frameOver = true;
+        winner = opp;
+        s.frameOver = true;
+        s.winner = winner;
+      } else if (eightPotted && wasBreak) {
+        s.ballsOnTable.add(8);
+      }
       nextPlayer = opp;
       s.currentPlayer = opp;
       ballInHandNext = true;
@@ -69,26 +144,51 @@ export class AmericanBilliards {
       s.foulStreak[opp] = 0;
     } else {
       for (const id of pottedBalls) s.ballsOnTable.delete(id);
-      s.scores[current] += points;
+      if (s.isOpenTable) {
+        const firstGroupPotted = pottedBalls
+          .map((id) => ballGroup(id))
+          .find((group) => group === 'SOLID' || group === 'STRIPE');
+        if (firstGroupPotted) {
+          s.assignments[current] = firstGroupPotted;
+          s.assignments[opp] = firstGroupPotted === 'SOLID' ? 'STRIPE' : 'SOLID';
+          s.isOpenTable = false;
+        }
+      }
+      const assignment = s.assignments[current];
+      const remaining = remainingGroup(s.ballsOnTable, assignment);
+      if (eightPotted) {
+        if (wasBreak) {
+          frameOver = true;
+          winner = current;
+        } else if (!assignment || remaining > 0) {
+          frameOver = true;
+          winner = opp;
+        } else {
+          frameOver = true;
+          winner = current;
+        }
+        s.frameOver = true;
+        s.winner = winner;
+      }
+      if (!frameOver) {
+        const keepsTurn = pottedBalls.some((id) => {
+          const group = ballGroup(id);
+          if (group === 'EIGHT') return false;
+          if (s.isOpenTable) return true;
+          return assignment && group === assignment;
+        });
+        if (!keepsTurn) {
+          nextPlayer = opp;
+          s.currentPlayer = opp;
+        }
+      }
       s.foulStreak[current] = 0;
       s.foulStreak[opp] = 0;
-      if (pottedBalls.length === 0) {
-        nextPlayer = opp;
-        s.currentPlayer = opp;
-      }
     }
 
     s.ballInHand = ballInHandNext;
-    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
-
-    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
-      frameOver = true;
-      if (s.scores[current] > s.scores[opp]) winner = current;
-      else if (s.scores[opp] > s.scores[current]) winner = opp;
-      else winner = 'TIE';
-      s.frameOver = true;
-      s.winner = winner;
-    }
+    s.breakInProgress = false;
+    s.scores = computeScores(s);
 
     return {
       legal: !foul,
@@ -98,7 +198,6 @@ export class AmericanBilliards {
       nextPlayer,
       ballInHandNext,
       scores: { ...s.scores },
-      currentBall: nextBall,
       frameOver,
       winner
     };

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -44,6 +44,10 @@ export class NineBall {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true;
+      reason = 'no rail after contact';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;

--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -1,9 +1,22 @@
 const BASE_TABLE_SCALE = 1.44;
 const BASE_TABLE_MOBILE_SCALE = 1.44;
 const BASE_TABLE_COMPACT_SCALE = 1.44;
-const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
+const BASE_PLAYFIELD_WIDTH_MM = 1981.2; // BCA 7 ft playing surface length (78")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '7ft': {
+    id: '7ft',
+    label: '7 ft (Official)',
+    playfield: Object.freeze({ widthMm: 1981.2, heightMm: 990.6 }), // 78" × 39"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
+  },
   '9ft': {
     id: '9ft',
     label: '9 ft (Tournament)',
@@ -75,7 +88,7 @@ export const TABLE_SIZE_OPTIONS = Object.freeze(
   }, {})
 );
 
-export const DEFAULT_TABLE_SIZE_ID = '9ft';
+export const DEFAULT_TABLE_SIZE_ID = '7ft';
 
 export function resolveTableSize(sizeId) {
   const key = typeof sizeId === 'string' ? sizeId.toLowerCase() : '';

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1048,11 +1048,23 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
   const TABLE_WIDTH_SCALE = 1.25;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
+  const TABLE_THICKNESS = 1.9278; // preserve legacy table height so ball height remains unchanged
+  const BALL_D_REF = 57.15; // 2.25" ball diameter
+  const BALL_SIZE_SCALE = 1.1545; // preserve legacy ball scaling
+  const LEGACY_BALL_DIAMETER = 2.5032825703675816; // keep existing ball size for continuity
+  const MM_TO_UNITS = LEGACY_BALL_DIAMETER / (BALL_D_REF * BALL_SIZE_SCALE);
+  // 7ft official pool table references (in mm, scaled from inches)
+  const TABLE_LENGTH_REF = 2286; // 90"
+  const TABLE_WIDTH_REF = 1270; // 50"
+  const PLAYFIELD_LENGTH_REF = 1981.2; // 78"
+  const PLAYFIELD_WIDTH_REF = 990.6; // 39"
+  const SIDE_RAIL_REF = (TABLE_WIDTH_REF - PLAYFIELD_WIDTH_REF) / 2; // 5.5"
+  const END_RAIL_REF = (TABLE_LENGTH_REF - PLAYFIELD_LENGTH_REF) / 2; // 6"
   const TABLE = {
-    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
-    THICK: 1.8 * TABLE_SCALE,
-    WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
+    W: TABLE_WIDTH_REF * MM_TO_UNITS,
+    H: TABLE_LENGTH_REF * MM_TO_UNITS,
+    THICK: TABLE_THICKNESS,
+    WALL: SIDE_RAIL_REF * MM_TO_UNITS
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
@@ -1112,30 +1124,20 @@ const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; 
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
-  const BALL_D_REF = 57.15;
+  // (BCA 7ft reference: 90" × 50" table, 78" × 39" playfield, 2.25" balls)
+  const WIDTH_REF = PLAYFIELD_LENGTH_REF;
+  const HEIGHT_REF = PLAYFIELD_WIDTH_REF;
   const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
   const D_RADIUS_REF = 292;
   const PINK_FROM_TOP_REF = 737;
   const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
   const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
   const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
-  const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
-  const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
-  const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
-  // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
-const END_RAIL_INNER_SCALE =
-  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
-  (2 * TABLE.WALL);
-const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
-const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAYFIELD_SHRINK = 0.85; // shrink the playfield footprint by ~15% on all sides while keeping table height intact
-const PLAY_W = (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
-const PLAY_H = (TABLE.H - 2 * END_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
+  const SIDE_RAIL_INNER_THICKNESS = SIDE_RAIL_REF * MM_TO_UNITS;
+  const END_RAIL_INNER_THICKNESS = END_RAIL_REF * MM_TO_UNITS;
+  const TARGET_RATIO = PLAYFIELD_LENGTH_REF / PLAYFIELD_WIDTH_REF;
+const PLAY_W = PLAYFIELD_WIDTH_REF * MM_TO_UNITS;
+const PLAY_H = PLAYFIELD_LENGTH_REF * MM_TO_UNITS;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
   tableWidth: TABLE.W,
   tableLength: TABLE.H,
@@ -1149,10 +1151,8 @@ const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   console.assert(
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
+    'Pool table inner ratio must match the 7ft 2:1 target after scaling.'
   );
-const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Provide an authentic 7ft (BCA) pool table footprint and playfield ratio for the mobile Pool Royale presentation while keeping the existing ball height/size to preserve gameplay feel. 
- Align 8‑ball (American) and 9‑ball shot logic with BCA/standard rules (open table → assignments, correct 8‑ball outcomes, and stricter foul handling) so AI, HUD and game logic reflect official behaviour. 

### Description
- Rebuilt table sizing and mapping to use official 7ft specs (90" × 50" table, 78" × 39" playfield) and updated the internal playfield math so the playfield keeps a precise 2:1 ratio while preserving legacy ball diameter/height; key changes in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added a 7ft table preset and made it the default in `webapp/src/config/poolRoyaleTables.js`. 
- Reworked American 8‑ball logic to a BCA‑style open‑table with assignments, proper 8‑ball resolution, break handling and ball‑in‑hand outcomes in `lib/americanBilliards.js`. 
- Tightened 9‑ball foul handling to include a "no rail after contact" foul in `lib/nineBall.js`. 
- Extended serialization and rule-layer state to carry `assignments`, `isOpenTable`, and `breakInProgress`, and updated `src/rules/PoolRoyaleRules.ts` to compute HUD, `ballOn` and scores consistently with the updated rule implementations. 

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready and serving at `http://localhost:4173/`, which succeeded. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate the 7ft table visually, but the screenshot run timed out (Playwright `Page.screenshot` timeout). 
- No unit test suite (`npm test` / `jest`) or other automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ece92b108329893564bffd616882)