### PR TITLE
Restore pocket camera activation and add legal-ball aim assist in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22612,6 +22612,74 @@ const powerRef = useRef(hud.power);
         return projectFromClient(client.x, client.y);
       };
 
+      const resolvePlayerAssistAimDirection = (
+        baseDir,
+        { snapStrength = 1 } = {}
+      ) => {
+        if (!baseDir || typeof baseDir.lengthSq !== 'function') return baseDir;
+        const normalized = baseDir.lengthSq() > 1e-6
+          ? baseDir.clone().normalize()
+          : null;
+        if (!normalized || !cue?.active) return normalized;
+        const currentHud = hudRef.current;
+        if ((currentHud?.turn ?? null) !== 0 || currentHud?.inHand || shooting) {
+          return normalized;
+        }
+        const ballsList = ballsRef.current?.length > 0 ? ballsRef.current : balls;
+        const activeBalls = Array.isArray(ballsList)
+          ? ballsList.filter((ball) => ball?.active && String(ball.id) !== 'cue')
+          : [];
+        if (activeBalls.length === 0) return normalized;
+        const frameSnapshot = frameRef.current ?? frameState;
+        const activeVariantId = activeVariantRef.current?.id ?? variantKey;
+        const targetOrder = resolveTargetPriorities(
+          frameSnapshot,
+          activeVariantId,
+          activeBalls
+        );
+        const legalTargetsRaw =
+          Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
+            ? frameSnapshot.ballOn
+            : targetOrder;
+        const legalTargets = new Set(
+          legalTargetsRaw
+            .map((entry) => normalizeTargetId(entry))
+            .filter((entry) => entry && isBallTargetId(entry))
+        );
+        const isLegalTargetBall = (ball) => {
+          if (!ball || legalTargets.size === 0) return true;
+          return Array.from(legalTargets).some((target) =>
+            matchesTargetId(ball, target)
+          );
+        };
+        const contact = calcTarget(cue, normalized, activeBalls);
+        if (contact?.targetBall && isLegalTargetBall(contact.targetBall)) {
+          return normalized;
+        }
+        const cuePos = cue?.pos ? new THREE.Vector2(cue.pos.x, cue.pos.y) : null;
+        if (!cuePos) return normalized;
+        let bestDir = null;
+        let bestDot = -Infinity;
+        activeBalls.forEach((ball) => {
+          if (!isLegalTargetBall(ball) || !ball?.pos) return;
+          const candidate = new THREE.Vector2(
+            ball.pos.x - cuePos.x,
+            ball.pos.y - cuePos.y
+          );
+          if (candidate.lengthSq() <= 1e-6) return;
+          candidate.normalize();
+          const dot = normalized.dot(candidate);
+          if (dot > bestDot) {
+            bestDot = dot;
+            bestDir = candidate;
+          }
+        });
+        if (!bestDir) return normalized;
+        const resolvedStrength = THREE.MathUtils.clamp(snapStrength, 0, 1);
+        if (resolvedStrength >= 0.999) return bestDir;
+        return normalized.clone().lerp(bestDir, resolvedStrength).normalize();
+      };
+
       const updateTopViewAimFromPointer = (ev) => {
         const cueBall = cueRef.current || cue;
         if (!cueBall?.active) return false;
@@ -22622,7 +22690,9 @@ const powerRef = useRef(hud.power);
           .sub(new THREE.Vector2(cueBall.pos.x, cueBall.pos.y));
         if (dir.lengthSq() < 1e-6) return false;
         dir.normalize();
-        aimDirRef.current.copy(dir);
+        const assistedDir = resolvePlayerAssistAimDirection(dir, { snapStrength: 1 });
+        if (!assistedDir || assistedDir.lengthSq() < 1e-6) return false;
+        aimDirRef.current.copy(assistedDir);
         cameraUpdateRef.current?.();
         return true;
       };
@@ -23544,7 +23614,7 @@ const powerRef = useRef(hud.power);
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
           const suppressPocketCameras =
-            suppressOpeningShotViews || broadcastSystem?.avoidPocketCameras;
+            broadcastSystem?.avoidPocketCameras;
           const forceActionActivation = broadcastSystem?.forceActionActivation;
           const orbitSnapshot = sphRef.current
             ? {
@@ -26863,7 +26933,10 @@ const powerRef = useRef(hud.power);
               aimDir.normalize();
             }
           } else {
-            aimDir.lerp(tmpAim, aimLerpFactor);
+            const playerAssistDir = isPlayerTurn
+              ? resolvePlayerAssistAimDirection(tmpAim, { snapStrength: 0.55 })
+              : tmpAim;
+            aimDir.lerp(playerAssistDir, aimLerpFactor);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
             }
@@ -28076,7 +28149,6 @@ const powerRef = useRef(hud.power);
           }
         }
         const suppressPocketCameras =
-          openingShotViewSuppressedRef.current ||
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
         const earlyPocketIntent = pocketSwitchIntentRef.current;


### PR DESCRIPTION
### Motivation
- Restore the pocket-camera availability during shots to the behavior from yesterday (pocket cams should be active by default during shot flow unless the broadcast system explicitly disables them). 
- Speed up player aiming by nudging the aim line toward the player’s legal object balls so players can target legal balls faster without hard-limiting their freedom to aim.

### Description
- Added a new helper `resolvePlayerAssistAimDirection` that computes an assisted aim direction by verifying legal targets, testing first-contact via `calcTarget`, and snapping or blending the input direction toward the closest legal-ball direction.
- Wired the assist into top-down pointer placement by using full-snap (`snapStrength: 1`) in `updateTopViewAimFromPointer` so pointer aiming snaps to legal balls when appropriate.
- Applied a softer assist (`snapStrength: 0.55`) during normal aim interpolation so the visible aim line gently biases toward legal balls without preventing manual adjustments.
- Restored pocket-camera activation by removing the opening-shot suppression gate from the pocket-camera suppression checks while retaining support for broadcast-system opt-out via `broadcastSystem?.avoidPocketCameras`.
- Modified only `webapp/src/pages/Games/PoolRoyale.jsx` (added ~76 lines, small deletions) and kept scope limited to player-turn aiming (not applied to AI or in-hand placement).

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported a repository ignore warning but no rule errors (file is ignored by repo lint config). 
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite started successfully. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173` to validate the running UI (artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb8d3d06c83299721f7535adb6e9e)