### PR TITLE
Fix American 8-ball break flow and Pool Royale in-hand + auto-aim behavior

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -34,6 +34,7 @@ export class AmericanBilliards {
 
     const current = s.currentPlayer
     const opp = current === 'A' ? 'B' : 'A'
+    const wasBreakShot = Boolean(s.breakInProgress)
     let foul = false
     let reason = ''
 
@@ -88,7 +89,7 @@ export class AmericanBilliards {
       s.foulStreak[current] = 0
       s.foulStreak[opp] = 0
 
-      if (isOpenTable) {
+      if (isOpenTable && !s.breakInProgress) {
         const groupBall = pottedBalls.find(id => id !== 8)
         if (groupBall) {
           const group = idToGroup(groupBall)
@@ -136,7 +137,7 @@ export class AmericanBilliards {
     }
 
     s.ballInHand = ballInHandNext
-    if (!foul || pottedBalls.length > 0 || shot.breakComplete) {
+    if (wasBreakShot || !foul || pottedBalls.length > 0 || shot.breakComplete) {
       s.breakInProgress = false
     }
     s.frameOver = frameOver

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -497,7 +497,9 @@ export class PoolRoyaleRules {
     const nextLabel =
       ballOn.length === 0
         ? 'frame over'
-        : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
+        : ballOn.includes('SOLID') && ballOn.includes('STRIPE')
+          ? 'open table'
+          : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
     const hud: HudInfo = {
       next: frameOver ? 'frame over' : nextLabel,
       phase:
@@ -508,10 +510,7 @@ export class PoolRoyaleRules {
             : 'open',
       scores
     };
-    const breakInProgress =
-      Boolean(previous?.state?.breakInProgress) && Boolean(result.foul)
-        ? true
-        : Boolean(snapshot.breakInProgress);
+    const breakInProgress = Boolean(snapshot.breakInProgress);
     const nextState: FrameState = {
       ...state,
       activePlayer: game.state.currentPlayer,

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -16,6 +16,50 @@ test('open table: first contact cannot be the 8-ball', () => {
   assert.equal(res.ballInHandNext, true)
 })
 
+
+test('legal break pot keeps table open until post-break shot', () => {
+  const game = new AmericanBilliards()
+  const breakShot = game.shotTaken({
+    contactOrder: [2],
+    potted: [2],
+    cueOffTable: false
+  })
+
+  assert.equal(breakShot.foul, false)
+  assert.equal(game.state.breakInProgress, false)
+  assert.equal(game.state.assignments.A, null)
+  assert.equal(game.state.assignments.B, null)
+
+  const nextShot = game.shotTaken({
+    contactOrder: [3],
+    potted: [3],
+    cueOffTable: false
+  })
+
+  assert.equal(nextShot.foul, false)
+  assert.equal(game.state.assignments.A, 'SOLID')
+  assert.equal(game.state.assignments.B, 'STRIPE')
+})
+
+
+test('break scratch ends break, passes turn, and grants ball in hand', () => {
+  const game = new AmericanBilliards()
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [0],
+    cueOffTable: false
+  })
+
+  assert.equal(res.foul, true)
+  assert.equal(res.reason, 'scratch')
+  assert.equal(res.nextPlayer, 'B')
+  assert.equal(res.ballInHandNext, true)
+  assert.equal(game.state.currentPlayer, 'B')
+  assert.equal(game.state.breakInProgress, false)
+  assert.equal(game.state.assignments.A, null)
+  assert.equal(game.state.assignments.B, null)
+})
+
 test('scratch gives opponent ball in hand and keeps object balls down', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -70,11 +70,11 @@ describe('PoolRoyaleRules', () => {
 
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
-    expect(cleared.ballOn).toEqual(['SOLID']);
-    expect(clearedMeta?.state?.assignments?.A).toBe('SOLID');
-    expect(clearedMeta?.state?.assignments?.B).toBe('STRIPE');
-    expect(clearedMeta?.hud?.next).toBe('solid');
-    expect(clearedMeta?.hud?.phase).toBe('groups');
+    expect(cleared.ballOn).toEqual(['SOLID', 'STRIPE']);
+    expect(clearedMeta?.state?.assignments?.A).toBeNull();
+    expect(clearedMeta?.state?.assignments?.B).toBeNull();
+    expect(clearedMeta?.hud?.next).toBe('open table');
+    expect(clearedMeta?.hud?.phase).toBe('open');
     expect(cleared.players.A.score).toBe(1);
 
     const scratchEvents: ShotEvent[] = [
@@ -87,9 +87,11 @@ describe('PoolRoyaleRules', () => {
 
     expect(scratch.foul?.reason).toBe('scratch');
     expect(scratchMeta?.state?.ballInHand).toBe(true);
+    expect(scratchMeta?.breakInProgress).toBe(false);
     expect(scratch.activePlayer).toBe('B');
-    expect(scratch.ballOn).toEqual(['STRIPE']);
-    expect(scratchMeta?.hud?.phase).toBe('groups');
+    expect(scratch.ballOn).toEqual(['SOLID', 'STRIPE']);
+    expect(scratchMeta?.hud?.next).toBe('open table');
+    expect(scratchMeta?.hud?.phase).toBe('open');
   });
 
   test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {


### PR DESCRIPTION
### Motivation
- Make 8‑ball break behaviour follow BCA/expected flow so a pot on the break leaves the table open, a missed non‑pot passes turn, and a scratch on the break is a foul that ends the break and gives opponent ball‑in‑hand.
- Prevent the client auto‑moving the cue ball on foul/transition into ball‑in‑hand so the user is able to place the cue anywhere permitted (full‑table for non‑UK variants).
- Ensure the aiming suggestion updates correctly after each shot by using the real `meta.breakInProgress` state for break/rack‑apex logic.

### Description
- Update `lib/americanBilliards.js` to record `wasBreakShot` and clear `breakInProgress` when a break shot completes or when a break foul/scratch occurs, while keeping open‑table assignments until the legal post‑break shot. (`wasBreakShot`, adjusted `s.breakInProgress` set logic).
- Change `src/rules/PoolRoyaleRules.ts` HUD mapping so when both `SOLID` and `STRIPE` are legal the `next` label shows `open table`, and simplify `breakInProgress` propagation to follow `snapshot.breakInProgress` directly.
- Improve Pool Royale in‑hand behaviour in `webapp/src/pages/Games/PoolRoyale.jsx` by allowing full‑table placement for non‑UK variants, removing automatic cue re‑positioning on foul/scratch transitions and pocket events, and adding a nearest‑free placement resolver and pointer‑offset drag state so touch/drag placement is responsive and does not get stuck near other balls (`resolveNearestFreeInHandSpot`, `inHandDrag.pointerTablePos`, `inHandDrag.cueOffset`, updated handlers `handleInHandDown`, `handleInHandMove`, `endInHandDrag`).
- Adjust auto‑aim suggestion code to use `frameSnapshot?.meta?.breakInProgress` when deciding rack‑apex targets so suggestions reflect the true break state after each shot.
- Add/update unit tests: `test/americanBilliards.test.js` gains a `break scratch ends break, passes turn, and grants ball in hand` case and `test/poolRoyaleRules.test.ts` expectations updated to assert `open table`/`breakInProgress=false` behaviour after break/scratch.
- No changes were made to Snooker Royal game logic or files as part of this PR; all gameplay fixes are scoped to the American 8‑ball logic and Pool Royale UI/rules.

### Testing
- Ran targeted unit tests with `npx jest test/americanBilliards.test.js test/poolRoyaleRules.test.ts --runInBand` and both suites passed (all tests green).
- Ran linting with `npx eslint lib/americanBilliards.js src/rules/PoolRoyaleRules.ts webapp/src/pages/Games/PoolRoyale.jsx test/americanBilliards.test.js test/poolRoyaleRules.test.ts` which produced non‑blocking warnings only (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699153ce0bc08329bc03f8aad9ca0a68)