### PR TITLE
Restore Pool Royale pocket camera flow and enforce rack-targeted AI breaks

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -636,6 +636,27 @@ function fallbackAimAtTarget (req) {
 export function planShot (req) {
   const r = req.state.ballRadius
   const cueBallId = resolveCueBallId(req.state)
+  if (req.state?.breakInProgress) {
+    const cue = req.state.balls.find(b => b.id === cueBallId && !b.pocketed)
+    const rackBalls = req.state.balls.filter(b => b.id !== cueBallId && !b.pocketed)
+    if (cue && rackBalls.length > 0) {
+      const rackTarget = rackBalls[0]
+      const rackCenter = rackBalls.reduce(
+        (acc, ball) => ({ x: acc.x + ball.x, y: acc.y + ball.y }),
+        { x: 0, y: 0 }
+      )
+      rackCenter.x /= rackBalls.length
+      rackCenter.y /= rackBalls.length
+      return {
+        angleRad: Math.atan2(rackCenter.y - cue.y, rackCenter.x - cue.x),
+        power: 1,
+        spin: { top: 0, side: 0, back: 0 },
+        targetBallId: rackTarget.id,
+        quality: 1,
+        rationale: 'break-rack-center'
+      }
+    }
+  }
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   const rng = Number.isFinite(req.rngSeed) ? createRng(req.rngSeed) : Math.random

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -194,6 +194,38 @@ test('supports non-zero cueBallId mappings', () => {
   assert([3, 11].includes(decision.targetBallId));
 });
 
+test('break shot aims from cue ball to rack center at full power', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 500, y: 450, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 480, y: 90, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 520, y: 90, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 500, y: 130, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: true
+    },
+    timeBudgetMs: 100,
+    rngSeed: 9
+  };
+
+  const decision = planShot(req);
+  assert.equal(decision.power, 1);
+  assert.equal(decision.rationale, 'break-rack-center');
+  const rackCenter = { x: 500, y: (90 + 90 + 130) / 3 };
+  const expected = Math.atan2(rackCenter.y - 450, rackCenter.x - 500);
+  assert(Math.abs(decision.angleRad - expected) < 1e-6);
+});
+
 test('respects group assignment in eight-ball', () => {
   const req = {
     game: 'EIGHT_POOL_UK',


### PR DESCRIPTION
### Motivation
- Restore the pocket-camera and broadcast/replay behavior so pocket closeups behave like the morning configuration and side-pocket anchors participate in broadcast switching. 
- Ensure AI behaves deterministically on opening breaks by aiming at the rack center and using full break power. 

### Description
- Re-enabled all six pocket anchors (`TL/TR/BL/BR/TM/BM`) and restored middle-pocket anchor resolution and outward vectors in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Restored dynamic pocket focus selection and the early-pocket activation/hold flow (including respecting `isMaxPowerShot` for early activation), and fixed the pocket view focus-point logic so the view follows active balls instead of hard-locking. 
- Added forced break planning in `lib/poolAi.js` so when `breakInProgress` the planner returns a full-power shot aimed at the computed rack center and includes a `targetBallId` and `rationale: 'break-rack-center'`. 
- Added a regression test in `test/poolAi.test.js` to verify break-shot rack targeting and adjusted existing AI tests to remain compatible. 

### Testing
- Ran the unit tests with `npm test -- test/poolAi.test.js` and all tests in that suite passed (`13 passed, 13 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5e69d6ac8329a74c79a07e899679)