### PR TITLE
Pool Royale: enforce correct opening-break AI, foul handoff, pocket cam offsets and immediate rail/pocket camera switching

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -38,6 +38,7 @@ export class AmericanBilliards {
     const playerGroup = s.assignments[current];
     const opponentGroup = s.assignments[opp];
     const isOpenTable = !playerGroup || !opponentGroup;
+    const breakInProgress = Boolean(s.breakInProgress);
     const solidsLeft = countRemainingGroup(s.ballsOnTable, 'SOLID');
     const stripesLeft = countRemainingGroup(s.ballsOnTable, 'STRIPE');
     const playerGroupRemaining =
@@ -55,7 +56,8 @@ export class AmericanBilliards {
     if (!foul && !isLegalFirstContact(first, {
       isOpenTable,
       playerGroup,
-      playerGroupRemaining
+      playerGroupRemaining,
+      breakInProgress
     })) {
       foul = true;
       reason = 'wrong first contact';
@@ -67,7 +69,7 @@ export class AmericanBilliards {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!foul && !breakInProgress && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true;
       reason = 'no cushion';
     }
@@ -90,7 +92,7 @@ export class AmericanBilliards {
     }
 
     if (!foul) {
-      if (isOpenTable) {
+      if (isOpenTable && !breakInProgress) {
         const groupBall = pottedBalls.find(id => id !== 8);
         if (groupBall) {
           const group = idToGroup(groupBall);
@@ -134,9 +136,7 @@ export class AmericanBilliards {
     }
 
     s.ballInHand = ballInHandNext;
-    if (!foul || pottedBalls.length > 0) {
-      s.breakInProgress = false;
-    }
+    s.breakInProgress = false;
     s.frameOver = frameOver;
     s.winner = winner;
 
@@ -174,8 +174,11 @@ function countRemainingGroup (balls, group) {
   return total;
 }
 
-function isLegalFirstContact (first, { isOpenTable, playerGroup, playerGroupRemaining }) {
+function isLegalFirstContact (first, { isOpenTable, playerGroup, playerGroupRemaining, breakInProgress }) {
   if (!Number.isFinite(first)) return false;
+  if (breakInProgress) {
+    return first >= 1 && first <= 15;
+  }
   if (isOpenTable) {
     return first !== 8;
   }


### PR DESCRIPTION
### Motivation
- Fix game behavior so AI only uses forced max-power for the opening break and aims at the rack front (not the middle pocket), and make fouls reliably hand off turn with ball-in-hand.
- Improve broadcast framing by moving middle-pocket cameras outward toward the wooden side-rail edges so pocket closeups read consistently on portrait screens.
- Make broadcast camera switching more responsive by using the rail-overhead action camera immediately for break/bank/cushion trajectories and switching pocket cameras as soon as the cue ball starts moving for guaranteed pots.

### Description
- Rules: updated American 8-ball break handling in `lib/americanBilliards.js` to treat break phase specially by allowing any rack-first contact, disabling the no-cushion foul during the break, preventing assignment lock on break pots, and clearing `breakInProgress` after the break shot so the rest of the frame uses normal rules.
- AI break: changed AI opening-break aiming in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a break target using the nearest front rack ball (front-most relative to the cue) and only force max power when `(frameSnapshot?.currentBreak ?? 0) === 0` (opening break) so later shots remain normal.
- Cameras and views in `webapp/src/pages/Games/PoolRoyale.jsx`: increased `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` to push middle-pocket cameras toward side rails, reduced `ACTION_CAM.smoothingTime` and `followSmoothingTime` to make transitions snappier, force the rail-overhead action camera for breaks and when `shotPrediction.railNormal` is present, and changed activation logic so `actionView`/`rail overhead` activation prefers immediate switching but still uses a movement trigger where appropriate.
- Pocket camera activation: require cue-ball movement (`> STOP_EPS`) before committing queued pocket activations so guaranteed pocket camera switches happen as motion begins rather than waiting too long.
- Foul handoff: ensure that when a foul is detected the shot resolution sets the next active player to the opponent and sets ball-in-hand metadata (`ballInHand` / `mustPlayFromBaulk`) so turn and placement behave correctly after fouls.

### Testing
- Built production bundle with `npm --prefix webapp run build` which completed successfully (Vite build succeeded with usual chunk warnings). (✅)
- Ran a `node` simulation against `AmericanBilliards` to verify break and scratch behavior (script executed and printed expected results: legal break is allowed, scratch foul hands turn and ball-in-hand). (✅)
- Ran a headless browser smoke-check via the environment's Playwright tool (Firefox run produced a screenshot artifact) to validate camera/view changes rendered without runtime errors. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69904b58135c8329960f2a37c4323020)