### PR TITLE
Refine Pool Royale: break-only max power, restore corner-pocket cams, and legal auto-aim assist

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -625,7 +625,7 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = req.state?.breakInProgress ? [1] : [0.5, 0.7, 0.85]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },


### PR DESCRIPTION
### Motivation
- Prevent AI from using maximum power on every shot by ensuring max power is used only for true break shots.
- Restore corner-pocket camera responsiveness so pocket cams switch for corner direct/guaranteed pots as before.
- Make auto-aim/suggestion prefer legal first-contact targets while preserving manual aim control and correct camera viewpoint.

### Description
- Changed AI planner sampling powers in `lib/poolAi.js` to use full power only when `req.state?.breakInProgress` is true and otherwise sample normal non-break powers (`[0.5, 0.7, 0.85]`).
- Source the AI `breakInProgress` flag from authoritative match meta state when building `aiState` (`breakInProgress: Boolean(metaState?.breakInProgress)`) so planner no longer stays stuck in break-mode.\
- Tightened forced-AI-break override logic to `aiTurnActive && breakInProgress && (aiWonBreak || openingPlayer === 'B')` so the AI only forces the break shot when the break is actually active for the AI.\
- Enforce runtime AI shot power so `plan.type === 'break'` yields full power and non-break shots use `clampPower(plan.power, 0.6)`, avoiding global max-power application.
- Restore corner-pocket camera early triggers by detecting direct predictions and early direct-pocket captures (`isDirectPrediction`, `isEarlyPocket`) while restricting pocket cams to corner pockets only and setting `forcedEarly: Boolean(isEarlyPocket)` for visibility logic.
- Change player auto-aim assist to prefer a legal-first-contact direction from `resolveLegalPlayerAimDirection` only when suggestion/auto-aim assistance is active (`autoAimRequestRef.current` or `suggestionAimKeyRef.current`), preserving manual control otherwise.

### Testing
- Ran `node --check lib/poolAi.js` to validate the AI planner file; the check succeeded.\
- Built the web client with `npm --prefix webapp run build`; the production build completed successfully with non-blocking Vite warnings.\
- Launched the dev server and captured a visual smoke-check screenshot via Playwright confirming UI renders and camera/aim changes (artifact: `artifacts/poolroyale-fix2.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eed46eb388329b8f3b8a4a212b8b9)