### PR TITLE
Improve Pool Royale mapping & aiming precision, enforce break dice flow, and fix break-scratch rule

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -59,7 +59,7 @@ export class AmericanBilliards {
       reason = 'wrong first contact'
     }
 
-    if (!wasBreakShot && !foul && (pottedList.includes(0) || shot.cueOffTable)) {
+    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
       foul = true
       reason = 'scratch'
     }

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -43,7 +43,7 @@ test('legal break pot keeps table open until post-break shot', () => {
 })
 
 
-test('break scratch does not foul and hands turn over with no ball in hand', () => {
+test('break scratch is a foul and gives opponent ball in hand', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({
     contactOrder: [1],
@@ -51,10 +51,10 @@ test('break scratch does not foul and hands turn over with no ball in hand', () 
     cueOffTable: false
   })
 
-  assert.equal(res.foul, false)
-  assert.equal(res.reason, undefined)
+  assert.equal(res.foul, true)
+  assert.equal(res.reason, 'scratch')
   assert.equal(res.nextPlayer, 'B')
-  assert.equal(res.ballInHandNext, false)
+  assert.equal(res.ballInHandNext, true)
   assert.equal(game.state.currentPlayer, 'B')
   assert.equal(game.state.breakInProgress, false)
   assert.equal(game.state.assignments.A, null)


### PR DESCRIPTION
### Motivation
- Make cushion/jaw/pocket collision boundaries visible so balls leaving the play area can be diagnosed visually.
- Ensure the match cannot be played before the break dice result is resolved so the break order is deterministic and UI/shooting is gated.
- Improve aiming/AI precision so first-contact and cushion interactions are more accurate and avoid false foul/aim warnings around breaks and pocket jaws.
- Align rule behavior so cue-ball scratches are handled consistently (including on break) to avoid ambiguous outcomes.

### Description
- Enabled the table mapping overlay for field, cushions, jaws, and pockets by updating `TABLE_MAPPING_VISUALS` in `webapp/src/pages/Games/PoolRoyale.jsx` so mapping lines are rendered in-game. (`field`, `cushions`, `jaws`, `pockets` set to `true`).
- Reworked first-contact/rail detection in the aiming prediction by testing the aim ray against the real `CUSHION_SEGMENTS` (ray/segment intersection) with a ball-radius offset, replacing the previous axis-aligned rail-limit checks in `calcTarget` in `webapp/src/pages/Games/PoolRoyale.jsx` to improve precision around jaws and cutouts.
- Enforced break-dice sequencing in the UI and input paths by adding `breakRollState` / `breakRollStateRef` checks: the shot slider locks while the break-roll is pending and `fire()` is blocked until `breakRollState === 'done'`, preventing shots before the dice resolution (changes in `PoolRoyale.jsx`).
- Refined aiming-legality coloring to treat break/open-table contexts appropriately and to recognize numeric ball ids as group targets (mapping `BALL_n` → `SOLID`/`STRIPE`/`BLACK`) so the aim guide no longer incorrectly flags legal break/open targets as wrong during previews (`PoolRoyale.jsx`).
- Updated American rules in `lib/americanBilliards.js` so a cue-ball pot (scratch) is treated as a foul even on the break and adjusted the unit test `test/americanBilliards.test.js` to reflect the expected foul/ball-in-hand outcome.

### Testing
- Ran unit tests with `npm test -- --runInBand test/americanBilliards.test.js test/poolRoyaleRules.test.ts` and observed both suites pass (2 suites, 10 tests) — PASS.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to verify rendering and captured a screenshot of the mapping overlay via a headless browser run (used for visual verification) — server started and screenshot produced.
- No test failures were introduced by these changes; automated test suites mentioned above passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992aaefb02c832980a05f3352ab5481)