### PR TITLE
Adjust Snooker Royal camera framing for closer standing view and tighter pocket cams

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1412,7 +1412,7 @@ const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
-const POCKET_CAM_DISTANCE_PULL = BALL_DIAMETER * 5; // pull pocket cameras inward by ~5 balls
+const POCKET_CAM_DISTANCE_PULL = BALL_DIAMETER * 10; // pull pocket cameras inward by ~10 balls (adds ~5 balls more)
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1432,7 +1432,7 @@ const POCKET_CAM = Object.freeze({
     POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.15,
+  heightOffset: BALL_R * 1.15 + BALL_DIAMETER * 5,
   heightOffsetShortMultiplier: 0.9,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
@@ -4929,7 +4929,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.32; // pull the standing camera a bit closer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.26; // pull the standing camera closer while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads


### PR DESCRIPTION
### Motivation
- Make the player (standing) camera appear closer to the table on portrait screens to improve visual clarity and feel.
- Tighten pocket camera framing by pulling them inward and lifting them slightly so potted balls read better on screen.
- Implement the requested visual change equivalent to moving pocket cams by ~5 balls closer while keeping existing framing rules intact.

### Description
- Updated `POCKET_CAM_DISTANCE_PULL` from `BALL_DIAMETER * 5` to `BALL_DIAMETER * 10` to pull pocket cameras further inward (adds ~5 balls more pull). 
- Increased pocket camera vertical offset by adding `BALL_DIAMETER * 5` to `POCKET_CAM.heightOffset` so pocket cameras are lifted slightly higher. 
- Tightened the standing camera framing by lowering `STANDING_VIEW_DISTANCE_SCALE` from `0.32` to `0.26` so the standing/orbit camera sits closer to the table. 
- All changes were made in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880c58e2688329af401afee33e867a)