### PR TITLE
Round corner-pocket chrome plate outer edges in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -600,6 +600,7 @@ const CHROME_CORNER_CENTER_OUTSET_SCALE = -0.065; // pull the corner fascia slig
 const CHROME_CORNER_SHORT_RAIL_SHIFT_SCALE = 0; // let the corner fascia terminate precisely where the cushion noses stop
 const CHROME_CORNER_SHORT_RAIL_CENTER_PULL_SCALE = 0; // stop pulling the chrome off the short-rail centreline so the jaws stay flush
 const CHROME_CORNER_EDGE_TRIM_SCALE = 0; // do not trim edges beyond the snooker baseline
+const CHROME_CORNER_POCKET_EDGE_ROUND_SCALE = 0.32; // round the edge near corner pockets so the fascia trims match the requested softened cut
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
@@ -685,16 +686,42 @@ function buildChromePlateGeometry({
     }
     shape.lineTo(topStartX, hh);
   } else {
+    const drawRectWithCornerRadii = ({ tl = 0, tr = 0, br = 0, bl = 0 }) => {
+      const clampRadius = (value) => Math.max(0, Math.min(value, hw, hh));
+      const rtl = clampRadius(tl);
+      const rtr = clampRadius(tr);
+      const rbr = clampRadius(br);
+      const rbl = clampRadius(bl);
+
+      shape.moveTo(-hw + rtl, hh);
+      shape.lineTo(hw - rtr, hh);
+      if (rtr > MICRO_EPS) {
+        shape.absarc(hw - rtr, hh - rtr, rtr, Math.PI / 2, 0, true);
+      }
+      shape.lineTo(hw, -hh + rbr);
+      if (rbr > MICRO_EPS) {
+        shape.absarc(hw - rbr, -hh + rbr, rbr, 0, -Math.PI / 2, true);
+      }
+      shape.lineTo(-hw + rbl, -hh);
+      if (rbl > MICRO_EPS) {
+        shape.absarc(-hw + rbl, -hh + rbl, rbl, -Math.PI / 2, -Math.PI, true);
+      }
+      shape.lineTo(-hw, hh - rtl);
+      if (rtl > MICRO_EPS) {
+        shape.absarc(-hw + rtl, hh - rtl, rtl, Math.PI, Math.PI / 2, true);
+      }
+      shape.lineTo(-hw + rtl, hh);
+    };
+
     const cornerKey = typeof corner === 'string' ? corner.toLowerCase() : '';
+    const pocketEdgeRadius = Math.min(
+      r * CHROME_CORNER_POCKET_EDGE_ROUND_SCALE,
+      Math.min(width, height) * 0.2
+    );
     switch (cornerKey) {
       case 'topleft': {
         if (r > MICRO_EPS) {
-          shape.moveTo(-hw + r, hh);
-          shape.lineTo(hw, hh);
-          shape.lineTo(hw, -hh);
-          shape.lineTo(-hw, -hh);
-          shape.lineTo(-hw, hh - r);
-          shape.absarc(-hw + r, hh - r, r, Math.PI, Math.PI / 2, true);
+          drawRectWithCornerRadii({ tl: r, br: pocketEdgeRadius, bl: pocketEdgeRadius });
         } else {
           shape.moveTo(TL.x, TL.y);
           shape.lineTo(TR.x, TR.y);
@@ -706,12 +733,7 @@ function buildChromePlateGeometry({
       }
       case 'topright': {
         if (r > MICRO_EPS) {
-          shape.moveTo(-hw, hh);
-          shape.lineTo(hw - r, hh);
-          shape.absarc(hw - r, hh - r, r, Math.PI / 2, 0, true);
-          shape.lineTo(hw, -hh);
-          shape.lineTo(-hw, -hh);
-          shape.lineTo(-hw, hh);
+          drawRectWithCornerRadii({ tr: r, br: pocketEdgeRadius, bl: pocketEdgeRadius });
         } else {
           shape.moveTo(TL.x, TL.y);
           shape.lineTo(TR.x, TR.y);
@@ -723,12 +745,7 @@ function buildChromePlateGeometry({
       }
       case 'bottomright': {
         if (r > MICRO_EPS) {
-          shape.moveTo(-hw, hh);
-          shape.lineTo(hw, hh);
-          shape.lineTo(hw, -hh + r);
-          shape.absarc(hw - r, -hh + r, r, 0, -Math.PI / 2, true);
-          shape.lineTo(-hw, -hh);
-          shape.lineTo(-hw, hh);
+          drawRectWithCornerRadii({ tl: pocketEdgeRadius, tr: pocketEdgeRadius, br: r });
         } else {
           shape.moveTo(TL.x, TL.y);
           shape.lineTo(TR.x, TR.y);
@@ -740,12 +757,7 @@ function buildChromePlateGeometry({
       }
       case 'bottomleft': {
         if (r > MICRO_EPS) {
-          shape.moveTo(-hw, hh);
-          shape.lineTo(hw, hh);
-          shape.lineTo(hw, -hh);
-          shape.lineTo(-hw + r, -hh);
-          shape.absarc(-hw + r, -hh + r, r, -Math.PI / 2, -Math.PI, true);
-          shape.lineTo(-hw, hh);
+          drawRectWithCornerRadii({ tl: pocketEdgeRadius, tr: pocketEdgeRadius, bl: r });
         } else {
           shape.moveTo(TL.x, TL.y);
           shape.lineTo(TR.x, TR.y);


### PR DESCRIPTION
### Motivation
- Make the chrome fascia near the corner pockets match the requested softened/rounded outer edges in the reference photo while preserving the pocket-cut geometry.
- Keep chrome plate geometry generation modular and safe so per-corner adjustments do not produce invalid shapes.

### Description
- Added a tuning constant `CHROME_CORNER_POCKET_EDGE_ROUND_SCALE` and computed `pocketEdgeRadius` to control the outer edge rounding near corner pockets in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Introduced a reusable helper `drawRectWithCornerRadii` inside `buildChromePlateGeometry` to emit a rectangle with independent corner radii and clamped values to prevent invalid geometry.
- Applied the helper for each corner orientation (`topLeft`, `topRight`, `bottomRight`, `bottomLeft`) so the two outer edges adjacent to each corner pocket are rounded while the main pocket-cut corner radius is preserved.
- Kept existing notch/clip logic and extrusion path flow unchanged so pocket cut subtraction and extrusion behave as before.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed with the file ignored by current ESLint config and reported no errors.
- Built the web app with `npm --prefix webapp run build` which completed successfully and produced the production `dist` assets.
- Started the dev server with `npm --prefix webapp run dev` and captured a portrait viewport screenshot of the running site via Playwright successfully, and attempted an in-game `/games/poolroyale` screenshot which timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0cb2f0d4832982d3d99ab560cf47)