### PR TITLE
Stabilize Domino Royal HDRI loading

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3048,19 +3048,36 @@ const isTelegramWebView = /Telegram/i.test(navigator.userAgent || '') || Boolean
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '');
 const isLowMemoryDevice = typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4;
 const isLowCoreDevice = typeof navigator.hardwareConcurrency === 'number' && navigator.hardwareConcurrency <= 4;
+const isLowProfileDevice = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
+const MAX_HDRI_CACHE_SIZE = prefersUhd ? 6 : 3;
 function resolveHdriResolutionOrder() {
-  if (prefersUhd) return ['4k'];
-  const lowProfile = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
-  return lowProfile ? ['1k', '2k', '4k'] : ['2k', '4k'];
+  if (prefersUhd) return ['4k', '2k'];
+  if (isLowProfileDevice) return ['1k'];
+  return ['2k', '1k'];
+}
+function shouldLoadExternalHdri() {
+  return prefersUhd || !isLowProfileDevice;
+}
+function pruneHdriCache() {
+  if (hdriTextureCache.size <= MAX_HDRI_CACHE_SIZE) return;
+  const entries = [...hdriTextureCache.entries()];
+  const overflow = Math.max(0, entries.length - MAX_HDRI_CACHE_SIZE);
+  for (let i = 0; i < overflow; i += 1) {
+    const [key, texture] = entries[i];
+    hdriTextureCache.delete(key);
+    texture?.dispose?.();
+  }
 }
 let activeEnvironmentHdri = null;
 
 async function loadHdriEnvironment(variant) {
   if (!variant?.assetId) return null;
+  if (!shouldLoadExternalHdri()) return null;
+  const allowedResolutions = resolveHdriResolutionOrder();
   const preferred = Array.isArray(variant.preferredResolutions)
-    ? variant.preferredResolutions.filter((res) => HDRI_RESOLUTION_ORDER.includes(res))
+    ? variant.preferredResolutions.filter((res) => allowedResolutions.includes(res))
     : [];
-  const order = preferred.length ? preferred : resolveHdriResolutionOrder();
+  const order = preferred.length ? preferred : allowedResolutions;
   let lastError = null;
   for (const res of order) {
     const cacheKey = `${variant.id}:${res}`;
@@ -3077,6 +3094,7 @@ async function loadHdriEnvironment(variant) {
         texture.mapping = THREE.EquirectangularReflectionMapping;
         const envMap = pmrem.fromEquirectangular(texture).texture;
         hdriTextureCache.set(cacheKey, envMap);
+        pruneHdriCache();
         texture.dispose?.();
         return envMap;
       } catch (error) {


### PR DESCRIPTION
### Motivation
- Domino Royal was crashing on lower-end environments due to aggressive HDRI downloads and unbounded HDRI texture caching causing memory pressure.
- The goal is to make HDRI loading and caching behave like other games by guarding downloads on low-profile devices and limiting memory usage.

### Description
- Added device-profile detection (`isLowProfileDevice`) and a `shouldLoadExternalHdri()` guard to skip heavy external HDRI downloads on constrained devices.
- Simplified HDRI resolution selection in `resolveHdriResolutionOrder()` to prefer safe defaults and honor `prefersUhd` when present.
- Introduced `MAX_HDRI_CACHE_SIZE` and `pruneHdriCache()` to cap `hdriTextureCache` and dispose old textures after new loads to reduce memory pressure.
- Updated `loadHdriEnvironment()` to respect the new guards and to use the allowed resolution list when filtering `variant.preferredResolutions`; added calls to `pruneHdriCache()` after caching textures.

Files changed:
- `webapp/public/domino-royal.html` (HDRI load/caching logic)

### Testing
- Started a local static server with `python -m http.server 8000` in `webapp/public`, which served the page successfully (succeeded). 
- Attempted a Playwright smoke test to load `domino-royal.html` and capture a screenshot, but the Playwright Chromium process crashed with a SIGSEGV in this environment (failed). 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b2c3b1f083299954140906abd416)