### PR TITLE
Pool Royale: reduce shot power, refine spin deadzone, and fix cue-ball pot handling

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const MAX_SPIN_OFFSET = 0.75;
-export const SPIN_STUN_RADIUS = 0.16;
+export const SPIN_STUN_RADIUS = 0.12;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
@@ -9,8 +9,9 @@ export const SPIN_LEVEL0_MAG = 0;
 export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
-export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = 0.04;
+export const STRAIGHT_SPIN_DEADZONE = 0.01;
+export const STUN_TOPSPIN_BIAS = 0.01;
+export const STUN_BACKSPIN_BIAS = 0.02;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -142,7 +143,8 @@ export const normalizeSpinInput = (spin) => {
   let y = clamp(spin?.y ?? 0, -1, 1);
   const distance = Math.hypot(x, y);
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
-    return { x: 0, y: STUN_TOPSPIN_BIAS };
+    const clampedY = clamp(y, -STUN_BACKSPIN_BIAS, STUN_TOPSPIN_BIAS);
+    return { x: 0, y: clampedY };
   }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };


### PR DESCRIPTION
### Motivation
- Make Pool Royale ball travel pace match Snooker Royal while reducing overall strike strength for a softer feel by trimming power; improve near-center spin behavior so small offsets produce realistic stun / slight draw; and ensure proper turn/ball-in-hand handling when the cue ball is potted to avoid incorrect extra turns.

### Description
- Reduced overall shot strength by introducing `SHOT_POWER_TRIM` and applying it to the `SHOT_FORCE_BOOST` calculation in `PoolRoyale.jsx` so Pool Royale strikes are ~15% softer while preserving roll pacing and related speed references.
- Tuned spin deadzone and center biases in `poolRoyaleSpinUtils.js` by lowering `SPIN_STUN_RADIUS` to `0.12`, shrinking `STRAIGHT_SPIN_DEADZONE` to `0.01`, reducing `STUN_TOPSPIN_BIAS` and adding `STUN_BACKSPIN_BIAS`, and updating `normalizeSpinInput` so tiny center offsets can produce a small backspin or topspin instead of always forcing a topspin bias.
- Fixed cue-ball-potted resolution in `PoolRoyale.jsx` by post-processing the rules result: when the cue ball is potted (and the frame isn't over) we now set the appropriate `ballInHand` / `mustPlayFromBaulk` flags in `meta.state` depending on the variant, ensure the active player is switched when required, and mark a foul if one was not already present so turn logic and HUD state reflect the foul/ball-in-hand correctly.
- Hardened end-of-game wrap-up by adding `try/catch` around the match wrap-up flow in `PoolRoyale.jsx` so an error during `handleTournamentResult` or related finalization does not leave the UI without a winner overlay or crash the game.
- Files changed: `webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.

### Testing
- No automated tests were executed for this change set (no unit/integration tests run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69895af3a3d08329a9145609680b6f60)