### PR TITLE
Pool Royale: improve cue follow preview, add rematch flow, restore American-billiards rotation scoring

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -8,8 +8,6 @@ export class AmericanBilliards {
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
       winner: null,
-      assignments: { A: null, B: null },
-      isOpenTable: true,
       breakInProgress: true
     };
   }
@@ -41,36 +39,10 @@ export class AmericanBilliards {
       reason = 'no contact';
     }
 
-    const solidsRemaining = countGroupRemaining(s.ballsOnTable, 'SOLIDS');
-    const stripesRemaining = countGroupRemaining(s.ballsOnTable, 'STRIPES');
-    const currentGroup = s.assignments[current];
-    if (!foul) {
-      if (s.isOpenTable) {
-        if (first === 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'SOLIDS') {
-        if (solidsRemaining > 0) {
-          if (!SOLIDS.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      } else if (currentGroup === 'STRIPES') {
-        if (stripesRemaining > 0) {
-          if (!STRIPES.has(first)) {
-            foul = true;
-            reason = 'wrong first contact';
-          }
-        } else if (first !== 8) {
-          foul = true;
-          reason = 'wrong first contact';
-        }
-      }
+    const lowest = lowestBall(s.ballsOnTable);
+    if (!foul && lowest != null && first !== lowest) {
+      foul = true;
+      reason = 'wrong first contact';
     }
 
     if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
@@ -83,9 +55,6 @@ export class AmericanBilliards {
       foul = true;
       reason = 'no cushion';
     }
-
-    const eightPotted = pottedBalls.includes(8);
-    const pottedObjectBalls = pottedBalls.filter((id) => id !== 8);
 
     let nextPlayer = current;
     let ballInHandNext = false;
@@ -104,48 +73,19 @@ export class AmericanBilliards {
       s.foulStreak[opp] = 0;
     }
 
-    for (const id of pottedObjectBalls) s.ballsOnTable.delete(id);
-
-    if (eightPotted) {
-      if (s.breakInProgress) {
-        frameOver = false;
-        winner = null;
-      } else if (foul || s.isOpenTable) {
-        frameOver = true;
-        winner = opp;
-      } else {
-        const groupRemaining =
-          currentGroup === 'SOLIDS'
-            ? countGroupRemaining(s.ballsOnTable, 'SOLIDS')
-            : countGroupRemaining(s.ballsOnTable, 'STRIPES');
-        if (currentGroup && groupRemaining === 0) {
-          frameOver = true;
-          winner = current;
-          s.ballsOnTable.delete(8);
-        } else {
-          frameOver = true;
-          winner = opp;
+    if (!foul) {
+      for (const id of pottedBalls) {
+        if (s.ballsOnTable.has(id)) {
+          s.ballsOnTable.delete(id);
+          s.scores[current] = (s.scores[current] ?? 0) + id;
         }
-      }
-      if (frameOver) {
-        s.ballsOnTable.delete(8);
-      }
-    }
-
-    if (!foul && s.isOpenTable && !s.breakInProgress) {
-      const firstAssigned = pottedList.find((id) => id !== 0 && id !== 8);
-      const assignedGroup = groupForBall(firstAssigned);
-      if (assignedGroup === 'SOLIDS' || assignedGroup === 'STRIPES') {
-        s.assignments[current] = assignedGroup;
-        s.assignments[opp] = assignedGroup === 'SOLIDS' ? 'STRIPES' : 'SOLIDS';
-        s.isOpenTable = false;
       }
     }
 
     if (!frameOver) {
       if (foul) {
         nextPlayer = opp;
-      } else if (pottedObjectBalls.length > 0 || (eightPotted && s.breakInProgress)) {
+      } else if (pottedBalls.length > 0) {
         nextPlayer = current;
       } else {
         nextPlayer = opp;
@@ -153,7 +93,15 @@ export class AmericanBilliards {
       }
     }
 
-    s.scores = computeScores(s.ballsOnTable, s.assignments);
+    if (s.ballsOnTable.size === 0) {
+      frameOver = true;
+      winner =
+        s.scores.A === s.scores.B
+          ? 'TIE'
+          : s.scores.A > s.scores.B
+            ? 'A'
+            : 'B';
+    }
 
     s.ballInHand = ballInHandNext;
     s.breakInProgress = false;
@@ -175,35 +123,10 @@ export class AmericanBilliards {
 
 export default AmericanBilliards;
 
-const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7]);
-const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15]);
-const TOTAL_GROUP_BALLS = 7;
-
-function groupForBall (id) {
-  if (SOLIDS.has(id)) return 'SOLIDS';
-  if (STRIPES.has(id)) return 'STRIPES';
-  return null;
-}
-
-function countGroupRemaining (balls, group) {
-  let count = 0;
-  if (group === 'SOLIDS') {
-    for (const id of SOLIDS) {
-      if (balls.has(id)) count += 1;
-    }
-  } else if (group === 'STRIPES') {
-    for (const id of STRIPES) {
-      if (balls.has(id)) count += 1;
-    }
+function lowestBall (balls) {
+  let lowest = null;
+  for (const id of balls) {
+    if (lowest == null || id < lowest) lowest = id;
   }
-  return count;
-}
-
-function computeScores (balls, assignments) {
-  const solidsRemaining = countGroupRemaining(balls, 'SOLIDS');
-  const stripesRemaining = countGroupRemaining(balls, 'STRIPES');
-  return {
-    A: assignments.A === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.A === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0,
-    B: assignments.B === 'SOLIDS' ? TOTAL_GROUP_BALLS - solidsRemaining : assignments.B === 'STRIPES' ? TOTAL_GROUP_BALLS - stripesRemaining : 0
-  };
+  return lowest;
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -28,9 +28,11 @@ export default function PoolRoyaleLobby() {
     const requestedType = searchParams.get('type');
     return requestedType === 'tournament' ? 'tournament' : 'regular';
   })();
+  const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
+  const autoStartRequested = searchParams.get('autostart') === '1';
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
-  const [mode, setMode] = useState('ai');
+  const [mode, setMode] = useState(initialMode);
   const [avatar, setAvatar] = useState('');
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
@@ -57,6 +59,7 @@ export default function PoolRoyaleLobby() {
   const stakeDebitRef = useRef(null);
   const matchTimeoutRef = useRef(null);
   const seatTimeoutRef = useRef(null);
+  const autoStartRef = useRef(false);
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
@@ -234,6 +237,11 @@ export default function PoolRoyaleLobby() {
 
     navigate(`/games/poolroyale?${params.toString()}`);
   };
+  useEffect(() => {
+    if (!autoStartRequested || autoStartRef.current || matching) return;
+    autoStartRef.current = true;
+    startGame();
+  }, [autoStartRequested, matching, startGame]);
 
   useEffect(() => {
     let active = true;

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.03;
+export const STUN_TOPSPIN_BIAS = 0.04;
 
 export const SPIN_DIRECTIONS = [
   {


### PR DESCRIPTION
### Motivation
- Improve aiming fidelity by making the cue-follow preview reflect actual post-impact direction including default forward spin and side influence.
- Provide a smooth end-of-match UX to let players claim rewards, see the final pot, and quickly return to lobby or play again with the same matchup/conditions.
- Restore the Classic American Billiards variant behavior so it scores as a 1–15 rotation (lowest ball on, scoring by potted ball numbers) rather than the previous group-based model.

### Description
- Accurate cue-follow preview: normalize spin input and feed it into `resolveTargetSpinDeflection`, then adjust the preview direction with power-aware draw/follow blending and side-spin influence; moved the `STUN_TOPSPIN_BIAS` constant to `0.04` in `poolRoyaleSpinUtils.js` and updated `resolveCueFollowPreview` in `PoolRoyale.jsx` to use `normalizeSpinInput` and improved blending math. (`webapp/src/pages/Games/poolRoyaleSpinUtils.js`, `webapp/src/pages/Games/PoolRoyale.jsx`) 
- End-of-match & rematch flow: added UI + state for winner overlay details (`finalPotLabel`), `Play again` and `Lobby` buttons, rematch invite handling (send/receive via `poolFrame` socket payloads: `rematchInvite`, `rematchResponse`, `rematchStart`), 15s accept window, timers and countdown indicators, table layout reset for rematch using a captured initial layout snapshot, and lobby autostart support when returning from lobby (`autostart=1`). Key additions live in `PoolRoyale.jsx` and `PoolRoyaleLobby.jsx` and wire into existing socket events. (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/PoolRoyaleLobby.jsx`) 
- American Billiards restoration: replaced the previous group-based logic with rotation-style scoring where players accumulate points equal to the potted ball numbers, enforced lowest-ball-first contact (`lowestBall`), updated serialization and HUD fields to include `scores`, and set `ballOn` to the lowest remaining ball; changes in both game logic lib and rules adapter. (`lib/americanBilliards.js`, `src/rules/PoolRoyaleRules.ts`) 
- Misc: capture and reuse initial table layout for quick reset between games, guard rematch invites to only be handled after frame-over, and small safety/cleanup helpers for rematch timers.

### Testing
- Launched the web UI dev server with `npm --prefix webapp run dev` and Vite reported ready (local dev server started successfully). (succeeded)
- Attempted an automated headless rendering check with Playwright to capture a screenshot of `/games/poolroyale?mode=ai&variant=american`, but the screenshot step timed out while the scene was rendering. (failed due to timeout)
- No unit tests were executed as part of this change set; runtime verification steps above are recorded instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fee05bbc8329a1959690953add8e)