### PR TITLE
Tune Pool Royale cameras & physics; align American 8‑ball rules with BCA

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -65,6 +65,10 @@ export class AmericanBilliards {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0)
+    if (wasBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true
+      reason = 'illegal break'
+    }
     if (!wasBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true
       reason = 'no cushion'
@@ -106,10 +110,19 @@ export class AmericanBilliards {
     }
 
     const eightPotted = pottedBalls.includes(8)
+    const pottedObjectOnBreak = wasBreakShot && pottedBalls.some(id => id !== 8)
     if (!frameOver && eightPotted) {
       if (s.breakInProgress) {
-        // BCA break: 8-ball is spotted and play continues.
-        s.ballsOnTable.add(8)
+        const scratchedOnBreak = pottedList.includes(0) || shot.cueOffTable
+        if (scratchedOnBreak) {
+          // BCA league handling: 8-ball made on the break plus scratch is loss of game.
+          frameOver = true
+          winner = opp
+          s.ballsOnTable.delete(8)
+        } else {
+          // BCA break: 8-ball is spotted and the game continues.
+          s.ballsOnTable.add(8)
+        }
       } else {
         const currentGroup = s.assignments[current]
         const remainingBeforeEight =
@@ -128,6 +141,10 @@ export class AmericanBilliards {
     if (!frameOver) {
       if (foul) {
         nextPlayer = opp
+      } else if (wasBreakShot && eightPotted && !pottedObjectOnBreak) {
+        // After spotting a lone 8-ball on break, hand play to the opponent.
+        nextPlayer = opp
+        s.currentPlayer = opp
       } else if (pottedBalls.length > 0) {
         nextPlayer = current
       } else {

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -43,6 +43,22 @@ test('legal break pot keeps table open until post-break shot', () => {
 })
 
 
+
+test('dry break with no rail is illegal under BCA handling', () => {
+  const game = new AmericanBilliards()
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [],
+    cueOffTable: false,
+    noCushionAfterContact: true
+  })
+
+  assert.equal(res.foul, true)
+  assert.equal(res.reason, 'illegal break')
+  assert.equal(res.nextPlayer, 'B')
+  assert.equal(res.ballInHandNext, true)
+})
+
 test('break scratch is a foul and gives opponent ball in hand', () => {
   const game = new AmericanBilliards()
   const res = game.shotTaken({
@@ -120,4 +136,33 @@ test('legal group clearance then 8-ball wins frame', () => {
   assert.equal(res.foul, false)
   assert.equal(res.frameOver, true)
   assert.equal(res.winner, 'A')
+})
+
+
+test('8-ball on break plus scratch is loss of frame (BCA)', () => {
+  const game = new AmericanBilliards()
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [8, 0],
+    cueOffTable: false
+  })
+
+  assert.equal(res.frameOver, true)
+  assert.equal(res.foul, true)
+  assert.equal(res.winner, 'B')
+})
+
+test('lone 8-ball on break is spotted and turn passes', () => {
+  const game = new AmericanBilliards()
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [8],
+    cueOffTable: false
+  })
+
+  assert.equal(res.frameOver, false)
+  assert.equal(res.foul, false)
+  assert.equal(res.nextPlayer, 'B')
+  assert.equal(game.state.currentPlayer, 'B')
+  assert.equal(game.state.ballsOnTable.has(8), true)
 })

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1313,14 +1313,14 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 0.985,
+  restitution: 0.992,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.995;
+const FRICTION = 0.9955;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1714,22 +1714,22 @@ const CUE_TIP_RADIUS = (BALL_R / 0.0525) * 0.006 * 1.5;
 const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak higher so max-strength jumps pop
 const CUE_BUTT_LIFT = BALL_R * 0.46; // lower the butt slightly while keeping the tip level with the cue-ball centre
 const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.14; // add extra butt clearance so the cue never clips newly raised cushions
-const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.1; // lift cue helper path to match raised cushions and updated ball lift
+const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.14; // lift cue helper path a touch more so helper rays clear cushion tops reliably
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
 const CUE_FRONT_SECTION_RATIO = 0.28;
-const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 2.8;
+const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 3.02;
 const CUE_OBSTRUCTION_RANGE = BALL_R * 9;
 const CUE_OBSTRUCTION_LIFT = BALL_R * 0.68;
 const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(5.2);
-const CUE_OBSTRUCTION_RAIL_CLEARANCE = CUE_OBSTRUCTION_CLEARANCE * 0.6;
+const CUE_OBSTRUCTION_RAIL_CLEARANCE = CUE_OBSTRUCTION_CLEARANCE * 0.68;
 const CUE_OBSTRUCTION_RAIL_INFLUENCE = 0.52;
 const CUE_OBSTRUCTION_SAMPLE_STEP = BALL_R * 0.6;
 const CUE_OBSTRUCTION_SAMPLE_MIN = 6;
 const CUE_OBSTRUCTION_SAMPLE_MAX = 18;
-const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.12, CUE_TIP_RADIUS * 1.55);
+const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.14, CUE_TIP_RADIUS * 1.62);
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * PHYSICS_PROFILE.maxTipOffsetRatio;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -5127,7 +5127,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
     (halfLength / Math.tan(halfVertical)) * RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
+const RAIL_OVERHEAD_DISTANCE_BIAS = 1.02; // pull the rail-overhead camera slightly closer to the cloth
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
@@ -5137,7 +5137,7 @@ const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
 );
-const CUE_VIEW_PHI_LIFT = 0.06; // keep the cue camera slightly higher before it bottoms out
+const CUE_VIEW_PHI_LIFT = 0.082; // allow the cue camera to dip a little lower for player aiming
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -5163,7 +5163,7 @@ const CUE_VIEW_AIM_LINE_LERP = 0.1; // aiming line interpolation factor while th
 const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor while the camera is near standing view
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
-const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.04; // add a touch more overhead bias while holding the rail angle
+const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.025; // keep the rail-overhead camera a bit more top-down while aiming
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;


### PR DESCRIPTION
### Motivation
- Implement requested UX tweaks for Pool Royale: bring the rail overhead broadcast camera slightly closer and more top‑down while letting the player/cue camera dip a bit lower for aiming, and avoid cue/helper clipping with cushions/balls. 
- Make the table feel a touch snappier by nudging roll speed and cushion bounce. 
- Fix 8‑ball behavior for the Pool Royale (American 8‑ball) variant to follow BCA‑style outcomes in edge cases (dry breaks, 8 on break + scratch, lone 8 on break). 

### Description
- Camera & helper tuning: adjusted broadcast/cue camera constants and helper/obstruction margins in `webapp/src/pages/Games/PoolRoyale.jsx` (rail overhead distance bias, cue view phi lift, cue helper lift/clearance and obstruction radii) so the rail camera pulls slightly closer and the cue/player view can sit lower while helper rays avoid rails/balls. 
- Physics tweaks: increased restitution and reduced friction slightly in the Pool Royale physics profile (`webapp/src/pages/Games/PoolRoyale.jsx`) to make balls roll a bit faster and cushions a touch bouncier. 
- BCA 8‑ball rule changes: updated American 8‑ball logic in `lib/americanBilliards.js` to treat a dry break (no cushion/pot) as `illegal break`, make an 8‑ball on the break + scratch a loss for the breaker, and spot a lone 8 on break and hand play to the opponent. 
- Tests: added/updated unit tests in `test/americanBilliards.test.js` to cover the new BCA‑oriented scenarios. 

### Testing
- Ran `node --test test/americanBilliards.test.js` and all new/updated American 8‑ball tests passed. 
- Ran `npx jest test/poolRoyaleRules.test.ts --runInBand` and PoolRoyale rules tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d5b2eebc83298fd600035339b144)