### PR TITLE
Guard local storage access in wallet and sound modules

### DIFF
--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -19,11 +19,12 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { loadGoogleProfile } from '../utils/google.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 import { mergeStoreTransactions } from '../utils/storeTransactions.js';
+import { safeGetItem, safeSetItem } from '../utils/storage.js';
 
 const urlParams = new URLSearchParams(window.location.search);
 const DEV_ACCOUNT_ID =
   urlParams.get('dev') ||
-  localStorage.getItem('devAccountId') ||
+  safeGetItem('devAccountId') ||
   import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_ID_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_ID_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
@@ -33,7 +34,7 @@ const DEV_ACCOUNTS = [
   DEV_ACCOUNT_ID_2,
 ].filter(Boolean);
 if (urlParams.get('dev')) {
-  localStorage.setItem('devAccountId', urlParams.get('dev'));
+  safeSetItem('devAccountId', urlParams.get('dev'));
 }
 
 function formatValue(value, decimals = 2) {
@@ -60,7 +61,7 @@ export default function Wallet({ hideClaim = false }) {
     telegramId = undefined;
   }
   const connectedTonAddress = useTonAddress();
-  const [tonWalletAddress, setTonWalletAddress] = useState(() => localStorage.getItem('walletAddress') || '');
+  const [tonWalletAddress, setTonWalletAddress] = useState(() => safeGetItem('walletAddress') || '');
   const [googleProfile, setGoogleProfile] = useState(() => (telegramId ? null : loadGoogleProfile()));
   const requiresAuth = !telegramId && !googleProfile?.id && !tonWalletAddress;
 
@@ -87,7 +88,7 @@ export default function Wallet({ hideClaim = false }) {
 
   useEffect(() => {
     if (connectedTonAddress) {
-      localStorage.setItem('walletAddress', connectedTonAddress);
+      safeSetItem('walletAddress', connectedTonAddress);
       setTonWalletAddress(connectedTonAddress);
     }
   }, [connectedTonAddress]);
@@ -114,8 +115,8 @@ export default function Wallet({ hideClaim = false }) {
 
 
   const loadBalances = async () => {
-    const devMode = urlParams.get('dev') || localStorage.getItem('devAccountId');
-    let id = devMode ? DEV_ACCOUNT_ID : localStorage.getItem('accountId');
+    const devMode = urlParams.get('dev') || safeGetItem('devAccountId');
+    let id = devMode ? DEV_ACCOUNT_ID : safeGetItem('accountId');
     let acc;
     if (id) {
       acc = { accountId: id };
@@ -125,9 +126,9 @@ export default function Wallet({ hideClaim = false }) {
         console.error('Failed to load account:', acc.error);
         return null;
       }
-      localStorage.setItem('accountId', acc.accountId);
+      safeSetItem('accountId', acc.accountId);
       if (acc.walletAddress) {
-        localStorage.setItem('walletAddress', acc.walletAddress);
+        safeSetItem('walletAddress', acc.walletAddress);
         setTonWalletAddress(acc.walletAddress);
       }
       id = acc.accountId;

--- a/webapp/src/utils/sound.js
+++ b/webapp/src/utils/sound.js
@@ -1,5 +1,7 @@
-let gameMuted = localStorage.getItem('gameMuted') === 'true';
-let gameVolume = parseFloat(localStorage.getItem('gameVolume') || '1');
+import { safeGetItem, safeSetItem } from './storage.js';
+
+let gameMuted = safeGetItem('gameMuted') === 'true';
+let gameVolume = parseFloat(safeGetItem('gameVolume') || '1');
 
 export function isGameMuted() {
   return gameMuted;
@@ -11,17 +13,13 @@ export function getGameVolume() {
 
 export function setGameMuted(val) {
   gameMuted = val;
-  try {
-    localStorage.setItem('gameMuted', val ? 'true' : 'false');
-  } catch (err) {}
+  safeSetItem('gameMuted', val ? 'true' : 'false');
   window.dispatchEvent(new Event('gameMuteChanged'));
 }
 
 export function setGameVolume(val) {
   gameVolume = val;
-  try {
-    localStorage.setItem('gameVolume', String(val));
-  } catch (err) {}
+  safeSetItem('gameVolume', String(val));
   window.dispatchEvent(new Event('gameVolumeChanged'));
 }
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors in environments where `localStorage` is unavailable or throws (e.g. restricted browsers / in-app webviews) by using the repository's safe storage helpers for persisted preferences and wallet state.

### Description
- Replaced direct `localStorage` reads/writes with `safeGetItem` / `safeSetItem` from `webapp/src/utils/storage.js` in `webapp/src/utils/sound.js` to protect sound preference access (`gameMuted`, `gameVolume`).
- Replaced `localStorage` usage in `webapp/src/pages/Wallet.jsx` for `devAccountId`, `walletAddress` and `accountId` with `safeGetItem` / `safeSetItem` and updated initial state and side-effects accordingly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c87f63f0832981a9444685829dac)