### PR TITLE
Tweak Pool Royale table chrome plates, cushions, corner relief, and ball lift

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -618,11 +618,11 @@ const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical 
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
-const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.04; // trim the fascia closer to the pocket cut so the inner edge tightens slightly
+const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.06; // trim the fascia closer to the pocket cut so the inner edge tightens slightly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.44; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.985; // trim the outer fascia extension so the outside edge tucks in slightly
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.95; // trim the outer fascia extension so the outside edge tucks in slightly
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.06; // extend the plate ends slightly toward the corner pockets
-const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.96; // tighten the middle fascia slightly so both flanks gain a touch more trim
+const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.94; // tighten the middle fascia slightly so both flanks gain a touch more trim
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.2; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
@@ -632,7 +632,7 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1; // keep the rounded chrome corner cut 
 const CHROME_SIDE_POCKET_CUT_SCALE = 1; // match the middle pocket chrome cut radius to the corner pockets
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // pull the rounded chrome cutouts inward so they sit deeper into the fascia mass
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.985; // pull the corner relief radius in slightly for a tighter rounded cut
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.975; // pull the corner relief radius in slightly for a tighter rounded cut
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.02; // enlarge the middle rail rounded cuts to match the chrome pocket arc
@@ -1256,7 +1256,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.075; // lift balls slightly so they sit visually on top of the cloth
+const BALL_CENTER_LIFT = BALL_R * 0.095; // lift balls slightly so they sit visually on top of the cloth
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -7967,8 +7967,8 @@ export function Table3D(
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.08; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.32; // shorten the long-rail cushions slightly less so the noses reach farther toward the corners
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
-  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.65; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.18; // trim short-rail cushions slightly more so the ends pull back from the corners
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.72; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.12; // trim short-rail cushions slightly more so the ends pull back from the corners
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.16; // push side-rail cushions away from the middle pockets toward the corners
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.02; // keep short-rail cushions level with the side rails


### PR DESCRIPTION
### Motivation
- Adjust visual/physical table geometry to match the requested fixture tweaks: trim the chrome fascia around the middle (side) pockets, slightly extend/retract cushions on long/short rails while preserving shape/height, reduce the rounded wood rail corner relief radius, and raise the visible ball position to avoid sinking into the cloth.

### Description
- Updated chrome plate trimming parameters in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `CHROME_SIDE_PLATE_CENTER_TRIM_SCALE` from `0.04` to `0.06`, `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE` from `0.985` to `0.95`, and `CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE` from `0.96` to `0.94` to tighten the middle-pocket chrome plates.
- Reduced wooden rail corner relief by adjusting `WOOD_CORNER_RELIEF_INWARD_SCALE` from `0.985` to `0.975` to slightly decrease the rounded cut radius on corner rails.
- Tweaked cushion length trims: increased `LONG_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.65` to `BALL_R * 0.72` and reduced `SHORT_RAIL_CUSHION_LENGTH_TRIM` from `BALL_R * 0.18` to `BALL_R * 0.12` so side cushions extend a bit more toward the short rail while short-rail cushions are trimmed slightly.
- Raised ball resting height by changing `BALL_CENTER_LIFT` from `BALL_R * 0.075` to `BALL_R * 0.095` so balls sit more clearly on top of the cloth.

### Testing
- Started the local web dev server with `npm --prefix webapp run dev` and confirmed Vite served the app successfully (server ready and reachable). (succeeded)
- Attempted an automated visual smoke check using Playwright to capture `/games/poolroyale`, but the screenshot run timed out and did not complete. (failed: screenshot timed out)
- No unit or integration test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698862a89bfc8329ad5a245640a2b382)