### PR TITLE
PoolRoyale: remove short-rail standing/tripod cameras, push pocket cams outward, and enforce immediate rail-overhead switching on shot trigger

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1055,7 +1055,6 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const DEFAULT_TABLE_BASE_ID = POOL_ROYALE_BASE_VARIANTS[0]?.id || 'classicCylinders';
 const ENABLE_CUE_GALLERY = false;
-const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
 const ENABLE_TABLE_MAPPING_LINES = true;
 const TABLE_MAPPING_VISUALS = Object.freeze({
@@ -1064,7 +1063,6 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   jaws: false,
   pockets: false
 });
-const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
 const LOCK_RAIL_OVERHEAD_FRAME = true;
@@ -1469,8 +1467,8 @@ const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
-const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // nudge middle-pocket cameras a bit farther toward the table edges and away from center framing
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.72; // push middle-pocket cameras slightly farther outward so side pocket shots sit more off-center
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 5.5; // push middle-pocket cameras farther toward the table edges and away from center framing
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 3.08; // push middle-pocket cameras farther outward so side pocket shots sit more off-center
 const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.18; // pull corner-pocket cameras slightly inward so they frame a bit closer toward table center
 const POCKET_CAM_SIDE_LATERAL_BIAS = 0.34; // bias only middle-pocket outward vectors toward the nearest edge; corner-pocket vectors stay unchanged
 const POCKET_CAM_BASE_MIN_OUTSIDE =
@@ -3119,7 +3117,6 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
-const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = true;
 const resolveBroadcastSystem = (id) =>
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === id) ??
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === DEFAULT_BROADCAST_SYSTEM_ID) ??
@@ -4639,49 +4636,7 @@ function createBroadcastCameras({
   const group = new THREE.Group();
   group.name = 'broadcastCameras';
   const cameras = {};
-
-  const darkMetal = new THREE.MeshStandardMaterial({
-    color: 0x1f2937,
-    metalness: 0.65,
-    roughness: 0.32
-  });
-  const lightMetal = new THREE.MeshStandardMaterial({
-    color: 0x334155,
-    metalness: 0.58,
-    roughness: 0.36
-  });
-  const plastic = new THREE.MeshStandardMaterial({
-    color: 0x1b2533,
-    metalness: 0.24,
-    roughness: 0.42
-  });
-  const rubber = new THREE.MeshStandardMaterial({
-    color: 0x080c14,
-    metalness: 0.0,
-    roughness: 0.94
-  });
-  const glass = new THREE.MeshStandardMaterial({
-    color: 0x97c6ff,
-    metalness: 0.0,
-    roughness: 0.08,
-    transparent: true,
-    opacity: 0.42,
-    envMapIntensity: 1.1
-  });
-
-  const footRadius = Math.min(0.85, PLAY_W * 0.22);
   const headHeight = Math.max(1.45, cameraHeight - floorY);
-  const hubHeight = Math.max(1.08, headHeight - 0.52);
-  const columnHeight = Math.max(0.42, headHeight - hubHeight);
-  const legLength = Math.sqrt(footRadius * footRadius + hubHeight * hubHeight);
-  const legGeo = new THREE.CylinderGeometry(0.034, 0.022, legLength, 14);
-  const footHeight = 0.045;
-  const footGeo = new THREE.CylinderGeometry(0.07, 0.07, footHeight, 16);
-  const columnGeo = new THREE.CylinderGeometry(0.052, 0.05, columnHeight, 16);
-  const hubGeo = new THREE.CylinderGeometry(0.12, 0.14, 0.08, 18);
-  const headBaseGeo = new THREE.CylinderGeometry(0.11, 0.13, 0.05, 18);
-  const panBarGeo = new THREE.CylinderGeometry(0.012, 0.012, 0.32, 12);
-  const gripGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.2, 12);
 
   const defaultFocus = new THREE.Vector3(
     0,
@@ -4725,104 +4680,6 @@ function createBroadcastCameras({
 
     const cameraAssembly = new THREE.Group();
     headPivot.add(cameraAssembly);
-
-    if (SHOW_SHORT_RAIL_TRIPODS) {
-      const tripod = new THREE.Group();
-      slider.add(tripod);
-
-      const top = new THREE.Vector3(0, hubHeight, 0);
-      [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3].forEach((angle) => {
-        const foot = new THREE.Vector3(
-          Math.cos(angle) * footRadius,
-          0,
-          Math.sin(angle) * footRadius
-        );
-        const mid = top.clone().add(foot).multiplyScalar(0.5);
-        const up = top.clone().sub(foot).normalize();
-        const leg = new THREE.Mesh(legGeo, darkMetal);
-        leg.position.copy(mid);
-        leg.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), up);
-        leg.castShadow = true;
-        leg.receiveShadow = true;
-        tripod.add(leg);
-
-        const footPad = new THREE.Mesh(footGeo, rubber);
-        footPad.position.set(foot.x, footHeight / 2, foot.z);
-        footPad.receiveShadow = true;
-        tripod.add(footPad);
-      });
-
-      const column = new THREE.Mesh(columnGeo, lightMetal);
-      column.position.y = hubHeight + columnHeight / 2;
-      column.castShadow = true;
-      column.receiveShadow = true;
-      slider.add(column);
-
-      const hub = new THREE.Mesh(hubGeo, lightMetal);
-      hub.position.y = hubHeight;
-      hub.castShadow = true;
-      hub.receiveShadow = true;
-      slider.add(hub);
-
-      const headBase = new THREE.Mesh(headBaseGeo, darkMetal);
-      headBase.position.y = headHeight;
-      headBase.castShadow = true;
-      slider.add(headBase);
-
-      const body = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.24, 0.22), plastic);
-      body.castShadow = true;
-      body.receiveShadow = true;
-      cameraAssembly.add(body);
-
-      const lensHousing = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.065, 0.07, 0.18, 24),
-        darkMetal
-      );
-      lensHousing.rotation.x = Math.PI / 2;
-      lensHousing.position.set(0, 0, -0.2);
-      lensHousing.castShadow = true;
-      cameraAssembly.add(lensHousing);
-
-      const hood = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.1, 0.16), rubber);
-      hood.position.set(0, 0, -0.32);
-      hood.castShadow = true;
-      cameraAssembly.add(hood);
-
-      const lensGlass = new THREE.Mesh(new THREE.CircleGeometry(0.06, 24), glass);
-      lensGlass.rotation.x = Math.PI / 2;
-      lensGlass.position.set(0, 0, -0.29);
-      cameraAssembly.add(lensGlass);
-
-      const topHandle = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.016, 0.016, 0.26, 12),
-        rubber
-      );
-      topHandle.rotation.z = Math.PI / 2;
-      topHandle.position.set(0, 0.16, 0);
-      topHandle.castShadow = true;
-      cameraAssembly.add(topHandle);
-
-      const viewfinder = new THREE.Mesh(
-        new THREE.BoxGeometry(0.16, 0.1, 0.08),
-        lightMetal
-      );
-      viewfinder.position.set(-0.22, 0.06, 0.05);
-      viewfinder.castShadow = true;
-      cameraAssembly.add(viewfinder);
-
-      const panBar = new THREE.Mesh(panBarGeo, lightMetal);
-      panBar.rotation.z = Math.PI / 2.3;
-      panBar.position.set(0.26, -0.08, 0);
-      panBar.castShadow = true;
-      headPivot.add(panBar);
-
-      const grip = new THREE.Mesh(gripGeo, rubber);
-      grip.rotation.z = Math.PI / 2.3;
-      grip.position.set(0.37, -0.12, 0);
-      grip.castShadow = true;
-      headPivot.add(grip);
-    }
-
     headPivot.lookAt(defaultFocus);
     headPivot.rotateY(Math.PI);
 
@@ -4843,184 +4700,6 @@ function createBroadcastCameras({
 
   return { group, cameras, slideLimit, cameraHeight, defaultFocus };
 }
-
-const createTripodBroadcastCamera = (() => {
-  const metalDark = new THREE.MeshStandardMaterial({
-    color: 0x1f2937,
-    metalness: 0.7,
-    roughness: 0.35
-  });
-  const metalLite = new THREE.MeshStandardMaterial({
-    color: 0x374151,
-    metalness: 0.6,
-    roughness: 0.4
-  });
-  const plastic = new THREE.MeshStandardMaterial({
-    color: 0x0ea5e9,
-    metalness: 0.1,
-    roughness: 0.6
-  });
-  const rubber = new THREE.MeshStandardMaterial({
-    color: 0x0b1220,
-    metalness: 0.0,
-    roughness: 0.95
-  });
-  const glass = new THREE.MeshStandardMaterial({
-    color: 0x9bd3ff,
-    metalness: 0.0,
-    roughness: 0.05,
-    transparent: true,
-    opacity: 0.35,
-    envMapIntensity: 1.5
-  });
-
-  const hubGeo = new THREE.CylinderGeometry(0.08, 0.1, 0.05, 16);
-  const legGeo = new THREE.CylinderGeometry(0.03, 0.015, 1.2, 12);
-  const footGeo = new THREE.CylinderGeometry(0.045, 0.045, 0.02, 12);
-  const braceGeo = new THREE.CylinderGeometry(0.01, 0.01, 0.7, 8);
-  const ballGeo = new THREE.SphereGeometry(0.07, 16, 16);
-  const plateGeo = new THREE.BoxGeometry(0.22, 0.02, 0.14);
-  const mountGeo = new THREE.BoxGeometry(0.2, 0.02, 0.12);
-  const handleGeo = new THREE.CylinderGeometry(0.01, 0.01, 0.35, 8);
-  const gripGeo = new THREE.CylinderGeometry(0.015, 0.015, 0.12, 10);
-  const bodyGeo = new THREE.BoxGeometry(0.42, 0.22, 0.2);
-  const lensTubeGeo = new THREE.CylinderGeometry(0.06, 0.065, 0.16, 24);
-  const lensGlassGeo = new THREE.CircleGeometry(0.058, 24);
-  const hoodGeo = new THREE.BoxGeometry(0.12, 0.09, 0.12);
-  const vfGeo = new THREE.BoxGeometry(0.14, 0.08, 0.08);
-  const topHandleGeo = new THREE.CylinderGeometry(0.015, 0.015, 0.24, 12);
-
-  const LEG_SPREAD = 0.45;
-  const LEG_TILT = 0.38;
-  const HUB_HEIGHT = 0.9;
-
-  return () => {
-    const group = new THREE.Group();
-    group.name = 'shortRailTripodCamera';
-    const base = new THREE.Group();
-    group.add(base);
-
-    const hub = new THREE.Mesh(hubGeo, metalLite);
-    hub.position.y = HUB_HEIGHT;
-    hub.castShadow = true;
-    hub.receiveShadow = true;
-    base.add(hub);
-
-    const legAngles = [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3];
-    legAngles.forEach((angle) => {
-      const leg = new THREE.Mesh(legGeo, metalDark);
-      leg.castShadow = true;
-      leg.receiveShadow = true;
-      const baseX = Math.cos(angle) * LEG_SPREAD;
-      const baseZ = Math.sin(angle) * LEG_SPREAD;
-      const tiltAxis = new THREE.Vector3(-Math.sin(angle), 0, Math.cos(angle)).normalize();
-      leg.position.set(baseX * 0.2, HUB_HEIGHT - 0.6, baseZ * 0.2);
-      leg.quaternion.setFromAxisAngle(tiltAxis, LEG_TILT);
-      base.add(leg);
-
-      const foot = new THREE.Mesh(footGeo, rubber);
-      foot.position.set(Math.cos(angle) * 0.65, 0.01, Math.sin(angle) * 0.65);
-      foot.receiveShadow = true;
-      base.add(foot);
-
-      const brace = new THREE.Mesh(braceGeo, metalLite);
-      brace.castShadow = true;
-      const from = new THREE.Vector3(0, HUB_HEIGHT, 0);
-      const to = new THREE.Vector3(Math.cos(angle) * 0.65, 0.02, Math.sin(angle) * 0.65);
-      const dirVec = new THREE.Vector3().subVectors(to, from);
-      const len = dirVec.length();
-      brace.scale.set(1, len / 0.7, 1);
-      brace.position.copy(from.clone().add(to).multiplyScalar(0.5));
-      brace.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dirVec.clone().normalize());
-      base.add(brace);
-    });
-
-    const headPivot = new THREE.Group();
-    headPivot.position.set(0, HUB_HEIGHT, 0);
-    base.add(headPivot);
-
-    const cameraAssembly = new THREE.Group();
-    cameraAssembly.rotation.y = Math.PI / 2;
-    headPivot.add(cameraAssembly);
-
-    const ball = new THREE.Mesh(ballGeo, metalDark);
-    ball.position.set(0, 0.1, 0);
-    ball.castShadow = true;
-    ball.receiveShadow = true;
-    cameraAssembly.add(ball);
-
-    const plate = new THREE.Mesh(plateGeo, metalLite);
-    plate.position.set(0, 0.2, 0);
-    plate.castShadow = true;
-    plate.receiveShadow = true;
-    cameraAssembly.add(plate);
-
-    const mount = new THREE.Mesh(mountGeo, metalDark);
-    mount.position.set(0, 0.23, 0);
-    mount.castShadow = true;
-    mount.receiveShadow = true;
-    cameraAssembly.add(mount);
-
-    const handle = new THREE.Mesh(handleGeo, metalLite);
-    handle.castShadow = true;
-    handle.position.set(0.09, 0.16, 0);
-    handle.rotation.z = Math.PI * -0.25;
-    cameraAssembly.add(handle);
-
-    const grip = new THREE.Mesh(gripGeo, rubber);
-    grip.position.set(0.24, 0.07, -0.09);
-    grip.rotation.z = Math.PI * -0.25;
-    grip.castShadow = true;
-    cameraAssembly.add(grip);
-
-    const body = new THREE.Mesh(bodyGeo, plastic);
-    body.position.set(0, 0.32, 0);
-    body.castShadow = true;
-    body.receiveShadow = true;
-    cameraAssembly.add(body);
-
-    const lensTube = new THREE.Mesh(lensTubeGeo, metalDark);
-    lensTube.rotation.z = Math.PI / 2;
-    lensTube.position.set(0.25, 0.32, 0);
-    lensTube.castShadow = true;
-    cameraAssembly.add(lensTube);
-
-    const lensGlass = new THREE.Mesh(lensGlassGeo, glass);
-    lensGlass.rotation.y = Math.PI / 2;
-    lensGlass.position.set(0.33, 0.32, 0);
-    cameraAssembly.add(lensGlass);
-
-    const hood = new THREE.Mesh(hoodGeo, rubber);
-    hood.position.set(0.38, 0.32, 0);
-    hood.castShadow = true;
-    hood.receiveShadow = true;
-    cameraAssembly.add(hood);
-
-    const viewfinder = new THREE.Mesh(vfGeo, metalLite);
-    viewfinder.position.set(-0.2, 0.36, 0.06);
-    viewfinder.castShadow = true;
-    cameraAssembly.add(viewfinder);
-
-    const topHandle = new THREE.Mesh(topHandleGeo, rubber);
-    topHandle.rotation.z = Math.PI / 2;
-    topHandle.position.set(0, 0.43, 0);
-    topHandle.castShadow = true;
-    cameraAssembly.add(topHandle);
-
-    const cableCurve = new THREE.CubicBezierCurve3(
-      new THREE.Vector3(-0.05, 0.4, 0.1),
-      new THREE.Vector3(-0.1, 0.3, 0.2),
-      new THREE.Vector3(-0.2, 0.1, 0.15),
-      new THREE.Vector3(-0.25, 0.02, 0.0)
-    );
-    const cableGeo = new THREE.TubeGeometry(cableCurve, 20, 0.005, 6, false);
-    const cable = new THREE.Mesh(cableGeo, rubber);
-    cable.castShadow = true;
-    cameraAssembly.add(cable);
-
-    return { group, headPivot };
-  };
-})();
 
 function spotPositions(baulkZ) {
   const halfH = PLAY_H / 2;
@@ -16581,44 +16260,6 @@ const powerRef = useRef(hud.power);
       });
       world.add(broadcastRig.group);
       broadcastCamerasRef.current = broadcastRig;
-
-      if (ENABLE_TRIPOD_CAMERAS) {
-        const tripodHeightBoost = 1.04;
-        const tripodScale =
-          ((TABLE_Y + BALL_R * 6 - floorY) / 1.33) * tripodHeightBoost;
-        const tripodTilt = THREE.MathUtils.degToRad(-12);
-        const tripodProximityPull = BALL_R * 2.5;
-        const tripodExtra = Math.max(BALL_R * 2, BALL_R * 6 - tripodProximityPull);
-        const tripodDesiredZ =
-          Math.max(PLAY_H / 2 + BALL_R * 12, shortRailTarget - BALL_R * 6) +
-          tripodExtra;
-        const tripodMaxZ = arenaHalfDepth - BALL_R * 4;
-        const tripodZOffset = Math.min(tripodMaxZ, tripodDesiredZ);
-        const tripodTarget = new THREE.Vector3(0, TABLE_Y + TABLE.THICK * 0.5, 0);
-        const tripodPositions = [
-          { x: 0, z: tripodZOffset },
-          { x: 0, z: -tripodZOffset }
-        ];
-        tripodPositions.forEach(({ x, z }) => {
-          const { group: tripodGroup, headPivot } = createTripodBroadcastCamera();
-          tripodGroup.scale.setScalar(tripodScale);
-          tripodGroup.position.set(x, floorY, z);
-          const toTarget = new THREE.Vector3()
-            .subVectors(tripodTarget, tripodGroup.position)
-            .setY(0);
-          if (toTarget.lengthSq() > 1e-6) {
-            const yaw = Math.atan2(toTarget.z, toTarget.x);
-            tripodGroup.rotation.y = yaw;
-          }
-          world.add(tripodGroup);
-          tripodGroup.updateWorldMatrix(true, false);
-          headPivot.up.set(0, 1, 0);
-          headPivot.lookAt(tripodTarget);
-          headPivot.rotateY(Math.PI);
-          headPivot.rotateX(tripodTilt);
-        });
-      }
-
       const DARTBOARD_TEXTURE_URL =
         'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/dartboard/dartboard_diff_2k.jpg';
       const hospitalityMats = {
@@ -23597,7 +23238,6 @@ const powerRef = useRef(hud.power);
               (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD));
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
-            !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
             allowRailOverheadActionView;
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;


### PR DESCRIPTION
### Motivation
- Remove the short-rail standing/tripod broadcast cameras completely because they were still causing glitches and should not remain behind flags. 
- Move middle-pocket cameras slightly farther toward the table sides so pocket closeups avoid the table center as requested. 
- Ensure the rail-overhead broadcasting camera becomes active immediately on shot trigger for breaks and rail-first/bank predictions so the view does not follow the cueball in those cases.

### Description
- Deleted the short-rail tripod/standing camera feature paths and factory so tripods are no longer created or referenced in `webapp/src/pages/Games/PoolRoyale.jsx` (removed feature-flag constants and the tripod factory/placement code). 
- Increased pocket camera offsets by changing `POCKET_CAM_SIDE_EDGE_SHIFT` to `BALL_R * 5.5` and `POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER` to `3.08` to push middle-pocket cameras farther outward. 
- Removed the gating that prevented immediate rail-overhead action view activation and now allow the rail-overhead action camera when `isBreakShot` or when `shotPrediction.railNormal` (rail-first/bank) is present so the rail-overhead is forced immediately on shot trigger. 
- Cleaned up supporting camera construction code in `createBroadcastCameras` to remove decorative tripod internals and placement blocks.

### Testing
- Ran `npm --prefix webapp run build` (Vite production build) and it completed successfully with only existing chunk-size warnings. 
- Ran repository `npm run build` (monorepo TypeScript build) which failed with a pre-existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` and is not caused by these changes. 
- Ran `npx eslint` and `prettier --check`/`--write` on `PoolRoyale.jsx` and fixed formatting; lint reported file ignore warnings as configured but no blocking errors. 
- Launched the local dev server with `npm --prefix webapp run dev`, loaded the app, and captured a screenshot showing the updated camera setup (artifact produced from the dev server).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a63b4de08329b38dad97a1162f57)