### PR TITLE
Tune ball physics, raise chalk/table base, replace pocket jaws with plastic presets, and improve aim spin deflection

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1204,7 +1204,7 @@ const CHALK_PRECISION_SLOW_MULTIPLIER = 0.25;
 const CHALK_AIM_LERP_SLOW = 0.08;
 const CHALK_TARGET_RING_RADIUS = BALL_R * 2;
 const CHALK_RING_OPACITY = 0.18;
-const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.26; // lift chalks slightly so they sit on the rail surface
+const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.34; // lift chalks slightly so they sit on the rail surface
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
@@ -1313,12 +1313,12 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.018;
+const ROLLING_RESISTANCE = 0.014;
 const BALL_BALL_FRICTION = 0.18;
 const RAIL_FRICTION = 0.16;
-const STOP_EPS = 0.02;
-const STOP_SOFTENING = 0.9; // ease balls into a stop instead of hard-braking at the speed threshold
-const STOP_FINAL_EPS = STOP_EPS * 0.45;
+const STOP_EPS = 0.012;
+const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
+const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
 const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing physics updates
 const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up cannot stall the render loop
@@ -1398,6 +1398,9 @@ const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({
 });
 const POCKET_LEATHER_TEXTURE_ANISOTROPY = 10;
 const POCKET_LEATHER_NORMAL_SCALE = new THREE.Vector2(2.4, 2.4);
+const POCKET_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 4, y: 4 });
+const POCKET_PLASTIC_TEXTURE_ANISOTROPY = 8;
+const POCKET_PLASTIC_NORMAL_SCALE = new THREE.Vector2(0.55, 0.55);
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84 * POCKET_VISUAL_EXPANSION; // trim the cloth aperture to match the smaller chrome + rail cuts
 const POCKET_CLOTH_BOTTOM_RADIUS = POCKET_CLOTH_TOP_RADIUS * 0.62;
 const POCKET_CLOTH_DEPTH = POCKET_RECESS_DEPTH * 1.05;
@@ -2520,6 +2523,203 @@ const ensurePocketLeatherTextures = (textureId = POCKET_LEATHER_TEXTURE_ID) => {
   return cacheEntry;
 };
 
+const pocketPlasticTextureCache = new Map();
+
+const applyPocketPlasticTextureDefaults = (
+  texture,
+  { isColor = false, repeat = POCKET_PLASTIC_TEXTURE_REPEAT } = {}
+) => {
+  if (!texture) return texture;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  const repeatX = repeat?.x ?? POCKET_PLASTIC_TEXTURE_REPEAT.x;
+  const repeatY = repeat?.y ?? POCKET_PLASTIC_TEXTURE_REPEAT.y;
+  texture.repeat.set(repeatX, repeatY);
+  texture.anisotropy = resolveTextureAnisotropy(POCKET_PLASTIC_TEXTURE_ANISOTROPY);
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  if (isColor) {
+    applySRGBColorSpace(texture);
+  }
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const adjustPlasticHexColor = (hex, amount) => {
+  const base = new THREE.Color(hex);
+  const target = amount >= 0 ? new THREE.Color(0xffffff) : new THREE.Color(0x000000);
+  base.lerp(target, Math.min(Math.abs(amount), 1));
+  return `#${base.getHexString()}`;
+};
+
+const ensurePocketPlasticTextures = (option = {}) => {
+  const primary = option?.baseColor ?? '#151515';
+  const accent = option?.accent ?? adjustPlasticHexColor(primary, -0.32);
+  const highlight = option?.highlight ?? adjustPlasticHexColor(primary, 0.18);
+  const cacheKey = `${primary}|${accent}|${highlight}`;
+  if (pocketPlasticTextureCache.has(cacheKey)) {
+    return pocketPlasticTextureCache.get(cacheKey);
+  }
+  if (typeof document === 'undefined') {
+    return { map: null, normal: null };
+  }
+  const size = 512;
+  const prng = (seed) => {
+    let value = seed >>> 0;
+    return () => {
+      value = (value * 1664525 + 1013904223) % 4294967296;
+      return value / 4294967296;
+    };
+  };
+  const rand = prng(314159265);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, size, size);
+
+  const seam = adjustPlasticHexColor(accent, -0.25);
+  const gradient = ctx.createLinearGradient(0, 0, size, size);
+  gradient.addColorStop(0, adjustPlasticHexColor(primary, -0.06));
+  gradient.addColorStop(0.4, primary);
+  gradient.addColorStop(1, adjustPlasticHexColor(accent, -0.12));
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  const repeat = 5;
+  const spacing = size / repeat;
+  const halfSpacing = spacing / 2;
+  const lineWidth = Math.max(1.4, spacing * 0.05);
+
+  ctx.strokeStyle = seam;
+  ctx.lineWidth = lineWidth;
+  ctx.globalAlpha = 0.95;
+  for (let offset = -size; offset <= size * 2; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset - size, size);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset + size, size);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.strokeStyle = adjustPlasticHexColor(highlight, 0.12);
+  ctx.lineWidth = lineWidth * 0.55;
+  ctx.globalAlpha = 0.65;
+  for (let offset = -size; offset <= size * 2; offset += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing - size, size);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(offset + halfSpacing, 0);
+    ctx.lineTo(offset + halfSpacing + size, size);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.22)';
+  const tuftRadius = Math.max(1.5, spacing * 0.07);
+  for (let y = -spacing; y <= size + spacing; y += spacing) {
+    for (let x = -spacing; x <= size + spacing; x += spacing) {
+      ctx.beginPath();
+      ctx.ellipse(x + halfSpacing, y + halfSpacing, tuftRadius, tuftRadius * 0.8, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'soft-light';
+  const grainLayers = 4;
+  for (let i = 0; i < grainLayers; i += 1) {
+    const opacity = 0.18 - i * 0.02;
+    ctx.fillStyle = `rgba(255,255,255,${opacity})`;
+    for (let g = 0; g < 1800; g += 1) {
+      const gx = rand() * size;
+      const gy = rand() * size;
+      const radius = 0.4 + rand() * 1.2;
+      ctx.beginPath();
+      ctx.ellipse(gx, gy, radius * 1.6, radius, rand() * Math.PI, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'overlay';
+  const sheenGradient = ctx.createRadialGradient(
+    size * 0.26,
+    size * 0.34,
+    size * 0.04,
+    size * 0.26,
+    size * 0.34,
+    size * 0.8
+  );
+  sheenGradient.addColorStop(0, 'rgba(255,255,255,0.22)');
+  sheenGradient.addColorStop(0.45, 'rgba(255,255,255,0.09)');
+  sheenGradient.addColorStop(1, 'rgba(0,0,0,0.4)');
+  ctx.fillStyle = sheenGradient;
+  ctx.fillRect(0, 0, size, size);
+  ctx.restore();
+
+  const bumpCanvas = document.createElement('canvas');
+  bumpCanvas.width = bumpCanvas.height = size;
+  const bumpCtx = bumpCanvas.getContext('2d');
+  const baseHeight = 128;
+  const bumpImage = bumpCtx.createImageData(size, size);
+  const bumpData = bumpImage.data;
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const idx = (y * size + x) * 4;
+      const ripple = Math.sin((x / size) * Math.PI * 4 + rand() * 0.8) * 6;
+      const rippleY = Math.cos((y / size) * Math.PI * 3 + rand() * 0.8) * 6;
+      const grain = (rand() - 0.5) * 26;
+      const value = THREE.MathUtils.clamp((baseHeight + ripple + rippleY + grain) / 255, 0, 1) * 255;
+      bumpData[idx] = bumpData[idx + 1] = bumpData[idx + 2] = value;
+      bumpData[idx + 3] = 255;
+    }
+  }
+
+  bumpCtx.putImageData(bumpImage, 0, 0);
+  bumpCtx.strokeStyle = `rgba(0,0,0,0.45)`;
+  bumpCtx.lineWidth = lineWidth * 0.8;
+  for (let offset = -size; offset <= size * 2; offset += spacing) {
+    bumpCtx.beginPath();
+    bumpCtx.moveTo(offset, 0);
+    bumpCtx.lineTo(offset - size, size);
+    bumpCtx.stroke();
+    bumpCtx.beginPath();
+    bumpCtx.moveTo(offset, 0);
+    bumpCtx.lineTo(offset + size, size);
+    bumpCtx.stroke();
+  }
+  bumpCtx.lineWidth = lineWidth * 0.5;
+  bumpCtx.strokeStyle = `rgba(255,255,255,0.2)`;
+  for (let offset = -size; offset <= size * 2; offset += spacing) {
+    bumpCtx.beginPath();
+    bumpCtx.moveTo(offset + halfSpacing, 0);
+    bumpCtx.lineTo(offset + halfSpacing - size, size);
+    bumpCtx.stroke();
+    bumpCtx.beginPath();
+    bumpCtx.moveTo(offset + halfSpacing, 0);
+    bumpCtx.lineTo(offset + halfSpacing + size, size);
+    bumpCtx.stroke();
+  }
+
+  const map = new THREE.CanvasTexture(canvas);
+  applyPocketPlasticTextureDefaults(map, { isColor: true });
+
+  const normalMap = new THREE.CanvasTexture(bumpCanvas);
+  applyPocketPlasticTextureDefaults(normalMap);
+
+  const textures = { map, normal: normalMap };
+  pocketPlasticTextureCache.set(cacheKey, textures);
+  return textures;
+};
+
 const createPocketMaterials = () => {
   const { jawMaterial, rimMaterial } = createPocketLinerMaterials(
     POCKET_LINER_OPTIONS[0] ?? null
@@ -2968,101 +3168,91 @@ const resolveBroadcastSystem = (id) =>
 
 const POCKET_LINER_PRESETS = Object.freeze([
   Object.freeze({
-    id: 'fabric_leather_02',
-    label: 'Fabric Leather 02',
-    textureId: 'fabric_leather_02'
+    id: 'plastic-black',
+    label: 'Plastic Black',
+    baseColor: '#151515'
   }),
   Object.freeze({
-    id: 'fabric_leather_01',
-    label: 'Fabric Leather 01',
-    textureId: 'fabric_leather_01'
+    id: 'plastic-dark-grey',
+    label: 'Plastic Dark Grey',
+    baseColor: '#2c2f33'
   }),
   Object.freeze({
-    id: 'brown_leather',
-    label: 'Brown Leather',
-    textureId: 'brown_leather'
+    id: 'plastic-grey',
+    label: 'Plastic Grey',
+    baseColor: '#5b5f64'
   }),
   Object.freeze({
-    id: 'leather_red_02',
-    label: 'Leather Red 02',
-    textureId: 'leather_red_02'
+    id: 'plastic-light-grey',
+    label: 'Plastic Light Grey',
+    baseColor: '#b8bcc2'
   }),
   Object.freeze({
-    id: 'leather_red_03',
-    label: 'Leather Red 03',
-    textureId: 'leather_red_03'
-  }),
-  Object.freeze({
-    id: 'leather_white',
-    label: 'Leather White',
-    textureId: 'leather_white'
+    id: 'plastic-magnolia',
+    label: 'Plastic Magnolia',
+    baseColor: '#f4f0e6'
   })
 ]);
 
 const DEFAULT_POCKET_LINER_OPTION_ID =
-  POCKET_LINER_PRESETS.find((preset) => preset.id === 'fabric_leather_02')?.id ??
+  POCKET_LINER_PRESETS.find((preset) => preset.id === 'plastic-black')?.id ??
   POCKET_LINER_PRESETS[0]?.id ??
-  'fabric_leather_02';
+  'plastic-black';
 
 const POCKET_LINER_OPTIONS = Object.freeze(
   POCKET_LINER_PRESETS.map((config) =>
     Object.freeze({
       id: config.id,
       label: `${config.label} Pocket Jaws`,
-      textureId: config.textureId ?? config.id,
-      thumbnail: polyHavenThumb(config.textureId ?? config.id),
-      roughness: 0.86,
-      metalness: 0.04,
-      clearcoat: 0.14,
-      clearcoatRoughness: 0.6,
-      sheen: 0.42,
-      sheenRoughness: 0.5,
-      envMapIntensity: 0.32
+      baseColor: config.baseColor ?? '#ffffff',
+      jawColor: config.baseColor ?? '#ffffff',
+      roughness: 0.28,
+      metalness: 0.06,
+      clearcoat: 0.62,
+      clearcoatRoughness: 0.22,
+      sheen: 0.16,
+      sheenRoughness: 0.38,
+      envMapIntensity: 0.35
     })
   )
 );
 
 function createPocketLinerMaterials(option) {
   const selection = option ?? POCKET_LINER_OPTIONS[0];
-  const textureId = selection?.textureId ?? POCKET_LEATHER_TEXTURE_ID;
-  const textures = ensurePocketLeatherTextures(textureId);
-  const baseColor = new THREE.Color(0xffffff);
+  const textures = ensurePocketPlasticTextures(selection);
+  const baseColor = new THREE.Color(selection?.baseColor ?? '#ffffff');
   const jawMaterial = new THREE.MeshPhysicalMaterial({
     color: baseColor,
-    roughness: selection.roughness ?? 0.86,
-    metalness: selection.metalness ?? 0.04,
-    clearcoat: selection.clearcoat ?? 0.14,
-    clearcoatRoughness: selection.clearcoatRoughness ?? 0.6,
-    sheen: selection.sheen ?? 0.42,
-    sheenRoughness: selection.sheenRoughness ?? 0.5,
+    roughness: selection.roughness ?? 0.28,
+    metalness: selection.metalness ?? 0.06,
+    clearcoat: selection.clearcoat ?? 0.62,
+    clearcoatRoughness: selection.clearcoatRoughness ?? 0.22,
+    sheen: selection.sheen ?? 0.16,
+    sheenRoughness: selection.sheenRoughness ?? 0.38,
     sheenColor: baseColor.clone(),
     envMapIntensity: selection.envMapIntensity ?? 0.32,
     map: textures.map ?? null,
-    normalMap: textures.normal ?? null,
-    roughnessMap: textures.roughness ?? null
+    normalMap: textures.normal ?? null
   });
   const rimMaterial = jawMaterial.clone();
-  rimMaterial.roughness = Math.min(1, (jawMaterial.roughness ?? 0.86) + 0.06);
-  rimMaterial.clearcoat = Math.min(0.2, (jawMaterial.clearcoat ?? 0.14) * 0.8);
+  rimMaterial.roughness = Math.min(1, (jawMaterial.roughness ?? 0.28) + 0.08);
+  rimMaterial.clearcoat = Math.min(0.35, (jawMaterial.clearcoat ?? 0.62) * 0.85);
   rimMaterial.clearcoatRoughness = Math.min(
     1,
-    (jawMaterial.clearcoatRoughness ?? 0.6) + 0.08
+    (jawMaterial.clearcoatRoughness ?? 0.22) + 0.08
   );
-  rimMaterial.sheen = Math.max(0.24, (jawMaterial.sheen ?? 0.42) * 0.7);
+  rimMaterial.sheen = Math.max(0.2, (jawMaterial.sheen ?? 0.16) * 0.7);
   rimMaterial.emissive = baseColor.clone().multiplyScalar(0.04);
   if (jawMaterial.normalMap) {
-    jawMaterial.normalScale = POCKET_LEATHER_NORMAL_SCALE.clone();
+    jawMaterial.normalScale = POCKET_PLASTIC_NORMAL_SCALE.clone();
   }
   if (rimMaterial.normalMap) {
-    rimMaterial.normalScale = POCKET_LEATHER_NORMAL_SCALE.clone();
+    rimMaterial.normalScale = POCKET_PLASTIC_NORMAL_SCALE.clone();
   }
-  applyPocketLeatherTextureDefaults(jawMaterial.map, { isColor: true });
-  applyPocketLeatherTextureDefaults(jawMaterial.normalMap);
-  applyPocketLeatherTextureDefaults(jawMaterial.roughnessMap);
-  applyPocketLeatherTextureDefaults(rimMaterial.map, { isColor: true });
-  applyPocketLeatherTextureDefaults(rimMaterial.normalMap);
-  applyPocketLeatherTextureDefaults(rimMaterial.roughnessMap);
-  registerPocketLeatherConsumer(textureId, [jawMaterial, rimMaterial]);
+  applyPocketPlasticTextureDefaults(jawMaterial.map, { isColor: true });
+  applyPocketPlasticTextureDefaults(jawMaterial.normalMap);
+  applyPocketPlasticTextureDefaults(rimMaterial.map, { isColor: true });
+  applyPocketPlasticTextureDefaults(rimMaterial.normalMap);
   jawMaterial.needsUpdate = true;
   rimMaterial.needsUpdate = true;
   return { jawMaterial, rimMaterial };
@@ -10005,8 +10195,8 @@ export function Table3D(
     slack: BALL_R * 0.35,
     sideReach: longRailW + chalkSideRailOffset + chalkSize * 0.5,
     endReach: endRailW + chalkEndRailOffset + chalkSize * 0.5,
-    overlapThreshold: chalkSize * 0.6,
-    nudgeDistance: chalkSize * 0.25
+    overlapThreshold: chalkSize * 0.78,
+    nudgeDistance: chalkSize * 0.34
   };
 
   const FACE_SHRINK_LONG = 1;
@@ -26681,8 +26871,19 @@ const powerRef = useRef(hud.power);
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + targetPowerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
+            const deflectedTargetDir = resolveTargetSpinDeflection(
+              rawTargetDir,
+              cueDir,
+              aimPreviewSpin,
+              powerStrength,
+              liftStrength
+            );
             const tDir =
-              rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : dir.clone();
+              deflectedTargetDir && deflectedTargetDir.lengthSq() > 1e-8
+                ? deflectedTargetDir.normalize()
+                : rawTargetDir.lengthSq() > 1e-8
+                  ? rawTargetDir.normalize()
+                  : dir.clone();
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
               BALL_CENTER_Y,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -538,8 +538,9 @@ export function createMurlanStyleTable({
   const trimHeight = 0.08 * scaleFactor;
   const trimOffset = 0.06 * scaleFactor;
   const clothRise = 0.07 * scaleFactor;
-  let baseHeight = 0.62 * scaleFactor;
+  let baseHeight = 0.66 * scaleFactor;
   const tableY = tableHeight - clothRise;
+  const baseLift = 0.03 * scaleFactor;
 
   const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
   if (baseHeight < minBaseHeight) {
@@ -658,7 +659,7 @@ export function createMurlanStyleTable({
       false
     );
     const baseMesh = new ThreeNamespace.Mesh(baseGeometry, baseMat);
-    baseMesh.position.y = tableY - baseHeight / 2;
+    baseMesh.position.y = tableY - baseHeight / 2 + baseLift;
     baseMesh.castShadow = true;
     baseMesh.receiveShadow = true;
     tableGroup.add(baseMesh);


### PR DESCRIPTION
### Motivation

- Make ball stopping feel more gradual and responsive by reducing abrupt hard-braking and smoothing rolling deceleration. 
- Visually adjust table elements so chalks and the table base sit slightly higher and chalks avoid overlapping the cue butt. 
- Replace leather pocket jaws with a plastic/monoblock-style finish in five colors to match the Murlan Royale reference. 
- Improve the aiming preview so the cue→target direction line accounts for spin deflection for more accurate visual guidance.

### Description

- Tuned physics/stop behavior by changing constants in `PoolRoyale.jsx`: updated `ROLLING_RESISTANCE`, `STOP_EPS`, `STOP_SOFTENING`, and `STOP_FINAL_EPS` to smooth deceleration and reduce sudden stops (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Raised chalk placement and assist nudging by increasing `CHALK_RAIL_SURFACE_LIFT` and bumping `chalkMeta.overlapThreshold` and `chalkMeta.nudgeDistance` so visible chalks lift higher and are nudged to avoid overlapping the cue (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Expanded the table base profile by increasing `baseHeight` and adding a small `baseLift` to raise the base mesh in the Murlan table creator (`webapp/src/utils/murlanTable.js`).
- Replaced pocket jaw leather pipeline with a plastic/monoblock workflow: introduced `POCKET_LINER_PRESETS` for five plastic colors, new `POCKET_PLASTIC_*` texture params and helper functions (`applyPocketPlasticTextureDefaults`, `ensurePocketPlasticTextures`) that procedurally build plastic-like maps and normal maps, and switched `createPocketLinerMaterials` to use plastic textures and material settings (gloss/clearcoat) instead of leather (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Improved aiming preview precision by applying spin deflection to the target direction in the aim/preview code path using `resolveTargetSpinDeflection` when building the target aim line (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Misc: updated chalk slot tuning and power/visual lines integration where necessary; changes are concentrated in `PoolRoyale.jsx` and `murlanTable.js` (see diff for exact locations).

### Testing

- Automated tests: none were executed in this change set (no unit/integration tests were run).
- Changes were committed locally (`git commit`) after edits; manual playtesting is recommended to validate feel (ball roll/stop), chalk positioning, pocket jaw appearance, and aiming-preview accuracy across spins.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0d654454832989f991a8326bd8aa)