### PR TITLE
Add loader stall timeout to Snooker Royal to avoid black screen

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -11153,6 +11153,8 @@ function SnookerRoyalGame({
   useEffect(() => {
     const manager = THREE.DefaultLoadingManager;
     let cancelled = false;
+    const LOADER_STALL_TIMEOUT_MS = 12000;
+    let stallTimeoutId = null;
     const prev = {
       onStart: manager.onStart,
       onLoad: manager.onLoad,
@@ -11164,6 +11166,20 @@ function SnookerRoyalGame({
       const ratio = Number.isFinite(loaded) ? loaded / safeTotal : 0;
       setLoadingProgress(Math.max(0, Math.min(1, ratio)));
     };
+    const clearStallTimeout = () => {
+      if (stallTimeoutId != null) {
+        window.clearTimeout(stallTimeoutId);
+        stallTimeoutId = null;
+      }
+    };
+    const armStallTimeout = () => {
+      clearStallTimeout();
+      stallTimeoutId = window.setTimeout(() => {
+        if (cancelled) return;
+        console.warn('Snooker Royal loader stalled; continuing without loading overlay.');
+        setLoadingActive(false);
+      }, LOADER_STALL_TIMEOUT_MS);
+    };
     const syncManagerState = () => {
       const loaded = Number(manager.itemsLoaded || 0);
       const total = Number(manager.itemsTotal || 0);
@@ -11172,10 +11188,12 @@ function SnookerRoyalGame({
         if (loaded >= total) {
           setLoadingProgress(1);
           setLoadingActive(false);
+          clearStallTimeout();
         }
       } else {
         setLoadingProgress(0);
         setLoadingActive(false);
+        clearStallTimeout();
       }
     };
     manager.onStart = (url, loaded, total) => {
@@ -11183,16 +11201,19 @@ function SnookerRoyalGame({
       if (cancelled) return;
       setLoadingActive(true);
       updateProgress(loaded, total);
+      armStallTimeout();
     };
     manager.onProgress = (url, loaded, total) => {
       prev.onProgress?.(url, loaded, total);
       if (cancelled) return;
       updateProgress(loaded, total);
+      armStallTimeout();
     };
     manager.onLoad = () => {
       prev.onLoad?.();
       if (cancelled) return;
       setLoadingProgress(1);
+      clearStallTimeout();
       window.setTimeout(() => {
         if (!cancelled) setLoadingActive(false);
       }, 200);
@@ -11201,10 +11222,12 @@ function SnookerRoyalGame({
       prev.onError?.(url);
       if (cancelled) return;
       setLoadingProgress((prevValue) => Math.max(prevValue, 0.9));
+      armStallTimeout();
     };
     syncManagerState();
     return () => {
       cancelled = true;
+      clearStallTimeout();
       manager.onStart = prev.onStart;
       manager.onLoad = prev.onLoad;
       manager.onProgress = prev.onProgress;


### PR DESCRIPTION
### Motivation
- Prevent users being stuck on a black loading overlay when Three.js asset loading stalls (network/CDN or loading-manager hang). 

### Description
- Add a 12s stall guard (`LOADER_STALL_TIMEOUT_MS = 12000`) and a `stallTimeoutId` to `webapp/src/pages/Games/SnookerRoyal.jsx` to detect loader stalls.  
- Implement `armStallTimeout` and `clearStallTimeout`, rearming the timeout on `manager.onStart`, `manager.onProgress`, and `manager.onError`, and clearing it on successful `manager.onLoad` and cleanup.  
- When the stall timeout fires the loading overlay is dismissed (`setLoadingActive(false)`) and a warning is logged so gameplay can continue instead of showing a black page.  

### Testing
- Built the webapp successfully with `npm --prefix webapp run build`, which completed without errors.  
- An automated Playwright screenshot attempt in the container failed because Chromium crashed (SIGSEGV), so a runtime browser capture could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb56234548329b3402695ddf07256)