### PR TITLE
Tighten Pool Royale pocket geometry, nudge cushions, and raise ball height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -628,14 +628,14 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.012; // keep side flush trim aligned with the snooker fascia edge
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.08; // open the rounded chrome corner cut a touch more so the chrome reveal reads larger at each corner
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.09; // open the middle pocket chrome cut slightly more
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.04; // tighten the rounded chrome corner cut so the radius reads slightly smaller
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.05; // tighten the middle pocket chrome cut to match the reduced corner radius
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.86; // ease the wooden rail pocket relief so the rounded corner cuts expand a hair and keep pace with the broader chrome reveal
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.92; // tighten the wooden rail pocket relief so the rounded corner cuts read slightly smaller
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.05; // open the middle rail rounded cuts slightly more to match the chrome reveal
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.02; // pull back the middle rail rounded cuts to keep the radius a bit tighter
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.05; // offset the wood cutouts outward so the rounded relief tracks the shifted middle pocket line
 
 function buildChromePlateGeometry({
@@ -1074,7 +1074,7 @@ const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.38; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
 const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.02; // round the middle jaws slightly more while keeping the corner match
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.76; // preserve the playable mouth while letting the corner fascia run longer and slimmer
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.72; // preserve the playable mouth while slightly tightening the corner jaw radius
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.03; // nudge jaws outward to track the cushion line precisely
@@ -1251,7 +1251,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.035; // lift balls slightly so they sit a touch higher above the cloth
+const BALL_CENTER_LIFT = BALL_R * 0.05; // lift balls slightly so they sit a touch higher above the cloth
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -7956,7 +7956,7 @@ export function Table3D(
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.035; // keep cushions closer to center to avoid overlap with rails
   const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.013; // pull short-rail cushions inward so they clear the wood rails
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.015; // nudge long-rail cushions inward for cleaner rail separation
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.022; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters


### PR DESCRIPTION
### Motivation
- Improve visual/play alignment of the Pool Royale table by making pocket cuts and jaw radii slightly smaller, moving cushions inward, and raising resting ball height so balls sit cleanly on the cloth.

### Description
- Reduced chrome pocket cut scales by changing `CHROME_CORNER_POCKET_CUT_SCALE` to `1.04` and `CHROME_SIDE_POCKET_CUT_SCALE` to `1.05` to tighten chrome cut radii.
- Tightened wooden rail pocket relief by updating `WOOD_RAIL_POCKET_RELIEF_SCALE` to `0.92` and `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE` to `1.02` to keep wood cuts consistent with chrome.
- Slightly reduced the corner jaw radius by changing `POCKET_JAW_CORNER_OUTER_SCALE` from `1.76` to `1.72` to make the jaw rounding smaller.
- Pulled long-rail cushions inward by increasing `CUSHION_LONG_RAIL_CENTER_NUDGE` to `TABLE.THICK * 0.022` so the four side cushions align a bit closer to the rails.
- Raised ball resting height by increasing `BALL_CENTER_LIFT` to `BALL_R * 0.05` so balls sit marginally higher on the cloth surface.
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx` and committed with the message "Adjust Pool Royale table geometry".

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, which validated the app boot step succeeded.
- Attempted an automated visual check using a Playwright script to capture a screenshot of `/#/games/poolroyale`, but the Chromium instance crashed in the container so no screenshot was produced.
- No unit or integration test suites were executed as part of this change (visual tweaks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b94bfb108329b5b1368cc170d27c)