### PR TITLE
Fix Domino Battle Royal GLTF texture breakage by cloning materials/textures per instance

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1833,6 +1833,55 @@ const CHAIR_MODEL_URLS = [
 ];
 const polyhavenModelCache = new Map();
 
+function cloneTextureForInstance(texture, textureCache) {
+  if (!texture?.isTexture) return texture;
+  if (textureCache.has(texture)) {
+    return textureCache.get(texture);
+  }
+  const clone = texture.clone();
+  clone.needsUpdate = true;
+  textureCache.set(texture, clone);
+  return clone;
+}
+
+function cloneMaterialForInstance(material, textureCache) {
+  if (!material?.isMaterial) return material;
+  const clone = material.clone();
+  for (const key of Object.keys(clone)) {
+    const value = clone[key];
+    if (value?.isTexture) {
+      clone[key] = cloneTextureForInstance(value, textureCache);
+    }
+  }
+  return clone;
+}
+
+function cloneModelForInstance(root) {
+  const clone = root.clone(true);
+  const sourceMeshes = [];
+  const cloneMeshes = [];
+  const textureCache = new Map();
+
+  root.traverse((node) => {
+    if (node?.isMesh) sourceMeshes.push(node);
+  });
+
+  clone.traverse((node) => {
+    if (node?.isMesh) cloneMeshes.push(node);
+  });
+
+  const count = Math.min(sourceMeshes.length, cloneMeshes.length);
+  for (let i = 0; i < count; i += 1) {
+    const sourceMesh = sourceMeshes[i];
+    const cloneMesh = cloneMeshes[i];
+    const sourceMaterials = Array.isArray(sourceMesh.material) ? sourceMesh.material : [sourceMesh.material];
+    const clonedMaterials = sourceMaterials.map((material) => cloneMaterialForInstance(material, textureCache));
+    cloneMesh.material = Array.isArray(sourceMesh.material) ? clonedMaterials : clonedMaterials[0];
+  }
+
+  return clone;
+}
+
 function createPolyhavenGltfLoader({ assetId, resolution }) {
   const manager = new THREE.LoadingManager();
   manager.setURLModifier((url) => {
@@ -1856,7 +1905,7 @@ async function loadPolyhavenModel(assetId) {
   if (!assetId) return null;
   if (polyhavenModelCache.has(assetId)) {
     const cached = polyhavenModelCache.get(assetId);
-    return cached.clone(true);
+    return cloneModelForInstance(cached);
   }
   const candidates = [
     { url: `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`, resolution: '2k' },
@@ -1890,7 +1939,7 @@ async function loadPolyhavenModel(assetId) {
     });
   });
   polyhavenModelCache.set(assetId, root);
-  return root.clone(true);
+  return cloneModelForInstance(root);
 }
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478;


### PR DESCRIPTION
### Motivation
- The Domino table/chair themes loaded from Poly Haven sometimes lost or shared textures when instances were cloned, due to returning `scene.clone(true)` which kept shared material/texture references and caused disposal/mutation side effects.

### Description
- Added `cloneTextureForInstance`, `cloneMaterialForInstance`, and `cloneModelForInstance` helpers to deep-clone textures and materials for each model instance. 
- Updated `loadPolyhavenModel()` to return per-instance clones via `cloneModelForInstance()` for both cache hits and fresh loads so each rendered theme gets isolated texture objects. 
- Change is contained to `webapp/public/domino-royal-game.js` and does not modify gameplay logic.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which succeeded. 
- Ran `npx eslint webapp/public/domino-royal-game.js` which produced a repository ignore warning but no blocking errors. 
- Launched the webapp dev server with `npm --prefix webapp run dev` and performed a visual smoke test by loading `/games/domino-royal` and capturing a Playwright screenshot; visual verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd81258348329bf02a59629bdf75c)