### PR TITLE
Adjust Pool Royale cue preview, pocket cameras, and BCA in-hand rules

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -10,7 +10,8 @@ export class AmericanBilliards {
       winner: null,
       assignments: { A: null, B: null },
       isOpenTable: true,
-      breakInProgress: true
+      breakInProgress: true,
+      breakBallInHand: false
     };
   }
 
@@ -154,6 +155,7 @@ export class AmericanBilliards {
     s.scores = computeScores(s.ballsOnTable, s.assignments);
 
     s.ballInHand = ballInHandNext;
+    s.breakBallInHand = Boolean(s.breakInProgress && foul);
     s.breakInProgress = false;
     s.frameOver = frameOver;
     s.winner = winner;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -40,6 +40,7 @@ type AmericanSerializedState = {
   assignments: { A: 'SOLIDS' | 'STRIPES' | null; B: 'SOLIDS' | 'STRIPES' | null };
   isOpenTable: boolean;
   breakInProgress: boolean;
+  breakBallInHand: boolean;
 };
 
 type NineSerializedState = {
@@ -136,7 +137,8 @@ function serializeAmericanState(state: AmericanBilliards['state']): AmericanSeri
     winner: state.winner,
     assignments: { ...state.assignments },
     isOpenTable: state.isOpenTable,
-    breakInProgress: state.breakInProgress
+    breakInProgress: state.breakInProgress,
+    breakBallInHand: state.breakBallInHand ?? false
   };
 }
 
@@ -150,7 +152,8 @@ function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerialize
     winner: snapshot.winner,
     assignments: { ...snapshot.assignments },
     isOpenTable: snapshot.isOpenTable,
-    breakInProgress: snapshot.breakInProgress
+    breakInProgress: snapshot.breakInProgress,
+    breakBallInHand: snapshot.breakBallInHand ?? false
   };
 }
 


### PR DESCRIPTION
### Motivation
- Fix aiming-preview accuracy so the cue-ball "direction"/follow line reflects applied spin (especially backspin/stun) and reacts to power. 
- Restore correct BCA-style ball-in-hand/break logic for American 8‑ball so the client can enforce proper in-hand restrictions. 
- Make pocket camera switching feel more immediate and stable: switch earlier for clearly-aligned pots, hold until the potted ball settles on the chrome holders, then return to a steady standing camera rather than an animated action view.

### Description
- Added `breakBallInHand` to the American rules state and carried it through serialization/deserialization in `lib/americanBilliards.js` and `src/rules/PoolRoyaleRules.ts` so break-in-hand status is preserved and exposed to the client API. (`breakBallInHand` default false, set on fouls during a break.)
- Adjusted in-hand placement check to consider the new `breakBallInHand` flag when deciding whether full-table in-hand placement is allowed (client-side check in `PoolRoyale.jsx`).
- Refined cue preview/follow computations (local + remote aim) in `webapp/src/pages/Games/PoolRoyale.jsx` to reflect spin and power more faithfully by:
  - Using `resolveTargetSpinDeflection` with planar inputs and applying a backspin blend toward the draw vector when backspin is present. 
  - Computing a `stunWeight` and scaling preview length by power, spin magnitude, and backspin/topspin contributions so the preview shortens for stun/backspin and lengthens with topspin/power. 
  - Applying the same adjustments for remote-aim previews to keep multiplayer visuals consistent.
- Tuning pocket camera behavior in `PoolRoyale.jsx`:
  - Introduced `POCKET_VIEW_EARLY_ALIGNMENT` and changed the pocket-view gating so clearly-aligned pots can trigger pocket cameras earlier (uses alignment score or prediction). 
  - Relaxed distance gating for early guaranteed/forced pocket views when alignment passes the early threshold. 
  - Extended the pocket hold timing (`POCKET_VIEW_POST_POT_HOLD_MS`) and keep pocket view alive until the potted ball's `pocketDrop` entry has settled on the chrome holders. 
  - On resume after a pocket view, force a return to a steady standing camera immediately (`restoreOrbitCamera(..., true)`) instead of re-activating a suspended action view.
- Small housekeeping: bumped pocket post-pot hold from `40ms` to `160ms` and added logic to extend pocket hold while `pocketDrop` entries are still rolling/settling.

### Testing
- No automated unit or integration tests were executed in this environment; changes were implemented and staged (`git` commit made) but runtime verification was not performed here.  
- Manual validation in the game client is recommended for: cue-preview fidelity (apply backspin/topspin and vary power), 8‑ball in-hand scenarios around breaks, and pocket-camera timing/return behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ee089de4832985687b2d0d1227a1)