### PR TITLE
Pool Royale: thicker aiming guides, cue/target power preview, and pocket visual tweaks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1420,7 +1420,7 @@ const POCKET_GUIDE_RING_TOWARD_STRAP = BALL_R * 0.08; // nudge the L segments to
 const POCKET_SIDE_GUIDE_STRAP_PULL = BALL_R * 0.08; // push only the side rails toward the leather strap
 const POCKET_DROP_RING_HOLD_MS = 120; // brief pause on the ring so the fall looks natural before rolling along the holder
 const POCKET_HOLDER_REST_SPACING = BALL_DIAMETER * 1.04; // keep balls flush without overlap as they settle against the strap
-const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.05; // pull the resting spot inward toward the pocket and strap
+const POCKET_HOLDER_REST_PULLBACK = BALL_R * 4.45; // pull the resting spot inward toward the pocket and strap
 const POCKET_HOLDER_REST_DROP = BALL_R * 1.98; // drop the resting spot so potted balls settle onto the chrome rails
 const POCKET_HOLDER_RUN_SPEED_MIN = BALL_DIAMETER * 2.2; // base roll speed along the holder rails after clearing the ring
 const POCKET_HOLDER_RUN_SPEED_MAX = BALL_DIAMETER * 5.6; // clamp the roll speed so balls don't overshoot the leather backstop
@@ -1457,7 +1457,7 @@ const POCKET_CAM = Object.freeze({
     POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
-  heightOffset: BALL_R * 1.34,
+  heightOffset: BALL_R * 1.45,
   heightOffsetShortMultiplier: 1.16,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
@@ -5003,7 +5003,7 @@ const CAMERA = {
 const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // keep orbit height safely above cushion lip while hugging the rail
 const AIM_LINE_MIN_Y = CUE_Y; // ensure the orbit never dips below the aiming line height
 const CAMERA_AIM_LINE_MARGIN = BALL_R * 0.075; // keep extra clearance above the aim line for the tighter orbit distance
-const AIM_LINE_WIDTH = Math.max(1.6, BALL_R * 0.18); // thicker guides for cue/target direction lines
+const AIM_LINE_WIDTH = Math.max(1.6, BALL_R * 0.18) * 3; // thicker guides for cue/target direction lines
 const AIM_TICK_HALF_LENGTH = Math.max(0.6, BALL_R * 0.975); // keep the impact tick proportional to the cue ball
 const AIM_DASH_SIZE = Math.max(0.45, BALL_R * 0.75);
 const AIM_GAP_SIZE = Math.max(0.45, BALL_R * 0.5);
@@ -5321,6 +5321,7 @@ const TMP_VEC3_CUE_SAMPLE_END = new THREE.Vector3();
 const TMP_VEC3_CUE_SAMPLE_POINT = new THREE.Vector3();
 const TMP_VEC3_OBSTRUCTION_TARGET = new THREE.Vector3();
 const TMP_VEC3_POWER = new THREE.Vector3();
+const TMP_VEC3_IMPACT = new THREE.Vector3();
 const TMP_COLOR_POWER = new THREE.Color();
 const POWER_LINE_COLOR_LOW = new THREE.Color(0x5fe39d);
 const POWER_LINE_COLOR_HIGH = new THREE.Color(0xff6a5c);
@@ -20789,6 +20790,7 @@ const powerRef = useRef(hud.power);
         tickGeom,
         new THREE.LineBasicMaterial({
           color: 0xffffff,
+          linewidth: AIM_LINE_WIDTH,
           depthTest: false,
           depthWrite: false
         })
@@ -25651,6 +25653,22 @@ const powerRef = useRef(hud.power);
             guideAimDir2D,
             balls
           );
+          const impactDir =
+            targetDir && (targetDir.x || targetDir.y)
+              ? TMP_VEC3_IMPACT.set(targetDir.x, 0, targetDir.y)
+              : null;
+          let cuePowerStrength = powerStrength;
+          let targetPowerStrength = powerStrength;
+          if (impactDir && impactDir.lengthSq() > 1e-8) {
+            impactDir.normalize();
+            const alignment = Math.abs(baseAimDir.dot(impactDir));
+            const targetTransfer = THREE.MathUtils.clamp(alignment, 0, 1);
+            const cueTransfer = Math.sqrt(
+              Math.max(1 - targetTransfer * targetTransfer, 0)
+            );
+            targetPowerStrength = powerStrength * targetTransfer;
+            cuePowerStrength = powerStrength * cueTransfer;
+          }
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
           const dir = baseAimDir.clone();
@@ -25751,23 +25769,23 @@ const powerRef = useRef(hud.power);
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
           const cueFollowDirSpinAdjusted = cueFollowDir.clone();
-          const cueFollowLength = BALL_R * (12 + powerStrength * 18);
+          const cueFollowLength = BALL_R * (12 + cuePowerStrength * 18);
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
-          cueAfterPower.material.color.copy(powerColor);
-          cueAfterPower.material.opacity = 0.35 + 0.45 * powerStrength;
+          cueAfterPower.material.color.copy(resolvePowerLineColor(cuePowerStrength));
+          cueAfterPower.material.opacity = 0.35 + 0.45 * cuePowerStrength;
           cueAfterPower.visible = updatePowerLinePoints(
             cueAfterPowerGeom,
             end,
             followEnd,
-            powerStrength
+            cuePowerStrength
           );
           const cueBackwards = cueFollowDirSpinAdjusted.dot(dir) < 0;
           cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
-          cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
+          cueAfter.material.opacity = 0.35 + 0.35 * cuePowerStrength;
           cueAfter.computeLineDistances();
           if (impactRingEnabled) {
             impactRing.visible = true;
@@ -25912,7 +25930,7 @@ const powerRef = useRef(hud.power);
           updateChalkVisibility(visibleChalkIndex);
           cueStick.visible = true;
           if (targetDir && targetBall) {
-            const travelScale = BALL_R * (14 + powerStrength * 22);
+            const travelScale = BALL_R * (14 + targetPowerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
             const tDir =
               rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : dir.clone();
@@ -25927,15 +25945,15 @@ const powerRef = useRef(hud.power);
               .add(tDir.clone().multiplyScalar(distanceScale));
             targetGeom.setFromPoints([targetStart, tEnd]);
             target.material.color.setHex(0xffd166);
-            target.material.opacity = 0.65 + 0.3 * powerStrength;
+            target.material.opacity = 0.65 + 0.3 * targetPowerStrength;
             target.visible = true;
-            targetPower.material.color.copy(powerColor);
-            targetPower.material.opacity = 0.4 + 0.5 * powerStrength;
+            targetPower.material.color.copy(resolvePowerLineColor(targetPowerStrength));
+            targetPower.material.opacity = 0.4 + 0.5 * targetPowerStrength;
             targetPower.visible = updatePowerLinePoints(
               targetPowerGeom,
               targetStart,
               tEnd,
-              powerStrength
+              targetPowerStrength
             );
             target.computeLineDistances();
           } else if (railNormal && cueDir) {
@@ -25993,6 +26011,22 @@ const powerRef = useRef(hud.power);
             guideAimDir2D,
             balls
           );
+          const impactDir =
+            targetDir && (targetDir.x || targetDir.y)
+              ? TMP_VEC3_IMPACT.set(targetDir.x, 0, targetDir.y)
+              : null;
+          let cuePowerStrength = powerStrength;
+          let targetPowerStrength = powerStrength;
+          if (impactDir && impactDir.lengthSq() > 1e-8) {
+            impactDir.normalize();
+            const alignment = Math.abs(baseDir.dot(impactDir));
+            const targetTransfer = THREE.MathUtils.clamp(alignment, 0, 1);
+            const cueTransfer = Math.sqrt(
+              Math.max(1 - targetTransfer * targetTransfer, 0)
+            );
+            targetPowerStrength = powerStrength * targetTransfer;
+            cuePowerStrength = powerStrength * cueTransfer;
+          }
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
           if (start.distanceTo(end) < 1e-4) {
@@ -26031,23 +26065,23 @@ const powerRef = useRef(hud.power);
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : baseDir.clone();
           const cueFollowDirSpinAdjusted = cueFollowDir.clone();
-          const cueFollowLength = BALL_R * (12 + powerStrength * 18);
+          const cueFollowLength = BALL_R * (12 + cuePowerStrength * 18);
           const followEnd = end
             .clone()
             .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
           cueAfterGeom.setFromPoints([end, followEnd]);
           cueAfter.visible = true;
-          cueAfterPower.material.color.copy(powerColor);
-          cueAfterPower.material.opacity = 0.35 + 0.45 * powerStrength;
+          cueAfterPower.material.color.copy(resolvePowerLineColor(cuePowerStrength));
+          cueAfterPower.material.opacity = 0.35 + 0.45 * cuePowerStrength;
           cueAfterPower.visible = updatePowerLinePoints(
             cueAfterPowerGeom,
             end,
             followEnd,
-            powerStrength
+            cuePowerStrength
           );
           const cueBackwards = cueFollowDirSpinAdjusted.dot(baseDir) < 0;
           cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
-          cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
+          cueAfter.material.opacity = 0.35 + 0.35 * cuePowerStrength;
           cueAfter.computeLineDistances();
           impactRing.visible = false;
           const maxPull = CUE_PULL_BASE;
@@ -26087,7 +26121,7 @@ const powerRef = useRef(hud.power);
           cueStick.visible = true;
           updateChalkVisibility(null);
           if (targetDir && targetBall) {
-            const travelScale = BALL_R * (14 + powerStrength * 22);
+            const travelScale = BALL_R * (14 + targetPowerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
             const tDir =
               rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : baseDir.clone();
@@ -26102,15 +26136,15 @@ const powerRef = useRef(hud.power);
               .add(tDir.clone().multiplyScalar(distanceScale));
             targetGeom.setFromPoints([targetStart, tEnd]);
             target.material.color.setHex(0xffd166);
-            target.material.opacity = 0.65 + 0.3 * powerStrength;
+            target.material.opacity = 0.65 + 0.3 * targetPowerStrength;
             target.visible = true;
-            targetPower.material.color.copy(powerColor);
-            targetPower.material.opacity = 0.4 + 0.5 * powerStrength;
+            targetPower.material.color.copy(resolvePowerLineColor(targetPowerStrength));
+            targetPower.material.opacity = 0.4 + 0.5 * targetPowerStrength;
             targetPower.visible = updatePowerLinePoints(
               targetPowerGeom,
               targetStart,
               tEnd,
-              powerStrength
+              targetPowerStrength
             );
             target.computeLineDistances();
           } else if (railNormal && cueDir) {
@@ -26898,6 +26932,8 @@ const powerRef = useRef(hud.power);
                 break;
               }
               if (b.mesh && table && !isCueBall) {
+                const popupScale =
+                  b.mesh.scale?.clone?.() ?? new THREE.Vector3(1, 1, 1);
                 if (pocketCameraStateRef.current) {
                   pocketPopupPendingRef.current.push({
                     position: new THREE.Vector3(
@@ -26906,6 +26942,7 @@ const powerRef = useRef(hud.power);
                       c.y
                     ),
                     material: b.mesh.material,
+                    scale: popupScale,
                     renderOrder: (b.mesh.renderOrder ?? 0) + 1
                   });
                 } else {
@@ -26915,6 +26952,7 @@ const powerRef = useRef(hud.power);
                     BALL_CENTER_Y + POCKET_POPUP_LIFT,
                     c.y
                   );
+                  popupMesh.scale.copy(popupScale);
                   popupMesh.renderOrder = (b.mesh.renderOrder ?? 0) + 1;
                   popupMesh.castShadow = false;
                   popupMesh.receiveShadow = false;
@@ -27193,6 +27231,9 @@ const powerRef = useRef(hud.power);
               if (!entry?.material || !entry?.position) return;
               const popupMesh = new THREE.Mesh(BALL_GEOMETRY, entry.material);
               popupMesh.position.copy(entry.position);
+              if (entry.scale) {
+                popupMesh.scale.copy(entry.scale);
+              }
               popupMesh.renderOrder = entry.renderOrder ?? 0;
               popupMesh.castShadow = false;
               popupMesh.receiveShadow = false;


### PR DESCRIPTION
### Motivation
- Improve aiming feedback so the cue-ball direction line shows true cue/target directions and gives clearer sense of power transfer. 
- Make potted-ball popups and chrome holder placement visually match reference photos (no overlap with leather straps and correct on-table sizing). 
- Raise pocket camera framing slightly for better visibility of popped balls and pocket action.

### Description
- Increased aiming guide stroke width by 3x by multiplying `AIM_LINE_WIDTH` and applied it to tick/line materials so the cue/target direction lines are noticeably thicker.  
- Added `TMP_VEC3_IMPACT` and logic to split `powerStrength` into `cuePowerStrength` and `targetPowerStrength` using impact alignment so cue-follow and target preview lengths/colors scale based on how much energy transfers to the object ball.  
- Adjusted pocket visuals: increased `POCKET_HOLDER_REST_PULLBACK` slightly and raised `POCKET_CAM.heightOffset` to lift pocket cameras a bit higher.  
- Made pocket popup meshes preserve the original ball mesh scale so popped balls match table ball sizes and added support to carry the popup scale through the pending popup pipeline.  

### Testing
- No automated tests were run for this change.  
- Changes were implemented and committed to `webapp/src/pages/Games/PoolRoyale.jsx` and contain only rendering/visual adjustments; manual play-testing is recommended to validate line thickness, power previews, popup sizing, and pocket camera framing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d62ed754832980a1798c528b6be7)