### PR TITLE
Improve Goal Rush puck visibility with shadow and contrast rings

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -1721,8 +1721,22 @@
     ctx.save();
     ctx.translate(puck.x, puck.y);
     ctx.rotate(puck.angle);
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.55)';
+    ctx.shadowBlur = Math.max(6, r * 0.45);
+    ctx.shadowOffsetY = Math.max(2, r * 0.08);
     if (puckImgLoaded && puckImg.complete && puckImg.naturalWidth > 0) {
       ctx.drawImage(puckImg, -r, -r, r * 2, r * 2);
+      ctx.shadowColor = 'transparent';
+      ctx.lineWidth = Math.max(2, r * 0.09);
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.85)';
+      ctx.beginPath();
+      ctx.arc(0, 0, r * 0.98, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.lineWidth = Math.max(1.5, r * 0.05);
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.65)';
+      ctx.beginPath();
+      ctx.arc(0, 0, r * 0.9, 0, Math.PI * 2);
+      ctx.stroke();
       ctx.restore();
       return;
     }


### PR DESCRIPTION
### Motivation
- The puck image could blend into the field or bright markings on some backgrounds, making it hard to see on mobile (portrait) screens; the change aims to make the puck consistently visible and legible during gameplay.
- Keep the existing canvas fallback rendering intact so the puck still displays when the image fails to load.

### Description
- Added a soft drop shadow (`shadowColor`, `shadowBlur`, `shadowOffsetY`) in `drawPuck()` to lift the puck visually off the pitch when the image is used (`webapp/public/goal-rush.html`).
- Drew a high-contrast dual-ring outline (dark outer stroke and light inner stroke) around the rendered puck image to guarantee visibility against light/dark backgrounds while preserving the existing vector fallback path.

### Testing
- Served the site locally with `python3 -m http.server 4173 --directory webapp/public` and loaded `/goal-rush.html` in a mobile-sized viewport to validate the visual change.
- Ran a Playwright script to capture a screenshot at `430x932` to confirm the puck is visible; the page and puck asset requests completed and the screenshot showed the updated puck rendering (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f7de8eb8832989a65cdeea9e3cf1)