### PR TITLE
Restore Pool Royale broadcast/replay camera behavior (reintroduce short-rail front/back cameras)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1064,6 +1064,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   jaws: false,
   pockets: false
 });
+const SHOW_SHORT_RAIL_TRIPODS = false;
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
 const LOCK_RAIL_OVERHEAD_FRAME = true;
@@ -4638,7 +4639,49 @@ function createBroadcastCameras({
   const group = new THREE.Group();
   group.name = 'broadcastCameras';
   const cameras = {};
+
+  const darkMetal = new THREE.MeshStandardMaterial({
+    color: 0x1f2937,
+    metalness: 0.65,
+    roughness: 0.32
+  });
+  const lightMetal = new THREE.MeshStandardMaterial({
+    color: 0x334155,
+    metalness: 0.58,
+    roughness: 0.36
+  });
+  const plastic = new THREE.MeshStandardMaterial({
+    color: 0x1b2533,
+    metalness: 0.24,
+    roughness: 0.42
+  });
+  const rubber = new THREE.MeshStandardMaterial({
+    color: 0x080c14,
+    metalness: 0.0,
+    roughness: 0.94
+  });
+  const glass = new THREE.MeshStandardMaterial({
+    color: 0x97c6ff,
+    metalness: 0.0,
+    roughness: 0.08,
+    transparent: true,
+    opacity: 0.42,
+    envMapIntensity: 1.1
+  });
+
+  const footRadius = Math.min(0.85, PLAY_W * 0.22);
   const headHeight = Math.max(1.45, cameraHeight - floorY);
+  const hubHeight = Math.max(1.08, headHeight - 0.52);
+  const columnHeight = Math.max(0.42, headHeight - hubHeight);
+  const legLength = Math.sqrt(footRadius * footRadius + hubHeight * hubHeight);
+  const legGeo = new THREE.CylinderGeometry(0.034, 0.022, legLength, 14);
+  const footHeight = 0.045;
+  const footGeo = new THREE.CylinderGeometry(0.07, 0.07, footHeight, 16);
+  const columnGeo = new THREE.CylinderGeometry(0.052, 0.05, columnHeight, 16);
+  const hubGeo = new THREE.CylinderGeometry(0.12, 0.14, 0.08, 18);
+  const headBaseGeo = new THREE.CylinderGeometry(0.11, 0.13, 0.05, 18);
+  const panBarGeo = new THREE.CylinderGeometry(0.012, 0.012, 0.32, 12);
+  const gripGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.2, 12);
 
   const defaultFocus = new THREE.Vector3(
     0,
@@ -4658,7 +4701,7 @@ function createBroadcastCameras({
   const cameraScale = 1.2;
   const cameraProximityScale = 0.6;
 
-  const createRailOverheadUnit = (zSign) => {
+  const createShortRailUnit = (zSign) => {
     const direction = Math.sign(zSign) || 1;
     const base = new THREE.Group();
     base.visible = false;
@@ -4683,6 +4726,103 @@ function createBroadcastCameras({
     const cameraAssembly = new THREE.Group();
     headPivot.add(cameraAssembly);
 
+    if (SHOW_SHORT_RAIL_TRIPODS) {
+      const tripod = new THREE.Group();
+      slider.add(tripod);
+
+      const top = new THREE.Vector3(0, hubHeight, 0);
+      [0, (2 * Math.PI) / 3, (4 * Math.PI) / 3].forEach((angle) => {
+        const foot = new THREE.Vector3(
+          Math.cos(angle) * footRadius,
+          0,
+          Math.sin(angle) * footRadius
+        );
+        const mid = top.clone().add(foot).multiplyScalar(0.5);
+        const up = top.clone().sub(foot).normalize();
+        const leg = new THREE.Mesh(legGeo, darkMetal);
+        leg.position.copy(mid);
+        leg.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), up);
+        leg.castShadow = true;
+        leg.receiveShadow = true;
+        tripod.add(leg);
+
+        const footPad = new THREE.Mesh(footGeo, rubber);
+        footPad.position.set(foot.x, footHeight / 2, foot.z);
+        footPad.receiveShadow = true;
+        tripod.add(footPad);
+      });
+
+      const column = new THREE.Mesh(columnGeo, lightMetal);
+      column.position.y = hubHeight + columnHeight / 2;
+      column.castShadow = true;
+      column.receiveShadow = true;
+      slider.add(column);
+
+      const hub = new THREE.Mesh(hubGeo, lightMetal);
+      hub.position.y = hubHeight;
+      hub.castShadow = true;
+      hub.receiveShadow = true;
+      slider.add(hub);
+
+      const headBase = new THREE.Mesh(headBaseGeo, darkMetal);
+      headBase.position.y = headHeight;
+      headBase.castShadow = true;
+      slider.add(headBase);
+
+      const body = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.24, 0.22), plastic);
+      body.castShadow = true;
+      body.receiveShadow = true;
+      cameraAssembly.add(body);
+
+      const lensHousing = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.065, 0.07, 0.18, 24),
+        darkMetal
+      );
+      lensHousing.rotation.x = Math.PI / 2;
+      lensHousing.position.set(0, 0, -0.2);
+      lensHousing.castShadow = true;
+      cameraAssembly.add(lensHousing);
+
+      const hood = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.1, 0.16), rubber);
+      hood.position.set(0, 0, -0.32);
+      hood.castShadow = true;
+      cameraAssembly.add(hood);
+
+      const lensGlass = new THREE.Mesh(new THREE.CircleGeometry(0.06, 24), glass);
+      lensGlass.rotation.x = Math.PI / 2;
+      lensGlass.position.set(0, 0, -0.29);
+      cameraAssembly.add(lensGlass);
+
+      const topHandle = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.016, 0.016, 0.26, 12),
+        rubber
+      );
+      topHandle.rotation.z = Math.PI / 2;
+      topHandle.position.set(0, 0.16, 0);
+      topHandle.castShadow = true;
+      cameraAssembly.add(topHandle);
+
+      const viewfinder = new THREE.Mesh(
+        new THREE.BoxGeometry(0.16, 0.1, 0.08),
+        lightMetal
+      );
+      viewfinder.position.set(-0.22, 0.06, 0.05);
+      viewfinder.castShadow = true;
+      cameraAssembly.add(viewfinder);
+
+      const panBar = new THREE.Mesh(panBarGeo, lightMetal);
+      panBar.rotation.z = Math.PI / 2.3;
+      panBar.position.set(0.26, -0.08, 0);
+      panBar.castShadow = true;
+      headPivot.add(panBar);
+
+      const grip = new THREE.Mesh(gripGeo, rubber);
+      grip.rotation.z = Math.PI / 2.3;
+      grip.position.set(0.37, -0.12, 0);
+      grip.castShadow = true;
+      headPivot.add(grip);
+    }
+
     headPivot.lookAt(defaultFocus);
     headPivot.rotateY(Math.PI);
 
@@ -4696,8 +4836,10 @@ function createBroadcastCameras({
     };
   };
 
-  cameras.overhead = createRailOverheadUnit(1);
-  cameras.back = cameras.overhead;
+  if (!LOCK_RAIL_OVERHEAD_FRAME) {
+    cameras.front = createShortRailUnit(-1);
+  }
+  cameras.back = createShortRailUnit(1);
 
   return { group, cameras, slideLimit, cameraHeight, defaultFocus };
 }
@@ -17893,8 +18035,11 @@ const powerRef = useRef(hud.power);
             }
           };
           const useBack = LOCK_RAIL_OVERHEAD_FRAME ? true : railDir >= 0;
-          applyPreset(rig.cameras.overhead ?? rig.cameras.back, useBack ? 1 : -1);
-          rig.activeRail = 'back';
+          applyPreset(useBack ? rig.cameras.back : rig.cameras.front, useBack ? 1 : -1);
+          if (!LOCK_RAIL_OVERHEAD_FRAME) {
+            applyPreset(useBack ? rig.cameras.front : rig.cameras.back, useBack ? -1 : 1);
+          }
+          rig.activeRail = useBack ? 'back' : 'front';
         };
 
         const resolveReplayTopViewCamera = ({
@@ -17966,9 +18111,11 @@ const powerRef = useRef(hud.power);
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
           const activeRail =
-            rig.cameras.overhead ??
-            rig.cameras.back ??
-            null;
+            rig.activeRail === 'front'
+              ? rig.cameras.front
+              : rig.activeRail === 'back'
+                ? rig.cameras.back
+                : rig.cameras.back ?? rig.cameras.front;
           const head = activeRail?.head ?? null;
           if (!head) return null;
           const position = head.getWorldPosition(new THREE.Vector3());


### PR DESCRIPTION
### Motivation

- Restore the Pool Royale broadcast and replay camera selection to the behavior that was active at ~5pm while keeping the pocket-camera flow and currently added pocket cameras unchanged.

### Description

- Reintroduced the short-rail front/back broadcast camera unit and its construction by adding `SHOW_SHORT_RAIL_TRIPODS` and `createShortRailUnit`, with optional tripod visuals and related materials/geometry.
- Wired `cameras.front` and `cameras.back` again (conditioned on `LOCK_RAIL_OVERHEAD_FRAME`) so broadcast presets apply to both rails and `rig.activeRail` is set from the front/back selection.
- Restored replay/broadcast resolution logic to choose the correct rail for replay framing by using `rig.activeRail` when resolving the rail-overhead replay camera.
- Limited changes to `webapp/src/pages/Games/PoolRoyale.jsx` so pocket-camera behavior already present in the build is preserved and only broadcast/replay camera wiring was reverted.

### Testing

- Ran `git diff --check` and it returned no whitespace/patch errors (success). 
- Ran `npm run build` in the `webapp` directory and the Vite production build completed successfully (non-blocking chunk warnings only). 
- Started the dev server with `npm run dev` and executed a Playwright script to load the app at the dev port and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920a8092f4832985b2f04a3d1d3aa9)