### PR TITLE
Fix Pool Royale middle-pocket freeze, AI opening-break aim, and pre-impact spin behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6924,6 +6924,26 @@ function calcTarget(cue, dir, balls) {
     };
   }
   const cuePos = cue.pos.clone();
+  if (!Number.isFinite(cuePos.x) || !Number.isFinite(cuePos.y)) {
+    return {
+      impact: new THREE.Vector2(),
+      targetDir: null,
+      cueDir: null,
+      targetBall: null,
+      railNormal: null,
+      tHit: 0
+    };
+  }
+  if (!Number.isFinite(dir?.x) || !Number.isFinite(dir?.y)) {
+    return {
+      impact: cuePos.clone(),
+      targetDir: null,
+      cueDir: null,
+      targetBall: null,
+      railNormal: null,
+      tHit: 0
+    };
+  }
   if (!dir || dir.lengthSq() < 1e-8) {
     return {
       impact: cuePos.clone(),
@@ -25966,9 +25986,8 @@ const powerRef = useRef(hud.power);
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
               isOpeningBreak &&
-              breakInProgress &&
               aiTurnActive &&
-              (breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
+              (aiWonBreak || openingPlayer === 'B' || breakRollState === 'done' || breakInProgress);
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
               if (rackBalls.length > 0) {
@@ -27743,7 +27762,8 @@ const powerRef = useRef(hud.power);
             if (hasSpin) {
               applySpinController(b, stepScale, hasLift);
             }
-            if (!hasLift) {
+            const preImpactCueSpinLocked = isCue && !b.impacted;
+            if (!hasLift && !preImpactCueSpinLocked) {
               const dt = SPIN_FIXED_DT * stepScale;
               if (b.omega) {
                 TMP_VEC3_A.set(b.vel.x, 0, b.vel.y);
@@ -27977,7 +27997,7 @@ const powerRef = useRef(hud.power);
                 ) {
                   activeShotView.hitConfirmed = true;
                 }
-                if (cueBall && cueBall.omega?.lengthSq() > 0) {
+                if (cueBall) {
                   cueBall.impacted = true;
                 }
               }


### PR DESCRIPTION
### Motivation
- Prevent the aiming system from encountering invalid vectors around the middle pockets that can freeze the aiming flow.
- Ensure the AI reliably executes an opening break aimed at the rack with max power when it wins the break/start of game.
- Stop cue-ball spin from producing unintended extra launch power or deflections before the first impact while preserving post-impact spin behaviour.

### Description
- Add defensive finite-value guards to `calcTarget` so the function returns safe defaults when `cue.pos` or `dir` contain `NaN`/`Infinity` values, avoiding propagated bad vectors that can stall aiming (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Relax the AI opening-break gate so the AI will force a `type: 'break'` plan aimed at the rack with `power: 1` whenever it is the opening breaker (`isOpeningBreak && aiTurnActive && (aiWonBreak || openingPlayer === 'B' || breakRollState === 'done' || breakInProgress)`).
- Lock spin-driven translation before first contact by skipping the spin->velocity integration when `isCue && !b.impacted`, preventing spin from increasing pre-impact cue speed or creating deflections; spin resumes after the first collision as before.
- Make cue-impact activation unconditional on collision events by setting `cueBall.impacted = true` on first-contact code paths so post-impact spin logic transitions correctly.

### Testing
- Ran `npm test -- --runInBand test/poolAi.test.js` and it passed (11 tests, all green).
- Ran `npm test -- --runInBand test/poolRoyaleSpinController.test.js` and it reported a failing expectation unrelated to these changes (center-spin stun bias expectation); other tests in that suite passed (4/5 tests passed, 1 failure).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported the file is ignored by repo eslint settings (warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee7ce481c83299c02378af40c8713)