### PR TITLE
Improve Pool Royale replay timing, in-hand controls, and AI planning

### DIFF
--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -37,9 +37,9 @@
  * @property {{x:number,y:number}} [aimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 2
-const LOOKAHEAD_CANDIDATES = 3
-const MONTE_CARLO_BASE_SAMPLES = 28
+const LOOKAHEAD_DEPTH = 3
+const LOOKAHEAD_CANDIDATES = 4
+const MONTE_CARLO_BASE_SAMPLES = 48
 
 function createRng (seed) {
   let state = (seed ?? 0) >>> 0
@@ -344,7 +344,7 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
   const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor)))
-  const jitterScale = 0.015 + 0.025 * distanceFactor
+  const jitterScale = 0.012 + 0.02 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -448,7 +448,12 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     const next = nextTargets[0]
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
   }
-  const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
+  const pocketDistances = req.state.pockets.map(p => dist(cueAfter, p))
+  const minPocketDist = pocketDistances.length ? Math.min(...pocketDistances) : Infinity
+  if (minPocketDist < r * 1.05) {
+    return null
+  }
+  const risk = Math.max(0, Math.min(1, 1 - minPocketDist / (r * 3.2)))
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
@@ -463,7 +468,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
   const pocketTightness = 1 - pocketOpen
-  const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
+  const difficultyPenalty = 0.3 * (0.45 * cutSeverity + 0.35 * shotLengthFactor + 0.2 * pocketTightness)
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -478,14 +483,14 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.38 * potChance +
-        0.18 * pocketOpen +
+      0.42 * potChance +
+        0.16 * pocketOpen +
         0.16 * centerAlign +
-        0.06 * nextScore +
-        0.06 * nearHole +
-        0.08 * runoutPotential +
-        0.08 * clearanceScore -
-        0.18 * risk -
+        0.07 * nextScore +
+        0.05 * nearHole +
+        0.1 * runoutPotential +
+        0.09 * clearanceScore -
+        0.22 * risk -
         difficultyPenalty
     )
   )
@@ -587,13 +592,15 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = [0.45, 0.65, 0.8, 0.92]
   const spins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.3, side: 0, back: -0.3 },
-    { top: -0.3, side: 0.3, back: 0 },
-    { top: -0.3, side: -0.3, back: 0 },
-    { top: 0, side: 0.3, back: 0 }
+    { top: 0.2, side: 0, back: -0.2 },
+    { top: -0.2, side: 0.2, back: 0 },
+    { top: -0.2, side: -0.2, back: 0 },
+    { top: 0, side: 0.25, back: 0 },
+    { top: 0.35, side: 0, back: 0 },
+    { top: -0.35, side: 0, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
@@ -618,29 +625,36 @@ export function planShot (req) {
           x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
           y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
         }
-        const dists = [4, 6, 8, 10, 12].map(m => m * r)
+        const dists = [4, 6, 8, 10, 12, 14, 16].map(m => m * r)
+        const perp = { x: -dir.y / distTP, y: dir.x / distTP }
+        const lateralOffsets = [0, r * 0.9, -r * 0.9, r * 1.6, -r * 1.6]
         for (const d of dists) {
-          const cand = { x: ghost.x + (dir.x / distTP) * d, y: ghost.y + (dir.y / distTP) * d }
-          if (
-            cand.x < r ||
-            cand.x > req.state.width - r ||
-            cand.y < r ||
-            cand.y > req.state.height - r
-          ) {
-            continue
+          for (const lateral of lateralOffsets) {
+            const cand = {
+              x: ghost.x + (dir.x / distTP) * d + perp.x * lateral,
+              y: ghost.y + (dir.y / distTP) * d + perp.y * lateral
+            }
+            if (
+              cand.x < r ||
+              cand.x > req.state.width - r ||
+              cand.y < r ||
+              cand.y > req.state.height - r
+            ) {
+              continue
+            }
+            if (
+              req.state.mustPlayFromBaulk &&
+              typeof req.state.baulkLineY === 'number' &&
+              cand.y < req.state.baulkLineY
+            ) {
+              continue
+            }
+            const overlap = req.state.balls.some(
+              b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            )
+            if (overlap) continue
+            placements.push(cand)
           }
-          if (
-            req.state.mustPlayFromBaulk &&
-            typeof req.state.baulkLineY === 'number' &&
-            cand.y < req.state.baulkLineY
-          ) {
-            continue
-          }
-          const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
-          )
-          if (overlap) continue
-          placements.push(cand)
         }
       } else {
         const cue = req.state.balls.find(b => b.id === 0)


### PR DESCRIPTION
### Motivation
- Make replays feel closer to live action (cue stroke timing, earlier pocket camera triggers) and avoid replay camera jumps caused by replay lead-in timing. 
- Improve in-hand cue-ball placement responsiveness so users can press-hold-drag to reposition quickly and naturally on mobile portrait. 
- Strengthen AI shot planning so the bot respects rules better and selects higher-quality shots with deeper lookahead and more robust sampling.

### Description
- Replay and camera: enable table mapping overlay by default (`ENABLE_TABLE_MAPPING_LINES = true`), trim replay recordings by removing cue-stroke lead-in (`trimReplayRecording`), reduce replay cue-stroke slowdown (`REPLAY_CUE_STROKE_SLOWDOWN = 1`), and bias pocket-camera early trigger/alignment when replay capture is active (`REPLAY_POCKET_EARLY_TRIGGER_MULTIPLIER`, `REPLAY_POCKET_EARLY_ALIGNMENT_BOOST`).
- In-hand controls: increase placement responsiveness (`IN_HAND_DRAG_SPEED`), add a small hold-to-drag threshold (`IN_HAND_DRAG_HOLD_THRESHOLD_PX`), and update drag state machine so an initial press can be tapped (no movement) or held-and-dragged to reposition; preserve cue placement when user only taps. 
- Physics constant: expose `BALL_GRAVITY` used for vertical lift / airborne settling (reused for max-power bounce gravity). 
- AI planner updates: in `webapp/public/lib/poolAi.js` increase lookahead depth/candidate counts and Monte‑Carlo sampling (`LOOKAHEAD_DEPTH`, `LOOKAHEAD_CANDIDATES`, `MONTE_CARLO_BASE_SAMPLES`), reduce jitter scale, refine pot/runout scoring weights and risk model, expand power/spin candidate sets and placement sampling for ball‑in‑hand cases, and adjust difficulty/risk penalties to favor safer/higher-quality choices. 
- AI integration: increase the open-source AI time budget when invoked (`timeBudgetMs` increased to allow deeper planning). 
- Minor: removed an untracked gradle wrapper binary from repository worktree during the edit (cleanup during the change set).

### Testing
- Automated tests: none run as part of this change (no unit/integration tests executed).
- Manual / local validation: changes were applied and committed; further playtesting is recommended for replay camera timing, in-hand UX on mobile, and AI behavior tuning across variants (american/9ball/uk).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a22166248329b139c379f5b0f8a1)