### PR TITLE
Treat Google-auth users like Telegram, add exchange coin drilldown, and reorganize profile hubs

### DIFF
--- a/bot/middleware/auth.js
+++ b/bot/middleware/auth.js
@@ -27,6 +27,8 @@ export function verifyTelegramInitData(initData, botToken = process.env.BOT_TOKE
 
 function attachAuth(req, token, initData) {
   const allowedToken = process.env.API_AUTH_TOKEN;
+  const googleId = req.get('x-google-id');
+  const googleEmail = req.get('x-google-email');
   if (initData) {
     const data = verifyTelegramInitData(initData);
     if (data) {
@@ -38,6 +40,13 @@ function attachAuth(req, token, initData) {
   }
   if (allowedToken && token === allowedToken) {
     req.auth = { apiToken: true };
+    return true;
+  }
+  if (googleId) {
+    req.auth = {
+      googleId: String(googleId),
+      googleEmail: googleEmail ? String(googleEmail) : undefined
+    };
     return true;
   }
   return false;

--- a/bot/routes/exchange.js
+++ b/bot/routes/exchange.js
@@ -47,6 +47,40 @@ async function fetchFromCoinCap() {
   }));
 }
 
+
+async function fetchCoinDetail(coinId) {
+  const [detailRes, chartRes] = await Promise.all([
+    fetch(`https://api.coingecko.com/api/v3/coins/${encodeURIComponent(coinId)}?localization=false&tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false`, { headers: { accept: 'application/json' } }),
+    fetch(`https://api.coingecko.com/api/v3/coins/${encodeURIComponent(coinId)}/market_chart?vs_currency=usd&days=7&interval=daily`, { headers: { accept: 'application/json' } })
+  ]);
+
+  if (!detailRes.ok) throw new Error(`Coin detail failed: ${detailRes.status}`);
+  if (!chartRes.ok) throw new Error(`Coin chart failed: ${chartRes.status}`);
+
+  const detail = await detailRes.json();
+  const chart = await chartRes.json();
+
+  return {
+    id: detail.id,
+    symbol: String(detail.symbol || '').toUpperCase(),
+    name: detail.name,
+    image: detail.image?.large || detail.image?.small || '',
+    description: detail.description?.en || '',
+    homepage: detail.links?.homepage?.[0] || '',
+    marketCapRank: normalizeNumber(detail.market_cap_rank, 9999),
+    currentPriceUsd: normalizeNumber(detail.market_data?.current_price?.usd),
+    marketCapUsd: normalizeNumber(detail.market_data?.market_cap?.usd),
+    totalVolumeUsd: normalizeNumber(detail.market_data?.total_volume?.usd),
+    high24hUsd: normalizeNumber(detail.market_data?.high_24h?.usd),
+    low24hUsd: normalizeNumber(detail.market_data?.low_24h?.usd),
+    athUsd: normalizeNumber(detail.market_data?.ath?.usd),
+    atlUsd: normalizeNumber(detail.market_data?.atl?.usd),
+    chart7d: Array.isArray(chart?.prices)
+      ? chart.prices.map(([timestamp, price]) => ({ timestamp, price: normalizeNumber(price) }))
+      : []
+  };
+}
+
 async function fetchTopMarkets() {
   const now = Date.now();
   if (cache.markets.length && now - cache.at < CACHE_TTL_MS) {
@@ -78,6 +112,20 @@ router.get('/markets', async (_req, res) => {
       return res.json({ ok: true, updatedAt: new Date(cache.at).toISOString(), markets: cache.markets, stale: true });
     }
     return res.status(502).json({ ok: false, error: error.message || 'Unable to fetch markets' });
+  }
+});
+
+
+router.get('/coins/:coinId', async (req, res) => {
+  try {
+    const coinId = String(req.params.coinId || '').trim();
+    if (!coinId) {
+      return res.status(400).json({ ok: false, error: 'coinId is required' });
+    }
+    const detail = await fetchCoinDetail(coinId);
+    return res.json({ ok: true, detail, updatedAt: new Date().toISOString() });
+  } catch (error) {
+    return res.status(502).json({ ok: false, error: error.message || 'Unable to fetch coin details' });
   }
 });
 

--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -77,15 +77,27 @@ export default function LoginOptions({ onAuthenticated, onTonConnected }) {
     let cancelled = false;
     setTonStatus('linking');
     (async () => {
-      const existingProfile = googleProfile || loadGoogleProfile();
-      const res = await createAccount(undefined, existingProfile || undefined, undefined, tonAddress);
-      if (cancelled) return;
-      if (res?.accountId) {
-        localStorage.setItem('accountId', res.accountId);
+      try {
+        const existingProfile = googleProfile || loadGoogleProfile();
+        const res = await createAccount(undefined, existingProfile || undefined, undefined, tonAddress);
+        if (cancelled) return;
+        if (res?.error) {
+          throw new Error(res.error);
+        }
+        if (res?.accountId) {
+          localStorage.setItem('accountId', res.accountId);
+        }
+        localStorage.setItem('walletAddress', tonAddress);
+        setTonStatus('ready');
+        if (onTonConnected) onTonConnected(tonAddress);
+      } catch (err) {
+        if (!cancelled) {
+          console.error('TON account setup failed', err);
+          localStorage.setItem('walletAddress', tonAddress);
+          if (onTonConnected) onTonConnected(tonAddress);
+          setTonStatus('error');
+        }
       }
-      localStorage.setItem('walletAddress', tonAddress);
-      setTonStatus('ready');
-      if (onTonConnected) onTonConnected(tonAddress);
     })();
     return () => {
       cancelled = true;
@@ -164,6 +176,9 @@ export default function LoginOptions({ onAuthenticated, onTonConnected }) {
           )}
           {tonStatus === 'ready' && (
             <p className="text-[11px] text-green-400">TON wallet linked. Reloading your profile…</p>
+          )}
+          {tonStatus === 'error' && (
+            <p className="text-[11px] text-amber-200">Wallet connected. Account sync had a delay, but you can continue now.</p>
           )}
         </div>
       </div>

--- a/webapp/src/pages/Exchange.jsx
+++ b/webapp/src/pages/Exchange.jsx
@@ -1,9 +1,34 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getExchangeMarkets, getExchangeConversionQuote } from '../utils/api.js';
+import {
+  getExchangeMarkets,
+  getExchangeConversionQuote,
+  getExchangeCoinDetails
+} from '../utils/api.js';
 
 function formatUsd(v) {
   if (!Number.isFinite(Number(v))) return '...';
   return Number(v).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 6 });
+}
+
+function MiniChart({ points = [] }) {
+  if (!points.length) return <p className="text-xs text-subtext">No chart data yet.</p>;
+  const values = points.map((p) => Number(p.price || 0));
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const path = values
+    .map((value, index) => {
+      const x = (index / Math.max(values.length - 1, 1)) * 100;
+      const y = 100 - ((value - min) / range) * 100;
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-24">
+      <path d={path} fill="none" stroke="#22c55e" strokeWidth="2.2" strokeLinecap="round" />
+    </svg>
+  );
 }
 
 export default function Exchange() {
@@ -11,6 +36,9 @@ export default function Exchange() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [updatedAt, setUpdatedAt] = useState('');
+  const [selectedCoinId, setSelectedCoinId] = useState('');
+  const [coinDetail, setCoinDetail] = useState(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   const [symbol, setSymbol] = useState('TON');
   const [amount, setAmount] = useState('1');
@@ -43,6 +71,20 @@ export default function Exchange() {
     setQuote(data);
   };
 
+  const loadCoinDetail = async (coinId) => {
+    setSelectedCoinId(coinId);
+    setDetailLoading(true);
+    const detailRes = await getExchangeCoinDetails(coinId);
+    if (detailRes?.error) {
+      setCoinDetail(null);
+      setError(detailRes.error);
+      setDetailLoading(false);
+      return;
+    }
+    setCoinDetail(detailRes.detail || null);
+    setDetailLoading(false);
+  };
+
   useEffect(() => {
     refresh();
     const id = setInterval(refresh, 10_000);
@@ -54,7 +96,7 @@ export default function Exchange() {
       <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
         <h1 className="text-xl font-semibold text-white">Exchange Infrastructure (Ready)</h1>
         <p className="text-xs text-subtext">
-          Live top 100 market-cap coins with 10s refresh. TPC conversion uses a configurable reference price until live markets are active.
+          Live top 100 market-cap coins with 10s refresh. Tap any coin to open a 7-day chart and live metrics from CoinGecko.
         </p>
         <p className="text-[11px] text-green-300">Last update: {updatedAt ? new Date(updatedAt).toLocaleTimeString() : '...'}</p>
       </div>
@@ -85,15 +127,43 @@ export default function Exchange() {
         )}
       </div>
 
+      {coinDetail && (
+        <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-white">{coinDetail.name} ({coinDetail.symbol})</h2>
+            <button className="text-xs text-subtext hover:text-white" onClick={() => setCoinDetail(null)}>Close</button>
+          </div>
+          <MiniChart points={coinDetail.chart7d} />
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <p>Price: <span className="text-white">{formatUsd(coinDetail.currentPriceUsd)}</span></p>
+            <p>Market Cap: <span className="text-white">{formatUsd(coinDetail.marketCapUsd)}</span></p>
+            <p>24h High: <span className="text-white">{formatUsd(coinDetail.high24hUsd)}</span></p>
+            <p>24h Low: <span className="text-white">{formatUsd(coinDetail.low24hUsd)}</span></p>
+          </div>
+          {coinDetail.homepage && (
+            <a className="text-xs text-primary underline" href={coinDetail.homepage} target="_blank" rel="noreferrer">Official website</a>
+          )}
+        </div>
+      )}
+
       <div className="bg-surface border border-border rounded-xl p-4">
         <h2 className="text-lg font-semibold text-white mb-3">Top 100 Coins (Market Cap)</h2>
         {loading && <p className="text-sm text-subtext">Loading market feed…</p>}
         {error && <p className="text-sm text-red-300">{error}</p>}
         <div className="space-y-2 max-h-[60vh] overflow-auto pr-1">
           {sorted.map((coin) => (
-            <div key={coin.id} className="flex items-center justify-between rounded-lg bg-background/50 border border-border px-3 py-2">
+            <button
+              key={coin.id}
+              type="button"
+              onClick={() => loadCoinDetail(coin.id)}
+              className={`w-full flex items-center justify-between rounded-lg bg-background/50 border px-3 py-2 text-left ${selectedCoinId === coin.id ? 'border-primary' : 'border-border'}`}
+            >
               <div className="flex items-center gap-2 min-w-0">
-                <img src={coin.image} alt={coin.symbol} className="w-6 h-6 rounded-full" />
+                {coin.image ? (
+                  <img src={coin.image} alt={coin.symbol} className="w-6 h-6 rounded-full" />
+                ) : (
+                  <div className="w-6 h-6 rounded-full bg-surface border border-border" />
+                )}
                 <div className="min-w-0">
                   <p className="text-sm text-white truncate">#{coin.marketCapRank} {coin.name} ({coin.symbol})</p>
                   <p className="text-[11px] text-subtext truncate">MCap: {formatUsd(coin.marketCapUsd)}</p>
@@ -105,9 +175,10 @@ export default function Exchange() {
                   {Number(coin.priceChange24h || 0).toFixed(2)}%
                 </p>
               </div>
-            </div>
+            </button>
           ))}
         </div>
+        {detailLoading && <p className="text-xs text-amber-300 mt-2">Loading selected coin details...</p>}
       </div>
     </div>
   );

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -29,7 +29,6 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
-import Wallet from './Wallet.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import { loadGoogleProfile, clearGoogleProfile } from '../utils/google.js';
 import useProfileLock from '../hooks/useProfileLock.js';
@@ -646,13 +645,18 @@ export default function MyAccount() {
         </div>
       </div>
 
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <p className="font-semibold text-white">Profile hubs</p>
+        <p className="text-xs text-subtext mt-1">Use Social Hub first for social identity connections, then use TPC Hub for wallet and token actions.</p>
+      </div>
+
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
         <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
           <div className="flex items-start gap-2">
             <FiExternalLink className="w-4 h-4 mt-1 text-primary" />
             <div>
-              <p className="font-semibold">Social links and sync</p>
-              <p className="text-xs text-subtext">Connect social identity so rewards and profile data stay consistent across platforms.</p>
+              <p className="font-semibold">Social Hub</p>
+              <p className="text-xs text-subtext">Manage all social connections for your profile here. Keep socials in sync across Telegram, Google, and X.</p>
             </div>
           </div>
 
@@ -860,8 +864,15 @@ export default function MyAccount() {
         </>
       )}
 
-      {/* Wallet section */}
-      <Wallet hideClaim />
+      <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
+        <p className="font-semibold text-white">TPC Hub</p>
+        <p className="text-xs text-subtext">All TPC wallet, statements, exchange and transfer tools are centralized in the TPC Hub.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <Link to="/hub" className="px-3 py-2 rounded-lg bg-primary hover:bg-primary-hover text-background text-sm font-semibold text-center">Open TPC Hub</Link>
+          <Link to="/wallet" className="px-3 py-2 rounded-lg border border-border hover:bg-background/70 text-sm text-center">Wallet</Link>
+          <Link to="/exchange" className="px-3 py-2 rounded-lg border border-border hover:bg-background/70 text-sm text-center">Exchange</Link>
+        </div>
+      </div>
       <DevNotifyModal
         open={showNotifyModal}
         onClose={() => setShowNotifyModal(false)}

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -85,6 +85,13 @@ export default function Wallet({ hideClaim = false }) {
   const [selectedTx, setSelectedTx] = useState(null);
   const dateInputRef = useRef(null);
 
+
+  useEffect(() => {
+    const syncGoogle = () => setGoogleProfile(loadGoogleProfile());
+    window.addEventListener('googleProfileUpdated', syncGoogle);
+    return () => window.removeEventListener('googleProfileUpdated', syncGoogle);
+  }, []);
+
   useEffect(() => {
     if (connectedTonAddress) {
       localStorage.setItem('walletAddress', connectedTonAddress);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -1,4 +1,5 @@
 import { getNativeBridgeHeaders } from './nativeBridge';
+import { loadGoogleProfile } from './google.js';
 
 // Use the API base URL from the build environment or fallback to the same origin
 // so the webapp works when served by the Express server in production.
@@ -77,6 +78,11 @@ function buildHeaders(base = {}) {
   const headers = { ...base };
   const initData = window?.Telegram?.WebApp?.initData;
   if (initData) headers['X-Telegram-Init-Data'] = initData;
+  const googleProfile = loadGoogleProfile();
+  if (googleProfile?.id) {
+    headers['X-Google-Id'] = googleProfile.id;
+    if (googleProfile.email) headers['X-Google-Email'] = googleProfile.email;
+  }
   const bridgeHeaders = getNativeBridgeHeaders();
   Object.entries(bridgeHeaders).forEach(([key, value]) => {
     if (value && !headers[key]) headers[key] = value;
@@ -708,4 +714,9 @@ export function getExchangeConversionQuote(from, amount) {
   const symbol = encodeURIComponent(String(from || 'TON').toUpperCase());
   const qty = encodeURIComponent(String(amount || '0'));
   return get(`/api/exchange/convert?from=${symbol}&amount=${qty}`);
+}
+
+export function getExchangeCoinDetails(coinId) {
+  if (!coinId) return Promise.resolve({ error: 'coinId required' });
+  return get(`/api/exchange/coins/${encodeURIComponent(coinId)}`);
 }


### PR DESCRIPTION
### Motivation
- Google-signed-in users were treated as unauthorised for profile/account endpoints while Telegram users worked, the exchange list needed clickable coin details and charts, the profile layout mixed wallet/social concerns, and TON wallet linking could get stuck; the changes address these gaps. 

### Description
- Propagate Google identity from the web client by adding `X-Google-Id` / `X-Google-Email` headers and a client helper `getExchangeCoinDetails` in `webapp/src/utils/api.js` so backend can recognize Google sessions. 
- Accept Google headers in backend auth and authorize Google-linked accounts by adding `attachAuth` handling and `isAccountOwner` checks so Google users receive the same access as Telegram users (`bot/middleware/auth.js`, `bot/routes/account.js`).
- Add an exchange drilldown endpoint `GET /api/exchange/coins/:coinId` that fetches CoinGecko detail + 7-day chart and return richer metrics (`bot/routes/exchange.js`).
- Improve Exchange UI to present the top-100 as clickable items, show a mini 7-day chart and detailed metrics when a coin is selected (`webapp/src/pages/Exchange.jsx`).
- Reorganize the account page into ordered hubs: add an in-profile **Social Hub** (Telegram/Google/X linking) and a **TPC Hub** launcher that routes to hub/wallet/exchange pages; remove the wallet embed from the main profile area (`webapp/src/pages/MyAccount.jsx`).
- Improve TON Connect UX by handling delayed account-sync errors to avoid perpetual linking state and surface a graceful status; sync wallet page auth on Google profile updates (`webapp/src/components/LoginOptions.jsx`, `webapp/src/pages/Wallet.jsx`).

### Testing
- Ran `node --check` on modified server files (`bot/middleware/auth.js`, `bot/routes/account.js`, `bot/routes/exchange.js`) and they passed without syntax errors. 
- Ran `npx eslint` with the repo’s default ignore rules which produced only ignored-file warnings for these files; running `npx eslint --no-ignore` reports many style-rule violations that appear to be pre-existing codebase lint mismatches (not functional errors). 
- Started the web dev server with `npm --prefix webapp run dev` and verified pages in a mobile viewport using Playwright; captured screenshots for `/exchange` and `/account` (exchange and account hubs images saved). 
- Initiated the frontend build which wrote build metadata; a full production build/CI smoke-run was not fully validated in this session. 

If you want, I can split the changes into smaller PRs (auth vs UI vs exchange) or add unit/integration tests around account auth logic and the new exchange endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699430b08a948329b2bc491215edc0ca)