### PR TITLE
Fix Snooker Royal black screen caused by initialization order errors

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6956,6 +6956,17 @@ function Table3D(
   const halfH = PLAY_H / 2;
   const baulkLineZ = -PLAY_H / 2 + BAULK_FROM_BAULK;
   const frameTopY = FRAME_TOP_Y;
+  const railH = RAIL_HEIGHT;
+  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.085; // push the cushions slightly farther outward to match the physical rail edge
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
+  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
+  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
+  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
+  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
+  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
+  const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const clothPlaneLocal = CLOTH_TOP_LOCAL + CLOTH_LIFT;
   const clothSurfaceY = clothPlaneLocal - CLOTH_DROP;
 
@@ -7843,7 +7854,6 @@ function Table3D(
     }
   });
 
-  const railH = RAIL_HEIGHT;
   const railsTopY = frameTopY + railH;
   const longRailW = ORIGINAL_RAIL_WIDTH; // keep the long rail caps as wide as the end rails so side pockets match visually
   const endRailW = ORIGINAL_RAIL_WIDTH;
@@ -7893,16 +7903,6 @@ function Table3D(
     mesh.material.needsUpdate = true;
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
-  const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.085; // push the cushions slightly farther outward to match the physical rail edge
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = -TABLE.THICK * 0.01; // push the short-rail cushions slightly farther from center so their noses sit flush against the rails
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.004; // keep a subtle setback along the long rails to prevent overlap
-  const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.34; // shorten the long-rail cushions slightly more so the noses stay clear of the pocket openings
-  const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.0; // trim the cushion tips near middle pockets so they stop at the rail cut
-  const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.55; // reduce long-rail cushion reach further to keep noses out of pocket perimeters
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.28; // lightly trim short-rail cushions to match the new pocket clearance
-  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
-  const SIDE_CUSHION_CORNER_SHIFT = BALL_R * 0.18; // slide the side cushions toward the middle pockets so each cushion end lines up flush with the pocket jaws
-  const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile
   const railsGroup = new THREE.Group();
   finishParts.accentParent = railsGroup;
   const outerCornerRadius =
@@ -14693,6 +14693,7 @@ const powerRef = useRef(hud.power);
       updateEnvironmentRef.current = applyHdriEnvironment;
       void applyHdriEnvironment(activeEnvironmentVariantRef.current);
       let worldScaleFactor = WORLD_SCALE * (tableSizeRef.current?.scale ?? 1);
+      let applyWorldScale = () => false;
       let cue;
       let clothMat;
       let cushionMat;
@@ -20015,7 +20016,7 @@ const powerRef = useRef(hud.power);
       }
       // ensure the camera respects the configured zoom limits
       sph.radius = clampOrbitRadius(sph.radius);
-      const applyWorldScale = () => {
+      applyWorldScale = () => {
         const tableScale = tableSizeRef.current?.scale ?? 1;
         const nextScale = WORLD_SCALE * tableScale;
         const changed = Math.abs(worldScaleFactor - nextScale) > 1e-4;


### PR DESCRIPTION
### Motivation
- The Snooker Royal page showed a black screen on startup due to runtime `ReferenceError`s caused by temporal-dead-zone (TDZ) initialization order issues inside the table construction code. 
- Early callbacks could also invoke `applyWorldScale` before it was assigned, producing additional startup errors and preventing the scene from rendering.

### Description
- Moved the `railH` declaration and all cushion/rail geometry constants earlier inside `Table3D` so they are defined before first use in `webapp/src/pages/Games/SnookerRoyal.jsx`. 
- Added a safe placeholder `applyWorldScale` prior to any callbacks and then assigned the real implementation later to prevent early invocation before initialization. 
- Cleaned up a duplicate/malformed constants block and adjusted the later `applyWorldScale` assignment so the function is available when called during setup.

### Testing
- Successfully built the webapp with `npm --prefix webapp run build` (Vite build completed). 
- Reproduced the runtime TDZ errors against `http://127.0.0.1:4173/games/snookerroyale` and then verified the errors were removed with Playwright console/pageerror checks (observed `ERROR_COUNT 0` after the fix). 
- Playwright screenshot attempts timed out in this environment due to heavy WebGL/canvas work, but console/runtime error checks confirm the black-screen crash is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb56234548329b3402695ddf07256)