### PR TITLE
Shrink Pool Royale balls by 5% and enlarge side chrome pocket cut

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -629,7 +629,7 @@ const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia 
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.012; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.012; // keep side flush trim aligned with the snooker fascia edge
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.04; // tighten the rounded chrome corner cut so the radius reads slightly smaller
-const CHROME_SIDE_POCKET_CUT_SCALE = 1.08; // open the middle pocket chrome cut radius slightly for a broader curve
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.12; // open the middle pocket chrome cut radius slightly for a broader curve
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 0.92; // tighten the wooden rail pocket relief so the rounded corner cuts read slightly smaller
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.984; // ease the wooden corner relief fractionally less so chrome widening does not alter the wood cut
@@ -1163,7 +1163,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
-const BALL_SIZE_SCALE = 1.1545 * 0.85 * 0.9 * 1.07 * 1.03 * 0.95; // trim balls by 5% while preserving the table mapping scale
+const BALL_SIZE_SCALE = 1.1545 * 0.85 * 0.9 * 1.07 * 1.03 * 0.95 * 0.95; // trim balls by an extra 5% while preserving the table mapping scale
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;


### PR DESCRIPTION
### Motivation
- Align visuals with design requests by making the play balls slightly smaller (~5%) while keeping the table mapping intact and enlarging the rounded chrome cut on the middle side pockets for a broader radius.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to multiply `BALL_SIZE_SCALE` by an extra `0.95` (additional ~5% reduction) and increased `CHROME_SIDE_POCKET_CUT_SCALE` from `1.08` to `1.12` to widen the middle pocket chrome cut.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987690cc0748329ab90528d3a421f85)