### PR TITLE
Make table markings invisible, retain breaker on legal break, and default auto-aim to best legal target

### DIFF
--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -493,7 +493,12 @@ export class PoolRoyaleRules {
       noCushionAfterContact: Boolean(context.noCushionAfterContact)
     });
     const pottedCount = potted.filter((id) => id !== 0).length;
+    const wasBreakShot = Boolean(previous?.state?.breakInProgress ?? true);
     const snapshot = serializeAmericanState(game.state);
+    if (wasBreakShot && pottedCount > 0 && !result.foul && !snapshot.frameOver) {
+      snapshot.currentPlayer = state.activePlayer;
+      game.state.currentPlayer = state.activePlayer;
+    }
     const ballOn = this.computeAmericanBallOn(snapshot);
     const scores = this.computeAmericanScores(snapshot);
     const frameOver = snapshot.frameOver;
@@ -608,7 +613,12 @@ export class PoolRoyaleRules {
       noCushionAfterContact: Boolean(context.noCushionAfterContact)
     });
     const pottedCount = potted.filter((id) => id !== 0).length;
+    const wasBreakShot = Boolean(previous?.state?.breakInProgress ?? true);
     const snapshot = serializeNineState(game.state);
+    if (wasBreakShot && pottedCount > 0 && !result.foul && !snapshot.gameOver) {
+      snapshot.currentPlayer = state.activePlayer;
+      game.state.currentPlayer = state.activePlayer;
+    }
     const lowest = lowestBall(snapshot.ballsOnTable);
     const hud: HudInfo = {
       next: snapshot.gameOver ? 'frame over' : lowest != null ? `ball ${lowest}` : 'nine',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8007,7 +8007,7 @@ export function Table3D(
   const markingMat = new THREE.MeshBasicMaterial({
     color: palette.markings,
     transparent: true,
-    opacity: 0.9,
+    opacity: 0,
     side: THREE.DoubleSide
   });
   const markingHeight = clothPlaneLocal - CLOTH_DROP + MICRO_EPS * 2;
@@ -26946,7 +26946,7 @@ const powerRef = useRef(hud.power);
           !shooting &&
           !shouldLockAiAim;
         const autoAimDir = shouldAutoAimPlayer
-          ? resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: true })
+          ? resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: false })
           : shouldAutoAimAi
             ? resolveAutoAimDirection({ turnOwner: 'ai', cycleToNext: false })
             : null;


### PR DESCRIPTION
### Motivation
- Make the table markings visually invisible while preserving geometry/mapping so the visual UX can hide the rails/baulk guides without changing gameplay geometry. 
- Ensure correct turn continuity after a legal break so the player who broke keeps shooting in American and 9-ball when an object ball is potted on the break. 
- Make the aiming line default to the best legal target suggestion at the start of a player turn instead of immediately cycling to the next target, improving aim guidance.

### Description
- Set the markings material opacity to `0` in `webapp/src/pages/Games/PoolRoyale.jsx` so marking meshes remain present but invisible to the player. 
- Change the player auto-aim bootstrap call to `resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: false })` so the aim locks to the best legal suggestion at turn start. 
- In `src/rules/PoolRoyaleRules.ts` adjust American and 9-ball shot application to detect a break (`wasBreakShot`) and, when a legal pot occurred (`pottedCount > 0` and `!result.foul`), set `snapshot.currentPlayer` and `game.state.currentPlayer` to `state.activePlayer` so the breaker retains the turn.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleRules.test.ts` and it passed (3/3 tests). 
- Ran `npm test -- --runInBand test/americanBilliards.test.js test/nineBall.test.js test/poolRoyaleRules.test.ts` and observed existing failures in `test/nineBall.test.js` (2 failing assertions) while `test/poolRoyaleRules.test.ts` and `test/americanBilliards.test.js` passed. 
- Attempted visual verification with Playwright to capture a screenshot of Pool Royale, but Chromium crashed (SIGSEGV) in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b9b50cb88329b1d96a4580f83eb5)