### PR TITLE
Improve profile page section grouping and layout

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -646,8 +646,13 @@ export default function MyAccount() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-        <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-base font-semibold">Profile setup</h3>
+          <span className="text-[11px] uppercase tracking-wide text-subtext">Identity & security</span>
+        </div>
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+          <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
           <div className="flex items-start gap-2">
             <FiExternalLink className="w-4 h-4 mt-1 text-primary" />
             <div>
@@ -704,164 +709,184 @@ export default function MyAccount() {
               <button onClick={handleConnectTwitter} className="px-3 py-2 border border-border hover:bg-background/70 rounded text-sm">Connect</button>
             </div>
           </div>
-        </div>
-
-        <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-1">
-            <p className="font-semibold text-white inline-flex items-center gap-2"><FiShield className="w-4 h-4 text-primary" />Profile protection</p>
-            <p className="text-xs text-subtext">
-              Lock this page with a PIN, pattern, password, or device biometrics/passkey. Unlocking works across browsers, with
-              recovery codes for emergencies.
-            </p>
-            <ul className="mt-2 text-xs text-subtext list-disc list-inside space-y-1">
-              <li>Use biometrics/passkeys when your device supports them.</li>
-              <li>Create a backup PIN or password for other browsers.</li>
-              <li>Store recovery codes offline to avoid lockouts.</li>
-            </ul>
           </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            className="px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded text-sm"
-            onClick={() => handleSecretLock({ method: 'pin', label: 'PIN / Pattern lock' })}
-          >
-            <FiLock className="inline w-3.5 h-3.5 mr-1" />
-            Set PIN / Pattern
-          </button>
-          <button
-            className="px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded text-sm"
-            onClick={() => handleSecretLock({ method: 'password', label: 'Password lock' })}
-          >
-            <FiLock className="inline w-3.5 h-3.5 mr-1" />
-            Set Password
-          </button>
-          <button
-            className="px-3 py-1 border border-border text-white rounded text-sm disabled:opacity-50"
-            onClick={handleDeviceLock}
-            disabled={!deviceSupported}
-          >
-            Use biometrics / passkey
-          </button>
-          {lockConfig && (
-            <button
-              className="px-3 py-1 border border-border text-white rounded text-sm"
-              onClick={() => {
-                disableLock();
-                setLockFeedback('Profile lock disabled for this session.', 'success');
-              }}
-            >
-              Disable lock
-            </button>
-          )}
-        </div>
-        {lockMessage && (
-          <p
-            className={`text-xs ${
-              lockMessageTone === 'success'
-                ? 'text-green-400'
-                : lockMessageTone === 'error'
-                  ? 'text-red-400'
-                  : 'text-subtext'
-            }`}
-          >
-            {lockMessage}
-          </p>
-        )}
-        {!deviceSupported && (
-          <p className="text-xs text-amber-300">
-            Passkeys/biometrics are not supported on this browser. Try Chrome, Safari, or a modern mobile browser.
-          </p>
-        )}
-        {(showRecoveryCodes.length ? showRecoveryCodes : issuedRecoveryCodes)?.length > 0 && (
-          <div className="rounded-lg border border-border bg-background/40 p-3 space-y-2">
-            <p className="text-xs text-white">Save these recovery codes (one-time use):</p>
-            <div className="flex flex-wrap gap-2 text-sm font-mono text-white">
-              {(showRecoveryCodes.length ? showRecoveryCodes : issuedRecoveryCodes).map((code) => (
-                <span key={code} className="px-2 py-1 rounded bg-surface/80 border border-border">
-                  {code}
-                </span>
-              ))}
+
+          <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="space-y-1">
+                <p className="font-semibold text-white inline-flex items-center gap-2"><FiShield className="w-4 h-4 text-primary" />Profile protection</p>
+                <p className="text-xs text-subtext">
+                  Lock this page with a PIN, pattern, password, or device biometrics/passkey. Unlocking works across browsers, with
+                  recovery codes for emergencies.
+                </p>
+                <ul className="mt-2 text-xs text-subtext list-disc list-inside space-y-1">
+                  <li>Use biometrics/passkeys when your device supports them.</li>
+                  <li>Create a backup PIN or password for other browsers.</li>
+                  <li>Store recovery codes offline to avoid lockouts.</li>
+                </ul>
+              </div>
             </div>
-            <p className="text-[11px] text-subtext">
-              Codes only show once after you set a new lock. Store them in a password manager or safe place.
-            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                className="px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded text-sm"
+                onClick={() => handleSecretLock({ method: 'pin', label: 'PIN / Pattern lock' })}
+              >
+                <FiLock className="inline w-3.5 h-3.5 mr-1" />
+                Set PIN / Pattern
+              </button>
+              <button
+                className="px-3 py-1 bg-primary hover:bg-primary-hover text-black rounded text-sm"
+                onClick={() => handleSecretLock({ method: 'password', label: 'Password lock' })}
+              >
+                <FiLock className="inline w-3.5 h-3.5 mr-1" />
+                Set Password
+              </button>
+              <button
+                className="px-3 py-1 border border-border text-white rounded text-sm disabled:opacity-50"
+                onClick={handleDeviceLock}
+                disabled={!deviceSupported}
+              >
+                Use biometrics / passkey
+              </button>
+              {lockConfig && (
+                <button
+                  className="px-3 py-1 border border-border text-white rounded text-sm"
+                  onClick={() => {
+                    disableLock();
+                    setLockFeedback('Profile lock disabled for this session.', 'success');
+                  }}
+                >
+                  Disable lock
+                </button>
+              )}
+            </div>
+            {lockMessage && (
+              <p
+                className={`text-xs ${
+                  lockMessageTone === 'success'
+                    ? 'text-green-400'
+                    : lockMessageTone === 'error'
+                      ? 'text-red-400'
+                      : 'text-subtext'
+                }`}
+              >
+                {lockMessage}
+              </p>
+            )}
+            {!deviceSupported && (
+              <p className="text-xs text-amber-300">
+                Passkeys/biometrics are not supported on this browser. Try Chrome, Safari, or a modern mobile browser.
+              </p>
+            )}
+            {(showRecoveryCodes.length ? showRecoveryCodes : issuedRecoveryCodes)?.length > 0 && (
+              <div className="rounded-lg border border-border bg-background/40 p-3 space-y-2">
+                <p className="text-xs text-white">Save these recovery codes (one-time use):</p>
+                <div className="flex flex-wrap gap-2 text-sm font-mono text-white">
+                  {(showRecoveryCodes.length ? showRecoveryCodes : issuedRecoveryCodes).map((code) => (
+                    <span key={code} className="px-2 py-1 rounded bg-surface/80 border border-border">
+                      {code}
+                    </span>
+                  ))}
+                </div>
+                <p className="text-[11px] text-subtext">
+                  Codes only show once after you set a new lock. Store them in a password manager or safe place.
+                </p>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-      </div>
+        </div>
+      </section>
 
-      <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
-      <div className="prism-box p-4 mt-4 space-y-3 mx-auto wide-card">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold">NFTs</h3>
-          <span className="text-xs text-subtext">Owned cosmetics & gifts</span>
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-base font-semibold">Assets & wallet</h3>
+          <span className="text-[11px] uppercase tracking-wide text-subtext">Balances & collectibles</span>
         </div>
-        <p className="text-sm text-subtext">
-          View every NFT you own in one place. Starter cosmetics are hidden so you only see items you&apos;ve unlocked.
-        </p>
-        <div className="rounded-lg border border-dashed border-border bg-surface/60 p-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div className="space-y-1">
-            <p className="font-medium text-sm">Open NFT library</p>
-            <p className="text-xs text-subtext">
-              Browse Pool Royale, Domino Royal, and gift NFTs without the default freebies.
+        <div className="grid grid-cols-1 gap-4">
+          <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
+          <div className="prism-box p-4 space-y-3 mx-auto wide-card">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold">NFTs</h3>
+              <span className="text-xs text-subtext">Owned cosmetics & gifts</span>
+            </div>
+            <p className="text-sm text-subtext">
+              View every NFT you own in one place. Starter cosmetics are hidden so you only see items you&apos;ve unlocked.
             </p>
+            <div className="rounded-lg border border-dashed border-border bg-surface/60 p-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div className="space-y-1">
+                <p className="font-medium text-sm">Open NFT library</p>
+                <p className="text-xs text-subtext">
+                  Browse Pool Royale, Domino Royal, and gift NFTs without the default freebies.
+                </p>
+              </div>
+              <Link
+                to="/nfts"
+                className="inline-flex items-center justify-center px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold"
+              >
+                Open
+              </Link>
+            </div>
           </div>
-          <Link
-            to="/nfts"
-            className="inline-flex items-center justify-center px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold"
-          >
-            Open
-          </Link>
         </div>
-      </div>
+      </section>
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
-        <>
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-            <label className="block font-semibold text-center">
-              Top Up Developer Account
-            </label>
-            <input
-              type="number"
-              placeholder="Amount"
-              value={devTopup}
-              onChange={(e) => setDevTopup(e.target.value)}
-              className="border p-1 rounded w-full max-w-xs mx-auto text-black"
-            />
-            <button
-              onClick={handleDevTopup}
-              disabled={devTopupSending}
-              className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background"
-            >
-              {devTopupSending ? 'Processing...' : 'Top Up'}
-            </button>
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-base font-semibold">Developer tools</h3>
+            <span className="text-[11px] uppercase tracking-wide text-subtext">Admin actions</span>
           </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="prism-box p-4 space-y-2 mx-auto wide-card">
+              <label className="block font-semibold text-center">
+                Top Up Developer Account
+              </label>
+              <input
+                type="number"
+                placeholder="Amount"
+                value={devTopup}
+                onChange={(e) => setDevTopup(e.target.value)}
+                className="border p-1 rounded w-full max-w-xs mx-auto text-black"
+              />
+              <button
+                onClick={handleDevTopup}
+                disabled={devTopupSending}
+                className="mt-1 px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background"
+              >
+                {devTopupSending ? 'Processing...' : 'Top Up'}
+              </button>
+            </div>
 
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-            <button
-              onClick={() => setShowNotifyModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
-            >
-              Notify
-            </button>
-          </div>
+            <div className="prism-box p-4 space-y-2 mx-auto wide-card">
+              <button
+                onClick={() => setShowNotifyModal(true)}
+                className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+              >
+                Notify
+              </button>
+            </div>
 
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-            <button
-              onClick={() => setShowTasksModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
-            >
-              Manage Tasks
-            </button>
+            <div className="prism-box p-4 space-y-2 mx-auto wide-card">
+              <button
+                onClick={() => setShowTasksModal(true)}
+                className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+              >
+                Manage Tasks
+              </button>
+            </div>
           </div>
 
           <InfluencerClaimsCard />
-        </>
+        </section>
       )}
 
-      {/* Wallet section */}
-      <Wallet hideClaim />
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-base font-semibold">Payments</h3>
+          <span className="text-[11px] uppercase tracking-wide text-subtext">Wallet controls</span>
+        </div>
+        <Wallet hideClaim />
+      </section>
       <DevNotifyModal
         open={showNotifyModal}
         onClose={() => setShowNotifyModal(false)}


### PR DESCRIPTION
### Motivation
- Improve the organization of the profile page scrolling area so related frames are grouped together for clearer scanability on mobile portrait while keeping the top header unchanged. 
- Reduce vertical clutter and make identity/security, assets, payments and developer actions easier to find when users scroll. 

### Description
- Reorganized the lower part of `MyAccount.jsx` into named sections with lightweight headers: `Profile setup` (social links + protection), `Assets & wallet` (balance + NFTs), `Developer tools` (admin actions), and `Payments` (wallet controls). 
- Moved existing social linking and profile-lock UI into the `Profile setup` section and preserved all behaviors (linking, saving, lock flows, recovery codes). 
- Grouped developer-only controls into a responsive grid and consolidated wallet/balance/NFT cards into the `Assets & wallet` and `Payments` sections to reduce long vertical stacks. 
- Kept the top profile header (avatar, name, completion card, and quick actions) unchanged to preserve the existing visual anchor. 

### Testing
- Built the webapp with `cd webapp && npm run build`, which completed successfully (the build still emits the existing chunk-size warnings). 
- Started the dev server with `npm run dev` and the app served locally for manual inspection. 
- Attempted an automated mobile screenshot with Playwright, but the Chromium process crashed in this environment (SIGSEGV) so the visual validation screenshot was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e07afef908329aca1f49d162c15ce)