### PR TITLE
Add 5 GLTF open-source character models and seat them in Murlan Royale arena

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -95,6 +95,15 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: CARD_THEMES.find((theme) => theme.id === 'onyx')?.thumbnail
   }
 ].concat(
+  MURLAN_OUTFIT_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+    id: `outfit-${theme.id}`,
+    type: 'outfit',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 540 + idx * 45,
+    description: theme.description || `${theme.label} player model with original textures.`,
+    thumbnail: theme.thumbnail
+  })),
   MURLAN_TABLE_CLOTHS.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,
     type: 'tableCloth',

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -2,52 +2,64 @@ import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const MURLAN_OUTFIT_THEMES = [
   {
-    id: 'midnight',
-    label: 'Royal Blue',
-    baseColor: '#1f3c88',
-    accentColor: '#f5d547',
+    id: 'soldier',
+    label: 'Soldier',
+    baseColor: '#4b5563',
+    accentColor: '#9ca3af',
     glow: '#0f172a',
-    thumbnail: swatchThumbnail(['#1f3c88', '#0f172a', '#f5d547'])
+    source: 'gltf',
+    preserveMaterials: true,
+    urls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Soldier.glb'],
+    description: 'Open-source GLB character from three.js examples with original textures.',
+    thumbnail: swatchThumbnail(['#4b5563', '#111827', '#9ca3af'])
   },
   {
-    id: 'ember',
-    label: 'Neon Red',
-    baseColor: '#a31621',
-    accentColor: '#ff8e3c',
-    glow: '#22080b',
-    thumbnail: swatchThumbnail(['#a31621', '#22080b', '#ff8e3c'])
+    id: 'michelle',
+    label: 'Michelle',
+    baseColor: '#7c3aed',
+    accentColor: '#f0abfc',
+    glow: '#1e1b4b',
+    source: 'gltf',
+    preserveMaterials: true,
+    urls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Michelle.glb'],
+    description: 'Open-source GLB character from three.js examples with original textures.',
+    thumbnail: swatchThumbnail(['#7c3aed', '#1e1b4b', '#f0abfc'])
   },
   {
-    id: 'glacier',
-    label: 'Ice',
+    id: 'xbot',
+    label: 'Xbot',
     baseColor: '#1b8dbf',
     accentColor: '#9ff0ff',
     glow: '#082433',
+    source: 'gltf',
+    preserveMaterials: true,
+    urls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Xbot.glb'],
+    description: 'Open-source GLB character from three.js examples with original textures.',
     thumbnail: swatchThumbnail(['#1b8dbf', '#082433', '#9ff0ff'])
   },
   {
-    id: 'forest',
-    label: 'Forest',
+    id: 'kira',
+    label: 'Kira',
     baseColor: '#1b7f4a',
     accentColor: '#b5f44a',
     glow: '#071f11',
+    source: 'gltf',
+    preserveMaterials: true,
+    urls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/kira.glb'],
+    description: 'Open-source GLB character from three.js examples with original textures.',
     thumbnail: swatchThumbnail(['#1b7f4a', '#071f11', '#b5f44a'])
   },
   {
-    id: 'royal',
-    label: 'Violet',
+    id: 'readyplayer',
+    label: 'Ready Player',
     baseColor: '#6b21a8',
     accentColor: '#f0abfc',
     glow: '#220a35',
+    source: 'gltf',
+    preserveMaterials: true,
+    urls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/readyplayer.me.glb'],
+    description: 'Open-source GLB character from three.js examples with original textures.',
     thumbnail: swatchThumbnail(['#6b21a8', '#220a35', '#f0abfc'])
-  },
-  {
-    id: 'onyx',
-    label: 'Onyx',
-    baseColor: '#1f2937',
-    accentColor: '#9ca3af',
-    glow: '#090b10',
-    thumbnail: swatchThumbnail(['#1f2937', '#090b10', '#9ca3af'])
   }
 ];
 


### PR DESCRIPTION
### Motivation
- Provide five free/open-source 3D human character options for Murlan Royale so players can choose different seated avatars with original textures. 
- Expose those characters in the table setup UI and the Store so users can unlock and select them like other appearance options. 
- Render characters seated on chairs in the 3D arena so they behave visually as players during gameplay.

### Description
- Added five GLTF-based outfit themes to `MURLAN_OUTFIT_THEMES` with metadata and public GLB URLs (Soldier, Michelle, Xbot, Kira, Ready Player) and thumbnails for the setup UI (`webapp/src/config/murlanThemes.js`).
- Added store entries that expose the new outfit/theme options in the Murlan store inventory so they can be unlocked (`webapp/src/config/murlanInventoryConfig.js`).
- Implemented character model support in the Murlan arena: added `buildCharacterTemplate` loader, `applyApproximateSeatedPose` helper, and import of `SkeletonUtils` to safely clone skeletons (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Integrated seated characters into scene setup and lifecycle: load the chosen outfit model, clone and attach one seated character per chair, rebuild characters when outfit selection changes (`rebuildCharacters`), and dispose character templates/instances on teardown.
- Updated the table setup preview for outfits to show image-backed character tiles and prevented color-rewrite of preserved GLTF materials by skipping outfit recolor when `preserveMaterials` is set.

### Testing
- Ran the production build with `npm --prefix webapp run build` (Vite build) and it completed successfully.
- Ran Playwright capture scripts against the running dev server to verify UI integration; WebKit and Firefox runs produced setup-panel screenshots showing the 5 character options, while Chromium failed to launch reliably in this environment (native binary crash / SIGSEGV) so in-scene WebGL captures were not produced there.
- Ran ESLint across the repo; linting reported many pre-existing errors across the codebase and therefore failed for the repository as a whole, but the new files follow the project style and the build succeeded despite repository lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3ed323cc832980965e45c5e08a14)