### PR TITLE
Restore repository to yesterday 10:00 AM baseline (Pool Royale AI / camera / variants)

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -18,6 +18,7 @@
  * @typedef {Object} AimRequest
  * @property {GameType} game
  * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean}} state
+ * @property {number} [state.cueBallId]
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -159,8 +160,16 @@ function currentGroup (state) {
   return undefined
 }
 
+function resolveCueBallId (state) {
+  if (Number.isFinite(state?.cueBallId)) return state.cueBallId
+  const cue = state?.balls?.find(b => b?.isCue === true)
+  if (cue && Number.isFinite(cue.id)) return cue.id
+  return 0
+}
+
 function chooseTargets (req) {
-  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
   if (req.game === 'NINE_BALL') {
     const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
     return lowest ? [lowest] : []
@@ -180,7 +189,7 @@ function chooseTargets (req) {
       if (eight) return [eight]
       return []
     }
-    return balls.filter(b => b.id !== 8)
+    return balls
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
@@ -203,7 +212,8 @@ function chooseTargets (req) {
 }
 
 function nextTargetsAfter (targetId, req) {
-  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
   if (req.game === 'NINE_BALL') {
     if (cloned.length === 0) return []
     const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
@@ -228,7 +238,7 @@ function nextTargetsAfter (targetId, req) {
       if (eight) return [eight]
       return []
     }
-    return cloned.filter(b => b.id !== 8)
+    return cloned
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
@@ -259,7 +269,8 @@ function nextTargetsAfter (targetId, req) {
 // preferring smaller cut angles and wider pocket views.
 function clearShotCandidates (req) {
   const r = req.state.ballRadius
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
   const maxCut = req.maxCutAngle ?? Math.PI / 4
@@ -286,10 +297,10 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
-        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r) ||
         req.state.balls.some(
-          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+          b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
         )
       ) {
         continue
@@ -356,13 +367,14 @@ function clampPointToTable (point, table, margin = 1) {
 }
 
 function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
+  const cueBallId = resolveCueBallId(state)
   const clamped = clampPointToTable(cueAfter, state, 1.1)
   return balls.map(ball => {
     const next = { ...ball }
     if (next.id === targetId) {
       next.pocketed = true
     }
-    if (next.id === 0) {
+    if (next.id === cueBallId) {
       next.x = clamped.x
       next.y = clamped.y
       next.vx = 0
@@ -377,6 +389,7 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
 // imprecision and rewards shorter, straighter shots.
 function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 20, rng = Math.random) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const baseAngle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
@@ -393,8 +406,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
       g.y < r ||
       g.y > req.state.height - r
     ) continue
-    if (pathBlocked(cue, g, balls, [0, target.id], r, 1.1)) continue
-    if (pathBlocked(target, entry, balls, [0, target.id], r)) continue
+    if (pathBlocked(cue, g, balls, [cueBallId, target.id], r, 1.1)) continue
+    if (pathBlocked(target, entry, balls, [cueBallId, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
     if (dist(g, ghost) > r * 0.5) continue
     success++
@@ -404,9 +417,10 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
 
 function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng = Math.random) {
   if (!req?.state || depth <= 0) return 0
+  const cueBallId = resolveCueBallId(req.state)
   const nextBalls = cloneBallsForNextShot(balls, cueAfter, targetId, req.state)
   const nextReq = { ...req, state: { ...req.state, balls: nextBalls, ballInHand: false } }
-  const cue = nextBalls.find(b => b.id === 0)
+  const cue = nextBalls.find(b => b.id === cueBallId)
   if (!cue) return 0
   const candidates = clearShotCandidates(nextReq)
   if (!candidates.length) return 0
@@ -445,6 +459,7 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
 
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false, options = {}) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const rng = options.rng ?? Math.random
   const balls = ballsOverride || req.state.balls
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -461,7 +476,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [0, target.id], r, 1.3)
+  const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
   if (laneClearance < 0.5) {
     return null
   }
@@ -469,9 +484,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
-    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
+    pathBlocked(cue, ghost, balls, [cueBallId, target.id], r, 1.1) ||
+    pathBlocked(target, entry, balls, [cueBallId, target.id], r) ||
+    balls.some(b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
@@ -543,7 +558,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 }
 
 function safetyShot (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -562,7 +578,8 @@ function safetyShot (req) {
 }
 
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   if (!cue || targets.length === 0) return null
 
@@ -618,6 +635,7 @@ function fallbackAimAtTarget (req) {
  */
 export function planShot (req) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   const rng = Number.isFinite(req.rngSeed) ? createRng(req.rngSeed) : Math.random
@@ -625,7 +643,7 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = req.state?.breakInProgress ? [1] : [0.5, 0.7, 0.85]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },
@@ -679,19 +697,19 @@ export function planShot (req) {
             continue
           }
           const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            b => b.id !== cueBallId && !b.pocketed && dist(cand, b) < r * 2
           )
           if (overlap) continue
           placements.push(cand)
         }
       } else {
-        const cue = req.state.balls.find(b => b.id === 0)
+        const cue = req.state.balls.find(b => b.id === cueBallId)
         placements.push({ x: cue.x, y: cue.y })
       }
 
       for (const cuePos of placements) {
         const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          b.id === cueBallId ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
 
         const baseCand = evaluate(

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -144,7 +144,7 @@ test('ball in hand baulk restriction only applies during break placement', () =>
   }
 });
 
-test('prefers any legal open-table object ball and avoids the 8-ball', () => {
+test('open-table targeting can select any object ball', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',
     state: {
@@ -164,8 +164,34 @@ test('prefers any legal open-table object ball and avoids the 8-ball', () => {
     rngSeed: 3
   };
   const decision = planShot(req);
-  assert.notEqual(decision.targetBallId, 8);
-  assert([1, 2].includes(decision.targetBallId));
+  assert([1, 2, 8].includes(decision.targetBallId));
+});
+
+test('supports non-zero cueBallId mappings', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      cueBallId: 16,
+      balls: [
+        { id: 16, x: 120, y: 160, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 280, y: 120, vx: 0, vy: 0, pocketed: false },
+        { id: 11, x: 320, y: 180, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: true
+    },
+    timeBudgetMs: 100,
+    rngSeed: 7
+  };
+  const decision = planShot(req);
+  assert([3, 11].includes(decision.targetBallId));
 });
 
 test('respects group assignment in eight-ball', () => {


### PR DESCRIPTION
### Motivation
- Restore the codebase to the known-good snapshot from yesterday at 10:00 AM to revert recent regressions in Pool Royale gameplay, camera and AI logic.
- Ensure the billiards AI correctly handles non-zero cue ball id mappings, break-placement rules, and target/group resolution that were changed by recent rollbacks.
- Reinstate camera/pocket anchor behavior and defensive guards in the PoolRoyale UI that prevent NaN/invalid vector errors during aiming and pocket camera switches.

### Description
- Restored three primary files to the baseline state: `lib/poolAi.js`, `test/poolAi.test.js`, and `webapp/src/pages/Games/PoolRoyale.jsx` to match the snapshot at or before `2026-02-13 10:00:00 -0800`.
- Added `resolveCueBallId(state)` and replaced hard-coded cue id usages (`0`) throughout the AI to support non-zero `cueBallId` mappings, including in `chooseTargets`, `nextTargetsAfter`, `clearShotCandidates`, `monteCarloPotChance`, `cloneBallsForNextShot`, `evaluate`, `safetyShot`, `fallbackAimAtTarget`, and `planShot`.
- Restored AI behavior changes: break power selection for `breakInProgress`, ball-in-hand placement/baulk restriction handling, runout/lookahead logic, and candidate selection behavior (open-table and group handling) to their previous logic.
- Restored and hardened Pool Royale UI changes: pocket camera ids/outward vectors extended (TM/BM), defensive checks to avoid NaN or invalid cue/dir vectors in `calcTarget`, improved pocket-camera switching intent logic, improved AI payload mapping (uses `cueBallId`) and several defensive/cleanup edits removing stale `launchSpeed` references.

### Testing
- Ran the targeted AI unit tests with `npm test -- test/poolAi.test.js` and all tests passed (`12/12` passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900cd8bed083298a2d3c2663290d2d)