### PR TITLE
Pool Royale: physical two-dice break roll, AI max-power break, UI gating & die visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15,6 +15,7 @@ import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
+import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
@@ -1679,7 +1680,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
-const CUE_TIP_GAP = BALL_R * 1.34 + CUE_TIP_CLEARANCE; // pull the cue tip farther back from the cue ball in aim view
+const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -5373,11 +5374,130 @@ const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.45;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 260; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
+const BREAK_DICE_ROLL_DELAY_MS = 560;
+const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 160; // guarantee visible pullback phase when captured stroke timings are too short
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // guarantee visible forward push into impact in replay view
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 24;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const BREAK_DIE_SIZE = BALL_R * 2.25;
+const BREAK_DIE_CORNER_RADIUS = BREAK_DIE_SIZE * 0.17;
+const BREAK_DIE_PIP_RADIUS = BREAK_DIE_SIZE * 0.095;
+const BREAK_DIE_PIP_SPREAD = BREAK_DIE_SIZE * 0.3;
+const BREAK_DIE_FACE_INSET = BREAK_DIE_SIZE * 0.065;
+const BREAK_DIE_BASE_HEIGHT = BALL_CENTER_Y + BALL_R * 2.4;
+
+function setBreakDieOrientation(die, value) {
+  const q = new THREE.Quaternion();
+  const eulers = {
+    1: new THREE.Euler(0, 0, 0),
+    2: new THREE.Euler(-Math.PI / 2, 0, 0),
+    3: new THREE.Euler(0, 0, Math.PI / 2),
+    4: new THREE.Euler(0, 0, -Math.PI / 2),
+    5: new THREE.Euler(Math.PI / 2, 0, 0),
+    6: new THREE.Euler(Math.PI, 0, 0)
+  };
+  q.setFromEuler(eulers[value] || eulers[1]);
+  die.setRotationFromQuaternion(q);
+}
+
+function makeBreakDie() {
+  const die = new THREE.Group();
+  const dieMaterial = new THREE.MeshPhysicalMaterial({
+    color: 0xffffff,
+    metalness: 0.25,
+    roughness: 0.35,
+    clearcoat: 1,
+    clearcoatRoughness: 0.15,
+    envMapIntensity: 1.3
+  });
+  const pipMaterial = new THREE.MeshPhysicalMaterial({
+    color: 0x0a0a0a,
+    roughness: 0.06,
+    metalness: 0.52,
+    clearcoat: 0.82,
+    clearcoatRoughness: 0.05
+  });
+  const body = new THREE.Mesh(
+    new RoundedBoxGeometry(BREAK_DIE_SIZE, BREAK_DIE_SIZE, BREAK_DIE_SIZE, 6, BREAK_DIE_CORNER_RADIUS),
+    dieMaterial
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  die.add(body);
+
+  const pipGeo = new THREE.SphereGeometry(BREAK_DIE_PIP_RADIUS, 24, 16, 0, Math.PI * 2, 0, Math.PI);
+  pipGeo.rotateX(Math.PI);
+  const faceDepth = BREAK_DIE_SIZE / 2 - BREAK_DIE_FACE_INSET * 0.6;
+  const spread = BREAK_DIE_PIP_SPREAD;
+  const faces = [
+    { normal: new THREE.Vector3(0, 1, 0), points: [[0, 0]] },
+    { normal: new THREE.Vector3(0, 0, 1), points: [[-spread, -spread], [spread, spread]] },
+    { normal: new THREE.Vector3(1, 0, 0), points: [[-spread, -spread], [0, 0], [spread, spread]] },
+    { normal: new THREE.Vector3(-1, 0, 0), points: [[-spread, -spread], [-spread, spread], [spread, -spread], [spread, spread]] },
+    { normal: new THREE.Vector3(0, 0, -1), points: [[-spread, -spread], [-spread, spread], [0, 0], [spread, -spread], [spread, spread]] },
+    { normal: new THREE.Vector3(0, -1, 0), points: [[-spread, -spread], [-spread, 0], [-spread, spread], [spread, -spread], [spread, 0], [spread, spread]] }
+  ];
+  faces.forEach(({ normal, points }) => {
+    const n = normal.clone().normalize();
+    const helper = Math.abs(n.y) > 0.9 ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(0, 1, 0);
+    const xAxis = new THREE.Vector3().crossVectors(helper, n).normalize();
+    const yAxis = new THREE.Vector3().crossVectors(n, xAxis).normalize();
+    points.forEach(([gx, gy]) => {
+      const base = new THREE.Vector3()
+        .addScaledVector(xAxis, gx)
+        .addScaledVector(yAxis, gy)
+        .addScaledVector(n, faceDepth);
+      const pip = new THREE.Mesh(pipGeo, pipMaterial);
+      pip.castShadow = true;
+      pip.receiveShadow = true;
+      pip.position.copy(base);
+      pip.quaternion.copy(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), n));
+      die.add(pip);
+    });
+  });
+
+  die.userData.setValue = (value) => {
+    die.userData.currentValue = value;
+    setBreakDieOrientation(die, value);
+  };
+  die.userData.currentValue = 1;
+  return die;
+}
+
+function spinBreakDie(die, { startPos, targetPos, duration = 920, bounceHeight = BREAK_DIE_SIZE * 0.65, forcedValue } = {}) {
+  return new Promise((resolve) => {
+    const spinStart = performance.now();
+    const from = startPos?.clone?.() ?? die.position.clone();
+    const to = targetPos?.clone?.() ?? die.position.clone();
+    const spinVec = new THREE.Vector3(1.2 + Math.random() * 0.7, 1.35 + Math.random() * 0.65, 1.05 + Math.random() * 0.75);
+    const wobble = new THREE.Vector3((Math.random() - 0.5) * BREAK_DIE_SIZE, 0, (Math.random() - 0.5) * BREAK_DIE_SIZE);
+    const targetValue = Number.isFinite(forcedValue) ? forcedValue : 1 + Math.floor(Math.random() * 6);
+    const step = () => {
+      const t = Math.min(1, (performance.now() - spinStart) / Math.max(1, duration));
+      const eased = 1 - Math.pow(1 - t, 3);
+      const next = from.clone().lerp(to, eased);
+      const wobbleStrength = Math.sin(eased * Math.PI);
+      next.addScaledVector(wobble, wobbleStrength * 0.45);
+      const bounce = Math.sin(Math.min(1, eased * 1.25) * Math.PI) * bounceHeight * (1 - eased * 0.45);
+      next.y = THREE.MathUtils.lerp(from.y, to.y, eased) + bounce;
+      die.position.copy(next);
+      const spinFactor = 1 - eased * 0.28;
+      die.rotation.x += spinVec.x * spinFactor * 0.22;
+      die.rotation.y += spinVec.y * spinFactor * 0.22;
+      die.rotation.z += spinVec.z * spinFactor * 0.22;
+      if (t < 1) {
+        requestAnimationFrame(step);
+        return;
+      }
+      if (typeof die.userData?.setValue === 'function') die.userData.setValue(targetValue);
+      die.position.copy(to);
+      resolve(targetValue);
+    };
+    requestAnimationFrame(step);
+  });
+}
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
 const resolveShortRailBroadcastDirection = ({
@@ -9886,7 +10006,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.76;
+  const brandPlateOutwardShift = endRailW * 0.82;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -9925,7 +10045,7 @@ export function Table3D(
           colorId: railMarkerStyle.colorId ?? DEFAULT_RAIL_MARKER_COLOR_ID
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
-  const railMarkerOutset = longRailW * 0.12;
+  const railMarkerOutset = longRailW * 0.08;
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -13331,6 +13451,11 @@ function PoolRoyaleGame({
   const aiTelemetryRef = useRef({ key: null, countdown: 0 });
   const inHandCameraRestoreRef = useRef(null);
   const openingShotViewSuppressedRef = useRef(true);
+  const [breakRollState, setBreakRollState] = useState('ai');
+  const [breakDiceValues, setBreakDiceValues] = useState({ ai: null, user: null });
+  const [breakRollMessage, setBreakRollMessage] = useState('AI rolls first for the break.');
+  const breakRollBusyRef = useRef(false);
+  const breakWinnerSeatRef = useRef(null);
 const initialHudInHand = useMemo(
   () => deriveInHandFromFrame(initialFrame),
   [initialFrame]
@@ -13406,6 +13531,82 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     hudRef.current = hud;
   }, [hud]);
+  const breakDiceValuesRef = useRef({ ai: null, user: null });
+  useEffect(() => {
+    breakDiceValuesRef.current = breakDiceValues;
+  }, [breakDiceValues]);
+
+  const breakRollPending = breakRollState !== 'done';
+  const rollBreakDie = useCallback(
+    async (seat = 'ai') => {
+      if (breakRollBusyRef.current || breakRollState === 'done') return;
+      breakRollBusyRef.current = true;
+      const seatLabel = seat === 'ai' ? 'AI' : 'You';
+      setBreakRollMessage(`${seatLabel} rolling from behind the line...`);
+      await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_ROLL_DELAY_MS));
+      const value = await rollBreakDie3DRef.current(seat);
+      setBreakDiceValues((prev) => ({ ...prev, [seat]: value }));
+      await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_RESULT_PAUSE_MS));
+      if (value % 2 === 0) {
+        setBreakRollMessage(`${seatLabel} rolled ${value} (even). Roll again.`);
+        breakRollBusyRef.current = false;
+        if (seat === 'ai') {
+          window.setTimeout(() => {
+            rollBreakDie('ai');
+          }, 180);
+        } else {
+          setBreakRollState('user');
+        }
+        return;
+      }
+      if (seat === 'ai') {
+        setBreakRollState('user');
+        setBreakRollMessage(`AI rolled ${value}. Tap Roll to throw your die.`);
+        breakRollBusyRef.current = false;
+        return;
+      }
+      const aiValue = breakDiceValuesRef.current?.ai;
+      if (!Number.isFinite(aiValue)) {
+        setBreakRollState('ai');
+        setBreakRollMessage('AI value missing. Restarting break roll.');
+        setBreakDiceValues({ ai: null, user: null });
+        breakRollBusyRef.current = false;
+        return;
+      }
+      if (aiValue === value) {
+        setBreakRollState('ai');
+        setBreakRollMessage(`Tie at ${value}. AI rerolls first.`);
+        setBreakDiceValues({ ai: null, user: null });
+        breakRollBusyRef.current = false;
+        return;
+      }
+      const breakerSeat = aiValue > value ? 'B' : 'A';
+      const breakerLabel = breakerSeat === 'A' ? 'You' : 'AI';
+      breakWinnerSeatRef.current = breakerSeat;
+      setBreakRollState('done');
+      setBreakRollMessage(`${breakerLabel} wins (${aiValue}-${value}) and breaks.`);
+      setHud((prev) => ({ ...prev, turn: breakerSeat === 'A' ? 0 : 1 }));
+      setFrameState((prev) => ({ ...prev, activePlayer: breakerSeat }));
+      breakRollBusyRef.current = false;
+    },
+    [breakRollState]
+  );
+
+  useEffect(() => {
+    if (breakRollState !== 'ai' || breakRollBusyRef.current) return;
+    rollBreakDie('ai');
+  }, [breakRollState, rollBreakDie]);
+
+
+  useEffect(() => {
+    const meshes = breakDiceMeshesRef.current;
+    const shouldShow = breakRollState !== 'done' && !hud.over;
+    [meshes?.ai, meshes?.user].forEach((die) => {
+      if (!die) return;
+      die.visible = shouldShow;
+    });
+  }, [breakRollState, hud.over]);
+
   useEffect(
     () => () => {
       if (ruleToastTimeoutRef.current) {
@@ -13432,6 +13633,21 @@ const powerRef = useRef(hud.power);
     lastShotReminderRef.current = { A: 0, B: 0 };
     setTurnCycle(0);
     setRuleToast(null);
+    breakRollBusyRef.current = false;
+    breakWinnerSeatRef.current = null;
+    setBreakDiceValues({ ai: null, user: null });
+    setBreakRollState('ai');
+    setBreakRollMessage('AI rolls first for the break.');
+    const anchors = breakDiceAnchorsRef.current;
+    const meshes = breakDiceMeshesRef.current;
+    if (anchors && meshes?.ai && meshes?.user) {
+      meshes.ai.position.copy(anchors.aiStart);
+      meshes.user.position.copy(anchors.userStart);
+      setBreakDieOrientation(meshes.ai, 1);
+      setBreakDieOrientation(meshes.user, 1);
+      meshes.ai.visible = true;
+      meshes.user.visible = true;
+    }
     setHud((prev) => ({
       ...prev,
       A: 0,
@@ -13818,6 +14034,9 @@ const powerRef = useRef(hud.power);
   }, []);
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
+  const breakDiceMeshesRef = useRef({ ai: null, user: null });
+  const breakDiceAnchorsRef = useRef(null);
+  const rollBreakDie3DRef = useRef(async () => 1);
   const pocketDropRef = useRef(new Map());
   const pocketRestIndexRef = useRef(new Map());
   const pocketPopupRef = useRef([]);
@@ -20965,6 +21184,41 @@ const powerRef = useRef(hud.power);
         rendererRef.current
       );
       const SPOTS = spotPositions(baulkZ);
+
+      const breakDiceGroup = new THREE.Group();
+      table.add(breakDiceGroup);
+      const aiBreakDie = makeBreakDie();
+      const userBreakDie = makeBreakDie();
+      breakDiceGroup.add(aiBreakDie);
+      breakDiceGroup.add(userBreakDie);
+      breakDiceMeshesRef.current = { ai: aiBreakDie, user: userBreakDie };
+      const breakLineDepth = PLAY_H * 0.37;
+      const breakCenterOffset = BALL_R * 3.1;
+      const makeBreakAnchors = () => ({
+        aiStart: new THREE.Vector3(0, BREAK_DIE_BASE_HEIGHT, breakLineDepth),
+        aiEnd: new THREE.Vector3(-breakCenterOffset, BREAK_DIE_BASE_HEIGHT, 0),
+        userStart: new THREE.Vector3(0, BREAK_DIE_BASE_HEIGHT, -breakLineDepth),
+        userEnd: new THREE.Vector3(breakCenterOffset, BREAK_DIE_BASE_HEIGHT, 0)
+      });
+      breakDiceAnchorsRef.current = makeBreakAnchors();
+      aiBreakDie.position.copy(breakDiceAnchorsRef.current.aiStart);
+      userBreakDie.position.copy(breakDiceAnchorsRef.current.userStart);
+      setBreakDieOrientation(aiBreakDie, 1);
+      setBreakDieOrientation(userBreakDie, 1);
+      rollBreakDie3DRef.current = async (seat = 'ai') => {
+        const anchors = breakDiceAnchorsRef.current || makeBreakAnchors();
+        breakDiceAnchorsRef.current = anchors;
+        const die = seat === 'ai' ? breakDiceMeshesRef.current.ai : breakDiceMeshesRef.current.user;
+        if (!die) return 1;
+        const startPos = seat === 'ai' ? anchors.aiStart : anchors.userStart;
+        const targetPos = seat === 'ai' ? anchors.aiEnd : anchors.userEnd;
+        return spinBreakDie(die, {
+          startPos,
+          targetPos,
+          duration: seat === 'ai' ? 980 : 930,
+          bounceHeight: BREAK_DIE_SIZE * 0.78
+        });
+      };
       const longestSide = Math.max(PLAY_W, PLAY_H);
       const secondarySpacingBase =
         Math.max(longestSide * 2.4, Math.max(TABLE.W, TABLE.H) * 2.6) * TABLE_DISPLAY_SCALE;
@@ -23087,6 +23341,7 @@ const powerRef = useRef(hud.power);
         const inHandPlacementActive = Boolean(
           currentHud?.inHand && !fullTableHandPlacement
         );
+        if (breakRollPending) return;
         if (
           !cue?.active ||
           (inHandPlacementActive && !cueBallPlacedFromHandRef.current) ||
@@ -23095,6 +23350,9 @@ const powerRef = useRef(hud.power);
           replayPlaybackRef.current
         )
           return;
+        if (breakWinnerSeatRef.current === 'A') {
+          breakWinnerSeatRef.current = null;
+        }
         if (currentHud?.inHand && (fullTableHandPlacement || inHandPlacementActive)) {
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
@@ -25640,6 +25898,40 @@ const powerRef = useRef(hud.power);
                 spin: { x: 0, y: 0 }
               };
             }
+            const frameSnapshot = frameRef.current ?? frameState;
+            const shouldForceAiBreak =
+              breakWinnerSeatRef.current === 'B' &&
+              (frameSnapshot?.currentBreak ?? 0) === 0 &&
+              breakRollState === 'done';
+            if (shouldForceAiBreak && cue?.pos) {
+              const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
+              if (rackBalls.length > 0) {
+                const rackCenter = rackBalls.reduce(
+                  (acc, ball) => {
+                    acc.x += ball.pos?.x ?? 0;
+                    acc.y += ball.pos?.y ?? 0;
+                    return acc;
+                  },
+                  { x: 0, y: 0 }
+                );
+                rackCenter.x /= rackBalls.length;
+                rackCenter.y /= rackBalls.length;
+                const breakDir = new THREE.Vector2(rackCenter.x - cue.pos.x, rackCenter.y - cue.pos.y);
+                if (breakDir.lengthSq() < 1e-6) {
+                  breakDir.set(0, 1);
+                }
+                breakDir.normalize();
+                plan = {
+                  ...plan,
+                  type: 'break',
+                  aimDir: breakDir,
+                  power: 1,
+                  spin: { x: 0, y: 0 },
+                  target: 'rack'
+                };
+                setBreakRollMessage('AI won the roll and is taking a maximum-power break.');
+              }
+            }
             aiPlanRef.current = plan;
             clearEarlyAiShot();
             stopAiThinking();
@@ -25695,6 +25987,9 @@ const powerRef = useRef(hud.power);
                 applyCameraBlend(aiCueViewBlendRef.current ?? AI_CAMERA_DROP_BLEND);
                 updateCamera();
                 fire();
+                if (breakWinnerSeatRef.current === 'B') {
+                  breakWinnerSeatRef.current = null;
+                }
               }, remaining);
             };
             if (dropDelay <= 0) {
@@ -28597,6 +28892,9 @@ const powerRef = useRef(hud.power);
         cueGalleryStateRef.current.prev = null;
         cueGalleryStateRef.current.position?.set(0, 0, 0);
         cueGalleryStateRef.current.target?.set(0, 0, 0);
+        breakDiceMeshesRef.current = { ai: null, user: null };
+        breakDiceAnchorsRef.current = null;
+        rollBreakDie3DRef.current = async () => 1;
         sceneRef.current = null;
       };
       } catch (e) {
@@ -28683,7 +28981,7 @@ const powerRef = useRef(hud.power);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
-  const showPowerSlider = !hud.over && !replayActive;
+  const showPowerSlider = !hud.over && !replayActive && !breakRollPending;
   useEffect(() => {
     if (!showPowerSlider) {
       return undefined;
@@ -28727,9 +29025,9 @@ const powerRef = useRef(hud.power);
 
   const isPlayerTurn = hud.turn === 0;
   const isOpponentTurn = hud.turn === 1;
-  const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
+  const showPlayerControls = isPlayerTurn && !hud.over && !replayActive && !breakRollPending;
   const showSpinController =
-    !hud.over && !replayActive && (isPlayerTurn || aiTakingShot);
+    !hud.over && !replayActive && !breakRollPending && (isPlayerTurn || aiTakingShot);
   const canRepositionCueBall = useMemo(
     () => showPlayerControls && deriveInHandFromFrame(frameState),
     [frameState, showPlayerControls]
@@ -29275,7 +29573,7 @@ const powerRef = useRef(hud.power);
     lastOpponentPot != null
       ? String(lastOpponentPot.id ?? lastOpponentPot.color)
       : null;
-  const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive;
+  const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive && !breakRollPending;
   const bottomHudScale = isPortrait ? uiScale * 1.08 : uiScale * 1.12;
   const avatarSizeClass = isPortrait ? 'h-[2.6rem] w-[2.6rem]' : 'h-[3.5rem] w-[3.5rem]';
   const nameWidthClass = isPortrait ? 'max-w-[9rem]' : 'max-w-[12rem]';
@@ -29350,6 +29648,25 @@ const powerRef = useRef(hud.power);
     <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
+
+      {breakRollState !== 'done' && !hud.over && (
+        <div className="pointer-events-none absolute inset-0 z-[95] flex items-center justify-center">
+          <div className="pointer-events-auto w-[min(20rem,88vw)] rounded-2xl border border-cyan-300/45 bg-slate-950/82 p-4 text-center shadow-[0_14px_32px_rgba(0,0,0,0.58)] backdrop-blur">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-100">Break dice roll</p>
+            <p className="mt-3 text-xs font-semibold text-white/90">{breakRollMessage}</p>
+            {breakRollState === 'user' && (
+              <button
+                type="button"
+                onClick={() => rollBreakDie('user')}
+                disabled={breakRollBusyRef.current}
+                className="mt-4 rounded-full border border-cyan-200 bg-cyan-200 px-5 py-2 text-xs font-black uppercase tracking-[0.2em] text-slate-950 shadow-[0_0_16px_rgba(34,211,238,0.45)] transition hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                Roll your die
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {replayBanner && (
         <div className="pointer-events-none absolute top-4 right-4 z-50">


### PR DESCRIPTION
### Motivation
- Replace the previous numeric/emoji break opener with a convincing on-table physics/animation flow so the AI and player toss actual dice that roll toward the table center. 
- Ensure the opening-break outcome is unambiguous and fair (AI rolls first, player responds, evens reroll, ties restart). 
- When AI wins the break roll, make the AI explicitly aim at the rack and use a maximum-power break to reflect the win. 
- Preserve prior visual tweaks (more visible cue tip, adjusted rail markers and branding plates) and block pre-break interactions to prevent early shots.

### Description
- Added 3D die geometry and helpers by importing `RoundedBoxGeometry` and implementing `makeBreakDie`, `spinBreakDie`, and `setBreakDieOrientation` to build Ludo-style dice and animate a physical roll. 
- Created persistent break dice in the scene (`breakDiceGroup`) with start/target anchors and exposed `rollBreakDie3DRef` so both AI and user rolls animate on-table. 
- Reworked the break flow to use two dice: AI throws first from behind the line, user throws via a single-use UI `Roll` button, even results trigger rerolls, ties restart, and the higher valid roll sets break ownership; roll orchestration performed by `rollBreakDie` and tracked by `breakRollState`, `breakDiceValues`, and `breakWinnerSeatRef`. 
- Gated player controls/UI until break resolution by using `breakRollPending` checks (prevents power slider, shot `fire`, spin controller, player controls and bottom HUD). 
- Updated AI opening behavior so if AI wins the roll the AI plan is forced to a rack-aimed `break` with `power = 1` and a message indicating a max-power break. 
- Added start/reset logic and cleanup for dice (`breakDiceMeshesRef`, `breakDiceAnchorsRef`, `rollBreakDie3DRef`) so dice are created/removed with the table and reset on new frame. 
- Kept earlier visual adjustments: increased `CUE_TIP_GAP`, moved brand plates outward (`brandPlateOutwardShift`) and pulled rail diamond markers inward (`railMarkerOutset`). 

### Testing
- Built the web app production bundle with `npm --prefix webapp run -s build` and the build completed successfully (Vite emitted only existing chunk-size warnings). 
- Launched the dev server and attempted to capture an automated page screenshot via Playwright to validate the physical dice animation; the headless screenshot timed out in this environment while rendering the heavy 3D scene (attempts logged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e068dcd288329a830f904fecbd0f0)