### PR TITLE
Improve Domino Royal table/chair/HDRI render resolution behavior

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1178,13 +1178,9 @@ function applyRendererQuality(quality = frameQuality) {
       ? quality.pixelRatioCap
       : resolveDefaultPixelRatioCap();
   const cappedRatio = prefersUhd ? Math.max(pixelRatioCap, 2) : pixelRatioCap;
-  const runtimePixelRatioCap = IS_TELEGRAM_RUNTIME ? Math.min(cappedRatio, 1) : cappedRatio;
+  const runtimePixelRatioCap = cappedRatio;
   renderer.setPixelRatio(Math.min(runtimePixelRatioCap, dpr));
-  if (IS_TELEGRAM_RUNTIME && quality && typeof quality === 'object') {
-    setRendererSize({ ...quality, renderScale: Math.min(quality.renderScale || 1, 1) });
-  } else {
-    setRendererSize(quality);
-  }
+  setRendererSize(quality);
 }
 applyRendererQuality();
 if (!app) {
@@ -1763,7 +1759,7 @@ const getPoolCarpetTextures = (() => {
   };
 })();
 
-const CHAIR_CLOTH_TEXTURE_SIZE = 512;
+const CHAIR_CLOTH_TEXTURE_SIZE = 1024;
 const CHAIR_CLOTH_REPEAT = 12;
 const DEFAULT_CHAIR_THEME = Object.freeze({
   id: "crimsonVelvet",
@@ -2932,7 +2928,8 @@ const isLowCoreDevice = typeof navigator.hardwareConcurrency === 'number' && nav
 const isLowProfileDevice = isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
 const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
-  if (prefersUhd) return ['4k', '2k'];
+  if (prefersUhd || frameQuality?.id === 'uhd120' || frameQuality?.id === 'ultra144') return ['4k', '2k'];
+  if (frameQuality?.id === 'qhd90') return ['2k', '1k'];
   if (isLowProfileDevice) return ['1k'];
   return ['2k', '1k'];
 }
@@ -3902,7 +3899,7 @@ function createRegularPolygonShape(sides = 8, radius = 1) {
 }
 
 function makeClothTexture({ top = "#155c2a", bottom = "#0b3a1d", border = "#041f10" } = {}) {
-  const size = 512;
+  const size = 1024;
   const canvas = document.createElement("canvas");
   canvas.width = canvas.height = size;
   const ctx = canvas.getContext("2d");


### PR DESCRIPTION
### Motivation
- Users reported cloth/chair/HDRI textures are too low-res and that selecting higher graphics profiles falls back to lower settings.
- The renderer forced Telegram WebView sessions to clamp DPR/render scale which prevented higher-quality presets from taking effect.

### Description
- Relaxed the Telegram-only DPR clamp in `applyRendererQuality` so selected presets actually apply by setting `runtimePixelRatioCap = cappedRatio` and always calling `setRendererSize(quality)` (file: `webapp/public/domino-royal-game.js`).
- Increased procedural chair cloth generation size by changing `CHAIR_CLOTH_TEXTURE_SIZE` from `512` to `1024` for sharper seat textures (file: `webapp/public/domino-royal-game.js`).
- Increased table felt procedural texture resolution from `512` to `1024` via `makeClothTexture` to improve table clarity (file: `webapp/public/domino-royal-game.js`).
- Updated HDRI resolution selection in `resolveHdriResolutionOrder` so `qhd90` prefers `2k` and `uhd120`/`ultra144` prefer `4k` (and `2k`) instead of always falling back to `1k` on low-profile devices (file: `webapp/public/domino-royal-game.js`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate syntax, which succeeded.
- Launched the webapp dev server (`npm --prefix webapp run dev`) and captured a visual verification screenshot of the Domino Royal scene in portrait mode, confirming higher-resolution textures and HDRI selection applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec92e1958832995c6014fbad0725c)