### PR TITLE
Refine Pool Royale cue-stick animation and replay/camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1064,7 +1064,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   pockets: false
 });
 const SHOW_SHORT_RAIL_TRIPODS = false;
-const LOCK_REPLAY_CAMERA = false;
+const LOCK_REPLAY_CAMERA = true; // keep replay on the standing broadcast framing instead of switching to shot/pocket cuts
 const FIXED_RAIL_REPLAY_CAMERA = false;
 const LOCK_RAIL_OVERHEAD_FRAME = true;
 const REPLAY_CUE_STICK_HOLD_MS = 760;
@@ -1702,6 +1702,7 @@ const PLAYER_CUE_STRIKE_MAX_MS = 1400;
 const PLAYER_CUE_FORWARD_MIN_MS = 520;
 const PLAYER_CUE_FORWARD_MAX_MS = 920;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
+const PLAYER_CUE_STROKE_SLOWDOWN = 1.85; // noticeably slow down cue-stick motion so pullback + forward push are clearly readable during live shots
 const CUE_STRIKE_HOLD_MS = 80;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
@@ -23499,12 +23500,16 @@ const powerRef = useRef(hud.power);
           }
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
           const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const forwardDuration = THREE.MathUtils.lerp(
+          const baseForwardDuration = THREE.MathUtils.lerp(
             PLAYER_CUE_FORWARD_MAX_MS,
             PLAYER_CUE_FORWARD_MIN_MS,
             forwardBlend
           );
-          const pullbackDuration = Math.max(120, forwardDuration * 0.65);
+          const forwardDuration = baseForwardDuration * PLAYER_CUE_STROKE_SLOWDOWN;
+          const pullbackDuration = Math.max(
+            120,
+            baseForwardDuration * 0.65 * PLAYER_CUE_STROKE_SLOWDOWN
+          );
           const startTime = performance.now();
           const followThrough = THREE.MathUtils.lerp(
             CUE_FOLLOW_THROUGH_MIN,
@@ -23519,13 +23524,16 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_SPEED_MAX,
             powerStrength
           );
-          const followDuration = THREE.MathUtils.clamp(
+          const baseFollowDuration = THREE.MathUtils.clamp(
             (followThrough / Math.max(followSpeed, 1e-6)) * 1000,
             CUE_FOLLOW_MIN_MS,
             CUE_FOLLOW_MAX_MS
           );
-          const followDurationResolved = followDuration;
-          const recoverDuration = Math.max(120, followDurationResolved * 0.6);
+          const followDurationResolved = baseFollowDuration * PLAYER_CUE_STROKE_SLOWDOWN;
+          const recoverDuration = Math.max(
+            120,
+            baseFollowDuration * 0.6 * PLAYER_CUE_STROKE_SLOWDOWN
+          );
           const impactTime = startTime + pullbackDuration + forwardDuration;
           const forwardPreviewHold =
             impactTime +
@@ -23599,7 +23607,8 @@ const powerRef = useRef(hud.power);
               suspendedActionView = actionView;
             }
           }
-          openingShotViewSuppressedRef.current = false;
+          // Keep the opening break on the stable standing camera; enable dynamic shot cameras from the next shot onward.
+          openingShotViewSuppressedRef.current = Boolean(isBreakShot);
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -27769,7 +27778,8 @@ const powerRef = useRef(hud.power);
               cueBall?.vel && typeof cueBall.vel.length === 'function'
                 ? cueBall.vel.length() * frameScale
                 : 0;
-            if (earlyPocketIntent.allowEarly && cueSpeed > STOP_EPS) {
+            const strokeAnimating = Boolean(cueStrokeStateRef.current);
+            if (earlyPocketIntent.allowEarly && cueSpeed > STOP_EPS && !strokeAnimating) {
               powerImpactHoldRef.current = 0;
             }
           }


### PR DESCRIPTION
### Motivation
- Players reported the cue-stick animation is too fast and the forward push is often not visible during live shots, while replay framing jumps to pocket/action cuts instead of showing the broadcast/standing view. 
- The initial break should remain on a stable standing camera instead of zooming/moving at game start to preserve player orientation.

### Description
- Locked replay framing by setting `LOCK_REPLAY_CAMERA = true` so replays use the standing/broadcast-style camera instead of switching to per-shot pocket/action cuts. 
- Slowed live cue-stick playback by increasing `PLAYER_CUE_STROKE_SLOWDOWN` to `1.85` and updated dependent forward/pull/follow/recover duration calculations so pullback and forward push are clearly visible. 
- Kept the opening break on the stable standing camera by changing `openingShotViewSuppressedRef.current` to `Boolean(isBreakShot)` so dynamic camera switches are deferred until after the break. 
- Prevented early pocket camera activation while a cue stroke animation is still running by checking `cueStrokeStateRef.current` before clearing `powerImpactHoldRef.current`. 
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and adjust camera/replay and cue-stroke timing logic.

### Testing
- Ran `cd webapp && npm run build` and the production build completed successfully. 
- Launched the dev server (`npm run dev`) successfully, but an automated Playwright screenshot attempt against the local server timed out in this environment. 
- Verified the modified file compiles as part of the build and the application starts in dev mode without runtime build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbb3977cc8329942f23ffa99aeced)