### PR TITLE
Tweak Pool Royale table geometry: cushions, chalk, pockets & jaws

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -578,7 +578,7 @@ function adjustSideNotchDepth(mp) {
   );
 }
 
-const POCKET_VISUAL_EXPANSION = 0.995;
+const POCKET_VISUAL_EXPANSION = 0.985;
 const CORNER_POCKET_INWARD_SCALE = 1.008; // ease the corner cuts back toward the rail so the mouth stays as wide as the bowl
 const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
 const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
@@ -1079,8 +1079,8 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.03; // nudge jaws outward to track the cushion line precisely
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 1.06; // extend the jaw bodies so the underside reaches deeper below the cloth
-const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.12; // trim the jaw height slightly so the top edge sits lower
+const POCKET_JAW_DEPTH_SCALE = 1.02; // extend the jaw bodies so the underside reaches deeper below the cloth
+const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.09; // trim the jaw height slightly so the top edge sits lower
 const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.015; // allow the jaw extrusion to extend farther down without lifting the top
 const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.21; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.1; // start easing earlier so the jaw thins gradually toward the cushions
@@ -1192,7 +1192,7 @@ const CHALK_PRECISION_SLOW_MULTIPLIER = 0.25;
 const CHALK_AIM_LERP_SLOW = 0.08;
 const CHALK_TARGET_RING_RADIUS = BALL_R * 2;
 const CHALK_RING_OPACITY = 0.18;
-const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.2; // lift chalks slightly so they sit on the rail surface
+const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.26; // lift chalks slightly so they sit on the rail surface
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
@@ -1207,9 +1207,9 @@ const POCKET_CORNER_MOUTH =
   CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
 const POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
-const POCKET_INTERIOR_TOP_SCALE = 1.012; // gently expand the interior diameter at the top of each pocket for a broader opening
+const POCKET_INTERIOR_TOP_SCALE = 1; // keep the interior diameter tight at the rim for slightly smaller pocket openings
 const POCKET_R = POCKET_VIS_R * 0.985;
-const POCKET_CENTER_OUTWARD_SHIFT = TABLE.THICK * 0.045; // shift pocket centers outward to keep the pocket stack aligned away from the playfield
+const POCKET_CENTER_OUTWARD_SHIFT = TABLE.THICK * 0.02; // shift pocket centers outward to keep the pocket stack aligned away from the playfield
 const CORNER_POCKET_CENTER_INSET = Math.max(
   0,
   POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION - POCKET_CENTER_OUTWARD_SHIFT
@@ -7968,6 +7968,7 @@ export function Table3D(
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.03; // lift short-rail cushions up to match the side-rail cushion top line
+  const LONG_RAIL_CUSHION_VERTICAL_LIFT = SHORT_RAIL_CUSHION_VERTICAL_LIFT; // lift long-rail cushions to the same top line as the short rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
@@ -10036,7 +10037,8 @@ export function Table3D(
     group.add(mesh);
     group.position.set(
       x,
-      cushionBaseY + (horizontal ? SHORT_RAIL_CUSHION_VERTICAL_LIFT : 0),
+      cushionBaseY +
+        (horizontal ? SHORT_RAIL_CUSHION_VERTICAL_LIFT : LONG_RAIL_CUSHION_VERTICAL_LIFT),
       z
     );
     if (!horizontal) group.rotation.y = Math.PI / 2;


### PR DESCRIPTION
### Motivation
- Align Pool Royale visuals with requested tweaks: raise the four cushions on the long rails to match short-rail height, lift chalks slightly, shorten pocket jaws top+bottom, and tighten pocket/cutout radii and corner pocket positions for a more official layout.
- Keep all adjustments local to Pool Royale table geometry so physics mapping and playfield proportions remain consistent.

### Description
- Modified table geometry constants in `webapp/src/pages/Games/PoolRoyale.jsx` to implement the visual changes (pocket, jaw, chalk, cushion values).
- Reduced pocket visual expansion and interior rim scale (`POCKET_VISUAL_EXPANSION` 0.995→0.985, `POCKET_INTERIOR_TOP_SCALE` 1.012→1) to tighten pocket/cutout radii.
- Shortened pocket jaw geometry by lowering the jaw top and reducing depth (`POCKET_JAW_VERTICAL_LIFT` TABLE.THICK*0.12→*0.09, `POCKET_JAW_DEPTH_SCALE` 1.06→1.02).
- Nudged pocket centers inward/outward behavior via `POCKET_CENTER_OUTWARD_SHIFT` (TABLE.THICK*0.045→*0.02) so corner pockets align closer to the official positions.
- Raised chalk placement (`CHALK_RAIL_SURFACE_LIFT` BALL_R*0.2→*0.26) so chalks sit visibly higher on rails.
- Unified cushion lift by adding `LONG_RAIL_CUSHION_VERTICAL_LIFT` and applying it so long-rail cushions are lifted to match the short-rail top line.

### Testing
- Started the local dev server with `npm --prefix webapp run dev` (Vite) and the application served successfully at the dev URL, indicating the bundle loads without syntax errors (success).
- Attempted an automated visual smoke capture using Playwright to validate the table appearance, but the screenshot attempt timed out (failure due to environment timeout).
- No unit tests were modified or run as these are visual/tuning changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698804c6c42c8329943c6c67cfae6540)