### PR TITLE
Make AI aim at rack and use max power on opening break

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -574,11 +574,48 @@ function fallbackAimAtTarget (req) {
   return rest
 }
 
+function openingBreakShot (req) {
+  if (!req?.state?.breakInProgress) return null
+  const cue = req.state.balls.find(b => b.id === 0 && !b.pocketed)
+  const targets = chooseTargets(req)
+  if (!cue || targets.length === 0) return null
+
+  const cueSide = cue.y < req.state.height / 2 ? -1 : 1
+  const rackTarget = targets.reduce((best, candidate) => {
+    if (!best) return candidate
+    const bestSide = Math.sign(best.y - req.state.height / 2) || cueSide
+    const candidateSide = Math.sign(candidate.y - req.state.height / 2) || cueSide
+    const bestOpposite = bestSide !== cueSide
+    const candidateOpposite = candidateSide !== cueSide
+    if (bestOpposite !== candidateOpposite) {
+      return candidateOpposite ? candidate : best
+    }
+    const bestDist = dist(cue, best)
+    const candidateDist = dist(cue, candidate)
+    return candidateDist < bestDist ? candidate : best
+  }, null)
+  if (!rackTarget) return null
+
+  const angle = Math.atan2(rackTarget.y - cue.y, rackTarget.x - cue.x)
+  return {
+    angleRad: angle,
+    power: 1,
+    spin: { top: 0, side: 0, back: 0 },
+    targetBallId: rackTarget.id,
+    aimPoint: { x: rackTarget.x, y: rackTarget.y },
+    quality: 0.2,
+    rationale: 'break-shot'
+  }
+}
+
 /**
  * @param {AimRequest} req
  * @returns {ShotDecision}
  */
 export function planShot (req) {
+  const breakShot = openingBreakShot(req)
+  if (breakShot) return breakShot
+
   const r = req.state.ballRadius
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -87,6 +87,40 @@ test('ball in hand aims for straight shot', () => {
 });
 
 
+
+
+test('break shot aims at rack with max power', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 500, y: 420, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 500, y: 120, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 480, y: 140, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 520, y: 140, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: true
+    },
+    timeBudgetMs: 100,
+    rngSeed: 5
+  };
+
+  const decision = planShot(req);
+  assert.equal(decision.rationale, 'break-shot');
+  assert.equal(decision.power, 1);
+  assert.equal(decision.targetBallId, 1);
+  assert(decision.aimPoint);
+  assert.equal(decision.aimPoint.x, 500);
+  assert.equal(decision.aimPoint.y, 120);
+});
 test('ball in hand baulk restriction only applies during break placement', () => {
   const baseState = {
     balls: [

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25108,6 +25108,7 @@ const powerRef = useRef(hud.power);
             ? frameSnapshot.ballOn[0]
             : frameSnapshot?.ballOn ?? null;
           const normalizedBallOn = normalizeAiGroup(rawBallOn);
+          const breakInProgress = Boolean(metaState?.breakInProgress);
           const aiState = {
             balls: aiBalls,
             pockets,
@@ -25117,7 +25118,8 @@ const powerRef = useRef(hud.power);
             friction: FRICTION,
             ballInHand: Boolean(metaState?.ballInHand),
             myGroup: normalizedAssignment,
-            ballOn: normalizedBallOn ?? null
+            ballOn: normalizedBallOn ?? null,
+            breakInProgress
           };
           const decision = planShot({
             game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
@@ -25153,7 +25155,9 @@ const powerRef = useRef(hud.power);
               : null;
           const pocketCenter =
             pocketIndex != null ? pocketsLocal[pocketIndex].clone() : null;
-          const power = THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, 0.95);
+          const power = breakInProgress
+            ? 1
+            : THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, 0.95);
           const sideSpin = decision.spin?.side ?? 0;
           const verticalSpin = (decision.spin?.back ?? 0) - (decision.spin?.top ?? 0);
           const spin = {


### PR DESCRIPTION
### Motivation
- The AI was not targeting the rack or using full power during the opening break, causing weak/misdirected breaks and inconsistent behavior in Pool Royale.

### Description
- Added an `openingBreakShot` path in `lib/poolAi.js` that triggers when `breakInProgress` is true and selects a rack-side target (preferring the side opposite the cue), returns `power: 1`, neutral spin, and `rationale: 'break-shot'`.
- Wired `webapp/src/pages/Games/PoolRoyale.jsx` to pass `breakInProgress` into the AI request and to apply full shot power when the planner indicates a break (forces applied `power` to `1` on break frames).
- Added a regression test in `test/poolAi.test.js` that verifies the planner returns a `break-shot` aiming at the rack head ball with `power === 1`.

### Testing
- Ran `node --test test/poolAi.test.js`, which completed successfully with all tests passing (12/12).
- Unit test coverage includes the new `break-shot` regression verifying aim, power, and aimPoint values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1cbd0ecc83298d88a9836f37cb91)