### PR TITLE
Improve cue-ball aim preview, pocket-camera timing, and 8‑ball (BCA) handling

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -108,9 +108,8 @@ export class AmericanBilliards {
 
     if (eightPotted) {
       if (s.breakInProgress) {
-        frameOver = true;
-        winner = foul ? opp : current;
-        s.ballsOnTable.delete(8);
+        frameOver = false;
+        winner = null;
       } else if (foul || s.isOpenTable) {
         frameOver = true;
         winner = opp;
@@ -128,9 +127,12 @@ export class AmericanBilliards {
           winner = opp;
         }
       }
+      if (frameOver) {
+        s.ballsOnTable.delete(8);
+      }
     }
 
-    if (!foul && s.isOpenTable) {
+    if (!foul && s.isOpenTable && !s.breakInProgress) {
       const firstAssigned = pottedList.find((id) => id !== 0 && id !== 8);
       const assignedGroup = groupForBall(firstAssigned);
       if (assignedGroup === 'SOLIDS' || assignedGroup === 'STRIPES') {


### PR DESCRIPTION
### Motivation
- Make the on-screen aiming guide show the true cue-ball post-impact direction when spin (especially backspin/draw) and power are applied.
- Restore correct American/8‑ball break and balls‑in‑hand behavior to match BCA-style expectations.
- Switch to pocket (capture) cameras earlier for direct pots and return to a steady standing camera to keep cue-ball motion visible after potting.

### Description
- Add `resolveCueFollowPreview` to compute a spin-aware cue follow direction and length (accounts for side/top/back spin, stun, and shot power) and use it for aim/cue-follow rendering in the main player and remote-aim paths (`PoolRoyale.jsx`).
- Replace several ad-hoc post-impact direction calculations with the new preview helper so the `cueAfter`/follow lines respond to spin and power consistently (local and remote aim code paths updated). The preview factors in `BACKSPIN_DIRECTION_PREVIEW`, `resolveBackspinPreviewLerp`, and power scaling.
- Pocket-camera behavior tuned: add `POCKET_CAM_EARLY_TRIGGER_DIST`, allow earlier pocket camera switching for direct predictions above `POCKET_EARLY_ALIGNMENT`, add `POCKET_VIEW_EARLY_HOLD_MS`, and make `POCKET_VIEW_POST_POT_HOLD_MS` derive from pocket drop timing; queue/activation and `resumeAfterPocket` logic updated to resume into a steady standing orbit so the cue-ball remains visible after a pot (`PoolRoyale.jsx`).
- American 8‑ball rule fix in `lib/americanBilliards.js`: do not immediately end the frame if the 8-ball is potted on the break; defer assignment/group logic until after the break so balls‑in‑hand / group assignment follow BCA-like expectations.

### Testing
- No automated tests were executed in this rollout; changes were implemented and committed but not run through a CI/test harness in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ee089de4832985687b2d0d1227a1)