### PR TITLE
Push Pool Royale middle-pocket cameras much further outside rails

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1470,7 +1470,7 @@ const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = 0; // keep middle-pocket cameras centered between the two corner-pocket cameras on each long side
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 1.28; // push middle-pocket cameras farther outside so they sit clearly off-table
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.6; // push middle-pocket cameras much farther outside so they clearly stay beyond the wooden side rail on portrait view
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +


### PR DESCRIPTION
### Motivation
- Ensure middle-pocket cinematic cameras sit clearly outside the wooden side rails in portrait view by moving their camera origin farther outward.

### Description
- Updated the pocket camera distance multiplier `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` in `webapp/src/pages/Games/PoolRoyale.jsx` so middle-pocket cameras are pushed much farther outward and no longer sit on/inside the wooden rail.
- The change increases the effective side-pocket camera distance so `cameraDistance = minOutside * POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` results in a visibly outward shift on portrait screens.

### Testing
- Ran `npm run build` (from `webapp/`) which completed successfully.
- Launched `vite preview` and captured an updated portrait screenshot artifact via Playwright to confirm the camera now sits clearly outside the side rails.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917aaef4d88329a9c9d1d303f2a9e6)