### PR TITLE
Compute full-history transaction intelligence in /api/stats and surface totals in UI

### DIFF
--- a/webapp/src/components/PlatformStatsCard.jsx
+++ b/webapp/src/components/PlatformStatsCard.jsx
@@ -138,7 +138,7 @@ export default function PlatformStatsCard() {
     ]);
 
     const activeMatches =
-      firstNumber(stats, ['activeUsers', 'activeMatches', 'matchesLive', 'games.active']);
+      firstNumber(stats, ['matchesLive', 'activeUsers', 'activeMatches', 'games.active']);
 
     const socialActions =
       firstNumber(stats, [

--- a/webapp/src/pages/PlatformStatsDetails.jsx
+++ b/webapp/src/pages/PlatformStatsDetails.jsx
@@ -187,7 +187,7 @@ export default function PlatformStatsDetails() {
       'tasksCompleted'
     ]);
 
-    const liveGames = pickNumber(stats, ['activeMatches', 'games.active', 'matchesLive']);
+    const liveGames = pickNumber(stats, ['matchesLive', 'activeMatches', 'games.active']);
     const gamesPlayed = pickNumber(stats, ['gamesPlayed', 'matchesPlayed', 'games.total', 'matches.total']);
 
     const transferCount = pickNumber(stats, [
@@ -301,20 +301,28 @@ export default function PlatformStatsDetails() {
     });
 
   const transactionHighlights = useMemo(() => {
-    const gameVolume = gameTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
-    const miningVolume = miningTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
-    const transferVolumeLive = transferTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+    const gameVolumeFromFeed = gameTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+    const miningVolumeFromFeed = miningTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+    const transferVolumeFromFeed = transferTransactions.reduce((sum, tx) => sum + Math.abs(tx.amount || 0), 0);
+
+    const gameCountFromStats = pickNumber(stats, ['gameTransactionsCount']);
+    const gameVolumeFromStats = pickNumber(stats, ['gameTransactionsVolume']);
+    const miningCountFromStats = pickNumber(stats, ['miningTransactionsCount']);
+    const miningVolumeFromStats = pickNumber(stats, ['miningTransactionsVolume']);
+    const transferCountFromStats = pickNumber(stats, ['transferCount']);
+    const transferVolumeFromStats = pickNumber(stats, ['transferVolume']);
 
     return {
-      gameCount: gameTransactions.length,
-      miningCount: miningTransactions.length,
-      transferCount: transferTotalCount ?? transferTransactions.length,
-      gameVolume,
-      miningVolume,
-      transferVolumeLive,
-      transferPreview: transferTransactions.slice(0, 8)
+      gameCount: gameCountFromStats ?? gameTransactions.length,
+      miningCount: miningCountFromStats ?? miningTransactions.length,
+      transferCount: transferCountFromStats ?? transferTotalCount ?? transferTransactions.length,
+      gameVolume: gameVolumeFromStats ?? gameVolumeFromFeed,
+      miningVolume: miningVolumeFromStats ?? miningVolumeFromFeed,
+      transferVolume: transferVolumeFromStats ?? transferVolumeFromFeed,
+      transferPreview: transferTransactions.slice(0, 8),
+      intelligenceGeneratedAt: stats?.intelligenceGeneratedAt || null
     };
-  }, [gameTransactions, miningTransactions, transferTransactions, transferTotalCount]);
+  }, [gameTransactions, miningTransactions, transferTransactions, transferTotalCount, stats]);
 
   const trustCards = [
     {
@@ -395,11 +403,20 @@ export default function PlatformStatsDetails() {
           <StatCard
             label="User transfers"
             value={formatStat(transactionHighlights.transferCount)}
-            helper={`${formatValue(transactionHighlights.transferVolumeLive)} TPC sent`}
+            helper={`${formatValue(transactionHighlights.transferVolume)} TPC sent`}
             icon={FaExchangeAlt}
             iconClass="text-cyan-300"
           />
         </div>
+        {transactionHighlights.intelligenceGeneratedAt ? (
+          <p className="mt-2 text-[11px] text-subtext">
+            Full-history totals synced at{' '}
+            {new Date(transactionHighlights.intelligenceGeneratedAt).toLocaleString(undefined, {
+              hour12: false
+            })}
+            .
+          </p>
+        ) : null}
         <div className="mt-3 max-h-56 space-y-2 overflow-y-auto">
           {transactionHighlights.transferPreview.length === 0 ? (
             <p className="rounded-md border border-white/10 bg-black/20 p-3 text-xs text-subtext">


### PR DESCRIPTION
### Motivation
- Existing intelligence numbers were derived from capped recent feeds and could under-report real totals for transfers, game rewards and mining; a full-history aggregate is required for accurate, auditable platform telemetry. 
- The Platform Intelligence Center should show a clear freshness timestamp and the true live matches count to aid operator decisions.

### Description
- Added a MongoDB aggregation in `bot/server.js` to compute full-history totals: `transferCount`, `transferVolume`, `gameTransactionsCount`, `gameTransactionsVolume`, `miningTransactionsCount`, `miningTransactionsVolume`, plus `matchesLive` and `intelligenceGeneratedAt` timestamp. 
- Updated `webapp/src/pages/PlatformStatsDetails.jsx` to prefer the full-history totals from `/api/stats` for the transaction cards and volumes while preserving the recent transfer preview list. 
- Adjusted `webapp/src/components/PlatformStatsCard.jsx` to prefer `matchesLive` when reporting live activity for more accurate display.
- The UI now surfaces the `intelligenceGeneratedAt` time so consumers can see when the full-history totals were computed.

### Testing
- Built the web UI with `npm --prefix webapp run build` which completed successfully. 
- Performed a syntax check on the backend with `node --check bot/server.js` which succeeded. 
- Launched the dev server and captured a screenshot of `/platform-stats` via an automated Playwright script to validate the rendered changes (screenshot produced). 
- `npx eslint --no-ignore` reported many pre-existing repository lint/style violations (baseline errors in `bot/server.js`) so a lint pass against the whole repo failed; the change itself follows the project style but a repository lint cleanup is required to get a clean ESLint result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e072a2dec832986112f1acb79cc87)