### PR TITLE
Pool Royale: remove short-rail standing cameras, prefer rail-overhead for middles, and fix break logic

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -49,23 +49,23 @@ export class AmericanBilliards {
           ? countRemainingGroup(s.ballsOnTable, 'STRIPE')
           : 0
 
-    if (!foul && !first) {
+    if (!wasBreakShot && !foul && !first) {
       foul = true
       reason = 'no contact'
     }
 
-    if (!foul && !isLegalFirstContact(first, { isOpenTable, playerGroup, playerGroupRemaining })) {
+    if (!wasBreakShot && !foul && !isLegalFirstContact(first, { isOpenTable, playerGroup, playerGroupRemaining })) {
       foul = true
       reason = 'wrong first contact'
     }
 
-    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!wasBreakShot && !foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true
       reason = 'scratch'
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0)
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!wasBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true
       reason = 'no cushion'
     }

--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -10,7 +10,8 @@ export class NineBall {
       ballInHand: false,
       gameOver: false,
       winner: null,
-      foulStreak: { A: 0, B: 0 }
+      foulStreak: { A: 0, B: 0 },
+      breakInProgress: true
     };
   }
 
@@ -24,27 +25,28 @@ export class NineBall {
     const current = s.currentPlayer;
     const opp = opponent(current);
     const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
+    const wasBreakShot = Boolean(s.breakInProgress);
     let foul = false;
     let reason = '';
 
     const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!wasBreakShot && !foul && !first) {
       foul = true;
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!wasBreakShot && !foul && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
     }
 
-    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!wasBreakShot && !foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true;
       reason = 'scratch';
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!wasBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true;
       reason = 'no cushion';
     }
@@ -86,6 +88,9 @@ export class NineBall {
     }
 
     s.ballInHand = ballInHandNext;
+    if (wasBreakShot || !foul || pottedBalls.length > 0 || shot.breakComplete) {
+      s.breakInProgress = false;
+    }
 
     if (!frameOver && s.foulStreak[current] >= foulLimit) {
       frameOver = true;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -49,6 +49,7 @@ type NineSerializedState = {
   foulStreak: { A: number; B: number };
   gameOver: boolean;
   winner: 'A' | 'B' | null;
+  breakInProgress: boolean;
 };
 
 type PoolMeta =
@@ -167,7 +168,8 @@ function serializeNineState(state: NineBall['state']): NineSerializedState {
     ballInHand: state.ballInHand,
     foulStreak: { ...state.foulStreak },
     gameOver: state.gameOver,
-    winner: state.winner
+    winner: state.winner,
+    breakInProgress: state.breakInProgress
   };
 }
 
@@ -178,7 +180,8 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
     ballInHand: snapshot.ballInHand,
     foulStreak: { ...snapshot.foulStreak },
     gameOver: snapshot.gameOver,
-    winner: snapshot.winner
+    winner: snapshot.winner,
+    breakInProgress: snapshot.breakInProgress
   };
 }
 
@@ -636,7 +639,7 @@ export class PoolRoyaleRules {
         variant: '9ball',
         state: snapshot,
         hud,
-        breakInProgress: false
+        breakInProgress: Boolean(snapshot.breakInProgress)
       } satisfies PoolMeta
     };
     return nextState;

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -4,6 +4,7 @@ import { AmericanBilliards } from '../lib/americanBilliards.js'
 
 test('open table: first contact cannot be the 8-ball', () => {
   const game = new AmericanBilliards()
+  game.state.breakInProgress = false
   const res = game.shotTaken({
     contactOrder: [8],
     potted: [],
@@ -42,7 +43,7 @@ test('legal break pot keeps table open until post-break shot', () => {
 })
 
 
-test('break scratch ends break, passes turn, and grants ball in hand', () => {
+test('break scratch does not foul and hands turn over with no ball in hand', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({
     contactOrder: [1],
@@ -50,10 +51,10 @@ test('break scratch ends break, passes turn, and grants ball in hand', () => {
     cueOffTable: false
   })
 
-  assert.equal(res.foul, true)
-  assert.equal(res.reason, 'scratch')
+  assert.equal(res.foul, false)
+  assert.equal(res.reason, undefined)
   assert.equal(res.nextPlayer, 'B')
-  assert.equal(res.ballInHandNext, true)
+  assert.equal(res.ballInHandNext, false)
   assert.equal(game.state.currentPlayer, 'B')
   assert.equal(game.state.breakInProgress, false)
   assert.equal(game.state.assignments.A, null)
@@ -62,6 +63,7 @@ test('break scratch ends break, passes turn, and grants ball in hand', () => {
 
 test('scratch gives opponent ball in hand and keeps object balls down', () => {
   const game = new AmericanBilliards()
+  game.state.breakInProgress = false
   const res = game.shotTaken({
     contactOrder: [1],
     potted: [1, 0],

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -105,13 +105,22 @@ describe('PoolRoyaleRules', () => {
     expect(initialFrame.ballOn).toEqual(['BALL_1']);
     expect(initialMeta?.hud?.next).toBe('ball 1');
 
+    const breakEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
+    const postBreak = rules.applyShot(initialFrame, breakEvents, { contactMade: true });
+    const postBreakMeta = postBreak.meta as any;
+
+    expect(postBreak.foul).toBeUndefined();
+    expect(postBreakMeta?.breakInProgress).toBe(false);
+    expect(postBreak.activePlayer).toBe('B');
+    expect(postBreak.ballOn).toEqual(['BALL_1']);
+
     const foulEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
-    const foulState = rules.applyShot(initialFrame, foulEvents, { contactMade: true });
+    const foulState = rules.applyShot(postBreak, foulEvents, { contactMade: true });
     const foulMeta = foulState.meta as any;
 
     expect(foulState.foul?.reason).toBe('wrong first contact');
     expect(foulMeta?.state?.ballInHand).toBe(true);
-    expect(foulState.activePlayer).toBe('B');
+    expect(foulState.activePlayer).toBe('A');
     expect(foulState.ballOn).toEqual(['BALL_1']);
 
     const recoveryEvents: ShotEvent[] = [


### PR DESCRIPTION
### Motivation
- Remove the short-rail standing/tripod camera geometry which was causing rendering/glitch issues and ensure broadcasts/replays only use the desired rail-overhead, player standing and corner pocket cameras.
- Make middle-pocket pots use the rail-overhead broadcast view instead of pocket close-up cameras to avoid incorrect framing and glitches.
- Prevent shots from being taken before the break-dice flow completes and ensure break shots are not treated as fouls while preserving normal post-break foul logic.
- Improve ball audio/visual fidelity so Pool Royale matches Snooker Royal loudness and rolls more cleanly on the cloth.

### Description
- Removed tripod/standing broadcast geometry and references from the Pool Royale broadcast rig in `webapp/src/pages/Games/PoolRoyale.jsx` so short-rail tripod assets are no longer created (previous `SHOW_SHORT_RAIL_TRIPODS` geometry removed).
- Disabled side/middle pocket camera cut-ins by returning `null` for side-pocket anchors (`TM`/`BM`) so those pots fall back to the rail-overhead broadcast framing in `PoolRoyale.jsx` (pocket camera resolution logic adjusted).
- Added a reactive `breakRollPendingRef` guard and early-return checks to block both user `fire` and AI `aiShoot` while break dice are pending, and moved the break-dice overlay lower on screen for portrait (`PoolRoyale.jsx`).
- Force immediate rail-overhead switch for break/rail-first/bank-triggered shots by invoking top/overhead view when `forceImmediateRailOverheadView` is true in `PoolRoyale.jsx`.
- Raised ball resting lift and hit volume by updating `BALL_CENTER_LIFT` and `BALL_HIT_VOLUME_SCALE` in `PoolRoyale.jsx` to better match Snooker Royal presentation.
- Updated rule logic in `lib/americanBilliards.js` and `lib/nineBall.js` to treat break shots as non-fouls (`wasBreakShot` checks) while preserving normal foul/turn-passing behavior after the break; added `breakInProgress` state for nine-ball and propagated it through serialization in `src/rules/PoolRoyaleRules.ts`.
- Adjusted and aligned tests in `test/americanBilliards.test.js` and `test/poolRoyaleRules.test.ts` to match the new break semantics and nine-ball serialization.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleRules.test.ts test/americanBilliards.test.js` and both test suites passed (all tests green).
- Iteratively fixed failing expectations during development until the automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b46849948329b64cd5b7c6cf96cb)