### PR TITLE
Pool Royale: lower cloth field slightly

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1269,7 +1269,7 @@ const CLOTH_LIFT = (() => {
   return Math.max(0, RAIL_HEIGHT - ballR - eps);
 })();
 const ACTION_CAMERA_START_BLEND = 1;
-const CLOTH_DROP = BALL_R * 0.18; // lower the cloth surface slightly for added depth
+const CLOTH_DROP = BALL_R * 0.2; // lower the cloth surface slightly for added depth
 const CLOTH_TOP_LOCAL = FRAME_TOP_Y + BALL_R * 0.09523809523809523;
 const MICRO_EPS = BALL_R * 0.022857142857142857;
 const POCKET_CUT_EXPANSION = POCKET_INTERIOR_TOP_SCALE; // align cloth apertures to the now-wider interior pocket diameter at the rim


### PR DESCRIPTION
### Motivation
- Make the Pool Royale playfield cloth sit a bit lower on-screen to match the requested visual tweak while leaving all other gameplay and presentation unchanged.

### Description
- Adjusted the cloth drop constant by changing `CLOTH_DROP` from `BALL_R * 0.18` to `BALL_R * 0.2` in `webapp/src/pages/Games/PoolRoyale.jsx` to lower the cloth plane slightly.

### Testing
- Ran `npx eslint` against the edited file which completed but reported the file is ignored by the repository lint ignore pattern (warning only).
- Started the web dev server with `npm --prefix webapp run dev` and the app served successfully for visual verification.
- Captured an automated portrait screenshot of the Pool Royale page via a Playwright script to validate the visual change (screenshot generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6be4007c83298b83d7641053179d)