### PR TITLE
Increase PoolRoyale middle-pocket camera outside multiplier to 2.6

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1470,7 +1470,7 @@ const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
 const POCKET_CAM_SIDE_EDGE_SHIFT = 0; // keep middle-pocket cameras centered between the two corner-pocket cameras on each long side
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 1.28; // push middle-pocket cameras farther outside so they sit clearly off-table
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.6; // push middle-pocket cameras much farther outside so middle-pocket closeups stay clearly beyond the wooden side rails on portrait screens
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +


### PR DESCRIPTION
### Motivation
- Ensure middle-pocket cinematic cameras sit clearly outside the wooden side rails in portrait framing because the prior change to `1.7` did not push them far enough. 
- Match the provided portrait reference so pocket closeups avoid including the rail and read visually correct on phone portrait screens.

### Description
- Updated `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` in `webapp/src/pages/Games/PoolRoyale.jsx` from `1.7` to `2.6` and adjusted the inline comment to state the portrait intent. 
- No other gameplay or camera logic was modified.

### Testing
- Ran `npm run build` (in `webapp/`) which completed successfully. 
- Ran `npm run preview -- --host 0.0.0.0 --port 4173` and captured a portrait screenshot via Playwright to verify the pocket camera framing, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917aaef4d88329a9c9d1d303f2a9e6)