### PR TITLE
Fix Pool Royale AI middle-pocket freeze and opening-break targeting

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -57,6 +57,21 @@ function dist (a, b) {
   return Math.hypot(dx, dy)
 }
 
+function safeDistance (a, b, fallback = 1e-6) {
+  const d = dist(a, b)
+  if (!Number.isFinite(d) || d <= 0) return fallback
+  return d
+}
+
+function ghostBallForEntry (target, entry, diameter) {
+  const targetToEntry = safeDistance(target, entry)
+  const scale = diameter / targetToEntry
+  return {
+    x: target.x - (entry.x - target.x) * scale,
+    y: target.y - (entry.y - target.y) * scale
+  }
+}
+
 function lineIntersectsBall (a, b, ball, radius) {
   const apx = ball.x - a.x
   const apy = ball.y - a.y
@@ -142,6 +157,35 @@ function pocketAlignment (pocket, target, width, height) {
   const len = Math.hypot(approach.x, approach.y) || 1
   const normal = pocketNormal(pocket, width, height)
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
+}
+
+function openingBreakShot (req) {
+  if (!req?.state?.breakInProgress) return null
+  const cue = req.state.balls.find(b => b.id === 0 && !b.pocketed)
+  if (!cue) return null
+  const objectBalls = req.state.balls.filter(b => b.id !== 0)
+  if (objectBalls.length === 0 || objectBalls.some(b => b.pocketed)) return null
+
+  let apex = objectBalls[0]
+  let bestDist = dist(cue, apex)
+  for (let i = 1; i < objectBalls.length; i++) {
+    const candidate = objectBalls[i]
+    const candidateDist = dist(cue, candidate)
+    if (candidateDist < bestDist) {
+      bestDist = candidateDist
+      apex = candidate
+    }
+  }
+
+  return {
+    angleRad: Math.atan2(apex.y - cue.y, apex.x - cue.x),
+    power: 1,
+    spin: { top: 0, side: 0, back: 0 },
+    targetBallId: apex.id,
+    aimPoint: { x: apex.x, y: apex.y },
+    quality: 0.5,
+    rationale: 'opening-break-rack-max-power'
+  }
 }
 
 function currentGroup (state) {
@@ -269,10 +313,7 @@ function clearShotCandidates (req) {
   for (const target of targets) {
     for (const pocket of pockets) {
       const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
-      const ghost = {
-        x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
-        y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
-      }
+      const ghost = ghostBallForEntry(target, entry, r * 2)
 
       // ensure ghost is within table bounds
       if (
@@ -299,7 +340,7 @@ function clearShotCandidates (req) {
       const potVec = { x: entry.x - target.x, y: entry.y - target.y }
       let cut = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
       if (cut > Math.PI) cut = Math.abs(cut - Math.PI * 2)
-      const viewAngle = Math.atan2(r * 2, dist(target, entry))
+      const viewAngle = Math.atan2(r * 2, safeDistance(target, entry))
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
@@ -448,10 +489,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const rng = options.rng ?? Math.random
   const balls = ballsOverride || req.state.balls
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
-  const ghost = {
-    x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
-    y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
-  }
+  const ghost = ghostBallForEntry(target, entry, r * 2)
   // if ghost lies outside playable area, shot is impossible
   if (
     ghost.x < r ||
@@ -492,8 +530,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
   if (cutAngle > Math.PI) cutAngle = Math.abs(cutAngle - Math.PI * 2)
   const centerAlign = 1 - Math.min(cutAngle / (Math.PI / 2), 1)
-  const nearHole = 1 - Math.min(dist(target, entry) / (r * 20), 1)
-  const viewAngle = Math.atan2(r * 2, dist(target, entry))
+  const targetToEntry = safeDistance(target, entry)
+  const nearHole = 1 - Math.min(targetToEntry / (r * 20), 1)
+  const viewAngle = Math.atan2(r * 2, targetToEntry)
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
   const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
   const pocketOpen = viewScore * (0.7 + 0.3 * entryAlignment)
@@ -579,10 +618,7 @@ function fallbackAimAtTarget (req) {
     }
     if (!bestPocket) continue
     const entry = pocketEntry(bestPocket, req.state.ballRadius, req.state.width, req.state.height, target)
-    const ghost = {
-      x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
-      y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
-    }
+    const ghost = ghostBallForEntry(target, entry, req.state.ballRadius * 2)
     if (
       ghost.x < req.state.ballRadius ||
       ghost.x > req.state.width - req.state.ballRadius ||
@@ -617,6 +653,9 @@ function fallbackAimAtTarget (req) {
  * @returns {ShotDecision}
  */
 export function planShot (req) {
+  const breakShot = openingBreakShot(req)
+  if (breakShot) return breakShot
+
   const r = req.state.ballRadius
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
@@ -653,8 +692,8 @@ export function planShot (req) {
         const distTP = Math.hypot(toPocket.x, toPocket.y) || 1
         const dir = { x: target.x - entry.x, y: target.y - entry.y }
         const ghost = {
-          x: target.x - (entry.x - target.x) * (r * 2 / dist(target, entry)),
-          y: target.y - (entry.y - target.y) * (r * 2 / dist(target, entry))
+          x: target.x - (entry.x - target.x) * (r * 2 / safeDistance(target, entry)),
+          y: target.y - (entry.y - target.y) * (r * 2 / safeDistance(target, entry))
         }
         const dists = [4, 6, 8, 10, 12].map(m => m * r)
         for (const d of dists) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -296,3 +296,62 @@ test('avoids unnecessary spin when natural position is good', () => {
   assert.equal(decision.power, 0.5);
   assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
 });
+
+test('opening break targets rack apex with max power', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 700, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 720, y: 240, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 720, y: 260, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: true
+    },
+    timeBudgetMs: 50
+  };
+
+  const decision = planShot(req);
+  assert.equal(decision.targetBallId, 1);
+  assert.equal(decision.power, 1);
+  assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
+  assert.equal(decision.rationale, 'opening-break-rack-max-power');
+});
+
+test('middle pocket alignment edge case keeps aim finite', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 500, y: 0, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50,
+    rngSeed: 7
+  };
+
+  const decision = planShot(req);
+  assert(Number.isFinite(decision.angleRad));
+  if (decision.aimPoint) {
+    assert(Number.isFinite(decision.aimPoint.x));
+    assert(Number.isFinite(decision.aimPoint.y));
+  }
+});


### PR DESCRIPTION
### Motivation

- Prevent AI aim computation from producing NaN/Infinite vectors when a target/pocket alignment produces a zero distance (this was causing freezes when aiming at middle pockets). 
- Ensure the AI uses a deterministic opening-break behavior: when the AI breaks at game start it should aim at the rack apex with max power. 
- Keep normal shot planning unchanged after the break while making the runtime (web) and library copies consistent.

### Description

- Added `safeDistance` and `ghostBallForEntry` helpers and replaced ad-hoc ghost/ratio math with these safe helpers to avoid divide-by-zero and keep aim vectors finite (`lib/poolAi.js` and `webapp/public/lib/poolAi.js`).
- Introduced `openingBreakShot(req)` and call it at the top of `planShot` so when `req.state.breakInProgress` and object balls are untouched the AI aims at the rack apex with `power: 1` and neutral spin. 
- Replaced inline ghost-ball projections and `dist(...)` uses with `ghostBallForEntry` / `safeDistance` across candidate gathering and evaluation to harden middle-pocket edge cases. 
- Mirrored the same fixes in the web runtime copy (`webapp/public/lib/poolAi.js`) and added two regression tests to `test/poolAi.test.js` to cover the opening-break behavior and a middle-pocket alignment edge case.
- Files changed: `lib/poolAi.js`, `webapp/public/lib/poolAi.js`, `test/poolAi.test.js`.

### Testing

- Ran the unit tests with `node --test test/poolAi.test.js` and all tests passed (`13/13` passing). 
- The added tests validate the opening-break target/power and that aim values remain finite for a middle-pocket alignment edge case. 
- No other automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ebe5e58f88329b925931044495e41)