### PR TITLE
Use GLTF-derived plastic textures for Pool Royale pocket jaws and update inventory

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -300,12 +300,11 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
-  fabric_leather_02: polyHavenThumb('fabric_leather_02'),
-  fabric_leather_01: polyHavenThumb('fabric_leather_01'),
-  brown_leather: polyHavenThumb('brown_leather'),
-  leather_red_02: polyHavenThumb('leather_red_02'),
-  leather_red_03: polyHavenThumb('leather_red_03'),
-  leather_white: polyHavenThumb('leather_white')
+  'plastic-black': swatchThumbnail(['#151515', '#2b2b2b', '#111111']),
+  'plastic-dark-grey': swatchThumbnail(['#2c2f33', '#3a3f45', '#1e2124']),
+  'plastic-grey': swatchThumbnail(['#5b5f64', '#6b7076', '#4b4f54']),
+  'plastic-light-grey': swatchThumbnail(['#b8bcc2', '#cdd1d6', '#a6aab0']),
+  'plastic-magnolia': swatchThumbnail(['#f4f0e6', '#ede6d9', '#d9d0c2'])
 });
 
 const CUE_STYLE_THUMBNAILS = Object.freeze({
@@ -378,7 +377,7 @@ export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
   cueStyle: ['birch-frost'],
-  pocketLiner: ['fabric_leather_02'],
+  pocketLiner: ['plastic-black'],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID],
   tableBase: POOL_ROYALE_BASE_VARIANTS.map((variant) => variant.id)
 });
@@ -429,12 +428,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   pocketLiner: Object.freeze({
-    fabric_leather_02: 'Fabric Leather 02 Pocket Jaws',
-    fabric_leather_01: 'Fabric Leather 01 Pocket Jaws',
-    brown_leather: 'Brown Leather Pocket Jaws',
-    leather_red_02: 'Leather Red 02 Pocket Jaws',
-    leather_red_03: 'Leather Red 03 Pocket Jaws',
-    leather_white: 'Leather White Pocket Jaws'
+    'plastic-black': 'Plastic Black Pocket Jaws',
+    'plastic-dark-grey': 'Plastic Dark Grey Pocket Jaws',
+    'plastic-grey': 'Plastic Grey Pocket Jaws',
+    'plastic-light-grey': 'Plastic Light Grey Pocket Jaws',
+    'plastic-magnolia': 'Plastic Magnolia Pocket Jaws'
   })
 });
 
@@ -521,58 +519,49 @@ export const POOL_ROYALE_STORE_ITEMS = [
     thumbnail: variant.thumbnail
   })),
   {
-    id: 'pocket-fabric-leather-02',
+    id: 'pocket-plastic-black',
     type: 'pocketLiner',
-    optionId: 'fabric_leather_02',
-    name: 'Fabric Leather 02 Pocket Jaws',
+    optionId: 'plastic-black',
+    name: 'Plastic Black Pocket Jaws',
     price: 520,
-    description: 'Warm stitched leather weave liners for the classic Pool Royale look.',
-    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_02
+    description: 'Deep black plastic jaws with a clean monoblock finish.',
+    thumbnail: POCKET_LINER_THUMBNAILS['plastic-black']
   },
   {
-    id: 'pocket-fabric-leather-01',
+    id: 'pocket-plastic-dark-grey',
     type: 'pocketLiner',
-    optionId: 'fabric_leather_01',
-    name: 'Fabric Leather 01 Pocket Jaws',
+    optionId: 'plastic-dark-grey',
+    name: 'Plastic Dark Grey Pocket Jaws',
     price: 530,
-    description: 'Soft-grain leather weave liners with a mellow brown finish.',
-    thumbnail: POCKET_LINER_THUMBNAILS.fabric_leather_01
+    description: 'Dark grey monoblock jaws with a muted satin sheen.',
+    thumbnail: POCKET_LINER_THUMBNAILS['plastic-dark-grey']
   },
   {
-    id: 'pocket-brown-leather',
+    id: 'pocket-plastic-grey',
     type: 'pocketLiner',
-    optionId: 'brown_leather',
-    name: 'Brown Leather Pocket Jaws',
+    optionId: 'plastic-grey',
+    name: 'Plastic Grey Pocket Jaws',
     price: 540,
-    description: 'Deep brown leather pockets with natural creases and aged texture.',
-    thumbnail: POCKET_LINER_THUMBNAILS.brown_leather
+    description: 'Balanced grey plastic jaws with a solid molded finish.',
+    thumbnail: POCKET_LINER_THUMBNAILS['plastic-grey']
   },
   {
-    id: 'pocket-leather-red-02',
+    id: 'pocket-plastic-light-grey',
     type: 'pocketLiner',
-    optionId: 'leather_red_02',
-    name: 'Leather Red 02 Pocket Jaws',
+    optionId: 'plastic-light-grey',
+    name: 'Plastic Light Grey Pocket Jaws',
     price: 560,
-    description: 'Bold red leather liners with pronounced seams and worn highlights.',
-    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_02
+    description: 'Light grey monoblock jaws with a brighter matte finish.',
+    thumbnail: POCKET_LINER_THUMBNAILS['plastic-light-grey']
   },
   {
-    id: 'pocket-leather-red-03',
+    id: 'pocket-plastic-magnolia',
     type: 'pocketLiner',
-    optionId: 'leather_red_03',
-    name: 'Leather Red 03 Pocket Jaws',
-    price: 570,
-    description: 'Deep crimson leather pocket liners with subtle stitch detailing.',
-    thumbnail: POCKET_LINER_THUMBNAILS.leather_red_03
-  },
-  {
-    id: 'pocket-leather-white',
-    type: 'pocketLiner',
-    optionId: 'leather_white',
-    name: 'Leather White Pocket Jaws',
+    optionId: 'plastic-magnolia',
+    name: 'Plastic Magnolia Pocket Jaws',
     price: 590,
-    description: 'Bright white leather pockets with crisp seam definition and clean grain.',
-    thumbnail: POCKET_LINER_THUMBNAILS.leather_white
+    description: 'Warm magnolia plastic jaws with a soft molded tone.',
+    thumbnail: POCKET_LINER_THUMBNAILS['plastic-magnolia']
   },
   {
     id: 'cue-redwood',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1204,7 +1204,7 @@ const CHALK_PRECISION_SLOW_MULTIPLIER = 0.25;
 const CHALK_AIM_LERP_SLOW = 0.08;
 const CHALK_TARGET_RING_RADIUS = BALL_R * 2;
 const CHALK_RING_OPACITY = 0.18;
-const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.26; // lift chalks slightly so they sit on the rail surface
+const CHALK_RAIL_SURFACE_LIFT = BALL_R * 0.34; // lift chalks slightly so they sit on the rail surface
 const BAULK_FROM_BAULK = BAULK_FROM_BAULK_REF * MM_TO_UNITS;
 const D_RADIUS = D_RADIUS_REF * MM_TO_UNITS;
 const BLACK_FROM_TOP = BLACK_FROM_TOP_REF * MM_TO_UNITS;
@@ -1313,12 +1313,12 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.018;
+const ROLLING_RESISTANCE = 0.014;
 const BALL_BALL_FRICTION = 0.18;
 const RAIL_FRICTION = 0.16;
-const STOP_EPS = 0.02;
-const STOP_SOFTENING = 0.9; // ease balls into a stop instead of hard-braking at the speed threshold
-const STOP_FINAL_EPS = STOP_EPS * 0.45;
+const STOP_EPS = 0.012;
+const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
+const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
 const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing physics updates
 const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up cannot stall the render loop
@@ -1398,6 +1398,13 @@ const POCKET_LEATHER_TEXTURE_REPEAT = Object.freeze({
 });
 const POCKET_LEATHER_TEXTURE_ANISOTROPY = 10;
 const POCKET_LEATHER_NORMAL_SCALE = new THREE.Vector2(2.4, 2.4);
+const POCKET_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 1.2, y: 1.2 });
+const POCKET_PLASTIC_TEXTURE_ANISOTROPY = 8;
+const POCKET_PLASTIC_NORMAL_SCALE = new THREE.Vector2(0.45, 0.45);
+const POCKET_PLASTIC_GLTF_URLS = Object.freeze([
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF-Binary/ToyCar.glb',
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ToyCar/glTF-Binary/ToyCar.glb'
+]);
 const POCKET_CLOTH_TOP_RADIUS = POCKET_VIS_R * 0.84 * POCKET_VISUAL_EXPANSION; // trim the cloth aperture to match the smaller chrome + rail cuts
 const POCKET_CLOTH_BOTTOM_RADIUS = POCKET_CLOTH_TOP_RADIUS * 0.62;
 const POCKET_CLOTH_DEPTH = POCKET_RECESS_DEPTH * 1.05;
@@ -2520,6 +2527,113 @@ const ensurePocketLeatherTextures = (textureId = POCKET_LEATHER_TEXTURE_ID) => {
   return cacheEntry;
 };
 
+const pocketPlasticTextureCache = {
+  textures: { map: null, normal: null, roughness: null },
+  loading: false,
+  ready: false
+};
+const pocketPlasticConsumers = new Set();
+
+const applyPocketPlasticTextureDefaults = (
+  texture,
+  { isColor = false, repeat = POCKET_PLASTIC_TEXTURE_REPEAT } = {}
+) => {
+  if (!texture) return texture;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  const repeatX = repeat?.x ?? POCKET_PLASTIC_TEXTURE_REPEAT.x;
+  const repeatY = repeat?.y ?? POCKET_PLASTIC_TEXTURE_REPEAT.y;
+  texture.repeat.set(repeatX, repeatY);
+  texture.anisotropy = resolveTextureAnisotropy(POCKET_PLASTIC_TEXTURE_ANISOTROPY);
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  if (isColor) {
+    applySRGBColorSpace(texture);
+  }
+  texture.needsUpdate = true;
+  return texture;
+};
+
+const registerPocketPlasticConsumer = (materials = []) => {
+  materials.forEach((material) => {
+    if (material) pocketPlasticConsumers.add(material);
+  });
+};
+
+const broadcastPocketPlasticTextures = () => {
+  if (!pocketPlasticConsumers.size) return;
+  pocketPlasticConsumers.forEach((material) => {
+    if (!material) return;
+    material.map = pocketPlasticTextureCache.textures.map ?? null;
+    material.normalMap = pocketPlasticTextureCache.textures.normal ?? null;
+    material.roughnessMap = pocketPlasticTextureCache.textures.roughness ?? null;
+    applyPocketPlasticTextureDefaults(material.map, { isColor: true });
+    applyPocketPlasticTextureDefaults(material.normalMap);
+    applyPocketPlasticTextureDefaults(material.roughnessMap);
+    material.needsUpdate = true;
+  });
+};
+
+const pickPlasticTextureMaterial = (scene) => {
+  let picked = null;
+  scene?.traverse?.((node) => {
+    if (picked || !node?.isMesh) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    materials.forEach((mat) => {
+      if (picked || !mat) return;
+      if (mat.map || mat.normalMap || mat.roughnessMap) {
+        picked = mat;
+      }
+    });
+  });
+  return picked;
+};
+
+const ensurePocketPlasticTextures = () => {
+  if (pocketPlasticTextureCache.ready || pocketPlasticTextureCache.loading) {
+    return pocketPlasticTextureCache.textures;
+  }
+  if (typeof window === 'undefined') {
+    return pocketPlasticTextureCache.textures;
+  }
+  pocketPlasticTextureCache.loading = true;
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  const loadFromUrls = async () => {
+    let lastError = null;
+    for (const url of POCKET_PLASTIC_GLTF_URLS) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await loader.loadAsync(url);
+        const scene = gltf?.scene || gltf?.scenes?.[0];
+        if (!scene) throw new Error('Missing scene for pocket plastic textures.');
+        const material = pickPlasticTextureMaterial(scene);
+        if (!material) throw new Error('Missing textured material for pocket plastic.');
+        pocketPlasticTextureCache.textures.map = material.map ?? null;
+        pocketPlasticTextureCache.textures.normal = material.normalMap ?? null;
+        pocketPlasticTextureCache.textures.roughness =
+          material.roughnessMap ?? material.metalnessMap ?? null;
+        applyPocketPlasticTextureDefaults(pocketPlasticTextureCache.textures.map, { isColor: true });
+        applyPocketPlasticTextureDefaults(pocketPlasticTextureCache.textures.normal);
+        applyPocketPlasticTextureDefaults(pocketPlasticTextureCache.textures.roughness);
+        pocketPlasticTextureCache.ready = true;
+        pocketPlasticTextureCache.loading = false;
+        broadcastPocketPlasticTextures();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    pocketPlasticTextureCache.loading = false;
+    pocketPlasticTextureCache.ready = true;
+    if (lastError) {
+      console.warn('Pool Royale plastic jaw texture load failed', lastError);
+    }
+  };
+  void loadFromUrls();
+  return pocketPlasticTextureCache.textures;
+};
+
 const createPocketMaterials = () => {
   const { jawMaterial, rimMaterial } = createPocketLinerMaterials(
     POCKET_LINER_OPTIONS[0] ?? null
@@ -2968,73 +3082,67 @@ const resolveBroadcastSystem = (id) =>
 
 const POCKET_LINER_PRESETS = Object.freeze([
   Object.freeze({
-    id: 'fabric_leather_02',
-    label: 'Fabric Leather 02',
-    textureId: 'fabric_leather_02'
+    id: 'plastic-black',
+    label: 'Plastic Black',
+    baseColor: '#151515'
   }),
   Object.freeze({
-    id: 'fabric_leather_01',
-    label: 'Fabric Leather 01',
-    textureId: 'fabric_leather_01'
+    id: 'plastic-dark-grey',
+    label: 'Plastic Dark Grey',
+    baseColor: '#2c2f33'
   }),
   Object.freeze({
-    id: 'brown_leather',
-    label: 'Brown Leather',
-    textureId: 'brown_leather'
+    id: 'plastic-grey',
+    label: 'Plastic Grey',
+    baseColor: '#5b5f64'
   }),
   Object.freeze({
-    id: 'leather_red_02',
-    label: 'Leather Red 02',
-    textureId: 'leather_red_02'
+    id: 'plastic-light-grey',
+    label: 'Plastic Light Grey',
+    baseColor: '#b8bcc2'
   }),
   Object.freeze({
-    id: 'leather_red_03',
-    label: 'Leather Red 03',
-    textureId: 'leather_red_03'
-  }),
-  Object.freeze({
-    id: 'leather_white',
-    label: 'Leather White',
-    textureId: 'leather_white'
+    id: 'plastic-magnolia',
+    label: 'Plastic Magnolia',
+    baseColor: '#f4f0e6'
   })
 ]);
 
 const DEFAULT_POCKET_LINER_OPTION_ID =
-  POCKET_LINER_PRESETS.find((preset) => preset.id === 'fabric_leather_02')?.id ??
+  POCKET_LINER_PRESETS.find((preset) => preset.id === 'plastic-black')?.id ??
   POCKET_LINER_PRESETS[0]?.id ??
-  'fabric_leather_02';
+  'plastic-black';
 
 const POCKET_LINER_OPTIONS = Object.freeze(
   POCKET_LINER_PRESETS.map((config) =>
     Object.freeze({
       id: config.id,
       label: `${config.label} Pocket Jaws`,
-      textureId: config.textureId ?? config.id,
-      thumbnail: polyHavenThumb(config.textureId ?? config.id),
-      roughness: 0.86,
-      metalness: 0.04,
-      clearcoat: 0.14,
-      clearcoatRoughness: 0.6,
-      sheen: 0.42,
-      sheenRoughness: 0.5,
-      envMapIntensity: 0.32
+      baseColor: config.baseColor ?? '#ffffff',
+      jawColor: config.baseColor ?? '#ffffff',
+      roughness: 0.28,
+      metalness: 0.06,
+      clearcoat: 0.62,
+      clearcoatRoughness: 0.22,
+      sheen: 0.16,
+      sheenRoughness: 0.38,
+      envMapIntensity: 0.35
     })
   )
 );
 
 function createPocketLinerMaterials(option) {
   const selection = option ?? POCKET_LINER_OPTIONS[0];
-  const textureId = selection?.textureId ?? POCKET_LEATHER_TEXTURE_ID;
-  const textures = ensurePocketLeatherTextures(textureId);
-  const baseColor = new THREE.Color(0xffffff);
+  const textures = ensurePocketPlasticTextures(selection);
+  const baseColor = new THREE.Color(selection?.baseColor ?? '#ffffff');
   const jawMaterial = new THREE.MeshPhysicalMaterial({
     color: baseColor,
-    roughness: selection.roughness ?? 0.86,
-    metalness: selection.metalness ?? 0.04,
-    clearcoat: selection.clearcoat ?? 0.14,
-    clearcoatRoughness: selection.clearcoatRoughness ?? 0.6,
-    sheen: selection.sheen ?? 0.42,
-    sheenRoughness: selection.sheenRoughness ?? 0.5,
+    roughness: selection.roughness ?? 0.28,
+    metalness: selection.metalness ?? 0.06,
+    clearcoat: selection.clearcoat ?? 0.62,
+    clearcoatRoughness: selection.clearcoatRoughness ?? 0.22,
+    sheen: selection.sheen ?? 0.16,
+    sheenRoughness: selection.sheenRoughness ?? 0.38,
     sheenColor: baseColor.clone(),
     envMapIntensity: selection.envMapIntensity ?? 0.32,
     map: textures.map ?? null,
@@ -3042,27 +3150,27 @@ function createPocketLinerMaterials(option) {
     roughnessMap: textures.roughness ?? null
   });
   const rimMaterial = jawMaterial.clone();
-  rimMaterial.roughness = Math.min(1, (jawMaterial.roughness ?? 0.86) + 0.06);
-  rimMaterial.clearcoat = Math.min(0.2, (jawMaterial.clearcoat ?? 0.14) * 0.8);
+  rimMaterial.roughness = Math.min(1, (jawMaterial.roughness ?? 0.28) + 0.08);
+  rimMaterial.clearcoat = Math.min(0.35, (jawMaterial.clearcoat ?? 0.62) * 0.85);
   rimMaterial.clearcoatRoughness = Math.min(
     1,
-    (jawMaterial.clearcoatRoughness ?? 0.6) + 0.08
+    (jawMaterial.clearcoatRoughness ?? 0.22) + 0.08
   );
-  rimMaterial.sheen = Math.max(0.24, (jawMaterial.sheen ?? 0.42) * 0.7);
+  rimMaterial.sheen = Math.max(0.2, (jawMaterial.sheen ?? 0.16) * 0.7);
   rimMaterial.emissive = baseColor.clone().multiplyScalar(0.04);
   if (jawMaterial.normalMap) {
-    jawMaterial.normalScale = POCKET_LEATHER_NORMAL_SCALE.clone();
+    jawMaterial.normalScale = POCKET_PLASTIC_NORMAL_SCALE.clone();
   }
   if (rimMaterial.normalMap) {
-    rimMaterial.normalScale = POCKET_LEATHER_NORMAL_SCALE.clone();
+    rimMaterial.normalScale = POCKET_PLASTIC_NORMAL_SCALE.clone();
   }
-  applyPocketLeatherTextureDefaults(jawMaterial.map, { isColor: true });
-  applyPocketLeatherTextureDefaults(jawMaterial.normalMap);
-  applyPocketLeatherTextureDefaults(jawMaterial.roughnessMap);
-  applyPocketLeatherTextureDefaults(rimMaterial.map, { isColor: true });
-  applyPocketLeatherTextureDefaults(rimMaterial.normalMap);
-  applyPocketLeatherTextureDefaults(rimMaterial.roughnessMap);
-  registerPocketLeatherConsumer(textureId, [jawMaterial, rimMaterial]);
+  applyPocketPlasticTextureDefaults(jawMaterial.map, { isColor: true });
+  applyPocketPlasticTextureDefaults(jawMaterial.normalMap);
+  applyPocketPlasticTextureDefaults(jawMaterial.roughnessMap);
+  applyPocketPlasticTextureDefaults(rimMaterial.map, { isColor: true });
+  applyPocketPlasticTextureDefaults(rimMaterial.normalMap);
+  applyPocketPlasticTextureDefaults(rimMaterial.roughnessMap);
+  registerPocketPlasticConsumer([jawMaterial, rimMaterial]);
   jawMaterial.needsUpdate = true;
   rimMaterial.needsUpdate = true;
   return { jawMaterial, rimMaterial };
@@ -10005,8 +10113,8 @@ export function Table3D(
     slack: BALL_R * 0.35,
     sideReach: longRailW + chalkSideRailOffset + chalkSize * 0.5,
     endReach: endRailW + chalkEndRailOffset + chalkSize * 0.5,
-    overlapThreshold: chalkSize * 0.6,
-    nudgeDistance: chalkSize * 0.25
+    overlapThreshold: chalkSize * 0.78,
+    nudgeDistance: chalkSize * 0.34
   };
 
   const FACE_SHRINK_LONG = 1;
@@ -26681,8 +26789,19 @@ const powerRef = useRef(hud.power);
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + targetPowerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
+            const deflectedTargetDir = resolveTargetSpinDeflection(
+              rawTargetDir,
+              cueDir,
+              aimPreviewSpin,
+              powerStrength,
+              liftStrength
+            );
             const tDir =
-              rawTargetDir.lengthSq() > 1e-8 ? rawTargetDir.normalize() : dir.clone();
+              deflectedTargetDir && deflectedTargetDir.lengthSq() > 1e-8
+                ? deflectedTargetDir.normalize()
+                : rawTargetDir.lengthSq() > 1e-8
+                  ? rawTargetDir.normalize()
+                  : dir.clone();
             const targetStart = new THREE.Vector3(
               targetBall.pos.x,
               BALL_CENTER_Y,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -538,8 +538,9 @@ export function createMurlanStyleTable({
   const trimHeight = 0.08 * scaleFactor;
   const trimOffset = 0.06 * scaleFactor;
   const clothRise = 0.07 * scaleFactor;
-  let baseHeight = 0.62 * scaleFactor;
+  let baseHeight = 0.66 * scaleFactor;
   const tableY = tableHeight - clothRise;
+  const baseLift = 0.03 * scaleFactor;
 
   const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
   if (baseHeight < minBaseHeight) {
@@ -658,7 +659,7 @@ export function createMurlanStyleTable({
       false
     );
     const baseMesh = new ThreeNamespace.Mesh(baseGeometry, baseMat);
-    baseMesh.position.y = tableY - baseHeight / 2;
+    baseMesh.position.y = tableY - baseHeight / 2 + baseLift;
     baseMesh.castShadow = true;
     baseMesh.receiveShadow = true;
     tableGroup.add(baseMesh);


### PR DESCRIPTION
### Motivation
- Replace the previous leather-derived pocket-jaw workflow (which caused errors and reused chair textures) with a robust plastic/monoblock workflow sourced from a GLTF asset, and update the store/inventory to reflect the new plastic presets. 
- Keep the user-facing presets and thumbnails consistent with the new plastic materials so players can pick pocket jaws that visually match the Murlan Royale reference. 
- Apply a small set of related visual/placement tweaks (chalk lift, table base lift, rolling/stop tuning and aim-preview accuracy) that were part of the recent adjustments to Pool Royale framing and feel.

### Description
- Replaced leather pipeline with a GLTF-based plastic texture loader in `PoolRoyale.jsx` by adding `POCKET_PLASTIC_GLTF_URLS`, a cached `pocketPlasticTextureCache`, `ensurePocketPlasticTextures()`, `pickPlasticTextureMaterial()` and broadcast/consumer helpers, and applied plastic default texture settings via `applyPocketPlasticTextureDefaults`. 
- Switched pocket liner material creation to use `ensurePocketPlasticTextures()` and plastic material parameters (color/roughness/clearcoat/etc.), registered pocket jaw/rim materials as plastic consumers, and wired normal/roughness maps into `createPocketLinerMaterials`. 
- Updated inventory/config to remove leather entries and add five plastic presets with thumbnails, labels, default unlock (`'plastic-black'`) and corresponding `POOL_ROYALE_STORE_ITEMS` entries in `webapp/src/config/poolRoyaleInventoryConfig.js`. 
- Minor related tuning: adjusted `CHALK_RAIL_SURFACE_LIFT`, `chalkMeta.overlapThreshold` and `nudgeDistance`, table base `baseHeight` and small `baseLift` in `murlanTable.js`, and tuned physics stop/rolling constants and aim preview target direction to account for spin deflection where applicable in `PoolRoyale.jsx`.

### Testing
- Automated tests: none executed for this change set (no unit/integration tests were run). 
- Commit: changes were committed locally; manual in-app / playtesting is recommended to validate pocket jaw appearance, texture loading, store/inventory entries, chalk placement, table base positioning, aim-preview accuracy and ball feel after the physics tweaks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0d654454832989f991a8326bd8aa)