### PR TITLE
Pool Royale: pocket camera tweaks, 8‑ball break/open‑table rule fix, and improved in‑hand drag/aiming

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -88,7 +88,7 @@ export class AmericanBilliards {
       s.foulStreak[current] = 0
       s.foulStreak[opp] = 0
 
-      if (isOpenTable) {
+      if (isOpenTable && !s.breakInProgress) {
         const groupBall = pottedBalls.find(id => id !== 8)
         if (groupBall) {
           const group = idToGroup(groupBall)
@@ -136,7 +136,9 @@ export class AmericanBilliards {
     }
 
     s.ballInHand = ballInHandNext
-    if (!foul || pottedBalls.length > 0 || shot.breakComplete) {
+    // A break only happens once. After resolving the first shot, the rack is no
+    // longer in break state even when the breaker fouls.
+    if (s.breakInProgress || shot.breakComplete) {
       s.breakInProgress = false
     }
     s.frameOver = frameOver

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -75,3 +75,45 @@ test('legal group clearance then 8-ball wins frame', () => {
   assert.equal(res.frameOver, true)
   assert.equal(res.winner, 'A')
 })
+
+test('break pot keeps table open until next legal non-break shot', () => {
+  const game = new AmericanBilliards()
+
+  const breakShot = game.shotTaken({
+    contactOrder: [1],
+    potted: [1],
+    cueOffTable: false
+  })
+
+  assert.equal(breakShot.foul, false)
+  assert.equal(game.state.breakInProgress, false)
+  assert.equal(game.state.assignments.A, null)
+  assert.equal(game.state.assignments.B, null)
+
+  const postBreakShot = game.shotTaken({
+    contactOrder: [2],
+    potted: [2],
+    cueOffTable: false
+  })
+
+  assert.equal(postBreakShot.foul, false)
+  assert.equal(game.state.assignments.A, 'SOLID')
+  assert.equal(game.state.assignments.B, 'STRIPE')
+})
+
+test('break foul still ends break phase and gives opponent ball in hand on open table', () => {
+  const game = new AmericanBilliards()
+
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [0],
+    cueOffTable: false
+  })
+
+  assert.equal(res.foul, true)
+  assert.equal(res.ballInHandNext, true)
+  assert.equal(game.state.breakInProgress, false)
+  assert.equal(game.state.currentPlayer, 'B')
+  assert.equal(game.state.assignments.A, null)
+  assert.equal(game.state.assignments.B, null)
+})

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -70,19 +70,35 @@ describe('PoolRoyaleRules', () => {
 
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
-    expect(cleared.ballOn).toEqual(['SOLID']);
-    expect(clearedMeta?.state?.assignments?.A).toBe('SOLID');
-    expect(clearedMeta?.state?.assignments?.B).toBe('STRIPE');
-    expect(clearedMeta?.hud?.next).toBe('solid');
-    expect(clearedMeta?.hud?.phase).toBe('groups');
+    expect(cleared.ballOn).toEqual(['SOLID', 'STRIPE']);
+    expect(clearedMeta?.state?.assignments?.A).toBeNull();
+    expect(clearedMeta?.state?.assignments?.B).toBeNull();
+    expect(clearedMeta?.hud?.next).toBe('solid / stripe');
+    expect(clearedMeta?.hud?.phase).toBe('open');
     expect(cleared.players.A.score).toBe(1);
+
+    const claimEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 3, ballId: 3 },
+      { type: 'POTTED', ball: 3, pocket: 'TR', ballId: 3 }
+    ];
+    const claimed = rules.applyShot(cleared, claimEvents, {
+      contactMade: true,
+      cushionAfterContact: true
+    });
+    const claimedMeta = claimed.meta as any;
+
+    expect(claimed.ballOn).toEqual(['SOLID']);
+    expect(claimedMeta?.state?.assignments?.A).toBe('SOLID');
+    expect(claimedMeta?.state?.assignments?.B).toBe('STRIPE');
+    expect(claimedMeta?.hud?.next).toBe('solid');
+    expect(claimedMeta?.hud?.phase).toBe('groups');
 
     const scratchEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 3, ballId: 3 },
       { type: 'POTTED', ball: 0, pocket: 'TR', ballId: 'cue' }
     ];
     const scratchContext: ShotContext = { cueBallPotted: true, contactMade: true };
-    const scratch = rules.applyShot(cleared, scratchEvents, scratchContext);
+    const scratch = rules.applyShot(claimed, scratchEvents, scratchContext);
     const scratchMeta = scratch.meta as any;
 
     expect(scratch.foul?.reason).toBe('scratch');

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1469,7 +1469,7 @@ const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
-const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 3; // push middle-pocket cameras toward the corner-side edges
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 4.35; // push middle-pocket cameras farther toward the side edges (away from center)
 const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.05; // push middle-pocket cameras farther toward side-rail edges and away from table center for stronger corner-like distance
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -1492,7 +1492,7 @@ const POCKET_CAM = Object.freeze({
   maxOutside: BALL_R * 30,
   // Lift pocket cameras slightly higher so pocket closeups read a touch more top-down.
   heightOffset: BALL_R * 2.32,
-  heightOffsetShortMultiplier: 1.28,
+  heightOffsetShortMultiplier: 1.52,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
     POCKET_CAM_BASE_OUTWARD_OFFSET * 1.9 * POCKET_CAM_INWARD_SCALE +
@@ -19358,32 +19358,12 @@ const powerRef = useRef(hud.power);
             restoreOrbitCamera(pocketView, true);
             return;
           }
-          const resumeAction =
-            pocketView?.resumeAction?.mode === 'action'
-              ? pocketView.resumeAction
-              : suspendedActionView?.mode === 'action'
-                ? suspendedActionView
-                : null;
-          if (resumeAction) {
-            resumeAction.stage = 'pair';
-            resumeAction.lastUpdate = now;
-            resumeAction.holdUntil = now + ACTION_CAM.followHoldMs;
-            resumeAction.pendingActivation = false;
-            resumeAction.activationDelay = null;
-            resumeAction.activationTravel = 0;
-            if (cameraRef.current) {
-              resumeAction.smoothedPos = cameraRef.current.position.clone();
-              const storedTarget = lastCameraTargetRef.current?.clone();
-              if (storedTarget) {
-                resumeAction.smoothedTarget = storedTarget;
-              }
-            }
-            activeShotView = resumeAction;
-            suspendedActionView = null;
-          } else {
-            activeShotView = null;
-            restoreOrbitCamera(pocketView);
-          }
+          // Skip the intermediate standing/action resume camera after a pocket
+          // event so we cut directly from pocket close-up back to the locked
+          // rail-overhead broadcast framing.
+          activeShotView = null;
+          suspendedActionView = null;
+          restoreOrbitCamera(pocketView);
         };
         const makeActionCameraView = (
           cueBall,
@@ -22817,6 +22797,7 @@ const powerRef = useRef(hud.power);
         return clampInHandPosition(target, { ignoreBaulk: forceCenter });
       };
       const inHandDrag = inHandDragRef.current;
+      const IN_HAND_DRAG_RESPONSE = 1.32;
       const updateCuePlacement = (pos) => {
         if (!cue || !pos) return;
         cue.mesh.visible = true;
@@ -22846,8 +22827,20 @@ const powerRef = useRef(hud.power);
       const resolveInHandDragPosition = (e) => {
         const client = getPointerClient(e);
         if (!client) return null;
-        const currentProjected = projectFromClient(client.x, client.y);
+        let currentProjected = projectFromClient(client.x, client.y);
         if (!currentProjected) return null;
+        const lastScreen = inHandDrag.lastScreen;
+        const lastPlaced = inHandDrag.lastPos;
+        if (lastScreen && lastPlaced) {
+          const previousProjected = projectFromClient(lastScreen.x, lastScreen.y);
+          if (previousProjected) {
+            const projectedDelta = currentProjected.clone().sub(previousProjected);
+            currentProjected = lastPlaced.clone().addScaledVector(
+              projectedDelta,
+              IN_HAND_DRAG_RESPONSE
+            );
+          }
+        }
         inHandDrag.lastScreen = client;
         return currentProjected;
       };
@@ -27012,9 +27005,6 @@ const powerRef = useRef(hud.power);
               aimDir.normalize();
             }
           } else if (autoAimDir && autoAimDir.lengthSq() > 1e-6) {
-            if (shouldAutoAimPlayer) {
-              autoAimRequestRef.current = false;
-            }
             aimDir.lerp(autoAimDir, aimLerpFactor);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();


### PR DESCRIPTION
### Motivation
- Make pocket camera views (especially middle-pocket cameras) align visually with corner pocket cameras by moving them outward and slightly higher.  
- Align American 8‑ball break/open‑table behavior with official rules so assignments are not locked by the break shot and the break phase ends after the opening shot.  
- Improve the touch feel for cue-ball placement (ball‑in‑hand) to be more responsive and precise like the air‑hockey puck.  
- Remove an unwanted intermediate standing camera cut during pocket replays and keep auto‑aim suggestions pointing at the next legal target until the user overrides them.

### Description
- Rules: Update American 8‑ball logic in `lib/americanBilliards.js` so assignments are only applied after the break (not during it) and `breakInProgress` is cleared after the first resolving shot (even on fouls).  
- Tests: Add unit tests to `test/americanBilliards.test.js` and update `test/poolRoyaleRules.test.ts` to cover break / open‑table scenarios and the new assignment flow.  
- Cameras: Tweak pocket camera constants in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing `POCKET_CAM_SIDE_EDGE_SHIFT` and `POCKET_CAM.heightOffsetShortMultiplier` so middle‑pocket cameras move farther toward side rails and sit slightly higher.  
- Replay/broadcast flow: Remove the intermediate standing/action resume cut after pocket camera closeups so broadcasts go directly from pocket closeup back to rail‑overhead framing.  
- In‑hand placement: Improve drag responsiveness by adding `IN_HAND_DRAG_RESPONSE` and using screen‑delta informed placement in `resolveInHandDragPosition` for quicker, more precise finger movement.  
- Auto‑aim: Keep auto‑aim suggestion behavior focused on legal next targets (aim line will lerp toward suggested target automatically after shots unless the player moves/overrides the aim).

### Testing
- Ran unit tests: `npm test -- --runInBand test/americanBilliards.test.js test/poolRoyaleRules.test.ts` and both test suites passed (all tests green).  
- Started front‑end dev server with Vite to validate changes; server ran but an automated Playwright screenshot attempt failed due to a Chromium runtime crash in the environment (SIGSEGV), so no browser snapshot was captured.  
- No manual QA steps were included in this PR; front‑end runtime changes are limited to camera placement constants and input handling logic to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699153ce0bc08329bc03f8aad9ca0a68)