### PR TITLE
Harden Domino Royal HDRI handling to reduce crashes on low-profile devices

### DIFF
--- a/webapp/public/domino-royal.html
+++ b/webapp/public/domino-royal.html
@@ -3048,14 +3048,16 @@ const isTelegramWebView = /Telegram/i.test(navigator.userAgent || '') || Boolean
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '');
 const isLowMemoryDevice = typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4;
 const isLowCoreDevice = typeof navigator.hardwareConcurrency === 'number' && navigator.hardwareConcurrency <= 4;
-const isLowProfileDevice = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
-const MAX_HDRI_CACHE_SIZE = prefersUhd ? 6 : 3;
+const isSaveDataMode = Boolean(navigator.connection?.saveData);
+const isLowProfileDevice = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice || isSaveDataMode;
+const MAX_HDRI_CACHE_SIZE = prefersUhd ? 6 : isLowProfileDevice ? 2 : 3;
 function resolveHdriResolutionOrder() {
   if (prefersUhd) return ['4k', '2k'];
   if (isLowProfileDevice) return ['1k'];
   return ['2k', '1k'];
 }
 function shouldLoadExternalHdri() {
+  if (renderer.getContext?.()?.isContextLost?.()) return false;
   return prefersUhd || !isLowProfileDevice;
 }
 function pruneHdriCache() {
@@ -3069,6 +3071,13 @@ function pruneHdriCache() {
   }
 }
 let activeEnvironmentHdri = null;
+function isCachedHdriTexture(texture) {
+  if (!texture) return false;
+  for (const cached of hdriTextureCache.values()) {
+    if (cached === texture) return true;
+  }
+  return false;
+}
 
 async function loadHdriEnvironment(variant) {
   if (!variant?.assetId) return null;
@@ -3115,10 +3124,15 @@ async function applyEnvironmentHdri(option = ENVIRONMENT_HDRI_OPTIONS[0]) {
       envMap?.dispose?.();
       return;
     }
-    if (scene.environment && scene.environment !== fallbackEnvTexture) {
+    if (scene.environment && scene.environment !== fallbackEnvTexture && !isCachedHdriTexture(scene.environment)) {
       scene.environment.dispose?.();
     }
-    if (hdriBackground && hdriBackground !== envMap && hdriBackground !== fallbackEnvTexture) {
+    if (
+      hdriBackground &&
+      hdriBackground !== envMap &&
+      hdriBackground !== fallbackEnvTexture &&
+      !isCachedHdriTexture(hdriBackground)
+    ) {
       hdriBackground.dispose?.();
     }
     scene.environment = envMap || fallbackEnvTexture;


### PR DESCRIPTION
### Motivation
- Domino Royal was aggressively loading and caching external HDRI environments which increases GPU memory pressure and can trigger WebGL context loss on low-profile or save-data devices.
- The game exhibited instability when environment textures were swapped and cached textures were accidentally disposed and later reused, causing crashes.
- Make Domino's HDRI behavior match other games by being more conservative about loading and disposing HDRI resources and trimming cache size on constrained devices. 

### Description
- Treat browser `navigator.connection.saveData` as a low-profile signal and include it in `isLowProfileDevice`, and reduce `MAX_HDRI_CACHE_SIZE` when running on low-profile devices by updating `webapp/public/domino-royal.html`.
- Avoid loading external HDRIs when the WebGL context is lost by adding a guard in `shouldLoadExternalHdri()`.
- Add `isCachedHdriTexture()` and skip disposing of `scene.environment` / `hdriBackground` when those textures are still present in the HDRI cache to prevent freeing GPU resources that are still referenced.

### Testing
- No automated tests were run for these static HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871626349c83298dfa3a7fbab0079a)