### PR TITLE
Pool Royale: prefer rail-overhead for break & middle-pocket events; limit AI max-break to opening

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19557,6 +19557,9 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (isSidePocket) {
+            return null;
+          }
           const triggerDistance = allowEarly
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
@@ -23645,7 +23648,7 @@ const powerRef = useRef(hud.power);
               )
             : null;
           const earlyPocketView =
-            !suppressPocketCameras && shotPrediction.ballId && followView
+            !suppressPocketCameras && !isBreakShot && shotPrediction.ballId && followView
               ? makePocketCameraView(shotPrediction.ballId, followView)
               : null;
           if (actionView && cameraRef.current) {
@@ -26030,12 +26033,14 @@ const powerRef = useRef(hud.power);
             }
             const frameSnapshot = frameRef.current ?? frameState;
             const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
+            const isOpeningBreak = (frameSnapshot?.currentBreak ?? 0) === 0;
             const aiTurnActive = currentHud?.turn === 1;
             const aiWonBreak = breakWinnerSeatRef.current === 'B';
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
               aiTurnActive &&
               breakInProgress &&
+              isOpeningBreak &&
               (aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter(
@@ -28162,6 +28167,8 @@ const powerRef = useRef(hud.power);
         const suppressPocketCameras =
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
+        const frameSnapshot = frameRef.current ?? frameState;
+        const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
         const earlyPocketIntent = pocketSwitchIntentRef.current;
         if (earlyPocketIntent && earlyPocketIntent.createdAt) {
           const now = performance.now();
@@ -28187,6 +28194,7 @@ const powerRef = useRef(hud.power);
         }
         if (
           !suppressPocketCameras &&
+          !breakInProgress &&
           shooting &&
           !topViewRef.current
         ) {


### PR DESCRIPTION
### Motivation
- Ensure broadcast framing stays on the rail-overhead camera during the opening break and for middle-pocket (side) interactions so the break and cushion/central-pocket flows use the broadcast view instead of pocket closeups.
- Make AI use maximum power only for the true opening break and preserve normal AI shot power/behavior for subsequent shots.
- Reduce unexpected pocket-camera switches during high-speed/chaotic break sequences.

### Description
- Suppress pocket-camera creation for middle/side pockets by returning `null` when `anchorPocketId` is `TM` or `BM` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Prevent early pocket camera activation for break shots by gating `earlyPocketView` with `!isBreakShot` so break intents do not trigger pocket cams.
- Add a `breakInProgress` runtime guard before allowing pocket-camera switching while shooting so pocket cameras are disabled while a break is underway.
- Tighten AI forced-break logic to only trigger on the true opening break by requiring `(frameSnapshot?.currentBreak ?? 0) === 0` (named `isOpeningBreak`) before forcing `type: 'break'` with `power: 1` and the rack-centre aim; other AI shots remain unchanged.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully (with chunk-size warnings only). 
- Started the dev server and captured a viewport screenshot using an automated Playwright script to validate camera framing, which completed successfully and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990329c771c832993887559f214fa76)