### PR TITLE
Restore Pool Royale pocket camera logic to prior behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19518,12 +19518,6 @@ const powerRef = useRef(hud.power);
             return null;
           }
           const anchorPocketId = pocketIdFromCenter(best.center);
-          const isCornerPocket =
-            anchorPocketId === 'TL' ||
-            anchorPocketId === 'TR' ||
-            anchorPocketId === 'BL' ||
-            anchorPocketId === 'BR';
-          if (!isCornerPocket) return null;
           const approachDir = best.pocketDir.clone();
           const anchorId = resolvePocketCameraAnchor(
             anchorPocketId,
@@ -23491,50 +23485,15 @@ const powerRef = useRef(hud.power);
         };
         if (shotPrediction.railNormal) replayTags.add('bank');
           const intentTimestamp = performance.now();
-          const isDirectHit =
-            shotPrediction.railNormal === null || shotPrediction.railNormal === undefined;
-          const predictedTargetBall =
-            shotPrediction.ballId != null
-              ? balls.find((ball) => String(ball.id) === String(shotPrediction.ballId))
-              : null;
-          const predictedTargetDir =
-            shotPrediction.dir && shotPrediction.dir.lengthSq() > 1e-6
-              ? shotPrediction.dir.clone().normalize()
-              : null;
-          let predictedCornerPocketId = null;
-          if (isDirectHit && predictedTargetBall?.active && predictedTargetDir) {
-            const candidatePocket = pocketCenters().reduce((best, center) => {
-              const toPocket = center.clone().sub(predictedTargetBall.pos);
-              const dist = toPocket.length();
-              if (dist < BALL_R * 1.5) return best;
-              const score = toPocket.normalize().dot(predictedTargetDir);
-              if (!best || score > best.score) {
-                return {
-                  center,
-                  score,
-                  id: pocketIdFromCenter(center)
-                };
-              }
-              return best;
-            }, null);
-            if (
-              candidatePocket &&
-              ['TL', 'TR', 'BL', 'BR'].includes(candidatePocket.id) &&
-              candidatePocket.score >= POCKET_EARLY_ALIGNMENT
-            ) {
-              predictedCornerPocketId = candidatePocket.id;
-            }
-          }
           if (shotPrediction.ballId && !isShortShot) {
+            const isDirectHit =
+              shotPrediction.railNormal === null || shotPrediction.railNormal === undefined;
             pocketSwitchIntentRef.current = {
               ballId: shotPrediction.ballId,
-              allowEarly: Boolean(predictedCornerPocketId),
-              forced: Boolean(predictedCornerPocketId),
+              allowEarly: isDirectHit,
+              forced: isDirectHit,
               createdAt: intentTimestamp
             };
-            if (predictedCornerPocketId) {
-              powerImpactHoldRef.current = 0;
-            }
           } else {
             pocketSwitchIntentRef.current = null;
           }


### PR DESCRIPTION
### Motivation
- Pocket camera activation had been narrowed to corner pockets and a more complex candidate check, which prevented the pocket cams from activating as they did previously. 
- Restore the previous, broader pocket-camera flow so pocket views trigger for valid pocket approaches and direct-hit predictions without changing other gameplay systems.

### Description
- Removed the corner-only gating in the pocket-camera selection so non-corner pockets can be considered again (`makePocketCameraView` no longer returns early for non-corner pockets). 
- Simplified shot-intent activation by setting `pocketSwitchIntentRef.current.allowEarly` and `.forced` from the direct-hit check (`railNormal` null/undefined) instead of relying on the prior candidate/corner-pocket scoring. 
- Left all existing pocket framing, distance, and threshold math intact and ensured generated build artifacts were not committed with the change.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully. 
- Launched a preview server with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and verified the app served. 
- Captured a Playwright screenshot of the running preview to validate the change visually, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f362e48f883299cc4303ed6cb61f6)