### PR TITLE
Pool Royale: remove spin deflection and refine replay, pocket cams, jaws, and ball-in-hand

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1051,7 +1051,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   pockets: false
 });
 const SHOW_SHORT_RAIL_TRIPODS = false;
-const LOCK_REPLAY_CAMERA = false;
+const LOCK_REPLAY_CAMERA = true;
 const REPLAY_CUE_STICK_HOLD_MS = 620;
 const REPLAY_CAMERA_START_DELAY_MS = 180;
 const REPLAY_POCKET_CAMERA_HOLD_MS = 420;
@@ -1087,9 +1087,9 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.03; // nudge jaws outward to track the cushion line precisely
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 0.9; // trim the jaw bodies so the underside sits shorter below the cloth
+const POCKET_JAW_DEPTH_SCALE = 0.98; // extend the jaw bodies slightly downward so the lower edge reads taller near the pocket corners
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.125; // lift jaws to match the cushion top so balls can't hop the pocket edge
-const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.022; // reduce the bottom reach slightly so jaws read shorter
+const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.014; // keep a little less bottom trim so the jaws extend farther from the underside
 const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.23; // keep the underside tight to the cloth depth instead of the deeper pocket floor
 const POCKET_JAW_EDGE_FLUSH_START = 0.1; // start easing earlier so the jaw thins gradually toward the cushions
 const POCKET_JAW_EDGE_FLUSH_END = 1; // ensure the jaw finish meets the chrome trim flush at the very ends
@@ -1469,9 +1469,9 @@ const POCKET_CAM = Object.freeze({
     POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
-  // Lift pocket cameras slightly so the pocket mouth is seen a bit more from above.
-  heightOffset: BALL_R * 1.72,
-  heightOffsetShortMultiplier: 1.2,
+  // Lift pocket cameras a bit more so the pocket mouth sits higher in frame.
+  heightOffset: BALL_R * 2.05,
+  heightOffsetShortMultiplier: 1.3,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
     POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 * POCKET_CAM_INWARD_SCALE +
@@ -1578,7 +1578,7 @@ const CUE_BACKSPIN_ROLL_BOOST = 3.4;
 const RAIL_SPIN_THROW_SCALE = BALL_R * 0.36; // match Snooker Royal rail throw for consistent cushion response
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // align spin inversion with Snooker Royal rebound behavior
-const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0.65; // allow cue follow line to reflect spin deflection
+const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable spin-based post-impact guide deflection so preview lines match the true contact geometry
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
@@ -5267,7 +5267,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 // Keep the orbit camera from slipping beneath the cue when dragged downwards.
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.32; // restore the 9pm in-hand orbit framing for cue-ball placement
-const IN_HAND_DRAG_SPEED = 2.6; // accelerate ball-in-hand drags for faster repositioning
+const IN_HAND_DRAG_SPEED = 6; // increase ball-in-hand drag travel so players can place the cue ball quickly across the full table
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
 const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.36; // nudge forward slightly at the floor of the cue view, then stop
 const STANDING_TO_CUE_FORWARD_PUSH = CAMERA.minR * 0.1; // gently push forward as the standing view lowers toward cue view
@@ -19611,6 +19611,14 @@ const powerRef = useRef(hud.power);
             return true;
           };
           if (hasCueSnapshots) {
+            if (targetTime <= REPLAY_CUE_START_HOLD_MS) {
+              const snapshotApplied = applyCueSnapshot();
+              if (snapshotApplied) {
+                cueStick.visible = true;
+                cueAnimating = true;
+                syncCueShadow();
+              }
+            }
             return;
           }
           if (!stroke) {
@@ -20195,6 +20203,10 @@ const powerRef = useRef(hud.power);
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
             cueStroke: trimmed.cueStroke ?? null,
+            frameTimeMs:
+              frameTimingRef.current && Number.isFinite(frameTimingRef.current.targetMs)
+                ? frameTimingRef.current.targetMs
+                : 1000 / 60,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
@@ -26089,11 +26101,9 @@ const powerRef = useRef(hud.power);
         if (playback) {
           const frameTiming = frameTimingRef.current;
           const targetReplayFrameTime =
-            Number.isFinite(playback?.frameTimeMs) && playback.frameTimeMs > 0
-              ? playback.frameTimeMs
-              : frameTiming && Number.isFinite(frameTiming.targetMs)
-                ? frameTiming.targetMs
-                : 1000 / 60;
+            frameTiming && Number.isFinite(frameTiming.targetMs)
+              ? frameTiming.targetMs
+              : 1000 / 60;
           if (lastReplayFrameAt && now - lastReplayFrameAt < targetReplayFrameTime) {
             rafRef.current = requestAnimationFrame(step);
             return;
@@ -27726,6 +27736,7 @@ const powerRef = useRef(hud.power);
                   b.swervePowerStrength = 0;
                   b.impacted = false;
                   inHandDragRef.current.lastPos = fallback.clone();
+                  cueBallPlacedFromHandRef.current = false;
                 } else if (b.mesh) {
                   b.mesh.visible = true;
                 }
@@ -27812,6 +27823,7 @@ const powerRef = useRef(hud.power);
                   b.swervePowerStrength = 0;
                   b.impacted = false;
                   inHandDragRef.current.lastPos = fallback.clone();
+                  cueBallPlacedFromHandRef.current = false;
                 } else if (b.mesh) {
                   b.mesh.visible = true;
                 }


### PR DESCRIPTION
### Motivation
- Make aiming preview match post-impact geometry by removing the spin-driven deflection from the guide lines so previewed cue/target directions reflect the true contact geometry. 
- Improve pocket framing and jaw visuals so pocket drops are clearer on portrait mobile screens. 
- Make replays steadier and visually consistent with live gameplay (show cue animation at start, lock camera choices, and match replay FPS to game frame timing). 
- Improve ball-in-hand UX so the cue ball remains centered on pocket fallback and can be moved quickly and precisely across the table. 

### Description
- Disabled spin-based post-impact guide deflection by setting `SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0` so preview lines no longer bend for spin. (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Raised pocket camera framing by increasing `POCKET_CAM.heightOffset` and `heightOffsetShortMultiplier` to lift pocket cams visually. (`POCKET_CAM` in `PoolRoyale.jsx`) 
- Locked replay camera switching with `LOCK_REPLAY_CAMERA = true` and tied replay pacing to the live frame timing source by reading `frameTimingRef.current.targetMs` for replay frame timing. Also added `frameTimeMs` to `replayPlayback` so replay playback uses consistent timing. (`startShotReplay` and `step` in `PoolRoyale.jsx`) 
- Ensure cue stick is visible at replay start even when per-frame cue snapshots exist by applying the first cue snapshot during the start-hold window (`REPLAY_CUE_START_HOLD_MS`). (`applyReplayCueStroke` in `PoolRoyale.jsx`) 
- Expanded pocket jaw geometry subtly by raising `POCKET_JAW_DEPTH_SCALE` and reducing `POCKET_JAW_BOTTOM_CLEARANCE` so jaws read slightly taller from the bottom. (`PoolRoyale.jsx`) 
- Increased ball-in-hand placement responsiveness by raising `IN_HAND_DRAG_SPEED` (from `2.6` to `6`) so the cue ball moves faster and across the full table. Also adjusted in-hand fallback logic so when the cue ball falls into a pocket while in-hand the ball remains active for manual repositioning (tweaks around `cueBallPlacedFromHandRef`). (`PoolRoyale.jsx`) 

### Testing
- Built the web app: ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished, chunks emitted). 
- Started local dev server (`npm --prefix webapp run dev`) and captured a portrait screenshot using Playwright to validate visual placement; the screenshot artifact was produced. 
- No unit tests were changed; build-time checks reported some large chunk warnings only (informational).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae4959c508329af11162fc4dd3b63)