### PR TITLE
Tweak Pool Royale pocket jaws, corner pocket positions, and cushion lift

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1079,9 +1079,9 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.03; // nudge jaws outward to track the cushion line precisely
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 1.06; // extend the jaw bodies so the underside reaches deeper below the cloth
+const POCKET_JAW_DEPTH_SCALE = 1.03; // trim the jaw bodies slightly so the underside doesn't hang as low below the cloth
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.12; // trim the jaw height slightly so the top edge sits lower
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.015; // allow the jaw extrusion to extend farther down without lifting the top
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.012; // reduce the extra bottom extension so the jaws read shorter
 const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.21; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.1; // start easing earlier so the jaw thins gradually toward the cushions
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
@@ -1210,6 +1210,7 @@ const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
 const POCKET_R = POCKET_VIS_R * 0.985;
 const POCKET_CENTER_OUTWARD_SHIFT = TABLE.THICK * 0.045; // shift pocket centers outward to keep the pocket stack aligned away from the playfield
+const CORNER_POCKET_SIDE_SHIFT = TABLE.THICK * 0.06; // slide corner pocket centres toward the side pockets slightly
 const CORNER_POCKET_CENTER_INSET = Math.max(
   0,
   POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION - POCKET_CENTER_OUTWARD_SHIFT
@@ -1364,8 +1365,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.11; // lift the cushion base slightly so the lip sits higher above the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.022; // trim the cushion tops a touch less so they sit higher than before
+const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.13; // lift the cushion base slightly so the lip sits higher above the cloth
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.02; // trim the cushion tops a touch less so they sit higher than before
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
@@ -5667,7 +5668,7 @@ function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null) {
 const cornerPocketCenter = (sx, sz) =>
   new THREE.Vector2(
     sx * (PLAY_W / 2 - CORNER_POCKET_CENTER_INSET),
-    sz * (PLAY_H / 2 - CORNER_POCKET_CENTER_INSET)
+    sz * (PLAY_H / 2 - CORNER_POCKET_CENTER_INSET - CORNER_POCKET_SIDE_SHIFT)
   );
 let sidePocketShift = 0;
 let cachedPocketCenters = null;
@@ -7958,9 +7959,9 @@ export function Table3D(
     mesh.material.needsUpdate = true;
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
-  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.012; // keep cushions closer to center to avoid overlap with rails
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.055; // pull short-rail cushions inward so they clear the wood rails
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.08; // nudge long-rail cushions inward for cleaner rail separation
+  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.016; // keep cushions closer to center to avoid overlap with rails
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.048; // pull short-rail cushions inward so they clear the wood rails
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.07; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters


### PR DESCRIPTION
### Motivation
- Visually tighten the pocket jaw profile so the jaws read shorter from the bottom when viewed on mobile portrait. 
- Slide corner pocket centres slightly toward the side pockets to better align the corner pockets with the side openings. 
- Raise and nudge cushions so the cushion tops/offsets match the revised pocket/jaw geometry and keep collision/visual framing consistent. 

### Description
- Adjusted pocket jaw sizing and clearance by reducing `POCKET_JAW_DEPTH_SCALE` from `1.06` to `1.03` and `POCKET_JAW_BOTTOM_CLEARANCE` from `TABLE.THICK * 0.015` to `TABLE.THICK * 0.012` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added `CORNER_POCKET_SIDE_SHIFT = TABLE.THICK * 0.06` and applied it to the corner pocket Y coordinate via `cornerPocketCenter` so corner centres move slightly toward the side pockets. 
- Raised cushion base and tuned cushion offsets by changing `CUSHION_EXTRA_LIFT` to `TABLE.THICK * 0.13`, `CUSHION_HEIGHT_DROP` to `TABLE.THICK * 0.02`, `CUSHION_RAIL_FLUSH` to `-TABLE.THICK * 0.016`, `CUSHION_SHORT_RAIL_CENTER_NUDGE` to `TABLE.THICK * 0.048`, and `CUSHION_LONG_RAIL_CENTER_NUDGE` to `TABLE.THICK * 0.07` in the same file. 

### Testing
- Started the web UI dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, and Vite reported ready on `http://localhost:4173/`. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to verify visuals, but the screenshot run timed out and failed. 
- Code changes were staged and committed (`git commit`) locally; no unit tests were executed as part of this PR run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879bffa1008329a10492a58e05647b)