### PR TITLE
Fix TON wallet reconnect loop after successful connection

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
@@ -63,19 +63,22 @@ export default function App() {
   useReferralClaim();
   useNativePushNotifications();
 
-  const publicOrigin = (() => {
+  const publicOrigin = useMemo(() => {
     const origin = window.location.origin;
     if (origin.startsWith('http')) return origin;
     return import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram.com';
-  })();
-  const baseUrl = `${publicOrigin}${import.meta.env.BASE_URL}`;
-  const manifestUrl = new URL('tonconnect-manifest.json', baseUrl).toString();
-  const returnUrl = window.location.href;
+  }, []);
+  const baseUrl = useMemo(() => `${publicOrigin}${import.meta.env.BASE_URL}`, [publicOrigin]);
+  const manifestUrl = useMemo(() => new URL('tonconnect-manifest.json', baseUrl).toString(), [baseUrl]);
+  const returnUrl = useMemo(
+    () => new URL(import.meta.env.BASE_URL || '/', publicOrigin).toString(),
+    [publicOrigin]
+  );
   const telegramReturnUrl = `https://t.me/${BOT_USERNAME}?startapp=account`;
-  const actionsConfiguration = {
+  const actionsConfiguration = useMemo(() => ({
     returnUrl,
     twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
-  };
+  }), [returnUrl, telegramReturnUrl]);
 
   return (
     <BrowserRouter>

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -16,7 +16,9 @@ export default function TonConnectSync() {
 
   useEffect(() => {
     const address = wallet?.account?.address || '';
-    syncWalletAddress(address);
+    if (address) {
+      syncWalletAddress(address);
+    }
   }, [wallet]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Prevent TonConnect from being reinitialized on routine rerenders which could trigger repeated connect prompts and break session persistence.
- Avoid clearing a persisted `walletAddress` during transient restore states where `useTonWallet` briefly reports no account.

### Description

- Memoized `publicOrigin`, `baseUrl`, `manifestUrl`, `returnUrl`, and `actionsConfiguration` in `App.jsx` using `useMemo` so provider inputs are stable across rerenders and do not force reconnects.  
- Replaced unstable `window.location.href` return URL with a stable app base `returnUrl` derived from `import.meta.env.BASE_URL` and `publicOrigin`.  
- Updated `TonConnectSync` so `syncWalletAddress` is only called when a valid address exists (preventing accidental removal of `localStorage.walletAddress` during transient empty states) while keeping `onStatusChange` handling disconnects.  
- Minor code cleanup to ensure provider configuration and wallet sync are resilient to route changes and component lifecycle events.

### Testing

- Ran the production build with `cd webapp && npm run build`, which completed successfully (Vite build succeeded with non-blocking chunk warnings).  
- No automated test suites were modified or added as part of this change and the build output indicates the app compiles correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994110f41788329ae6d2328a666426c)