### PR TITLE
Disable dynamic shot camera tracking and pocket zoom in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1521,6 +1521,7 @@ const POCKET_CHAOS_MOVING_THRESHOLD = 3;
 const POCKET_GUARANTEED_ALIGNMENT = 0.85;
 const POCKET_EARLY_ALIGNMENT = 0.7;
 const POCKET_INTENT_TIMEOUT_MS = 4200;
+const DYNAMIC_SHOT_CAMERA_ENABLED = false;
 const ACTION_CAM = Object.freeze({
   pairMinDistance: BALL_R * 28,
   pairMaxDistance: BALL_R * 72,
@@ -19247,6 +19248,7 @@ const powerRef = useRef(hud.power);
           railNormal,
           { longShot = false, travelDistance = 0, isBreakShot = false } = {}
         ) => {
+          if (!DYNAMIC_SHOT_CAMERA_ENABLED) return null;
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
           const targetBall =
@@ -19325,6 +19327,7 @@ const powerRef = useRef(hud.power);
           };
         };
         const makePocketCameraView = (ballId, followView, options = {}) => {
+          if (!DYNAMIC_SHOT_CAMERA_ENABLED) return null;
           if (!followView) return null;
           const {
             forceEarly = false,


### PR DESCRIPTION
### Motivation
- Prevent the camera from dynamically following or zooming to the cue ball and pockets during shots to give a stable, non-dynamic broadcast/aiming view.
- Provide an explicit, easy-to-toggle flag to globally disable shot-follow and pocket cutaway behavior.

### Description
- Added a feature toggle `DYNAMIC_SHOT_CAMERA_ENABLED` (set to `false`) to `webapp/src/pages/Games/PoolRoyale.jsx` to control dynamic shot cameras.
- Short-circuited `makeActionCameraView(...)` to return `null` when `DYNAMIC_SHOT_CAMERA_ENABLED` is disabled so action/follow views are not created.
- Short-circuited `makePocketCameraView(...)` to return `null` when `DYNAMIC_SHOT_CAMERA_ENABLED` is disabled so pocket capture/zoom views are not created.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which exited with a lint warning because the file is ignored by the repo lint config and produced no errors.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite served the app successfully.
- Attempted an automated Playwright screenshot to validate the running UI but the headless Chromium process crashed in this environment, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e7a294508329938ba8f6736f3fb8)