### PR TITLE
Fix Domino Royal runtime teardown to prevent crashes on remount

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -15,9 +15,17 @@ export default function DominoRoyalArena() {
       document.head.appendChild(styleTag);
     }
 
+    const staleScript = document.querySelector(GAME_SCRIPT_SELECTOR);
+    const hasRuntime = typeof window !== 'undefined' && typeof window.__dominoRoyalRuntime?.destroy === 'function';
+    if (staleScript && !hasRuntime) {
+      staleScript.remove();
+    }
+
     const existingScript = document.querySelector(GAME_SCRIPT_SELECTOR);
     if (existingScript) {
-      return undefined;
+      return () => {
+        window.__dominoRoyalRuntime?.destroy?.('arena unmount');
+      };
     }
 
     const script = document.createElement('script');
@@ -27,6 +35,7 @@ export default function DominoRoyalArena() {
     document.body.appendChild(script);
 
     return () => {
+      window.__dominoRoyalRuntime?.destroy?.('arena unmount');
       script.remove();
     };
   }, []);


### PR DESCRIPTION
### Motivation
- Prevent duplicate/half-alive Domino Royal runtimes that caused crashes after navigating away and back to the arena. 
- Ensure the 3D renderer, event listeners and overlays are disposed cleanly before re-initializing the game script. 

### Description
- Added a pre-init guard that calls `window.__dominoRoyalRuntime.destroy()` if a prior runtime exists before loading `domino-royal-game.js`. 
- Introduced runtime lifecycle state (`dominoRoyalDestroyed`) and RAF tracking (`tickFrameHandle`) and cancelation to stop the render loop cleanly. 
- Implemented a formal `window.__dominoRoyalRuntime.destroy()` that cancels RAF, removes `resize`/`visibilitychange` listeners, disposes `controls`/`renderer`, and removes runtime DOM overlays like `seatOverlay`. 
- Updated `DominoRoyalArena` mount/unmount logic to remove stale script tags, call the runtime `destroy()` on unmount, and avoid loading duplicate runtimes. 

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully. 
- Performed a mobile-playwright smoke check that opened `/games/domino-royal?mode=classic&players=2`, navigated away and back, and verified stability with `canvas_count 1` and `pageerrors 0`. 
- Captured a mobile portrait screenshot after the rerender check at `browser:/tmp/codex_browser_invocations/14477db8af3cdfe1/artifacts/artifacts/domino-after-fix.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1a1a74e48329a808267fbb0bf310)