### PR TITLE
Fix side-pocket camera freeze and force AI opening break

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18707,6 +18707,18 @@ const powerRef = useRef(hud.power);
             } else {
               railDir = activeShotView.railDir;
             }
+            let approachDir = activeShotView.approach
+              ? activeShotView.approach.clone()
+              : new THREE.Vector2(0, -railDir);
+            if (approachDir.lengthSq() < 1e-6) {
+              approachDir.set(0, -railDir);
+            }
+            approachDir.normalize();
+            if (activeShotView.approach) {
+              activeShotView.approach.copy(approachDir);
+            } else {
+              activeShotView.approach = approachDir.clone();
+            }
             let broadcastRailDir =
               activeShotView.broadcastRailDir ?? (anchorType === 'side' ? null : railDir);
             const fallbackBroadcast = signed(
@@ -18737,18 +18749,6 @@ const powerRef = useRef(hud.power);
             };
             const heightScale =
               activeShotView.heightScale ?? POCKET_CAM.heightScale ?? 1;
-            let approachDir = activeShotView.approach
-              ? activeShotView.approach.clone()
-              : new THREE.Vector2(0, -railDir);
-            if (approachDir.lengthSq() < 1e-6) {
-              approachDir.set(0, -railDir);
-            }
-            approachDir.normalize();
-            if (activeShotView.approach) {
-              activeShotView.approach.copy(approachDir);
-            } else {
-              activeShotView.approach = approachDir.clone();
-            }
             const resolvedAnchorId = resolvePocketCameraAnchor(
               activeShotView.pocketId ?? pocketIdFromCenter(pocketCenter),
               pocketCenter,
@@ -26036,9 +26036,8 @@ const powerRef = useRef(hud.power);
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
               isOpeningBreak &&
-              breakInProgress &&
               aiTurnActive &&
-              (breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
+              (aiWonBreak || (breakInProgress && openingPlayer === 'B'));
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
               if (rackBalls.length > 0) {


### PR DESCRIPTION
### Motivation

- The pocket camera flow could reference an unset `approachDir` for middle/side pockets causing a runtime freeze during pocket-focused camera transitions.  
- At game start when AI wins the break roll it was sometimes aiming the middle pocket instead of the rack and not using full power for the opening break.  

### Description

- Initialize and normalize `approachDir` early and persist it on `activeShotView` before calling `resolveShortRailBroadcastDirection`, preventing the pocket-camera code from using an undefined approach vector.  
- Use the computed `approachDir` when resolving broadcast direction and when selecting the pocket camera anchor to make side-pocket camera selection stable.  
- Adjust AI opening-break logic so when the AI is the opening breaker it forces a `break` plan that aims at the rack with `power: 1`, while keeping normal AI shot behavior after the opening break.  
- Changes made in `webapp/src/pages/Games/PoolRoyale.jsx` only.  

### Testing

- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (file is ignored by repo lint config; no blocking errors).  
- Ran targeted Jest tests with `npm test -- --runInBand test/poolAi.test.js test/poolUkAdvancedAi.test.js` and both test suites passed (2 test suites, 17 tests all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ebe5e58f88329b925931044495e41)