### PR TITLE
Adjust Pool Royale cushion lengths

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7964,8 +7964,8 @@ export function Table3D(
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.08; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
-  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.7; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.48; // trim short-rail cushions slightly more so the longer side doesn't overhang the pocket cut
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.82; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.36; // trim short-rail cushions slightly more so the longer side doesn't overhang the pocket cut
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.095; // push side-rail cushions away from the middle pockets toward the corners
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.02; // keep short-rail cushions level with the side rails


### PR DESCRIPTION
### Motivation
- Implement visual adjustments so long-rail cushions extend a bit more toward the short rails while short-rail cushions are slightly reduced, preserving middle-pocket cushions and overall cushion height/shape.

### Description
- Tweak cushion trim constants in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `LONG_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.7` to `BALL_R * 0.82` and `SHORT_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.48` to `BALL_R * 0.36` to alter cushion reach.

### Testing
- Started the dev server with `npm --prefix webapp run dev` and Vite served the app (accessible on `http://localhost:4173/`).
- Attempted an automated screenshot with Playwright to validate the visual change but the screenshot timed out (render/screenshot timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882e5f06e48329801b169a4e60a882)