### PR TITLE
Tune Pool Royale pocket geometry, rack lift, and ball-in-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -620,23 +620,24 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.34; // trim the side fascia reach 
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.1; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.18; // trim the fascia closer to the pocket cut so the inner edge tightens slightly
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.08; // widen the middle fascia a touch so both flanks expand toward the corner pockets
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.89; // trim the outside plate body slightly more so the outer red-marked strip is reduced
-const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.12; // extend the plate ends a bit farther toward the corner pockets (green-marked areas)
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.86; // trim the outside plate body a touch more so the outer red-marked strip is reduced
+const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.16; // extend the plate ends a bit farther toward the corner pockets (green-marked areas)
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.9; // tighten the middle fascia slightly so both flanks gain a touch more trim
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.058; // push middle chrome plates a little farther outward away from table center
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
-const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.036; // trim more from the outside edge to match the requested red-marked cutback
+const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.042; // trim a bit more from the outside edge to match the requested red-marked cutback
 const CHROME_CORNER_POCKET_CUT_SCALE = 1; // keep the rounded chrome corner cut equal to the middle pockets
-const CHROME_SIDE_POCKET_CUT_SCALE = 1; // match the middle pocket chrome cut radius to the corner pockets
+const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open the middle pocket chrome cut radius a touch while keeping the rounded profile
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.975; // pull the corner relief radius in slightly for a tighter rounded cut
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 1.01; // enlarge the corner relief radius slightly while keeping the rounded cut vertically straight
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.03; // enlarge middle rail rounded cuts a touch to follow the widened middle chrome arc
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.068; // move middle wooden relief outward a bit more with the shifted side-pocket geometry
+const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.78; // nudge the rack slightly upward on screen so object balls sit a touch higher
 
 function buildChromePlateGeometry({
   width,
@@ -20938,7 +20939,7 @@ const powerRef = useRef(hud.power);
           const rackColors = POOL_VARIANT_COLOR_SETS.american.objectColors || [];
           const rackNumbers = POOL_VARIANT_COLOR_SETS.american.objectNumbers || [];
           const rackPatterns = POOL_VARIANT_COLOR_SETS.american.objectPatterns || [];
-          const rackStartZ = SPOTS.pink[1] + BALL_R * 2;
+          const rackStartZ = SPOTS.pink[1] + BALL_R * 2 + RACK_VERTICAL_SCREEN_LIFT;
           const rackPositions = generateRackPositions(
             rackColors.length,
             'triangle',
@@ -21395,7 +21396,7 @@ const powerRef = useRef(hud.power);
       const appliedTraining = false;
 
       if (!appliedTraining) {
-        const rackStartZ = SPOTS.pink[1] + BALL_R * 2;
+        const rackStartZ = SPOTS.pink[1] + BALL_R * 2 + RACK_VERTICAL_SCREEN_LIFT;
         const rackLayout = variantConfig?.rackLayout || 'triangle';
         const rackColors = Array.isArray(variantConfig?.objectColors)
           ? variantConfig.objectColors
@@ -25671,11 +25672,7 @@ const powerRef = useRef(hud.power);
           const nextMeta =
             safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
           if (nextMeta?.state && typeof nextMeta.state === 'object') {
-            if (nextMeta.variant === 'uk') {
-              nextMeta.state = { ...nextMeta.state, mustPlayFromBaulk: true };
-            } else {
-              nextMeta.state = { ...nextMeta.state, ballInHand: true };
-            }
+            nextMeta.state = { ...nextMeta.state, ballInHand: true };
           }
           safeState = {
             ...safeState,


### PR DESCRIPTION
### Motivation
- Align Pool Royale table visuals and UX with the provided design notes: slightly larger rounded pocket cuts, chrome plate reach adjustments, balls placed visually higher, and clearer ball‑in‑hand placement behavior.

### Description
- Adjusted chrome/middle pocket constants to slightly enlarge middle chrome pocket cut and expand/trims the chrome side plates toward corner pockets and outer edge (`CHROME_SIDE_POCKET_CUT_SCALE`, `CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE`, `CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE`, `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`).
- Increased the wooden rail corner relief radius to make the corner rounded cut marginally bigger and visually straighter (`WOOD_CORNER_RELIEF_INWARD_SCALE`).
- Added a vertical screen lift for the rack and applied it to both decorative and gameplay rack placement paths (`RACK_VERTICAL_SCREEN_LIFT` and usage when computing `rackStartZ`).
- Simplified foul handling so fouls set `ballInHand` (full table placement) in the resulting meta state instead of forcing `mustPlayFromBaulk` in this UI flow.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (command executed; file is ignored by repo lint config) and it completed without errors for the modified file.
- Ran `npm run lint` which reported pre-existing repository-wide lint errors unrelated to this change (task-level outcome: failed due to unrelated files).
- Ran `npm run build` which failed due to a pre-existing TypeScript error in another rules file (`src/rules/SnookerRoyalRules.ts`) and not caused by these edits.
- Launched the dev webserver (`vite`) and executed an automated Playwright script to load `/games/poolroyale` and capture a screenshot to validate visual changes (screenshot artifact created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b1fe7aa9883299b694a9f9f737571)