### PR TITLE
Adjust Pool Royale spin, cushion cut collisions, and break-in-hand rules

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -502,6 +502,10 @@ export class PoolRoyaleRules {
       phase: frameOver ? 'complete' : snapshot.isOpenTable ? 'open' : 'groups',
       scores
     };
+    const breakInProgress =
+      Boolean(previous?.state?.breakInProgress) && Boolean(result.foul)
+        ? true
+        : Boolean(snapshot.breakInProgress);
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,
@@ -526,7 +530,7 @@ export class PoolRoyaleRules {
         variant: 'american',
         state: snapshot,
         hud,
-        breakInProgress: false
+        breakInProgress
       } satisfies PoolMeta
     };
     return nextState;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1546,7 +1546,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 420;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 220;
 const POCKET_VIEW_POST_POT_HOLD_MS = 80;
 const POCKET_VIEW_MAX_HOLD_MS = 1400;
-const SPIN_GLOBAL_SCALE = 0.6; // keep overall spin impact unchanged
+const SPIN_GLOBAL_SCALE = 0.72; // boost overall spin impact by 20%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -5020,7 +5020,7 @@ let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = BALL_R * 0.12;
 const RAIL_CONTACT_RADIUS = BALL_R;
-const CUSHION_CUT_CONTACT_RADIUS = RAIL_CONTACT_RADIUS * 1.04;
+const CUSHION_CUT_CONTACT_RADIUS = RAIL_CONTACT_RADIUS * 1.12;
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
 let CUSHION_SEGMENTS = [];
 const BREAK_VIEW = Object.freeze({
@@ -6043,7 +6043,7 @@ function reflectRails(ball) {
   const limX = RAIL_LIMIT_X;
   const limY = RAIL_LIMIT_Y;
   const railRadius = RAIL_CONTACT_RADIUS;
-  const cutRadius = Math.min(railRadius, CUSHION_CUT_CONTACT_RADIUS);
+  const cutRadius = Math.max(railRadius, CUSHION_CUT_CONTACT_RADIUS);
   const railLimitX = limX + (BALL_R - railRadius);
   const railLimitY = limY + (BALL_R - railRadius);
   const cornerRad = THREE.MathUtils.degToRad(CUSHION_CUT_ANGLE);
@@ -21467,6 +21467,15 @@ const powerRef = useRef(hud.power);
               meta.state?.breakInProgress ??
               meta.breakInProgress
           );
+        }
+        if (meta.variant === 'american') {
+          return Boolean(
+            meta.state?.breakInProgress ??
+              meta.breakInProgress
+          );
+        }
+        if (meta.variant === '9ball') {
+          return Boolean(meta.breakInProgress);
         }
         return false;
       };

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = 0;
+export const STUN_TOPSPIN_BIAS = -0.03;
 
 export const SPIN_DIRECTIONS = [
   {


### PR DESCRIPTION
### Motivation
- Increase overall spin response and reduce unwanted follow on centre hits so Pool Royale feels closer to the Snooker Royal reference. 
- Prevent balls escaping the table on angled cushion cuts by tightening cushion-cut collision mapping. 
- Ensure ball-in-hand / break handling follows BCA-style expectations for American and 9-ball modes so in-hand placement and break fouls behave correctly.

### Description
- Increased global spin scaling by 20% by updating `SPIN_GLOBAL_SCALE` from `0.6` to `0.72` in `webapp/src/pages/Games/PoolRoyale.jsx` to boost overall spin impact. 
- Reduced centre-hit topspin bias by setting `STUN_TOPSPIN_BIAS` to `-0.03` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to slightly reduce forward roll on exact-centre hits. 
- Tightened cushion-cut collision mapping by increasing `CUSHION_CUT_CONTACT_RADIUS` multiplier and using `Math.max` for the computed cut radius in `webapp/src/pages/Games/PoolRoyale.jsx` so angled cuts register a more robust collision and bounce back correctly. 
- Kept American/9-ball break-in-hand state when appropriate by changing the break handling in `src/rules/PoolRoyaleRules.ts` to compute and propagate `breakInProgress` from the serialized state and shot result. 
- Updated in-hand placement restriction logic in `webapp/src/pages/Games/PoolRoyale.jsx` so `isBreakRestrictedInHand` also checks `american` and `9ball` variants (uses `meta.state?.breakInProgress` / `meta.breakInProgress`).

### Testing
- No automated tests were executed for this change set. 
- Changes were inspected via repository search and committed (`git commit "Adjust pool royale spin and break handling"`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988beb1713c83299df46c6ce5f1ce64)