### PR TITLE
Fix TonConnect identity, icon and auto-close wallet modal

### DIFF
--- a/frontend/dist/tonconnect-manifest.json
+++ b/frontend/dist/tonconnect-manifest.json
@@ -1,5 +1,7 @@
 {
-  "url": "https://example.com",
   "name": "TonPlaygram",
-  "iconUrl": "https://wallet.tg/images/logo.png"
+  "url": "https://tonplaygram-bot.onrender.com",
+  "iconUrl": "https://tonplaygram-bot.onrender.com/assets/icons/generated/app-icon-192.png",
+  "termsOfUseUrl": "https://tonplaygram-bot.onrender.com/terms",
+  "privacyPolicyUrl": "https://tonplaygram-bot.onrender.com/privacy"
 }

--- a/frontend/public/tonconnect-manifest.json
+++ b/frontend/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TonPlaygram",
   "url": "https://tonplaygram-bot.onrender.com",
-  "iconUrl": "https://tonplaygram-bot.onrender.com/assets/icons/TON.webp",
+  "iconUrl": "https://tonplaygram-bot.onrender.com/assets/icons/generated/app-icon-192.png",
   "termsOfUseUrl": "https://tonplaygram-bot.onrender.com/terms",
   "privacyPolicyUrl": "https://tonplaygram-bot.onrender.com/privacy"
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -51,7 +51,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <TonConnectUIProvider
       // Always point manifest at the canonical origin.
-      manifestUrl={`${CANONICAL_ORIGIN.replace(/\/$/, '')}/tonconnect-manifest.json`}
+      manifestUrl={`${CANONICAL_ORIGIN.replace(/\/$/, '')}/tonconnect-manifest.json?v=2026-02-17`}
       actionsConfiguration={{
         returnStrategy: 'back',
         // Only used in Telegram WebView; harmless elsewhere.

--- a/webapp/public/tonconnect-manifest.json
+++ b/webapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TonPlaygram",
   "url": "https://tonplaygram-bot.onrender.com",
-  "iconUrl": "https://tonplaygram-bot.onrender.com/assets/icons/TON.webp",
+  "iconUrl": "https://tonplaygram-bot.onrender.com/assets/icons/generated/app-icon-192.png",
   "termsOfUseUrl": "https://tonplaygram-bot.onrender.com/terms",
   "privacyPolicyUrl": "https://tonplaygram-bot.onrender.com/privacy"
 }

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -94,7 +94,8 @@ export default function App() {
   // under an unexpected domain (Telegram proxy domains, mirrors, etc.).
   const manifestUrl = useMemo(() => {
     const canon = canonicalOrigin.replace(/\/$/, '');
-    return `${canon}/tonconnect-manifest.json`;
+    // Cache-bust manifest so wallets always read the latest app name/icon.
+    return `${canon}/tonconnect-manifest.json?v=2026-02-17`;
   }, [canonicalOrigin]);
   const returnUrl = useMemo(() => {
     if (typeof window !== 'undefined' && window.location?.href) {

--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -30,5 +30,19 @@ export default function TonConnectSync() {
     return () => unsubscribe();
   }, [tonConnectUI]);
 
+  useEffect(() => {
+    const closeIfConnected = () => {
+      const connectedAddress = tonConnectUI?.wallet?.account?.address || wallet?.account?.address || '';
+      if (connectedAddress) tonConnectUI.closeModal();
+    };
+
+    const events = ['visibilitychange', 'focus', 'pageshow'];
+    events.forEach((eventName) => window.addEventListener(eventName, closeIfConnected));
+
+    return () => {
+      events.forEach((eventName) => window.removeEventListener(eventName, closeIfConnected));
+    };
+  }, [tonConnectUI, wallet]);
+
   return null;
 }


### PR DESCRIPTION
### Motivation
- Wallet apps showed stale or inconsistent dapp identity and icon and the TonConnect modal sometimes remained open after in-wallet approval. The changes ensure the wallet sees the canonical app identity and the UI auto-closes once a connection is established.

### Description
- Point TonConnect manifest loading at the canonical origin and add a cache-busting query string (`?v=2026-02-17`) in both `webapp` and `frontend` entrypoints so wallets fetch fresh metadata instead of stale cached values (changed in `webapp/src/App.jsx` and `frontend/src/main.tsx`).
- Standardize the TonConnect manifest identity and icon by switching the manifest `iconUrl` to the generated app icon (`/assets/icons/generated/app-icon-192.png`) in `webapp/public/tonconnect-manifest.json`, `frontend/public/tonconnect-manifest.json`, and `frontend/dist/tonconnect-manifest.json`.
- Improve modal UX by auto-closing the TonConnect modal after returning from wallet approval when a connection exists, by listening for `visibilitychange`, `focus`, and `pageshow` and invoking `tonConnectUI.closeModal()` when an address is present (changed in `webapp/src/components/TonConnectSync.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build produced some chunk-size warnings but finished). ✅
- Launched dev server with Vite and ran a headless Playwright script to load the app in a mobile viewport and capture a screenshot; the Playwright run succeeded after extending timeout and produced a screenshot artifact. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994762790d08329be412e25afde2fa6)