### PR TITLE
Adjust Pool Royale table surface, ball sizing, and top-down camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1051,7 +1051,9 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
   const TABLE_WIDTH_SCALE = 1.25;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
-  const TABLE_SURFACE_EXPANSION = 1.12; // widen/lengthen the table footprint by ~12% while keeping pockets/balls unchanged
+  const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
+  const TABLE_SURFACE_EXPANSION = 1.25; // widen/lengthen the table footprint by ~12% while keeping pockets/balls unchanged
+  const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,
     H:
@@ -1160,8 +1162,8 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
-const MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_SIZE_SCALE = 1.1545; // reduce balls by 10% for a slightly smaller play feel
+const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
+const BALL_SIZE_SCALE = 1.1545 * 0.85; // reduce balls by 15% to match the updated visual scale
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -5020,9 +5022,9 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.02; // lower the camera a touch to sit closer to the table
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.05; // lift the top view slightly higher
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.02; // lower the 2D top view slightly to keep framing consistent after the table shrink
+const TOP_VIEW_RADIUS_SCALE = 1.05; // lift the 2D top view slightly higher to keep the framing airy
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider


### PR DESCRIPTION
### Motivation
- Implement the requested visual adjustments for Pool Royale: widen the table by ~10–15% while keeping pockets and play layout unchanged, lift the 2D/top-down camera a bit higher, and reduce ball size by 15% to match the new table footprint.

### Description
- Increase the table surface expansion and add a compensation factor (`TABLE_SURFACE_REFERENCE`, `TABLE_SURFACE_EXPANSION`, `TABLE_SURFACE_COMPENSATION`) so the table footprint is widened while allowing pocket/play metrics to remain consistent (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Compensate world unit conversion by adjusting `MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION` so pocket and playfield capture radii remain aligned with the larger surface.
- Reduce ball visuals by adjusting `BALL_SIZE_SCALE = 1.1545 * 0.85` (15% smaller) and recalc `BALL_DIAMETER`/`BALL_R` from the new scale.
- Raise the top-down camera framing by increasing `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` to `1.05` so the 2D view appears slightly higher on-screen.

### Testing
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and Vite started successfully and served the site (local network URL reported). 
- Attempted to capture a portrait screenshot with a Playwright script targeting `/games/poolroyale`, but the headless browser crashed/timed out in this environment so no visual screenshot could be produced. 
- No automated unit tests were run as the change is a visual/scale tweak and was validated by starting the dev server only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861f3608088329b2056584bd199e31)