### PR TITLE
Fix platform stats for storefront totals and unauthenticated account handling

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -828,6 +828,7 @@ app.get('/api/stats', async (req, res) => {
       User.countDocuments({ ...AUTHENTIC_ACCOUNT_QUERY, telegramId: { $exists: true, $ne: null } }),
       User.countDocuments({ ...AUTHENTIC_ACCOUNT_QUERY, googleId: { $exists: true, $nin: ['', null] } }),
       User.countDocuments({
+        isBanned: { $ne: true },
         $and: [
           { $or: [{ telegramId: { $exists: false } }, { telegramId: null }] },
           { $or: [{ googleId: { $exists: false } }, { googleId: { $in: ['', null] } }] }

--- a/webapp/src/components/PlatformStatsCard.jsx
+++ b/webapp/src/components/PlatformStatsCard.jsx
@@ -4,6 +4,15 @@ import { FaCoins, FaFireAlt, FaGamepad, FaLayerGroup, FaStore, FaUsers } from 'r
 import { GiToken } from 'react-icons/gi';
 
 import { getAppStats } from '../utils/api.js';
+import { POOL_ROYALE_STORE_ITEMS } from '../config/poolRoyaleInventoryConfig.js';
+import { SNOOKER_ROYALE_STORE_ITEMS } from '../config/snookerRoyalInventoryConfig.js';
+import { AIR_HOCKEY_STORE_ITEMS } from '../config/airHockeyInventoryConfig.js';
+import { CHESS_BATTLE_STORE_ITEMS } from '../config/chessBattleInventoryConfig.js';
+import { LUDO_BATTLE_STORE_ITEMS } from '../config/ludoBattleInventoryConfig.js';
+import { MURLAN_ROYALE_STORE_ITEMS } from '../config/murlanInventoryConfig.js';
+import { DOMINO_ROYAL_STORE_ITEMS } from '../config/dominoRoyalInventoryConfig.js';
+import { SNAKE_STORE_ITEMS } from '../config/snakeInventoryConfig.js';
+import { TEXAS_HOLDEM_STORE_ITEMS } from '../config/texasHoldemInventoryConfig.js';
 
 const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
@@ -11,6 +20,18 @@ const compactFormatter = new Intl.NumberFormat('en-US', {
   notation: 'compact',
   maximumFractionDigits: 1
 });
+
+const TOTAL_STORE_ITEMS = [
+  POOL_ROYALE_STORE_ITEMS,
+  SNOOKER_ROYALE_STORE_ITEMS,
+  AIR_HOCKEY_STORE_ITEMS,
+  CHESS_BATTLE_STORE_ITEMS,
+  LUDO_BATTLE_STORE_ITEMS,
+  MURLAN_ROYALE_STORE_ITEMS,
+  DOMINO_ROYAL_STORE_ITEMS,
+  SNAKE_STORE_ITEMS,
+  TEXAS_HOLDEM_STORE_ITEMS
+].reduce((sum, items) => sum + (Array.isArray(items) ? items.length : 0), 0);
 
 function toNumber(value) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -98,12 +119,16 @@ export default function PlatformStatsCard() {
     const nftBurned =
       firstNumber(stats, ['nftsBurned', 'nftBurned', 'nft.burned', 'nfts.retired']);
 
-    const nftStoreItems = firstNumber(stats, [
+    const nftStoreItemsFromApi = firstNumber(stats, [
       'nftStoreItems',
       'storeNfts',
       'store.nftItems',
       'nfts.store'
     ]);
+    const nftStoreItems =
+      nftStoreItemsFromApi !== null && nftStoreItemsFromApi > 0
+        ? nftStoreItemsFromApi
+        : TOTAL_STORE_ITEMS;
 
     const totalNftItems = firstNumber(stats, [
       'totalNftItems',
@@ -199,7 +224,7 @@ export default function PlatformStatsCard() {
     {
       label: 'Store NFTs',
       value: formatStat(normalizedStats.nftStoreItems),
-      helper: 'Total NFT cosmetics sold in the storefront',
+      helper: 'Total NFT cosmetics listed in the storefront',
       icon: FaStore,
       iconClass: 'text-indigo-300'
     },

--- a/webapp/src/pages/PlatformStatsDetails.jsx
+++ b/webapp/src/pages/PlatformStatsDetails.jsx
@@ -28,7 +28,7 @@ export default function PlatformStatsDetails() {
       { label: 'Authentic accounts', value: summary.authenticAccounts ?? stats?.accounts ?? 0 },
       { label: 'Telegram accounts', value: summary.telegramAccounts ?? stats?.telegramAccounts ?? 0 },
       { label: 'Google accounts', value: summary.googleAccounts ?? stats?.googleAccounts ?? 0 },
-      { label: 'Unauthenticated accounts', value: summary.unauthenticatedAccounts ?? stats?.unauthenticatedAccounts ?? 0 },
+      { label: 'Unauthenticated accounts (active)', value: summary.unauthenticatedAccounts ?? stats?.unauthenticatedAccounts ?? 0 },
       { label: 'Banned accounts', value: summary.bannedAccounts ?? stats?.bannedAccounts ?? 0 },
       { label: 'Active users now', value: stats?.activeUsers ?? 0 }
     ],
@@ -39,7 +39,7 @@ export default function PlatformStatsDetails() {
     <div className="space-y-4 text-text pb-4">
       <h2 className="text-2xl font-bold text-center mt-4">Platform Stats Details</h2>
       <p className="text-xs text-subtext text-center">
-        Home now only counts authentic Telegram/Google accounts. Guest-only accounts are tracked here for fraud review.
+        Home now only counts authentic Telegram/Google accounts. Any guest-only accounts should be moved into the banned pool.
       </p>
 
       <div className="grid grid-cols-2 gap-2">


### PR DESCRIPTION
### Motivation

- The Home "Store NFTs" metric showed `0` when API data was missing, but it should reflect the total number of items available in the storefront catalog.  
- Unauthenticated guest accounts should be reported as active-only and not include already-banned accounts so cleanup workflows can target the right users.  
- The Platform Stats details copy needed clarification to align with the intended banning/cleanup flow for guest-only accounts.

### Description

- Updated `webapp/src/components/PlatformStatsCard.jsx` to import per-game store item lists and compute a `TOTAL_STORE_ITEMS` fallback so the `Store NFTs` stat uses the API value when present and otherwise shows the configured catalog size.  
- Adjusted the `Store NFTs` helper text to read "Total NFT cosmetics listed in the storefront" to match the new meaning.  
- Changed the server stats aggregation in `bot/server.js` so unauthenticated account counting excludes `isBanned: true` users, making the unauthenticated metric represent active guest accounts only.  
- Updated `webapp/src/pages/PlatformStatsDetails.jsx` to rename the card to `Unauthenticated accounts (active)` and clarify the explanatory copy about how guest-only accounts should be handled.

### Testing

- Ran `npx eslint webapp/src/components/PlatformStatsCard.jsx webapp/src/pages/PlatformStatsDetails.jsx bot/server.js`, which completed but returned repository ignore warnings for those paths.  
- Ran `npm run build`, which failed due to an unrelated pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` and is not caused by these changes.  
- Launched the web dev server and executed a Playwright script to render the homepage at a mobile portrait viewport and capture a screenshot, which completed successfully and produced an artifact showing the updated platform stats card.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d96a284a88329a9db57a923426d9f)