### PR TITLE
Allow Google/wallet access to profiles, add exchange coin details, and improve wallet/profile UX

### DIFF
--- a/webapp/src/components/LoginOptions.jsx
+++ b/webapp/src/components/LoginOptions.jsx
@@ -76,17 +76,26 @@ export default function LoginOptions({ onAuthenticated, onTonConnected }) {
     if (!tonAddress) return;
     let cancelled = false;
     setTonStatus('linking');
+    localStorage.setItem('walletAddress', tonAddress);
+    if (onTonConnected) onTonConnected(tonAddress);
+
     (async () => {
-      const existingProfile = googleProfile || loadGoogleProfile();
-      const res = await createAccount(undefined, existingProfile || undefined, undefined, tonAddress);
-      if (cancelled) return;
-      if (res?.accountId) {
-        localStorage.setItem('accountId', res.accountId);
+      try {
+        const existingProfile = googleProfile || loadGoogleProfile();
+        const res = await createAccount(undefined, existingProfile || undefined, undefined, tonAddress);
+        if (cancelled) return;
+        if (res?.accountId) {
+          localStorage.setItem('accountId', res.accountId);
+        }
+        setTonStatus('ready');
+      } catch (err) {
+        console.error('TON account setup failed', err);
+        if (!cancelled) {
+          setTonStatus('ready');
+        }
       }
-      localStorage.setItem('walletAddress', tonAddress);
-      setTonStatus('ready');
-      if (onTonConnected) onTonConnected(tonAddress);
     })();
+
     return () => {
       cancelled = true;
     };

--- a/webapp/src/pages/Exchange.jsx
+++ b/webapp/src/pages/Exchange.jsx
@@ -1,9 +1,35 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getExchangeMarkets, getExchangeConversionQuote } from '../utils/api.js';
+import { getExchangeMarkets, getExchangeConversionQuote, getExchangeCoinDetails } from '../utils/api.js';
 
 function formatUsd(v) {
   if (!Number.isFinite(Number(v))) return '...';
   return Number(v).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 6 });
+}
+
+function Sparkline({ points = [] }) {
+  if (!points.length) return <p className="text-xs text-subtext">Chart data unavailable.</p>;
+  const prices = points.map((p) => Number(p.priceUsd)).filter((v) => Number.isFinite(v));
+  if (!prices.length) return <p className="text-xs text-subtext">Chart data unavailable.</p>;
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const range = max - min || 1;
+  const coords = prices.map((p, i) => {
+    const x = (i / Math.max(prices.length - 1, 1)) * 100;
+    const y = 100 - ((p - min) / range) * 100;
+    return `${x},${y}`;
+  }).join(' ');
+
+  return (
+    <div className="space-y-1">
+      <svg viewBox="0 0 100 100" className="w-full h-28 rounded bg-background/60 border border-border" preserveAspectRatio="none">
+        <polyline points={coords} fill="none" stroke="#22d3ee" strokeWidth="2" />
+      </svg>
+      <div className="flex items-center justify-between text-[11px] text-subtext">
+        <span>7d low: {formatUsd(min)}</span>
+        <span>7d high: {formatUsd(max)}</span>
+      </div>
+    </div>
+  );
 }
 
 export default function Exchange() {
@@ -11,6 +37,9 @@ export default function Exchange() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [updatedAt, setUpdatedAt] = useState('');
+  const [selectedCoin, setSelectedCoin] = useState(null);
+  const [coinDetails, setCoinDetails] = useState(null);
+  const [detailsLoading, setDetailsLoading] = useState(false);
 
   const [symbol, setSymbol] = useState('TON');
   const [amount, setAmount] = useState('1');
@@ -43,6 +72,21 @@ export default function Exchange() {
     setQuote(data);
   };
 
+  const loadCoin = async (coin) => {
+    setSelectedCoin(coin);
+    setCoinDetails(null);
+    setDetailsLoading(true);
+    try {
+      const data = await getExchangeCoinDetails(coin.id);
+      if (data?.error) throw new Error(data.error);
+      setCoinDetails(data.coin || null);
+    } catch (err) {
+      setError(err.message || 'Failed to load coin details');
+    } finally {
+      setDetailsLoading(false);
+    }
+  };
+
   useEffect(() => {
     refresh();
     const id = setInterval(refresh, 10_000);
@@ -54,7 +98,7 @@ export default function Exchange() {
       <div className="bg-surface border border-border rounded-xl p-4 space-y-2">
         <h1 className="text-xl font-semibold text-white">Exchange Infrastructure (Ready)</h1>
         <p className="text-xs text-subtext">
-          Live top 100 market-cap coins with 10s refresh. TPC conversion uses a configurable reference price until live markets are active.
+          Live top 100 market-cap coins with 10s refresh. Tap any coin to open live chart + details from CoinGecko.
         </p>
         <p className="text-[11px] text-green-300">Last update: {updatedAt ? new Date(updatedAt).toLocaleTimeString() : '...'}</p>
       </div>
@@ -62,18 +106,8 @@ export default function Exchange() {
       <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
         <h2 className="text-lg font-semibold text-white">Convert to TPC</h2>
         <div className="flex gap-2">
-          <input
-            value={symbol}
-            onChange={(e) => setSymbol(e.target.value.toUpperCase())}
-            className="bg-background border border-border rounded px-3 py-2 w-24"
-            placeholder="TON"
-          />
-          <input
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            className="bg-background border border-border rounded px-3 py-2 flex-1"
-            placeholder="Amount"
-          />
+          <input value={symbol} onChange={(e) => setSymbol(e.target.value.toUpperCase())} className="bg-background border border-border rounded px-3 py-2 w-24" placeholder="TON" />
+          <input value={amount} onChange={(e) => setAmount(e.target.value)} className="bg-background border border-border rounded px-3 py-2 flex-1" placeholder="Amount" />
           <button onClick={convert} className="px-4 py-2 bg-primary text-black rounded font-semibold">Quote</button>
         </div>
         {quote && (
@@ -86,14 +120,15 @@ export default function Exchange() {
       </div>
 
       <div className="bg-surface border border-border rounded-xl p-4">
-        <h2 className="text-lg font-semibold text-white mb-3">Top 100 Coins (Market Cap)</h2>
+        <h2 className="text-lg font-semibold text-white mb-1">Top 100 Coins (Market Cap)</h2>
+        <p className="text-[11px] text-subtext mb-3">Loaded: {sorted.length}/100 coins</p>
         {loading && <p className="text-sm text-subtext">Loading market feed…</p>}
         {error && <p className="text-sm text-red-300">{error}</p>}
         <div className="space-y-2 max-h-[60vh] overflow-auto pr-1">
           {sorted.map((coin) => (
-            <div key={coin.id} className="flex items-center justify-between rounded-lg bg-background/50 border border-border px-3 py-2">
+            <button key={coin.id} onClick={() => loadCoin(coin)} className="w-full flex items-center justify-between rounded-lg bg-background/50 border border-border px-3 py-2 text-left">
               <div className="flex items-center gap-2 min-w-0">
-                <img src={coin.image} alt={coin.symbol} className="w-6 h-6 rounded-full" />
+                {coin.image ? <img src={coin.image} alt={coin.symbol} className="w-6 h-6 rounded-full" /> : <div className="w-6 h-6 rounded-full bg-background border border-border" />}
                 <div className="min-w-0">
                   <p className="text-sm text-white truncate">#{coin.marketCapRank} {coin.name} ({coin.symbol})</p>
                   <p className="text-[11px] text-subtext truncate">MCap: {formatUsd(coin.marketCapUsd)}</p>
@@ -101,14 +136,35 @@ export default function Exchange() {
               </div>
               <div className="text-right">
                 <p className="text-sm text-white">{formatUsd(coin.currentPriceUsd)}</p>
-                <p className={`text-[11px] ${Number(coin.priceChange24h) >= 0 ? 'text-green-300' : 'text-red-300'}`}>
-                  {Number(coin.priceChange24h || 0).toFixed(2)}%
-                </p>
+                <p className={`text-[11px] ${Number(coin.priceChange24h) >= 0 ? 'text-green-300' : 'text-red-300'}`}>{Number(coin.priceChange24h || 0).toFixed(2)}%</p>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>
+
+      {selectedCoin && (
+        <div className="fixed inset-0 z-50 bg-black/70 p-4 flex items-end sm:items-center justify-center" onClick={() => setSelectedCoin(null)}>
+          <div className="w-full max-w-xl bg-surface border border-border rounded-xl p-4 space-y-3" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-white">{selectedCoin.name} ({selectedCoin.symbol})</h3>
+              <button onClick={() => setSelectedCoin(null)} className="text-xs px-2 py-1 border border-border rounded">Close</button>
+            </div>
+            {detailsLoading && <p className="text-sm text-subtext">Loading chart + info…</p>}
+            {coinDetails && (
+              <>
+                <Sparkline points={coinDetails.chart} />
+                <div className="grid grid-cols-2 gap-2 text-xs">
+                  <div className="rounded border border-border bg-background/50 p-2">Price: {formatUsd(coinDetails.currentPriceUsd)}</div>
+                  <div className="rounded border border-border bg-background/50 p-2">24h Vol: {formatUsd(coinDetails.volume24hUsd)}</div>
+                  <div className="rounded border border-border bg-background/50 p-2">ATH: {formatUsd(coinDetails.athUsd)}</div>
+                  <div className="rounded border border-border bg-background/50 p-2">ATL: {formatUsd(coinDetails.atlUsd)}</div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -161,7 +161,7 @@ export default function MyAccount() {
         setTonWalletAddress(walletToStore);
       }
 
-      const data = await getAccountInfo(accountPayload.accountId);
+      const data = await getAccountInfo(accountPayload.accountId, { googleId: googleProfile?.id, walletAddress: tonWalletAddress || connectedTonAddress });
       if (!data || data?.error) {
         throw new Error(data?.error || 'Unable to fetch your profile.');
       }
@@ -642,6 +642,26 @@ export default function MyAccount() {
               <FiBell className="w-4 h-4" />
               Inbox
             </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-surface border border-border rounded-xl p-4 space-y-3">
+        <h3 className="text-base font-semibold text-white">Profile hubs</h3>
+        <p className="text-xs text-subtext">1) TPC Hub for all token/account actions. 2) Social Hub for messaging + community actions.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <Link to="/hub" className="rounded-lg border border-border bg-background/60 p-3">
+            <p className="text-sm font-semibold text-white">1. TPC Hub</p>
+            <p className="text-[11px] text-subtext mt-1">Wallet status, account statements, exchange and core TPC tools.</p>
+          </Link>
+          <div className="rounded-lg border border-border bg-background/60 p-3">
+            <p className="text-sm font-semibold text-white">2. Social Hub</p>
+            <div className="mt-2 flex flex-wrap gap-2 text-xs">
+              <Link to="/messages" className="px-2 py-1 rounded border border-border">Messages</Link>
+              <Link to="/notifications" className="px-2 py-1 rounded border border-border">Notifications</Link>
+              <Link to="/trending" className="px-2 py-1 rounded border border-border">Trending</Link>
+              <Link to="/referral" className="px-2 py-1 rounded border border-border">Referral</Link>
+            </div>
           </div>
         </div>
       </div>

--- a/webapp/src/pages/TPCHub.jsx
+++ b/webapp/src/pages/TPCHub.jsx
@@ -51,7 +51,7 @@ export default function TPCHub() {
         if (cancelled) return;
         setAccountId(account.accountId);
         localStorage.setItem('accountId', account.accountId);
-        const tx = await getAccountTransactions(account.accountId);
+        const tx = await getAccountTransactions(account.accountId, { googleId: googleProfile?.id, walletAddress: tonAddress || localStorage.getItem('walletAddress') });
         if (!cancelled) {
           setTransactions(Array.isArray(tx) ? tx : tx?.transactions || []);
         }

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -105,7 +105,7 @@ export default function Wallet({ hideClaim = false }) {
 
   const refreshTransactions = async (id) => {
     if (!id) return;
-    const txRes = await getAccountTransactions(id);
+    const txRes = await getAccountTransactions(id, { googleId: googleProfile?.id, walletAddress: tonWalletAddress || connectedTonAddress });
     const list = txRes.transactions || [];
     const merged = mergeStoreTransactions(list, id);
     setTransactions(merged);
@@ -134,7 +134,7 @@ export default function Wallet({ hideClaim = false }) {
     }
     setAccountId(acc.accountId || id);
 
-    const bal = await getAccountBalance(acc.accountId || id);
+    const bal = await getAccountBalance(acc.accountId || id, { googleId: googleProfile?.id, walletAddress: tonWalletAddress || connectedTonAddress });
     if (bal?.error || typeof bal.balance !== 'number') {
       console.error('Failed to load TPC balance:', bal?.error);
       setTpcBalance(0);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -637,12 +637,12 @@ export function createAccount(telegramId, googleProfile, accountId, walletAddres
   return post('/api/account/create', body);
 }
 
-export function getAccountBalance(accountId) {
-  return post('/api/account/balance', { accountId });
+export function getAccountBalance(accountId, access = {}) {
+  return post('/api/account/balance', { accountId, ...access });
 }
 
-export function getAccountInfo(accountId) {
-  return post('/api/account/info', { accountId });
+export function getAccountInfo(accountId, access = {}) {
+  return post('/api/account/info', { accountId, ...access });
 }
 
 export function sendAccountTpc(fromAccount, toAccount, amount, note) {
@@ -651,8 +651,13 @@ export function sendAccountTpc(fromAccount, toAccount, amount, note) {
   return post('/api/account/send', body);
 }
 
-export function getAccountTransactions(accountId) {
-  return post('/api/account/transactions', { accountId });
+export function getAccountTransactions(accountId, access = {}) {
+  return post('/api/account/transactions', { accountId, ...access });
+}
+
+export function getExchangeCoinDetails(coinId) {
+  const id = encodeURIComponent(String(coinId || '').trim());
+  return get(`/api/exchange/coin/${id}`);
 }
 
 export function getGameTransactions(limit = 1000) {


### PR DESCRIPTION
### Motivation
- Google-authenticated users and users that connect a TON wallet should be treated the same as Telegram users and be allowed to view their profile, balances and transactions without receiving "unauthorized" errors.
- The Exchange should offer clickable coins with drilldown charts and metadata so users can inspect coin details and 7-day price history.
- Profile page layout must include the Social hub inside the profile and present hub actions in a clear ordered way.
- TON wallet UX during connect should immediately reflect connection state and not get stuck while background account setup runs or fails.

### Description
- Backend: added `canAccessUser` access helper and `normalizeAddress` to `bot/routes/account.js` so `googleId` and `walletAddress` are accepted as valid access context for `balance`, `info` and `transactions` endpoints instead of relying only on Telegram init auth.
- Backend: added `GET /api/exchange/coin/:id` (CoinGecko) with a 7-day market chart and metadata via `fetchCoinDetails` in `bot/routes/exchange.js` so per-coin drilldowns are available.
- Frontend: updated API helpers (`getAccountBalance`, `getAccountInfo`, `getAccountTransactions`) to accept an `access` object and added `getExchangeCoinDetails` in `webapp/src/utils/api.js` so callers can send `googleId`/`walletAddress` context.
- Frontend: wired callers in `MyAccount`, `Wallet`, and `TPCHub` to pass `{ googleId, walletAddress }`, added a clickable coin list + modal with sparkline and stats in `Exchange.jsx`, and injected a “Profile hubs” block (TPC Hub first, Social Hub second) into `MyAccount.jsx`.
- Frontend: improved TON Connect flow in `LoginOptions.jsx` so the wallet address is persisted immediately and the UI no longer stays stuck in a linking state if background account creation errors occur.

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully (no compile/runtime JS errors during the build).
- Attempted a Playwright smoke run to capture screenshots of the Exchange and Account pages, but the headless Chromium process crashed (SIGSEGV) in the environment so browser screenshots could not be generated; the crash is environment-level and unrelated to the app changes.
- Manual code validation: exercised account flows in code by ensuring callers send `googleId`/`walletAddress` and backend `canAccessUser` allows access for Google/wallet contexts, and verified `GET /api/exchange/markets` + `GET /api/exchange/coin/:id` code paths exist and return normalized coin payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699430b08a948329b2bc491215edc0ca)