### PR TITLE
Adjust Pool Royale break rules, camera transitions, and cue-ball placement handling

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -88,7 +88,7 @@ export class AmericanBilliards {
       s.foulStreak[current] = 0
       s.foulStreak[opp] = 0
 
-      if (isOpenTable) {
+      if (isOpenTable && !s.breakInProgress) {
         const groupBall = pottedBalls.find(id => id !== 8)
         if (groupBall) {
           const group = idToGroup(groupBall)

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -497,7 +497,9 @@ export class PoolRoyaleRules {
     const nextLabel =
       ballOn.length === 0
         ? 'frame over'
-        : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
+        : ballOn.includes('SOLID') && ballOn.includes('STRIPE')
+          ? 'open table'
+          : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
     const hud: HudInfo = {
       next: frameOver ? 'frame over' : nextLabel,
       phase:

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -16,6 +16,31 @@ test('open table: first contact cannot be the 8-ball', () => {
   assert.equal(res.ballInHandNext, true)
 })
 
+
+test('legal break pot keeps table open until post-break shot', () => {
+  const game = new AmericanBilliards()
+  const breakShot = game.shotTaken({
+    contactOrder: [2],
+    potted: [2],
+    cueOffTable: false
+  })
+
+  assert.equal(breakShot.foul, false)
+  assert.equal(game.state.breakInProgress, false)
+  assert.equal(game.state.assignments.A, null)
+  assert.equal(game.state.assignments.B, null)
+
+  const nextShot = game.shotTaken({
+    contactOrder: [3],
+    potted: [3],
+    cueOffTable: false
+  })
+
+  assert.equal(nextShot.foul, false)
+  assert.equal(game.state.assignments.A, 'SOLID')
+  assert.equal(game.state.assignments.B, 'STRIPE')
+})
+
 test('scratch gives opponent ball in hand and keeps object balls down', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -70,11 +70,11 @@ describe('PoolRoyaleRules', () => {
 
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
-    expect(cleared.ballOn).toEqual(['SOLID']);
-    expect(clearedMeta?.state?.assignments?.A).toBe('SOLID');
-    expect(clearedMeta?.state?.assignments?.B).toBe('STRIPE');
-    expect(clearedMeta?.hud?.next).toBe('solid');
-    expect(clearedMeta?.hud?.phase).toBe('groups');
+    expect(cleared.ballOn).toEqual(['SOLID', 'STRIPE']);
+    expect(clearedMeta?.state?.assignments?.A).toBeNull();
+    expect(clearedMeta?.state?.assignments?.B).toBeNull();
+    expect(clearedMeta?.hud?.next).toBe('open table');
+    expect(clearedMeta?.hud?.phase).toBe('open');
     expect(cleared.players.A.score).toBe(1);
 
     const scratchEvents: ShotEvent[] = [
@@ -88,8 +88,8 @@ describe('PoolRoyaleRules', () => {
     expect(scratch.foul?.reason).toBe('scratch');
     expect(scratchMeta?.state?.ballInHand).toBe(true);
     expect(scratch.activePlayer).toBe('B');
-    expect(scratch.ballOn).toEqual(['STRIPE']);
-    expect(scratchMeta?.hud?.phase).toBe('groups');
+    expect(scratch.ballOn).toEqual(['SOLID', 'STRIPE']);
+    expect(scratchMeta?.hud?.phase).toBe('open');
   });
 
   test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {


### PR DESCRIPTION
### Motivation
- Ensure American 8-ball open-table break behaviour matches official flow by not assigning groups during the break shot.
- Improve mobile/touch UX for ball-in-hand placement so the cue ball moves as responsively as the air-hockey puck and reduces sticky placement near other balls.
- Remove an unintended intermediate standing camera hop during pocket→rail overhead transitions and tighten pocket camera framing and auto-aim suggestion behaviour.

### Description
- Update break assignment logic in `lib/americanBilliards.js` to only assign groups when the table is open and not during an active break (`isOpenTable && !s.breakInProgress`).
- Change HUD label production in `src/rules/PoolRoyaleRules.ts` so when both `SOLID` and `STRIPE` are legal the `next` HUD shows `open table` instead of joining the two groups.
- Tweak pocket camera framing constants in `webapp/src/pages/Games/SnookerRoyal.jsx` by increasing `POCKET_CAM_SIDE_EDGE_SHIFT` and setting `heightOffsetShortMultiplier` to match middle-pocket camera height with corners.
- Replace the intermediate standing/action camera switch with a direct application of the rail-overhead replay camera when `preferRailOverhead` applies, preventing the brief standing-camera hop (changes in `SnookerRoyal.jsx` broadcast/action view logic).
- Improve in-hand cue-ball handling in `SnookerRoyal.jsx` by adding pointer-offset drag state, resolving nearest-valid free placement when the finger is near other balls, and updating pointer event handlers to use the offset so movement is precise and responsive.
- Narrow auto-aim/rack-apex suggestions so rack-apex targeting is only considered while a real break is in progress (change to evaluate `frameSnapshot?.meta?.breakInProgress`).
- Add/update unit tests to lock in the new break behaviour and integration: `test/americanBilliards.test.js` adds a `legal break pot` case and `test/poolRoyaleRules.test.ts` expectations updated to reflect open-table post-break state.

### Testing
- Ran the targeted unit tests with `npx jest test/americanBilliards.test.js test/poolRoyaleRules.test.ts --runInBand` and all tests passed (both suites green).
- Ran linting with `npx eslint` on touched files and received non-blocking warnings only (no errors).
- Launched the local dev server (`npm --prefix webapp run dev`) and captured a reference screenshot to validate UI camera placement changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699153ce0bc08329bc03f8aad9ca0a68)