### PR TITLE
Improve platform stats accuracy and surface ledger integrity metrics

### DIFF
--- a/webapp/src/components/PlatformStatsCard.jsx
+++ b/webapp/src/components/PlatformStatsCard.jsx
@@ -93,7 +93,7 @@ export default function PlatformStatsCard() {
   }, []);
 
   const normalizedStats = useMemo(() => {
-    const users = firstNumber(stats, ['accounts', 'users', 'totalUsers', 'community.users']);
+    const users = firstNumber(stats, ['totalUsers', 'accounts', 'users', 'community.users']);
     const telegramUsers = firstNumber(stats, [
       'telegramAccounts',
       'usersByProvider.telegram',
@@ -138,11 +138,12 @@ export default function PlatformStatsCard() {
     ]);
 
     const activeMatches =
-      firstNumber(stats, ['activeUsers', 'activeMatches', 'matchesLive', 'games.active']);
+      firstNumber(stats, ['activeMatches', 'matchesLive', 'games.active', 'activeUsers']);
 
     const socialActions =
       firstNumber(stats, [
         'bundlesSold',
+        'claimTransactions',
         'socialActions',
         'engagements',
         'social.totalActions',
@@ -175,7 +176,7 @@ export default function PlatformStatsCard() {
       value: formatStat(normalizedStats.users),
       helper:
         normalizedStats.telegramUsers === null && normalizedStats.googleUsers === null
-          ? 'Total accounts on the platform'
+          ? 'Total authenticated + guest accounts on the platform'
           : `Telegram: ${formatStat(normalizedStats.telegramUsers)} • Google: ${formatStat(normalizedStats.googleUsers)}`,
       icon: FaUsers,
       iconClass: 'text-sky-300'
@@ -217,7 +218,7 @@ export default function PlatformStatsCard() {
     {
       label: 'Live matches',
       value: formatStat(normalizedStats.activeMatches),
-      helper: 'Currently online players',
+      helper: 'Current in-progress games or active sessions',
       icon: FaGamepad,
       iconClass: 'text-emerald-300'
     },

--- a/webapp/src/pages/PlatformStatsDetails.jsx
+++ b/webapp/src/pages/PlatformStatsDetails.jsx
@@ -138,8 +138,10 @@ export default function PlatformStatsDetails() {
 
   const normalized = useMemo(() => {
     const totalUsers =
+      pickNumber(stats, ['totalUsers', 'users', 'community.users']) ??
+      pickNumber(stats, ['accounts']) ??
       pickNumber(summary, ['authenticAccounts']) ??
-      pickNumber(stats, ['accounts', 'users', 'totalUsers', 'community.users']);
+      pickNumber(stats, ['totalUsers', 'accounts', 'users', 'community.users']);
     const telegramUsers =
       pickNumber(summary, ['telegramAccounts']) ??
       pickNumber(stats, [
@@ -206,6 +208,12 @@ export default function PlatformStatsDetails() {
     const nftMinted = pickNumber(stats, ['nftsCreated', 'nftMinted', 'nftsMinted', 'nfts.total']);
     const nftBurned = pickNumber(stats, ['nftsBurned', 'nftBurned', 'nfts.retired']);
 
+    const gameTransactions = pickNumber(stats, ['gameTransactions']);
+    const gameVolume = pickNumber(stats, ['gameVolume']);
+    const miningTransactionsCount = pickNumber(stats, ['miningTransactions']);
+    const miningVolume = pickNumber(stats, ['miningVolume']);
+    const integrityGap = pickNumber(stats, ['integrity.ledgerGap']);
+
     const userActivityRatio =
       totalUsers > 0 && activeUsers !== null ? (activeUsers / totalUsers) * 100 : null;
     const authCoverage =
@@ -231,6 +239,11 @@ export default function PlatformStatsDetails() {
       transferVolume,
       nftMinted,
       nftBurned,
+      gameTransactions,
+      gameVolume,
+      miningTransactionsCount,
+      miningVolume,
+      integrityGap,
       burnRate
     };
   }, [stats, summary]);
@@ -280,9 +293,16 @@ export default function PlatformStatsDetails() {
     {
       label: 'Bundles sold',
       value: formatStat(normalized.bundleSales),
-      helper: 'Store and social monetization actions',
+      helper: 'Store conversion count (bundle purchases)',
       icon: FaGlobe,
       iconClass: 'text-violet-300'
+    },
+    {
+      label: 'Ledger integrity gap',
+      value: formatStat(normalized.integrityGap),
+      helper: 'Minted-from-ledger minus claimed distribution',
+      icon: FaShieldAlt,
+      iconClass: 'text-amber-300'
     },
     {
       label: 'NFT lifecycle',
@@ -380,15 +400,15 @@ export default function PlatformStatsDetails() {
         <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
           <StatCard
             label="Game transactions"
-            value={formatStat(transactionHighlights.gameCount)}
-            helper={`${formatValue(transactionHighlights.gameVolume)} TPC moved`}
+            value={formatStat(normalized.gameTransactions ?? transactionHighlights.gameCount)}
+            helper={`${formatValue(normalized.gameVolume ?? transactionHighlights.gameVolume)} TPC moved`}
             icon={FaGamepad}
             iconClass="text-indigo-300"
           />
           <StatCard
             label="Mining transactions"
-            value={formatStat(transactionHighlights.miningCount)}
-            helper={`${formatValue(transactionHighlights.miningVolume)} TPC rewarded`}
+            value={formatStat(normalized.miningTransactionsCount ?? transactionHighlights.miningCount)}
+            helper={`${formatValue(normalized.miningVolume ?? transactionHighlights.miningVolume)} TPC rewarded`}
             icon={FaBolt}
             iconClass="text-emerald-300"
           />
@@ -471,7 +491,7 @@ export default function PlatformStatsDetails() {
       </section>
 
       <p className="text-center text-[11px] text-subtext">
-        {loading ? 'Syncing live platform telemetry…' : 'Telemetry synced. Values shown are direct API outputs with computed ratios.'}
+        {loading ? 'Syncing live platform telemetry…' : 'Telemetry synced. Counts are sourced from persisted ledger aggregates with computed ratios.'}
       </p>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Provide accurate, ledger-derived platform metrics instead of mixed placeholders so the dashboard reflects real transaction and balance data. 
- Expose diagnostic fields (ledger gap, totals and volumes) required to audit token flow, transfers, game/mining activity and NFT lifecycle.

### Description
- Backend: enhance `/api/stats` aggregation to compute true ledger aggregates including `transferCount`, `transferVolume`, `gameTransactions`, `gameVolume`, `miningTransactions`, `miningVolume`, `claimTransactions`, `withdrawTransactions`, `giftedOutValue`, `giftRedemptions`, and a new `integrity` block with `ledgerGap`; ensure `nftsBurned` is never negative. (file: `bot/server.js`)
- UI: prefer `totalUsers` as primary user count and improve metric key order and helper text in the compact Platform Stats card. (file: `webapp/src/components/PlatformStatsCard.jsx`)
- UI: Platform Intelligence Center now reads the new backend fields, surfaces a `Ledger integrity gap` KPI, and prefers backend aggregates for transaction cards when available. (file: `webapp/src/pages/PlatformStatsDetails.jsx`)

### Testing
- Ran `npm --prefix webapp run build` to compile the frontend; build completed successfully. (pass)
- Ran `node --check bot/server.js` for basic Node syntax validation; no syntax errors reported. (pass)
- Started the dev server and captured a mobile screenshot of `/platform-stats` to validate rendering of the intelligence center. (pass)
- Ran `npx eslint` on the modified files: initial lint (with project ignores) produced non-fatal warnings; running eslint with `--no-ignore` surfaced many style/errors in `bot/server.js` (these are real issues flagged by the workspace linter and should be addressed separately). (partial / requires follow-up)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e072a2dec832986112f1acb79cc87)