### PR TITLE
Restore 7am pocket camera flow and AI rack-break aim

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18726,6 +18726,18 @@ const powerRef = useRef(hud.power);
             } else {
               railDir = activeShotView.railDir;
             }
+            let approachDir = activeShotView.approach
+              ? activeShotView.approach.clone()
+              : new THREE.Vector2(0, -railDir);
+            if (approachDir.lengthSq() < 1e-6) {
+              approachDir.set(0, -railDir);
+            }
+            approachDir.normalize();
+            if (activeShotView.approach) {
+              activeShotView.approach.copy(approachDir);
+            } else {
+              activeShotView.approach = approachDir.clone();
+            }
             let broadcastRailDir =
               activeShotView.broadcastRailDir ?? (anchorType === 'side' ? null : railDir);
             const fallbackBroadcast = signed(
@@ -18756,18 +18768,6 @@ const powerRef = useRef(hud.power);
             };
             const heightScale =
               activeShotView.heightScale ?? POCKET_CAM.heightScale ?? 1;
-            let approachDir = activeShotView.approach
-              ? activeShotView.approach.clone()
-              : new THREE.Vector2(0, -railDir);
-            if (approachDir.lengthSq() < 1e-6) {
-              approachDir.set(0, -railDir);
-            }
-            approachDir.normalize();
-            if (activeShotView.approach) {
-              activeShotView.approach.copy(approachDir);
-            } else {
-              activeShotView.approach = approachDir.clone();
-            }
             const resolvedAnchorId = resolvePocketCameraAnchor(
               activeShotView.pocketId ?? pocketIdFromCenter(pocketCenter),
               pocketCenter,
@@ -18811,13 +18811,11 @@ const powerRef = useRef(hud.power);
             const focusBallPos2D = focusBall?.active
               ? new THREE.Vector2(focusBall.pos.x, focusBall.pos.y)
               : null;
-            if (!activeShotView.fixedTarget2D) {
-              activeShotView.fixedTarget2D =
-                focusBallPos2D?.clone?.() ??
-                activeShotView.lastBallPos?.clone?.() ??
-                pocketCenter2D.clone();
-            }
-            const focusPoint2D = activeShotView.fixedTarget2D.clone();
+            const focusPoint2D =
+              focusBallPos2D ??
+              activeShotView.fixedTarget2D?.clone?.() ??
+              activeShotView.lastBallPos?.clone?.() ??
+              pocketCenter2D;
             const focusTarget = new THREE.Vector3(
               focusPoint2D.x * worldScaleFactor,
               focusHeightLocal,
@@ -25991,17 +25989,16 @@ const powerRef = useRef(hud.power);
             }
             const frameSnapshot = frameRef.current ?? frameState;
             const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
+            const isOpeningBreak = breakInProgress || (frameSnapshot?.currentBreak ?? 0) === 0;
             const aiTurnActive = currentHud?.turn === 1;
             const aiWonBreak = breakWinnerSeatRef.current === 'B';
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
+              isOpeningBreak &&
               aiTurnActive &&
-              breakInProgress &&
-              (aiWonBreak || openingPlayer === 'B');
+              (breakInProgress || breakRollState === 'done' || aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
-              const rackBalls = ballsList.filter(
-                (ball) => ball?.active && String(ball?.id).toLowerCase() !== 'cue'
-              );
+              const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
               if (rackBalls.length > 0) {
                 const rackCenter = rackBalls.reduce(
                   (acc, ball) => {


### PR DESCRIPTION
### Motivation
- Restore the pocket-camera broadcast/replay behavior to the prior morning logic so corner pocket cameras behave stably and broadcast/replay switching matches the earlier UX.
- Ensure the AI reliably aims at the rack for opening breaks even when break metadata or roll resolution is delayed.
- Remove edge cases that caused side-pocket camera resolution and rack-target selection inconsistencies.

### Description
- Resolve and persist `approachDir` earlier in the pocket-view pipeline so short-rail broadcast direction computation receives a stable approach vector before calling `resolveShortRailBroadcastDirection` (changes in `PoolRoyale.jsx`).
- Restore dynamic pocket camera focus selection by preferring the live focus ball position and falling back to `fixedTarget2D`, last ball position, or pocket center when computing `focusTarget` (changes in `PoolRoyale.jsx`).
- Change opening-break AI logic to use an `isOpeningBreak` check and include `breakRollState === 'done'` in the forced-break condition so AI still targets the rack when break metadata is delayed or the roll has resolved (changes in `PoolRoyale.jsx`).
- Normalize rack-ball filtering for break aiming by excluding the cue ball using numeric id checks (`ball.id !== 0`) when computing the rack center (changes in `PoolRoyale.jsx`).

### Testing
- Ran the targeted unit tests with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js`, and the suite passed (2 tests, all passed).
- Attempted a Playwright screenshot run to validate in-browser camera flow, but the local dev server was unreachable (`ERR_EMPTY_RESPONSE`), so the end-to-end capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5e69d6ac8329a74c79a07e899679)