### PR TITLE
Fix Pool Royale AI legal targeting and restore pocket cam auto-switch

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -144,6 +144,22 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+
+function isCueBallId (id) {
+  if (id === 0) return true
+  if (typeof id !== 'string') return false
+  const normalized = id.trim().toLowerCase()
+  return normalized === 'cue' || normalized === 'cue_ball' || normalized === 'cueball'
+}
+
+function isCueBall (ball) {
+  return Boolean(ball) && isCueBallId(ball.id)
+}
+
+function findCueBall (balls = []) {
+  return balls.find(isCueBall)
+}
+
 function currentGroup (state) {
   let g = state.myGroup
   if (!g || g === 'UNASSIGNED') {
@@ -160,7 +176,7 @@ function currentGroup (state) {
 }
 
 function chooseTargets (req) {
-  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
+  const balls = req.state.balls.filter(b => !b.pocketed && !isCueBall(b))
   if (req.game === 'NINE_BALL') {
     const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
     return lowest ? [lowest] : []
@@ -203,7 +219,7 @@ function chooseTargets (req) {
 }
 
 function nextTargetsAfter (targetId, req) {
-  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
+  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && !isCueBall(b))
   if (req.game === 'NINE_BALL') {
     if (cloned.length === 0) return []
     const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
@@ -259,7 +275,7 @@ function nextTargetsAfter (targetId, req) {
 // preferring smaller cut angles and wider pocket views.
 function clearShotCandidates (req) {
   const r = req.state.ballRadius
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
   const maxCut = req.maxCutAngle ?? Math.PI / 4
@@ -286,10 +302,10 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
-        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        pathBlocked(cue, ghost, req.state.balls, [cue?.id, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cue?.id, target.id], r) ||
         req.state.balls.some(
-          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+          b => !isCueBall(b) && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
         )
       ) {
         continue
@@ -362,7 +378,7 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
     if (next.id === targetId) {
       next.pocketed = true
     }
-    if (next.id === 0) {
+    if (isCueBall(next)) {
       next.x = clamped.x
       next.y = clamped.y
       next.vx = 0
@@ -393,8 +409,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
       g.y < r ||
       g.y > req.state.height - r
     ) continue
-    if (pathBlocked(cue, g, balls, [0, target.id], r, 1.1)) continue
-    if (pathBlocked(target, entry, balls, [0, target.id], r)) continue
+    if (pathBlocked(cue, g, balls, [cue?.id, target.id], r, 1.1)) continue
+    if (pathBlocked(target, entry, balls, [cue?.id, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
     if (dist(g, ghost) > r * 0.5) continue
     success++
@@ -406,7 +422,7 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   if (!req?.state || depth <= 0) return 0
   const nextBalls = cloneBallsForNextShot(balls, cueAfter, targetId, req.state)
   const nextReq = { ...req, state: { ...req.state, balls: nextBalls, ballInHand: false } }
-  const cue = nextBalls.find(b => b.id === 0)
+  const cue = findCueBall(nextBalls)
   if (!cue) return 0
   const candidates = clearShotCandidates(nextReq)
   if (!candidates.length) return 0
@@ -461,7 +477,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [0, target.id], r, 1.3)
+  const laneClearance = clearanceMargin(cue, target, balls, [cue?.id, target.id], r, 1.3)
   if (laneClearance < 0.5) {
     return null
   }
@@ -469,9 +485,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
-    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
+    pathBlocked(cue, ghost, balls, [cue?.id, target.id], r, 1.1) ||
+    pathBlocked(target, entry, balls, [cue?.id, target.id], r) ||
+    balls.some(b => !isCueBall(b) && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
@@ -543,7 +559,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 }
 
 function safetyShot (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -562,7 +578,7 @@ function safetyShot (req) {
 }
 
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const targets = chooseTargets(req)
   if (!cue || targets.length === 0) return null
 
@@ -679,19 +695,19 @@ export function planShot (req) {
             continue
           }
           const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            b => !isCueBall(b) && !b.pocketed && dist(cand, b) < r * 2
           )
           if (overlap) continue
           placements.push(cand)
         }
       } else {
-        const cue = req.state.balls.find(b => b.id === 0)
+        const cue = findCueBall(req.state.balls)
         placements.push({ x: cue.x, y: cue.y })
       }
 
       for (const cuePos of placements) {
         const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          isCueBall(b) ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
 
         const baseCand = evaluate(

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -148,6 +148,21 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function isCueBallId (id) {
+  if (id === 0) return true
+  if (typeof id !== 'string') return false
+  const normalized = id.trim().toLowerCase()
+  return normalized === 'cue' || normalized === 'cue_ball' || normalized === 'cueball'
+}
+
+function isCueBall (ball) {
+  return Boolean(ball) && isCueBallId(ball.id)
+}
+
+function findCueBall (balls = []) {
+  return balls.find(isCueBall)
+}
+
 function currentGroup (state) {
   let g = state.myGroup
   if (!g || g === 'UNASSIGNED') {
@@ -179,7 +194,7 @@ function parseBallOnIds (state) {
 }
 
 function chooseTargets (req) {
-  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
+  const balls = req.state.balls.filter(b => !b.pocketed && !isCueBall(b))
   const ballOnIds = parseBallOnIds(req.state)
   if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
     if (ballOnIds.length > 0) {
@@ -210,7 +225,7 @@ function chooseTargets (req) {
 }
 
 function nextTargetsAfter (targetId, req) {
-  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
+  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && !isCueBall(b))
   if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
     if (cloned.length === 0) return []
     const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
@@ -245,7 +260,7 @@ function nextTargetsAfter (targetId, req) {
 // preferring smaller cut angles and wider pocket views.
 function clearShotCandidates (req) {
   const r = req.state.ballRadius
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
   const maxCut = req.maxCutAngle ?? Math.PI / 4
@@ -272,10 +287,10 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
-        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        pathBlocked(cue, ghost, req.state.balls, [cue?.id, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cue?.id, target.id], r) ||
         req.state.balls.some(
-          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+          b => !isCueBall(b) && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
         )
       ) {
         continue
@@ -290,7 +305,7 @@ function clearShotCandidates (req) {
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
-      const laneClearance = clearanceMargin(cue, target, req.state.balls, [0, target.id], r, 1.35)
+      const laneClearance = clearanceMargin(cue, target, req.state.balls, [cue?.id, target.id], r, 1.35)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const clearanceScore = Math.max(0, Math.min((laneClearance - 0.4) / 0.8, 1))
@@ -354,7 +369,7 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
     if (next.id === targetId) {
       next.pocketed = true
     }
-    if (next.id === 0) {
+    if (isCueBall(next)) {
       next.x = clamped.x
       next.y = clamped.y
       next.vx = 0
@@ -385,8 +400,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
       g.y < r ||
       g.y > req.state.height - r
     ) continue
-    if (pathBlocked(cue, g, balls, [0, target.id], r, 1.1)) continue
-    if (pathBlocked(target, entry, balls, [0, target.id], r)) continue
+    if (pathBlocked(cue, g, balls, [cue?.id, target.id], r, 1.1)) continue
+    if (pathBlocked(target, entry, balls, [cue?.id, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
     if (dist(g, ghost) > r * 0.5) continue
     success++
@@ -398,7 +413,7 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   if (!req?.state || depth <= 0) return 0
   const nextBalls = cloneBallsForNextShot(balls, cueAfter, targetId, req.state)
   const nextReq = { ...req, state: { ...req.state, balls: nextBalls, ballInHand: false } }
-  const cue = nextBalls.find(b => b.id === 0)
+  const cue = findCueBall(nextBalls)
   if (!cue) return 0
   const candidates = clearShotCandidates(nextReq)
   if (!candidates.length) return 0
@@ -453,7 +468,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [0, target.id], r, 1.3)
+  const laneClearance = clearanceMargin(cue, target, balls, [cue?.id, target.id], r, 1.3)
   if (laneClearance < 0.5) {
     return null
   }
@@ -461,9 +476,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
-    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
+    pathBlocked(cue, ghost, balls, [cue?.id, target.id], r, 1.1) ||
+    pathBlocked(target, entry, balls, [cue?.id, target.id], r) ||
+    balls.some(b => !isCueBall(b) && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
@@ -536,7 +551,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 }
 
 function safetyShot (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -555,7 +570,7 @@ function safetyShot (req) {
 }
 
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cue = findCueBall(req.state.balls)
   const targets = chooseTargets(req)
   if (!cue || targets.length === 0) return null
 
@@ -685,19 +700,19 @@ export function planShot (req) {
             continue
           }
           const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            b => !isCueBall(b) && !b.pocketed && dist(cand, b) < r * 2
           )
           if (overlap) continue
           placements.push(cand)
         }
       } else {
-        const cue = req.state.balls.find(b => b.id === 0)
+        const cue = findCueBall(req.state.balls)
         placements.push({ x: cue.x, y: cue.y })
       }
 
       for (const cuePos of placements) {
         const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          isCueBall(b) ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
 
         const powers = buildPowerOptions(req, cuePos, target)


### PR DESCRIPTION
### Motivation
- Prevent the AI from ever treating the cue ball as an object ball (it should only aim at the 15 legal object balls) and support multiple cue identifiers (`0`, `'cue'`, `'cue_ball'`, etc.).
- Restore the pocket-camera auto-switch behavior when a pot is developing in the rail-overhead + pocket camera mode and ensure the AI break aims at the rack center.

### Description
- Added `isCueBallId`, `isCueBall`, and `findCueBall` helpers and updated the AI planner to exclude the cue ball from target selection and obstruction checks instead of relying on `id === 0`. (`lib/poolAi.js` and mirrored `webapp/public/lib/poolAi.js`).
- Replaced filters and checks that used `id === 0` with `!isCueBall(b)` or `findCueBall(...)`, and updated `cloneBallsForNextShot`/next-shot logic to treat cue-ball identity generically so the AI proposals only reference real object balls.
- Adjusted AI-open-source mapping in `PoolRoyale.jsx` to send the cue as `'cue'` (while retaining compatibility for legacy `0`), and changed lowest-ball and rack-center calculations to exclude the cue ball so the AI will target legal balls and aim the break at the rack center.
- Restored pocket cam auto-switch behavior by gating `powerImpactHoldRef` and post-shot camera holds behind `RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY` and by keeping the early pocket-switch logic (so pocket cameras can cut when a target is being potted); also added a small replay-frame camera override for stored replay frames in `PoolRoyale.jsx`.
- Modified the public copy of the planner so runtime and browser bundles remain consistent (`webapp/public/lib/poolAi.js`).

### Testing
- Ran the unit/integration tests with `npm test -- test/poolAi.test.js test/poolRoyaleOnlineFlow.test.js` and both test suites passed (`PASS test/poolAi.test.js` and `PASS test/poolRoyaleOnlineFlow.test.js`).
- Launched the dev webserver (`npm --prefix webapp run dev`) and captured a screenshot of the running UI to validate camera/AI behavior manually (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f17ef5f1083298df3108c69e17dc2)