### PR TITLE
Adjust Pool Royale camera depth and cushion inset

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1709,8 +1709,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.36; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.3; // keep short-rail cushions unchanged
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.38; // pull long-rail cushions farther inward toward the table center
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.32; // pull short-rail cushions slightly inward to match
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -4945,7 +4945,7 @@ const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.08;
-const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.18; // let the standing view dip slightly lower while still staying above the cue
+const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.12; // let the standing view dip slightly lower while still staying above the cue
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
@@ -5108,7 +5108,8 @@ const CAMERA_MIN_HORIZONTAL =
   ((Math.max(PLAY_W, PLAY_H) / 2 + SIDE_RAIL_INNER_THICKNESS) * WORLD_SCALE) +
   CAMERA_RAIL_SAFETY;
 const CAMERA_DOWNWARD_PULL = 1.9;
-const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.29;
+const CAMERA_DYNAMIC_PULL_RANGE = CAMERA.minR * 0.32;
+const CAMERA_LOW_VIEW_PULL_RANGE = CAMERA.minR * 0.08;
 const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
@@ -16752,6 +16753,17 @@ const powerRef = useRef(hud.power);
           if (dynamicPull > 1e-5) {
             const adjusted = clampOrbitRadius(
               finalRadius - dynamicPull,
+              cueMinRadius
+            );
+            finalRadius =
+              minRadiusForRails != null
+                ? Math.max(adjusted, minRadiusForRails)
+                : adjusted;
+          }
+          const lowViewPull = CAMERA_LOW_VIEW_PULL_RANGE * (1 - phiProgress);
+          if (lowViewPull > 1e-5) {
+            const adjusted = clampOrbitRadius(
+              finalRadius - lowViewPull,
               cueMinRadius
             );
             finalRadius =


### PR DESCRIPTION
### Motivation
- Improve the standing/player camera so it can be lowered a bit more while keeping the same angle and gently pull the view closer to the cue ball as the player lowers the camera. 
- Tighten the visible rail/cushion footprint so the four side cushions sit slightly more inward for a tighter table visual.

### Description
- Reduced the lowest standing orbit tilt by changing `CAMERA_LOWEST_PHI` to be a bit less steep so the standing view can dip lower while staying above the cue. 
- Increased `CAMERA_DYNAMIC_PULL_RANGE` and added a new `CAMERA_LOW_VIEW_PULL_RANGE` to let the orbit logic ease the camera slightly closer to the cue ball as the view lowers, and applied that pull in the camera blending path. 
- Nudged cushion face insets by updating `CUSHION_FACE_INSET_LONG` and `CUSHION_FACE_INSET_SHORT` so long and short rail cushions are pulled slightly inward. 
- All edits made in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the Vite server started successfully. 
- Attempted an automated screenshot of the Pool Royale page with Playwright to validate camera/cushion framing, but the Playwright run timed out while taking the screenshot. 
- No unit or integration test suite was executed against the modified logic in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870f1ce8ac8329896bf4d3d543b126)