### PR TITLE
Improve AI aiming: add next-legal-target suggestions and reduce shot power

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -36,6 +36,8 @@
  * @property {string} rationale
  * @property {{x:number,y:number}} [cueBallPosition]
  * @property {{x:number,y:number}} [aimPoint]
+ * @property {number} [nextSuggestedTargetBallId]
+ * @property {{x:number,y:number}} [nextSuggestedAimPoint]
  */
 
 const LOOKAHEAD_DEPTH = 2
@@ -330,6 +332,57 @@ function clearShotCandidates (req) {
   return candidates
 }
 
+function buildLegalTargetSuggestions (req, limit = 3) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return []
+
+  const candidates = clearShotCandidates(req)
+  const suggestions = []
+  for (const candidate of candidates) {
+    if (suggestions.length >= limit) break
+    const entry = pocketEntry(candidate.pocket, req.state.ballRadius, req.state.width, req.state.height, candidate.target)
+    const ghost = {
+      x: candidate.target.x - (entry.x - candidate.target.x) * (req.state.ballRadius * 2 / dist(candidate.target, entry)),
+      y: candidate.target.y - (entry.y - candidate.target.y) * (req.state.ballRadius * 2 / dist(candidate.target, entry))
+    }
+    suggestions.push({
+      targetBallId: candidate.target.id,
+      aimPoint: ghost,
+      targetPocket: entry,
+      rank: candidate.rank
+    })
+  }
+
+  if (suggestions.length > 0) return suggestions
+
+  // fallback: suggest direct legal contacts even when no pot is available
+  const legalTargets = chooseTargets(req)
+  const fallback = legalTargets
+    .map(target => ({ target, distance: dist(cue, target) }))
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit)
+    .map(({ target, distance }) => ({
+      targetBallId: target.id,
+      aimPoint: { x: target.x, y: target.y },
+      targetPocket: null,
+      rank: 1 / Math.max(distance, 1)
+    }))
+  return fallback
+}
+
+function attachNextSuggestion (decision, req) {
+  if (!decision) return decision
+  const suggestions = buildLegalTargetSuggestions(req, 4)
+  const alt = suggestions.find(s => s.targetBallId !== decision.targetBallId) || suggestions[0]
+  if (!alt) return decision
+  return {
+    ...decision,
+    nextSuggestedTargetBallId: alt.targetBallId,
+    nextSuggestedAimPoint: alt.aimPoint
+  }
+}
+
 export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
@@ -560,17 +613,14 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 function safetyShot (req) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
-  const corners = [
-    { x: 0, y: 0 },
-    { x: req.state.width, y: 0 },
-    { x: 0, y: req.state.height },
-    { x: req.state.width, y: req.state.height }
-  ]
-  const target = corners.reduce((best, c) => (dist(cue, c) > dist(cue, best) ? c : best), corners[0])
+  const legalTargets = chooseTargets(req)
+  const target = legalTargets.length > 0
+    ? legalTargets.reduce((best, ball) => (dist(cue, ball) < dist(cue, best) ? ball : best), legalTargets[0])
+    : { x: req.state.width / 2, y: req.state.height / 2 }
   const angle = Math.atan2(target.y - cue.y, target.x - cue.x)
   return {
     angleRad: angle,
-    power: 0.5,
+    power: 0.4,
     spin: { top: 0, side: 0, back: 0 },
     quality: 0,
     rationale: 'safety'
@@ -611,7 +661,7 @@ function fallbackAimAtTarget (req) {
     const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
     const candidate = {
       angleRad: angle,
-      power: 0.65,
+      power: 0.52,
       spin: { top: 0, side: 0, back: 0 },
       targetBallId: target.id,
       targetPocket: bestPocket,
@@ -643,7 +693,7 @@ export function planShot (req) {
   let fallback = null
   let hasViableShot = false
 
-  const powers = req.state?.breakInProgress ? [1] : [0.5, 0.7, 0.85]
+  const powers = req.state?.breakInProgress ? [1] : [0.4, 0.56, 0.68]
   const spins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: -0.3 },
@@ -739,7 +789,8 @@ export function planShot (req) {
           for (const spin of spins) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
-              return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
+              if (best && best.quality >= 0.1) return attachNextSuggestion(best, req)
+              return attachNextSuggestion(fallbackAimAtTarget(req) || safetyShot(req), req)
             }
             const cand = evaluate(
               req,
@@ -767,13 +818,13 @@ export function planShot (req) {
   }
 
   if (best) {
-    if (best.quality >= 0.1) return best
-    if (hasViableShot) return best
+    if (best.quality >= 0.1) return attachNextSuggestion(best, req)
+    if (hasViableShot) return attachNextSuggestion(best, req)
   }
-  if (!hasViableShot) return safetyShot(req)
+  if (!hasViableShot) return attachNextSuggestion(safetyShot(req), req)
   fallback = fallbackAimAtTarget(req)
-  if (fallback) return fallback
-  return safetyShot(req)
+  if (fallback) return attachNextSuggestion(fallback, req)
+  return attachNextSuggestion(safetyShot(req), req)
 }
 
 export default planShot

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -319,6 +319,58 @@ test('avoids unnecessary spin when natural position is good', () => {
     timeBudgetMs: 50
   };
   const decision = planShot(req);
-  assert.equal(decision.power, 0.5);
+  assert.equal(decision.power, 0.4);
   assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
+});
+
+
+test('decision includes a next legal target suggestion', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 350, y: 220, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 620, y: 260, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    timeBudgetMs: 60,
+    rngSeed: 6
+  };
+
+  const decision = planShot(req);
+  assert(Number.isFinite(decision.nextSuggestedTargetBallId));
+  assert(decision.nextSuggestedAimPoint);
+  assert(Number.isFinite(decision.nextSuggestedAimPoint.x));
+  assert(Number.isFinite(decision.nextSuggestedAimPoint.y));
+});
+
+test('non-break shot powers are reduced by 20 percent', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 200, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 420, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      breakInProgress: false
+    },
+    timeBudgetMs: 50,
+    rngSeed: 9
+  };
+  const decision = planShot(req);
+  assert(decision.power <= 0.68);
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1607,7 +1607,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.9; // reduce overall Pool Royale power by 10% for a slightly faster pace
+const SHOT_POWER_ADJUSTMENT = 0.72; // apply an additional 20% reduction from the current tuning
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *


### PR DESCRIPTION
### Motivation
- Reduce AI foul-prone behavior and make aim suggestions available so the UI can auto-suggest a legal follow-up while still allowing player adjustment. 
- Soften overall shot strength to meet the requested 20% reduction for Pool Royale non-break shots and gameplay tuning.

### Description
- Added next-legal-target suggestion metadata to shot decisions (`nextSuggestedTargetBallId`, `nextSuggestedAimPoint`) and implemented `buildLegalTargetSuggestions` + `attachNextSuggestion` to produce/attach suggestions from clear-shot candidates or legal direct-contact fallbacks (file: `lib/poolAi.js`).
- Improved safety/fallback choices to prefer legal object-ball contact (nearest legal target) and lowered fallback/safety default powers to reduce fouls (file: `lib/poolAi.js`).
- Reduced AI planner non-break power tiers from `[0.5,0.7,0.85]` to `[0.4,0.56,0.68]` so candidate powers are ~20% lower (file: `lib/poolAi.js`).
- Applied a 20% reduction to overall Pool Royale gameplay tuning by changing `SHOT_POWER_ADJUSTMENT` from `0.9` to `0.72` (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated unit tests to reflect the lowered baseline power and to verify the new suggestion fields (file: `test/poolAi.test.js`).

### Testing
- Ran `npm test -- test/poolAi.test.js` and the suite passed: 14 tests, 1 suite (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bca848108329bd39fd191dea3c66)