### PR TITLE
Pool Royale: Restrict AI max power, corner-only pocket cam, and legal-target auto-aim

### DIFF
--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -240,6 +240,42 @@ test('prefers target with smallest cut angle', () => {
   assert.equal(decision.targetBallId, 1);
 });
 
+
+test('uses max power only during break shots', () => {
+  const baseReq = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 520, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 80,
+    rngSeed: 9
+  };
+
+  const normal = planShot(baseReq);
+  assert(normal.power <= 0.78);
+
+  const breaking = planShot({
+    ...baseReq,
+    state: {
+      ...baseReq.state,
+      breakInProgress: true
+    }
+  });
+  assert(breaking.power <= 0.98);
+  assert(breaking.power >= normal.power);
+});
+
 test('cue ball remains within table bounds for varied power and spin', () => {
   const cue = { id: 0, x: 500, y: 250, vx: 0, vy: 0, pocketed: false };
   const target = { id: 1, x: 600, y: 250, vx: 0, vy: 0, pocketed: false };

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -607,15 +607,19 @@ function fallbackAimAtTarget (req) {
 
 function buildPowerOptions (req, cuePos, target) {
   const r = req.state.ballRadius
+  const isBreakShot = Boolean(req.state.breakInProgress)
   const shotDist = dist(cuePos, target)
-  const base = clamp(shotDist / (r * 32), 0.4, 0.92)
+  const normalMax = 0.78
+  const breakMax = 0.98
+  const maxPower = isBreakShot ? breakMax : normalMax
+  const base = clamp(shotDist / (r * 32), 0.4, maxPower)
   const candidates = [
     base - 0.14,
     base - 0.06,
     base,
     base + 0.08,
     base + 0.18
-  ].map(value => clamp(value, 0.35, 0.98))
+  ].map(value => clamp(value, 0.35, maxPower))
   return Array.from(new Set(candidates.map(v => Number(v.toFixed(3)))))
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19490,20 +19490,12 @@ const powerRef = useRef(hud.power);
               : forceCornerCapture
                 ? 1
                 : null;
-          const isDirectPrediction =
-            shotPrediction?.ballId === ballId &&
-            (shotPrediction?.railNormal === null ||
-              shotPrediction?.railNormal === undefined);
           const isGuaranteedPocket =
             shotPrediction?.ballId === ballId &&
             predictedAlignment != null &&
             predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
-          const isEarlyPocket =
-            predictedAlignment != null &&
-            predictedAlignment >= POCKET_EARLY_ALIGNMENT &&
-            isDirectPrediction;
-          const allowEarly = forceCornerCapture || isEarlyPocket;
-          if (!forceCornerCapture && !isGuaranteedPocket && !allowEarly) return null;
+          const allowEarly = Boolean(forceCornerCapture);
+          if (!forceCornerCapture && !isGuaranteedPocket) return null;
           if (!allowEarly && bestScore < POCKET_CAM.dotThreshold) return null;
           const predictedTravelForBall =
             shotPrediction?.ballId === ballId
@@ -19527,6 +19519,7 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (isSidePocket) return null;
           const triggerDistance = allowEarly
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
@@ -24036,8 +24029,11 @@ const powerRef = useRef(hud.power);
           }
         };
         const normalizeTargetId = (value) => {
-          if (typeof value === 'string') return value.toUpperCase();
-          return null;
+          if (typeof value !== 'string') return null;
+          const normalized = value.toUpperCase();
+          if (normalized === 'SOLIDS') return 'SOLID';
+          if (normalized === 'STRIPES') return 'STRIPE';
+          return normalized;
         };
         const isBallTargetId = (id) =>
           typeof id === 'string' &&
@@ -24151,6 +24147,22 @@ const powerRef = useRef(hud.power);
             pushTargetId('BLACK');
           }
           return order;
+        };
+        const buildLegalTargetSet = (frameSnapshot, activeVariantId, activeBalls = []) => {
+          const targetOrder = resolveTargetPriorities(
+            frameSnapshot,
+            activeVariantId,
+            activeBalls
+          );
+          const legalTargetsRaw =
+            Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
+              ? frameSnapshot.ballOn
+              : targetOrder;
+          return new Set(
+            legalTargetsRaw
+              .map((entry) => normalizeTargetId(entry))
+              .filter((entry) => entry && isBallTargetId(entry))
+          );
         };
         const pocketCentersCached = pocketEntranceCenters();
         const scoreBallForAim = (ball, cuePos) => {
@@ -25130,7 +25142,8 @@ const powerRef = useRef(hud.power);
             friction: FRICTION,
             ballInHand: Boolean(metaState?.ballInHand),
             myGroup: normalizedAssignment,
-            ballOn: normalizedBallOn ?? null
+            ballOn: normalizedBallOn ?? null,
+            breakInProgress: Boolean(metaState?.breakInProgress)
           };
           const decision = planShot({
             game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
@@ -25166,7 +25179,9 @@ const powerRef = useRef(hud.power);
               : null;
           const pocketCenter =
             pocketIndex != null ? pocketsLocal[pocketIndex].clone() : null;
-          const power = THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, 0.95);
+          const isBreakShot = Boolean(metaState?.breakInProgress);
+          const maxAiPower = isBreakShot ? 0.95 : 0.78;
+          const power = THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, maxAiPower);
           const sideSpin = decision.spin?.side ?? 0;
           const verticalSpin = (decision.spin?.back ?? 0) - (decision.spin?.top ?? 0);
           const spin = {
@@ -25251,19 +25266,10 @@ const powerRef = useRef(hud.power);
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           const frameSnapshot = frameRef.current ?? frameState;
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
-          const targetOrder = resolveTargetPriorities(
+          const legalTargets = buildLegalTargetSet(
             frameSnapshot,
             activeVariantId,
             activeBalls
-          );
-          const legalTargetsRaw =
-            Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
-              ? frameSnapshot.ballOn
-              : targetOrder;
-          const legalTargets = new Set(
-            legalTargetsRaw
-              .map((entry) => normalizeTargetId(entry))
-              .filter((entry) => entry && isBallTargetId(entry))
           );
           const isLegalTargetBall = (ball) => {
             if (!ball) return false;
@@ -25527,11 +25533,6 @@ const powerRef = useRef(hud.power);
                   activeVariantId
                 )
               : [];
-          const targetOrder = resolveTargetPriorities(
-            frameSnapshot,
-            activeVariantId,
-            activeBalls
-          );
           const legalTargetsRaw = Array.isArray(frameSnapshot?.ballOn)
             ? frameSnapshot.ballOn
             : [];
@@ -25714,19 +25715,10 @@ const powerRef = useRef(hud.power);
             : [];
           if (activeBalls.length === 0) return baseDir;
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
-          const targetOrder = resolveTargetPriorities(
+          const legalTargets = buildLegalTargetSet(
             frameSnapshot,
             activeVariantId,
             activeBalls
-          );
-          const legalTargetsRaw =
-            Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
-              ? frameSnapshot.ballOn
-              : targetOrder;
-          const legalTargets = new Set(
-            legalTargetsRaw
-              .map((entry) => normalizeTargetId(entry))
-              .filter((entry) => entry && isBallTargetId(entry))
           );
           const isLegalTargetBall = (ball) => {
             if (!ball || legalTargets.size === 0) return true;
@@ -25780,14 +25772,10 @@ const powerRef = useRef(hud.power);
             activeVariantId,
             activeBalls
           );
-          const legalTargetsRaw =
-            Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
-              ? frameSnapshot.ballOn
-              : targetOrder;
-          const legalTargets = new Set(
-            legalTargetsRaw
-              .map((entry) => normalizeTargetId(entry))
-              .filter((entry) => entry && isBallTargetId(entry))
+          const legalTargets = buildLegalTargetSet(
+            frameSnapshot,
+            activeVariantId,
+            activeBalls
           );
           const isLegalTargetBall = (ball) => {
             if (!ball || legalTargets.size === 0) return true;


### PR DESCRIPTION
### Motivation
- Players observed the AI always using max power after the break, which should be limited to the opening break only.
- Pocket camera was switching for non-corner captures and early/uncertain pockets, producing poor framing; it should only trigger for corner pockets when the pocketing is effectively guaranteed.
- The aiming/auto-aim logic needed to respect rule-based legal targets consistently for both AI and user suggestions so auto-aim picks only legal balls.

### Description
- Limit AI shot power candidates in `buildPowerOptions` by using `normalMax = 0.78` and `breakMax = 0.98`, and clamp candidates to `maxPower` so only break shots can use near-max power (`webapp/public/lib/poolAi.js`).
- Pass `breakInProgress` from runtime `meta.state` into the AI request (`aiState.breakInProgress`) and clamp executed AI power in the game code to match the planner limits (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Restrict pocket camera activation to corner pockets and require a guaranteed pocket prediction (except when `forceCornerCapture` is explicitly used), and explicitly reject side-pocket camera captures to keep pocket cams corner-only (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Normalize target aliases (`SOLIDS` → `SOLID`, `STRIPES` → `STRIPE`) and centralize legal-target construction into `buildLegalTargetSet`, then reuse that set in aim-normalization and auto-aim flows so both AI and player auto-aims only pick legal balls (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add a regression test `uses max power only during break shots` verifying normal vs break shot power behavior (`test/poolAi.test.js`).

### Testing
- Ran unit tests with `node --test test/poolAi.test.js`, and all tests passed (12/12).
- Ran ESLint on the modified files with `npx eslint ... --no-warn-ignored`, which produced no errors in this run.
- Launched the local webapp dev server and captured a visual snapshot to validate runtime integration of the changes (dev server started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eed46eb388329b8f3b8a4a212b8b9)