### PR TITLE
Move Graphics/FPS into in-game Table Setup, add table-tennis assets, and restore HDRI visibility

### DIFF
--- a/webapp/public/assets/icons/table-tennis-fps-fhd90.svg
+++ b/webapp/public/assets/icons/table-tennis-fps-fhd90.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="FHD 90Hz">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">90</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-fps-hd50.svg
+++ b/webapp/public/assets/icons/table-tennis-fps-hd50.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="HD 50Hz">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">50</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-fps-qhd105.svg
+++ b/webapp/public/assets/icons/table-tennis-fps-qhd105.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="QHD 105Hz">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">105</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-fps-uhd120.svg
+++ b/webapp/public/assets/icons/table-tennis-fps-uhd120.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="UHD 120Hz">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ec4899"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">120</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-graphics-high.svg
+++ b/webapp/public/assets/icons/table-tennis-graphics-high.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="High">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f43f5e"/>
+      <stop offset="100%" stop-color="#7c2d12"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">H</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-graphics-low.svg
+++ b/webapp/public/assets/icons/table-tennis-graphics-low.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Low">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#0f766e"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">L</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-graphics-medium.svg
+++ b/webapp/public/assets/icons/table-tennis-graphics-medium.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Medium">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">M</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-mode-ai.svg
+++ b/webapp/public/assets/icons/table-tennis-mode-ai.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Vs AI">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">AI</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-mode-online.svg
+++ b/webapp/public/assets/icons/table-tennis-mode-online.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Online">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">PVP</text>
+</svg>

--- a/webapp/public/assets/icons/table-tennis-royale.svg
+++ b/webapp/public/assets/icons/table-tennis-royale.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Table Tennis Royal">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#4f46e5"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="84" fill="#060b1d"/>
+  <rect x="24" y="24" width="464" height="464" rx="70" fill="url(#g)" opacity="0.35"/>
+  <rect x="92" y="154" width="328" height="204" rx="22" fill="#1e3a8a" stroke="#ffffff" stroke-width="8"/>
+  <line x1="256" y1="154" x2="256" y2="358" stroke="#fff" stroke-width="6"/>
+  <line x1="92" y1="256" x2="420" y2="256" stroke="#fff" stroke-width="6"/>
+  <circle cx="330" cy="188" r="16" fill="#ffffff"/>
+  <rect x="170" y="285" width="96" height="14" rx="7" fill="#f97316" transform="rotate(-16 170 285)"/>
+  <text x="256" y="108" text-anchor="middle" fill="#fff" font-size="44" font-family="Arial, sans-serif" font-weight="700">TTR</text>
+</svg>

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -21,7 +21,7 @@ export const gameThumbnails = {
   murlanroyale: '/assets/icons/Murlan%20Royal%20logo.png',
   chessbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
-  tabletennisroyal: '/assets/icons/Pool%20Royal%20game%20logo.png'
+  tabletennisroyal: '/assets/icons/table-tennis-royale.svg'
 };
 
 const buildLobbyIconSet = (keys, icon) =>
@@ -128,13 +128,17 @@ export const lobbyOptionIcons = {
     ['mode-ai', 'mode-online', 'queue-instant', 'queue-mobile', 'queue-hdr'],
     '/assets/icons/chess-royale.svg'
   ),
-  tabletennisroyal: buildLobbyIconSet(
-    [
-      'mode-ai',
-      'mode-online'
-    ],
-    '/assets/icons/pool-royale.svg'
-  ),
+  tabletennisroyal: {
+    'mode-ai': '/assets/icons/table-tennis-mode-ai.svg',
+    'mode-online': '/assets/icons/table-tennis-mode-online.svg',
+    'fps-hd50': '/assets/icons/table-tennis-fps-hd50.svg',
+    'fps-fhd90': '/assets/icons/table-tennis-fps-fhd90.svg',
+    'fps-qhd105': '/assets/icons/table-tennis-fps-qhd105.svg',
+    'fps-uhd120': '/assets/icons/table-tennis-fps-uhd120.svg',
+    'graphics-low': '/assets/icons/table-tennis-graphics-low.svg',
+    'graphics-medium': '/assets/icons/table-tennis-graphics-medium.svg',
+    'graphics-high': '/assets/icons/table-tennis-graphics-high.svg'
+  },
   ludobattleroyal: buildLobbyIconSet(
     [
       'queue-instant',

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -838,7 +838,10 @@ export default function TableTennisRoyal() {
       scene.add(key);
       lightRig.current = { ambient, key };
 
-      const floor = new THREE.Mesh(new THREE.PlaneGeometry(U(30), U(30)), new THREE.MeshStandardMaterial({ color: 0x0f1222, roughness: 0.95, metalness: 0.05 }));
+      const floor = new THREE.Mesh(
+        new THREE.PlaneGeometry(U(30), U(30)),
+        new THREE.ShadowMaterial({ color: 0x000000, opacity: 0.24 })
+      );
       floor.rotation.x = -Math.PI / 2;
       floor.position.y = 0;
       floor.receiveShadow = true;
@@ -1343,13 +1346,13 @@ export default function TableTennisRoyal() {
               fontSize: 18,
             }}
             aria-label="Open table menu"
-            title="Table menu"
+            title="Table setup"
           >
             ⚙️
           </button>
           {showTableMenu && (
             <div style={{ marginTop: 8, width: 220, background: "rgba(5,10,20,0.92)", border: "1px solid rgba(255,255,255,0.18)", borderRadius: 12, padding: 10, color: "#fff", fontSize: 12 }}>
-              <div style={{ fontWeight: 800, marginBottom: 8 }}>Table Menu</div>
+              <div style={{ fontWeight: 800, marginBottom: 8 }}>Table Setup</div>
               <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 8 }}>
                 <span>Graphics</span>
                 <select value={graphicsQuality} onChange={(e) => setGraphicsQuality(e.target.value as GraphicsQuality)} style={{ padding: "6px 8px", borderRadius: 8, fontSize: 12 }}>

--- a/webapp/src/pages/Games/TableTennisRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TableTennisRoyalLobby.jsx
@@ -12,8 +12,6 @@ export default function TableTennisRoyalLobby() {
   useTelegramBackButton();
   const [avatar, setAvatar] = useState('');
   const [mode, setMode] = useState('ai');
-  const [graphics, setGraphics] = useState('high');
-  const [fps, setFps] = useState('fhd90');
 
   useEffect(() => {
     try {
@@ -27,8 +25,6 @@ export default function TableTennisRoyalLobby() {
   const startGame = () => {
     const params = new URLSearchParams();
     params.set('mode', mode);
-    params.set('graphics', graphics);
-    params.set('fps', fps);
     navigate(`/games/tabletennisroyal?${params.toString()}`);
   };
 
@@ -51,15 +47,15 @@ export default function TableTennisRoyalLobby() {
           </div>
         </div>
 
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
           <div className="flex items-center justify-between">
             <h3 className="font-semibold text-white">Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
           </div>
-          <div className="mt-3 grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
-              { id: 'ai', label: 'Vs AI', icon: '🤖' },
-              { id: 'online', label: '1v1 Online', icon: '🌐', disabled: true }
+              { id: 'ai', label: 'Vs AI', desc: 'Practice rallies', icon: '🤖' },
+              { id: 'online', label: '1v1 Online', desc: 'Live matchmaking', icon: '🌐', disabled: true }
             ].map((item) => (
               <button
                 key={item.id}
@@ -74,51 +70,15 @@ export default function TableTennisRoyalLobby() {
                 </div>
                 <div className="text-center">
                   <p className="lobby-option-label">{item.label}</p>
+                  <p className="lobby-option-subtitle">{item.disabled ? 'Coming soon' : item.desc}</p>
                 </div>
               </button>
             ))}
           </div>
         </div>
 
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">FPS profile</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Frame rate</span>
-          </div>
-          <div className="mt-3 grid grid-cols-1 gap-3">
-            {[
-              { id: 'hd50', label: 'HD Performance (50 Hz)' },
-              { id: 'fhd90', label: 'Full HD (90 Hz)' },
-              { id: 'qhd105', label: 'Quad HD (105 Hz)' },
-              { id: 'uhd120', label: 'Ultra HD (120 Hz cap)' }
-            ].map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setFps(item.id)}
-                className={`lobby-option-card ${fps === item.id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
-              >
-                <p className="lobby-option-label">{item.label}</p>
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Graphics</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Quality</span>
-          </div>
-          <div className="mt-3 grid grid-cols-3 gap-3">
-            {['low', 'medium', 'high'].map((id) => (
-              <button
-                key={id}
-                onClick={() => setGraphics(id)}
-                className={`lobby-option-card ${graphics === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
-              >
-                <p className="lobby-option-label capitalize">{id}</p>
-              </button>
-            ))}
-          </div>
+        <div className="rounded-2xl border border-white/10 bg-black/30 p-4 text-xs text-white/70">
+          Graphics and FPS are configured inside the game from <span className="font-semibold text-white">⚙️ Table Menu</span>.
         </div>
 
         <button


### PR DESCRIPTION
### Motivation
- Keep the pre-game lobby focused on mode selection and reduce duplication by moving device/graphics controls into the in-match UI where they take effect.
- Improve discoverability by renaming the small gear menu to `Table Setup` so players know where to configure performance options.
- Use dedicated Table Tennis assets and visuals so the lobby and thumbnails match the game identity and reveal HDRI backgrounds in-scene.

### Description
- Removed the `Graphics` and `FPS profile` selectors from `webapp/src/pages/Games/TableTennisRoyalLobby.jsx` and stopped passing them in the start URL, replacing them with a short note pointing to the in-game table menu.
- Kept the `Graphics`, `FPS profile` and `Venue HDRI` controls inside `webapp/src/pages/Games/TableTennisRoyal.tsx` and relabeled the gear UI to `Table Setup` (button `title` and menu header updated to `Table setup`).
- Swapped the solid ground material for a `THREE.ShadowMaterial` receiver in `TableTennisRoyal.tsx` to restore HDRI visibility while retaining shadows.
- Added a set of new SVG icons under `webapp/public/assets/icons/` and wired them into `webapp/src/config/gameAssets.js` so `tabletennisroyal` uses dedicated thumbnails and lobby icons instead of reused Pool Royale assets.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully.
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and performed visual verification.
- Captured Playwright screenshots for verification: `artifacts/table-tennis-lobby-v2.png` and `artifacts/table-tennis-table-setup-v2.png`, both produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d2498bf483298b82c43cdf3007e3)