### PR TITLE
American Billiards: rotation scoring + rematch & replay UI, aim-line follow refined

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -8,8 +8,6 @@ export class AmericanBilliards {
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
       winner: null,
-      assignments: { A: null, B: null },
-      isOpenTable: true,
       breakInProgress: true
     };
   }
@@ -36,41 +34,14 @@ export class AmericanBilliards {
     let reason = '';
 
     const first = contactOrder[0];
+    const lowest = lowestBall(s.ballsOnTable);
     if (!foul && !first) {
       foul = true;
       reason = 'no contact';
     }
-
-    const solidsRemaining = countGroupRemaining(s.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countGroupRemaining(s.ballsOnTable, 'STRIPES');
-    const currentGroup = s.assignments[current];
-    if (!foul) {
-      if (s.isOpenTable) {
-        if (first === 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'SOLIDS') {
-        if (solidsRemaining > 0) {
-          if (!SOLIDS.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'STRIPES') {
-        if (stripesRemaining > 0) {
-          if (!STRIPES.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      }
+    if (!foul && lowest != null && first !== lowest) {
+      foul = true;
+      reason = 'wrong first contact';
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -84,8 +55,7 @@ export class AmericanBilliards {
       reason = 'no cushion';
     }
 
-    const eightPotted = pottedBalls.includes(8);
-    const pottedObjectBalls = pottedBalls.filter((id) => id !== 8);
+    const pottedObjectBalls = pottedBalls.slice();
 
     let nextPlayer = current;
     let ballInHandNext = false;
@@ -106,54 +76,27 @@ export class AmericanBilliards {
 
     for (const id of pottedObjectBalls) s.ballsOnTable.delete(id);
 
-    if (eightPotted) {
-      if (s.breakInProgress) {
-        frameOver = false;
-        winner = null;
-      } else if (foul || s.isOpenTable) {
-        frameOver = true;
-        winner = opp;
-      } else {
-        const groupRemaining =
-          currentGroup === 'SOLIDS'
-            ? countGroupRemaining(s.ballsOnTable, 'SOLIDS')
-            : countGroupRemaining(s.ballsOnTable, 'STRIPES');
-        if (currentGroup && groupRemaining === 0) {
-          frameOver = true;
-          winner = current;
-          s.ballsOnTable.delete(8);
-        } else {
-          frameOver = true;
-          winner = opp;
-        }
-      }
-      if (frameOver) {
-        s.ballsOnTable.delete(8);
-      }
+    if (!foul && pottedObjectBalls.length > 0) {
+      const earned = pottedObjectBalls.reduce((sum, id) => sum + (Number(id) || 0), 0);
+      s.scores[current] = (s.scores[current] ?? 0) + earned;
     }
-
-    if (!foul && s.isOpenTable && !s.breakInProgress) {
-      const firstAssigned = pottedList.find((id) => id !== 0 && id !== 8);
-      const assignedGroup = groupForBall(firstAssigned);
-      if (assignedGroup === 'SOLIDS' || assignedGroup === 'STRIPES') {
-        s.assignments[current] = assignedGroup;
-        s.assignments[opp] = assignedGroup === 'SOLIDS' ? 'STRIPES' : 'SOLIDS';
-        s.isOpenTable = false;
-      }
+    if (s.ballsOnTable.size === 0) {
+      frameOver = true;
+      if (s.scores.A > s.scores.B) winner = 'A';
+      else if (s.scores.B > s.scores.A) winner = 'B';
+      else winner = 'TIE';
     }
 
     if (!frameOver) {
       if (foul) {
         nextPlayer = opp;
-      } else if (pottedObjectBalls.length > 0 || (eightPotted && s.breakInProgress)) {
+      } else if (pottedObjectBalls.length > 0) {
         nextPlayer = current;
       } else {
         nextPlayer = opp;
         s.currentPlayer = opp;
       }
     }
-
-    s.scores = computeScores(s.ballsOnTable, s.assignments);
 
     s.ballInHand = ballInHandNext;
     s.breakInProgress = false;
@@ -175,35 +118,10 @@ export class AmericanBilliards {
 
 export default AmericanBilliards;
 
-const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7]);
-const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15]);
-const TOTAL_GROUP_BALLS = 7;
-
-function groupForBall (id) {
-  if (SOLIDS.has(id)) return 'SOLIDS';
-  if (STRIPES.has(id)) return 'STRIPES';
-  return null;
-}
-
-function countGroupRemaining (balls, group) {
-  let count = 0;
-  if (group === 'SOLIDS') {
-    for (const id of SOLIDS) {
-      if (balls.has(id)) count += 1;
-    }
-  } else if (group === 'STRIPES') {
-    for (const id of STRIPES) {
-      if (balls.has(id)) count += 1;
-    }
+function lowestBall (balls) {
+  let lowest = null;
+  for (const id of balls) {
+    if (lowest == null || id < lowest) lowest = id;
   }
-  return count;
-}
-
-function computeScores (balls, assignments) {
-  const solidsRemaining = countGroupRemaining(balls, 'SOLIDS');
-  const stripesRemaining = countGroupRemaining(balls, 'STRIPES');
-  return {
-    A: assignments.A === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.A === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0,
-    B: assignments.B === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.B === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0
-  };
+  return lowest;
 }

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -37,9 +37,8 @@ type AmericanSerializedState = {
   foulStreak: { A: number; B: number };
   frameOver: boolean;
   winner: 'A' | 'B' | 'TIE' | null;
-  assignments: { A: 'SOLIDS' | 'STRIPES' | null; B: 'SOLIDS' | 'STRIPES' | null };
-  isOpenTable: boolean;
   breakInProgress: boolean;
+  scores: { A: number; B: number };
 };
 
 type NineSerializedState = {
@@ -134,9 +133,8 @@ function serializeAmericanState(state: AmericanBilliards['state']): AmericanSeri
     foulStreak: { ...state.foulStreak },
     frameOver: state.frameOver,
     winner: state.winner,
-    assignments: { ...state.assignments },
-    isOpenTable: state.isOpenTable,
-    breakInProgress: state.breakInProgress
+    breakInProgress: state.breakInProgress,
+    scores: { ...state.scores }
   };
 }
 
@@ -148,9 +146,8 @@ function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerialize
     foulStreak: { ...snapshot.foulStreak },
     frameOver: snapshot.frameOver,
     winner: snapshot.winner,
-    assignments: { ...snapshot.assignments },
-    isOpenTable: snapshot.isOpenTable,
-    breakInProgress: snapshot.breakInProgress
+    breakInProgress: snapshot.breakInProgress,
+    scores: { ...snapshot.scores }
   };
 }
 
@@ -219,15 +216,6 @@ function lowestBall(balls: Iterable<number>): number | null {
     }
   }
   return lowest;
-}
-
-function countAmericanGroup(balls: Iterable<number>, group: 'SOLIDS' | 'STRIPES'): number {
-  let count = 0;
-  for (const value of balls) {
-    if (group === 'SOLIDS' && value >= 1 && value <= 7) count += 1;
-    if (group === 'STRIPES' && value >= 9 && value <= 15) count += 1;
-  }
-  return count;
 }
 
 export class PoolRoyaleRules {
@@ -306,6 +294,7 @@ export class PoolRoyaleRules {
         game.state.ballInHand = true;
         const snapshot = serializeAmericanState(game.state);
         const ballOn = this.computeAmericanBallOn(snapshot);
+        const lowest = lowestBall(snapshot.ballsOnTable);
         const scores = this.computeAmericanScores(snapshot);
         const base: FrameState = {
           balls: [],
@@ -318,8 +307,8 @@ export class PoolRoyaleRules {
           frameOver: false
         };
         const hud: HudInfo = {
-          next: snapshot.isOpenTable ? 'open table' : ballOn.map((entry) => entry.toLowerCase()).join(' / '),
-          phase: snapshot.isOpenTable ? 'open' : 'groups',
+          next: lowest != null ? `ball ${lowest}` : 'frame over',
+          phase: 'run',
           scores
         };
         base.meta = {
@@ -487,19 +476,16 @@ export class PoolRoyaleRules {
       placedFromHand: Boolean(context.placedFromHand),
       noCushionAfterContact: Boolean(context.noCushionAfterContact)
     });
-    const pottedCount = potted.filter((id) => id !== 0 && id !== 8).length;
+    const pottedCount = potted.filter((id) => id !== 0).length;
     const snapshot = serializeAmericanState(game.state);
     const ballOn = this.computeAmericanBallOn(snapshot);
     const scores = this.computeAmericanScores(snapshot);
     const frameOver = snapshot.frameOver;
-    const nextLabel = snapshot.isOpenTable
-      ? 'open table'
-      : ballOn.length === 0
-        ? '8 ball'
-        : ballOn.map((entry) => entry.toLowerCase()).join(' / ');
+    const lowest = lowestBall(snapshot.ballsOnTable);
+    const nextLabel = lowest != null ? `ball ${lowest}` : 'frame over';
     const hud: HudInfo = {
       next: frameOver ? 'frame over' : nextLabel,
-      phase: frameOver ? 'complete' : snapshot.isOpenTable ? 'open' : 'groups',
+      phase: frameOver ? 'complete' : 'run',
       scores
     };
     const breakInProgress =
@@ -537,45 +523,16 @@ export class PoolRoyaleRules {
   }
 
   private computeAmericanScores(state: AmericanSerializedState): { A: number; B: number } {
-    const solidsRemaining = countAmericanGroup(state.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countAmericanGroup(state.ballsOnTable, 'STRIPES');
-    const total = 7;
     return {
-      A:
-        state.assignments.A === 'SOLIDS'
-          ? total - solidsRemaining
-          : state.assignments.A === 'STRIPES'
-            ? total - stripesRemaining
-            : 0,
-      B:
-        state.assignments.B === 'SOLIDS'
-          ? total - solidsRemaining
-          : state.assignments.B === 'STRIPES'
-            ? total - stripesRemaining
-            : 0
+      A: state.scores?.A ?? 0,
+      B: state.scores?.B ?? 0
     };
   }
 
   private computeAmericanBallOn(state: AmericanSerializedState): string[] {
     if (state.frameOver) return [];
-    const solidsRemaining = countAmericanGroup(state.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countAmericanGroup(state.ballsOnTable, 'STRIPES');
-    const current = state.currentPlayer;
-    const assignment = state.assignments[current];
-    if (state.isOpenTable || !assignment) {
-      const available: string[] = [];
-      if (solidsRemaining > 0) available.push('SOLID');
-      if (stripesRemaining > 0) available.push('STRIPE');
-      if (available.length === 0 && state.ballsOnTable.includes(8)) available.push('BLACK');
-      return available;
-    }
-    if (assignment === 'SOLIDS') {
-      if (solidsRemaining > 0) return ['SOLID'];
-    } else if (assignment === 'STRIPES') {
-      if (stripesRemaining > 0) return ['STRIPE'];
-    }
-    if (state.ballsOnTable.includes(8)) return ['BLACK'];
-    return [];
+    const lowest = lowestBall(state.ballsOnTable);
+    return lowest != null ? [`BALL_${lowest}`] : [];
   }
 
   private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -28,16 +28,28 @@ export default function PoolRoyaleLobby() {
     const requestedType = searchParams.get('type');
     return requestedType === 'tournament' ? 'tournament' : 'regular';
   })();
+  const initialVariant = (() => {
+    const requested = searchParams.get('variant');
+    if (requested === 'american' || requested === '9ball' || requested === 'uk') return requested;
+    return 'uk';
+  })();
+  const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
+  const initialBallSet = searchParams.get('ballSet') === 'american' ? 'american' : 'uk';
+  const initialStake = {
+    token: searchParams.get('token') || 'TPC',
+    amount: Number(searchParams.get('amount')) || 100
+  };
+  const autoMatchRequested = searchParams.get('autoMatch') === '1';
 
-  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
-  const [mode, setMode] = useState('ai');
+  const [stake, setStake] = useState(initialStake);
+  const [mode, setMode] = useState(initialMode);
   const [avatar, setAvatar] = useState('');
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
-  const [variant, setVariant] = useState('uk');
-  const [ukBallSet, setUkBallSet] = useState('uk');
+  const [variant, setVariant] = useState(initialVariant);
+  const [ukBallSet, setUkBallSet] = useState(initialBallSet);
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -57,6 +69,7 @@ export default function PoolRoyaleLobby() {
   const stakeDebitRef = useRef(null);
   const matchTimeoutRef = useRef(null);
   const seatTimeoutRef = useRef(null);
+  const autoMatchHandledRef = useRef(false);
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
@@ -234,6 +247,14 @@ export default function PoolRoyaleLobby() {
 
     navigate(`/games/poolroyale?${params.toString()}`);
   };
+
+  useEffect(() => {
+    if (!autoMatchRequested || autoMatchHandledRef.current) return;
+    if (mode !== 'online' || playType !== 'regular') return;
+    if (matching || isSearching) return;
+    autoMatchHandledRef.current = true;
+    startGame();
+  }, [autoMatchRequested, isSearching, matching, mode, playType, startGame]);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
### Motivation
- Fix American Billiards to use lowest-ball (rotation) first-contact logic and rotation-style scoring so game outcome matches the historical American variant. 
- Show true cue-ball follow/preview direction after impact by accounting for the cue-ball’s default forward roll/topspin in the aiming visuals. 
- Improve end-of-game UX by showing the last-potted-ball replay and providing robust rematch flows (local, AI, and online) with lobby and auto-match fallback. 

### Description
- Reworked game rules and state for American Billiards in `lib/americanBilliards.js` and `src/rules/PoolRoyaleRules.ts` to use lowest-ball-first contact, rotation scoring, and include `scores` in serialization and HUD updates. 
- Updated Pool Royale rules to consume the new American state (HUD labels, next-ball text, winner resolution) and simplified ball-on computation to show the next lowest ball. 
- Added a default forward-roll contribution to the cue-follow preview (`resolveDefaultCueFollowSpin`) and applied it for both player and remote aim previews so the cue-follow line better matches actual post-impact direction. 
- Implemented post-game flow in `webapp/src/pages/Games/PoolRoyale.jsx`: capture last potted ball, show it on the winner overlay, add `Play Again` and `Lobby` actions, add `resetTableForNewGame()` to rerack/reset ball layout, and wire rematch networking handlers (`poolRematchInvite`, `poolRematchResponse`, `poolRematchStart`) with a 15s accept timeout and auto-match fallback. 
- Enhanced lobby to accept query params for variant/ballSet/auto-match and automatically start online matchmaking when `autoMatch=1` is present (`PoolRoyaleLobby.jsx`). 
- Minor UI/UX and state hygiene: added post-game action state, timers/cleanup for rematch invites, and preserved existing 8-ball/9-ball behavior. 

### Testing
- Started the webapp dev server (`npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`) which served the app at `http://localhost:4173/` successfully. 
- Automated a headless browser check with Playwright that loaded `/games/poolroyale?variant=american&mode=ai&type=regular` and captured a screenshot of the rematch/winner UI; the page loaded and a screenshot artifact was produced. 
- No unit test suite was executed as part of this change; manual/run-time smoke checks described above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fee05bbc8329a1959690953add8e)