### PR TITLE
Detect Telegram WebView and open Domino Royal in full-page (avoid iframe)

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -1,22 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { isTelegramWebView } from '../../utils/telegram.js';
 
 export default function DominoRoyalArena({ search }) {
-  const [src, setSrc] = useState(() => `/domino-royal.html${search || ''}`);
+  const isTelegram = useMemo(() => isTelegramWebView(), []);
+  const [src, setSrc] = useState(() => (isTelegram ? '' : `/domino-royal.html${search || ''}`));
 
   useEffect(() => {
-    setSrc(`/domino-royal.html${search || ''}`);
-  }, [search]);
+    const target = `/domino-royal.html${search || ''}`;
+    if (isTelegram) {
+      window.location.replace(target);
+      return;
+    }
+    setSrc(target);
+  }, [isTelegram, search]);
 
   return (
     <div className="relative w-full h-full bg-black">
-      <iframe
-        key={src}
-        src={src}
-        title="Domino Royal 3D"
-        className="absolute inset-0 h-full w-full border-0"
-        allow="fullscreen; autoplay; clipboard-read; clipboard-write; accelerometer; gyroscope"
-        allowFullScreen
-      />
+      {isTelegram ? (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center text-white">
+          <p className="text-lg font-semibold">Launching Domino Royal…</p>
+          <p className="text-sm text-white/70">
+            The domino arena opens in a full-page view for better stability in Telegram.
+          </p>
+        </div>
+      ) : (
+        <iframe
+          key={src}
+          src={src}
+          title="Domino Royal 3D"
+          className="absolute inset-0 h-full w-full border-0"
+          allow="fullscreen; autoplay; clipboard-read; clipboard-write; accelerometer; gyroscope"
+          allowFullScreen
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The Domino Royal arena was embedded via an `iframe`, which can cause instability or crashes inside the Telegram in-app WebView, so the game should open in a full-page view when running inside Telegram for better stability and parity with other games.

### Description
- Import and use `isTelegramWebView()` and `useMemo` to detect the Telegram WebView environment in `DominoRoyalArena.jsx`.
- When in Telegram, redirect to the standalone HTML entry by calling `window.location.replace('/domino-royal.html...')` instead of loading the `iframe`.
- Render a brief launch message while the redirect occurs, and keep the `iframe` for non-Telegram environments by conditionally rendering it.

### Testing
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the site served successfully (Vite reported ready). — succeeded.
- Ran a Playwright script that opened `http://localhost:4173/games/domino-royal` with a Telegram-like user agent and captured a screenshot `artifacts/domino-royal.png` to verify the Telegram redirect/launch flow. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c9050de48329b8808c38f4523357)