### PR TITLE
Revert "Pool Royale: prefer rail-overhead for break & middle-pocket events; limit AI max-break to opening"

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19557,9 +19557,6 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
-          if (isSidePocket) {
-            return null;
-          }
           const triggerDistance = allowEarly
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
@@ -23648,7 +23645,7 @@ const powerRef = useRef(hud.power);
               )
             : null;
           const earlyPocketView =
-            !suppressPocketCameras && !isBreakShot && shotPrediction.ballId && followView
+            !suppressPocketCameras && shotPrediction.ballId && followView
               ? makePocketCameraView(shotPrediction.ballId, followView)
               : null;
           if (actionView && cameraRef.current) {
@@ -26033,14 +26030,12 @@ const powerRef = useRef(hud.power);
             }
             const frameSnapshot = frameRef.current ?? frameState;
             const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
-            const isOpeningBreak = (frameSnapshot?.currentBreak ?? 0) === 0;
             const aiTurnActive = currentHud?.turn === 1;
             const aiWonBreak = breakWinnerSeatRef.current === 'B';
             const openingPlayer = frameSnapshot?.activePlayer ?? (aiTurnActive ? 'B' : 'A');
             const shouldForceAiBreak =
               aiTurnActive &&
               breakInProgress &&
-              isOpeningBreak &&
               (aiWonBreak || openingPlayer === 'B');
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter(
@@ -28167,8 +28162,6 @@ const powerRef = useRef(hud.power);
         const suppressPocketCameras =
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
-        const frameSnapshot = frameRef.current ?? frameState;
-        const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
         const earlyPocketIntent = pocketSwitchIntentRef.current;
         if (earlyPocketIntent && earlyPocketIntent.createdAt) {
           const now = performance.now();
@@ -28194,7 +28187,6 @@ const powerRef = useRef(hud.power);
         }
         if (
           !suppressPocketCameras &&
-          !breakInProgress &&
           shooting &&
           !topViewRef.current
         ) {


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#14983