### PR TITLE
Tune Pool Royale shot power, spin handling, and cue-scratch / end-game safeguards

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -1,7 +1,7 @@
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const MAX_SPIN_OFFSET = 0.75;
-export const SPIN_STUN_RADIUS = 0.16;
+export const SPIN_STUN_RADIUS = 0.12;
 export const SPIN_RING1_RADIUS = 0.33;
 export const SPIN_RING2_RADIUS = 0.66;
 export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = 0.04;
+export const STUN_TOPSPIN_BIAS = 0.012;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -142,7 +142,10 @@ export const normalizeSpinInput = (spin) => {
   let y = clamp(spin?.y ?? 0, -1, 1);
   const distance = Math.hypot(x, y);
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
-    return { x: 0, y: STUN_TOPSPIN_BIAS };
+    if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
+      return { x: 0, y: 0 };
+    }
+    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
   }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };


### PR DESCRIPTION
### Motivation
- Make Pool Royale ball travel and spin behavior feel closer to Snooker Royal while keeping Pool strokes slightly softer and more realistic.
- Improve cue-ball stun/backspin responsiveness when the user places the spin near the cue center.
- Ensure correct turn/foul handling when the cue ball is potted and prevent end-of-match crashes that hide the winner overlay.

### Description
- Adjust shot power scaling by changing `SHOT_POWER_*` constants and `SHOT_FORCE_BOOST` so Pool Royale mirrors Snooker Royal scaling but applies an additional 15% reduction (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Strengthen backspin preview by raising the minimum blend in `resolveBackspinPreviewLerp` to make slight backspin more visible to the player (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Refine spin normalization: lower `SPIN_STUN_RADIUS`, reduce `STUN_TOPSPIN_BIAS`, and change `normalizeSpinInput` so small center offsets produce a true neutral stun or a signed tiny topspin/backspin bias (improves stun/backspin behavior when user leaves the dot at/near center) (`webapp/src/pages/Games/poolRoyaleSpinUtils.js`).
- Fix cue-ball scratch handling by detecting when the cue ball was potted and, if the resolved rules state still assigns the same active player, force the active player to switch and mark the shot as a foul/scratch so the opponent receives the turn and in-hand state is applied (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Harden end-of-game wrap-up by surrounding match-finalization logic with a `try/catch` and providing a safe fallback winner overlay to avoid crashes that hide the winner/Play Again UI (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were executed for this change.  Manual/interactive validation is recommended (play a few rounds, test cue-ball center / slightly-lower spin, potting cue ball for both player and AI, and end-of-game finish) to confirm tuning and the turn/wrap-up fixes behave as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69895af3a3d08329a9145609680b6f60)