### PR TITLE
PoolRoyale: raise rails, cushions and chalk; tighten cushions; lift pocket cams; add standing→cue forward push

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1068,7 +1068,7 @@ const REPLAY_CUE_STICK_HOLD_MS = 620;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
-const RAIL_HEIGHT = TABLE.THICK * 1.52; // raise rails slightly so the cushions sit higher
+const RAIL_HEIGHT = TABLE.THICK * 1.68; // raise rails slightly so the cushions sit higher
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.018; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1192,7 +1192,7 @@ const CHALK_PRECISION_SLOW_MULTIPLIER = 0.25;
 const CHALK_AIM_LERP_SLOW = 0.08;
 const CHALK_TARGET_RING_RADIUS = BALL_R * 2;
 const CHALK_RING_OPACITY = 0.18;
-const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.11; // lift chalks slightly so they sit on the rail surface
+const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.2; // lift chalks slightly so they sit on the rail surface
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
@@ -1252,7 +1252,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = 0; // align balls to the cloth surface to match snooker seating
+const BALL_CENTER_LIFT = BALL_R * 0.06; // lift balls slightly so they sit visually on top of the cloth
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1364,8 +1364,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.065; // lift the cushion base slightly so the lip sits higher above the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.055; // trim the cushion tops a touch less so they sit higher than before
+const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.11; // lift the cushion base slightly so the lip sits higher above the cloth
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.022; // trim the cushion tops a touch less so they sit higher than before
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -1453,8 +1453,8 @@ const POCKET_CAM = Object.freeze({
     POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.05,
-  heightOffsetShortMultiplier: 1.02,
+  heightOffset: BALL_R * 1.34,
+  heightOffsetShortMultiplier: 1.16,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
     POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 * POCKET_CAM_INWARD_SCALE +
@@ -1709,8 +1709,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.42; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.32; // pull short-rail cushions slightly inward to match
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.56; // pull long-rail cushions farther inward toward the table center
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.46; // pull short-rail cushions slightly inward to match
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -5117,6 +5117,7 @@ const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.32; // restore the 9pm in-hand orbit 
 const IN_HAND_DRAG_SPEED = 1.7; // match the faster air-hockey drag pace for cue-ball placement
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
+const STANDING_TO_CUE_FORWARD_PUSH = CAMERA.minR * 0.1; // gently push forward as the standing view lowers toward cue view
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;
 const CUE_VIEW_FORWARD_SLIDE_RESET_BLEND = 0.45;
 const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended toward cue view for finer aiming
@@ -7957,9 +7958,9 @@ export function Table3D(
     mesh.material.needsUpdate = true;
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
-  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.035; // keep cushions closer to center to avoid overlap with rails
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.013; // pull short-rail cushions inward so they clear the wood rails
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.028; // nudge long-rail cushions inward for cleaner rail separation
+  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.012; // keep cushions closer to center to avoid overlap with rails
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.055; // pull short-rail cushions inward so they clear the wood rails
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.08; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
@@ -16770,6 +16771,19 @@ const powerRef = useRef(hud.power);
               minRadiusForRails != null
                 ? Math.max(adjusted, minRadiusForRails)
                 : adjusted;
+          }
+          if (STANDING_TO_CUE_FORWARD_PUSH > 1e-6) {
+            const forwardPush = STANDING_TO_CUE_FORWARD_PUSH * (1 - blend);
+            if (forwardPush > 1e-6) {
+              const adjusted = clampOrbitRadius(
+                finalRadius - forwardPush,
+                cueMinRadius
+              );
+              finalRadius =
+                minRadiusForRails != null
+                  ? Math.max(adjusted, minRadiusForRails)
+                  : adjusted;
+            }
           }
           const tiltZoom = CAMERA_TILT_ZOOM * (1 - phiProgress);
           if (tiltZoom > 1e-5) {


### PR DESCRIPTION
### Motivation
- Improve portrait framing by lifting rails, cushions, chalks and pocket cameras so table elements read higher on-screen. 
- Pull all six cushions slightly inward to tighten the table footprint and avoid seam/overlap issues with the wooden rails. 
- Keep the standing→cue camera transition feeling natural by adding a gradual forward push while lowering to cue view.

### Description
- Tuned spatial constants in `webapp/src/pages/Games/PoolRoyale.jsx` including `RAIL_HEIGHT`, `CHALK_RAIL_SURFACE_LIFT`, `CUSHION_EXTRA_LIFT`, and `CUSHION_HEIGHT_DROP` to lift rails, chalks and cushions upward. 
- Increased cushion insets and rail-center nudges by updating `CUSHION_FACE_INSET_LONG`, `CUSHION_FACE_INSET_SHORT`, `CUSHION_SHORT_RAIL_CENTER_NUDGE`, and `CUSHION_LONG_RAIL_CENTER_NUDGE` so all cushions are pulled inward toward the table center. 
- Raised pocket camera framing by bumping `POCKET_CAM.heightOffset` and `POCKET_CAM.heightOffsetShortMultiplier` to lift pocket cams a bit higher. 
- Increased `STANDING_TO_CUE_FORWARD_PUSH` and applied it in the camera blend logic so the orbit translates forward progressively while lowering into cue view.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite reported ready, which succeeded. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` using a portrait viewport, but the Playwright run timed out while loading the scene. 
- No unit or CI tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698734ad5b8c8329852c73d756995541)