### PR TITLE
Refine account connection UX; remove TPC Hub nav and consolidate developer tools

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -16,7 +16,6 @@ import InfluencerAdmin from './pages/InfluencerAdmin.jsx';
 import Nfts from './pages/Nfts.jsx';
 import PlatformStatsDetails from './pages/PlatformStatsDetails.jsx';
 import Exchange from './pages/Exchange.jsx';
-import TPCHub from './pages/TPCHub.jsx';
 
 import SnakeAndLadder from './pages/Games/SnakeAndLadder.jsx';
 import SnakeMultiplayer from './pages/Games/SnakeMultiplayer.jsx';
@@ -187,8 +186,6 @@ export default function App() {
             <Route path="/nfts" element={<Nfts />} />
             <Route path="/platform-stats" element={<PlatformStatsDetails />} />
             <Route path="/exchange" element={<Exchange />} />
-            <Route path="/hub" element={<TPCHub />} />
-
             {/* Internal tools (used for automated store thumbnail generation) */}
             <Route
               path="/tools/store-thumb/poolroyale/table-finish/:finishId"

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -3,8 +3,7 @@ import {
   AiOutlinePlayCircle,
   AiOutlineCheckSquare,
   AiOutlineUser,
-  AiOutlineShop,
-  AiOutlineAppstore
+  AiOutlineShop
 } from 'react-icons/ai';
 import { GiMining } from 'react-icons/gi';
 import NavItem from './NavItem.jsx';
@@ -12,13 +11,12 @@ import NavItem from './NavItem.jsx';
 export default function Navbar() {
   return (
     <nav className="fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
-      <div className="container mx-auto px-3 py-3 grid grid-cols-7 gap-1 text-[11px]">
+      <div className="container mx-auto px-3 py-3 grid grid-cols-6 gap-1 text-[11px]">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
         <NavItem to="/mining" icon={GiMining} label="Mining" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
         <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
         <NavItem to="/store" icon={AiOutlineShop} label="Store" />
-        <NavItem to="/hub" icon={AiOutlineAppstore} label="TPC Hub" />
         <NavItem to="/account" icon={AiOutlineUser} label="Profile" />
       </div>
     </nav>

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -33,6 +33,7 @@ import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
+import { loadGoogleProfile } from '../utils/google.js';
 
 
 export default function Home() {
@@ -43,6 +44,14 @@ export default function Home() {
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
+  const hasGoogle = Boolean(loadGoogleProfile()?.id);
+  let telegramId = null;
+  try {
+    telegramId = getTelegramId();
+  } catch {
+    telegramId = null;
+  }
+  const hasTelegram = Boolean(telegramId);
 
   const handleOpenTelegramAuth = () => {
     const deepLink = 'tg://resolve?domain=TonPlaygramBot&startapp=account';
@@ -56,7 +65,7 @@ export default function Home() {
       .then(() => setStatus('online'))
       .catch(() => setStatus('offline'));
 
-    const id = getTelegramId();
+    const id = telegramId;
     const saved = loadAvatar();
     if (saved) {
       setPhotoUrl(saved);
@@ -82,7 +91,7 @@ export default function Home() {
     }
 
     const handleUpdate = () => {
-      const id = getTelegramId();
+      const id = telegramId;
       const saved = loadAvatar();
       if (saved) {
         setPhotoUrl(saved);
@@ -133,21 +142,30 @@ export default function Home() {
 
         <TonConnectButton />
         <div className="w-full rounded-xl border border-border bg-surface/60 p-3 mb-2 space-y-2">
-          <p className="text-xs text-subtext">1 TPC account • sign in with Telegram, Google, or Web3 wallet.</p>
+          <p className="text-xs text-subtext">1 TPC account • connect only what is still missing.</p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-            <button
-              onClick={handleOpenTelegramAuth}
-              className="px-3 py-2 rounded-lg bg-[#229ED9] text-white text-sm font-semibold"
-            >
-              Continue with Telegram
-            </button>
-            <div className="flex items-center justify-center rounded-lg border border-border bg-background/60 px-2 py-1">
-              <LinkGoogleButton telegramId={null} label="Continue with Google" />
-            </div>
-            <div className="rounded-lg border border-border bg-background/60 px-2 py-1 flex items-center justify-center">
-              <TonConnectButton small className="mt-0" />
-            </div>
+            {!hasTelegram && (
+              <button
+                onClick={handleOpenTelegramAuth}
+                className="px-3 py-2 rounded-lg bg-[#229ED9] text-white text-sm font-semibold"
+              >
+                Continue with Telegram
+              </button>
+            )}
+            {!hasGoogle && (
+              <div className="flex items-center justify-center rounded-lg border border-border bg-background/60 px-2 py-1">
+                <LinkGoogleButton telegramId={telegramId || null} label="Continue with Google" />
+              </div>
+            )}
+            {!walletAddress && (
+              <div className="rounded-lg border border-border bg-background/60 px-2 py-1 flex items-center justify-center">
+                <TonConnectButton small className="mt-0" />
+              </div>
+            )}
           </div>
+          {hasTelegram && hasGoogle && walletAddress && (
+            <p className="text-xs text-green-400">All account connection methods are already linked.</p>
+          )}
           <Link to="/exchange" className="inline-flex text-xs text-primary underline">Open Exchange (Top 100 + TPC converter)</Link>
         </div>
 

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -359,6 +359,12 @@ export default function MyAccount() {
   ];
   const completedChecklistCount = profileChecklist.filter((item) => item.done).length;
   const profileCompletion = Math.round((completedChecklistCount / profileChecklist.length) * 100);
+  const devPanelTools = [
+    { label: 'Top up', value: 'Instant TPC credit testing' },
+    { label: 'Notify', value: 'Broadcast update to all users' },
+    { label: 'Manage tasks', value: 'Create, update, and remove quests' },
+    { label: 'Claims', value: 'Review influencer payout requests' }
+  ];
 
   const handleDevTopup = async () => {
     const amt = Number(devTopup);
@@ -654,7 +660,7 @@ export default function MyAccount() {
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
         <div className="bg-surface border border-border rounded-xl p-4 space-y-4">
           <div className="space-y-2">
-            <p className="font-semibold text-white">TPC Hub</p>
+            <p className="font-semibold text-white">Wallet & Account Tools</p>
             <p className="text-xs text-subtext">Core account actions and TPC tools in one place.</p>
             <div className="flex flex-wrap gap-2 text-xs sm:text-sm">
               <Link to="/wallet" className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background/60 px-3 py-2"><FiGrid className="w-4 h-4" />Wallet</Link>
@@ -841,17 +847,29 @@ export default function MyAccount() {
       </div>
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
-        <>
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-            <label className="block font-semibold text-center">
-              Top Up Developer Account
-            </label>
+        <div className="prism-box p-4 mt-4 space-y-4 mx-auto wide-card">
+          <div className="space-y-1">
+            <p className="text-lg font-semibold text-white">Developer Control Panel</p>
+            <p className="text-xs text-subtext">All core admin actions are grouped in one frame for faster operation on mobile.</p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {devPanelTools.map((tool) => (
+              <div key={tool.label} className="rounded-lg border border-border bg-background/60 p-2">
+                <p className="text-sm font-semibold text-white">{tool.label}</p>
+                <p className="text-[11px] text-subtext">{tool.value}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-lg border border-border bg-background/60 p-3 space-y-2">
+            <label className="block font-semibold text-sm">Top Up Developer Account</label>
             <input
               type="number"
               placeholder="Amount"
               value={devTopup}
               onChange={(e) => setDevTopup(e.target.value)}
-              className="border p-1 rounded w-full max-w-xs mx-auto text-black"
+              className="border p-1 rounded w-full max-w-xs text-black"
             />
             <button
               onClick={handleDevTopup}
@@ -862,26 +880,30 @@ export default function MyAccount() {
             </button>
           </div>
 
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             <button
               onClick={() => setShowNotifyModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
+              className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full"
             >
-              Notify
+              Open Notify Center
+            </button>
+            <button
+              onClick={() => setShowTasksModal(true)}
+              className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full"
+            >
+              Open Task Manager
             </button>
           </div>
 
-          <div className="prism-box p-4 mt-4 space-y-2 mx-auto wide-card">
-            <button
-              onClick={() => setShowTasksModal(true)}
-              className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
-            >
-              Manage Tasks
-            </button>
+          <div className="rounded-lg border border-border bg-background/60 p-3 text-xs text-subtext space-y-1">
+            <p><span className="text-white">Dev account:</span> {DEV_ACCOUNT_ID}</p>
+            <p><span className="text-white">Profile account:</span> {profile.accountId}</p>
+            <p><span className="text-white">Telegram:</span> {telegramId || 'not linked'}</p>
+            <p><span className="text-white">Google:</span> {googleLinked ? 'linked' : 'not linked'}</p>
           </div>
 
           <InfluencerClaimsCard />
-        </>
+        </div>
       )}
 
       <DevNotifyModal

--- a/webapp/src/pages/Wallet.jsx
+++ b/webapp/src/pages/Wallet.jsx
@@ -18,6 +18,8 @@ import { AiOutlineCalendar } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import { loadGoogleProfile } from '../utils/google.js';
 import LoginOptions from '../components/LoginOptions.jsx';
+import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
+import TonConnectButton from '../components/TonConnectButton.jsx';
 import { mergeStoreTransactions } from '../utils/storeTransactions.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -63,6 +65,9 @@ export default function Wallet({ hideClaim = false }) {
   const [tonWalletAddress, setTonWalletAddress] = useState(() => localStorage.getItem('walletAddress') || '');
   const [googleProfile, setGoogleProfile] = useState(() => (telegramId ? null : loadGoogleProfile()));
   const requiresAuth = !telegramId && !googleProfile?.id && !tonWalletAddress && !connectedTonAddress;
+  const hasTelegram = Boolean(telegramId);
+  const hasGoogle = Boolean(googleProfile?.id);
+  const hasWallet = Boolean(connectedTonAddress || tonWalletAddress);
 
   const [accountId, setAccountId] = useState('');
   const [tpcBalance, setTpcBalance] = useState(null);
@@ -311,6 +316,31 @@ export default function Wallet({ hideClaim = false }) {
   return (
     <div className="relative p-4 space-y-4 text-text wide-card">
       <h2 className="text-xl font-bold text-center">TPC Account Wallet</h2>
+      <div className="bg-surface border border-border rounded-xl p-4 space-y-3 wide-card mx-auto">
+        <h3 className="text-base font-semibold text-white">Identity & Wallet Connections</h3>
+        <div className="grid grid-cols-1 gap-2">
+          <div className="rounded-lg border border-border bg-background/60 p-3 flex items-center justify-between">
+            <span className="text-sm">Telegram</span>
+            <span className={`text-xs font-semibold ${hasTelegram ? 'text-green-300' : 'text-amber-300'}`}>{hasTelegram ? 'Connected' : 'Not connected'}</span>
+          </div>
+          <div className="rounded-lg border border-border bg-background/60 p-3 flex items-center justify-between gap-2">
+            <span className="text-sm">Google</span>
+            {hasGoogle ? (
+              <span className="text-xs font-semibold text-green-300">Connected</span>
+            ) : (
+              <LinkGoogleButton telegramId={telegramId || null} label="Connect" onAuthenticated={setGoogleProfile} />
+            )}
+          </div>
+          <div className="rounded-lg border border-border bg-background/60 p-3 flex items-center justify-between gap-2">
+            <span className="text-sm">TON Wallet</span>
+            {hasWallet ? (
+              <span className="text-xs font-semibold text-green-300">Connected</span>
+            ) : (
+              <TonConnectButton small className="mt-0" />
+            )}
+          </div>
+        </div>
+      </div>
       <div className="prism-box p-6 space-y-2 min-h-40 flex flex-col items-start wide-card mx-auto">
         <p className="text-xs break-all w-full text-left">
           <span className="text-white text-outline-black">Account:</span>{' '}


### PR DESCRIPTION
### Motivation
- Remove the separate TPC Hub entrypoint and keep wallet/account tools where users expect them (Profile & Wallet). 
- Avoid duplicate connection cards on Home when a user is already connected via Telegram/Google/TON. 
- Provide a single compact control frame on Profile that acts as an advanced developer control panel. 
- Surface connection status in Wallet so identity + wallet tools are available in a hub-style frame without a separate route.

### Description
- Removed the TPC Hub navigation item and its route so the app no longer exposes a separate `/hub` page and the bottom nav is reduced to 6 items (`webapp/src/components/Navbar.jsx`, `webapp/src/App.jsx`).
- Home connection area now only renders the Telegram / Google / TON connect cards when that method is not already linked, and shows an "all linked" status when all are connected (`webapp/src/pages/Home.jsx`).
- Reintroduced a compact `Identity & Wallet Connections` frame inside the Wallet page showing Telegram / Google / TON connection status and inline connect actions (`webapp/src/pages/Wallet.jsx`).
- Renamed the Profile section label from `TPC Hub` to `Wallet & Account Tools` and consolidated developer-only actions into a single `Developer Control Panel` containing top-up, notify center, task manager, claims and quick diagnostics (`webapp/src/pages/MyAccount.jsx`).
- Minor layout/grid adjustments to the navbar to match the reduced number of items and small UI text/content tweaks to connect flows.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Started the dev server (`npm --prefix webapp run dev`) and verified the site served locally during validation (Vite reported ready). 
- Automated visual check: captured a Playwright screenshot of the updated Profile page (`artifacts/account-updated.png`) to validate the new Developer Control Panel frame visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69945325422883299afadd3e7a18a0a5)