### PR TITLE
Adjust Pool Royale pocket camera offsets for middle and corner pockets

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -177,7 +177,10 @@ public class CueCamera : MonoBehaviour
     public float pocketCameraMiddleHeightOffset = 0.04f;
     // Sideways push applied when the target action happens around the middle
     // pockets so the framing sits farther from the table centre line.
-    public float pocketCameraMiddleSideOffset = 0.28f;
+    public float pocketCameraMiddleSideOffset = 0.32f;
+    // Sideways push for corner-pocket camera framing. Keep this lower than the
+    // middle-pocket offset so corner shots sit a touch closer to table centre.
+    public float pocketCameraCornerSideOffset = 0.2f;
     // Portion of the half table length treated as the middle pocket zone.
     [Range(0f, 1f)]
     public float pocketCameraMiddleZone = 0.32f;
@@ -794,19 +797,25 @@ public class CueCamera : MonoBehaviour
             float middleZone = Mathf.Clamp01(pocketCameraMiddleZone) * halfLength;
             float zFromCenter = Mathf.Abs(sourceFocus.z - tableBounds.center.z);
             bool isMiddlePocketBand = zFromCenter <= middleZone;
+            float maxX = Mathf.Max(0f, tableBounds.extents.x - broadcastFrameMargin);
+            float sideSign = Mathf.Sign(sourceFocus.x);
+            if (Mathf.Approximately(sideSign, 0f))
+            {
+                sideSign = 1f;
+            }
+
             if (isMiddlePocketBand)
             {
-                float sideSign = Mathf.Sign(sourceFocus.x);
-                if (Mathf.Approximately(sideSign, 0f))
-                {
-                    sideSign = 1f;
-                }
-
-                float maxX = Mathf.Max(0f, tableBounds.extents.x - broadcastFrameMargin);
                 float sideOffset = Mathf.Clamp(Mathf.Abs(pocketCameraMiddleSideOffset), 0f, maxX);
                 focus.x = Mathf.Clamp(sideSign * sideOffset, -maxX, maxX);
                 focus.z = sourceFocus.z;
                 height += Mathf.Max(0f, pocketCameraMiddleHeightOffset);
+            }
+            else
+            {
+                float sideOffset = Mathf.Clamp(Mathf.Abs(pocketCameraCornerSideOffset), 0f, maxX);
+                focus.x = Mathf.Clamp(sideSign * sideOffset, -maxX, maxX);
+                focus.z = sourceFocus.z;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Move middle-pocket broadcast cameras slightly farther outward and pull corner-pocket cameras slightly closer to table centre to match desired framing adjustments for Pool Royale.
- Allow independent tuning of corner vs middle pocket framing so adjustments don't interfere with each other.
- Preserve existing middle-pocket height lift so middle-pocket cameras still clear the rail line.

### Description
- Increased `pocketCameraMiddleSideOffset` from `0.28f` to `0.32f` in `billiards.Unity/CueCamera.cs` to push middle-pocket cameras outward.
- Added `pocketCameraCornerSideOffset = 0.2f` and a separate branch in `ApplyBroadcastCamera` so corner-pocket cameras use the new corner offset while middle pockets retain their height adjustment.
- Clamped computed offsets using the table bounds (`maxX`) and preserved the existing `pocketCameraMiddleHeightOffset` behavior to avoid framing or occlusion regressions.

### Testing
- Reviewed the updated camera framing logic in `billiards.Unity/CueCamera.cs` for correctness and clamping behavior.
- No automated Unity editor or playmode tests were executed in this environment.
- No automated test failures reported; no runtime validation was performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699198ab73a48329a3098808db026a29)