### PR TITLE
Adjust Pool Royale jaw/cue/ball alignment and opening in-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1103,7 +1103,7 @@ const POCKET_JAW_SIDE_OUTER_SCALE =
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.036; // nudge corner jaws a touch farther outward to keep the jaw shoulder aligned with the rail cut
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
 const POCKET_JAW_DEPTH_SCALE = 0.98; // extend all jaw bodies slightly so the inside profile reads a touch longer
-const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.102; // lower all six jaws slightly while keeping enough lip to prevent hop-outs
+const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.094; // lower all six jaws a touch more so the jaw mouths sit visibly farther down
 const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.03; // side-pocket jaw bottom clearance (keep middle-pocket jaw height unchanged)
 const POCKET_JAW_CORNER_BOTTOM_CLEARANCE = TABLE.THICK * 0.008; // reduce only corner-pocket bottom clearance so corner jaws extend farther downward
 const POCKET_JAW_FLOOR_CONTACT_LIFT = TABLE.THICK * 0.23; // keep the underside tight to the cloth depth instead of the deeper pocket floor
@@ -1281,7 +1281,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.148; // lift the balls a touch so they read higher while still rolling on the cloth surface
+const BALL_CENTER_LIFT = BALL_R * 0.172; // lift the balls slightly more so the bottom tangent sits on the cloth instead of dipping below it
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1677,7 +1677,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.18; // widen the visible air gap so the blue tip never kisses the cue ball
-const CUE_TIP_GAP = BALL_R * 1.16 + CUE_TIP_CLEARANCE; // pull the cue tip farther away so the blue tip is visible before impact
+const CUE_TIP_GAP = BALL_R * 1.22 + CUE_TIP_CLEARANCE; // pull the cue tip a bit farther from the cue ball so it does not look too close in aim view
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -22319,7 +22319,18 @@ const powerRef = useRef(hud.power);
         return false;
       };
 
-      const allowFullTableInHand = () => !isBreakRestrictedInHand();
+      const isOpeningInHandPlacement = () => {
+        const currentHud = hudRef.current;
+        return Boolean(
+          currentHud?.inHand &&
+            (currentHud?.turn ?? 0) === 0 &&
+            turnCycle === 0 &&
+            !cueBallPlacedFromHandRef.current
+        );
+      };
+
+      const allowFullTableInHand = () =>
+        !isBreakRestrictedInHand() && !isOpeningInHandPlacement();
 
       const isSpotFree = (point, clearanceMultiplier = 2.05) => {
         if (!point) return false;


### PR DESCRIPTION
### Motivation
- Improve visual alignment so pocket jaws, balls and cue stick read correctly in the aiming view (balls should sit on the cloth, cue tip should not appear too close, pocket jaws slightly lower). 
- Enforce expected ball-in-hand behavior at game start so the cue ball begins behind the baulk/white line for the first placement.

### Description
- Lowered pocket jaw vertical placement by adjusting `POCKET_JAW_VERTICAL_LIFT` to sit the jaw mouths fractionally lower for better visual alignment (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Raised ball center lift by increasing `BALL_CENTER_LIFT` so the ball bottom tangent visually sits on the cloth surface instead of appearing sunk (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Increased the cue tip gap (`CUE_TIP_GAP`) to pull the cue tip slightly farther from the cue ball so the cue does not look too close when aiming (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added `isOpeningInHandPlacement()` and updated `allowFullTableInHand()` so that on the opening turn (first placement, turnCycle==0) the full-table in-hand placement is restricted and the cue ball must remain behind the baulk/white line until initial placement is completed (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; linter returned a repository ignore warning for the file (no actionable lint errors emitted for the change).
- Ran `npm run build`; TypeScript build failed due to a pre-existing unrelated error in `src/rules/SnookerRoyalRules.ts` (not caused by these changes).
- Started the web dev server with the app (`npm --prefix webapp run dev`) which launched Vite and served the site locally (dev server reachable), but a Playwright screenshot attempt failed because Chromium crashed in the execution environment (SIGSEGV), so visual verification via headless browser could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c528162fc83299fb28f25b7658e33)