### PR TITLE
Pool Royale: disable middle-pocket cameras, fix AI opening break, and normalize spin power/preview

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6084,7 +6084,7 @@ const getPocketCenterById = (id) => {
       return null;
   }
 };
-const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
+const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
@@ -6104,9 +6104,8 @@ const resolvePocketCameraAnchor = (pocketId, center, approachDir, ballPos) => {
     case 'BR':
       return pocketId;
     case 'TM':
-      return 'TM';
     case 'BM':
-      return 'BM';
+      return null;
     default:
       return pocketId;
   }
@@ -6825,14 +6824,13 @@ function resolveCueFollowPreview({
   spin,
   powerStrength,
   cuePowerStrength,
-  liftStrength = 0
+  _liftStrength = 0
 }) {
   const normalizedSpin = normalizeSpinInput(spin);
   const clampedPower = THREE.MathUtils.clamp(powerStrength ?? 0, 0, 1);
   const clampedCuePower = Number.isFinite(cuePowerStrength)
     ? THREE.MathUtils.clamp(cuePowerStrength ?? 0, 0, 1)
     : clampedPower;
-  const impactPower = clampedCuePower;
   const baseDir = cueDir ? cueDir.clone() : null;
   if (!baseDir || baseDir.lengthSq() < 1e-8) {
     baseDir?.set(0, 0, 1);
@@ -6845,51 +6843,11 @@ function resolveCueFollowPreview({
   } else {
     aimVec.normalize();
   }
-  const spinAdjusted =
-    resolveTargetSpinDeflection(
-      baseDir ?? aimVec,
-      aimVec,
-      normalizedSpin,
-      impactPower,
-      liftStrength
-    ) ?? baseDir ?? aimVec;
-  const spinX = normalizedSpin?.x ?? 0;
   const spinY = normalizedSpin?.y ?? 0;
-  const spinMagnitude = Math.hypot(spinX, spinY);
+  const spinMagnitude = Math.hypot(normalizedSpin?.x ?? 0, spinY);
   const backspinWeight = Math.max(0, -spinY);
   const topspinWeight = Math.max(0, spinY);
-  const backspinLerp = resolveBackspinPreviewLerp(backspinWeight);
-  const topspinLerp = Math.min(0.35, Math.pow(topspinWeight, 0.6) * 0.35);
-  const previewDir = spinAdjusted.clone();
-  const backwards = aimVec.clone().multiplyScalar(-1);
-  const cutAlignment = THREE.MathUtils.clamp(previewDir.dot(aimVec), -1, 1);
-  const cutPenalty = Math.sqrt(Math.max(0, 1 - Math.abs(cutAlignment)));
-  if (BACKSPIN_DIRECTION_PREVIEW > 0 && backspinLerp > 1e-4) {
-    const drawBlend = THREE.MathUtils.clamp(
-      backspinLerp * BACKSPIN_DIRECTION_PREVIEW * (0.7 + 0.3 * impactPower),
-      0,
-      1
-    );
-    previewDir.lerp(backwards, drawBlend);
-  } else if (topspinLerp > 1e-4) {
-    const followBlend = THREE.MathUtils.clamp(
-      topspinLerp * (0.75 + impactPower * 0.35) * (1 - cutPenalty * 0.45),
-      0,
-      1
-    );
-    previewDir.lerp(aimVec, followBlend);
-  }
-  const sideInfluence =
-    Math.min(Math.abs(spinX), 1) *
-    (0.18 + impactPower * 0.22) *
-    (1 - cutPenalty * 0.3);
-  if (sideInfluence > 1e-4) {
-    const perp = new THREE.Vector3(-previewDir.z, 0, previewDir.x);
-    if (perp.lengthSq() > 1e-8) {
-      perp.normalize();
-      previewDir.add(perp.multiplyScalar(spinX * sideInfluence));
-    }
-  }
+  const previewDir = aimVec.clone();
   if (previewDir.lengthSq() > 1e-8) previewDir.normalize();
   const power = clampedPower;
   const cuePower = clampedCuePower;
@@ -6907,7 +6865,7 @@ function resolveCueFollowPreview({
   return {
     dir: previewDir,
     length,
-    backwards: previewDir.dot(aimVec) < 0
+    backwards: false
   };
 }
 
@@ -19507,6 +19465,7 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (isSidePocket) return null;
           const triggerDistance = allowEarly
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
@@ -23593,23 +23552,17 @@ const powerRef = useRef(hud.power);
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
           const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const topspinPowerScale = resolveTopspinPowerScale(clampedPower);
           const scaledSpin = {
             x: (physicsSpin.x ?? 0) * SPIN_GLOBAL_SCALE,
             y: (physicsSpin.y ?? 0) * SPIN_GLOBAL_SCALE
           };
           const baseSide = scaledSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = scaledSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER;
+          let spinTop = scaledSpin.y * (ranges.forward ?? 0);
           if (scaledSpin.y < 0) {
             spinTop *= BACKSPIN_MULTIPLIER;
           } else if (scaledSpin.y > 0) {
-            spinTop = scaledSpin.y * (ranges.forward ?? 0) * topspinPowerScale;
             spinTop *= TOPSPIN_MULTIPLIER;
-            if (Math.abs(baseSide) > 1e-6) {
-              spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
-            }
           }
           cue.vel.copy(base);
           if (cue.spin) {
@@ -25966,9 +25919,8 @@ const powerRef = useRef(hud.power);
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
               isOpeningBreak &&
-              breakInProgress &&
               aiTurnActive &&
-              (breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
+              (breakInProgress || breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
               if (rackBalls.length > 0) {


### PR DESCRIPTION
### Motivation
- Prevent game freeze caused by middle-pocket camera/view activation and reduce unexpected camera switches during shots. 
- Ensure AI performs a proper opening break (aims at the rack and uses max power only for the opening break). 
- Remove unintended power amplification and pre-impact deflection introduced by spin so shot power and initial aim remain consistent with player expectation.

### Description
- Limit pocket camera anchors to corner pockets only by removing middle-pocket IDs from `POCKET_CAMERA_IDS` and resolving middle-pocket anchors to `null`, and add a runtime guard to skip side/middle pocket camera activation (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Update AI opening-break logic so when AI wins/starts the break it sets the plan to a `break` aimed at the rack center with `power: 1` and zero spin, and only forces this for the opening break path. 
- Remove spin-driven pre-impact aim deflection in the cue-follow preview so the preview line remains aligned to the visible aim line before impact. 
- Stop scaling applied spin components by shot power at execution time so spin no longer increases effective shot power (keep backspin/topspin multipliers intact but remove power amplification).

### Testing
- Ran linter: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed (file is ignored by project ESLint patterns; no errors reported). 
- Started the dev server: `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully. 
- Captured a headless browser screenshot with Playwright of the running app to validate the UI load (`page.screenshot`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed323b0a483299bc20868c7fecdc6)