### PR TITLE
Pool Royale: full-table ball‑in‑hand, spin-after-impact, and raised pocket cams

### DIFF
--- a/lib/poolUk8Ball.js
+++ b/lib/poolUk8Ball.js
@@ -220,7 +220,9 @@ export class UkPool {
       shotsNext = 1;
       s.currentPlayer = nextPlayer;
       s.shotsRemaining = shotsNext;
-      s.mustPlayFromBaulk = Boolean(isBreak);
+      // Ball in hand after a foul should allow full-table placement.
+      // Only the opening break shot itself is baulk-restricted.
+      s.mustPlayFromBaulk = false;
       s.lastEvent = 'FOUL';
       if (blackPotted) {
         frameOver = true;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -489,10 +489,7 @@ export class PoolRoyaleRules {
       phase: frameOver ? 'complete' : 'run',
       scores
     };
-    const breakInProgress =
-      Boolean(previous?.state?.breakInProgress) && Boolean(result.foul)
-        ? true
-        : Boolean(snapshot.breakInProgress);
+    const breakInProgress = Boolean(snapshot.breakInProgress);
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -81,6 +81,7 @@ describe('PoolRoyaleRules', () => {
     const scratchMeta = scratch.meta as any;
 
     expect(scratch.foul?.reason).toBe('scratch');
+    expect(scratchMeta?.breakInProgress).toBe(false);
     expect(scratchMeta?.state?.ballInHand).toBe(true);
     expect(scratch.activePlayer).toBe('B');
     expect(scratch.ballOn).toEqual(['STRIPE']);

--- a/test/poolUk8Ball.test.js
+++ b/test/poolUk8Ball.test.js
@@ -4,7 +4,7 @@ import { UkPool } from '../lib/poolUk8Ball.js';
 import { selectShot, recordShotOutcome, __resetShotMemory } from '../lib/poolUkAdvancedAi.js';
 import planShot from '../lib/poolAi.js';
 
-test('scratch on break gives opponent ball in hand', () => {
+test('scratch on break gives opponent full-table ball in hand', () => {
   const game = new UkPool();
   game.startBreak();
   const res = game.shotTaken({
@@ -17,7 +17,7 @@ test('scratch on break gives opponent ball in hand', () => {
   assert.equal(res.foul, true);
   assert.equal(res.nextPlayer, 'B');
   assert.equal(res.shotsRemainingNext, 1);
-  assert.equal(game.state.mustPlayFromBaulk, true);
+  assert.equal(game.state.mustPlayFromBaulk, false);
 });
 
 test('after foul player must hit a valid colour first', () => {
@@ -227,7 +227,7 @@ test('potting black when one colour cleared on open table is legal', () => {
   assert.equal(res.winner, 'A');
 });
 
-test('after foul cue must be played from baulk', () => {
+test('after foul cue can be played from anywhere on table', () => {
   const game = new UkPool();
   game.shotTaken({
     contactOrder: ['blue'],
@@ -243,8 +243,7 @@ test('after foul cue must be played from baulk', () => {
     noCushionAfterContact: false,
     placedFromHand: false
   });
-  assert.equal(res.foul, true);
-  assert.equal(res.reason, 'must play from baulk');
+  assert.equal(res.foul, false);
 });
 
 test('shots after frame end are not fouls', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1490,8 +1490,8 @@ const POCKET_CAM = Object.freeze({
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
   // Lift pocket cameras a bit higher so pocket closeups read more top-down.
-  heightOffset: BALL_R * 2.18,
-  heightOffsetShortMultiplier: 1.24,
+  heightOffset: BALL_R * 2.3,
+  heightOffsetShortMultiplier: 1.3,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
     POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 * POCKET_CAM_INWARD_SCALE +
@@ -6506,6 +6506,7 @@ function decaySpin(ball, stepScale, airborne = false) {
 
 function applySpinController(ball, stepScale, airborne = false) {
   if (!ball?.spin || ball.spin.lengthSq() < 1e-6) return false;
+  if (ball.id === 'cue' && !ball.impacted) return false;
   if (airborne && ball.id === 'cue') {
     ball.spin.set(0, 0);
     if (ball.pendingSpin) ball.pendingSpin.set(0, 0);


### PR DESCRIPTION
### Motivation
- Clarify ball‑in‑hand behavior so a foul grants full‑table placement (not restricted to baulk), while the opening break still uses baulk rules. 
- Ensure cue spin / swerve only takes effect after the cue has contacted a ball or rail so previews and pre‑impact deflection are removed. 
- Improve pocket closeups by lifting pocket camera framing slightly for a more top‑down view.

### Description
- UK 8‑ball foul handling: clear `mustPlayFromBaulk` on fouls so the incoming player receives full‑table in‑hand placement (file: `lib/poolUk8Ball.js`).
- PoolRoyale state mapping: derive `breakInProgress` directly from the serialized game engine state to avoid carrying break placement restrictions across fouls (file: `src/rules/PoolRoyaleRules.ts`).
- Spin activation: prevent cue‑ball spin from affecting motion before first impact by short‑circuitting in the spin controller when the cue has not yet `impacted` (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Pocket camera lift: increased `POCKET_CAM.heightOffset` and `heightOffsetShortMultiplier` to lift pocket cameras slightly higher (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Tests updated to reflect the new behavior and expectations for in‑hand/foul and break metadata (files: `test/poolUk8Ball.test.js`, `test/poolRoyaleRules.test.ts`).

### Testing
- Ran targeted unit tests for UK pool changes: `npm test -- test/poolUk8Ball.test.js -t "scratch on break|after foul cue can"` — passed.
- Ran the full Jest run for modified suites: an earlier run surfaced failures that were addressed by updating test expectations; targeted tests now pass but the full monorepo `npm test` still shows unrelated failures when run previously.
- Attempted TypeScript build with `npm run build` which failed due to a pre‑existing type error in `src/rules/SnookerRoyalRules.ts` unrelated to these changes (build error reported by `tsc`).
- Started the web dev server (`npm --prefix webapp run dev`) successfully but an automated Playwright screenshot attempt failed due to the Chromium process crashing (SIGSEGV) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6b2b9cc083298b24eb12aac3b1db)