### PR TITLE
Pool Royale: faster rail-overhead switching, adjust pocket cams, restrict AI max-power break

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1470,6 +1470,7 @@ const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 1.24; // move middle-pocket cameras farther outside so their pocket distance matches the corner-pocket camera feel
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1528,8 +1529,8 @@ const ACTION_CAM = Object.freeze({
   shortRailBias: 0.52,
   followShortRailBias: 0.42,
   heightOffset: BALL_R * 9.2,
-  smoothingTime: 0.32,
-  followSmoothingTime: 0.24,
+  smoothingTime: 0.24,
+  followSmoothingTime: 0.18,
   followDistance: BALL_R * 54,
   followHeightOffset: BALL_R * 7.4,
   followHoldMs: 900
@@ -19588,7 +19589,8 @@ const powerRef = useRef(hud.power);
           const minOutside = isSidePocket
             ? POCKET_CAM.minOutside
             : POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside;
-          const cameraDistance = minOutside;
+          const cameraDistance =
+            minOutside * (isSidePocket ? POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER : 1);
           const broadcastRailDir = isSidePocket
             ? resolveShortRailBroadcastDirection({
                 pocketCenter: best.center,
@@ -23878,8 +23880,12 @@ const powerRef = useRef(hud.power);
             pocketViewActivated = true;
           }
           if (!pocketViewActivated && actionView) {
+            const requiresCueBallMovementTrigger =
+              isBreakShot || (!earlyPocketView && !suppressPocketCameras);
             const shouldActivateActionView =
-              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
+              !requiresCueBallMovementTrigger &&
+              (!isLongShot || forceActionActivation) &&
+              !isMaxPowerShot;
             if (shouldActivateActionView && !holdActive) {
               suspendedActionView = null;
               activeShotView = actionView;
@@ -23887,12 +23893,18 @@ const powerRef = useRef(hud.power);
             } else {
               actionView.pendingActivation = true;
               const baseDelay = actionView.activationDelay ?? null;
-              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
+              const delayed = requiresCueBallMovementTrigger
+                ? baseDelay ?? 0
+                : Math.max(baseDelay ?? 0, holdUntil ?? 0);
               actionView.activationDelay = delayed > 0 ? delayed : null;
               const baseTravel = actionView.activationTravel ?? 0;
               actionView.activationTravel = Math.max(
                 baseTravel,
-                isMaxPowerShot ? BALL_R * 6 : 0
+                requiresCueBallMovementTrigger
+                  ? BALL_R * 0.2
+                  : isMaxPowerShot
+                    ? BALL_R * 6
+                    : 0
               );
               suspendedActionView = actionView;
             }
@@ -26036,7 +26048,8 @@ const powerRef = useRef(hud.power);
             const frameSnapshot = frameRef.current ?? frameState;
             const breakInProgress = Boolean(frameSnapshot?.meta?.state?.breakInProgress);
             const aiTurnActive = currentHud?.turn === 1;
-            const shouldForceAiBreak = aiTurnActive && breakInProgress;
+            const isOpeningBreak = (frameSnapshot?.currentBreak ?? 0) === 0;
+            const shouldForceAiBreak = aiTurnActive && breakInProgress && isOpeningBreak;
             if (shouldForceAiBreak && cue?.pos) {
               const rackBalls = ballsList.filter(
                 (ball) => ball?.active && String(ball?.id).toLowerCase() !== 'cue'


### PR DESCRIPTION
### Motivation

- Implement gameplay-camera and AI tweaks so breaks feel more authentic and broadcast cameras respond faster during breaks and follow shots.
- Make middle-pocket broadcast framing match corner-pocket distance so pocket closeups read consistently on portrait screens.

### Description

- Reduced action-camera smoothing (`ACTION_CAM.smoothingTime` and `followSmoothingTime`) to make action/rail-overhead transitions more responsive in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` and applied it when computing side-pocket camera distance so middle-pocket cameras are pushed slightly outward to match corner-pocket feel.
- Updated action-view activation flow to prefer immediate rail-overhead switching for break shots and non-guaranteed shots by skipping long hold delays and using a `requiresCueBallMovementTrigger` predicate.
- Scoped the AI forced max-power break path to the opening break only by requiring `(frameSnapshot?.currentBreak ?? 0) === 0` in the AI shot-planning logic.

### Testing

- Ran linter with `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which produced a file-ignore warning but no blocking errors (warning only).
- Built the web app with `npm --prefix webapp run build` which completed successfully and produced a production bundle.
- Attempted an automated visual smoke check with Playwright to capture a screenshot, but the headless Chromium run timed out/crashed in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69904b58135c8329960f2a37c4323020)