### PR TITLE
Fix Pool Royale open-table aiming and AI group targeting

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -4,6 +4,7 @@ export class AmericanBilliards {
       ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
       currentPlayer: 'A',
       scores: { A: 0, B: 0 },
+      assignments: { A: null, B: null },
       ballInHand: false,
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
@@ -34,13 +35,28 @@ export class AmericanBilliards {
     let reason = '';
 
     const first = contactOrder[0];
+    const playerGroup = s.assignments[current];
+    const opponentGroup = s.assignments[opp];
+    const isOpenTable = !playerGroup || !opponentGroup;
+    const solidsLeft = countRemainingGroup(s.ballsOnTable, 'SOLID');
+    const stripesLeft = countRemainingGroup(s.ballsOnTable, 'STRIPE');
+    const playerGroupRemaining =
+      playerGroup === 'SOLID'
+        ? solidsLeft
+        : playerGroup === 'STRIPE'
+          ? stripesLeft
+          : 0;
+
     if (!foul && !first) {
       foul = true;
       reason = 'no contact';
     }
 
-    const lowest = lowestBall(s.ballsOnTable);
-    if (!foul && lowest != null && first !== lowest) {
+    if (!foul && !isLegalFirstContact(first, {
+      isOpenTable,
+      playerGroup,
+      playerGroupRemaining
+    })) {
       foul = true;
       reason = 'wrong first contact';
     }
@@ -74,12 +90,36 @@ export class AmericanBilliards {
     }
 
     if (!foul) {
-      for (const id of pottedBalls) {
-        if (s.ballsOnTable.has(id)) {
-          s.ballsOnTable.delete(id);
-          s.scores[current] = (s.scores[current] ?? 0) + id;
+      if (isOpenTable) {
+        const groupBall = pottedBalls.find(id => id !== 8);
+        if (groupBall) {
+          const group = idToGroup(groupBall);
+          s.assignments[current] = group;
+          s.assignments[opp] = oppositeGroup(group);
         }
       }
+      for (const id of pottedBalls) {
+        if (s.ballsOnTable.has(id)) {
+          if (id === 8) continue;
+          s.ballsOnTable.delete(id);
+          s.scores[current] = (s.scores[current] ?? 0) + 1;
+        }
+      }
+    }
+
+    const eightPotted = pottedBalls.includes(8);
+    if (!frameOver && eightPotted) {
+      const currentGroup = s.assignments[current];
+      const remainingBeforeEight =
+        currentGroup === 'SOLID'
+          ? countRemainingGroup(s.ballsOnTable, 'SOLID')
+          : currentGroup === 'STRIPE'
+            ? countRemainingGroup(s.ballsOnTable, 'STRIPE')
+            : 0;
+      const legalEight = !foul && currentGroup && remainingBeforeEight === 0;
+      frameOver = true;
+      winner = legalEight ? current : opp;
+      s.ballsOnTable.delete(8);
     }
 
     if (!frameOver) {
@@ -93,18 +133,10 @@ export class AmericanBilliards {
       }
     }
 
-    if (s.ballsOnTable.size === 0) {
-      frameOver = true;
-      winner =
-        s.scores.A === s.scores.B
-          ? 'TIE'
-          : s.scores.A > s.scores.B
-            ? 'A'
-            : 'B';
-    }
-
     s.ballInHand = ballInHandNext;
-    s.breakInProgress = false;
+    if (!foul || pottedBalls.length > 0) {
+      s.breakInProgress = false;
+    }
     s.frameOver = frameOver;
     s.winner = winner;
 
@@ -123,10 +155,38 @@ export class AmericanBilliards {
 
 export default AmericanBilliards;
 
-function lowestBall (balls) {
-  let lowest = null;
+function idToGroup (id) {
+  if (id >= 1 && id <= 7) return 'SOLID';
+  if (id >= 9 && id <= 15) return 'STRIPE';
+  return null;
+}
+
+function oppositeGroup (group) {
+  return group === 'SOLID' ? 'STRIPE' : 'SOLID';
+}
+
+function countRemainingGroup (balls, group) {
+  let total = 0;
   for (const id of balls) {
-    if (lowest == null || id < lowest) lowest = id;
+    if (group === 'SOLID' && id >= 1 && id <= 7) total += 1;
+    if (group === 'STRIPE' && id >= 9 && id <= 15) total += 1;
   }
-  return lowest;
+  return total;
+}
+
+function isLegalFirstContact (first, { isOpenTable, playerGroup, playerGroupRemaining }) {
+  if (!Number.isFinite(first)) return false;
+  if (isOpenTable) {
+    return first !== 8;
+  }
+  if (playerGroupRemaining <= 0) {
+    return first === 8;
+  }
+  if (playerGroup === 'SOLID') {
+    return first >= 1 && first <= 7;
+  }
+  if (playerGroup === 'STRIPE') {
+    return first >= 9 && first <= 15;
+  }
+  return false;
 }

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -161,9 +161,26 @@ function currentGroup (state) {
 
 function chooseTargets (req) {
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
-  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
+  if (req.game === 'NINE_BALL') {
     const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
     return lowest ? [lowest] : []
+  }
+  if (req.game === 'AMERICAN_BILLIARDS') {
+    const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
+    const stripes = balls.filter(b => b.id >= 9 && b.id <= 15)
+    const eight = balls.find(b => b.id === 8)
+    const group = currentGroup(req.state)
+    if (group === 'SOLIDS') {
+      if (solids.length > 0) return solids
+      if (eight) return [eight]
+      return []
+    }
+    if (group === 'STRIPES') {
+      if (stripes.length > 0) return stripes
+      if (eight) return [eight]
+      return []
+    }
+    return balls.filter(b => b.id !== 8)
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
@@ -187,10 +204,31 @@ function chooseTargets (req) {
 
 function nextTargetsAfter (targetId, req) {
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
-  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
+  if (req.game === 'NINE_BALL') {
     if (cloned.length === 0) return []
     const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
     return lowest ? [lowest] : []
+  }
+  if (req.game === 'AMERICAN_BILLIARDS') {
+    const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
+    const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15)
+    const eight = cloned.find(b => b.id === 8)
+    let group = currentGroup(req.state)
+    if (!group || group === 'UNASSIGNED') {
+      if (targetId >= 1 && targetId <= 7) group = 'SOLIDS'
+      else if (targetId >= 9 && targetId <= 15) group = 'STRIPES'
+    }
+    if (group === 'SOLIDS') {
+      if (solids.length > 0) return solids
+      if (eight) return [eight]
+      return []
+    }
+    if (group === 'STRIPES') {
+      if (stripes.length > 0) return stripes
+      if (eight) return [eight]
+      return []
+    }
+    return cloned.filter(b => b.id !== 8)
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -53,6 +53,8 @@ describe('PoolRoyaleRules', () => {
     expect(initialMeta?.breakInProgress).toBe(true);
     expect(initialMeta?.state?.ballInHand).toBe(true);
     expect(initialMeta?.hud?.next).toBe('open table');
+    expect(initialMeta?.hud?.phase).toBe('open');
+    expect(initialMeta?.state?.assignments?.A).toBeNull();
     expect(initialFrame.ballOn).toEqual(['SOLID', 'STRIPE']);
 
     const breakEvents: ShotEvent[] = [
@@ -69,7 +71,10 @@ describe('PoolRoyaleRules', () => {
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
     expect(cleared.ballOn).toEqual(['SOLID']);
+    expect(clearedMeta?.state?.assignments?.A).toBe('SOLID');
+    expect(clearedMeta?.state?.assignments?.B).toBe('STRIPE');
     expect(clearedMeta?.hud?.next).toBe('solid');
+    expect(clearedMeta?.hud?.phase).toBe('groups');
     expect(cleared.players.A.score).toBe(1);
 
     const scratchEvents: ShotEvent[] = [

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26873,15 +26873,6 @@ const powerRef = useRef(hud.power);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
             }
-            if (isPlayerTurn) {
-              const legalDir = resolveLegalPlayerAimDirection(aimDir);
-              if (legalDir && legalDir.lengthSq() > 1e-6) {
-                aimDir.lerp(legalDir, 0.5);
-                if (aimDir.lengthSq() > 1e-6) {
-                  aimDir.normalize();
-                }
-              }
-            }
           }
         }
         const appliedSpin = applySpinConstraints(aimDir, true);


### PR DESCRIPTION
### Motivation

- Align American 8‑ball behaviour with official open-table / group assignment flow so players can aim freely while auto-aim still helps, and so HUD/ballOn reflect open vs grouped phases. 
- Let AI and rules track object-ball groups by ball numbers (solids/stripes) and only allow 8‑ball targets once the group is cleared, preventing the previous lowest-ball-only behaviour.

### Description

- Implemented group assignment state and legal-first-contact logic in the American rule engine, including 8‑ball win/loss handling and updated scoring semantics in `lib/americanBilliards.js`.
- Extended rule serialization and HUD metadata to include `assignments` and to compute `ballOn` as `SOLID`/`STRIPE`/`BLACK` or open-table lists in `src/rules/PoolRoyaleRules.ts`.
- Updated AI target selection in `lib/poolAi.js` to prefer group targets (1–7 as SOLID, 9–15 as STRIPE), avoid the 8‑ball on open table, and choose the 8 only after the group is cleared.
- Relaxed the gameplay aiming enforcement so manual player aim is no longer forcibly snapped back to a legal object-ball direction while preserving auto-aim assistance in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added and adapted unit tests to validate open-table HUD/assignment state, assignment transitions after the break, 8‑ball handling, and AI target behaviour (tests updated in `test/poolRoyaleRules.test.ts` and `test/poolAi.test.js`).

### Testing

- Ran the rule/AI unit tests: `npm test -- test/poolAi.test.js test/poolRoyaleRules.test.ts` and all targeted tests passed (14/14 tests in those suites).
- Started the webapp dev server with Vite: `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to validate UI integration and captured a screenshot of the Pool Royale view.
- No automated test failures were observed after changes; unit tests covering American open-table flow, assignment persistence, 8‑ball resolution, and AI target selection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3721c6988329b846bf5a130fc470)