### PR TITLE
Pool Royale: restrict camera set, enforce rail-overhead on breaks, and fix break foul logic

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -35,6 +35,7 @@ export class AmericanBilliards {
     const current = s.currentPlayer
     const opp = current === 'A' ? 'B' : 'A'
     const wasBreakShot = Boolean(s.breakInProgress)
+    const isBreakShot = wasBreakShot
     let foul = false
     let reason = ''
 
@@ -49,23 +50,23 @@ export class AmericanBilliards {
           ? countRemainingGroup(s.ballsOnTable, 'STRIPE')
           : 0
 
-    if (!foul && !first) {
+    if (!isBreakShot && !foul && !first) {
       foul = true
       reason = 'no contact'
     }
 
-    if (!foul && !isLegalFirstContact(first, { isOpenTable, playerGroup, playerGroupRemaining })) {
+    if (!isBreakShot && !foul && !isLegalFirstContact(first, { isOpenTable, playerGroup, playerGroupRemaining })) {
       foul = true
       reason = 'wrong first contact'
     }
 
-    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!isBreakShot && !foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true
       reason = 'scratch'
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0)
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!isBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true
       reason = 'no cushion'
     }

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -10,7 +10,8 @@ export class NineBall {
       ballInHand: false,
       gameOver: false,
       winner: null,
-      foulStreak: { A: 0, B: 0 }
+      foulStreak: { A: 0, B: 0 },
+      breakInProgress: true
     };
   }
 
@@ -24,27 +25,28 @@ export class NineBall {
     const current = s.currentPlayer;
     const opp = opponent(current);
     const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const isBreakShot = Boolean(s.breakInProgress);
     let foul = false;
     let reason = '';
 
     const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!isBreakShot && !foul && !first) {
       foul = true;
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!isBreakShot && !foul && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
     }
 
-    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!isBreakShot && !foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true;
       reason = 'scratch';
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!isBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true;
       reason = 'no cushion';
     }
@@ -86,6 +88,7 @@ export class NineBall {
     }
 
     s.ballInHand = ballInHandNext;
+    if (isBreakShot) s.breakInProgress = false;
 
     if (!frameOver && s.foulStreak[current] >= foulLimit) {
       frameOver = true;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -49,6 +49,7 @@ type NineSerializedState = {
   foulStreak: { A: number; B: number };
   gameOver: boolean;
   winner: 'A' | 'B' | null;
+  breakInProgress: boolean;
 };
 
 type PoolMeta =
@@ -167,7 +168,8 @@ function serializeNineState(state: NineBall['state']): NineSerializedState {
     ballInHand: state.ballInHand,
     foulStreak: { ...state.foulStreak },
     gameOver: state.gameOver,
-    winner: state.winner
+    winner: state.winner,
+    breakInProgress: Boolean(state.breakInProgress)
   };
 }
 
@@ -178,7 +180,8 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
     ballInHand: snapshot.ballInHand,
     foulStreak: { ...snapshot.foulStreak },
     gameOver: snapshot.gameOver,
-    winner: snapshot.winner
+    winner: snapshot.winner,
+    breakInProgress: Boolean(snapshot.breakInProgress)
   };
 }
 
@@ -636,7 +639,7 @@ export class PoolRoyaleRules {
         variant: '9ball',
         state: snapshot,
         hud,
-        breakInProgress: false
+        breakInProgress: Boolean(snapshot.breakInProgress)
       } satisfies PoolMeta
     };
     return nextState;

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { AmericanBilliards } from '../lib/americanBilliards.js'
 
-test('open table: first contact cannot be the 8-ball', () => {
+test('break shot ignores first-contact foul checks and just passes turn when nothing drops', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({
     contactOrder: [8],
@@ -10,10 +10,10 @@ test('open table: first contact cannot be the 8-ball', () => {
     cueOffTable: false
   })
 
-  assert.equal(res.foul, true)
-  assert.equal(res.reason, 'wrong first contact')
+  assert.equal(res.foul, false)
   assert.equal(res.nextPlayer, 'B')
-  assert.equal(res.ballInHandNext, true)
+  assert.equal(res.ballInHandNext, false)
+  assert.equal(game.state.breakInProgress, false)
 })
 
 
@@ -42,7 +42,7 @@ test('legal break pot keeps table open until post-break shot', () => {
 })
 
 
-test('break scratch ends break, passes turn, and grants ball in hand', () => {
+test('break scratch is treated as a legal break and still passes turn', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({
     contactOrder: [1],
@@ -50,18 +50,18 @@ test('break scratch ends break, passes turn, and grants ball in hand', () => {
     cueOffTable: false
   })
 
-  assert.equal(res.foul, true)
-  assert.equal(res.reason, 'scratch')
+  assert.equal(res.foul, false)
   assert.equal(res.nextPlayer, 'B')
-  assert.equal(res.ballInHandNext, true)
+  assert.equal(res.ballInHandNext, false)
   assert.equal(game.state.currentPlayer, 'B')
   assert.equal(game.state.breakInProgress, false)
   assert.equal(game.state.assignments.A, null)
   assert.equal(game.state.assignments.B, null)
 })
 
-test('scratch gives opponent ball in hand and keeps object balls down', () => {
+test('post-break scratch gives opponent ball in hand and keeps object balls down', () => {
   const game = new AmericanBilliards()
+  game.state.breakInProgress = false
   const res = game.shotTaken({
     contactOrder: [1],
     potted: [1, 0],

--- a/test/nineBall.test.js
+++ b/test/nineBall.test.js
@@ -2,8 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { NineBall } from '../lib/nineBall.js';
 
-test('must hit lowest ball first or foul', () => {
+test('must hit lowest ball first or foul after the break', () => {
   const game = new NineBall();
+  game.state.breakInProgress = false;
   const res = game.shotTaken({
     contactOrder: [2],
     potted: [],
@@ -29,8 +30,9 @@ test('potting nine after legal contact wins', () => {
   assert.equal(res.winner, 'A');
 });
 
-test('scratch gives opponent ball in hand', () => {
+test('scratch gives opponent ball in hand after the break', () => {
   const game = new NineBall();
+  game.state.breakInProgress = false;
   const res1 = game.shotTaken({
     contactOrder: [1],
     potted: [0],

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -105,13 +105,22 @@ describe('PoolRoyaleRules', () => {
     expect(initialFrame.ballOn).toEqual(['BALL_1']);
     expect(initialMeta?.hud?.next).toBe('ball 1');
 
+    const breakEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
+    const breakState = rules.applyShot(initialFrame, breakEvents, { contactMade: true });
+    const breakMeta = breakState.meta as any;
+
+    expect(breakState.foul).toBeUndefined();
+    expect(breakMeta?.breakInProgress).toBe(false);
+    expect(breakState.activePlayer).toBe('B');
+    expect(breakState.ballOn).toEqual(['BALL_1']);
+
     const foulEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
-    const foulState = rules.applyShot(initialFrame, foulEvents, { contactMade: true });
+    const foulState = rules.applyShot(breakState, foulEvents, { contactMade: true });
     const foulMeta = foulState.meta as any;
 
     expect(foulState.foul?.reason).toBe('wrong first contact');
     expect(foulMeta?.state?.ballInHand).toBe(true);
-    expect(foulState.activePlayer).toBe('B');
+    expect(foulState.activePlayer).toBe('A');
     expect(foulState.ballOn).toEqual(['BALL_1']);
 
     const recoveryEvents: ShotEvent[] = [

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1284,7 +1284,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.24; // lift balls a bit more so they roll clearly on the cloth top surface
+const BALL_CENTER_LIFT = BALL_R * 0.27; // lift balls a touch more so they sit cleanly above the cloth and roll without visual clipping
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1631,7 +1631,7 @@ const SPIN_POWER_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.25;
 const SPIN_POWER_MIN_SCALE = 0.35;
 const SPIN_POWER_MAX_SCALE = 1.25;
 const BALL_COLLISION_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.8;
-const BALL_HIT_VOLUME_SCALE = 0.72; // match Snooker Royale ball-hit volume
+const BALL_HIT_VOLUME_SCALE = 0.82; // raise pool ball-hit loudness so collisions read at the same perceived level as Snooker Royale
 const RAIL_HIT_SOUND_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.2;
 const RAIL_HIT_SOUND_COOLDOWN_MS = 140;
 const CROWD_VOLUME_SCALE = 1;
@@ -6089,7 +6089,7 @@ const getPocketCenterById = (id) => {
       return null;
   }
 };
-const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
+const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR'];
 const CORNER_POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
@@ -6131,10 +6131,6 @@ const resolvePocketCameraAnchor = (pocketId, center, approachDir, ballPos) => {
     case 'BL':
     case 'BR':
       return pocketId;
-    case 'TM':
-      return 'TM';
-    case 'BM':
-      return 'BM';
     default:
       return pocketId;
   }
@@ -19562,6 +19558,7 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (isSidePocket) return null;
           const triggerDistance = forceCornerCapture
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : POCKET_CAM.triggerDist;
@@ -23398,7 +23395,8 @@ const powerRef = useRef(hud.power);
           (inHandPlacementActive && !cueBallPlacedFromHandRef.current) ||
           !allStopped(balls) ||
           currentHud?.over ||
-          replayPlaybackRef.current
+          replayPlaybackRef.current ||
+          breakRollPending
         )
           return;
         if (breakWinnerSeatRef.current === 'A') {
@@ -23596,9 +23594,10 @@ const powerRef = useRef(hud.power);
             (!isShortShot &&
               (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD));
           const allowLongShotCameraSwitch =
-            (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
-            !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
-            allowRailOverheadActionView;
+            forceImmediateRailOverheadView ||
+            ((forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
+              !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
+              allowRailOverheadActionView);
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
           const suppressPocketCameras =
@@ -29881,7 +29880,7 @@ const powerRef = useRef(hud.power);
       <div ref={mountRef} className="absolute inset-0" />
 
       {breakRollState !== 'done' && !hud.over && (
-        <div className="pointer-events-none absolute inset-0 z-[95] flex items-center justify-center">
+        <div className="pointer-events-none absolute inset-0 z-[95] flex items-center justify-center translate-y-[12vh]">
           <div className="pointer-events-auto w-[min(20rem,88vw)] rounded-2xl border border-cyan-300/45 bg-slate-950/82 p-4 text-center shadow-[0_14px_32px_rgba(0,0,0,0.58)] backdrop-blur">
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-100">Break dice roll</p>
             <p className="mt-3 text-xs font-semibold text-white/90">{breakRollMessage}</p>


### PR DESCRIPTION
### Motivation

- Stop unstable short-rail / middle-pocket camera behavior and ensure broadcast/replay only uses the intended rail overhead and corner/pocket cameras.  
- Make break shots and cushion/double-triggered shots consistently switch to the rail-overhead broadcast camera and avoid false fouls on break.  
- Improve presentation (dice UI placement, ball audio/height) for clearer UX on mobile portrait.  

### Description

- Removed middle-pocket pocket cameras from the active pocket camera set by changing `POCKET_CAMERA_IDS` to only `['TL','TR','BL','BR']` and returning `null` for side-pocket anchors so the system falls back to the rail overhead camera (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Force rail-overhead activation for break and cushion/double-trigger shot flows while preserving existing action/pocket logic and respect `RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY` semantics (`PoolRoyale.jsx` camera selection/activation adjustments).  
- Prevent player from firing while break dice roll is pending and moved the break dice panel lower on screen (`PoolRoyale.jsx`).  
- Raised visual ball rest position slightly (`BALL_CENTER_LIFT`) and increased collision audio loudness (`BALL_HIT_VOLUME_SCALE`) to match perceived snooker levels (`PoolRoyale.jsx`).  
- Adjusted rule engines so break shots are not treated as fouls: exempted first-contact/foul checks during an active break in `AmericanBilliards` and `NineBall`, and ensure `breakInProgress` is cleared after a break shot (`lib/americanBilliards.js`, `lib/nineBall.js`).  
- Persisted `breakInProgress` in nine-ball serialization and `PoolRoyaleRules` metadata so UI/rules reflect the break state (`src/rules/PoolRoyaleRules.ts`).  
- Updated tests to reflect new break semantics and camera behavior and adapted logic accordingly (`test/*.test.js`, `test/poolRoyaleRules.test.ts`).  

### Testing

- Ran the unit tests for billiards rules: `npm test -- --runInBand test/americanBilliards.test.js test/nineBall.test.js test/poolRoyaleRules.test.ts`, all tests passed.  
- Ran focused rule tests: `npm test -- --runInBand test/poolRoyaleRules.test.ts`, passed.  
- Started the web dev server for the frontend with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a mobile-viewport screenshot from the running app to validate UI placement and camera defaults.  

Files changed (high level): `webapp/src/pages/Games/PoolRoyale.jsx`, `lib/americanBilliards.js`, `lib/nineBall.js`, `src/rules/PoolRoyaleRules.ts`, and updated tests in `test/` to reflect the new break behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b46849948329b64cd5b7c6cf96cb)