### PR TITLE
Align Profile cards with Wallet layout and move Balance summary to bottom

### DIFF
--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -985,8 +985,7 @@ export default function MyAccount() {
         </div>
       </div>
 
-      <BalanceSummary className="bg-surface border border-border rounded-xl p-4 wide-card" />
-      <div className="prism-box p-4 mt-4 space-y-3 mx-auto wide-card">
+      <div className="bg-surface border border-border rounded-xl p-4 mt-4 space-y-3 wide-card">
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold">NFTs</h3>
           <span className="text-xs text-subtext">Owned cosmetics & gifts</span>
@@ -1013,7 +1012,7 @@ export default function MyAccount() {
       </div>
 
       {profile && profile.accountId === DEV_ACCOUNT_ID && (
-        <div className="prism-box p-4 mt-4 space-y-4 mx-auto wide-card">
+        <div className="bg-surface border border-border rounded-xl p-4 mt-4 space-y-4 wide-card">
           <div className="space-y-1">
             <p className="text-lg font-semibold text-white">
               Developer Control Panel
@@ -1104,6 +1103,8 @@ export default function MyAccount() {
           <InfluencerClaimsCard />
         </div>
       )}
+
+      <BalanceSummary className="bg-surface border border-border rounded-xl p-4 mt-4 wide-card" />
 
       <DevNotifyModal
         open={showNotifyModal}


### PR DESCRIPTION
### Motivation
- Ensure the Profile page cards (Wallet summary, Developer Control Panel, NFTs) use the same visual container style and sizing so the page matches the Wallet & Account Tools layout on mobile portrait. 
- Place the Wallet summary at the bottom of the Profile page so the frame ordering matches the requested layout (NFTs and Dev panel above, wallet below).

### Description
- Replaced the NFT card container with the same card styling used by Wallet & Account Tools by changing its wrapper to `bg-surface border border-border rounded-xl p-4 mt-4 space-y-3 wide-card` in `webapp/src/pages/MyAccount.jsx`.
- Replaced the Developer Control Panel container with the same card styling to match size and shape with other cards in `webapp/src/pages/MyAccount.jsx`.
- Moved the `BalanceSummary` component so the Wallet summary appears after the NFT and Developer sections by relocating its JSX to the bottom of the Profile page in `webapp/src/pages/MyAccount.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (Vite warnings about large chunks were non-blocking). 
- Launched a dev server and captured an automated mobile-portrait screenshot of `/account` using Playwright with mocked profile/API responses to verify layout and presence of all frames. 
- Verified the Profile page loads in dev mode with mocked localStorage values and shows the Wallet summary at the bottom and the NFT/Dev cards using the updated card styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699477d992d883298d02de1435948f64)