### PR TITLE
Adjust Snooker standing and pocket camera offsets

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -164,13 +164,13 @@ public class CueCamera : MonoBehaviour
     // Height offset above the table focus, captured on start.
     public float standingCameraHeight = 0.48f;
     // Pull the standing camera inward so the framing matches the Pool Royale view.
-    public float standingCameraDistanceInset = 0.08f;
+    public float standingCameraDistanceInset = 0.12f;
     // Additional height offset applied after caching the standing camera pose.
-    public float standingCameraHeightOffset = -0.04f;
+    public float standingCameraHeightOffset = -0.06f;
 
     [Header("Pocket camera framing")]
     // Pull the pocket camera slightly inward for tighter pocket coverage.
-    public float pocketCameraDistanceInset = 0.14f;
+    public float pocketCameraDistanceInset = 0.2f;
     // Nudge the pocket camera look target downward for a slightly steeper angle.
     public float pocketCameraLookDownOffset = 0.03f;
 


### PR DESCRIPTION
### Motivation
- Bring the Snooker Royale camera framing closer to the table by pulling the standing camera inward and making it sit slightly lower for a tighter portrait composition.
- Make pocket (corner) cameras tighter so their distance matches the closer framing used by the Pool Royale view.

### Description
- Updated `standingCameraDistanceInset` in `billiards.Unity/CueCamera.cs` from `0.08f` to `0.12f` to pull the standing camera inward. 
- Updated `standingCameraHeightOffset` in `billiards.Unity/CueCamera.cs` from `-0.04f` to `-0.06f` to lower the cached standing camera height. 
- Updated `pocketCameraDistanceInset` in `billiards.Unity/CueCamera.cs` from `0.14f` to `0.2f` to tighten pocket camera framing.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b1e521148329a6c355099af4a4bf)