### PR TITLE
Revert "Pool Royale: remove short-rail standing cameras, push middle-pocket cams outward, and force rail-overhead on break/bank shots"

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1064,6 +1064,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   jaws: false,
   pockets: false
 });
+const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
 const LOCK_RAIL_OVERHEAD_FRAME = true;
@@ -1468,8 +1469,8 @@ const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
-const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 6.2; // push middle-pocket cameras farther toward the side rails and away from table center framing
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 3.24; // push middle-pocket cameras farther outward so side pocket shots stay away from the table center
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // nudge middle-pocket cameras a bit farther toward the table edges and away from center framing
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.72; // push middle-pocket cameras slightly farther outward so side pocket shots sit more off-center
 const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.18; // pull corner-pocket cameras slightly inward so they frame a bit closer toward table center
 const POCKET_CAM_SIDE_LATERAL_BIAS = 0.34; // bias only middle-pocket outward vectors toward the nearest edge; corner-pocket vectors stay unchanged
 const POCKET_CAM_BASE_MIN_OUTSIDE =
@@ -4639,7 +4640,48 @@ function createBroadcastCameras({
   group.name = 'broadcastCameras';
   const cameras = {};
 
+  const darkMetal = new THREE.MeshStandardMaterial({
+    color: 0x1f2937,
+    metalness: 0.65,
+    roughness: 0.32
+  });
+  const lightMetal = new THREE.MeshStandardMaterial({
+    color: 0x334155,
+    metalness: 0.58,
+    roughness: 0.36
+  });
+  const plastic = new THREE.MeshStandardMaterial({
+    color: 0x1b2533,
+    metalness: 0.24,
+    roughness: 0.42
+  });
+  const rubber = new THREE.MeshStandardMaterial({
+    color: 0x080c14,
+    metalness: 0.0,
+    roughness: 0.94
+  });
+  const glass = new THREE.MeshStandardMaterial({
+    color: 0x97c6ff,
+    metalness: 0.0,
+    roughness: 0.08,
+    transparent: true,
+    opacity: 0.42,
+    envMapIntensity: 1.1
+  });
+
+  const footRadius = Math.min(0.85, PLAY_W * 0.22);
   const headHeight = Math.max(1.45, cameraHeight - floorY);
+  const hubHeight = Math.max(1.08, headHeight - 0.52);
+  const columnHeight = Math.max(0.42, headHeight - hubHeight);
+  const legLength = Math.sqrt(footRadius * footRadius + hubHeight * hubHeight);
+  const legGeo = new THREE.CylinderGeometry(0.034, 0.022, legLength, 14);
+  const footHeight = 0.045;
+  const footGeo = new THREE.CylinderGeometry(0.07, 0.07, footHeight, 16);
+  const columnGeo = new THREE.CylinderGeometry(0.052, 0.05, columnHeight, 16);
+  const hubGeo = new THREE.CylinderGeometry(0.12, 0.14, 0.08, 18);
+  const headBaseGeo = new THREE.CylinderGeometry(0.11, 0.13, 0.05, 18);
+  const panBarGeo = new THREE.CylinderGeometry(0.012, 0.012, 0.32, 12);
+  const gripGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.2, 12);
 
   const defaultFocus = new THREE.Vector3(
     0,
@@ -4684,6 +4726,102 @@ function createBroadcastCameras({
     const cameraAssembly = new THREE.Group();
     headPivot.add(cameraAssembly);
 
+    if (SHOW_SHORT_RAIL_TRIPODS) {
+      const tripod = new THREE.Group();
+      slider.add(tripod);
+
+      const top = new THREE.Vector3(0, hubHeight, 0);
+      [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3].forEach((angle) => {
+        const foot = new THREE.Vector3(
+          Math.cos(angle) * footRadius,
+          0,
+          Math.sin(angle) * footRadius
+        );
+        const mid = top.clone().add(foot).multiplyScalar(0.5);
+        const up = top.clone().sub(foot).normalize();
+        const leg = new THREE.Mesh(legGeo, darkMetal);
+        leg.position.copy(mid);
+        leg.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), up);
+        leg.castShadow = true;
+        leg.receiveShadow = true;
+        tripod.add(leg);
+
+        const footPad = new THREE.Mesh(footGeo, rubber);
+        footPad.position.set(foot.x, footHeight / 2, foot.z);
+        footPad.receiveShadow = true;
+        tripod.add(footPad);
+      });
+
+      const column = new THREE.Mesh(columnGeo, lightMetal);
+      column.position.y = hubHeight + columnHeight / 2;
+      column.castShadow = true;
+      column.receiveShadow = true;
+      slider.add(column);
+
+      const hub = new THREE.Mesh(hubGeo, lightMetal);
+      hub.position.y = hubHeight;
+      hub.castShadow = true;
+      hub.receiveShadow = true;
+      slider.add(hub);
+
+      const headBase = new THREE.Mesh(headBaseGeo, darkMetal);
+      headBase.position.y = headHeight;
+      headBase.castShadow = true;
+      slider.add(headBase);
+
+      const body = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.24, 0.22), plastic);
+      body.castShadow = true;
+      body.receiveShadow = true;
+      cameraAssembly.add(body);
+
+      const lensHousing = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.065, 0.07, 0.18, 24),
+        darkMetal
+      );
+      lensHousing.rotation.x = Math.PI / 2;
+      lensHousing.position.set(0, 0, -0.2);
+      lensHousing.castShadow = true;
+      cameraAssembly.add(lensHousing);
+
+      const hood = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.1, 0.16), rubber);
+      hood.position.set(0, 0, -0.32);
+      hood.castShadow = true;
+      cameraAssembly.add(hood);
+
+      const lensGlass = new THREE.Mesh(new THREE.CircleGeometry(0.06, 24), glass);
+      lensGlass.rotation.x = Math.PI / 2;
+      lensGlass.position.set(0, 0, -0.29);
+      cameraAssembly.add(lensGlass);
+
+      const topHandle = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.016, 0.016, 0.26, 12),
+        rubber
+      );
+      topHandle.rotation.z = Math.PI / 2;
+      topHandle.position.set(0, 0.16, 0);
+      topHandle.castShadow = true;
+      cameraAssembly.add(topHandle);
+
+      const viewfinder = new THREE.Mesh(
+        new THREE.BoxGeometry(0.16, 0.1, 0.08),
+        lightMetal
+      );
+      viewfinder.position.set(-0.22, 0.06, 0.05);
+      viewfinder.castShadow = true;
+      cameraAssembly.add(viewfinder);
+
+      const panBar = new THREE.Mesh(panBarGeo, lightMetal);
+      panBar.rotation.z = Math.PI / 2.3;
+      panBar.position.set(0.26, -0.08, 0);
+      panBar.castShadow = true;
+      headPivot.add(panBar);
+
+      const grip = new THREE.Mesh(gripGeo, rubber);
+      grip.rotation.z = Math.PI / 2.3;
+      grip.position.set(0.37, -0.12, 0);
+      grip.castShadow = true;
+      headPivot.add(grip);
+    }
 
     headPivot.lookAt(defaultFocus);
     headPivot.rotateY(Math.PI);
@@ -23458,10 +23596,9 @@ const powerRef = useRef(hud.power);
             (!isShortShot &&
               (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD));
           const allowLongShotCameraSwitch =
-            forceImmediateRailOverheadView ||
-            ((!suppressOpeningShotViews || forceImmediateRailOverheadView) &&
-              !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
-              allowRailOverheadActionView);
+            (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
+            !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
+            allowRailOverheadActionView;
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
           const suppressPocketCameras =


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#15048