### PR TITLE
Adjust Snooker Royal standing camera framing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -4910,7 +4910,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.82; // match Pool Royale standing orbit coordinates
+const STANDING_VIEW_PHI = 0.84; // match Pool Royale standing orbit coordinates
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.0012; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -4926,7 +4926,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.97;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.95;
-const STANDING_VIEW_DISTANCE_SCALE = 0.5; // pull the standing camera slightly closer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.46; // pull the standing camera slightly closer while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads


### PR DESCRIPTION
### Motivation
- Make the standing (player) camera feel closer to the table and sit slightly lower on portrait screens so the table and balls appear tighter and more responsive to the player view (`Snooker Royal` standing camera framing). 

### Description
- Tweak two camera constants in `webapp/src/pages/Games/SnookerRoyal.jsx`: changed `STANDING_VIEW_PHI` from `0.82` to `0.84` and `STANDING_VIEW_DISTANCE_SCALE` from `0.5` to `0.46` to pull the standing camera closer and lower the view slightly.

### Testing
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported ready (dev server started successfully). 
- Attempted an automated Playwright screenshot to validate the visual change, but the screenshot run timed out in this environment (no image captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870b9e1f6c83298e82ca314ceffbd3)