### PR TITLE
Adjust Pool Royale chrome plates, cushions, and ball lift

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -618,11 +618,11 @@ const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical 
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.58; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
-const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.06; // trim the fascia closer to the pocket cut so the inner edge tightens slightly
-const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.44; // trim fascia span so the middle plates finish at the side rail edge
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.95; // trim the outer fascia extension so the outside edge tucks in slightly
+const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.08; // trim the fascia closer to the pocket cut so the inner edge tightens slightly
+const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.32; // trim fascia span so the middle plates finish at the side rail edge
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.88; // trim the outer fascia extension so the outside edge tucks in slightly
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.06; // extend the plate ends slightly toward the corner pockets
-const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.94; // tighten the middle fascia slightly so both flanks gain a touch more trim
+const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.9; // tighten the middle fascia slightly so both flanks gain a touch more trim
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.2; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = -0.16; // nudge the middle fascia further inward so it sits closer to the table center without moving the pocket cut
@@ -1256,7 +1256,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.095; // lift balls slightly so they sit visually on top of the cloth
+const BALL_CENTER_LIFT = BALL_R * 0.115; // lift balls slightly so they sit visually on top of the cloth
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -7963,14 +7963,14 @@ export function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.012; // keep cushions closer to center to avoid overlap with rails
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.055; // pull short-rail cushions inward so they clear the wood rails
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.045; // pull short-rail cushions inward so they clear the wood rails
   const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.08; // nudge long-rail cushions inward for cleaner rail separation
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.32; // shorten the long-rail cushions slightly less so the noses reach farther toward the corners
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.72; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.12; // trim short-rail cushions slightly more so the ends pull back from the corners
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.08; // trim short-rail cushions slightly more so the ends pull back from the corners
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
-  const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.16; // push side-rail cushions away from the middle pockets toward the corners
+  const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.18; // push side-rail cushions away from the middle pockets toward the corners
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.02; // keep short-rail cushions level with the side rails
   const LONG_RAIL_CUSHION_VERTICAL_LIFT = SHORT_RAIL_CUSHION_VERTICAL_LIFT; // keep long-rail cushions at the same height as the short rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation
- Tweak Pool Royale pocket/chrome geometry to match reference marks and tighten the chrome plate edges at middle pockets.
- Adjust cushion placements so side-rail cushions extend slightly toward corners while short-rail cushions move a bit away from table center and keep overall shape/height.
- Raise ball rest height so balls visually sit on top of the cloth rather than appearing partially under it.

### Description
- Updated chrome fascia sizing constants in `webapp/src/pages/Games/PoolRoyale.jsx` to trim the middle-pocket chrome span by changing `CHROME_SIDE_PLATE_CENTER_TRIM_SCALE`, `CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE`, `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`, and `CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE` to tighter values.
- Adjusted cushion positioning constants in the same file by reducing `CUSHION_SHORT_RAIL_CENTER_NUDGE`, shortening `SHORT_RAIL_CUSHION_LENGTH_TRIM`, and increasing `SIDE_CUSHION_CORNER_SHIFT` so side cushions extend slightly toward the corners and short-rail cushions move a touch outward.
- Increased `BALL_CENTER_LIFT` so balls are lifted a bit higher and rest visibly on the cloth.
- Changes applied only to `webapp/src/pages/Games/PoolRoyale.jsx` and committed with the message `Adjust pool royale rails and ball lift`.

### Testing
- No automated tests were run on these changes (no `npm test`/CI executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886fd061248329841c85d9d632ea8f)