### PR TITLE
Improve cue follow preview, rematch flow & restore American rotation rules

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -8,8 +8,6 @@ export class AmericanBilliards {
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
       winner: null,
-      assignments: { A: null, B: null },
-      isOpenTable: true,
       breakInProgress: true
     };
   }
@@ -36,41 +34,14 @@ export class AmericanBilliards {
     let reason = '';
 
     const first = contactOrder[0];
+    const lowest = lowestBall(s.ballsOnTable);
     if (!foul && !first) {
       foul = true;
       reason = 'no contact';
     }
-
-    const solidsRemaining = countGroupRemaining(s.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countGroupRemaining(s.ballsOnTable, 'STRIPES');
-    const currentGroup = s.assignments[current];
-    if (!foul) {
-      if (s.isOpenTable) {
-        if (first === 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'SOLIDS') {
-        if (solidsRemaining > 0) {
-          if (!SOLIDS.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'STRIPES') {
-        if (stripesRemaining > 0) {
-          if (!STRIPES.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      }
+    if (!foul && lowest != null && first !== lowest) {
+      foul = true;
+      reason = 'wrong first contact';
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -84,8 +55,8 @@ export class AmericanBilliards {
       reason = 'no cushion';
     }
 
-    const eightPotted = pottedBalls.includes(8);
-    const pottedObjectBalls = pottedBalls.filter((id) => id !== 8);
+    const pottedObjectBalls = pottedBalls.filter((id) => id > 0);
+    const shotPoints = pottedObjectBalls.reduce((sum, id) => sum + id, 0);
 
     let nextPlayer = current;
     let ballInHandNext = false;
@@ -105,47 +76,14 @@ export class AmericanBilliards {
     }
 
     for (const id of pottedObjectBalls) s.ballsOnTable.delete(id);
-
-    if (eightPotted) {
-      if (s.breakInProgress) {
-        frameOver = false;
-        winner = null;
-      } else if (foul || s.isOpenTable) {
-        frameOver = true;
-        winner = opp;
-      } else {
-        const groupRemaining =
-          currentGroup === 'SOLIDS'
-            ? countGroupRemaining(s.ballsOnTable, 'SOLIDS')
-            : countGroupRemaining(s.ballsOnTable, 'STRIPES');
-        if (currentGroup && groupRemaining === 0) {
-          frameOver = true;
-          winner = current;
-          s.ballsOnTable.delete(8);
-        } else {
-          frameOver = true;
-          winner = opp;
-        }
-      }
-      if (frameOver) {
-        s.ballsOnTable.delete(8);
-      }
-    }
-
-    if (!foul && s.isOpenTable && !s.breakInProgress) {
-      const firstAssigned = pottedList.find((id) => id !== 0 && id !== 8);
-      const assignedGroup = groupForBall(firstAssigned);
-      if (assignedGroup === 'SOLIDS' || assignedGroup === 'STRIPES') {
-        s.assignments[current] = assignedGroup;
-        s.assignments[opp] = assignedGroup === 'SOLIDS' ? 'STRIPES' : 'SOLIDS';
-        s.isOpenTable = false;
-      }
+    if (!foul && shotPoints > 0) {
+      s.scores[current] = (s.scores[current] ?? 0) + shotPoints;
     }
 
     if (!frameOver) {
       if (foul) {
         nextPlayer = opp;
-      } else if (pottedObjectBalls.length > 0 || (eightPotted && s.breakInProgress)) {
+      } else if (pottedObjectBalls.length > 0) {
         nextPlayer = current;
       } else {
         nextPlayer = opp;
@@ -153,7 +91,12 @@ export class AmericanBilliards {
       }
     }
 
-    s.scores = computeScores(s.ballsOnTable, s.assignments);
+    if (s.ballsOnTable.size === 0) {
+      frameOver = true;
+      if (s.scores.A > s.scores.B) winner = 'A';
+      else if (s.scores.B > s.scores.A) winner = 'B';
+      else winner = 'TIE';
+    }
 
     s.ballInHand = ballInHandNext;
     s.breakInProgress = false;
@@ -175,35 +118,10 @@ export class AmericanBilliards {
 
 export default AmericanBilliards;
 
-const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7]);
-const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15]);
-const TOTAL_GROUP_BALLS = 7;
-
-function groupForBall (id) {
-  if (SOLIDS.has(id)) return 'SOLIDS';
-  if (STRIPES.has(id)) return 'STRIPES';
-  return null;
-}
-
-function countGroupRemaining (balls, group) {
-  let count = 0;
-  if (group === 'SOLIDS') {
-    for (const id of SOLIDS) {
-      if (balls.has(id)) count += 1;
-    }
-  } else if (group === 'STRIPES') {
-    for (const id of STRIPES) {
-      if (balls.has(id)) count += 1;
-    }
+function lowestBall (balls) {
+  let lowest = null;
+  for (const id of balls) {
+    if (lowest == null || id < lowest) lowest = id;
   }
-  return count;
-}
-
-function computeScores (balls, assignments) {
-  const solidsRemaining = countGroupRemaining(balls, 'SOLIDS');
-  const stripesRemaining = countGroupRemaining(balls, 'STRIPES');
-  return {
-    A: assignments.A === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.A === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0,
-    B: assignments.B === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.B === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0
-  };
+  return lowest;
 }

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -37,8 +37,7 @@ type AmericanSerializedState = {
   foulStreak: { A: number; B: number };
   frameOver: boolean;
   winner: 'A' | 'B' | 'TIE' | null;
-  assignments: { A: 'SOLIDS' | 'STRIPES' | null; B: 'SOLIDS' | 'STRIPES' | null };
-  isOpenTable: boolean;
+  scores: { A: number; B: number };
   breakInProgress: boolean;
 };
 
@@ -134,8 +133,7 @@ function serializeAmericanState(state: AmericanBilliards['state']): AmericanSeri
     foulStreak: { ...state.foulStreak },
     frameOver: state.frameOver,
     winner: state.winner,
-    assignments: { ...state.assignments },
-    isOpenTable: state.isOpenTable,
+    scores: { ...state.scores },
     breakInProgress: state.breakInProgress
   };
 }
@@ -148,8 +146,7 @@ function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerialize
     foulStreak: { ...snapshot.foulStreak },
     frameOver: snapshot.frameOver,
     winner: snapshot.winner,
-    assignments: { ...snapshot.assignments },
-    isOpenTable: snapshot.isOpenTable,
+    scores: { ...snapshot.scores },
     breakInProgress: snapshot.breakInProgress
   };
 }
@@ -219,15 +216,6 @@ function lowestBall(balls: Iterable<number>): number | null {
     }
   }
   return lowest;
-}
-
-function countAmericanGroup(balls: Iterable<number>, group: 'SOLIDS' | 'STRIPES'): number {
-  let count = 0;
-  for (const value of balls) {
-    if (group === 'SOLIDS' && value >= 1 && value <= 7) count += 1;
-    if (group === 'STRIPES' && value >= 9 && value <= 15) count += 1;
-  }
-  return count;
 }
 
 export class PoolRoyaleRules {
@@ -318,8 +306,8 @@ export class PoolRoyaleRules {
           frameOver: false
         };
         const hud: HudInfo = {
-          next: snapshot.isOpenTable ? 'open table' : ballOn.map((entry) => entry.toLowerCase()).join(' / '),
-          phase: snapshot.isOpenTable ? 'open' : 'groups',
+          next: ballOn.length > 0 ? `ball ${ballOn[0].replace('BALL_', '').toLowerCase()}` : 'rack',
+          phase: 'rotation',
           scores
         };
         base.meta = {
@@ -492,14 +480,13 @@ export class PoolRoyaleRules {
     const ballOn = this.computeAmericanBallOn(snapshot);
     const scores = this.computeAmericanScores(snapshot);
     const frameOver = snapshot.frameOver;
-    const nextLabel = snapshot.isOpenTable
-      ? 'open table'
-      : ballOn.length === 0
-        ? '8 ball'
-        : ballOn.map((entry) => entry.toLowerCase()).join(' / ');
+    const nextLabel =
+      ballOn.length === 0
+        ? 'rack'
+        : `ball ${ballOn[0].replace('BALL_', '').toLowerCase()}`;
     const hud: HudInfo = {
       next: frameOver ? 'frame over' : nextLabel,
-      phase: frameOver ? 'complete' : snapshot.isOpenTable ? 'open' : 'groups',
+      phase: frameOver ? 'complete' : 'rotation',
       scores
     };
     const breakInProgress =
@@ -537,45 +524,17 @@ export class PoolRoyaleRules {
   }
 
   private computeAmericanScores(state: AmericanSerializedState): { A: number; B: number } {
-    const solidsRemaining = countAmericanGroup(state.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countAmericanGroup(state.ballsOnTable, 'STRIPES');
-    const total = 7;
     return {
-      A:
-        state.assignments.A === 'SOLIDS'
-          ? total - solidsRemaining
-          : state.assignments.A === 'STRIPES'
-            ? total - stripesRemaining
-            : 0,
-      B:
-        state.assignments.B === 'SOLIDS'
-          ? total - solidsRemaining
-          : state.assignments.B === 'STRIPES'
-            ? total - stripesRemaining
-            : 0
+      A: state.scores?.A ?? 0,
+      B: state.scores?.B ?? 0
     };
   }
 
   private computeAmericanBallOn(state: AmericanSerializedState): string[] {
     if (state.frameOver) return [];
-    const solidsRemaining = countAmericanGroup(state.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countAmericanGroup(state.ballsOnTable, 'STRIPES');
-    const current = state.currentPlayer;
-    const assignment = state.assignments[current];
-    if (state.isOpenTable || !assignment) {
-      const available: string[] = [];
-      if (solidsRemaining > 0) available.push('SOLID');
-      if (stripesRemaining > 0) available.push('STRIPE');
-      if (available.length === 0 && state.ballsOnTable.includes(8)) available.push('BLACK');
-      return available;
-    }
-    if (assignment === 'SOLIDS') {
-      if (solidsRemaining > 0) return ['SOLID'];
-    } else if (assignment === 'STRIPES') {
-      if (stripesRemaining > 0) return ['STRIPE'];
-    }
-    if (state.ballsOnTable.includes(8)) return ['BLACK'];
-    return [];
+    const lowest = lowestBall(state.ballsOnTable);
+    if (lowest == null) return [];
+    return [`BALL_${lowest}`];
   }
 
   private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -28,16 +28,26 @@ export default function PoolRoyaleLobby() {
     const requestedType = searchParams.get('type');
     return requestedType === 'tournament' ? 'tournament' : 'regular';
   })();
+  const initialStakeToken = searchParams.get('token') || 'TPC';
+  const initialStakeAmount = Number(searchParams.get('amount')) || 100;
+  const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
+  const initialVariant = (() => {
+    const requested = searchParams.get('variant');
+    if (requested === 'american' || requested === '9ball') return requested;
+    return 'uk';
+  })();
+  const initialUkBallSet = searchParams.get('ballSet') === 'american' ? 'american' : 'uk';
+  const autoMatch = searchParams.get('autoMatch') === '1';
 
-  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
-  const [mode, setMode] = useState('ai');
+  const [stake, setStake] = useState({ token: initialStakeToken, amount: initialStakeAmount });
+  const [mode, setMode] = useState(initialMode);
   const [avatar, setAvatar] = useState('');
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
   const [aiFlagIndex, setAiFlagIndex] = useState(null);
-  const [variant, setVariant] = useState('uk');
-  const [ukBallSet, setUkBallSet] = useState('uk');
+  const [variant, setVariant] = useState(initialVariant);
+  const [ukBallSet, setUkBallSet] = useState(initialUkBallSet);
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
@@ -57,6 +67,7 @@ export default function PoolRoyaleLobby() {
   const stakeDebitRef = useRef(null);
   const matchTimeoutRef = useRef(null);
   const seatTimeoutRef = useRef(null);
+  const autoMatchStartedRef = useRef(false);
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
@@ -234,6 +245,12 @@ export default function PoolRoyaleLobby() {
 
     navigate(`/games/poolroyale?${params.toString()}`);
   };
+
+  useEffect(() => {
+    if (!autoMatch || autoMatchStartedRef.current) return;
+    autoMatchStartedRef.current = true;
+    startGame();
+  }, [autoMatch, startGame]);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
### Motivation

- Make the aiming visuals show the true post-impact cue-ball direction by accounting for forward roll bias and spin influence.  
- Provide a clear end-of-game UX: show final-pot replay, award the winner, and present quick actions to `Lobby` or `Play again`.  
- Restore the American Billiards variant to rotation-style rules where the lowest-numbered ball must be contacted first and scoring is by total potted-ball numbers.

### Description

- Refined cue-follow preview logic in `webapp/src/pages/Games/PoolRoyale.jsx` by adding `DEFAULT_FORWARD_ROLL_SPIN`, injecting a small natural forward-roll contribution and blending spin/top/backspin into the preview direction via `resolveCueFollowPreview`, so the visual follow line better matches post-impact travel.  
- Kept final-shot replay behavior visible and added match-end UI and flow in `webapp/src/pages/Games/PoolRoyale.jsx` including: winner overlay + coin burst, a match-end action panel with `Lobby` and `Play again` buttons, rematch invite/request/response handling over the existing socket stream (`poolFrame` rematch payload), countdown timers for invites, and logic to rerack the table from an initial snapshot for immediate rematch readiness.  
- Implemented rematch/lobby integration and auto-match params by preserving selected match options in URLs and adding auto-start support from lobby query params in `webapp/src/pages/Games/PoolRoyaleLobby.jsx`.  
- Restored American Billiards rotation rules by changing `lib/americanBilliards.js` to require contact with the lowest-numbered ball, accumulate scoring as the sum of potted ball numbers, and declare the winner by total points when all balls are cleared; and updated `src/rules/PoolRoyaleRules.ts` to serialize/deserialize the new `scores` shape, compute `ballOn` as the lowest ball (rotation), and show appropriate HUD labels.

### Testing

- No automated tests were executed during this rollout; unit/CI runs were not invoked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fee05bbc8329a1959690953add8e)