### PR TITLE
Disable dynamic shot camera movement in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1056,6 +1056,7 @@ const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'e
 const DEFAULT_TABLE_BASE_ID = POOL_ROYALE_BASE_VARIANTS[0]?.id || 'classicCylinders';
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
+const DISABLE_DYNAMIC_SHOT_CAMERA = true;
 const ENABLE_CUE_STROKE_ANIMATION = true;
 const ENABLE_TABLE_MAPPING_LINES = true;
 const TABLE_MAPPING_VISUALS = Object.freeze({
@@ -19247,6 +19248,7 @@ const powerRef = useRef(hud.power);
           railNormal,
           { longShot = false, travelDistance = 0, isBreakShot = false } = {}
         ) => {
+          if (DISABLE_DYNAMIC_SHOT_CAMERA) return null;
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
           const targetBall =
@@ -19325,6 +19327,7 @@ const powerRef = useRef(hud.power);
           };
         };
         const makePocketCameraView = (ballId, followView, options = {}) => {
+          if (DISABLE_DYNAMIC_SHOT_CAMERA) return null;
           if (!followView) return null;
           const {
             forceEarly = false,


### PR DESCRIPTION
### Motivation
- Player request: prevent the camera from dynamically zooming/following the cue ball during shots to keep a stable view.  
- Provide a single, easy toggle to disable all dynamic shot camera behaviors in the Pool Royale scene.

### Description
- Added a boolean toggle `DISABLE_DYNAMIC_SHOT_CAMERA = true` in `webapp/src/pages/Games/PoolRoyale.jsx` to control dynamic shot cameras.  
- Early-return from `makeActionCameraView(...)` when the toggle is enabled to prevent creation of the cue-follow/action camera.  
- Early-return from `makePocketCameraView(...)` when the toggle is enabled to prevent pocket/zoom camera creation.  
- The change keeps the existing orbit/standing camera systems intact and only disables the dynamic shot-follow/pocket cut paths.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed but reported the file is ignored by repo lint patterns (warning).  
- Started the dev server (`vite`) and the app served successfully at the local dev URL (Vite reported ready).  
- Attempted an automated Playwright screenshot of `/games/poolroyale`, but the screenshot timed out in the browser container (no artifact produced).  
- Ran the monorepo build (`npm run build`), which failed due to a pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e7a294508329938ba8f6736f3fb8)