### PR TITLE
Force AI opening break to target rack at max power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25910,11 +25910,13 @@ const powerRef = useRef(hud.power);
             }
             const frameSnapshot = frameRef.current ?? frameState;
             const isOpeningBreak = (frameSnapshot?.currentBreak ?? 0) === 0;
-            const openingPlayer = frameSnapshot?.activePlayer ?? (currentHud?.turn === 1 ? 'B' : 'A');
+            const aiTurnActive = currentHud?.turn === 1;
+            const aiWonBreak = breakWinnerSeatRef.current === 'B';
+            const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
-              breakRollState === 'done' &&
               isOpeningBreak &&
-              openingPlayer === 'B';
+              aiTurnActive &&
+              (breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
               if (rackBalls.length > 0) {
@@ -25942,6 +25944,15 @@ const powerRef = useRef(hud.power);
                   target: 'rack'
                 };
                 setBreakRollMessage('AI won the roll and is taking a maximum-power break.');
+              } else {
+                plan = {
+                  ...plan,
+                  type: 'break',
+                  aimDir: new THREE.Vector2(0, 1),
+                  power: 1,
+                  spin: { x: 0, y: 0 },
+                  target: 'rack'
+                };
               }
             }
             aiPlanRef.current = plan;


### PR DESCRIPTION
### Motivation
- The AI sometimes selects non-break aims (middle pockets or safety) on the opening turn when roll-state sync lags, so the opening break must reliably target the rack and use full power.

### Description
- Hardened opening-break detection in `webapp/src/pages/Games/PoolRoyale.jsx` so the forced-break logic triggers whenever it is the AI's active turn on the opening break, even when roll-state synchronization is delayed.
- When forcing a break the AI plan is assigned `type: 'break'`, `power: 1`, and neutral spin, with the aim direction computed toward the rack cluster center.
- Added a defensive fallback break plan that aims straight up-table with `power: 1` when rack balls are temporarily unavailable so the AI still executes a break.
- Kept existing camera/preview and cue-pull behaviour and set the HUD power based on the clamped plan power.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolAi.test.js`, which passed (11 tests passing).
- Ran ESLint with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`, which completed and reported the file is ignored by the current ESLint ignore settings but produced no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1cbd0ecc83298d88a9836f37cb91)