### PR TITLE
Add public user-transfer telemetry to Platform Intelligence Center

### DIFF
--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -663,6 +663,10 @@ export function getMiningTransactions(limit = 1000) {
   return get(`/api/mining/transactions?limit=${limit}`);
 }
 
+export function getPublicTransfers(limit = 1000) {
+  return get(`/api/account/transfers/public?limit=${limit}`);
+}
+
 export function depositAccount(accountId, amount, extra = {}) {
   return post(
     '/api/account/deposit',


### PR DESCRIPTION
### Motivation
- Provide a single Platform Intelligence view that includes game rewards, mining rewards, and user-to-user transfers so platform operators can inspect all inter-account flows and audit activity. 

### Description
- Added a backend aggregation endpoint `GET /api/account/transfers/public` that exposes public wallet transfers derived from wallet `send` transactions with `amount`, `token`, `date`, `note`, `fromAccount`, `fromName`, `toAccount`, and `toName` (see `bot/routes/account.js`).
- Added a frontend API helper `getPublicTransfers(limit)` pointing to `/api/account/transfers/public` in `webapp/src/utils/api.js` so the webapp can fetch transfer telemetry.
- Extended the Platform Intelligence UI (`webapp/src/pages/PlatformStatsDetails.jsx`) to fetch game transactions, mining transactions and the new transfer feed, compute counts/volumes and render: high-level cards for game/mining/transfer activity and a recent transfer preview list showing `sender → receiver` entries with amount, token, date and note.
- Key files changed: `bot/routes/account.js`, `webapp/src/utils/api.js`, `webapp/src/pages/PlatformStatsDetails.jsx`.

### Testing
- Ran unit tests: `npm test -- --runInBand test/walletRoutes.test.js` and the suite passed (2 tests, both passed). 
- Built the webapp assets with `npm --prefix webapp run build` and the build completed successfully. 
- Launched the dev server and captured a screenshot of `/platform-stats` to validate the new transactions feed rendered (artifact captured during automated run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db6aebc0c8329a5ba5c39a8711a46)