### PR TITLE
Align Domino Royal table setup menu with Murlan Royale layout

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -28,13 +28,24 @@
   #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
   #configButton:hover{background:rgba(0,0,0,.6);border-color:rgba(148,197,255,.45);}
   #configButton svg{width:1.4rem;height:1.4rem;}
-  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);max-height:min(72dvh, 480px);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:0.85rem 1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.65rem;overflow:hidden;}
+  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);max-height:min(78dvh, 520px);background:rgba(3,7,18,.88);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:0.95rem 1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.75rem;overflow:hidden;}
   #configPanel.active{display:flex;}
-  #configPanel h3{margin:0;font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.75);}
-  #configSections{display:flex;flex-direction:column;gap:.55rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
+  #configPanel .config-header{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem;}
+  #configPanel .config-kicker{margin:0;font-size:.6rem;text-transform:uppercase;letter-spacing:.35rem;color:rgba(148,197,255,.75);}
+  #configPanel .config-desc{margin:.3rem 0 0;font-size:.7rem;line-height:1.3;color:rgba(226,232,240,.65);}
+  #configSections{display:flex;flex-direction:column;gap:.75rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
   #configSections::-webkit-scrollbar{width:.35rem;}
   #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
   #configSections::-webkit-scrollbar-track{background:transparent;}
+  .config-card{border:1px solid rgba(255,255,255,.1);background:rgba(255,255,255,.05);border-radius:.95rem;padding:.75rem;display:flex;flex-direction:column;gap:.65rem;}
+  .config-card-title{margin:0;font-size:.6rem;letter-spacing:.32rem;text-transform:uppercase;color:rgba(226,232,240,.75);}
+  .config-card-subtitle{margin:.25rem 0 0;font-size:.7rem;line-height:1.3;color:rgba(226,232,240,.6);}
+  .config-card-body{display:flex;flex-direction:column;gap:.65rem;}
+  .config-subsection{display:flex;flex-direction:column;gap:.35rem;}
+  .config-subsection-title{margin:0;font-size:.55rem;letter-spacing:.32rem;text-transform:uppercase;color:rgba(226,232,240,.6);}
+  .config-grid{display:grid;gap:.5rem;}
+  .config-grid.two-col{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .config-grid.one-col{grid-template-columns:repeat(1,minmax(0,1fr));}
   #seatOverlay{position:fixed;inset:0;pointer-events:none;z-index:4;}
   .seat-badge{position:absolute;transform:translate(-50%,-50%);pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:.35rem;min-width:3.5rem;}
   .seat-badge-avatar{position:relative;width:3.15rem;height:3.15rem;display:grid;place-items:center;}
@@ -75,11 +86,16 @@
   .toast{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + 4.5rem);transform:translateX(-50%);padding:.4rem .75rem;border-radius:999px;background:rgba(15,23,42,.8);border:1px solid rgba(255,255,255,.18);color:#f8fafc;font-size:.72rem;font-weight:700;z-index:7;box-shadow:0 10px 24px rgba(0,0,0,.45);pointer-events:none;}
   .config-section{display:flex;flex-direction:column;gap:.3rem;}
   .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
-  .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
-  .config-option span{font-size:clamp(.5rem,1.45vw,.58rem);text-transform:uppercase;letter-spacing:.24rem;color:rgba(148,197,255,.68);}
+  .config-option{border-radius:0.95rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.55rem;display:flex;flex-direction:column;gap:.35rem;font-size:.7rem;line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
+  .config-option--tile{align-items:center;text-align:center;}
+  .config-option--row{align-items:flex-start;text-align:left;padding:.6rem .75rem;}
+  .config-option-label{font-size:.65rem;font-weight:700;color:#e2e8f0;}
   .config-option.active{border-color:rgba(56,189,248,.7);background:rgba(56,189,248,.15);box-shadow:0 0 0 1px rgba(56,189,248,.35),0 12px 24px rgba(8,145,178,.28);}
   .config-option:disabled{opacity:.45;cursor:not-allowed;}
   .config-option:not(.active):hover{border-color:rgba(255,255,255,.32);transform:translateY(-1px);}
+  .config-preview{width:100%;height:3.5rem;border-radius:.75rem;border:1px solid rgba(255,255,255,.12);overflow:hidden;position:relative;background:#0f172a;display:flex;align-items:center;justify-content:center;}
+  .config-preview img{width:100%;height:100%;object-fit:cover;display:block;}
+  .config-preview-overlay{position:absolute;inset:0;background:linear-gradient(135deg, rgba(0,0,0,.32), rgba(0,0,0,0) 45%, rgba(0,0,0,.45));pointer-events:none;}
   .config-close{display:flex;justify-content:flex-end;}
   .config-close button{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.12);color:#f1f5f9;border-radius:999px;padding:.35rem;display:grid;place-items:center;transition:background .2s ease, border-color .2s ease;}
   .config-close button:hover{background:rgba(248,250,252,.16);border-color:rgba(248,250,252,.38);}
@@ -121,7 +137,12 @@
       </svg>
     </button>
   </div>
-  <h3 id="configTitle">Table Setup</h3>
+  <div class="config-header">
+    <div>
+      <p class="config-kicker" id="configTitle">Table Setup</p>
+      <p class="config-desc">Personalize the Domino Royale table, chairs, and tiles.</p>
+    </div>
+  </div>
   <div id="configSections"></div>
 </div>
 <div id="topRightActions" aria-label="Top actions">
@@ -4982,13 +5003,27 @@ window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
 
 function createOptionPreview(key, option) {
   const swatch = document.createElement('div');
-  swatch.style.width = '100%';
-  swatch.style.height = '1.5rem';
-  swatch.style.borderRadius = '0.75rem';
-  swatch.style.border = '1px solid rgba(255,255,255,0.12)';
+  swatch.className = 'config-preview';
+  const addOverlay = () => {
+    const overlay = document.createElement('div');
+    overlay.className = 'config-preview-overlay';
+    swatch.appendChild(overlay);
+  };
+  const addThumbnail = (thumb, alt) => {
+    if (!thumb) return false;
+    const img = document.createElement('img');
+    img.src = thumb;
+    img.alt = alt || 'Preview';
+    img.loading = 'lazy';
+    swatch.appendChild(img);
+    return true;
+  };
   switch (key) {
     case 'environmentHdri': {
-      swatch.style.background = 'linear-gradient(135deg, rgba(255,255,255,0.12), rgba(0,0,0,0.4))';
+      const hasThumb = addThumbnail(option?.thumbnail, option?.name || option?.label || 'HDRI');
+      if (!hasThumb) {
+        swatch.style.background = 'linear-gradient(135deg, rgba(255,255,255,0.12), rgba(0,0,0,0.4))';
+      }
       const badge = document.createElement('span');
       badge.textContent = option?.name || option?.label || 'HDRI';
       badge.style.display = 'inline-block';
@@ -5005,20 +5040,25 @@ function createOptionPreview(key, option) {
       if (Array.isArray(option?.swatches) && option.swatches.length >= 2) {
         swatch.style.background = `linear-gradient(135deg, ${option.swatches[0]}, ${option.swatches[1]})`;
       }
+      addOverlay();
       break;
     }
     case 'tableTheme': {
-      swatch.style.background = 'linear-gradient(135deg, #0f172a, #1f2937)';
-      const label = document.createElement('span');
-      label.textContent = option?.label || 'Table';
-      label.style.display = 'inline-block';
-      label.style.padding = '0.12rem 0.4rem';
-      label.style.borderRadius = '0.5rem';
-      label.style.background = 'rgba(255,255,255,0.08)';
-      label.style.fontSize = '0.72rem';
-      label.style.fontWeight = '700';
-      label.style.letterSpacing = '0.04em';
-      swatch.appendChild(label);
+      const hasThumb = addThumbnail(option?.thumbnail, option?.label || 'Table');
+      if (!hasThumb) {
+        swatch.style.background = 'linear-gradient(135deg, #0f172a, #1f2937)';
+        const label = document.createElement('span');
+        label.textContent = option?.label || 'Table';
+        label.style.display = 'inline-block';
+        label.style.padding = '0.12rem 0.4rem';
+        label.style.borderRadius = '0.5rem';
+        label.style.background = 'rgba(255,255,255,0.08)';
+        label.style.fontSize = '0.72rem';
+        label.style.fontWeight = '700';
+        label.style.letterSpacing = '0.04em';
+        swatch.appendChild(label);
+      }
+      addOverlay();
       break;
     }
     case 'tableWood':
@@ -5055,7 +5095,10 @@ function createOptionPreview(key, option) {
       }
       break;
     case 'tableCloth':
-      swatch.style.background = `linear-gradient(135deg, ${option.feltTop}, ${option.feltBottom})`;
+      if (!addThumbnail(option?.thumbnail, option?.label || 'Table cloth')) {
+        swatch.style.background = `linear-gradient(135deg, ${option.feltTop}, ${option.feltBottom})`;
+      }
+      addOverlay();
       break;
     case 'tableBase':
       swatch.style.background = `linear-gradient(135deg, ${option.base}, ${option.trim})`;
@@ -5118,7 +5161,10 @@ function createOptionPreview(key, option) {
       break;
     }
     case 'chairTheme':
-      swatch.style.background = option.seatColor;
+      if (!addThumbnail(option?.thumbnail, option?.label || 'Chair theme')) {
+        swatch.style.background = option.seatColor;
+      }
+      addOverlay();
       break;
     default:
       swatch.style.background = '#1f2937';
@@ -5129,90 +5175,50 @@ function createOptionPreview(key, option) {
 function refreshConfigUI() {
   if (!configSectionsEl) return;
   configSectionsEl.replaceChildren();
-  const commentaryWrapper = document.createElement('div');
-  commentaryWrapper.className = 'config-section';
-  const commentaryLabel = document.createElement('h4');
-  commentaryLabel.textContent = 'Commentary';
-  commentaryWrapper.appendChild(commentaryLabel);
-  const commentaryGrid = document.createElement('div');
-  commentaryGrid.className = 'config-options';
-  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
-  COMMENTARY_PRESETS.forEach((preset) => {
-    const presetButton = document.createElement('button');
-    presetButton.type = 'button';
-    presetButton.className = 'config-option';
-    presetButton.disabled = !commentarySupported;
-    if (preset.id === commentaryPresetId) {
-      presetButton.classList.add('active');
+  const createCard = (title, subtitle) => {
+    const card = document.createElement('div');
+    card.className = 'config-card';
+    if (title) {
+      const header = document.createElement('div');
+      const cardTitle = document.createElement('p');
+      cardTitle.className = 'config-card-title';
+      cardTitle.textContent = title;
+      header.appendChild(cardTitle);
+      if (subtitle) {
+        const cardSubtitle = document.createElement('p');
+        cardSubtitle.className = 'config-card-subtitle';
+        cardSubtitle.textContent = subtitle;
+        header.appendChild(cardSubtitle);
+      }
+      card.appendChild(header);
     }
-    const presetLabel = document.createElement('span');
-    presetLabel.textContent = preset.name;
-    presetButton.appendChild(presetLabel);
-    const presetTone = document.createElement('div');
-    presetTone.textContent = preset.tone;
-    presetTone.style.fontSize = '0.7rem';
-    presetTone.style.color = 'rgba(226,232,240,0.78)';
-    presetTone.style.fontWeight = '600';
-    presetTone.style.lineHeight = '1.35';
-    presetButton.appendChild(presetTone);
-    presetButton.addEventListener('click', () => {
-      if (!commentarySupported) return;
-      setCommentaryPresetId(preset.id);
-    });
-    commentaryGrid.appendChild(presetButton);
-  });
-  const muteButton = document.createElement('button');
-  muteButton.type = 'button';
-  muteButton.className = 'config-option';
-  muteButton.setAttribute('aria-pressed', String(commentaryMuted));
-  muteButton.disabled = !commentarySupported;
-  if (commentaryMuted) {
-    muteButton.classList.add('active');
-  }
-  const muteLabel = document.createElement('span');
-  muteLabel.textContent = commentaryMuted ? 'Commentary muted' : 'Commentary on';
-  muteButton.appendChild(muteLabel);
-  const muteHelper = document.createElement('div');
-  muteHelper.textContent = commentaryMuted ? 'Tap to unmute the announcer' : 'Tap to mute the announcer';
-  muteHelper.style.fontSize = '0.65rem';
-  muteHelper.style.color = 'rgba(226,232,240,0.78)';
-  muteHelper.style.fontWeight = '700';
-  muteHelper.style.lineHeight = '1.35';
-  muteButton.appendChild(muteHelper);
-  muteButton.addEventListener('click', () => {
-    setCommentaryMuted(!commentaryMuted);
-  });
-  commentaryGrid.appendChild(muteButton);
-  commentaryWrapper.appendChild(commentaryGrid);
-  if (!commentarySupported) {
-    const commentaryNote = document.createElement('p');
-    commentaryNote.textContent = 'Voice commentary requires a browser with Web Speech support.';
-    commentaryNote.style.margin = '0';
-    commentaryNote.style.fontSize = '0.65rem';
-    commentaryNote.style.color = 'rgba(226,232,240,0.7)';
-    commentaryNote.style.lineHeight = '1.4';
-    commentaryWrapper.appendChild(commentaryNote);
-  }
-  configSectionsEl.appendChild(commentaryWrapper);
+    return card;
+  };
+
+  const tableCard = createCard('Personalize Arena', 'Table surface, chairs, and tiles.');
+  const tableBody = document.createElement('div');
+  tableBody.className = 'config-card-body';
   TABLE_SETUP_SECTIONS.forEach((section) => {
     const wrapper = document.createElement('div');
-    wrapper.className = 'config-section';
-    const label = document.createElement('h4');
+    wrapper.className = 'config-subsection';
+    const label = document.createElement('p');
+    label.className = 'config-subsection-title';
     label.textContent = section.label;
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
-    optionsGrid.className = 'config-options';
+    optionsGrid.className = 'config-grid two-col';
     const availableOptions = getUnlockedOptions(section.key, dominoInventory);
     availableOptions.forEach((option) => {
       const idx = findDominoOptionIndex(section.key, option.id);
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'config-option';
+      button.className = 'config-option config-option--tile';
       if (appearance[section.key] === idx) {
         button.classList.add('active');
       }
       button.appendChild(createOptionPreview(section.key, option));
       const name = document.createElement('span');
+      name.className = 'config-option-label';
       name.textContent = option.label ?? option.id;
       button.appendChild(name);
       button.addEventListener('click', () => {
@@ -5224,24 +5230,21 @@ function refreshConfigUI() {
       optionsGrid.appendChild(button);
     });
     wrapper.appendChild(optionsGrid);
-    configSectionsEl.appendChild(wrapper);
+    tableBody.appendChild(wrapper);
   });
+  tableCard.appendChild(tableBody);
+  configSectionsEl.appendChild(tableCard);
 
-  const feedbackWrapper = document.createElement('div');
-  feedbackWrapper.className = 'config-section';
-  const feedbackLabel = document.createElement('h4');
-  feedbackLabel.textContent = 'Audio & haptics';
-  feedbackWrapper.appendChild(feedbackLabel);
+  const feedbackCard = createCard('Audio & haptics');
   const feedbackGrid = document.createElement('div');
-  feedbackGrid.className = 'config-options';
-  feedbackGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(140px, 1fr))';
+  feedbackGrid.className = 'config-grid one-col';
   [
     { key: 'sound', label: feedbackSettings.sound ? 'Sound on' : 'Sound muted', helper: 'Procedural knocks & win jingles' },
     { key: 'haptics', label: feedbackSettings.haptics ? 'Haptics on' : 'Haptics off', helper: 'Short vibrations on plays' }
   ].forEach((option) => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'config-option';
+    button.className = 'config-option config-option--row';
     if (feedbackSettings[option.key]) {
       button.classList.add('active');
     }
@@ -5267,22 +5270,17 @@ function refreshConfigUI() {
   feedbackHint.style.fontSize = '0.65rem';
   feedbackHint.style.color = 'rgba(226,232,240,0.7)';
   feedbackHint.style.lineHeight = '1.4';
-  feedbackWrapper.appendChild(feedbackGrid);
-  feedbackWrapper.appendChild(feedbackHint);
-  configSectionsEl.appendChild(feedbackWrapper);
+  feedbackCard.appendChild(feedbackGrid);
+  feedbackCard.appendChild(feedbackHint);
+  configSectionsEl.appendChild(feedbackCard);
 
-  const graphicsWrapper = document.createElement('div');
-  graphicsWrapper.className = 'config-section';
-  const graphicsLabel = document.createElement('h4');
-  graphicsLabel.textContent = 'Graphics';
-  graphicsWrapper.appendChild(graphicsLabel);
+  const graphicsCard = createCard('Graphics');
   const graphicsGrid = document.createElement('div');
-  graphicsGrid.className = 'config-options';
-  graphicsGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(200px, 1fr))';
+  graphicsGrid.className = 'config-grid one-col';
   FRAME_RATE_OPTIONS.forEach((option) => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'config-option';
+    button.className = 'config-option config-option--row';
     if (frameRateId === option.id) {
       button.classList.add('active');
     }
@@ -5330,8 +5328,70 @@ function refreshConfigUI() {
     });
     graphicsGrid.appendChild(button);
   });
-  graphicsWrapper.appendChild(graphicsGrid);
-  configSectionsEl.appendChild(graphicsWrapper);
+  graphicsCard.appendChild(graphicsGrid);
+  configSectionsEl.appendChild(graphicsCard);
+
+  const commentaryCard = createCard('Commentary');
+  const commentaryGrid = document.createElement('div');
+  commentaryGrid.className = 'config-grid one-col';
+  const commentarySupported = Boolean(speechSynth && speechUtteranceCtor);
+  COMMENTARY_PRESETS.forEach((preset) => {
+    const presetButton = document.createElement('button');
+    presetButton.type = 'button';
+    presetButton.className = 'config-option config-option--row';
+    presetButton.disabled = !commentarySupported;
+    if (preset.id === commentaryPresetId) {
+      presetButton.classList.add('active');
+    }
+    const presetLabel = document.createElement('span');
+    presetLabel.textContent = preset.name;
+    presetButton.appendChild(presetLabel);
+    const presetTone = document.createElement('div');
+    presetTone.textContent = preset.tone;
+    presetTone.style.fontSize = '0.7rem';
+    presetTone.style.color = 'rgba(226,232,240,0.78)';
+    presetTone.style.fontWeight = '600';
+    presetTone.style.lineHeight = '1.35';
+    presetButton.appendChild(presetTone);
+    presetButton.addEventListener('click', () => {
+      if (!commentarySupported) return;
+      setCommentaryPresetId(preset.id);
+    });
+    commentaryGrid.appendChild(presetButton);
+  });
+  const muteButton = document.createElement('button');
+  muteButton.type = 'button';
+  muteButton.className = 'config-option config-option--row';
+  muteButton.setAttribute('aria-pressed', String(commentaryMuted));
+  muteButton.disabled = !commentarySupported;
+  if (commentaryMuted) {
+    muteButton.classList.add('active');
+  }
+  const muteLabel = document.createElement('span');
+  muteLabel.textContent = commentaryMuted ? 'Commentary muted' : 'Commentary on';
+  muteButton.appendChild(muteLabel);
+  const muteHelper = document.createElement('div');
+  muteHelper.textContent = commentaryMuted ? 'Tap to unmute the announcer' : 'Tap to mute the announcer';
+  muteHelper.style.fontSize = '0.65rem';
+  muteHelper.style.color = 'rgba(226,232,240,0.78)';
+  muteHelper.style.fontWeight = '700';
+  muteHelper.style.lineHeight = '1.35';
+  muteButton.appendChild(muteHelper);
+  muteButton.addEventListener('click', () => {
+    setCommentaryMuted(!commentaryMuted);
+  });
+  commentaryGrid.appendChild(muteButton);
+  commentaryCard.appendChild(commentaryGrid);
+  if (!commentarySupported) {
+    const commentaryNote = document.createElement('p');
+    commentaryNote.textContent = 'Voice commentary requires a browser with Web Speech support.';
+    commentaryNote.style.margin = '0';
+    commentaryNote.style.fontSize = '0.65rem';
+    commentaryNote.style.color = 'rgba(226,232,240,0.7)';
+    commentaryNote.style.lineHeight = '1.4';
+    commentaryCard.appendChild(commentaryNote);
+  }
+  configSectionsEl.appendChild(commentaryCard);
 }
 
 function closeConfigPanel() {


### PR DESCRIPTION
### Motivation
- The Domino Battle Royal table setup panel should match the visual hierarchy, thumbnail sizing, and layout used by the Murlan Royale setup to provide consistent UX across Royale games and match the requested design.

### Description
- Restyled the setup panel in `webapp/public/domino-royal.html` by increasing the panel height, padding, and updating the header to a Murlan-like kicker + description layout (`#configPanel`, `.config-header`, `.config-kicker`, `.config-desc`).
- Reorganized the configuration UI into card-like groups and grid variants by adding `.config-card`, `.config-card-body`, `.config-subsection`, `.config-grid.two-col`, and `.config-grid.one-col` and switched section rendering to use these cards inside `refreshConfigUI()`.
- Reworked option preview and option element markup by adding `.config-preview`, `.config-preview-overlay`, `.config-option--tile`, `.config-option--row`, `.config-option-label`, and updating `createOptionPreview()` to render lazy `img` thumbnails when available and add overlay styling for parity with Murlan thumbnails.
- Adjusted interactive rendering logic in `refreshConfigUI()` to build the new card/grid structure, use the new CSS classes, and preserve existing behavior (selection, persistence, and event handlers) while changing presentation only.

### Testing
- Launched a static server with `python -m http.server 4173` in `webapp/public` to serve the updated `domino-royal.html`, which started successfully (automated server start).
- Attempted an automated Playwright script to open `http://127.0.0.1:4173/domino-royal.html`, click the `#configButton`, and capture a screenshot, but the Playwright Chromium process crashed in this environment so the screenshot step failed with a browser crash error.
- No unit tests were added or executed; the changes are UI-only and were committed with `git commit` after validation of file diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986bb86de688329b05e5a0f64e753f0)