### PR TITLE
Fix Pool Royale sound effects not playing when stored volume is invalid

### DIFF
--- a/webapp/src/utils/sound.js
+++ b/webapp/src/utils/sound.js
@@ -1,34 +1,48 @@
-let gameMuted = localStorage.getItem('gameMuted') === 'true';
-let gameVolume = parseFloat(localStorage.getItem('gameVolume') || '1');
-
-export function isGameMuted() {
-  return gameMuted;
+const clampVolume = (value) => {
+  if (!Number.isFinite(value)) return 1
+  return Math.max(0, Math.min(1, value))
 }
 
-export function getGameVolume() {
-  return gameVolume;
-}
-
-export function setGameMuted(val) {
-  gameMuted = val;
+const readStorage = (key) => {
   try {
-    localStorage.setItem('gameMuted', val ? 'true' : 'false');
-  } catch (err) {}
-  window.dispatchEvent(new Event('gameMuteChanged'));
+    if (typeof window === 'undefined' || !window.localStorage) return null
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
 }
 
-export function setGameVolume(val) {
-  gameVolume = val;
+let gameMuted = readStorage('gameMuted') === 'true'
+let gameVolume = clampVolume(parseFloat(readStorage('gameVolume') ?? '1'))
+
+export function isGameMuted () {
+  return gameMuted
+}
+
+export function getGameVolume () {
+  return clampVolume(gameVolume)
+}
+
+export function setGameMuted (val) {
+  gameMuted = val
   try {
-    localStorage.setItem('gameVolume', String(val));
+    localStorage.setItem('gameMuted', val ? 'true' : 'false')
   } catch (err) {}
-  window.dispatchEvent(new Event('gameVolumeChanged'));
+  window.dispatchEvent(new Event('gameMuteChanged'))
 }
 
-export function toggleGameMuted() {
-  setGameMuted(!gameMuted);
+export function setGameVolume (val) {
+  gameVolume = clampVolume(Number(val))
+  try {
+    localStorage.setItem('gameVolume', String(gameVolume))
+  } catch (err) {}
+  window.dispatchEvent(new Event('gameVolumeChanged'))
 }
 
-export function toggleGameVolume() {
-  setGameVolume(gameVolume === 0 ? 1 : 0);
+export function toggleGameMuted () {
+  setGameMuted(!gameMuted)
+}
+
+export function toggleGameVolume () {
+  setGameVolume(gameVolume === 0 ? 1 : 0)
 }


### PR DESCRIPTION
### Motivation
- Pool Royale SFX could be silently muted or cause non-finite gain calculations if `gameVolume` in `localStorage` was missing or corrupted.
- Accessing `localStorage` in restricted contexts could throw and break sound bootstrap.
- Make audio preference handling defensive so gameplay audio reliably restores across environments.

### Description
- Add `clampVolume` to validate and clamp volume to the `[0,1]` range before use or persist.
- Add `readStorage` wrapper to safely read `localStorage` with try/catch and a fallback when `window`/`localStorage` is unavailable.
- Initialize `gameMuted`/`gameVolume` using the safe reader and clamped values, and update `getGameVolume`/`setGameVolume` to always use sanitized numbers.
- Keep existing mute/volume toggle APIs but ensure persisted values are written back as cleaned numeric values to avoid future corruption.

### Testing
- Ran `npx eslint --no-ignore webapp/src/utils/sound.js`, which completed successfully (no lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a57706b48329bba8c3e61ce188f7)