### PR TITLE
Improve Pool Royale table geometry, 8‑ball AI heuristics, and replay camera capture

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -65,8 +65,9 @@ public class BilliardsSolver
         double height = PhysicsConstants.TableHeight;
         double cornerMouth = PhysicsConstants.CornerPocketMouth;
         double sideMouth = PhysicsConstants.SidePocketMouth;
-        double cornerCut = cornerMouth / Math.Sqrt(2.0);
-        double sideCut = sideMouth / 2.0;
+        double cutScale = Math.Max(PhysicsConstants.PocketAngleCutScale, 0.01);
+        double cornerCut = cornerMouth / Math.Sqrt(2.0) * cutScale;
+        double sideCut = sideMouth / 2.0 * cutScale;
         double cornerJawRadius = cornerCut * PhysicsConstants.CornerJawRadiusScale;
         double cornerJawInset = PhysicsConstants.CornerJawInset;
         double cornerJawCenter = cornerCut + cornerJawInset;

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -45,6 +45,7 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1014984; // scaled with table reduction
     public const double SidePocketMouth = 0.1116013;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
+    public const double PocketAngleCutScale = 1.035;    // extend angle cut slightly for truer mouth mapping
     public const double CornerJawRadiusScale = 0.94;
     public const double CornerJawInset = 0.006;
     public const double SideJawInset = 0.006;
@@ -55,7 +56,7 @@ public static class PhysicsConstants
     public const double PocketMouthGuardInset = BallRadius * 0.35;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
-    public const int CornerJawSegments = 32;
-    public const int SideJawSegments = 24;
-    public const int JawCushionSegments = 2;           // how many segments nearest the rails behave as cushions
+    public const int CornerJawSegments = 40;
+    public const int SideJawSegments = 30;
+    public const int JawCushionSegments = 3;           // how many segments nearest the rails behave as cushions
 }

--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -56,7 +56,7 @@
  * Each entry: { success:number, attempts:number }
  */
 const shotMemory = new Map()
-const MIN_POT_PROBABILITY = 0.32
+const MIN_POT_PROBABILITY = 0.36
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 12 // ~15 degrees
 
 function normaliseColourKey (input) {
@@ -67,6 +67,17 @@ function normaliseColourKey (input) {
   if (lower.startsWith('blue') || lower.startsWith('yellow')) return 'blue'
   if (lower.startsWith('black')) return 'black'
   return lower || 'any'
+}
+
+function normaliseBallOn (input) {
+  if (!input || typeof input !== 'string') return null
+  const lower = input.toLowerCase()
+  if (lower.startsWith('yellow') || lower.startsWith('blue')) return 'blue'
+  if (lower.startsWith('red')) return 'red'
+  if (lower.startsWith('solid')) return 'red'
+  if (lower.startsWith('stripe')) return 'blue'
+  if (lower.startsWith('black')) return 'black'
+  return null
 }
 
 export function recordShotOutcome (plan, success) {
@@ -282,8 +293,9 @@ function generatePotCandidates (state, colour) {
       state.ballRadius,
       1.4
     )
-    if (laneClearance < 0.65) continue
+    if (laneClearance < 0.7) continue
     const angle = bestAngle
+    if (Number.isFinite(angle) && angle > Math.PI * 0.55) continue
     const distCT = dist(cue, ball)
     const distTP = bestDist
     for (const params of CUE_VARIATIONS) {
@@ -552,7 +564,7 @@ function estimatePotProbability (shot, state) {
   const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.65) / 0.7))
 
   // sharper lines receive a steeper falloff to mimic pro precision
-  const eliteStraightWindow = 0.65
+  const eliteStraightWindow = 0.55
   let angleScore = Math.max(0, 1 - Math.pow(Math.max(0, cutRatio - eliteStraightWindow), 1.35))
 
   // banks are harder; drop probability but still evaluate
@@ -562,7 +574,7 @@ function estimatePotProbability (shot, state) {
 
   // combine distance, angle, and lane cleanliness with stronger emphasis on accuracy
   const entranceBonus = Math.max(0, Math.min(1, pocketViewDeg / 55))
-  let P = angleScore * 0.5 + distScore * 0.18 + clearanceScore * 0.24 + entranceBonus * 0.08
+  let P = angleScore * 0.52 + distScore * 0.16 + clearanceScore * 0.24 + entranceBonus * 0.08
 
   if (shot.isKick) {
     P *= 0.9
@@ -602,7 +614,18 @@ function estimatePotProbability (shot, state) {
   const cueAfter = simulateCueRollout(state, shot)
   const center = { x: state.width / 2, y: state.height / 2 }
   const centerScore = 1 - Math.min(dist(cueAfter, center) / maxD, 1)
-  P = P * 0.8 + centerScore * 0.2
+  const railProximity = Math.min(
+    cueAfter.x,
+    state.width - cueAfter.x,
+    cueAfter.y,
+    state.height - cueAfter.y
+  )
+  if (railProximity < state.ballRadius * 3) {
+    P -= 0.08 * (1 - railProximity / (state.ballRadius * 3))
+  }
+  const longShotPenalty = Math.min((shot.distCT + shot.distTP) / (maxD * 0.85), 1) * 0.12
+  P -= longShotPenalty
+  P = P * 0.78 + centerScore * 0.22
   return Math.max(0, Math.min(1, P))
 }
 
@@ -764,9 +787,9 @@ function evaluateCandidates (state, colour, candidates) {
       }
       const baseValue = 1.05
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
-      const positionWeight = 1.25
+      const positionWeight = 1.4
       const shapeWindow = nextShapeWindow(nextState, colour)
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.65) - riskPenalty(risk)
+      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
       best = { c, EV }
@@ -861,7 +884,7 @@ function chooseBestAction (state, colour) {
 
 // Public entry
 export function selectShot (state, rules = {}) {
-  let colour = state.ballOn
+  let colour = normaliseBallOn(state.ballOn) ?? state.ballOn
   if (!state.isOpenTable && colour) {
     const hasOwn = state.balls.some(b => b.colour === colour && !b.pocketed)
     if (!hasOwn) colour = 'black'

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -159,6 +159,7 @@ function currentGroup (state) {
   // Map the textual colour assignment to the corresponding group.
   if (norm === 'RED') return 'SOLIDS'
   if (norm === 'BLUE') return 'STRIPES'
+  if (norm === 'YELLOW') return 'SOLIDS'
   if (norm === 'SOLIDS' || norm === 'STRIPES') return norm
   return undefined
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19154,18 +19154,18 @@ const powerRef = useRef(hud.power);
           let resolvedTarget = null;
           let resolvedFov = fovSnapshot;
           let resolvedMinTargetY = null;
-          resolvedPosition =
-            overheadReplayCamera?.position?.clone?.() ??
-            activeCamera?.position?.clone?.() ??
-            null;
-          resolvedTarget =
-            overheadReplayCamera?.target?.clone?.() ??
-            targetSnapshot;
+          if (!pocketActive && !overheadReplayCamera) {
+            return null;
+          }
+          resolvedPosition = pocketActive
+            ? activeCamera?.position?.clone?.() ?? null
+            : overheadReplayCamera?.position?.clone?.() ?? null;
+          resolvedTarget = pocketActive
+            ? targetSnapshot
+            : overheadReplayCamera?.target?.clone?.() ?? targetSnapshot;
           resolvedFov = Number.isFinite(overheadReplayCamera?.fov)
             ? overheadReplayCamera.fov
-            : Number.isFinite(activeCamera?.fov)
-              ? activeCamera.fov
-              : fovSnapshot;
+            : fovSnapshot;
           resolvedMinTargetY = minTargetY;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {


### PR DESCRIPTION
### Motivation
- Make pocket/cushion geometry more faithful to the physical table so angle/cut math and pocket mouths match reality more closely. 
- Improve AI shot selection for 8‑ball (UK rules) so the bot understands yellow/blue naming, aims more accurately, and values consistent position play. 
- Prevent undesired standing/broadcast camera frames from being captured during the replay recording path so replays show the intended pocket/overhead camera views only.

### Description
- Table geometry: added `PocketAngleCutScale` and applied a `cutScale` when computing `cornerCut`/`sideCut`, increased jaw tessellation (`CornerJawSegments`, `SideJawSegments`) and `JawCushionSegments` to produce tighter, smoother pocket/jaw proxies (`billiards/PhysicsConstants.cs`, `billiards/BilliardsSolver.cs`).
- AI detection/fallbacks: map yellow→solids in the lightweight planner to handle UK naming variants (`webapp/public/lib/poolAi.js`).
- UK advanced AI tuning: raised `MIN_POT_PROBABILITY`, added `normaliseBallOn` to normalize ball‑on strings, tightened lane clearance and extreme‑cut filtering, adjusted elite straightness window and probability weighting, applied rail‑proximity and long‑shot penalties, and increased positional weighting for runout evaluation; also use normalized ball‑on when selecting the colour to play (`lib/poolUkAdvancedAi.js`).
- Replay camera: change `captureReplayCameraSnapshot` to avoid returning a standing/broadcast snapshot when no pocket camera or overhead replay camera is available, and prefer pocket/active camera snapshots when `pocketActive` is true to remove the infrequently used player standing camera frame from replays (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c82d663c8329a58f17f759604c08)