### PR TITLE
Pool AI: reduce fouls, add next-legal target suggestion, and lower shot power

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -36,6 +36,8 @@
  * @property {string} rationale
  * @property {{x:number,y:number}} [cueBallPosition]
  * @property {{x:number,y:number}} [aimPoint]
+ * @property {number} [nextLegalTargetBallId]
+ * @property {{x:number,y:number}} [nextLegalAimPoint]
  */
 
 const LOOKAHEAD_DEPTH = 2
@@ -76,6 +78,27 @@ function pathBlocked (a, b, balls, ignoreIds, radius, margin = 1) {
       !ignoreIds.includes(ball.id) &&
       lineIntersectsBall(a, b, ball, radius * margin)
   )
+}
+
+function firstBallHitAlongLine (cue, aimPoint, balls, cueBallId, radius) {
+  const dirX = aimPoint.x - cue.x
+  const dirY = aimPoint.y - cue.y
+  const len = Math.hypot(dirX, dirY)
+  if (len <= 1e-6) return null
+  const nx = dirX / len
+  const ny = dirY / len
+  let closest = null
+  for (const ball of balls) {
+    if (!ball || ball.pocketed || ball.id === cueBallId) continue
+    const relX = ball.x - cue.x
+    const relY = ball.y - cue.y
+    const t = relX * nx + relY * ny
+    if (t <= 0 || t >= len) continue
+    const perp = Math.abs(relX * ny - relY * nx)
+    if (perp > radius * 2.05) continue
+    if (!closest || t < closest.t) closest = { ball, t }
+  }
+  return closest?.ball ?? null
 }
 
 function clearanceMargin (a, b, balls, ignoreIds, radius, multiplier = 1.35) {
@@ -330,6 +353,55 @@ function clearShotCandidates (req) {
   return candidates
 }
 
+function nextLegalSuggestion (req, excludeBallId = null) {
+  const candidates = clearShotCandidates(req)
+  for (const { target, pocket } of candidates) {
+    if (excludeBallId != null && target.id === excludeBallId) continue
+    const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+    const ghost = {
+      x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
+      y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
+    }
+    return {
+      nextLegalTargetBallId: target.id,
+      nextLegalAimPoint: ghost,
+      nextLegalTargetPocket: entry
+    }
+  }
+
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  const targets = chooseTargets(req).filter(target => target.id !== excludeBallId)
+  if (!cue || targets.length === 0) return null
+  let fallback = null
+  for (const target of targets) {
+    for (const pocket of req.state.pockets) {
+      const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+      const ghost = {
+        x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
+        y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
+      }
+      if (
+        ghost.x < req.state.ballRadius ||
+        ghost.x > req.state.width - req.state.ballRadius ||
+        ghost.y < req.state.ballRadius ||
+        ghost.y > req.state.height - req.state.ballRadius
+      ) continue
+      const align = pocketAlignment(pocket, target, req.state.width, req.state.height)
+      if (!fallback || align > fallback.align) {
+        fallback = { target, entry, ghost, align }
+      }
+    }
+  }
+
+  if (!fallback) return null
+  return {
+    nextLegalTargetBallId: fallback.target.id,
+    nextLegalAimPoint: fallback.ghost,
+    nextLegalTargetPocket: fallback.entry
+  }
+}
+
 export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
@@ -474,6 +546,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     ghost.y < r ||
     ghost.y > req.state.height - r
   ) {
+    return null
+  }
+  const firstHit = firstBallHitAlongLine(cue, ghost, balls, cueBallId, r)
+  if (firstHit && firstHit.id !== target.id) {
     return null
   }
   const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
@@ -767,12 +843,17 @@ export function planShot (req) {
   }
 
   if (best) {
+    const suggestion = nextLegalSuggestion(req, best.targetBallId)
+    if (suggestion) best = { ...best, ...suggestion }
     if (best.quality >= 0.1) return best
     if (hasViableShot) return best
   }
   if (!hasViableShot) return safetyShot(req)
   fallback = fallbackAimAtTarget(req)
-  if (fallback) return fallback
+  if (fallback) {
+    const suggestion = nextLegalSuggestion(req, fallback.targetBallId)
+    return suggestion ? { ...fallback, ...suggestion } : fallback
+  }
   return safetyShot(req)
 }
 

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -322,3 +322,50 @@ test('avoids unnecessary spin when natural position is good', () => {
   assert.equal(decision.power, 0.5);
   assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
 });
+
+test('rejects lines where an illegal ball is hit first', () => {
+  const req = {
+    game: 'NINE_BALL',
+    state: {
+      balls: [
+        { id: 0, x: 100, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 600, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 350, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }, { x: 0, y: 250 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50,
+    rngSeed: 5
+  };
+  const decision = planShot(req);
+  assert.notEqual(decision.targetBallId, 1);
+});
+
+test('returns next legal target suggestion metadata', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 420, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 680, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 680, y: 120, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }, { x: 1000, y: 0 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 50,
+    rngSeed: 11
+  };
+  const decision = planShot(req);
+  assert.equal(typeof decision.nextLegalTargetBallId, 'number');
+  assert.ok(decision.nextLegalTargetBallId !== decision.targetBallId);
+  assert.ok(decision.nextLegalAimPoint);
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23573,7 +23573,7 @@ const powerRef = useRef(hud.power);
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = shotAimDir
             .clone()
-            .multiplyScalar(speedBase * powerScale);
+            .multiplyScalar(speedBase * powerScale * 0.8);
           const predictedCueSpeed = base.length();
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {


### PR DESCRIPTION
### Motivation
- Reduce AI-caused fouls by preventing plans that would contact an illegal ball first along the cue line.  
- Help players and AI by providing a suggested next legal target/aim point so the aim-line UI can default to a legal target while still allowing manual override.  
- Lower overall shot strength by 20% to meet game balancing requirements.

### Description
- Added a geometric check `firstBallHitAlongLine` and integrated it into the evaluator so candidate shots are rejected when a different (illegal) ball would be struck first. (files: `lib/poolAi.js`, `webapp/public/lib/poolAi.js`)  
- Introduced `nextLegalSuggestion` to compute a fallback legal target/pocket/aimPoint and extended the `ShotDecision` shape with `nextLegalTargetBallId`, `nextLegalAimPoint`, and `nextLegalTargetPocket`; suggestions are attached to both the chosen `best` plan and fallback plans. (files: `lib/poolAi.js`, `webapp/public/lib/poolAi.js`)  
- Reduced the effective shot launch velocity by multiplying the computed shot base by `0.8` so shots are ~20% weaker in practice. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)  
- Synced the updated AI planner into the browser bundle at `webapp/public/lib/poolAi.js`.  
- Added unit tests covering illegal-first-hit rejection and next-legal-target suggestion metadata, and updated `test/poolAi.test.js` accordingly.

### Testing
- Ran `npm test -- test/poolAi.test.js` and the suite passed (14/14 tests) after changes. ✅  
- Ran `npm test -- test/poolUk8Ball.test.js`; this suite reported 2 failing tests unrelated to the updated AI suggestion/legality code and shot-power tweak (failures observed in UK rule/AI tests). ⚠️  
- Confirmed the changed AI code is mirrored in the browser-friendly `webapp/public/lib/poolAi.js` and that the new suggestion metadata is present on returned decisions in unit tests. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990762a23f48329a9efec4c3d9ce1c3)