### PR TITLE
Fix Pool Royale pocket potting regression in rail containment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6452,7 +6452,103 @@ function reflectRails(ball) {
       return { type: collided, normal, tangent, preImpactVel };
     }
   }
+
+  // Safety containment: only enforce hard table limits when the ball is not
+  // near any pocket mouth/capture lane, otherwise pocket mapping can be blocked.
+  const tablePocketMarkers =
+    table?.userData?.pockets && Array.isArray(table.userData.pockets)
+      ? table.userData.pockets
+      : null;
+  const safetyPocketCenters =
+    tablePocketMarkers && tablePocketMarkers.length > 0
+      ? tablePocketMarkers.map(
+          (marker) => new THREE.Vector2(marker.position.x, marker.position.z)
+        )
+      : pocketCenters();
+  const nearestPocket = safetyPocketCenters.reduce((best, center, index) => {
+    const dist = ball.pos.distanceTo(center);
+    const markerRadius =
+      tablePocketMarkers && tablePocketMarkers[index]
+        ? tablePocketMarkers[index]?.userData?.captureRadius
+        : null;
+    const captureRadius =
+      typeof markerRadius === 'number'
+        ? markerRadius
+        : index >= 4
+          ? SIDE_CAPTURE_R
+          : CAPTURE_R;
+    if (!best || dist < best.dist) {
+      return { dist, captureRadius };
+    }
+    return best;
+  }, null);
+  const insidePocketCapture =
+    nearestPocket && nearestPocket.dist <= nearestPocket.captureRadius;
+  const nearPocketSafetyLane =
+    nearestPocket &&
+    nearestPocket.dist <=
+      nearestPocket.captureRadius + Math.max(BALL_R * 0.7, CUSHION_CUT_NEAR_POCKET_BUFFER);
+  if (!insidePocketCapture && !nearPocketSafetyLane) {
+    const hardRailLimitX = limX + (BALL_R - railRadius);
+    const hardRailLimitY = limY + (BALL_R - railRadius);
+    let normal = null;
+    const preClampVel = ball.vel.clone();
+    if (ball.pos.x < -hardRailLimitX) {
+      ball.pos.x = -hardRailLimitX;
+      if (ball.vel.x < 0) ball.vel.x = Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+      normal = new THREE.Vector2(1, 0);
+    } else if (ball.pos.x > hardRailLimitX) {
+      ball.pos.x = hardRailLimitX;
+      if (ball.vel.x > 0) ball.vel.x = -Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+      normal = new THREE.Vector2(-1, 0);
+    }
+    if (ball.pos.y < -hardRailLimitY) {
+      ball.pos.y = -hardRailLimitY;
+      if (ball.vel.y < 0) ball.vel.y = Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+      normal = new THREE.Vector2(0, 1);
+    } else if (ball.pos.y > hardRailLimitY) {
+      ball.pos.y = hardRailLimitY;
+      if (ball.vel.y > 0) ball.vel.y = -Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+      normal = new THREE.Vector2(0, -1);
+    }
+    if (normal) {
+      const tangent = new THREE.Vector2(-normal.y, normal.x);
+      return {
+        type: 'rail',
+        normal,
+        tangent,
+        preImpactVel: preClampVel
+      };
+    }
+  }
   return null;
+}
+
+function activateCueSpinAfterImpact(ball) {
+  if (!ball || ball.id !== 'cue') return;
+  if (!ball.pendingSpin || ball.pendingSpin.lengthSq() < 1e-8) {
+    ball.impacted = true;
+    return;
+  }
+  ball.spin.copy(ball.pendingSpin);
+  ball.pendingSpin.set(0, 0);
+  if (ball.omega) {
+    TMP_VEC3_A.set(ball.vel.x, 0, ball.vel.y);
+    if (TMP_VEC3_A.lengthSq() < 1e-8 && ball.launchDir?.lengthSq?.() > 1e-8) {
+      TMP_VEC3_A.set(ball.launchDir.x, 0, ball.launchDir.y);
+    }
+    if (TMP_VEC3_A.lengthSq() > 1e-8) {
+      TMP_VEC3_A.normalize();
+      TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x).normalize();
+      TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(ball.spin.x * BALL_R);
+      TMP_VEC3_C.y += ball.spin.y * BALL_R;
+      const impulseMag = BALL_MASS * Math.max(ball.vel.length(), SHOT_BASE_SPEED * 0.5);
+      TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+      TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+      ball.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+    }
+  }
+  ball.impacted = true;
 }
 
 function resolveSpinFrame(ball) {
@@ -6819,8 +6915,9 @@ function calcTarget(cue, dir, balls) {
   let targetBall = null;
   let railNormal = null;
 
-  const limX = RAIL_LIMIT_X;
-  const limY = RAIL_LIMIT_Y;
+  const railRadius = RAIL_CONTACT_RADIUS;
+  const limX = RAIL_LIMIT_X + (BALL_R - railRadius);
+  const limY = RAIL_LIMIT_Y + (BALL_R - railRadius);
   const checkRail = (t, normal) => {
     if (t >= 0 && t < tHit) {
       tHit = t;
@@ -23228,22 +23325,12 @@ const powerRef = useRef(hud.power);
           }
           cue.vel.copy(base);
           if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
+            cue.spin.set(0, 0);
           }
           if (cue.omega) {
             cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
           }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+          if (cue.pendingSpin) cue.pendingSpin.set(spinSide, spinTop);
           cue.spinMode = 'standard';
           cue.swerveStrength = 0;
           cue.swervePowerStrength = 0;
@@ -27290,7 +27377,9 @@ const powerRef = useRef(hud.power);
               b.launchDir = null;
             }
             const railImpact = reflectRails(b);
-            if (railImpact && b.id === 'cue') b.impacted = true;
+            if (railImpact && b.id === 'cue') {
+              activateCueSpinAfterImpact(b);
+            }
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;
             }
@@ -27450,8 +27539,8 @@ const powerRef = useRef(hud.power);
                 ) {
                   activeShotView.hitConfirmed = true;
                 }
-                if (cueBall && cueBall.omega?.lengthSq() > 0) {
-                  cueBall.impacted = true;
+                if (cueBall) {
+                  activateCueSpinAfterImpact(cueBall);
                 }
               }
             }


### PR DESCRIPTION
### Motivation
- A previous containment fallback caused valid potting to be blocked by hard clamping near pocket mouths, so restore natural potting while still preventing balls from escaping the table. 
- Maintain the anti-escape safety for non-pocket rail regions and keep cue spin deferred until the ball actually makes contact so preview and real-world impacts remain consistent.

### Description
- Updated `reflectRails` containment logic to prefer runtime pocket markers from `table.userData.pockets` (with fallback to `pocketCenters()`), and compute pocket capture radii from marker `userData` when available. 
- Added a near-pocket safety lane exclusion so hard containment is skipped around pocket mouths (`nearestPocket.captureRadius + buffer`) to avoid blocking pocket mapping, and preserved synthetic rail-impact returns for true out-of-bounds corrections using a `preClampVel`. 
- Introduced `activateCueSpinAfterImpact(ball)` which transfers `pendingSpin` into `spin`/`omega` on first contact and computes the corresponding angular impulse, and wired its invocation into both rail-impact handling and ball-ball collision handling. 
- Changed shot launch flow to zero active `spin`/`omega` on launch and store intended spin into `pendingSpin`, and adjusted aiming prediction in `calcTarget` to use the contact-radius-adjusted rail bounds for consistent guidance.

### Testing
- Built the app with `npm --prefix webapp run build` and the production build completed successfully. 
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app starts for manual/visual checks. 
- Captured a portrait smoke-check screenshot via Playwright against the local dev server to validate that pocket mapping and UI render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c95725ab08329818cc2cb00060ea0)