### PR TITLE
Align Domino Royale asset & HDRI resolutions with Murlan Royale

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1887,11 +1887,7 @@ async function loadPolyhavenModel(assetId) {
     const cached = polyhavenModelCache.get(assetId);
     return cached.clone(true);
   }
-  const resolutionOrder = isLowProfileDevice
-    ? ['1k', '2k']
-    : prefersUhd
-      ? ['4k', '2k', '1k']
-      : ['2k', '1k', '4k'];
+  const resolutionOrder = ['2k', '1k'];
   const candidates = resolutionOrder.map((resolution) => ({
     url: `https://dl.polyhaven.org/file/ph-assets/Models/gltf/${resolution}/${assetId}/${assetId}_${resolution}.gltf`,
     resolution
@@ -2924,17 +2920,15 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
   return options.filter((option) => isDominoOptionUnlocked(key, option.id, inventory));
 }
 
-const HDRI_RESOLUTION_ORDER = Object.freeze(['1k', '2k', '4k']);
+const HDRI_RESOLUTION_ORDER = Object.freeze(['4k']);
 const isTelegramWebView = IS_TELEGRAM_RUNTIME;
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || '');
 const isLowMemoryDevice = typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4;
 const isLowCoreDevice = typeof navigator.hardwareConcurrency === 'number' && navigator.hardwareConcurrency <= 4;
 const isLowProfileDevice = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
-const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
+const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 2 : 3;
 function resolveHdriResolutionOrder() {
-  if (prefersUhd) return ['4k', '2k'];
-  if (isLowProfileDevice) return ['1k'];
-  return ['2k', '1k'];
+  return [...HDRI_RESOLUTION_ORDER];
 }
 function shouldLoadExternalHdri() {
   return true;


### PR DESCRIPTION
### Motivation
- Make Domino Royale load the same-quality environment and model assets (HDRIs, table and chairs) as Murlan Royale so visuals and performance presets are consistent across the two arenas.

### Description
- Use the same PolyHaven model resolution order as Murlan by changing `loadPolyhavenModel` to prefer `2k` then `1k` for GLTF model candidates in `webapp/public/domino-royal-game.js`.
- Force the HDRI resolution policy to the Murlan-style variant by setting `HDRI_RESOLUTION_ORDER` to `['4k']` so environment maps align with the Murlan presets.
- Increase HDRI cache allowances by changing `MAX_HDRI_CACHE_SIZE` to `prefersUhd ? 4 : isLowProfileDevice ? 2 : 3` to reduce thrash when switching high-res environments.
- Simplify `resolveHdriResolutionOrder` to return the configured `HDRI_RESOLUTION_ORDER` so the Domino logic follows the centralized HDRI ordering.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the file passed static syntax checking.
- Ran `npx eslint webapp/public/domino-royal-game.js`, which reported the file is ignored by the project ESLint configuration so no blocking lint errors were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb05f301883298544ae8bcdb42577)