### PR TITLE
Adjust Pool Royale pocket camera offsets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1469,9 +1469,9 @@ const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
-const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.4; // slide middle-pocket cameras farther toward the table edges so they stay away from center framing
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.6; // push only middle-pocket cameras much farther outside so they clearly stay beyond the wooden side rail on portrait view
-const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.28; // keep corner-pocket camera outside distance at the original morning baseline
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // nudge middle-pocket cameras a bit farther toward the table edges and away from center framing
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.72; // push middle-pocket cameras slightly farther outward so side pocket shots sit more off-center
+const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.18; // pull corner-pocket cameras slightly inward so they frame a bit closer toward table center
 const POCKET_CAM_SIDE_LATERAL_BIAS = 0.34; // bias only middle-pocket outward vectors toward the nearest edge; corner-pocket vectors stay unchanged
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +


### PR DESCRIPTION
### Motivation
- Tweak pocket-camera placement to improve portrait framing by nudging middle-pocket cameras slightly farther outward and pulling corner-pocket cameras slightly inward so corner views sit closer to the table center.

### Description
- Updated three constants in `webapp/src/pages/Games/PoolRoyale.jsx`: `POCKET_CAM_SIDE_EDGE_SHIFT` from `BALL_R * 4.4` to `BALL_R * 4.7`, `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` from `2.6` to `2.72`, and `POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER` from `1.28` to `1.18` to adjust the outward/inward camera offsets.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (file is ignored by repo lint rules so a warning was reported), launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a home-route screenshot via Playwright (succeeded), and attempted a Playwright capture of the in-game pocket view which timed out (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699198ab73a48329a3098808db026a29)