### PR TITLE
Restore Pool Royale AI/UI to Feb 13 07:30 AM snapshot

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -18,6 +18,7 @@
  * @typedef {Object} AimRequest
  * @property {GameType} game
  * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean}} state
+ * @property {number} [state.cueBallId]
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -159,8 +160,16 @@ function currentGroup (state) {
   return undefined
 }
 
+function resolveCueBallId (state) {
+  if (Number.isFinite(state?.cueBallId)) return state.cueBallId
+  const cue = state?.balls?.find(b => b?.isCue === true)
+  if (cue && Number.isFinite(cue.id)) return cue.id
+  return 0
+}
+
 function chooseTargets (req) {
-  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
   if (req.game === 'NINE_BALL') {
     const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
     return lowest ? [lowest] : []
@@ -180,7 +189,7 @@ function chooseTargets (req) {
       if (eight) return [eight]
       return []
     }
-    return balls.filter(b => b.id !== 8)
+    return balls
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
@@ -203,7 +212,8 @@ function chooseTargets (req) {
 }
 
 function nextTargetsAfter (targetId, req) {
-  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
   if (req.game === 'NINE_BALL') {
     if (cloned.length === 0) return []
     const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
@@ -228,7 +238,7 @@ function nextTargetsAfter (targetId, req) {
       if (eight) return [eight]
       return []
     }
-    return cloned.filter(b => b.id !== 8)
+    return cloned
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
@@ -259,7 +269,8 @@ function nextTargetsAfter (targetId, req) {
 // preferring smaller cut angles and wider pocket views.
 function clearShotCandidates (req) {
   const r = req.state.ballRadius
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
   const maxCut = req.maxCutAngle ?? Math.PI / 4
@@ -286,10 +297,10 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
-        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r) ||
         req.state.balls.some(
-          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+          b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
         )
       ) {
         continue
@@ -356,13 +367,14 @@ function clampPointToTable (point, table, margin = 1) {
 }
 
 function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
+  const cueBallId = resolveCueBallId(state)
   const clamped = clampPointToTable(cueAfter, state, 1.1)
   return balls.map(ball => {
     const next = { ...ball }
     if (next.id === targetId) {
       next.pocketed = true
     }
-    if (next.id === 0) {
+    if (next.id === cueBallId) {
       next.x = clamped.x
       next.y = clamped.y
       next.vx = 0
@@ -377,6 +389,7 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
 // imprecision and rewards shorter, straighter shots.
 function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 20, rng = Math.random) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const baseAngle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
@@ -393,8 +406,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
       g.y < r ||
       g.y > req.state.height - r
     ) continue
-    if (pathBlocked(cue, g, balls, [0, target.id], r, 1.1)) continue
-    if (pathBlocked(target, entry, balls, [0, target.id], r)) continue
+    if (pathBlocked(cue, g, balls, [cueBallId, target.id], r, 1.1)) continue
+    if (pathBlocked(target, entry, balls, [cueBallId, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
     if (dist(g, ghost) > r * 0.5) continue
     success++
@@ -404,9 +417,10 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
 
 function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng = Math.random) {
   if (!req?.state || depth <= 0) return 0
+  const cueBallId = resolveCueBallId(req.state)
   const nextBalls = cloneBallsForNextShot(balls, cueAfter, targetId, req.state)
   const nextReq = { ...req, state: { ...req.state, balls: nextBalls, ballInHand: false } }
-  const cue = nextBalls.find(b => b.id === 0)
+  const cue = nextBalls.find(b => b.id === cueBallId)
   if (!cue) return 0
   const candidates = clearShotCandidates(nextReq)
   if (!candidates.length) return 0
@@ -445,6 +459,7 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
 
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false, options = {}) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const rng = options.rng ?? Math.random
   const balls = ballsOverride || req.state.balls
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -461,7 +476,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [0, target.id], r, 1.3)
+  const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
   if (laneClearance < 0.5) {
     return null
   }
@@ -469,9 +484,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
-    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
+    pathBlocked(cue, ghost, balls, [cueBallId, target.id], r, 1.1) ||
+    pathBlocked(target, entry, balls, [cueBallId, target.id], r) ||
+    balls.some(b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
@@ -543,7 +558,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 }
 
 function safetyShot (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -562,7 +578,8 @@ function safetyShot (req) {
 }
 
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   if (!cue || targets.length === 0) return null
 
@@ -618,6 +635,7 @@ function fallbackAimAtTarget (req) {
  */
 export function planShot (req) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   const rng = Number.isFinite(req.rngSeed) ? createRng(req.rngSeed) : Math.random
@@ -625,7 +643,7 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = [0.5, 0.7, 0.85]
+  const powers = req.state?.breakInProgress ? [1] : [0.5, 0.7, 0.85]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },
@@ -679,19 +697,19 @@ export function planShot (req) {
             continue
           }
           const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            b => b.id !== cueBallId && !b.pocketed && dist(cand, b) < r * 2
           )
           if (overlap) continue
           placements.push(cand)
         }
       } else {
-        const cue = req.state.balls.find(b => b.id === 0)
+        const cue = req.state.balls.find(b => b.id === cueBallId)
         placements.push({ x: cue.x, y: cue.y })
       }
 
       for (const cuePos of placements) {
         const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          b.id === cueBallId ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
 
         const baseCand = evaluate(

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -144,7 +144,7 @@ test('ball in hand baulk restriction only applies during break placement', () =>
   }
 });
 
-test('prefers any legal open-table object ball and avoids the 8-ball', () => {
+test('open-table targeting can select any object ball', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',
     state: {
@@ -164,8 +164,34 @@ test('prefers any legal open-table object ball and avoids the 8-ball', () => {
     rngSeed: 3
   };
   const decision = planShot(req);
-  assert.notEqual(decision.targetBallId, 8);
-  assert([1, 2].includes(decision.targetBallId));
+  assert([1, 2, 8].includes(decision.targetBallId));
+});
+
+test('supports non-zero cueBallId mappings', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      cueBallId: 16,
+      balls: [
+        { id: 16, x: 120, y: 160, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 280, y: 120, vx: 0, vy: 0, pocketed: false },
+        { id: 11, x: 320, y: 180, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: true
+    },
+    timeBudgetMs: 100,
+    rngSeed: 7
+  };
+  const decision = planShot(req);
+  assert([3, 11].includes(decision.targetBallId));
 });
 
 test('respects group assignment in eight-ball', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24211,7 +24211,7 @@ const powerRef = useRef(hud.power);
           if (legalTargets.size === 0) {
             if (activeVariantId === 'american' || activeVariantId === '9ball') {
               const lowestActive = activeBalls
-                .filter((b) => b.id !== 0)
+                .filter((b) => String(b?.id).toLowerCase() !== 'cue')
                 .reduce(
                   (best, ball) => (best == null || ball.id < best.id ? ball : best),
                   null
@@ -25081,13 +25081,14 @@ const powerRef = useRef(hud.power);
           const toAi = (vec) => ({ x: vec.x + width / 2, y: vec.y + height / 2 });
           const pocketsLocal = pocketEntranceCenters();
           const pockets = pocketsLocal.map((center) => toAi(center));
+          const cueBallId = 16;
           const mapBallId = (ball) => {
             if (!ball) return null;
-            if (ball === cueBall) return 0;
+            if (ball === cueBall) return cueBallId;
             if (typeof ball.id === 'number') return ball.id;
             if (typeof ball.id === 'string') {
               const lower = ball.id.toLowerCase();
-              if (lower === 'cue' || lower === 'cue_ball') return 0;
+              if (lower === 'cue' || lower === 'cue_ball') return cueBallId;
               const match = lower.match(/\d+/);
               if (match) return Number(match[0]);
             }
@@ -25107,7 +25108,7 @@ const powerRef = useRef(hud.power);
               pocketed: !ball.active
             });
           });
-          if (!aiBalls.some((ball) => ball.id === 0 && !ball.pocketed)) {
+          if (!aiBalls.some((ball) => ball.id === cueBallId && !ball.pocketed)) {
             return null;
           }
           const metaState = frameSnapshot?.meta?.state ?? null;
@@ -25128,9 +25129,11 @@ const powerRef = useRef(hud.power);
             height,
             ballRadius: BALL_R,
             friction: FRICTION,
+            cueBallId,
             ballInHand: Boolean(metaState?.ballInHand),
             myGroup: normalizedAssignment,
-            ballOn: normalizedBallOn ?? null
+            ballOn: normalizedBallOn ?? null,
+            breakInProgress: Boolean(metaState?.breakInProgress)
           };
           const decision = planShot({
             game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
@@ -25552,16 +25555,22 @@ const powerRef = useRef(hud.power);
             .forEach((entry) => {
               if (!combinedTargets.includes(entry)) combinedTargets.push(entry);
             });
-          const preferredActiveBalls =
-            assignmentTargets.length > 0
+          const legalCandidateBalls =
+            combinedTargets.length > 0
               ? activeBalls.filter((ball) =>
-                  assignmentTargets.some((target) => matchesTargetId(ball, target))
+                  combinedTargets.some((target) => matchesTargetId(ball, target))
                 )
               : activeBalls;
+          const preferredActiveBalls =
+            assignmentTargets.length > 0
+              ? legalCandidateBalls.filter((ball) =>
+                  assignmentTargets.some((target) => matchesTargetId(ball, target))
+                )
+              : legalCandidateBalls;
           const candidateBalls =
             assignmentTargets.length > 0 && preferredActiveBalls.length > 0
               ? preferredActiveBalls
-              : activeBalls;
+              : legalCandidateBalls;
           const pickFallbackBall = () =>
             candidateBalls.reduce((best, ball) => {
               if (!best) return ball;
@@ -25610,7 +25619,7 @@ const powerRef = useRef(hud.power);
           if (!targetBall && combinedTargets.length > 0) {
             targetBall =
               pickDirectPreferredBall(combinedTargets) ||
-              pickPreferredBall(combinedTargets, activeBalls, cuePos);
+              pickPreferredBall(combinedTargets, candidateBalls, cuePos);
           }
 
           if (!targetBall && activeVariantId === 'uk') {
@@ -25626,20 +25635,20 @@ const powerRef = useRef(hud.power);
             if (preferredColours.length > 0) {
               targetBall =
                 pickDirectPreferredBall(preferredColours) ||
-                pickPreferredBall(preferredColours, activeBalls, cuePos);
+                pickPreferredBall(preferredColours, candidateBalls, cuePos);
             }
           }
 
           if (!targetBall) {
-            targetBall = pickPreferredBall(['BLACK'], activeBalls, cuePos);
+            targetBall = pickPreferredBall(['BLACK'], candidateBalls, cuePos);
           }
 
           if (!targetBall) {
             targetBall = pickPreferredBall(
-              activeBalls
+              candidateBalls
                 .map((ball) => toBallColorId(ball.id))
                 .filter((entry) => entry && isBallTargetId(entry)),
-              activeBalls,
+              candidateBalls,
               cuePos
             );
           }
@@ -25651,7 +25660,7 @@ const powerRef = useRef(hud.power);
           if (targetBall && !isDirectLaneOpen(targetBall)) {
             const rerouted =
               pickDirectPreferredBall(combinedTargets) ||
-              pickPreferredBall(combinedTargets, activeBalls, cuePos) ||
+              pickPreferredBall(combinedTargets, candidateBalls, cuePos) ||
               pickFallbackBall();
             if (rerouted) targetBall = rerouted;
           }
@@ -25980,16 +25989,17 @@ const powerRef = useRef(hud.power);
             }
             const frameSnapshot = frameRef.current ?? frameState;
             const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
-            const isOpeningBreak = breakInProgress || (frameSnapshot?.currentBreak ?? 0) === 0;
             const aiTurnActive = currentHud?.turn === 1;
             const aiWonBreak = breakWinnerSeatRef.current === 'B';
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
-              isOpeningBreak &&
               aiTurnActive &&
-              (aiWonBreak || openingPlayer === 'B' || breakRollState === 'done' || breakInProgress);
+              breakInProgress &&
+              (aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
-              const rackBalls = ballsList.filter((ball) => ball?.active && ball.id !== 0);
+              const rackBalls = ballsList.filter(
+                (ball) => ball?.active && String(ball?.id).toLowerCase() !== 'cue'
+              );
               if (rackBalls.length > 0) {
                 const rackCenter = rackBalls.reduce(
                   (acc, ball) => {
@@ -26044,7 +26054,10 @@ const powerRef = useRef(hud.power);
             // Reset the cue pull so AI strokes visibly wind up before firing.
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
-            const aiPower = clampPower(plan.power, 0.6);
+            const isBreakPlan = plan?.type === 'break';
+            const aiPower = isBreakPlan
+              ? 1
+              : clampPower(plan.power, 0.6);
             powerRef.current = aiPower;
             setHud((s) => ({ ...s, power: aiPower }));
             const spinToApply = plan.spin ?? { x: 0, y: 0 };
@@ -26882,7 +26895,17 @@ const powerRef = useRef(hud.power);
               aimDir.normalize();
             }
           } else {
-            aimDir.lerp(tmpAim, aimLerpFactor);
+            const shouldAssistLegalAim =
+              isPlayerTurn &&
+              (autoAimRequestRef.current || suggestionAimKeyRef.current != null);
+            const legalPlayerAim = shouldAssistLegalAim
+              ? resolveLegalPlayerAimDirection(tmpAim)
+              : tmpAim;
+            const desiredAim =
+              legalPlayerAim && legalPlayerAim.lengthSq() > 1e-6
+                ? legalPlayerAim
+                : tmpAim;
+            aimDir.lerp(desiredAim, aimLerpFactor);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
             }


### PR DESCRIPTION
### Motivation
- Revert Pool Royale AI and gameplay/UI behavior to the snapshot from 2026-02-13 07:30 AM to restore previous targeting, cue-ball handling, and related UI logic.
- Ensure AI supports non-standard cue-ball identifiers and preserves prior break/aim behavior expected by tests and gameplay.

### Description
- Restored and refactored cue-ball handling by adding `resolveCueBallId` and replacing hard-coded `id === 0` checks with `cueBallId` usage across `lib/poolAi.js` to support non-zero or string-mapped cue IDs. (lib/poolAi.js)
- Restored target-selection and candidate filtering logic so open-table behavior and group-assignment rules match the snapshot, and updated Monte Carlo, lookahead, and evaluation paths to respect the resolved cue-ball id and break placement constraints. (lib/poolAi.js)
- Updated AI-to-UI integration to map cue-ball IDs (mapped to `cueBallId`) when building `aiState`, changed candidate ball selection to use `candidateBalls`/`legalCandidateBalls`, enforced maximum-power break plans, and added legal-aim assist resolution for player aim paths. (webapp/src/pages/Games/PoolRoyale.jsx)
- Updated and extended tests to reflect restored behavior including open-table targeting and support for non-zero cueBallId mappings. (test/poolAi.test.js)

### Testing
- Ran `npm test -- --runTestsByPath test/poolAi.test.js` and the targeted suite passed: 1 test suite, 12 tests all passed.
- Verified the restored files were updated and the AI unit tests exercised the cue-ball id and open-table target behaviors successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699011760b748329a9bed7508e739936)