### PR TITLE
Adjust Pool Royale table geometry: lift cushions & balls, tighten pocket radii

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -578,7 +578,7 @@ function adjustSideNotchDepth(mp) {
   );
 }
 
-const POCKET_VISUAL_EXPANSION = 1.02;
+const POCKET_VISUAL_EXPANSION = 0.995;
 const CORNER_POCKET_INWARD_SCALE = 1.008; // ease the corner cuts back toward the rail so the mouth stays as wide as the bowl
 const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
 const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
@@ -1252,7 +1252,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.06; // lift balls slightly so they sit visually on top of the cloth
+const BALL_CENTER_LIFT = BALL_R * 0.075; // lift balls slightly so they sit visually on top of the cloth
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1364,8 +1364,8 @@ const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cushions and rails to hide seams
-const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.11; // lift the cushion base slightly so the lip sits higher above the cloth
-const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.022; // trim the cushion tops a touch less so they sit higher than before
+const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.125; // lift the cushion base slightly so the lip sits higher above the cloth
+const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.018; // trim the cushion tops a touch less so they sit higher than before
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth


### PR DESCRIPTION
### Motivation
- Make small visual tuning to the Pool Royale table so cushions and balls sit slightly higher on screen and pocket/cutout mouths read a bit smaller to match the requested adjustments.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to reduce pocket visual expansion by changing `POCKET_VISUAL_EXPANSION` from `1.02` to `0.995` to shrink pocket/cutout radii.
- Increased `BALL_CENTER_LIFT` from `BALL_R * 0.06` to `BALL_R * 0.075` so all balls sit slightly higher on the cloth.
- Raised cushions by changing `CUSHION_EXTRA_LIFT` from `TABLE.THICK * 0.11` to `TABLE.THICK * 0.125` and adjusted `CUSHION_HEIGHT_DROP` from `TABLE.THICK * 0.022` to `TABLE.THICK * 0.018` for a small upward shift of cushion geometry.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which reported Vite ready and serving locally, indicating the app builds and serves successfully.
- Attempted an automated visual check using Playwright to capture a screenshot, but the Playwright run timed out and did not complete. No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987fc477d748329a02e780fb680cf89)