### PR TITLE
Adjust Pool Royale middle-pocket camera to sit outside rail

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1470,7 +1470,7 @@ const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = 0; // keep middle-pocket cameras centered between the two corner-pocket cameras on each long side
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 1.28; // push middle-pocket cameras farther outside so they sit clearly off-table
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 1.7; // push middle-pocket cameras farther outside so they sit beyond the wooden rail edge like the portrait reference
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +


### PR DESCRIPTION
### Motivation
- Place the middle-pocket cinematic cameras so they sit outside the wooden rail edge in portrait view to match the provided red-marked reference.

### Description
- Increased `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` in `webapp/src/pages/Games/PoolRoyale.jsx` from `1.28` to `1.7` so middle-pocket pocket cameras are pushed farther outward beyond the wooden rail.

### Testing
- Ran `npm run build` (in `webapp/`) which completed successfully and validated the change by running `vite preview` and capturing a portrait screenshot via Playwright to confirm the new camera framing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917aaef4d88329a9c9d1d303f2a9e6)