### PR TITLE
Fix Pool Royale AI power, pocket-camera switching, and legal-target aim logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1621,6 +1621,7 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_ADJUSTMENT *
   SHOT_POWER_BOOST;
 const SHOT_BREAK_MULTIPLIER = 1.5;
+const AI_NON_BREAK_MAX_POWER = 0.8;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
@@ -6085,6 +6086,7 @@ const getPocketCenterById = (id) => {
   }
 };
 const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
+const CORNER_POCKET_IDS = new Set(['TL', 'TR', 'BL', 'BR']);
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
   TR: new THREE.Vector2(1, -1).normalize(),
@@ -19527,9 +19529,12 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          const isCornerPocket = CORNER_POCKET_IDS.has(anchorPocketId);
+          if (!forceCornerCapture && !isCornerPocket) return null;
           const triggerDistance = allowEarly
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
+          if (!forceCornerCapture && !isGuaranteedPocket) return null;
           if (!forceCornerCapture && best.dist > triggerDistance) return null;
           const baseHeightOffset = POCKET_CAM.heightOffset;
           const shortPocketHeightMultiplier =
@@ -24152,6 +24157,38 @@ const powerRef = useRef(hud.power);
           }
           return order;
         };
+        const buildLegalTargetsSet = (frameSnapshot, activeVariantId, activeBalls = []) => {
+          const targets = new Set();
+          const push = (entry) => {
+            const normalized = normalizeTargetId(entry);
+            if (!normalized || !isBallTargetId(normalized)) return;
+            targets.add(normalized);
+            const numericGroup = mapNumberToGroup(normalized);
+            if (numericGroup) targets.add(numericGroup);
+          };
+          const metaState = frameSnapshot?.meta?.state ?? null;
+          const shooterSeat =
+            metaState?.currentPlayer ?? frameSnapshot?.activePlayer ?? null;
+          const assignments = metaState?.assignments ?? {};
+          const assignmentTargets = mapAssignmentToTargets(
+            shooterSeat ? assignments[shooterSeat] : null,
+            activeVariantId
+          );
+          assignmentTargets.forEach(push);
+          const targetOrder = resolveTargetPriorities(
+            frameSnapshot,
+            activeVariantId,
+            activeBalls
+          );
+          targetOrder.forEach(push);
+          const legalTargetsRaw = Array.isArray(frameSnapshot?.ballOn)
+            ? frameSnapshot.ballOn
+            : frameSnapshot?.ballOn != null
+              ? [frameSnapshot.ballOn]
+              : [];
+          legalTargetsRaw.forEach(push);
+          return targets;
+        };
         const pocketCentersCached = pocketEntranceCenters();
         const scoreBallForAim = (ball, cuePos) => {
           if (!ball || !cuePos) return -Infinity;
@@ -24197,16 +24234,10 @@ const powerRef = useRef(hud.power);
           const isRotationVariant =
             activeVariantId === 'american' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);
-          const targetOrder = resolveTargetPriorities(state, activeVariantId, activeBalls);
-          const legalTargetsRaw = Array.isArray(state?.ballOn) && state.ballOn.length > 0
-            ? state.ballOn
-            : targetOrder.length > 0
-              ? targetOrder
-              : ['RED'];
-          const legalTargets = new Set(
-            legalTargetsRaw
-              .map((entry) => normalizeTargetId(entry))
-              .filter((entry) => entry && isBallTargetId(entry))
+          const legalTargets = buildLegalTargetsSet(
+            state,
+            activeVariantId,
+            activeBalls
           );
           if (legalTargets.size === 0) {
             if (activeVariantId === 'american' || activeVariantId === '9ball') {
@@ -25166,7 +25197,9 @@ const powerRef = useRef(hud.power);
               : null;
           const pocketCenter =
             pocketIndex != null ? pocketsLocal[pocketIndex].clone() : null;
-          const power = THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, 0.95);
+          const isOpeningBreak = (frameSnapshot?.currentBreak ?? 0) === 0;
+          const maxPower = isOpeningBreak ? 1 : AI_NON_BREAK_MAX_POWER;
+          const power = THREE.MathUtils.clamp(decision.power ?? 0.6, 0.3, maxPower);
           const sideSpin = decision.spin?.side ?? 0;
           const verticalSpin = (decision.spin?.back ?? 0) - (decision.spin?.top ?? 0);
           const spin = {
@@ -25251,19 +25284,10 @@ const powerRef = useRef(hud.power);
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           const frameSnapshot = frameRef.current ?? frameState;
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
-          const targetOrder = resolveTargetPriorities(
+          const legalTargets = buildLegalTargetsSet(
             frameSnapshot,
             activeVariantId,
             activeBalls
-          );
-          const legalTargetsRaw =
-            Array.isArray(frameSnapshot?.ballOn) && frameSnapshot.ballOn.length > 0
-              ? frameSnapshot.ballOn
-              : targetOrder;
-          const legalTargets = new Set(
-            legalTargetsRaw
-              .map((entry) => normalizeTargetId(entry))
-              .filter((entry) => entry && isBallTargetId(entry))
           );
           const isLegalTargetBall = (ball) => {
             if (!ball) return false;
@@ -26044,7 +26068,13 @@ const powerRef = useRef(hud.power);
             // Reset the cue pull so AI strokes visibly wind up before firing.
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
-            const aiPower = clampPower(plan.power, 0.6);
+            const isPlannedBreakShot = plan?.type === 'break' || isOpeningBreak;
+            const aiPower = clampPower(
+              isPlannedBreakShot
+                ? plan.power
+                : Math.min(plan.power ?? 0.6, AI_NON_BREAK_MAX_POWER),
+              0.6
+            );
             powerRef.current = aiPower;
             setHud((s) => ({ ...s, power: aiPower }));
             const spinToApply = plan.spin ?? { x: 0, y: 0 };
@@ -27156,15 +27186,9 @@ const powerRef = useRef(hud.power);
             }
           }
           const targetBallColor = targetBall ? toBallColorId(targetBall.id) : null;
-          const legalTargetsRaw =
-            frameRef.current?.ballOn ?? frameState.ballOn ?? [];
-          const legalTargets = Array.isArray(legalTargetsRaw)
-            ? legalTargetsRaw
-                .map((entry) =>
-                  typeof entry === 'string' ? entry.toUpperCase() : entry
-                )
-                .filter(Boolean)
-            : [];
+          const frameSnapshot = frameRef.current ?? frameState;
+          const activeVariantId = activeVariantRef.current?.id ?? variantKey;
+          const legalTargets = buildLegalTargetsSet(frameSnapshot, activeVariantId, ballsRef.current || []);
           const suggestionPlan = userSuggestionPlanRef.current;
           const suggestionMatchesTarget =
             suggestionPlan?.targetBall &&
@@ -27180,8 +27204,8 @@ const powerRef = useRef(hud.power);
             targetBall &&
             !railNormal &&
             targetBallColor &&
-            legalTargets.length > 0 &&
-            !legalTargets.includes(targetBallColor);
+            legalTargets.size > 0 &&
+            !Array.from(legalTargets).some((target) => matchesTargetId(targetBall, target));
           const primaryColor = aimingWrong
             ? 0xff3333
             : targetBall && !railNormal


### PR DESCRIPTION
### Motivation
- Prevent AI from always using maximum power except for the opening break so gameplay feels human and positioning-oriented. 
- Avoid switching to pocket-camera for middle/side pockets unless the pot is effectively guaranteed and prefer corner pocket closeups. 
- Make aim-line legality and auto-aim decisions consistent with the game rules by centralizing how legal targets are derived.

### Description
- Add `AI_NON_BREAK_MAX_POWER` and cap non-break AI shot power in both AI planning and execution paths so only break shots use full power, applied where AI plan decisions are read and when the AI fires. 
- Add `CORNER_POCKET_IDS` and gate pocket-camera activation to corner pockets and require a guaranteed pocket alignment (unless explicitly forced) before switching to pocket view. 
- Introduce `buildLegalTargetsSet(frameSnapshot, activeVariantId, activeBalls)` to consolidate legal-target resolution (assignments + `ballOn` + priority logic) and replace scattered target/`ballOn` checks with this unified set across AI planning, plan normalization, and aim-line “wrong target” detection. 
- All changes are implemented in `webapp/src/pages/Games/PoolRoyale.jsx` (AI power, camera gating, and legal-target logic) and wired into the existing AI/planning/aim flows.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite reported non-blocking chunk-size/dynamic-import warnings). 
- Launched the dev server with `npm --prefix webapp run dev` and captured a screenshot using Playwright to verify the app loads and UI renders after changes. 
- No automated unit tests were modified; the changes were validated via the full app build and a live dev-page render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eed46eb388329b8f3b8a4a212b8b9)