### PR TITLE
Pool Royale: use max power only for break, restrict pocket cams to guaranteed corner pots, and fix legal auto-aim

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -625,7 +625,7 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = req.state?.breakInProgress ? [1] : [0.45, 0.58, 0.72]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },


### PR DESCRIPTION
### Motivation
- Players reported the AI always using maximum power for every shot instead of only for the opening break, and the pocket camera switching too aggressively for non-corner pockets.  
- The aiming line sometimes targeted illegal first-contact balls or did not prefer legal targets when suggesting/auto-aiming.  
- Improve gameplay feel: AI shot power should be normal after the break, pocket cams should only switch for high-confidence corner pots, and the aim assistance must prefer legal targets while letting the user override.

### Description
- Limit AI max-power sampling to the opening break by changing the sampled `powers` in the planner to use `[1]` only when `breakInProgress` is true, otherwise sample lower power values. (modified `lib/poolAi.js`)  
- Propagate `breakInProgress` into the AI request state sent from the client, so the planner knows when the break is happening. (updated AI state build in `webapp/src/pages/Games/PoolRoyale.jsx`)  
- Enforce runtime AI shot execution power: only use full power when the plan type is `break`; clamp regular AI shots into a reasonable range. (updated AI shot execution code in `webapp/src/pages/Games/PoolRoyale.jsx`)  
- Tighten pocket camera activation: only allow pocket-camera views for corner pockets (TL/TR/BL/BR) and only when the shot prediction qualifies as a guaranteed direct pot; removed early/side-pocket early triggers for non-corner captures. (updated `makePocketCameraView` in `webapp/src/pages/Games/PoolRoyale.jsx`)  
- Improve legal aiming behaviour: when computing aim lerp fallback, prefer a legal-first-contact aim from `resolveLegalPlayerAimDirection` for player auto-aim so the visible aiming line prefers legal targets but the user can still move the line manually. (updated the main aim update loop in `webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Ran `node --check lib/poolAi.js` to validate the modified AI planner file: succeeded.  
- Built the web client with `npm --prefix webapp run build`: succeeded (production build completed; Vite emitted unrelated, non-blocking warnings about large chunks and some dynamic/static import notices).  
- Ran ESLint on the changed files (via project lint tasks): completed with warnings (no blocking errors).  
- Captured a visual smoke-check screenshot of the running dev server to confirm no runtime crash during UI rendering (artifact available from the build run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eed46eb388329b8f3b8a4a212b8b9)