### PR TITLE
Improve Pool AI foul-avoidance, add legal-target suggestions, and reduce shot power

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -36,6 +36,9 @@
  * @property {string} rationale
  * @property {{x:number,y:number}} [cueBallPosition]
  * @property {{x:number,y:number}} [aimPoint]
+ * @property {number} [suggestedTargetBallId]
+ * @property {{x:number,y:number}} [suggestedAimPoint]
+ * @property {Array<{targetBallId:number,aimPoint:{x:number,y:number}}>} [legalTargetSuggestions]
  */
 
 const LOOKAHEAD_DEPTH = 2
@@ -264,6 +267,26 @@ function nextTargetsAfter (targetId, req) {
   return cloned
 }
 
+function buildLegalTargetSuggestions (req, cue, max = 5) {
+  if (!cue) return []
+  const cueBallId = resolveCueBallId(req.state)
+  const radius = req.state.ballRadius
+  const legal = chooseTargets(req)
+  const ranked = []
+  for (const target of legal) {
+    const blocked = pathBlocked(cue, target, req.state.balls, [cueBallId, target.id], radius, 1.05)
+    const lane = clearanceMargin(cue, target, req.state.balls, [cueBallId, target.id], radius, 1.25)
+    const score = (blocked ? 0 : 1) * 1.2 + lane * 0.55 - dist(cue, target) / Math.max(req.state.width, req.state.height)
+    ranked.push({ target, score, blocked })
+  }
+  ranked.sort((a, b) => b.score - a.score)
+  const suggestions = ranked.slice(0, max).map(({ target }) => ({
+    targetBallId: target.id,
+    aimPoint: { x: target.x, y: target.y }
+  }))
+  return suggestions
+}
+
 // Identify target/pocket pairs that satisfy core aiming criteria:
 // minimal cut angle and clear pocket entry. Returns sorted candidates,
 // preferring smaller cut angles and wider pocket views.
@@ -477,7 +500,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
-  if (laneClearance < 0.5) {
+  if (laneClearance < 0.62) {
     return null
   }
   if (scratchRiskAlongLine(cue, ghost, req.state.pockets || [], r)) {
@@ -501,7 +524,18 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     const next = nextTargets[0]
     nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
   }
-  const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
+  const pocketProximity = req.state.pockets.reduce((best, p) => Math.min(best, dist(cueAfter, p)), Infinity)
+  const edgeProximity = Math.min(cueAfter.x, req.state.width - cueAfter.x, cueAfter.y, req.state.height - cueAfter.y)
+  const scratchRisk = pocketProximity < r * 1.6
+    ? Math.min(1, 1 - pocketProximity / (r * 1.6))
+    : 0
+  const railTrapRisk = edgeProximity < r * 1.7
+    ? Math.min(1, 1 - edgeProximity / (r * 1.7))
+    : 0
+  const risk = Math.min(1, scratchRisk * 0.75 + railTrapRisk * 0.35)
+  if (risk > 0.55) {
+    return null
+  }
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
@@ -608,6 +642,8 @@ function fallbackAimAtTarget (req) {
     ) {
       continue
     }
+    const blocked = pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], req.state.ballRadius, 1.05)
+    if (blocked) continue
     const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
     const candidate = {
       angleRad: angle,
@@ -653,6 +689,8 @@ export function planShot (req) {
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
+  const cueBall = req.state.balls.find((b) => b.id === cueBallId)
+  const legalTargetSuggestions = buildLegalTargetSuggestions(req, cueBall)
   let candidatePairs = clearShotCandidates(req)
   if (candidatePairs.length === 0) {
     // fallback: evaluate all target/pocket combinations
@@ -767,13 +805,38 @@ export function planShot (req) {
   }
 
   if (best) {
-    if (best.quality >= 0.1) return best
-    if (hasViableShot) return best
+    const enriched = {
+      ...best,
+      legalTargetSuggestions,
+      suggestedTargetBallId: legalTargetSuggestions[0]?.targetBallId,
+      suggestedAimPoint: legalTargetSuggestions[0]?.aimPoint
+    }
+    if (best.quality >= 0.1) return enriched
+    if (hasViableShot) return enriched
   }
-  if (!hasViableShot) return safetyShot(req)
+  if (!hasViableShot) {
+    return {
+      ...safetyShot(req),
+      legalTargetSuggestions,
+      suggestedTargetBallId: legalTargetSuggestions[0]?.targetBallId,
+      suggestedAimPoint: legalTargetSuggestions[0]?.aimPoint
+    }
+  }
   fallback = fallbackAimAtTarget(req)
-  if (fallback) return fallback
-  return safetyShot(req)
+  if (fallback) {
+    return {
+      ...fallback,
+      legalTargetSuggestions,
+      suggestedTargetBallId: legalTargetSuggestions[0]?.targetBallId,
+      suggestedAimPoint: legalTargetSuggestions[0]?.aimPoint
+    }
+  }
+  return {
+    ...safetyShot(req),
+    legalTargetSuggestions,
+    suggestedTargetBallId: legalTargetSuggestions[0]?.targetBallId,
+    suggestedAimPoint: legalTargetSuggestions[0]?.aimPoint
+  }
 }
 
 export default planShot

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1607,7 +1607,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.9; // reduce overall Pool Royale power by 10% for a slightly faster pace
+const SHOT_POWER_ADJUSTMENT = 0.72; // apply an extra 20% cut versus the current baseline to soften all shots
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Reduce AI-caused fouls by making the planner avoid risky shots and blocked ghost-ball aims. 
- Provide a non-intrusive suggested next legal target and aim point so UI/AI can default the aim line while letting the user override it. 
- Soften shot strength across Pool Royale by applying a 20% additional reduction to the power baseline for a more comfortable mobile experience.

### Description
- Added `buildLegalTargetSuggestions` and attached suggestion metadata (`legalTargetSuggestions`, `suggestedTargetBallId`, `suggestedAimPoint`) to `planShot` output so UI/AI can suggest a next legal target and aim point; changes applied in `lib/poolAi.js` and mirrored in `webapp/public/lib/poolAi.js`.
- Tightened candidate filtering by raising the lane-clearance threshold and added post-shot foul scoring that combines scratch proximity and rail-trap proximity, rejecting candidates with high foul risk in `evaluate`.
- Prevented fallback-aim from returning ghost-ball aims when the ghost line is blocked by checking `pathBlocked` before accepting fallback candidates.
- Reduced Pool Royale global shot power baseline by changing `SHOT_POWER_ADJUSTMENT` from `0.9` to `0.72` in `webapp/src/pages/Games/PoolRoyale.jsx` so shots are ~20% softer.

### Testing
- Ran `node --check lib/poolAi.js` and `node --check webapp/public/lib/poolAi.js` to validate syntax and both succeeded. 
- Executed `npm test -- --runInBand test/poolAi.test.js` and the suite passed (12 tests, all green). 
- Verified the public/runtime AI file was updated to mirror logic changes and that the modified code runs without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990762a23f48329a9efec4c3d9ce1c3)