### PR TITLE
Reduce AI non-break power and exclude cue ball from auto-aim in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23948,7 +23948,7 @@ const powerRef = useRef(hud.power);
           Math.hypot(PLAY_W, PLAY_H) + Math.max(PLAY_W, PLAY_H);
         const computePowerFromDistance = (dist) => {
           const n = THREE.MathUtils.clamp(dist / MAX_ROUTE_DISTANCE, 0, 1);
-          return THREE.MathUtils.lerp(0.35, 0.9, n);
+          return THREE.MathUtils.lerp(0.26, 0.78, n);
         };
         const computePlanSpin = (plan, stateSnapshot) => {
           const fallback = { x: 0, y: -0.1 };
@@ -25264,6 +25264,7 @@ const powerRef = useRef(hud.power);
               (ball) =>
                 ball?.active &&
                 String(ball.id) !== 'cue' &&
+                Number(ball.id) !== 0 &&
                 isLegalTargetBall(ball)
             );
             if (!cuePos || candidates.length === 0) return null;
@@ -25477,7 +25478,7 @@ const powerRef = useRef(hud.power);
           const cycleToNext = Boolean(options?.cycleToNext);
 
           const activeBalls = ballsList.filter(
-            (ball) => ball.active && String(ball.id) !== 'cue'
+            (ball) => ball.active && String(ball.id) !== 'cue' && Number(ball.id) !== 0
           );
           if (activeBalls.length === 0) return null;
           const clearance = BALL_R * 1.5;
@@ -25701,7 +25702,9 @@ const powerRef = useRef(hud.power);
           const frameSnapshot = frameRef.current ?? frameState;
           const ballsList = ballsRef.current?.length > 0 ? ballsRef.current : balls;
           const activeBalls = Array.isArray(ballsList)
-            ? ballsList.filter((ball) => ball?.active && String(ball.id) !== 'cue')
+            ? ballsList.filter(
+                (ball) => ball?.active && String(ball.id) !== 'cue' && Number(ball.id) !== 0
+              )
             : [];
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
           const targetOrder = resolveTargetPriorities(
@@ -25972,7 +25975,13 @@ const powerRef = useRef(hud.power);
             // Reset the cue pull so AI strokes visibly wind up before firing.
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
-            const aiPower = clampPower(plan.power, 0.6);
+            const isBreakPlan = plan.type === 'break';
+            const normalizedPlanPower = Number.isFinite(plan.power)
+              ? plan.power
+              : computePowerFromDistance(BALL_R * 12);
+            const aiPower = isBreakPlan
+              ? 1
+              : clampPower(Math.min(normalizedPlanPower, 0.86), 0.22);
             powerRef.current = aiPower;
             setHud((s) => ({ ...s, power: aiPower }));
             const spinToApply = plan.spin ?? { x: 0, y: 0 };


### PR DESCRIPTION
### Motivation

- Prevent AI from always firing at near-max power except for the opening break so AI shots feel more tactical and consistent.  
- Fix player auto-aim / aiming-line choosing cushions by accident because the cue ball was being considered as a target.  

### Description

- Lowered the AI power scaling curve in `computePowerFromDistance` to use `lerp(0.26, 0.78)` instead of `lerp(0.35, 0.9)` to reduce aggressive default shot strength.  
- Updated AI firing logic so opening break plans keep full power (`1.0`) while non-break plans use a normalized plan power (fallback via `computePowerFromDistance`) and are clamped to a safer range with a lower minimum (`clampPower(..., 0.22)`) and an upper cap (`0.86`) for consistency.  
- Excluded the cue ball from auto-aim and planning candidate pools by ignoring both `'cue'` and numeric `0` ids when building `activeBalls` and `candidates`, which prevents the aim guide from locking to invalid self-targets or cushion-first directions.  
- All edits are in `webapp/src/pages/Games/PoolRoyale.jsx` and touch AI planning, power computation, and user suggestion/auto-aim selection code paths.  

### Testing

- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed but the file is ignored by project lint config and reported an ignore warning.  
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which produced the same ignore-warning behavior under current project settings.  
- No unit/integration tests were added or run for runtime verification in this change; manual runtime playtesting is recommended to validate AI behavior and aiming visuals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2f3651648329ad73f90be3cd9186)