### PR TITLE
Add Table Tennis Royal game, lobby, and store integration

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -41,6 +41,8 @@ const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal
 const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import TableTennisRoyal from './pages/Games/TableTennisRoyal.tsx';
+import TableTennisRoyalLobby from './pages/Games/TableTennisRoyalLobby.jsx';
 import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 
@@ -144,6 +146,11 @@ export default function App() {
               element={<PoolRoyaleLobby />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/tabletennisroyal/lobby"
+              element={<TableTennisRoyalLobby />}
+            />
+            <Route path="/games/tabletennisroyal" element={<TableTennisRoyal />} />
             <Route
               path="/games/snookerroyale/lobby"
               element={<SnookerRoyalLobby />}

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -15,7 +15,7 @@ function getGameFromTableId(id) {
       'snake',
       'goalrush',
       'poolroyale',
-      'poolroyale',
+      'tabletennisroyal',
     ].includes(prefix)
   )
     return prefix;
@@ -177,6 +177,11 @@ export default function PlayerInvitePopup({
                   id: 'poolroyale',
                   src: '/assets/icons/pool-royale.svg',
                   alt: 'Pool Royale',
+                },
+                {
+                  id: 'tabletennisroyal',
+                  src: '/assets/icons/pool-royale.svg',
+                  alt: 'Table Tennis Royal',
                 },
                 {
                   id: 'snookerroyale',

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -14,6 +14,7 @@ export const gameThumbnails = {
   texasholdem: '/assets/icons/Texas%20holdem%20poker%20game%20logo.png',
   'domino-royal': '/assets/icons/Domino%20battle%20Royal%20logo.png',
   poolroyale: '/assets/icons/Pool%20Royal%20game%20logo.png',
+  tabletennisroyal: '/assets/icons/pool-royale.svg',
   snookerroyale: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
   goalrush: '/assets/icons/Goal%20rush%20logo.png',
   airhockey: '/assets/icons/Air%20hockey%20game%20logo.png',
@@ -51,6 +52,17 @@ export const lobbyOptionIcons = {
     'mode-online': 'lobby/pool-royale/mode-online.webp'
   },
   poolroyale: {
+    'type-regular': 'lobby/pool-royale/type-regular.webp',
+    'type-tournament': 'lobby/pool-royale/type-tournament.webp',
+    'mode-ai': 'lobby/pool-royale/mode-ai.webp',
+    'mode-online': 'lobby/pool-royale/mode-online.webp',
+    'variant-uk': '/assets/icons/8ballrack.png',
+    'variant-american': '/assets/icons/American%20Billiards%20.png',
+    'variant-9ball': '/assets/icons/9ballrack.png',
+    'ball-uk': '/assets/icons/8ballrack.png',
+    'ball-american': '/assets/icons/American%20Billiards%20.png'
+  },
+  tabletennisroyal: {
     'type-regular': 'lobby/pool-royale/type-regular.webp',
     'type-tournament': 'lobby/pool-royale/type-tournament.webp',
     'mode-ai': 'lobby/pool-royale/mode-ai.webp',
@@ -145,6 +157,11 @@ export const lobbyOptionIcons = {
 
 export const variantThumbnails = {
   poolroyale: {
+    uk: '/assets/icons/8ballrack.png',
+    american: '/assets/icons/American%20Billiards%20.png',
+    '9ball': '/assets/icons/9ballrack.png'
+  },
+  tabletennisroyal: {
     uk: '/assets/icons/8ballrack.png',
     american: '/assets/icons/American%20Billiards%20.png',
     '9ball': '/assets/icons/9ballrack.png'

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -13,6 +13,14 @@ const gamesCatalog = [
     image: '/assets/icons/Domino%20battle%20Royal%20logo.png',
     description: 'Classic domino strategy with modern 3D flair.'
   },
+
+  {
+    name: 'Table Tennis Royal',
+    route: '/games/tabletennisroyal/lobby',
+    slug: 'tabletennisroyal',
+    image: '/assets/icons/pool-royale.svg',
+    description: 'Fast 3D table tennis rallies with royal custom arenas.'
+  },
   {
     name: 'Pool Royale',
     route: '/games/poolroyale/lobby',

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -1,0 +1,840 @@
+import React, { Component, useCallback, useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+
+type ErrState = { error: unknown | null; message: string; stack: string };
+class ErrorBoundary extends Component<{ children?: React.ReactNode }, ErrState> {
+  constructor(p: any) {
+    super(p);
+    this.state = { error: null, message: '', stack: '' };
+  }
+  static getDerivedStateFromError(error: unknown): ErrState {
+    const e: any = error;
+    return {
+      error: error ?? null,
+      message: typeof e?.message === 'string' ? e.message : String(error ?? 'Unknown error'),
+      stack: typeof e?.stack === 'string' ? e.stack : '(no stack)',
+    };
+  }
+  render() {
+    if (!this.state.error) return (this.props.children as React.ReactNode) || null;
+    return (
+      <div style={{ inset: 0, position: 'absolute', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#111' }}>
+        <div style={{ color: '#fff', maxWidth: 760, padding: 16 }}>
+          <div style={{ fontWeight: 700, marginBottom: 8 }}>React render error</div>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: 12, background: '#222', padding: 12, borderRadius: 8 }}>{this.state.message + '\n\n' + this.state.stack}</pre>
+        </div>
+      </div>
+    );
+  }
+}
+
+type Side = 'player' | 'ai';
+type Difficulty = 'easy' | 'medium' | 'hard';
+type Phase = 'ready' | 'serving' | 'rally' | 'gameOver';
+type Call = '' | 'SERVE' | 'FAULT' | 'LET' | 'NET' | 'OUT' | 'DOUBLE' | 'MISS';
+
+type Score = { player: number; ai: number; server: Side; pointsPlayed: number };
+type Gesture = { active: boolean; x: number; y: number; lastX: number; lastY: number; vx: number; vy: number; lastT: number };
+type BallState = {
+  p: THREE.Vector3;
+  v: THREE.Vector3;
+  spin: THREE.Vector3;
+  served: boolean;
+  lastBounceSide: Side | null;
+  bouncesOnSide: number;
+  serveBounce1: Side | null;
+  serveBounce2: Side | null;
+  netTouchedThisRally: boolean;
+};
+
+const M2U = 2.6;
+const U = (m: number) => m * M2U;
+const TIME_SCALE = 0.62;
+
+const TABLE = { L: U(2.74), W: U(1.525), H: U(0.76), THICK: U(0.03), APRON_H: U(0.10), LEG_H: U(0.68) } as const;
+const NET = { H: U(0.1525), T: U(0.02), POST_R: U(0.012), POST_H: U(0.18) } as const;
+const BALL = { R: U(0.02) } as const;
+const PADDLE = { bladeW: U(0.15), bladeH: U(0.02), bladeD: U(0.19), handleW: U(0.032), handleD: U(0.11), y: TABLE.H + U(0.12), reach: U(0.18) } as const;
+
+const PHYS = {
+  g: -9.81 * M2U,
+  dtClamp: 1 / 50,
+  airDrag: 0.9996,
+  tableRest: 0.82,
+  netRest: 0.18,
+  magnus: 0.00115,
+  spinDamp: 0.9978,
+  maxSpeed: U(11.0),
+} as const;
+
+const POWER = {
+  serveSpeedBase: U(3.0),
+  serveSpeedMax: U(4.1),
+  serveUpMin: U(1.05),
+  hitSpeedBase: U(2.35),
+  hitSpeedMax: U(7.6),
+  targetZPad: U(0.45),
+  swipeXToSpin: 0.00062,
+  swipeYToSpin: 0.00046,
+  edgeSpinK: 0.010,
+} as const;
+
+const AI = {
+  lerp: { easy: 0.10, medium: 0.15, hard: 0.19 },
+  react: { easy: 0.10, medium: 0.16, hard: 0.22 },
+  jitter: { easy: U(0.10), medium: U(0.06), hard: U(0.04) },
+  hitChance: { easy: 0.86, medium: 0.93, hard: 0.97 },
+  serveDelayMs: { easy: 900, medium: 750, hard: 620 },
+  sideBias: { easy: 0.60, medium: 0.75, hard: 0.88 },
+  aimStrength: { easy: 0.55, medium: 0.75, hard: 0.95 },
+  spinStrength: { easy: 0.55, medium: 0.75, hard: 0.95 },
+  hitPowerScale: { easy: 0.72, medium: 0.78, hard: 0.84 },
+} as const;
+
+const CAM = { follow: 0.07, yBase: TABLE.H + U(0.72), zBase: TABLE.L * 0.88 } as const;
+
+const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v));
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+const sgn = (v: number) => (v >= 0 ? 1 : -1);
+
+function hasWebGL(): boolean {
+  try {
+    const c = document.createElement('canvas');
+    return !!(c.getContext('webgl') || (c.getContext as any)('experimental-webgl'));
+  } catch {
+    return false;
+  }
+}
+
+function observeResize(el: HTMLElement, cb: () => void) {
+  const anyWin: any = window as any;
+  if (typeof anyWin.ResizeObserver !== 'undefined') {
+    const ro = new anyWin.ResizeObserver(cb);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }
+  const onResize = () => cb();
+  window.addEventListener('resize', onResize);
+  return () => window.removeEventListener('resize', onResize);
+}
+
+function isGameOver(s: Score) {
+  if (s.player >= 11 || s.ai >= 11) return Math.abs(s.player - s.ai) >= 2;
+  return false;
+}
+
+function nextServer(s: Score): Side {
+  const deuce = s.player >= 10 && s.ai >= 10;
+  if (deuce) return s.pointsPlayed % 2 === 0 ? s.server : s.server === 'player' ? 'ai' : 'player';
+  return Math.floor(s.pointsPlayed / 2) % 2 === 0 ? 'player' : 'ai';
+}
+
+function sideOfZ(z: number): Side {
+  return z >= 0 ? 'player' : 'ai';
+}
+
+function swipeMag(g: Gesture) {
+  const sx = Math.abs(g.vx) * 1000;
+  const sy = Math.abs(g.vy) * 1000;
+  return Math.hypot(sx, sy);
+}
+
+function serveSpeedFromSwipe(g: Gesture) {
+  const t = clamp(swipeMag(g) / 2.6, 0, 1);
+  return lerp(POWER.serveSpeedBase, POWER.serveSpeedMax, t);
+}
+
+function hitSpeedFromSwipe(g: Gesture) {
+  const t = clamp(swipeMag(g) / 2.2, 0, 1);
+  return lerp(POWER.hitSpeedBase, POWER.hitSpeedMax, t);
+}
+
+function useTouch(rootRef: React.RefObject<HTMLDivElement>) {
+  const g = useRef<Gesture>({ active: false, x: 0.5, y: 0.72, lastX: 0.5, lastY: 0.72, vx: 0, vy: 0, lastT: 0 });
+  const update = useCallback((clientX: number, clientY: number) => {
+    const el = rootRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const nx = clamp((clientX - r.left) / r.width, 0, 1);
+    const ny = clamp((clientY - r.top) / r.height, 0, 1);
+    const t = performance.now();
+    const dt = Math.max(1, t - g.current.lastT);
+    const vx = (nx - g.current.lastX) / dt;
+    const vy = (ny - g.current.lastY) / dt;
+    g.current.vx = lerp(g.current.vx, vx, 0.72);
+    g.current.vy = lerp(g.current.vy, vy, 0.72);
+    g.current.lastX = nx;
+    g.current.lastY = ny;
+    g.current.lastT = t;
+    g.current.x = nx;
+    g.current.y = ny;
+  }, [rootRef]);
+
+  const onDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    g.current.active = true;
+    g.current.lastT = performance.now();
+    update(e.clientX, e.clientY);
+  }, [update]);
+
+  const onMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!g.current.active) return;
+    update(e.clientX, e.clientY);
+  }, [update]);
+
+  const onUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    try { (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId); } catch {}
+    g.current.active = false;
+    g.current.vx *= 0.6;
+    g.current.vy *= 0.6;
+  }, []);
+
+  return { g, onDown, onMove, onUp };
+}
+
+const PADDLE_SCALE = 1.18;
+const BASE_HEAD_RADIUS = 0.4049601584672928;
+
+function makeWeaveTex(w = 256, h = 256) {
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext('2d');
+  if (!ctx) {
+    const tex = new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1);
+    tex.needsUpdate = true;
+    return tex;
+  }
+  ctx.fillStyle = '#e9e9e9';
+  ctx.fillRect(0, 0, w, h);
+  ctx.fillStyle = '#dcdcdc';
+  for (let y = 0; y < h; y += 8) for (let x = 0; x < w; x += 8) if (((x + y) / 8) % 2 < 1) ctx.fillRect(x, y, 8, 8);
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(6, 2);
+  return tex;
+}
+
+function makeNetAlpha(w = 512, h = 256, pitch = 10) {
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext('2d');
+  if (!ctx) {
+    const tex = new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1);
+    tex.needsUpdate = true;
+    return tex;
+  }
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, w, h);
+  ctx.globalCompositeOperation = 'destination-out';
+  ctx.fillStyle = '#fff';
+  for (let y = 3; y < h; y += pitch) for (let x = 3; x < w; x += pitch) ctx.fillRect(x, y, pitch - 6, pitch - 6);
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(6, 2);
+  return tex;
+}
+
+function createMaterials() {
+  return {
+    whiteMat: new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.45, metalness: 0.0 }),
+    tableMat: new THREE.MeshStandardMaterial({ color: 0x0a2d57, roughness: 0.82, metalness: 0.05 }),
+    apronMat: new THREE.MeshStandardMaterial({ color: 0x10204d, roughness: 0.82, metalness: 0.05 }),
+    steelMat: new THREE.MeshStandardMaterial({ color: 0x9aa3ad, roughness: 0.3, metalness: 0.8 }),
+    wheelMat: new THREE.MeshStandardMaterial({ color: 0x222222, roughness: 0.9, metalness: 0.1 }),
+    woodMat: new THREE.MeshStandardMaterial({ color: 0x8d5622, roughness: 0.6, metalness: 0.05 }),
+    netMat: new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.9, metalness: 0.0, alphaMap: makeNetAlpha(), map: makeWeaveTex(), transparent: true, side: THREE.DoubleSide }),
+  };
+}
+
+function buildTableLikeSnippet() {
+  const m = createMaterials();
+  const g = new THREE.Group();
+  const top = new THREE.Mesh(new THREE.BoxGeometry(TABLE.W, TABLE.THICK, TABLE.L), m.tableMat);
+  top.position.set(0, TABLE.H - TABLE.THICK / 2, 0);
+  top.castShadow = true;
+  top.receiveShadow = true;
+  g.add(top);
+
+  const apronDepth = U(0.025);
+  const apronGeoF = new THREE.BoxGeometry(TABLE.W + U(0.04), apronDepth, U(0.02));
+  const apronFront = new THREE.Mesh(apronGeoF, m.apronMat);
+  apronFront.position.set(0, TABLE.H - TABLE.THICK - apronDepth / 2, TABLE.L / 2 + U(0.01));
+  const apronBack = apronFront.clone();
+  apronBack.position.z = -TABLE.L / 2 - U(0.01);
+  g.add(apronFront, apronBack);
+
+  const sideApronGeo = new THREE.BoxGeometry(U(0.02), apronDepth, TABLE.L + U(0.04));
+  const apronLeft = new THREE.Mesh(sideApronGeo, m.apronMat);
+  apronLeft.position.set(-TABLE.W / 2 - U(0.01), TABLE.H - TABLE.THICK - apronDepth / 2, 0);
+  const apronRight = apronLeft.clone();
+  apronRight.position.x = TABLE.W / 2 + U(0.01);
+  g.add(apronLeft, apronRight);
+
+  const borderT = U(0.018);
+  const lineH = U(0.0025);
+  const lineY = TABLE.H + lineH / 2;
+  const mkLine = (w: number, h: number, d: number, x: number, y: number, z: number) => {
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), m.whiteMat);
+    mesh.position.set(x, y, z);
+    g.add(mesh);
+  };
+  mkLine(borderT, lineH, TABLE.L, -TABLE.W / 2 + borderT / 2, lineY, 0);
+  mkLine(borderT, lineH, TABLE.L, TABLE.W / 2 - borderT / 2, lineY, 0);
+  mkLine(TABLE.W, lineH, borderT, 0, lineY, TABLE.L / 2 - borderT / 2);
+  mkLine(TABLE.W, lineH, borderT, 0, lineY, -TABLE.L / 2 + borderT / 2);
+  mkLine(borderT, lineH, TABLE.L - borderT * 2, 0, lineY, 0);
+
+  const netGroup = new THREE.Group();
+  g.add(netGroup);
+  const postR = U(0.012);
+  const netWidth = TABLE.W + postR * 1.2;
+  const netPlane = new THREE.Mesh(new THREE.PlaneGeometry(netWidth, NET.H), m.netMat);
+  netPlane.position.set(0, TABLE.H + NET.H / 2, 0);
+  netGroup.add(netPlane);
+
+  const bandT = U(0.014);
+  const bandTop = new THREE.Mesh(new THREE.BoxGeometry(netWidth, bandT, U(0.004)), m.whiteMat);
+  bandTop.position.set(0, TABLE.H + NET.H - bandT / 2, 0);
+  const bandBottom = bandTop.clone();
+  bandBottom.position.set(0, TABLE.H + bandT / 2, 0);
+  netGroup.add(bandTop, bandBottom);
+
+  const postH = NET.H + U(0.08);
+  const postGeo = new THREE.CylinderGeometry(postR, postR, postH, 28);
+  const postRight = new THREE.Mesh(postGeo, m.steelMat);
+  postRight.position.set(TABLE.W / 2 + postR * 0.6, TABLE.H + postH / 2, 0);
+  const postLeft = postRight.clone();
+  postLeft.position.x = -TABLE.W / 2 - postR * 0.6;
+  g.add(postRight, postLeft);
+
+  const clampGeo = new THREE.BoxGeometry(U(0.06), U(0.025), U(0.05));
+  const clampRight = new THREE.Mesh(clampGeo, m.steelMat);
+  clampRight.position.set(TABLE.W / 2 + U(0.03), TABLE.H + U(0.03), 0);
+  const clampLeft = clampRight.clone();
+  clampLeft.position.x = -TABLE.W / 2 - U(0.03);
+  g.add(clampRight, clampLeft);
+
+  const tubeR = U(0.02);
+  const wheelRadius = U(0.035);
+  const wheelThickness = U(0.02);
+  const legClearance = U(0.004);
+  const legH = TABLE.H - TABLE.THICK - legClearance - wheelRadius;
+  const offsetZ = TABLE.L * 0.36;
+  const offsetX = TABLE.W * 0.42;
+
+  const frame = (zSign: number) => {
+    const G = new THREE.Group();
+    const upGeo = new THREE.CylinderGeometry(tubeR, tubeR, legH, 26);
+    const upL = new THREE.Mesh(upGeo, m.steelMat);
+    const upR = new THREE.Mesh(upGeo, m.steelMat);
+    const cross = new THREE.Mesh(new THREE.CylinderGeometry(tubeR, tubeR, offsetX * 2, 26), m.steelMat);
+    upL.position.set(-offsetX, wheelRadius + legH / 2, zSign * offsetZ);
+    upR.position.set(offsetX, wheelRadius + legH / 2, zSign * offsetZ);
+    cross.rotation.z = Math.PI / 2;
+    cross.position.set(0, wheelRadius + U(0.11), zSign * offsetZ);
+    G.add(upL, upR, cross);
+
+    const wheelGeo = new THREE.CylinderGeometry(wheelRadius, wheelRadius, wheelThickness, 24);
+    const wL = new THREE.Mesh(wheelGeo, m.wheelMat);
+    const wR = wL.clone();
+    wL.rotation.x = Math.PI / 2;
+    wR.rotation.x = Math.PI / 2;
+    wL.position.set(-offsetX, wheelRadius, zSign * offsetZ);
+    wR.position.set(offsetX, wheelRadius, zSign * offsetZ);
+    G.add(wL, wR);
+    g.add(G);
+  };
+  frame(-1);
+  frame(1);
+
+  return { group: g, materials: m };
+}
+
+function buildCurvedPaddle(frontHex: number, backHex: number, woodMat: THREE.Material) {
+  const group = new THREE.Group();
+  const headRadius = BASE_HEAD_RADIUS;
+  const sh = new THREE.Shape();
+  sh.absellipse(0, 0, headRadius, headRadius * 0.92, 0, Math.PI * 2, false, 0);
+  const headFrontMat = new THREE.MeshStandardMaterial({ color: frontHex, roughness: 0.7, metalness: 0.05 });
+  const headBackMat = new THREE.MeshStandardMaterial({ color: backHex, roughness: 0.7, metalness: 0.05 });
+  const edgeMat = new THREE.MeshStandardMaterial({ color: 0x222222, roughness: 0.8, metalness: 0.2 });
+
+  const headFront = new THREE.Mesh(new THREE.ExtrudeGeometry(sh, { depth: 0.006, bevelEnabled: true, bevelSize: 0.004, bevelThickness: 0.003, curveSegments: 64, steps: 1 }), headFrontMat);
+  headFront.rotation.x = Math.PI / 2;
+  headFront.position.y = 0.001;
+
+  const headBack = headFront.clone();
+  headBack.material = headBackMat;
+  headBack.position.y = -0.005;
+
+  const headEdge = new THREE.Mesh(new THREE.TorusGeometry(headRadius, 0.004, 16, 96), edgeMat);
+  headEdge.rotation.x = Math.PI / 2;
+
+  const HANDLE_DEPTH = 0.028;
+  const s = new THREE.Shape();
+  const hw = 0.11;
+  const hh = 0.24;
+  const rr = 0.06;
+  s.moveTo(-hw + rr, -hh);
+  s.lineTo(hw - rr, -hh);
+  s.quadraticCurveTo(hw, -hh, hw, -hh + rr);
+  s.lineTo(hw, hh - rr);
+  s.quadraticCurveTo(hw, hh, hw - rr, hh);
+  s.lineTo(-hw + rr, hh);
+  s.quadraticCurveTo(-hw, hh, -hw, hh - rr);
+  s.lineTo(-hw, -hh + rr);
+  s.quadraticCurveTo(-hw, -hh, -hw + rr, -hh);
+
+  const handleGeo = new THREE.ExtrudeGeometry(s, { depth: HANDLE_DEPTH, bevelEnabled: true, bevelSize: 0.008, bevelThickness: 0.008, curveSegments: 64, steps: 1 });
+  handleGeo.rotateX(Math.PI / 2);
+  const handle = new THREE.Mesh(handleGeo, woodMat);
+  handle.position.set(0, -0.28, 0.01);
+
+  group.add(headFront, headBack, headEdge, handle);
+
+  const desiredHeadRadiusWorld = PADDLE.bladeW * 0.62;
+  const scale = (desiredHeadRadiusWorld / headRadius) * PADDLE_SCALE;
+  group.scale.setScalar(scale);
+  return group;
+}
+
+export default function TableTennisRoyal() {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const { g, onDown, onMove, onUp } = useTouch(rootRef);
+
+  const [difficulty, setDifficulty] = useState<Difficulty>('medium');
+  const difficultyRef = useRef<Difficulty>('medium');
+  useEffect(() => {
+    difficultyRef.current = difficulty;
+  }, [difficulty]);
+
+  const [ui, setUi] = useState<{ phase: Phase; score: Score; call: Call; hint: string }>({ phase: 'ready', score: { player: 0, ai: 0, server: 'player', pointsPlayed: 0 }, call: '', hint: 'Tap to serve' });
+  const [boot, setBoot] = useState<string>('Booting…');
+  const [fatal, setFatal] = useState<string>('');
+  const aiServeAt = useRef<number>(0);
+
+  const sim = useRef<{ phase: Phase; score: Score; ball: BallState; call: Call; hint: string; callCooldownUntil: number }>({
+    phase: 'ready',
+    score: { player: 0, ai: 0, server: 'player', pointsPlayed: 0 },
+    call: '',
+    hint: 'Tap to serve',
+    callCooldownUntil: 0,
+    ball: { p: new THREE.Vector3(0, TABLE.H + U(0.23), TABLE.L * 0.25), v: new THREE.Vector3(), spin: new THREE.Vector3(), served: false, lastBounceSide: null, bouncesOnSide: 0, serveBounce1: null, serveBounce2: null, netTouchedThisRally: false },
+  });
+
+  const three = useRef<{ renderer: THREE.WebGLRenderer; scene: THREE.Scene; camera: THREE.PerspectiveCamera; clock: THREE.Clock; raf: number; table: THREE.Group; paddleP: THREE.Group; paddleA: THREE.Group; ballM: THREE.Mesh } | null>(null);
+
+  const setCallRef = useCallback((c: Call) => {
+    const now = performance.now();
+    if (now < sim.current.callCooldownUntil && c === 'NET') return;
+    sim.current.call = c;
+    if (c === 'NET') sim.current.callCooldownUntil = now + 250;
+  }, []);
+
+  const syncUiFromSim = useCallback(() => {
+    const s = sim.current;
+    setUi({ phase: s.phase, score: { ...s.score }, call: s.call, hint: s.hint });
+  }, []);
+
+  useEffect(() => {
+    const id = window.setInterval(syncUiFromSim, 100);
+    return () => window.clearInterval(id);
+  }, [syncUiFromSim]);
+
+  const placeForServe = useCallback((srv: Side) => {
+    const s = sim.current;
+    const b = s.ball;
+    const z = srv === 'player' ? TABLE.L * 0.25 : -TABLE.L * 0.25;
+    b.p.set(0, TABLE.H + U(0.23), z);
+    b.v.set(0, 0, 0);
+    b.spin.set(0, 0, 0);
+    b.served = false;
+    b.lastBounceSide = null;
+    b.bouncesOnSide = 0;
+    b.serveBounce1 = null;
+    b.serveBounce2 = null;
+    b.netTouchedThisRally = false;
+    s.phase = 'ready';
+    s.call = '';
+    s.hint = srv === 'player' ? 'Tap to serve' : 'AI serving…';
+
+    const t = three.current;
+    if (t) {
+      t.ballM.position.copy(b.p);
+      t.paddleP.position.set(0, PADDLE.y, TABLE.L * 0.25);
+      t.paddleA.position.set(0, PADDLE.y, -TABLE.L * 0.25);
+    }
+    aiServeAt.current = performance.now() + AI.serveDelayMs[difficultyRef.current];
+  }, []);
+
+  const awardPoint = useCallback((winner: Side, call: Call) => {
+    const s = sim.current;
+    if (winner === 'player') s.score.player += 1;
+    else s.score.ai += 1;
+    s.score.pointsPlayed += 1;
+    s.call = call;
+    if (isGameOver(s.score)) {
+      s.phase = 'gameOver';
+      s.hint = winner === 'player' ? 'You win!' : 'AI wins';
+      return;
+    }
+    s.score.server = nextServer(s.score);
+    placeForServe(s.score.server);
+  }, [placeForServe]);
+
+  const serve = useCallback(() => {
+    const s = sim.current;
+    const b = s.ball;
+    if (s.phase !== 'ready' || s.score.server !== 'player') return;
+    s.phase = 'serving';
+    s.call = 'SERVE';
+    s.hint = '';
+
+    const targetX = lerp(-TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18), g.current.lastX);
+    const targetZ = -TABLE.L / 2 + POWER.targetZPad;
+    const speed = serveSpeedFromSwipe(g.current);
+    const tmpTarget = new THREE.Vector3(targetX, TABLE.H + U(0.14), targetZ);
+    const tmpDir = new THREE.Vector3().subVectors(tmpTarget, b.p);
+    if (tmpDir.lengthSq() > 1e-9) {
+      tmpDir.normalize();
+      b.v.copy(tmpDir.multiplyScalar(speed));
+      b.v.y = Math.max(b.v.y, POWER.serveUpMin);
+    }
+
+    const swipeX = g.current.vx * 1000;
+    const swipeY = g.current.vy * 1000;
+    b.spin.set(-swipeY * POWER.swipeYToSpin, swipeX * POWER.swipeXToSpin, 0);
+    b.served = true;
+  }, [g]);
+
+  const reset = useCallback(() => {
+    sim.current.score = { player: 0, ai: 0, server: 'player', pointsPlayed: 0 };
+    sim.current.phase = 'ready';
+    sim.current.call = '';
+    sim.current.hint = 'Tap to serve';
+    placeForServe('player');
+  }, [placeForServe]);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const safeFail = (msg: string, err?: unknown) => {
+      const extra = err ? `\n${String((err as any)?.stack ?? (err as any)?.message ?? err)}` : '';
+      setFatal(msg + extra);
+    };
+
+    try {
+      setBoot('Checking WebGL…');
+      if (!hasWebGL()) return safeFail('WebGL is not available. Enable hardware acceleration or try another browser.');
+
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      renderer.domElement.style.position = 'absolute';
+      renderer.domElement.style.inset = '0';
+      renderer.domElement.style.width = '100%';
+      renderer.domElement.style.height = '100%';
+      renderer.domElement.style.display = 'block';
+
+      const scene = new THREE.Scene();
+      scene.background = new THREE.Color('#070b1a');
+      const camera = new THREE.PerspectiveCamera(55, 1, 0.01, U(300));
+      scene.add(new THREE.AmbientLight(0xffffff, 0.55));
+      const key = new THREE.DirectionalLight(0xffffff, 1.0);
+      key.position.set(U(2.2), U(4.2), U(2.2));
+      key.castShadow = true;
+      key.shadow.mapSize.set(2048, 2048);
+      scene.add(key);
+
+      const floor = new THREE.Mesh(new THREE.PlaneGeometry(U(30), U(30)), new THREE.MeshStandardMaterial({ color: 0x0f1222, roughness: 0.95, metalness: 0.05 }));
+      floor.rotation.x = -Math.PI / 2;
+      floor.receiveShadow = true;
+      scene.add(floor);
+
+      const { group: table, materials } = buildTableLikeSnippet();
+      scene.add(table);
+
+      const playerPaddle = new THREE.Group();
+      const pFancy = buildCurvedPaddle(0xff4d6d, 0x333333, materials.woodMat);
+      const pWrist = new THREE.Group();
+      pWrist.rotation.set(THREE.MathUtils.degToRad(-18), 0, THREE.MathUtils.degToRad(12));
+      pWrist.add(pFancy);
+      playerPaddle.add(pWrist);
+      playerPaddle.position.set(0, PADDLE.y, TABLE.L * 0.25);
+      table.add(playerPaddle);
+
+      const aiPaddle = new THREE.Group();
+      const aFancy = buildCurvedPaddle(0x49dcb1, 0x333333, materials.woodMat);
+      const aWrist = new THREE.Group();
+      aWrist.rotation.set(THREE.MathUtils.degToRad(-22), 0, THREE.MathUtils.degToRad(-12));
+      aWrist.add(aFancy);
+      aiPaddle.add(aWrist);
+      aiPaddle.position.set(0, PADDLE.y, -TABLE.L * 0.25);
+      table.add(aiPaddle);
+
+      const ballM = new THREE.Mesh(new THREE.SphereGeometry(BALL.R, 26, 26), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4, metalness: 0.0 }));
+      ballM.castShadow = true;
+      ballM.position.copy(sim.current.ball.p);
+      table.add(ballM);
+
+      const clock = new THREE.Clock();
+      mount.style.position = 'absolute';
+      mount.style.inset = '0';
+      mount.appendChild(renderer.domElement);
+
+      const resize = () => {
+        const w = mount.clientWidth || 1;
+        const h = mount.clientHeight || 1;
+        renderer.setSize(w, h, false);
+        camera.aspect = w / h;
+        camera.updateProjectionMatrix();
+      };
+      const unobs = observeResize(mount, resize);
+      resize();
+
+      three.current = { renderer, scene, camera, clock, raf: 0, table, paddleP: playerPaddle, paddleA: aiPaddle, ballM };
+      placeForServe(sim.current.score.server);
+      setBoot('');
+
+      const tmpTarget = new THREE.Vector3();
+      const tmpDir = new THREE.Vector3();
+      const tmpCross = new THREE.Vector3();
+
+      const tick = () => {
+        try {
+          const t = three.current;
+          if (!t) return;
+          const dt = Math.min(t.clock.getDelta(), PHYS.dtClamp) * TIME_SCALE;
+          const s = sim.current;
+          const b = s.ball;
+          const diff = difficultyRef.current;
+
+          const px = lerp(-TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18), g.current.x);
+          const pz = lerp(U(0.12), TABLE.L / 2 - U(0.22), g.current.y);
+          t.paddleP.position.x = lerp(t.paddleP.position.x, px, 0.30);
+          t.paddleP.position.z = lerp(t.paddleP.position.z, pz, 0.30);
+          t.paddleP.position.y = PADDLE.y;
+
+          const predX = b.p.x + b.v.x * AI.react[diff];
+          const wantX = b.p.z < 0 ? predX : 0;
+          const jitter = (Math.random() * 2 - 1) * AI.jitter[diff];
+          t.paddleA.position.x = lerp(t.paddleA.position.x, clamp(wantX + jitter, -TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18)), AI.lerp[diff]);
+          t.paddleA.position.z = lerp(t.paddleA.position.z, -TABLE.L / 2 + U(0.22), AI.lerp[diff] * 0.92);
+          t.paddleA.position.y = PADDLE.y;
+
+          const targetX = t.paddleP.position.x * 0.20 + b.p.x * 0.06;
+          const targetY = CAM.yBase + b.p.y * 0.08;
+          const targetZ = CAM.zBase + b.p.z * 0.06;
+          t.camera.position.x = lerp(t.camera.position.x, targetX, CAM.follow);
+          t.camera.position.y = lerp(t.camera.position.y, targetY, CAM.follow);
+          t.camera.position.z = lerp(t.camera.position.z, targetZ, CAM.follow);
+          t.camera.lookAt(b.p.x * 0.10, TABLE.H + U(0.22) + b.p.y * 0.03, -TABLE.L * 0.06);
+
+          if (s.phase === 'ready' && s.score.server === 'ai' && !b.served && performance.now() >= aiServeAt.current) {
+            s.phase = 'serving';
+            s.call = 'SERVE';
+            s.hint = '';
+            const wide = Math.random() < AI.sideBias[diff];
+            const mag = wide ? 0.75 : 0.45;
+            const targetXAi = clamp((Math.random() * 2 - 1) * (TABLE.W * mag), -TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18));
+            tmpTarget.set(targetXAi, TABLE.H + U(0.14), TABLE.L / 2 - POWER.targetZPad);
+            const speed = POWER.serveSpeedBase * AI.hitPowerScale[diff];
+            tmpDir.subVectors(tmpTarget, b.p);
+            if (tmpDir.lengthSq() > 1e-9) {
+              tmpDir.normalize();
+              b.v.copy(tmpDir.multiplyScalar(speed));
+              b.v.y = Math.max(b.v.y, POWER.serveUpMin);
+            }
+            b.spin.set(0, -targetXAi * 0.0010 * AI.spinStrength[diff], 0);
+            b.served = true;
+          }
+
+          if (s.phase === 'gameOver') {
+            t.renderer.render(t.scene, t.camera);
+            t.raf = requestAnimationFrame(tick);
+            return;
+          }
+
+          if (s.phase === 'ready' && !b.served) {
+            const refP = s.score.server === 'player' ? t.paddleP : t.paddleA;
+            b.p.set(refP.position.x, TABLE.H + U(0.23), refP.position.z + (s.score.server === 'player' ? -U(0.10) : U(0.10)));
+            t.ballM.position.copy(b.p);
+            t.renderer.render(t.scene, t.camera);
+            t.raf = requestAnimationFrame(tick);
+            return;
+          }
+
+          tmpCross.crossVectors(b.spin, b.v).multiplyScalar(PHYS.magnus);
+          b.v.addScaledVector(tmpCross, dt);
+          b.v.y += PHYS.g * dt;
+          b.v.multiplyScalar(PHYS.airDrag);
+          b.spin.multiplyScalar(PHYS.spinDamp);
+          if (b.v.length() > PHYS.maxSpeed) b.v.setLength(PHYS.maxSpeed);
+          b.p.addScaledVector(b.v, dt);
+
+          const inZ = Math.abs(b.p.z) <= NET.T / 2 + BALL.R;
+          const inX = Math.abs(b.p.x) <= TABLE.W / 2 + BALL.R;
+          const inY = b.p.y <= TABLE.H + NET.H + BALL.R;
+          if (inZ && inX && inY) {
+            b.netTouchedThisRally = true;
+            setCallRef('NET');
+            b.v.z = -b.v.z * PHYS.netRest;
+            b.p.z = sgn(b.p.z) * (NET.T / 2 + BALL.R + U(0.001));
+          }
+
+          const topY = TABLE.H + TABLE.THICK / 2;
+          if (b.p.y - BALL.R <= topY && Math.abs(b.p.x) <= TABLE.W / 2 && Math.abs(b.p.z) <= TABLE.L / 2 && b.v.y < 0) {
+            b.p.y = topY + BALL.R;
+            b.v.y = -b.v.y * PHYS.tableRest;
+            const side = sideOfZ(b.p.z);
+            if (b.lastBounceSide === side) b.bouncesOnSide += 1;
+            else { b.lastBounceSide = side; b.bouncesOnSide = 1; }
+
+            if (s.phase === 'serving') {
+              if (b.serveBounce1 == null) b.serveBounce1 = side;
+              else if (b.serveBounce2 == null && side !== b.serveBounce1) b.serveBounce2 = side;
+              const serverSide: Side = s.score.server;
+              const receiverSide: Side = s.score.server === 'player' ? 'ai' : 'player';
+              if (b.serveBounce1 !== serverSide) return void awardPoint(receiverSide, 'FAULT');
+              if (b.serveBounce2 === receiverSide) {
+                s.phase = 'rally';
+                if (!b.netTouchedThisRally) s.call = '';
+              }
+            }
+            if (s.phase === 'rally' && b.bouncesOnSide >= 2) return void awardPoint(side === 'player' ? 'ai' : 'player', 'DOUBLE');
+          }
+
+          const outXZ = Math.abs(b.p.x) > TABLE.W / 2 + U(0.30) || Math.abs(b.p.z) > TABLE.L / 2 + U(0.55);
+          const floorHit = b.p.y - BALL.R <= 0;
+          if (floorHit || outXZ) return void awardPoint(sideOfZ(b.p.z) === 'player' ? 'ai' : 'player', outXZ ? 'OUT' : 'MISS');
+
+          const tryHit = (pad: THREE.Object3D, who: Side) => {
+            const dx = b.p.x - pad.position.x;
+            const dz = b.p.z - pad.position.z;
+            if (Math.hypot(dx, dz) > PADDLE.reach + BALL.R || Math.abs(b.p.y - pad.position.y) > U(0.28)) return false;
+            if (who === 'ai' && Math.random() > AI.hitChance[diff]) return false;
+
+            if (who === 'player') {
+              tmpTarget.set(lerp(-TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18), g.current.x), TABLE.H + U(0.14), -TABLE.L / 2 + POWER.targetZPad);
+              const speed = hitSpeedFromSwipe(g.current);
+              tmpDir.subVectors(tmpTarget, b.p);
+              if (tmpDir.lengthSq() > 1e-9) {
+                tmpDir.normalize();
+                b.v.copy(tmpDir.multiplyScalar(speed));
+                b.v.z = -Math.abs(b.v.z);
+                b.v.y = Math.max(b.v.y, U(1.05));
+              }
+              const edge = clamp(dx / (PADDLE.bladeW * 0.5), -1, 1);
+              b.spin.x += (-g.current.vy * 1000) * POWER.swipeYToSpin;
+              b.spin.y += (g.current.vx * 1000) * POWER.swipeXToSpin + edge * POWER.edgeSpinK;
+            } else {
+              const wide = Math.random() < AI.sideBias[diff];
+              const mag = wide ? 0.75 : 0.40;
+              tmpTarget.set(clamp((Math.random() * 2 - 1) * (TABLE.W * mag), -TABLE.W / 2 + U(0.18), TABLE.W / 2 - U(0.18)), TABLE.H + U(0.14), TABLE.L / 2 - POWER.targetZPad);
+              const base = lerp(POWER.hitSpeedBase, POWER.hitSpeedMax * 0.70, AI.aimStrength[diff]) * AI.hitPowerScale[diff];
+              tmpDir.subVectors(tmpTarget, b.p);
+              if (tmpDir.lengthSq() > 1e-9) {
+                tmpDir.normalize();
+                b.v.copy(tmpDir.multiplyScalar(base));
+                b.v.z = Math.abs(b.v.z);
+                b.v.y = Math.max(b.v.y, U(1.00));
+              }
+              const edge = clamp(dx / (PADDLE.bladeW * 0.5), -1, 1);
+              const edgeSpin = edge * POWER.edgeSpinK * AI.spinStrength[diff];
+              b.spin.x += (Math.random() * 2 - 1) * U(0.10) * AI.spinStrength[diff];
+              b.spin.y += (Math.random() * 2 - 1) * U(0.14) * AI.spinStrength[diff] + edgeSpin;
+            }
+            b.lastBounceSide = null;
+            b.bouncesOnSide = 0;
+            b.netTouchedThisRally = false;
+            s.phase = 'rally';
+            s.call = '';
+            return true;
+          };
+
+          tryHit(t.paddleP, 'player');
+          tryHit(t.paddleA, 'ai');
+          t.ballM.position.copy(b.p);
+          t.renderer.render(t.scene, t.camera);
+          t.raf = requestAnimationFrame(tick);
+        } catch (e) {
+          setFatal('Runtime error:\n' + String((e as any)?.stack ?? e));
+        }
+      };
+
+      three.current.raf = requestAnimationFrame(tick);
+      return () => {
+        unobs();
+        const t = three.current;
+        if (t) {
+          cancelAnimationFrame(t.raf);
+          try { mount.removeChild(t.renderer.domElement); } catch {}
+          t.renderer.dispose();
+          t.scene.traverse((o: any) => {
+            o.geometry?.dispose?.();
+            if (Array.isArray(o.material)) o.material.forEach((m: any) => m?.dispose?.());
+            else o.material?.dispose?.();
+          });
+        }
+        three.current = null;
+      };
+    } catch (e) {
+      safeFail('Init error:', e);
+    }
+  }, [awardPoint, difficultyRef, g, placeForServe, serve, setCallRef]);
+
+  const phaseLabel = ui.phase === 'ready' ? 'READY' : ui.phase === 'serving' ? 'SERVE' : ui.phase === 'rally' ? 'RALLY' : 'GAME';
+  const serverLabel = ui.score.server === 'player' ? 'YOU' : 'AI';
+
+  return (
+    <ErrorBoundary>
+      <div
+        ref={rootRef}
+        className="w-full h-[92vh] relative select-none"
+        style={{ background: '#070b1a', touchAction: 'none' }}
+        onPointerDown={(e) => {
+          onDown(e);
+          if (sim.current.phase === 'ready' && sim.current.score.server === 'player') serve();
+        }}
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+      >
+        <div ref={mountRef} style={{ position: 'absolute', inset: 0 }} />
+        {(boot || fatal) && (
+          <div style={{ position: 'absolute', left: 8, top: 56, right: 8, background: fatal ? 'rgba(180,0,0,0.55)' : 'rgba(0,0,0,0.55)', color: '#fff', fontSize: 12, padding: '8px 10px', borderRadius: 14, pointerEvents: 'none' }}>
+            {fatal || boot}
+          </div>
+        )}
+        <div style={{ position: 'absolute', left: 0, right: 0, top: 8, display: 'flex', justifyContent: 'center' }}>
+          <div style={{ background: 'rgba(0,0,0,0.65)', color: '#fff', fontSize: 12, padding: '8px 12px', borderRadius: 16, display: 'flex', gap: 10, alignItems: 'center' }}>
+            <span style={{ fontWeight: 800 }}>YOU {ui.score.player}</span>
+            <span>•</span>
+            <span style={{ fontWeight: 800 }}>AI {ui.score.ai}</span>
+            <span style={{ opacity: 0.85 }}>SERVER {serverLabel}</span>
+            <span style={{ opacity: 0.85 }}>{phaseLabel}</span>
+            {ui.call && <span style={{ fontWeight: 800 }}>• {ui.call}</span>}
+          </div>
+        </div>
+
+        {ui.hint && <div style={{ position: 'absolute', left: 8, top: 92, background: 'rgba(0,0,0,0.55)', color: '#fff', fontSize: 12, padding: '8px 10px', borderRadius: 14 }}>{ui.hint}</div>}
+
+        <div style={{ position: 'absolute', left: 8, bottom: 8, display: 'flex', gap: 8, alignItems: 'center' }}>
+          <select value={difficulty} onChange={(e) => setDifficulty(e.target.value as Difficulty)} style={{ padding: '6px 8px', borderRadius: 10, fontSize: 12 }}>
+            <option value="easy">AI easy</option>
+            <option value="medium">AI medium</option>
+            <option value="hard">AI hard</option>
+          </select>
+          <button onClick={reset} style={{ padding: '6px 10px', borderRadius: 10, fontSize: 12 }}>Reset</button>
+        </div>
+
+        <div style={{ position: 'absolute', right: 8, bottom: 8, maxWidth: 560, background: 'rgba(0,0,0,0.55)', color: '#fff', fontSize: 12, padding: '8px 10px', borderRadius: 14 }}>
+          Drag to move paddle • Tap to serve • Aim with finger X • Swipe faster = more speed
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+}

--- a/webapp/src/pages/Games/TableTennisRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TableTennisRoyalLobby.jsx
@@ -1,0 +1,706 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import { socket } from '../../utils/socket.js';
+import { getOnlineUsers } from '../../utils/api.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { runPoolRoyaleOnlineFlow } from './poolRoyaleOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon, getVariantThumbnail } from '../../config/gameAssets.js';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+
+const PLAYER_FLAG_STORAGE_KEY = 'tableTennisRoyalPlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'tableTennisRoyalAiFlag';
+
+export default function TableTennisRoyalLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'tournament' ? 'tournament' : 'regular';
+  })();
+  const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
+  const autoStartRequested = searchParams.get('autostart') === '1';
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState(initialMode);
+  const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [variant, setVariant] = useState('uk');
+  const [ukBallSet, setUkBallSet] = useState('uk');
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const [onlinePlayers, setOnlinePlayers] = useState([]);
+  const [matching, setMatching] = useState(false);
+  const [spinningPlayer, setSpinningPlayer] = useState('');
+  const [matchPlayers, setMatchPlayers] = useState([]);
+  const matchPlayersRef = useRef([]);
+  const [readyList, setReadyList] = useState([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [matchingError, setMatchingError] = useState('');
+  const [matchStatus, setMatchStatus] = useState('');
+  const spinIntervalRef = useRef(null);
+  const accountIdRef = useRef(null);
+  const pendingTableRef = useRef('');
+  const cleanupRef = useRef(() => {});
+  const stakeDebitRef = useRef(null);
+  const matchTimeoutRef = useRef(null);
+  const seatTimeoutRef = useRef(null);
+  const autoStartRef = useRef(false);
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    matchPlayersRef.current = matchPlayers;
+  }, [matchPlayers]);
+
+  useEffect(() => {
+    if (variant !== 'uk') {
+      setUkBallSet('uk');
+    }
+  }, [variant]);
+
+  const navigateToPoolRoyale = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
+    const selfId = accountId || accountIdRef.current;
+    const selfEntry = roster.find((p) => String(p.id) === String(selfId));
+    const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
+    const starterId = currentTurn || roster?.[0]?.id || null;
+    const selfIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const seat = selfIndex === 1 ? 'B' : 'A';
+    const starterSeat = starterId && String(starterId) === String(selfId) ? seat : seat === 'A' ? 'B' : 'A';
+    const friendlyName =
+      selfEntry?.name ||
+      getTelegramFirstName() ||
+      getTelegramId() ||
+      (selfId ? `TPC ${selfId}` : 'Player');
+    const friendlyAvatar = selfEntry?.avatar || avatar;
+    const opponentName =
+      opponentEntry?.name ||
+      opponentEntry?.username ||
+      opponentEntry?.telegramName ||
+      (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
+    const opponentAvatar = opponentEntry?.avatar || '';
+    cleanupRef.current?.({ account: accountId, skipRefReset: true });
+    const params = new URLSearchParams();
+    params.set('variant', variant);
+    if (variant === 'uk' && ukBallSet === 'american') {
+      params.set('ballSet', 'american');
+    }
+    params.set('type', playType);
+    params.set('mode', 'online');
+    params.set('tableId', startedId);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (friendlyAvatar) params.set('avatar', friendlyAvatar);
+    const tgId = getTelegramId();
+    if (tgId) params.set('tgId', tgId);
+    const resolvedAccountId = accountIdRef.current;
+    if (resolvedAccountId) params.set('accountId', resolvedAccountId);
+    if (tableSize) params.set('tableSize', tableSize);
+    params.set('seat', seat);
+    params.set('starter', starterSeat);
+    const name = (friendlyName || '').trim();
+    if (name) params.set('name', name);
+    if (opponentName) params.set('opponent', opponentName);
+    if (opponentAvatar) params.set('opponentAvatar', opponentAvatar);
+    navigate(`/games/tabletennisroyal?${params.toString()}`);
+  };
+
+  const startGame = async () => {
+    const isOnlineMatch = mode === 'online' && playType === 'regular';
+    if (matching) return;
+    await cleanupRef.current?.();
+    setMatchStatus('');
+    setMatchingError('');
+
+    if (isOnlineMatch) {
+      await runPoolRoyaleOnlineFlow({
+        stake,
+        variant,
+        ballSet: ukBallSet,
+        playType,
+        mode,
+        tableSize,
+        avatar,
+        deps: { ensureAccountId, getAccountBalance, addTransaction, getTelegramId, getTelegramFirstName, socket },
+        state: {
+          setMatchingError,
+          setMatchStatus,
+          setMatching,
+          setIsSearching,
+          setMatchPlayers,
+          setReadyList,
+          setSpinningPlayer
+        },
+        refs: {
+          accountIdRef,
+          matchPlayersRef,
+          pendingTableRef,
+          cleanupRef,
+          spinIntervalRef,
+          stakeDebitRef,
+          matchTimeoutRef,
+          seatTimeoutRef
+        },
+        onGameStart: navigateToPoolRoyale
+      });
+      return;
+    }
+
+    let tgId;
+    let accountId;
+    try {
+      tgId = getTelegramId();
+      accountId = await ensureAccountId();
+    } catch (error) {
+      const message = 'Unable to verify your TPC account. Please retry.';
+      setMatchingError(message);
+      try {
+        window?.Telegram?.WebApp?.showAlert?.(message);
+      } catch {}
+      console.error('[TableTennisRoyalLobby] ensureAccountId failed (offline)', error);
+      return;
+    }
+
+    accountIdRef.current = accountId;
+
+    const params = new URLSearchParams();
+    params.set('variant', variant);
+    if (variant === 'uk' && ukBallSet === 'american') {
+      params.set('ballSet', 'american');
+    }
+    params.set('tableSize', tableSize);
+    params.set('type', playType);
+    params.set('mode', mode);
+    if (isOnlineMatch) {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
+    if (playType === 'tournament') params.set('players', players);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    const devAcc1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+    const devAcc2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+    if (devAcc) params.set('dev', devAcc);
+    if (devAcc1) params.set('dev1', devAcc1);
+    if (devAcc2) params.set('dev2', devAcc2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    if (playType === 'tournament') {
+      window.location.href = `/pool-royale-bracket.html?${params.toString()}`;
+      return;
+    }
+
+    navigate(`/games/tabletennisroyal?${params.toString()}`);
+  };
+  useEffect(() => {
+    if (!autoStartRequested || autoStartRef.current || matching) return;
+    autoStartRef.current = true;
+    startGame();
+  }, [autoStartRequested, matching, startGame]);
+
+  useEffect(() => {
+    let active = true;
+    const loadOnline = () => {
+      getOnlineUsers()
+        .then((data) => {
+          if (!active) return;
+          const list = Array.isArray(data?.users)
+            ? data.users
+            : Array.isArray(data)
+            ? data
+            : [];
+          setOnlinePlayers(list);
+        })
+        .catch(() => {});
+    };
+    loadOnline();
+    const id = setInterval(loadOnline, 15000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  const matchingCandidates = useMemo(() => {
+    const base = (onlinePlayers || []).map((p) => ({
+      id: p.accountId || p.playerId || p.id,
+      name: p.username || p.name || p.telegramName || p.telegramId || p.accountId
+    }));
+    const lobbyEntries = (matchPlayers || []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    const merged = [...base, ...lobbyEntries].filter((p) => p.id);
+    const seen = new Set();
+    return merged.filter((p) => {
+      const key = String(p.id);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [matchPlayers, onlinePlayers]);
+
+  useEffect(() => {
+    if (spinIntervalRef.current) {
+      clearInterval(spinIntervalRef.current);
+      spinIntervalRef.current = null;
+    }
+    if (!matching || matchingCandidates.length === 0) return undefined;
+    setSpinningPlayer(matchingCandidates[0].name || 'Searching…');
+    spinIntervalRef.current = setInterval(() => {
+      const pick = matchingCandidates[Math.floor(Math.random() * matchingCandidates.length)];
+      setSpinningPlayer(pick?.name || 'Searching…');
+    }, 500);
+    return () => {
+      if (spinIntervalRef.current) clearInterval(spinIntervalRef.current);
+    };
+  }, [matching, matchingCandidates]);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  useEffect(() => {
+    if (playType === 'tournament') {
+      setMode('ai');
+    }
+  }, [playType]);
+
+  useEffect(() => {
+    if (mode !== 'online' || playType !== 'regular') {
+      cleanupRef.current?.();
+      setMatching(false);
+      setMatchStatus('');
+      setMatchPlayers([]);
+      setReadyList([]);
+      setIsSearching(false);
+    }
+  }, [mode, playType]);
+
+  useEffect(() => {
+    if (!matching) return;
+    const readyIds = new Set((readyList || []).map((id) => String(id)));
+    const selfId = accountIdRef.current;
+    if (selfId && readyIds.has(String(selfId)) && readyIds.size >= 2) {
+      setMatchStatus('All players ready. Launching match…');
+    }
+  }, [matching, readyList]);
+
+  const readyIds = useMemo(
+    () => new Set((readyList || []).map((id) => String(id))),
+    [readyList]
+  );
+
+  const winnerParam = searchParams.get('winner');
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-6 p-4 pb-8">
+        {winnerParam && (
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-center text-sm font-semibold text-emerald-200">
+            {winnerParam === '1' ? 'You won!' : 'CPU won!'}
+          </div>
+        )}
+        <GameLobbyHeader slug="tabletennisroyal" title="Table Tennis Royal Lobby" badge={`${onlinePlayers.length} online`} />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+              {avatar ? (
+                <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+              <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+              </div>
+            </button>
+          </div>
+          <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Match Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                id: 'regular',
+                label: 'Regular',
+                desc: 'Quick single match',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                iconKey: 'type-regular'
+              },
+              {
+                id: 'tournament',
+                label: 'Tournament',
+                desc: 'Bracket challenge',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                iconKey: 'type-tournament'
+              }
+            ].map(({ id, label, desc, accent, iconKey }) => {
+              const active = playType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setPlayType(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('tabletennisroyal', iconKey)}
+                        alt={label}
+                        fallback={id === 'regular' ? '🎯' : '🏆'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Play Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Opponents</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              { id: 'ai', label: 'Vs AI', desc: 'Practice precision', iconKey: 'mode-ai' },
+              {
+                id: 'online',
+                label: '1v1 Online',
+                desc: 'Live matchmaking',
+                iconKey: 'mode-online',
+                disabled: playType === 'tournament'
+              }
+            ].map(({ id, label, desc, iconKey, disabled }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => !disabled && setMode(id)}
+                  disabled={disabled}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('tabletennisroyal', iconKey)}
+                        alt={label}
+                        fallback={id === 'ai' ? '🤖' : '🌐'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">
+                      {disabled ? 'Tournament bracket only' : desc}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Variant</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Ruleset</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              { id: 'uk', label: '8Ball' },
+              { id: 'american', label: 'American' },
+              { id: '9ball', label: '9-Ball' }
+            ].map(({ id, label }) => {
+              const active = variant === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setVariant(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-sky-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getVariantThumbnail('tabletennisroyal', id)}
+                        alt={label}
+                        fallback="🎱"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {variant === 'uk' && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Ball Colors</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Visuals</span>
+            </div>
+            <p className="text-xs text-white/60">
+              Keep UK yellow/red sets or switch to solids &amp; stripes visuals while retaining 8Ball rules.
+            </p>
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                { id: 'uk', label: 'Yellow & Red' },
+                { id: 'american', label: 'Solids & Stripes' }
+              ].map(({ id, label }) => {
+                const active = ukBallSet === id;
+                return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setUkBallSet(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('tabletennisroyal', `ball-${id}`)}
+                        alt={label}
+                        fallback={id === 'uk' ? '🟡' : '🔵'}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        )}
+
+        {playType === 'tournament' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <h3 className="font-semibold text-white">Tournament Players</h3>
+            <div className="flex flex-wrap gap-2">
+              {[8, 16, 24].map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setPlayers(p)}
+                  className={`rounded-xl border px-4 py-2 text-sm font-semibold transition ${
+                    players === p
+                      ? 'border-primary bg-primary/15 text-primary'
+                      : 'border-white/10 bg-white/5 text-white/70 hover:border-white/30'
+                  }`}
+                >
+                  {p} Players
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-white/50">Winner takes pot minus 10% developer fee.</p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Stake</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">TPC</span>
+            </div>
+            <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            <p className="text-center text-xs text-white/50">
+              Online games use your TPC stake as escrow, while AI matches stay free.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-white">Online Arena</h3>
+                <p className="text-sm text-white/60">
+                  We match players by TPC account number, stake ({stake.amount} {stake.token}), and Table Tennis Royal game type.
+                </p>
+              </div>
+              <div className="text-xs text-white/50">{onlinePlayers.length} online</div>
+            </div>
+            {matchingError && <div className="text-sm text-red-400">{matchingError}</div>}
+            {matching && (
+              <div className="space-y-2">
+                {matchStatus && <div className="text-xs text-white/50">{matchStatus}</div>}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Spinning wheel</span>
+                  <span className="text-xs text-white/50">Searching for stake match…</span>
+                </div>
+                <div className="lobby-tile w-full flex items-center justify-between">
+                  <span>🎯 {spinningPlayer || 'Searching…'}</span>
+                  <span className="text-xs text-white/60">Stake {stake.amount} {stake.token}</span>
+                </div>
+                <div className="space-y-1">
+                  {matchPlayers.map((p) => (
+                    <div
+                      key={p.id}
+                      className="lobby-tile w-full flex items-center justify-between"
+                    >
+                      <div>
+                        <p className="text-sm font-semibold">{p.name || `TPC ${p.id}`}</p>
+                        <p className="text-xs text-white/50">Account #{p.id}</p>
+                      </div>
+                      <span
+                        className={`text-xs font-semibold ${
+                          readyIds.has(String(p.id)) ? 'text-emerald-400' : 'text-white/50'
+                        }`}
+                      >
+                        {readyIds.has(String(p.id)) ? 'Ready' : 'Waiting'}
+                      </span>
+                    </div>
+                  ))}
+                  {matchPlayers.length === 0 && (
+                    <div className="lobby-tile w-full text-sm text-white/50">
+                      Waiting for another player in this pool arena…
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {!matching && (
+              <div className="text-sm text-white/50">
+                Start to join a 1v1 pool arena. We keep you at the same table until the match begins.
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"
+          disabled={mode === 'online' && (isSearching || matching)}
+        >
+          {mode === 'online' ? (matching ? 'Waiting for opponent…' : 'START ONLINE') : 'START'}
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -642,6 +642,14 @@ const storeMeta = {
     typeLabels: TYPE_LABELS,
     accountId: POOL_STORE_ACCOUNT_ID
   },
+  tabletennisroyal: {
+    name: 'Table Tennis Royal',
+    items: POOL_ROYALE_STORE_ITEMS,
+    defaults: POOL_ROYALE_DEFAULT_LOADOUT,
+    labels: POOL_ROYALE_OPTION_LABELS,
+    typeLabels: TYPE_LABELS,
+    accountId: POOL_STORE_ACCOUNT_ID
+  },
   snookerroyale: {
     name: 'Snooker Royal',
     items: SNOOKER_ROYALE_STORE_ITEMS,
@@ -868,6 +876,7 @@ export default function Store() {
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'poolroyale' })),
+      tabletennisroyal: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tabletennisroyal' })),
       snookerroyale: SNOOKER_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'snookerroyale' })),
       airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
@@ -883,6 +892,7 @@ export default function Store() {
   const ownedCheckers = useMemo(
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
+      tabletennisroyal: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
       snookerroyale: (type, optionId) => isSnookerOptionUnlocked(type, optionId, snookerOwned),
       airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
@@ -898,6 +908,7 @@ export default function Store() {
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      tabletennisroyal: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       snookerroyale: (item) => SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
@@ -913,6 +924,7 @@ export default function Store() {
   const typeLabelResolver = useMemo(
     () => ({
       poolroyale: TYPE_LABELS,
+      tabletennisroyal: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
@@ -1418,7 +1430,7 @@ export default function Store() {
 
       for (const [slug, group] of Object.entries(groupedBySlug)) {
         for (const entry of group.items) {
-          if (slug === 'poolroyale') {
+          if (slug === 'poolroyale' || slug === 'tabletennisroyal') {
             const updated = await addPoolRoyalUnlock(entry.type, entry.optionId, resolvedAccountId);
             setPoolOwned(updated);
           } else if (slug === 'snookerroyale') {


### PR DESCRIPTION
### Motivation
- Add a new game mode "Table Tennis Royal" with the same lobby, store and invite/watch integration pattern as existing Royale games so it appears across Games, Store, Achievements and invite flows. 
- Reuse Pool Royale table-menu/graphics/options (HDRIs, store items, previews) to ensure parity for table menu, HDRI purchase/use and graphics options.

### Description
- Added a new Three.js game page `webapp/src/pages/Games/TableTennisRoyal.tsx` implementing the provided gameplay code with camera/power tuning, touch controls, AI, physics and HUD. 
- Added a new lobby `webapp/src/pages/Games/TableTennisRoyalLobby.jsx` cloned from Pool Royale lobby and adapted to launch `/games/tabletennisroyal` with the same table/menu options and UI patterns. 
- Registered routes and lazy imports in `webapp/src/App.jsx` for `/games/tabletennisroyal` and `/games/tabletennisroyal/lobby`. 
- Added the game to catalog and asset mappings in `webapp/src/config/gamesCatalog.js` and `webapp/src/config/gameAssets.js` (thumbnails, lobby icons, variant thumbnails) so it shows on Games and lobby UI. 
- Integrated store support by reusing Pool Royale inventory for `tabletennisroyal` in `webapp/src/pages/Store.jsx` so HDRIs and other Pool items are purchasable/applicable for the new game and unlock flows update the shared Pool inventory. 
- Extended invite/watch UI mapping in `webapp/src/components/PlayerInvitePopup.jsx` and invite modal so players can pick/invite/watch Table Tennis Royal matches.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (vite build passed). 
- Launched dev server and captured a mobile-portrait screenshot of the Games page using Playwright to validate the new game appears at `/games` (screenshot produced). 
- No unit tests were added; manual/automated smoke checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b4af43a4832987647dd5590ecd02)