### PR TITLE
Adjust Pool Royale table geometry and cue ball behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -578,7 +578,7 @@ function adjustSideNotchDepth(mp) {
   );
 }
 
-const POCKET_VISUAL_EXPANSION = 1.034;
+const POCKET_VISUAL_EXPANSION = 1.02;
 const CORNER_POCKET_INWARD_SCALE = 1.008; // ease the corner cuts back toward the rail so the mouth stays as wide as the bowl
 const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
 const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
@@ -628,10 +628,10 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.012; // keep side flush trim aligned with the snooker fascia edge
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.14; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.12; // mirror the snooker middle pocket chrome cut sizing
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.08; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.06; // mirror the snooker middle pocket chrome cut sizing
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.9; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.86; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
@@ -1072,9 +1072,9 @@ const RAIL_HEIGHT = TABLE.THICK * 1.38; // raise rails slightly so the cushions 
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
-const POCKET_JAW_CORNER_INNER_SCALE = 1.46; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
+const POCKET_JAW_CORNER_INNER_SCALE = 1.38; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
 const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.02; // round the middle jaws slightly more while keeping the corner match
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.84; // preserve the playable mouth while letting the corner fascia run longer and slimmer
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.76; // preserve the playable mouth while letting the corner fascia run longer and slimmer
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.03; // nudge jaws outward to track the cushion line precisely
@@ -1104,7 +1104,7 @@ const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thi
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.82; // extend the corner jaw reach so the entry width matches the visible bowl while stretching the fascia forward
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // push the middle jaw reach a touch wider so the openings read larger
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1.02; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // trim the middle jaw arc radius so the side-pocket jaws read a touch tighter
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = TABLE.THICK * -0.016; // nudge the middle jaws down so their rims sit level with the cloth
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.085; // push the middle pocket jaws farther outward so the midpoint jaws open up away from centre
@@ -1239,7 +1239,7 @@ const CLOTH_LIFT = (() => {
   return Math.max(0, RAIL_HEIGHT - ballR - eps);
 })();
 const ACTION_CAMERA_START_BLEND = 1;
-const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
+const CLOTH_DROP = BALL_R * 0.12; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth apertures to the now-wider interior pocket diameter at the rim
@@ -1707,7 +1707,7 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.26; // pull the cushion noses farther inward toward the table center
+const CUSHION_FACE_INSET = SIDE_RAIL_INNER_THICKNESS * 0.3; // pull the cushion noses farther inward toward the table center
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -26602,11 +26602,11 @@ const powerRef = useRef(hud.power);
             if (b.pos.distanceTo(c) < captureRadius) {
               const isCueBall = b.id === 'cue';
               const inHandActive = Boolean(hudRef.current?.inHand);
+              const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               if (isCueBall && inHandActive) {
                 const fallback = defaultInHandPosition({ forceCenter: true });
                 if (fallback) {
                   updateCuePlacement(fallback);
-                  b.active = true;
                   b.mesh.visible = true;
                   b.vel.set(0, 0);
                   b.spin?.set(0, 0);
@@ -26616,7 +26616,10 @@ const powerRef = useRef(hud.power);
                   b.swervePowerStrength = 0;
                   b.impacted = false;
                   inHandDragRef.current.lastPos = fallback.clone();
+                } else if (b.mesh) {
+                  b.mesh.visible = true;
                 }
+                b.active = true;
                 if (!hudRef.current?.inHand) {
                   hudRef.current = { ...hudRef.current, inHand: true };
                   setHud((prev) => ({ ...prev, inHand: true }));
@@ -26686,6 +26689,49 @@ const powerRef = useRef(hud.power);
               b.swervePowerStrength = 0;
               b.launchDir = null;
               if (b.id === 'cue') b.impacted = false;
+              if (isCueBall) {
+                const fallback = defaultInHandPosition({ forceCenter: true });
+                if (fallback) {
+                  updateCuePlacement(fallback);
+                  b.mesh.visible = true;
+                  b.vel.set(0, 0);
+                  b.spin?.set(0, 0);
+                  b.pendingSpin?.set(0, 0);
+                  b.spinMode = 'standard';
+                  b.swerveStrength = 0;
+                  b.swervePowerStrength = 0;
+                  b.impacted = false;
+                  inHandDragRef.current.lastPos = fallback.clone();
+                } else if (b.mesh) {
+                  b.mesh.visible = true;
+                }
+                b.active = true;
+                removePocketDropEntry(b.id);
+                if (!hudRef.current?.inHand) {
+                  hudRef.current = { ...hudRef.current, inHand: true };
+                  setHud((prev) => ({ ...prev, inHand: true }));
+                }
+                const mappedColor = toBallColorId(b.id);
+                const colorId =
+                  mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
+                potted.push({ id: b.id, color: colorId, pocket: pocketId });
+                if (
+                  activeShotView?.mode === 'pocket' &&
+                  activeShotView.ballId === b.id
+                ) {
+                  const pocketView = activeShotView;
+                  pocketView.completed = true;
+                  const now = performance.now();
+                  pocketView.holdUntil = Math.max(
+                    pocketView.holdUntil ?? now,
+                    now + POCKET_VIEW_POST_POT_HOLD_MS
+                  );
+                  if (b?.pos) {
+                    pocketView.lastBallPos.set(b.pos.x, b.pos.y);
+                  }
+                }
+                break;
+              }
               if (b.mesh && table && !isCueBall) {
                 if (pocketCameraStateRef.current) {
                   pocketPopupPendingRef.current.push({
@@ -26714,7 +26760,6 @@ const powerRef = useRef(hud.power);
                   });
                 }
               }
-              const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               const dropStart = performance.now();
               const fromX = b.pos.x;
               const fromZ = b.pos.y;


### PR DESCRIPTION
### Motivation
- Improve play feel and visuals by bringing balls up to the cloth plane, pulling cushions slightly inward, and reducing chrome/wood/jaw cut sizes so balls roll and pocket reliably.
- Prevent the cue ball from remaining stuck on the pocket holder when potted so gameplay continues uninterrupted.

### Description
- Tuned table/pocket geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx`, including `POCKET_VISUAL_EXPANSION`, `CHROME_CORNER_POCKET_CUT_SCALE`, `CHROME_SIDE_POCKET_CUT_SCALE`, `WOOD_RAIL_POCKET_RELIEF_SCALE`, `POCKET_JAW_CORNER_INNER_SCALE`, `POCKET_JAW_CORNER_OUTER_SCALE`, `SIDE_POCKET_JAW_RADIUS_EXPANSION`, `CLOTH_DROP`, and `CUSHION_FACE_INSET` to lift balls onto the cloth, tighten pocket/rail cuts, and pull the six cushions inward visually.
- Updated pocket capture logic so the cue ball is handled specially: when the cue ball enters a pocket it is immediately placed back to the in-hand position via `defaultInHandPosition`/`updateCuePlacement`, `hud.inHand` is set, `removePocketDropEntry` is used to clear holder state, and the potted list is still recorded to preserve game resolution flow.
- Small visibility/activation fixes ensure the cue mesh is visible when respawning from a pocket and that `b.active` is set so the in-hand placement works reliably.

### Testing
- Launched the web dev server with `npm --prefix webapp run dev` and confirmed Vite served the app at `http://localhost:4173/` successfully. 
- Attempted a Playwright screenshot to validate visual placement, but the Chromium headless run crashed in this environment so no screenshot was captured. 
- No unit tests were run as these are primarily visual/behavioral adjustments; local manual validation is recommended in a graphical environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698627bb00d48329a9823a13a7745d1e)