### PR TITLE
Align Pool Royale table to 7ft specs and implement BCA-style 8‑ball / 9‑ball rule changes

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -1,11 +1,36 @@
+const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7]);
+const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15]);
+
+function opponent (p) {
+  return p === 'A' ? 'B' : 'A';
+}
+
+function groupForBall (id) {
+  if (SOLIDS.has(id)) return 'SOLIDS';
+  if (STRIPES.has(id)) return 'STRIPES';
+  return null;
+}
+
+function remainingForGroup (ballsOnTable, group) {
+  if (!group) return 0;
+  if (group === 'SOLIDS') {
+    return Array.from(ballsOnTable).filter(id => SOLIDS.has(id)).length;
+  }
+  if (group === 'STRIPES') {
+    return Array.from(ballsOnTable).filter(id => STRIPES.has(id)).length;
+  }
+  return 0;
+}
+
 export class AmericanBilliards {
   constructor () {
     this.state = {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
-      scores: { A: 0, B: 0 },
       ballInHand: false,
-      foulStreak: { A: 0, B: 0 },
+      assignments: { A: null, B: null },
+      isOpenTable: true,
+      breakInProgress: true,
       frameOver: false,
       winner: null
     };
@@ -27,21 +52,37 @@ export class AmericanBilliards {
         winner: s.winner
       };
     }
+
     const current = s.currentPlayer;
-    const opp = current === 'A' ? 'B' : 'A';
-    const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const opp = opponent(current);
+    const first = contactOrder[0];
+    const pottedBalls = pottedList.filter(id => id !== 0);
+    const eightPotted = pottedBalls.includes(8);
     let foul = false;
     let reason = '';
 
-    const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!first) {
       foul = true;
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!foul && s.isOpenTable && first === 8) {
       foul = true;
-      reason = 'wrong first contact';
+      reason = 'illegal 8-ball contact';
+    }
+
+    if (!foul && !s.isOpenTable) {
+      const assignment = s.assignments[current];
+      const remaining = remainingForGroup(s.ballsOnTable, assignment);
+      if (remaining > 0) {
+        if (groupForBall(first) !== assignment) {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      } else if (first !== 8) {
+        foul = true;
+        reason = 'must contact 8-ball';
+      }
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -49,46 +90,78 @@ export class AmericanBilliards {
       reason = 'scratch';
     }
 
-    const pottedBalls = pottedList.filter(id => id !== 0);
-    const points = pottedBalls.reduce((a, b) => a + b, 0);
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true;
+      reason = 'no rail';
+    }
 
     let nextPlayer = current;
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
-    const targetScore = 61;
+    const wasBreak = Boolean(s.breakInProgress);
 
-    if (foul) {
-      const foulPoints = Math.max(1, points);
-      s.scores[opp] += foulPoints;
-      // Balls pocketed on a foul are respotted.
-      nextPlayer = opp;
-      s.currentPlayer = opp;
-      ballInHandNext = true;
-      s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
-      s.foulStreak[opp] = 0;
-    } else {
-      for (const id of pottedBalls) s.ballsOnTable.delete(id);
-      s.scores[current] += points;
-      s.foulStreak[current] = 0;
-      s.foulStreak[opp] = 0;
-      if (pottedBalls.length === 0) {
-        nextPlayer = opp;
-        s.currentPlayer = opp;
+    if (eightPotted && !wasBreak) {
+      const assignment = s.assignments[current];
+      const remaining = remainingForGroup(s.ballsOnTable, assignment);
+      if (foul || s.isOpenTable || remaining > 0) {
+        frameOver = true;
+        winner = opp;
+      } else {
+        frameOver = true;
+        winner = current;
       }
     }
 
-    s.ballInHand = ballInHandNext;
-    const nextBall = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
-
-    if (s.scores[current] >= targetScore || s.scores[opp] >= targetScore || s.ballsOnTable.size === 0) {
+    if (foul && eightPotted && !wasBreak) {
       frameOver = true;
-      if (s.scores[current] > s.scores[opp]) winner = current;
-      else if (s.scores[opp] > s.scores[current]) winner = opp;
-      else winner = 'TIE';
-      s.frameOver = true;
-      s.winner = winner;
+      winner = opp;
     }
+
+    if (foul) {
+      nextPlayer = opp;
+      ballInHandNext = true;
+      s.currentPlayer = opp;
+    }
+
+    if (!frameOver) {
+      if (wasBreak && eightPotted) {
+        s.ballsOnTable.add(8);
+      }
+      for (const id of pottedBalls) {
+        if (id === 8 && wasBreak) continue;
+        s.ballsOnTable.delete(id);
+      }
+    }
+
+    if (!frameOver && !foul && !wasBreak && s.isOpenTable) {
+      const firstGroupBall = pottedBalls.find(id => groupForBall(id));
+      if (firstGroupBall) {
+        const group = groupForBall(firstGroupBall);
+        s.assignments[current] = group;
+        s.assignments[opp] = group === 'SOLIDS' ? 'STRIPES' : 'SOLIDS';
+        s.isOpenTable = false;
+      }
+    }
+
+    if (
+      !frameOver &&
+      !foul &&
+      pottedBalls.filter(id => id !== 8).length === 0 &&
+      !(wasBreak && eightPotted)
+    ) {
+      nextPlayer = opp;
+      s.currentPlayer = opp;
+    }
+
+    if (wasBreak) {
+      s.breakInProgress = false;
+      s.isOpenTable = true;
+    }
+
+    s.ballInHand = ballInHandNext;
+    s.frameOver = frameOver;
+    s.winner = winner;
 
     return {
       legal: !foul,
@@ -97,8 +170,6 @@ export class AmericanBilliards {
       potted: pottedList,
       nextPlayer,
       ballInHandNext,
-      scores: { ...s.scores },
-      currentBall: nextBall,
       frameOver,
       winner
     };

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -10,7 +10,8 @@ export class NineBall {
       ballInHand: false,
       gameOver: false,
       winner: null,
-      foulStreak: { A: 0, B: 0 }
+      foulStreak: { A: 0, B: 0 },
+      breakInProgress: true
     };
   }
 
@@ -38,12 +39,18 @@ export class NineBall {
       reason = 'wrong first contact';
     }
 
+    if (!foul && shot.noCushionAfterContact && pottedList.length === 0) {
+      foul = true;
+      reason = 'no rail';
+    }
+
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true;
       reason = 'scratch';
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
+    const ninePotted = pottedBalls.includes(9);
 
     let nextPlayer = current;
     let ballInHandNext = false;
@@ -67,7 +74,7 @@ export class NineBall {
       for (const id of pottedBalls) s.ballsOnTable.delete(id);
       s.foulStreak[current] = 0;
       s.foulStreak[opp] = 0;
-      if (pottedBalls.includes(9)) {
+      if (ninePotted) {
         frameOver = true;
         winner = current;
         s.gameOver = true;
@@ -82,6 +89,7 @@ export class NineBall {
     }
 
     s.ballInHand = ballInHandNext;
+    s.breakInProgress = false;
 
     if (!frameOver && s.foulStreak[current] >= foulLimit) {
       frameOver = true;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1044,16 +1044,39 @@ const ENABLE_TABLE_MAPPING_LINES = false;
 const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const REPLAY_CUE_STICK_HOLD_MS = 620;
-  const TABLE_BASE_SCALE = 1.2;
-  const TABLE_WIDTH_SCALE = 1.25;
-  const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
-  const TABLE_LENGTH_SCALE = 0.8;
-  const TABLE = {
-    W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE,
-    H: 132 * TABLE_SCALE * TABLE_LENGTH_SCALE * TABLE_FOOTPRINT_SCALE,
-    THICK: 1.8 * TABLE_SCALE,
-    WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
-  };
+const TABLE_BASE_SCALE = 1.2;
+const TABLE_WIDTH_SCALE = 1.25;
+const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
+const TABLE_THICK = 1.8 * TABLE_SCALE;
+const TABLE_WALL = 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE;
+const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
+const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
+const SIDE_RAIL_INNER_THICKNESS = TABLE_WALL * SIDE_RAIL_INNER_SCALE;
+const END_RAIL_INNER_REDUCTION = SIDE_RAIL_INNER_REDUCTION;
+const END_RAIL_INNER_SCALE = 1 - END_RAIL_INNER_REDUCTION;
+const END_RAIL_INNER_THICKNESS = TABLE_WALL * END_RAIL_INNER_SCALE;
+// Official 7ft pool playfield (78" × 39") mapped to the current ball diameter.
+const WIDTH_REF = 1981.2;
+const HEIGHT_REF = 990.6;
+const BALL_D_REF = 57.15;
+const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (19.5")
+const D_RADIUS_REF = 292;
+const PINK_FROM_TOP_REF = 737;
+const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
+const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses
+const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses
+const BALL_DIAMETER = 2.5032825703675816; // preserve current ball size in world units
+const BALL_SCALE = BALL_DIAMETER / 4;
+const BALL_R = BALL_DIAMETER / 2;
+const MM_TO_UNITS = BALL_DIAMETER / BALL_D_REF;
+const PLAY_H = WIDTH_REF * MM_TO_UNITS;
+const PLAY_W = HEIGHT_REF * MM_TO_UNITS;
+const TABLE = {
+  W: PLAY_W + 2 * SIDE_RAIL_INNER_THICKNESS,
+  H: PLAY_H + 2 * END_RAIL_INNER_THICKNESS,
+  THICK: TABLE_THICK,
+  WALL: TABLE_WALL
+};
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
 const RAIL_HEIGHT = TABLE.THICK * 1.38; // raise rails slightly so the cushions sit higher
@@ -1111,31 +1134,6 @@ const SIDE_POCKET_RIM_SURFACE_OFFSET_SCALE = POCKET_RIM_SURFACE_OFFSET_SCALE; //
 const SIDE_POCKET_RIM_SURFACE_ABSOLUTE_LIFT = POCKET_RIM_SURFACE_ABSOLUTE_LIFT; // keep the middle pocket rims aligned to the same vertical gap
 const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so chrome + cushions line up identically
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
-  // Reuse the Pool Royale playfield and pocket metrics so pockets + balls line up exactly with that table
-  // (WPA 9ft reference: 100" × 50", 2.25" balls)
-  const WIDTH_REF = 2540;
-  const HEIGHT_REF = 1270;
-  const BALL_D_REF = 57.15;
-  const BAULK_FROM_BAULK_REF = WIDTH_REF * 0.25; // Head string at 1/4 table length (25")
-  const D_RADIUS_REF = 292;
-  const PINK_FROM_TOP_REF = 737;
-  const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 114.3; // 4.5" corner pocket mouth between cushion noses (Pool Royale match)
-  const SIDE_MOUTH_REF = 127; // 5" side pocket mouth between cushion noses (Pool Royale match)
-  const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
-  const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
-  const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
-  // Relax the aspect ratio so the table reads wider on screen while keeping the playfield height untouched
-  // and preserving pocket proportions from the previous build.
-  const TARGET_RATIO = 1.83;
-const END_RAIL_INNER_SCALE =
-  (TABLE.H - TARGET_RATIO * (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS)) /
-  (2 * TABLE.WALL);
-const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
-const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAYFIELD_SHRINK = 0.85; // shrink the playfield footprint by ~15% on all sides while keeping table height intact
-const PLAY_W = (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
-const PLAY_H = (TABLE.H - 2 * END_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
   tableWidth: TABLE.W,
   tableLength: TABLE.H,
@@ -1147,15 +1145,11 @@ export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
 const innerLong = Math.max(PLAY_W, PLAY_H);
 const innerShort = Math.min(PLAY_W, PLAY_H);
 const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
-  console.assert(
-    Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
-    'Pool table inner ratio must match the widened 1.83:1 target after scaling.'
-  );
-const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
-const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
-const BALL_SCALE = BALL_DIAMETER / 4;
-const BALL_R = BALL_DIAMETER / 2;
+const TARGET_RATIO = WIDTH_REF / HEIGHT_REF;
+console.assert(
+  Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
+  'Pool table inner ratio must match the official 7ft 2:1 target after scaling.'
+);
 const ENABLE_BALL_FLOOR_SHADOWS = true;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
@@ -4906,7 +4900,7 @@ function applySnookerScaling({
     }
   }
   if (Array.isArray(balls)) {
-    const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5;
+    const expectedRadius = BALL_R;
     balls.forEach((ball) => {
       if (!ball) return;
       ball.colliderRadius = expectedRadius;
@@ -23834,6 +23828,13 @@ const powerRef = useRef(hud.power);
             return null;
           }
           const metaState = frameSnapshot?.meta?.state ?? null;
+          const activeSeat = metaState?.currentPlayer ?? frameSnapshot?.activePlayer ?? 'A';
+          const assignment =
+            metaState && metaState.assignments ? metaState.assignments[activeSeat] : null;
+          const myGroup =
+            variantId === 'american'
+              ? assignment || (metaState?.isOpenTable ? 'UNASSIGNED' : null)
+              : null;
           const aiState = {
             balls: aiBalls,
             pockets,
@@ -23841,10 +23842,15 @@ const powerRef = useRef(hud.power);
             height,
             ballRadius: BALL_R,
             friction: FRICTION,
-            ballInHand: Boolean(metaState?.ballInHand)
+            ballInHand: Boolean(metaState?.ballInHand),
+            myGroup,
+            ballOn:
+              Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length === 1
+                ? frameSnapshot.ballOn[0]
+                : null
           };
           const decision = planShot({
-            game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
+            game: variantId === 'american' ? 'EIGHT_POOL_UK' : 'NINE_BALL',
             state: aiState,
             timeBudgetMs: Math.min(AI_THINKING_BUDGET_MS, 320)
           });


### PR DESCRIPTION
### Motivation
- Provide an accurate 7ft (78" × 39") pool table footprint scaled for mobile while keeping the current ball size and visual height intact. 
- Ensure 8‑ball and 9‑ball logic match BCA-style behaviour (group assignment, legal first contact, 8‑ball win/loss/scratch handling and no‑rail fouls) so gameplay and AI decisions follow official rules.

### Description
- Remap table and playfield math to an official 7ft footprint: introduce `WIDTH_REF`/`HEIGHT_REF` for 7ft, compute `MM_TO_UNITS`, `PLAY_W`/`PLAY_H`, and update `POOL_ROYALE_TABLE_DIMENSIONS` and related pocket/baulk/spot mappings in `webapp/src/pages/Games/PoolRoyale.jsx` while preserving current world `BALL_DIAMETER`/`BALL_R` and the table visual height.
- Use the explicit ball radius (`BALL_R`) for colliders/mesh scaling and add an assertion that the playfield ratio matches the 7ft (2:1) target.
- Implement BCA-style American 8‑ball state and shot handling in `lib/americanBilliards.js`: add `assignments`, `isOpenTable`, `breakInProgress`, assignment detection on first potted object ball, illegal 8‑ball contact on an open table, required contact with the 8 when groups are cleared, scratch/no‑rail handling, 8‑ball win/loss resolution and break handling (spot/respot 8 on break as appropriate).
- Tighten 9‑ball foul handling and track break state in `lib/nineBall.js` by adding `noCushionAfterContact` (no‑rail) fouls and `breakInProgress` tracking to the nine‑ball state.
- Update rules serialization and integration in `src/rules/PoolRoyaleRules.ts` to carry the new `assignments`, `isOpenTable`, and `breakInProgress` fields for American/9ball variants, compute `ballOn` for American 8‑ball, and surface updated HUD/phase data (open/break/groups/complete) to the UI.
- Feed assignment/ball‑on hints into the AI planner by passing `myGroup`/`ballOn` and switching AI `game` to `EIGHT_POOL_UK` for American 8‑ball planning so AI target selection respects solids/stripes.
- Minor cleanup to wire `breakInProgress` through 9‑ball meta and keep HUD state consistent when breaks finish.
- Files touched: `lib/americanBilliards.js`, `lib/nineBall.js`, `src/rules/PoolRoyaleRules.ts`, `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready at the local network URL (server start succeeded).
- Attempted an automated page screenshot of `/games/poolroyale` via Playwright to visually validate the table; the screenshot attempt timed out (Playwright timeout) so the visual capture failed.
- No unit test suite (`npm test`/`jest`) or CI test run was executed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ece92b108329893564bffd616882)