### PR TITLE
Remove Live Help Agent card and disable Murlan 3D human characters

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -4,7 +4,6 @@ import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
 import HomeSocialHub from '../components/HomeSocialHub.jsx';
 import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
-import PlatformHelpAgentCard from '../components/PlatformHelpAgentCard.jsx';
 
 import {
   FaArrowUp,
@@ -252,8 +251,6 @@ export default function Home() {
           future of crypto gaming. 🚀
         </p>
       </div>
-      <PlatformHelpAgentCard />
-
       <div className="flex justify-center space-x-4 mt-4">
         <a
           href="https://x.com/TonPlaygram?t=SyGyXA0H8PdLz7z2kfIWQw&s=09"


### PR DESCRIPTION
### Motivation
- Remove the TonPlaygram Live Help Agent UI card from the Home screen and stop rendering 3D human characters in the Murlan Royale scene while keeping gameplay and appearance controls otherwise unchanged.

### Description
- Removed the `PlatformHelpAgentCard` render/import from `webapp/src/pages/Home.jsx` so the Live Help Agent card no longer appears in the Home UI.
- Added `ENABLE_3D_HUMAN_CHARACTERS = false` flag to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and made character-related flows conditional on this flag.
- Made `CUSTOMIZATION_SECTIONS` conditional so the `3D Players` option is omitted when 3D humans are disabled, and guarded initial character loading/attachment so characters are not created when disabled.
- Updated rebuild/update paths to clear existing character instances and no-op safely when `ENABLE_3D_HUMAN_CHARACTERS` is false, and to set `characterThemeId` to `null` in that case.

### Testing
- Ran lint: `npx eslint webapp/src/pages/Home.jsx webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced warnings (files ignored by current eslint config) and no errors.
- Built the web app with `npm --prefix webapp run build` which completed successfully.
- Started the dev server with `npm --prefix webapp run dev` and verified the site served successfully.
- Captured automated screenshots using Playwright for visual verification of the Home page (no Live Help Agent) and the ` /games/murlanroyale` route (no 3D human characters), both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940c21ac6c8329bd8cb16d51a7cb14)