### PR TITLE
Move Domino Royal into React runtime (load module in-app and add cleanup)

### DIFF
--- a/webapp/public/pwa/offline-assets.json
+++ b/webapp/public/pwa/offline-assets.json
@@ -234,7 +234,7 @@
   "/assets/sounds/wooden-door-knock-102902.mp3",
   "/assets/sounds/yabba-dabba-doo.mp3",
   "/chess-royale.html",
-  "/domino-royal.html",
+  "/domino-royal.js",
   "/flag-emojis.js",
   "/free-kick-api.js",
   "/game-preloads/pool-royale-preload.txt",

--- a/webapp/public/service-worker.js
+++ b/webapp/public/service-worker.js
@@ -55,7 +55,7 @@ const PREFETCH_RUNTIME_ASSETS = [
   '/texas-holdem.js',
   '/lib/texasHoldem.js',
   '/lib/texasHoldemGame.js',
-  '/domino-royal.html',
+  '/domino-royal.js',
   '/murlan-royale.html',
   '/roulette.html',
   '/chess-royale.html',

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -1,22 +1,201 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+
+import './domino-royal.css';
+
+const FONT_LINKS = [
+  {
+    id: 'domino-royal-font-preconnect',
+    rel: 'preconnect',
+    href: 'https://fonts.googleapis.com'
+  },
+  {
+    id: 'domino-royal-font-preconnect-gstatic',
+    rel: 'preconnect',
+    href: 'https://fonts.gstatic.com',
+    crossOrigin: 'anonymous'
+  },
+  {
+    id: 'domino-royal-font',
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap'
+  }
+];
 
 export default function DominoRoyalArena({ search }) {
-  const [src, setSrc] = useState(() => `/domino-royal.html${search || ''}`);
-
   useEffect(() => {
-    setSrc(`/domino-royal.html${search || ''}`);
+    const head = document.head;
+    FONT_LINKS.forEach(({ id, ...attrs }) => {
+      if (document.getElementById(id)) return;
+      const link = document.createElement('link');
+      link.id = id;
+      Object.entries(attrs).forEach(([key, value]) => {
+        if (value) link.setAttribute(key, value);
+      });
+      head.appendChild(link);
+    });
+
+    if (window.__dominoRoyalCleanup) {
+      window.__dominoRoyalCleanup();
+    }
+
+    const existingScript = document.querySelector('script[data-domino-royal]');
+    if (existingScript) {
+      existingScript.remove();
+    }
+
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = '/domino-royal.js';
+    script.dataset.dominoRoyal = 'true';
+    document.body.appendChild(script);
+
+    return () => {
+      if (window.__dominoRoyalCleanup) {
+        window.__dominoRoyalCleanup();
+      }
+      script.remove();
+    };
   }, [search]);
 
   return (
     <div className="relative w-full h-full bg-black">
-      <iframe
-        key={src}
-        src={src}
-        title="Domino Royal 3D"
-        className="absolute inset-0 h-full w-full border-0"
-        allow="fullscreen; autoplay; clipboard-read; clipboard-write; accelerometer; gyroscope"
-        allowFullScreen
-      />
+      <div id="app" />
+      <div id="status" role="status">
+        Ready
+      </div>
+      <button id="configButton" type="button" aria-label="Table setup">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
+          />
+        </svg>
+      </button>
+      <div
+        id="configPanel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="configTitle"
+        tabIndex={-1}
+        aria-hidden="true"
+      >
+        <div className="config-close">
+          <button id="configClose" type="button" aria-label="Close table setup">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+            </svg>
+          </button>
+        </div>
+        <h3 id="configTitle">Table Setup</h3>
+        <div id="configSections" />
+      </div>
+      <div id="topRightActions" aria-label="Top actions">
+        <button id="btnRules" className="top-action" type="button" aria-label="Rules" title="Rules">
+          <span aria-hidden="true">ℹ️</span>
+        </button>
+        <button id="muteButton" className="top-action" type="button" aria-label="Mute" title="Mute">
+          <span className="icon" id="muteIcon" aria-hidden="true">
+            🔊
+          </span>
+          <span id="muteLabel" className="visually-hidden">
+            Mute
+          </span>
+        </button>
+      </div>
+      <div id="railControls" aria-label="Game controls">
+        <button id="draw" type="button">
+          Draw
+        </button>
+        <button id="pass" type="button">
+          Pass
+        </button>
+      </div>
+      <button id="viewToggle" type="button" aria-label="Switch view" title="Switch view" />
+      <div id="quickActions" aria-label="Quick actions">
+        <button className="quick-action" type="button" data-action="chat">
+          <span className="icon" aria-hidden="true">
+            💬
+          </span>
+          <span>Chat</span>
+        </button>
+        <button className="quick-action" type="button" data-action="gift">
+          <span className="icon" aria-hidden="true">
+            🎁
+          </span>
+          <span>Gift</span>
+        </button>
+      </div>
+      <div id="rules">
+        <div className="card">
+          <h2>Domino Royal — Rules for 2–4 players</h2>
+          <ol>
+            <li>
+              <b>Set:</b> Double-Six (28 tiles, 0–6). Each tile is unique (a,b) with a≤b. No duplicates.
+            </li>
+            <li>
+              <b>Dealing:</b> 7 tiles per player. The rest form the <i>stock</i> (boneyard).
+            </li>
+            <li>
+              <b>Opening:</b> The player with the highest double starts. If no double, the highest tile opens.
+            </li>
+            <li>
+              <b>On the table:</b> Every tile lies flat on the green cloth, touching end-to-end without overlapping. Keep
+              the chain flush as you pivot at the rails so the spacing stays even.
+            </li>
+            <li>
+              <b>Matching:</b> The touching halves must show the same pip value. Doubles stand upright in place; all other
+              tiles extend the snake in a straight line.
+            </li>
+            <li>
+              <b>No move?</b> Draw from the face-down stock stack near you (tap the Draw button below it) until you can
+              play. If the stock is empty, pass.
+            </li>
+            <li>
+              <b>Ending:</b> The winner is the first out. If play is blocked, the lowest pip total wins.
+            </li>
+          </ol>
+          <div className="row">
+            <button id="closeRules">Close</button>
+          </div>
+        </div>
+      </div>
+      <div id="chatModal" className="modal-overlay" aria-hidden="true">
+        <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="chatTitle">
+          <div className="modal-header">
+            <h3 id="chatTitle">Quick Chat</h3>
+            <button className="modal-close" id="chatClose" type="button" aria-label="Close chat">
+              ✕
+            </button>
+          </div>
+          <div className="quick-messages" id="chatMessages" />
+          <button className="modal-primary" id="chatSend" type="button">
+            Send
+          </button>
+        </div>
+      </div>
+      <div id="giftModal" className="modal-overlay" aria-hidden="true">
+        <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="giftTitle">
+          <div className="modal-header">
+            <h3 id="giftTitle">Send Gift</h3>
+            <button className="modal-close" id="giftClose" type="button" aria-label="Close gifts">
+              ✕
+            </button>
+          </div>
+          <div className="gift-players" id="giftPlayers" />
+          <div id="giftTiers" />
+          <div className="gift-cost">
+            <span>Cost:</span>
+            <span id="giftCost">0</span>
+            <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" />
+          </div>
+          <button className="modal-primary" id="giftSend" type="button">
+            Send Gift
+          </button>
+          <p className="gift-note">10% charge and the amount of the gift will be deducted from your balance.</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/webapp/src/pages/Games/domino-royal.css
+++ b/webapp/src/pages/Games/domino-royal.css
@@ -1,0 +1,83 @@
+:root{--bg:#050812;--panel:#0b1220;--panel-border:#233050;--accent:#22c55e;--accent-2:#f59e0b;--fg:#e8eef7;--muted:#94a3b8;--glass:rgba(11,18,32,0.9);}
+  *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+  html,body{margin:0;height:100%;background:var(--bg);overflow:hidden;font-family:'Luckiest Guy','Comic Sans MS',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;}
+  #app{position:fixed;inset:0;width:100dvw;height:100dvh;}
+  canvas{display:block;width:100dvw !important;height:100dvh !important;touch-action:none;}
+  button{font-weight:800;border:0;border-radius:12px;padding:.6rem 1rem;background:var(--panel);color:var(--fg);border:1px solid var(--panel-border);box-shadow:0 10px 28px rgba(0,0,0,.38);} 
+  button:active{transform:translateY(1px);}
+  #status{position:fixed;top:calc(0.65rem + env(safe-area-inset-top, 0px));left:50%;transform:translateX(-50%);padding:.45rem .9rem;border-radius:14px;background:rgba(11,18,32,0.85);color:var(--fg);font-weight:800;z-index:4;backdrop-filter:blur(10px);border:1px solid var(--panel-border);box-shadow:0 12px 32px rgba(0,0,0,.35);}
+  #railControls{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + clamp(0.45rem, 5vh, 1.6rem));transform:translateX(-50%);display:flex;flex-direction:row;flex-wrap:wrap;justify-content:center;gap:.65rem;align-items:center;background:var(--glass);color:var(--fg);padding:.6rem .85rem;border-radius:14px;border:1px solid var(--panel-border);box-shadow:0 10px 28px rgba(0,0,0,0.38);z-index:4;pointer-events:auto;backdrop-filter:blur(10px);}
+  #railControls button{background:#121d33;color:#fff;font-size:.95rem;padding:.65rem 1rem;border-radius:10px;border:1px solid var(--panel-border);box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);}
+  #draw{font-size:1rem;padding:.7rem 1.15rem;background:linear-gradient(135deg, rgba(34,197,94,.95), rgba(12,180,75,.9));color:#041204;border:1px solid rgba(34,197,94,.6);}
+  #pass{background:rgba(37,45,71,.92);color:#e5e7eb;border:1px solid rgba(35,48,80,.85);} 
+  #topRightActions{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));right:calc(0.75rem + env(safe-area-inset-right,0px));display:flex;flex-direction:column;gap:.6rem;z-index:6;pointer-events:auto;}
+  #topRightActions .top-action{width:2.75rem;height:2.75rem;border-radius:999px;background:rgba(0,0,0,.58);color:#fff;display:grid;place-items:center;font-size:1.3rem;box-shadow:0 6px 18px rgba(0,0,0,.35);backdrop-filter:blur(6px);padding:0;border:1px solid rgba(255,255,255,.18);}
+  #btnRules{font-size:1.3rem;}
+  #btnRules span{pointer-events:none;}
+  .visually-hidden{position:absolute !important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+  #configButton{position:fixed;top:calc(0.75rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));width:3rem;height:3rem;border-radius:999px;background:rgba(0,0,0,.7);color:#fff;border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;box-shadow:0 6px 18px rgba(0,0,0,.35);z-index:3;backdrop-filter:blur(8px);padding:0;transition:background .2s ease, border-color .2s ease;}
+  #configButton:hover{background:rgba(0,0,0,.6);border-color:rgba(148,197,255,.45);}
+  #configButton svg{width:1.4rem;height:1.4rem;}
+  #configPanel{position:fixed;top:calc(4.4rem + env(safe-area-inset-top,0px));left:calc(0.75rem + env(safe-area-inset-left,0px));max-width:min(320px, 84vw);max-height:min(72dvh, 480px);background:rgba(3,7,18,.92);color:#fff;border-radius:1.25rem;box-shadow:0 24px 40px rgba(2,6,23,.55);padding:0.85rem 1rem;border:1px solid rgba(148,197,255,.2);z-index:3;backdrop-filter:blur(10px);display:none;flex-direction:column;gap:0.65rem;overflow:hidden;}
+  #configPanel.active{display:flex;}
+  #configPanel h3{margin:0;font-size:.62rem;text-transform:uppercase;letter-spacing:.28rem;color:rgba(148,197,255,.75);}
+  #configSections{display:flex;flex-direction:column;gap:.55rem;overflow-y:auto;padding-right:.3rem;margin-right:-.3rem;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;}
+  #configSections::-webkit-scrollbar{width:.35rem;}
+  #configSections::-webkit-scrollbar-thumb{background:rgba(148,197,255,.35);border-radius:999px;}
+  #configSections::-webkit-scrollbar-track{background:transparent;}
+  #seatOverlay{position:fixed;inset:0;pointer-events:none;z-index:4;}
+  .seat-badge{position:absolute;transform:translate(-50%,-50%);pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:.35rem;min-width:3.5rem;}
+  .seat-badge-avatar{position:relative;width:3.15rem;height:3.15rem;display:grid;place-items:center;}
+  .seat-badge .avatar-timer-ring{position:absolute;inset:-4%;border-radius:50%;pointer-events:none;background:var(--timer-gradient);-webkit-mask:radial-gradient(farthest-side,transparent 65%,black 66%);mask:radial-gradient(farthest-side,transparent 65%,black 66%);box-shadow:0 0 0 2px rgba(255,255,255,.22);}
+  .seat-badge-core{position:relative;width:100%;height:100%;border-radius:999px;display:grid;place-items:center;font-size:1.3rem;font-weight:800;color:#0b1224;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.2),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e);overflow:hidden;border:2px solid rgba(255,255,255,.32);box-shadow:0 8px 18px rgba(0,0,0,.35),0 0 0 2px rgba(6,12,24,.45);}
+  .seat-badge-core.has-photo{background-size:cover;background-position:center;color:transparent;text-indent:-9999px;}
+  .seat-badge-name{position:relative;font-size:.85rem;font-weight:800;letter-spacing:.01em;color:#e8eef7;text-shadow:0 2px 8px rgba(0,0,0,.42);padding:.2rem .55rem;border-radius:999px;background:rgba(7,12,24,.75);border:1px solid rgba(255,255,255,.16);backdrop-filter:blur(8px);box-shadow:0 8px 16px rgba(0,0,0,.28);}
+  #viewToggle{position:fixed;left:calc(0.75rem + env(safe-area-inset-left,0px));top:calc(4.1rem + env(safe-area-inset-top,0px));padding:.65rem 1rem;border-radius:999px;border:1px solid rgba(255,255,255,.16);background:rgba(12,16,28,.78);color:#ffe8a3;font-weight:800;font-size:.98rem;box-shadow:0 10px 24px rgba(0,0,0,.32);backdrop-filter:blur(10px);pointer-events:auto;z-index:4;}
+  #quickActions{position:fixed;left:calc(0.75rem + env(safe-area-inset-left,0px));bottom:calc(env(safe-area-inset-bottom,0px) + 1rem);display:flex;flex-direction:column;gap:.6rem;z-index:6;pointer-events:auto;}
+  #quickActions .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:rgba(0,0,0,.6);border:1px solid rgba(255,255,255,.18);color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:0 8px 18px rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:0;}
+  #quickActions .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
+  #quickActions .quick-action .icon{font-size:1.1rem;line-height:1;}
+  .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;z-index:7;}
+  .modal-overlay.active{display:flex;}
+  .modal-card{width:min(340px, 88vw);background:var(--panel);border:1px solid var(--panel-border);border-radius:16px;padding:1rem;color:var(--fg);box-shadow:0 18px 40px rgba(0,0,0,.5);display:flex;flex-direction:column;gap:.75rem;}
+  .modal-header{display:flex;align-items:center;justify-content:space-between;gap:.5rem;}
+  .modal-header h3{margin:0;font-size:1rem;letter-spacing:.04em;}
+  .modal-close{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.15);border-radius:999px;width:2rem;height:2rem;display:grid;place-items:center;color:#fff;padding:0;}
+  .quick-messages{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.45rem;max-height:12rem;overflow:auto;}
+  .quick-messages button{font-size:.7rem;padding:.4rem;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;font-weight:700;}
+  .quick-messages button.active{border-color:rgba(34,197,94,.8);background:rgba(34,197,94,.2);color:#eafff0;}
+  .modal-primary{width:100%;padding:.6rem 1rem;border-radius:12px;background:linear-gradient(135deg, rgba(34,197,94,.95), rgba(16,185,129,.85));color:#04210f;font-weight:800;border:1px solid rgba(34,197,94,.6);}
+  .gift-players{display:flex;flex-direction:column;gap:.4rem;max-height:8.5rem;overflow:auto;}
+  .gift-players button{display:flex;align-items:center;gap:.5rem;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.35rem .5rem;font-size:.72rem;font-weight:700;}
+  .gift-players button.active{border-color:rgba(34,197,94,.8);background:rgba(34,197,94,.2);}
+  .gift-players img{width:1.25rem;height:1.25rem;border-radius:999px;object-fit:cover;}
+  .gift-tier{display:flex;flex-direction:column;gap:.35rem;}
+  .gift-tier h4{margin:0;font-size:.7rem;letter-spacing:.18em;text-transform:uppercase;color:rgba(226,232,240,.7);}
+  .gift-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.4rem;}
+  .gift-button{display:flex;align-items:center;justify-content:space-between;gap:.3rem;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.35rem .5rem;font-size:.7rem;font-weight:700;}
+  .gift-button.active{border-color:rgba(245,158,11,.75);background:rgba(245,158,11,.15);}
+  .gift-button img{width:1rem;height:1rem;}
+  .gift-cost{display:flex;align-items:center;justify-content:center;gap:.35rem;font-size:.7rem;color:rgba(226,232,240,.9);}
+  .gift-cost img{width:.9rem;height:.9rem;}
+  .gift-note{font-size:.6rem;line-height:1.4;text-align:center;color:rgba(226,232,240,.7);}
+  .chat-bubble{position:fixed;display:flex;align-items:center;gap:.35rem;padding:.35rem .6rem;border-radius:999px;background:rgba(8,13,26,.88);border:1px solid rgba(255,255,255,.12);color:#f8fafc;font-size:.7rem;font-weight:700;box-shadow:0 10px 24px rgba(0,0,0,.45);z-index:7;pointer-events:none;white-space:nowrap;}
+  .chat-bubble img,.chat-bubble .avatar{width:1.2rem;height:1.2rem;border-radius:999px;display:grid;place-items:center;background:rgba(255,255,255,.2);font-size:.75rem;}
+  .toast{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + 4.5rem);transform:translateX(-50%);padding:.4rem .75rem;border-radius:999px;background:rgba(15,23,42,.8);border:1px solid rgba(255,255,255,.18);color:#f8fafc;font-size:.72rem;font-weight:700;z-index:7;box-shadow:0 10px 24px rgba(0,0,0,.45);pointer-events:none;}
+  .config-section{display:flex;flex-direction:column;gap:.3rem;}
+  .config-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:.45rem;}
+  .config-option{border-radius:0.85rem;border:1px solid rgba(255,255,255,.12);background:rgba(15,23,42,.55);color:#e2e8f0;padding:.4rem .5rem;display:flex;flex-direction:column;align-items:flex-start;gap:.3rem;font-size:clamp(.62rem,1.75vw,.72rem);line-height:1.35;font-weight:600;transition:border-color .2s ease, box-shadow .2s ease, transform .2s ease;}
+  .config-option span{font-size:clamp(.5rem,1.45vw,.58rem);text-transform:uppercase;letter-spacing:.24rem;color:rgba(148,197,255,.68);}
+  .config-option.active{border-color:rgba(56,189,248,.7);background:rgba(56,189,248,.15);box-shadow:0 0 0 1px rgba(56,189,248,.35),0 12px 24px rgba(8,145,178,.28);}
+  .config-option:disabled{opacity:.45;cursor:not-allowed;}
+  .config-option:not(.active):hover{border-color:rgba(255,255,255,.32);transform:translateY(-1px);}
+  .config-close{display:flex;justify-content:flex-end;}
+  .config-close button{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.12);color:#f1f5f9;border-radius:999px;padding:.35rem;display:grid;place-items:center;transition:background .2s ease, border-color .2s ease;}
+  .config-close button:hover{background:rgba(248,250,252,.16);border-color:rgba(248,250,252,.38);}
+  @media (max-width:640px){
+    #configPanel{left:50%;transform:translateX(-50%);top:calc(4.75rem + env(safe-area-inset-top,0px));}
+  }
+  #rules{position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(5,8,18,.75);z-index:6;backdrop-filter:blur(2px);}
+  #rules .card{max-width:720px;background:var(--panel);color:var(--fg);border-radius:16px;box-shadow:0 18px 38px rgba(0,0,0,.45);padding:16px 18px;border:1px solid var(--panel-border);} 
+  #rules h2{margin:0 0 6px 0;font-size:18px;letter-spacing:0.35px;}
+  #rules ol{margin:6px 0 0 18px;color:var(--muted);}
+  #rules .row{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}

--- a/webapp/src/pwa/preloadGames.js
+++ b/webapp/src/pwa/preloadGames.js
@@ -14,7 +14,7 @@ const GAME_ENTRYPOINTS = [
   '/texas-holdem.js',
   '/lib/texasHoldem.js',
   '/lib/texasHoldemGame.js',
-  '/domino-royal.html',
+  '/domino-royal.js',
   '/murlan-royale.html',
   '/roulette.html',
   '/chess-royale.html',


### PR DESCRIPTION
### Motivation
- Domino Royal was served as a large standalone HTML page inside an iframe which caused instability in embedded WebViews (e.g. Telegram) and made lifecycle management and PWA caching awkward.  

### Description
- Replace the iframe approach by loading the game module at runtime from React in `DominoRoyalArena.jsx` (injects font links, mounts game DOM and app shell, and loads `/domino-royal.js`).  
- Extract the inline game styles into `webapp/src/pages/Games/domino-royal.css` and move the game logic into a module `webapp/public/domino-royal.js`.  
- Add a cleanup hook `window.__dominoRoyalCleanup` and guard variables (`running`, `tickHandle`) in the module to stop the render loop and remove event listeners on unmount.  
- Update PWA/service-worker/preload manifests to reference the new entrypoint `/domino-royal.js` instead of the old `/domino-royal.html`, and minor JSX prop fix (`tabIndex={-1}`).  

### Testing
- Started the dev server with `npm --prefix webapp run dev` and confirmed Vite reported ready (local server reachable).  
- Exercised the page with a headless Playwright script that opened `http://127.0.0.1:4173/games/domino-royal` and produced a screenshot artifact, which completed successfully.  
- No unit tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c9050de48329b8808c38f4523357)