### PR TITLE
Fix Pool Royale: hide mapping overlays, preserve breaker on legal break, and strengthen auto-aim

### DIFF
--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -76,6 +76,7 @@ describe('PoolRoyaleRules', () => {
     expect(clearedMeta?.hud?.next).toBe('open table');
     expect(clearedMeta?.hud?.phase).toBe('open');
     expect(cleared.players.A.score).toBe(1);
+    expect(cleared.activePlayer).toBe('A');
 
     const scratchEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 3, ballId: 3 },
@@ -105,22 +106,25 @@ describe('PoolRoyaleRules', () => {
     expect(initialFrame.ballOn).toEqual(['BALL_1']);
     expect(initialMeta?.hud?.next).toBe('ball 1');
 
-    const breakEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
+    const breakEvents: ShotEvent[] = [
+      { type: 'HIT', firstContact: 2, ballId: 2 },
+      { type: 'POTTED', ball: 2, pocket: 'TM', ballId: 2 }
+    ];
     const postBreak = rules.applyShot(initialFrame, breakEvents, { contactMade: true });
     const postBreakMeta = postBreak.meta as any;
 
     expect(postBreak.foul).toBeUndefined();
     expect(postBreakMeta?.breakInProgress).toBe(false);
-    expect(postBreak.activePlayer).toBe('B');
+    expect(postBreak.activePlayer).toBe('A');
     expect(postBreak.ballOn).toEqual(['BALL_1']);
 
-    const foulEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 2, ballId: 2 }];
+    const foulEvents: ShotEvent[] = [{ type: 'HIT', firstContact: 3, ballId: 3 }];
     const foulState = rules.applyShot(postBreak, foulEvents, { contactMade: true });
     const foulMeta = foulState.meta as any;
 
     expect(foulState.foul?.reason).toBe('wrong first contact');
     expect(foulMeta?.state?.ballInHand).toBe(true);
-    expect(foulState.activePlayer).toBe('A');
+    expect(foulState.activePlayer).toBe('B');
     expect(foulState.ballOn).toEqual(['BALL_1']);
 
     const recoveryEvents: ShotEvent[] = [
@@ -133,7 +137,7 @@ describe('PoolRoyaleRules', () => {
 
     expect(recoveryMeta?.breakInProgress).toBe(false);
     expect(recoveryMeta?.state?.ballInHand).toBe(false);
-    expect(recoveryState.ballOn).toEqual(['BALL_2']);
-    expect(recoveryMeta?.hud?.next).toBe('ball 2');
+    expect(recoveryState.ballOn).toEqual(['BALL_3']);
+    expect(recoveryMeta?.hud?.next).toBe('ball 3');
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1059,10 +1059,10 @@ const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
 const ENABLE_TABLE_MAPPING_LINES = true;
 const TABLE_MAPPING_VISUALS = Object.freeze({
-  field: true,
-  cushions: true,
-  jaws: true,
-  pockets: true
+  field: false,
+  cushions: false,
+  jaws: false,
+  pockets: false
 });
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
@@ -26300,6 +26300,15 @@ const powerRef = useRef(hud.power);
         } catch (err) {
           console.error('Pool Royale shot resolution failed:', err);
         }
+        const preShotMeta =
+          currentState && typeof currentState.meta === 'object' ? currentState.meta : null;
+        const preShotBreakInProgress =
+          !isTraining &&
+          (variantId === 'american' || variantId === '9ball') &&
+          Boolean(preShotMeta?.breakInProgress ?? preShotMeta?.state?.breakInProgress);
+        const pottedObjectOnBreak = potted.some(
+          (entry) => entry && entry.id !== 'cue' && entry.color !== 'CUE'
+        );
         if (isTraining) {
           if (!trainingRulesRef.current) {
             safeState = {
@@ -26312,6 +26321,24 @@ const powerRef = useRef(hud.power);
           if (trainingModeRef.current === 'solo') {
             safeState = { ...safeState, activePlayer: 'A' };
           }
+        }
+        if (preShotBreakInProgress && pottedObjectOnBreak && !safeState?.foul) {
+          const breaker = currentState?.activePlayer === 'B' ? 'B' : 'A';
+          const nextMeta =
+            safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
+          if (nextMeta?.state && typeof nextMeta.state === 'object') {
+            nextMeta.state = {
+              ...nextMeta.state,
+              currentPlayer: breaker,
+              ballInHand: false
+            };
+          }
+          safeState = {
+            ...safeState,
+            activePlayer: breaker,
+            foul: undefined,
+            meta: nextMeta ?? safeState.meta
+          };
         }
         if (!isTraining && cueBallPotted) {
           const nextPlayer = currentState?.activePlayer === 'B' ? 'A' : 'B';
@@ -26959,8 +26986,10 @@ const powerRef = useRef(hud.power);
           } else if (autoAimDir && autoAimDir.lengthSq() > 1e-6) {
             if (shouldAutoAimPlayer) {
               autoAimRequestRef.current = false;
+              aimDir.copy(autoAimDir);
+            } else {
+              aimDir.lerp(autoAimDir, aimLerpFactor);
             }
-            aimDir.lerp(autoAimDir, aimLerpFactor);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
             }


### PR DESCRIPTION
### Motivation
- Make table mapping markings visually invisible while keeping mapping logic intact to preserve gameplay math but remove visual clutter. 
- Correct turn resolution on the break so that in American and 9-ball a legal pot on the break keeps the breaker shooting (free/open table behavior). 
- Ensure the aiming helper immediately snaps the aiming line to the best legal suggestion for the player when auto-suggestion is requested, while still allowing the user to override.

### Description
- Set `TABLE_MAPPING_VISUALS` entries (`field`, `cushions`, `jaws`, `pockets`) to `false` so mapping overlays are not rendered while the underlying mapping logic remains unchanged (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added pre-shot break detection and logic that, when the pre-shot was a break in progress and an object ball was potted (and the resolved shot is not a foul), forces the `activePlayer`/meta to remain the breaker and clears `ballInHand` so the breaker continues to shoot for American/9-ball (`PoolRoyale.jsx` near shot resolution).
- Modified auto-aim application so when `shouldAutoAimPlayer` is true the aim direction is immediately applied with `aimDir.copy(autoAimDir)` rather than only lerping; non-forced auto-aim still lerps to keep smoothing behavior (`PoolRoyale.jsx` in the aim update loop).
- Updated/extended rules unit tests to assert break-pot continuation and related 9-ball flow changes in `test/poolRoyaleRules.test.ts`.

### Testing
- Ran the focused test file with `npm test -- --runTestsByPath test/poolRoyaleRules.test.ts` and all tests in that file passed (3 passed). 
- Attempted a Playwright-based page screenshot of the running dev site to validate visual changes, but Chromium crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b9b50cb88329b1d96a4580f83eb5)