### PR TITLE
Harden game audio defaults and clamp persisted volume

### DIFF
--- a/webapp/src/utils/sound.js
+++ b/webapp/src/utils/sound.js
@@ -1,34 +1,59 @@
-let gameMuted = localStorage.getItem('gameMuted') === 'true';
-let gameVolume = parseFloat(localStorage.getItem('gameVolume') || '1');
+const DEFAULT_GAME_VOLUME = 1
 
-export function isGameMuted() {
-  return gameMuted;
+function clampVolume (value) {
+  if (!Number.isFinite(value)) return DEFAULT_GAME_VOLUME
+  return Math.min(1, Math.max(0, value))
 }
 
-export function getGameVolume() {
-  return gameVolume;
-}
-
-export function setGameMuted(val) {
-  gameMuted = val;
+function readStoredGameMuted () {
   try {
-    localStorage.setItem('gameMuted', val ? 'true' : 'false');
-  } catch (err) {}
-  window.dispatchEvent(new Event('gameMuteChanged'));
+    return localStorage.getItem('gameMuted') === 'true'
+  } catch (err) {
+    return false
+  }
 }
 
-export function setGameVolume(val) {
-  gameVolume = val;
+function readStoredGameVolume () {
   try {
-    localStorage.setItem('gameVolume', String(val));
+    const raw = localStorage.getItem('gameVolume')
+    if (raw == null || raw === '') return DEFAULT_GAME_VOLUME
+    return clampVolume(parseFloat(raw))
+  } catch (err) {
+    return DEFAULT_GAME_VOLUME
+  }
+}
+
+let gameMuted = readStoredGameMuted()
+let gameVolume = readStoredGameVolume()
+
+export function isGameMuted () {
+  return gameMuted
+}
+
+export function getGameVolume () {
+  return gameVolume
+}
+
+export function setGameMuted (val) {
+  gameMuted = val
+  try {
+    localStorage.setItem('gameMuted', val ? 'true' : 'false')
   } catch (err) {}
-  window.dispatchEvent(new Event('gameVolumeChanged'));
+  window.dispatchEvent(new Event('gameMuteChanged'))
 }
 
-export function toggleGameMuted() {
-  setGameMuted(!gameMuted);
+export function setGameVolume (val) {
+  gameVolume = clampVolume(Number(val))
+  try {
+    localStorage.setItem('gameVolume', String(gameVolume))
+  } catch (err) {}
+  window.dispatchEvent(new Event('gameVolumeChanged'))
 }
 
-export function toggleGameVolume() {
-  setGameVolume(gameVolume === 0 ? 1 : 0);
+export function toggleGameMuted () {
+  setGameMuted(!gameMuted)
+}
+
+export function toggleGameVolume () {
+  setGameVolume(gameVolume === 0 ? 1 : 0)
 }


### PR DESCRIPTION
### Motivation
- Prevent a bad or missing `gameVolume` value in `localStorage` from producing `NaN` or effectively silent SFX for Pool Royale / Snooker and make mute state reads resilient to storage failures.

### Description
- Add `DEFAULT_GAME_VOLUME` and `clampVolume` to ensure any volume value is normalized into the `[0, 1]` range.
- Introduce safe readers `readStoredGameMuted` and `readStoredGameVolume` that catch storage errors and fall back to sensible defaults.
- Apply clamping when updating `gameVolume` and when persisting it to `localStorage`, while preserving existing `gameMuteChanged` and `gameVolumeChanged` event dispatches.

### Testing
- Ran `npx eslint --no-ignore webapp/src/utils/sound.js`, which completed with no lint errors after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a57706b48329bba8c3e61ce188f7)