### PR TITLE
Fix rail containment fallback for Pool Royale balls escaping table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6261,11 +6261,58 @@ function reflectRails(ball) {
   const pocketGuard = POCKET_GUARD_RADIUS;
   const guardClearance = POCKET_GUARD_CLEARANCE;
   const cornerDepthLimit = CORNER_POCKET_DEPTH_LIMIT;
+  const nearPocketRadius = Math.max(CAPTURE_R, SIDE_CAPTURE_R) + BALL_R * 0.22;
+  const enforceRailContainment = () => {
+    const nearPocket = pocketCenters().some(
+      (center) => ball.pos.distanceTo(center) < nearPocketRadius
+    );
+    if (nearPocket) return null;
+    let collided = null;
+    let collisionNormal = null;
+    if (ball.pos.x < -railLimitX) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = -railLimitX - ball.pos.x;
+      ball.pos.x = -railLimitX + overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(1, 0);
+    }
+    if (ball.pos.x > railLimitX) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = ball.pos.x - railLimitX;
+      ball.pos.x = railLimitX - overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(-1, 0);
+    }
+    if (ball.pos.y < -railLimitY) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = -railLimitY - ball.pos.y;
+      ball.pos.y = -railLimitY + overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(0, 1);
+    }
+    if (ball.pos.y > railLimitY) {
+      preImpactVel = ball.vel.clone();
+      const overshoot = ball.pos.y - railLimitY;
+      ball.pos.y = railLimitY - overshoot;
+      collided = 'rail';
+      collisionNormal = new THREE.Vector2(0, -1);
+    }
+    if (!collided) return null;
+    const stamp =
+      typeof performance !== 'undefined' && performance.now
+        ? performance.now()
+        : Date.now();
+    ball.lastRailHitAt = stamp;
+    ball.lastRailHitType = collided;
+    const normal = collisionNormal ?? new THREE.Vector2(0, 1);
+    const tangent = new THREE.Vector2(-normal.y, normal.x);
+    return { type: collided, normal, tangent, preImpactVel };
+  };
   let preImpactVel = null;
   const hasCushionSegments =
     Array.isArray(CUSHION_SEGMENTS) && CUSHION_SEGMENTS.length > 0;
   if (hasCushionSegments) {
-    const nearPocketRadius =
+    const segmentNearPocketRadius =
       Math.max(CAPTURE_R, SIDE_CAPTURE_R) + CUSHION_CUT_NEAR_POCKET_BUFFER;
     const centers = pocketCenters();
     let nearestPocketDist = Infinity;
@@ -6279,7 +6326,7 @@ function reflectRails(ball) {
         nearestPocketIndex = index;
       }
     });
-    const nearPocket = nearestPocketDist < nearPocketRadius;
+    const nearPocket = nearestPocketDist < segmentNearPocketRadius;
     const inCaptureZone = nearestPocketDist < nearestCaptureRadius;
     const pocketGuardClearance =
       nearestPocketIndex >= 4 ? SIDE_POCKET_GUARD_CLEARANCE : POCKET_GUARD_CLEARANCE;
@@ -6359,6 +6406,8 @@ function reflectRails(ball) {
         preImpactVel
       };
     }
+    const containmentImpact = enforceRailContainment();
+    if (containmentImpact) return containmentImpact;
   }
   if (!hasCushionSegments) {
     for (const { sx, sy } of CORNER_SIGNS) {
@@ -6430,55 +6479,8 @@ function reflectRails(ball) {
       }
     }
 
-    const nearPocketRadius =
-      Math.max(CAPTURE_R, SIDE_CAPTURE_R) + BALL_R * 0.22;
-    const nearPocket = pocketCenters().some(
-      (c) => ball.pos.distanceTo(c) < nearPocketRadius
-    );
-    if (nearPocket) return null;
-    let collided = null;
-    let collisionNormal = null;
-    if (ball.pos.x < -railLimitX && ball.vel.x < 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = -railLimitX - ball.pos.x;
-      ball.pos.x = -railLimitX + overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(1, 0);
-    }
-    if (ball.pos.x > railLimitX && ball.vel.x > 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = ball.pos.x - railLimitX;
-      ball.pos.x = railLimitX - overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(-1, 0);
-    }
-    if (ball.pos.y < -railLimitY && ball.vel.y < 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = -railLimitY - ball.pos.y;
-      ball.pos.y = -railLimitY + overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(0, 1);
-    }
-    if (ball.pos.y > railLimitY && ball.vel.y > 0) {
-      preImpactVel = ball.vel.clone();
-      const overshoot = ball.pos.y - railLimitY;
-      ball.pos.y = railLimitY - overshoot;
-      collided = 'rail';
-      collisionNormal = new THREE.Vector2(0, -1);
-    }
-    if (collided) {
-      const stamp =
-        typeof performance !== 'undefined' && performance.now
-          ? performance.now()
-          : Date.now();
-      ball.lastRailHitAt = stamp;
-      ball.lastRailHitType = collided;
-    }
-    if (collided) {
-      const normal = collisionNormal ?? new THREE.Vector2(0, 1);
-      const tangent = new THREE.Vector2(-normal.y, normal.x);
-      return { type: collided, normal, tangent, preImpactVel };
-    }
+    const containmentImpact = enforceRailContainment();
+    if (containmentImpact) return containmentImpact;
   }
   return null;
 }


### PR DESCRIPTION
### Motivation
- Prevent balls from getting stuck or escaping beyond the rails when cushion segment collision geometry misses an impact. The previous behavior could leave balls outside the playable limits and never resolve their state.
- Ensure pocket captures are not disturbed by the containment fallback so valid pocket drops remain possible.

### Description
- Added a shared `enforceRailContainment` helper inside `reflectRails` that detects out-of-bounds ball positions and pushes them back inside rail limits while producing a rail-impact response (`{ type, normal, tangent, preImpactVel }`).
- Applied the containment fallback to both the segmented-cushion and legacy non-segmented collision paths so containment works consistently regardless of `CUSHION_SEGMENTS` mode.
- Guarded the fallback with a pocket-proximity check using a `nearPocketRadius` so containment is skipped when a ball is legitimately within pocket-capture zones.
- Localized variable renames and small refactors (`segmentNearPocketRadius`) to avoid shadowing and keep the existing pocket/cut/jaw logic intact in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which reported the file is ignored by repository lint ignore rules (no file-level lint errors introduced).
- Ran the repo lint script `npm run -s lint`; it failed due to extensive pre-existing lint errors across generated/dist and unrelated files, not introduced by this change.
- No unit tests were added; manual runtime validation was the focus (fix targets in-engine physics containment behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bd342aec8329bd051887957e664c)