### PR TITLE
Fix Domino Royal black screen by repairing Three.js module paths

### DIFF
--- a/webapp/public/vendor/three/examples/jsm/controls/OrbitControls.js
+++ b/webapp/public/vendor/three/examples/jsm/controls/OrbitControls.js
@@ -9,7 +9,7 @@ import {
 	Plane,
 	Ray,
 	MathUtils
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/webapp/public/vendor/three/examples/jsm/environments/RoomEnvironment.js
+++ b/webapp/public/vendor/three/examples/jsm/environments/RoomEnvironment.js
@@ -10,7 +10,7 @@ import {
  	MeshStandardMaterial,
  	PointLight,
  	Scene,
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 
 class RoomEnvironment extends Scene {
 

--- a/webapp/public/vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js
+++ b/webapp/public/vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js
@@ -1,7 +1,7 @@
 import {
 	BoxGeometry,
 	Vector3
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 
 const _tempNormal = new Vector3();
 

--- a/webapp/public/vendor/three/examples/jsm/loaders/DRACOLoader.js
+++ b/webapp/public/vendor/three/examples/jsm/loaders/DRACOLoader.js
@@ -6,7 +6,7 @@ import {
 	Loader,
 	LinearSRGBColorSpace,
 	SRGBColorSpace
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 
 const _taskCache = new WeakMap();
 

--- a/webapp/public/vendor/three/examples/jsm/loaders/GLTFLoader.js
+++ b/webapp/public/vendor/three/examples/jsm/loaders/GLTFLoader.js
@@ -64,7 +64,7 @@ import {
 	VectorKeyframeTrack,
 	SRGBColorSpace,
 	InstancedBufferAttribute
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
 
 class GLTFLoader extends Loader {

--- a/webapp/public/vendor/three/examples/jsm/loaders/RGBELoader.js
+++ b/webapp/public/vendor/three/examples/jsm/loaders/RGBELoader.js
@@ -5,7 +5,7 @@ import {
 	HalfFloatType,
 	LinearFilter,
 	LinearSRGBColorSpace
-} from 'three';
+} from '/vendor/three/build/three.module.js';
 
 // https://github.com/mrdoob/three.js/issues/5552
 // http://en.wikipedia.org/wiki/RGBE_image_format

--- a/webapp/public/vendor/three/examples/jsm/utils/BufferGeometryUtils.js
+++ b/webapp/public/vendor/three/examples/jsm/utils/BufferGeometryUtils.js
@@ -1,0 +1,57 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  TriangleFanDrawMode,
+  TriangleStripDrawMode,
+  TrianglesDrawMode,
+} from '/vendor/three/build/three.module.js';
+
+export function toTrianglesDrawMode(geometry, drawMode) {
+  if (drawMode === TrianglesDrawMode) return geometry;
+  if (!(geometry instanceof BufferGeometry)) {
+    throw new Error('THREE.BufferGeometryUtils.toTrianglesDrawMode(): geometry is not a BufferGeometry instance.');
+  }
+
+  const index = geometry.getIndex();
+  if (index === null) {
+    console.warn('THREE.BufferGeometryUtils.toTrianglesDrawMode(): Geometry has no index.');
+    return geometry;
+  }
+
+  const numberOfTriangles = index.count - 2;
+  const newIndices = [];
+
+  if (drawMode === TriangleFanDrawMode) {
+    for (let i = 1; i <= numberOfTriangles; i++) {
+      newIndices.push(index.getX(0));
+      newIndices.push(index.getX(i));
+      newIndices.push(index.getX(i + 1));
+    }
+  } else if (drawMode === TriangleStripDrawMode) {
+    for (let i = 0; i < numberOfTriangles; i++) {
+      if (i % 2 === 0) {
+        newIndices.push(index.getX(i));
+        newIndices.push(index.getX(i + 1));
+        newIndices.push(index.getX(i + 2));
+      } else {
+        newIndices.push(index.getX(i + 2));
+        newIndices.push(index.getX(i + 1));
+        newIndices.push(index.getX(i));
+      }
+    }
+  } else {
+    console.error('THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unknown draw mode:', drawMode);
+    return geometry;
+  }
+
+  if ((newIndices.length / 3) !== numberOfTriangles) {
+    console.error('THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unable to generate correct amount of triangles.');
+  }
+
+  const newGeometry = geometry.clone();
+  newGeometry.setIndex(newIndices);
+  newGeometry.clearGroups();
+  return newGeometry;
+}
+
+export { BufferAttribute };


### PR DESCRIPTION
### Motivation
- The Domino Royal page rendered a black/blank screen because vendored Three.js example modules used bare `three` specifiers that the browser could not resolve from `/public`.
- `GLTFLoader` also imported a missing `BufferGeometryUtils.js` which caused runtime 404s and prevented initialization of the 3D scene.
- The change aims to make the vendored example modules load in the browser environment without bundler rewrites so the game can initialize its renderer and scene.

### Description
- Updated example modules to import Three from the explicit browser path by replacing `from 'three'` with `from '/vendor/three/build/three.module.js'` in `OrbitControls.js`, `RoomEnvironment.js`, `RoundedBoxGeometry.js`, `DRACOLoader.js`, `GLTFLoader.js`, and `RGBELoader.js`.
- Added `webapp/public/vendor/three/examples/jsm/utils/BufferGeometryUtils.js` implementing `toTrianglesDrawMode` so `GLTFLoader` can successfully import the utility at runtime.
- Ensured the renderer root element `#app` is populated (3D `canvas` created) and the Domino bootstrap proceeds to a playable state when run in the dev server.
- Left CDN fallback GLB asset requests unchanged; remote 403/404s may still appear but no longer block game startup.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully without the previous runtime module errors.
- Started the dev server and ran an automated Playwright check which navigated to `/games/domino-royal`, verified `#status` progressed to `Turn: Player 1` and that a `canvas` was present, and captured a screenshot; the check succeeded.
- Observed remaining 403/404 responses from some remote GLB/CDN URLs but confirmed they do not prevent the scene from initializing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940b3fb9a08329b4090aef02bdf491)