### PR TITLE
Add 50-level Pool Royale training mode with shot bank and rewards

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,99 +1,146 @@
-const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress';
+const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
+const TRAINING_LEVEL_COUNT = 50
 
-export const TRAINING_LEVELS = [
-  {
-    level: 1,
-    title: 'Opening break',
-    objective: 'Place the cue ball, hit the rack cleanly, and pocket any object ball.',
-    reward: 'Unlocks aim assist calibration.'
-  },
-  {
-    level: 2,
-    title: 'Position & safety',
-    objective: 'Avoid fouls while leaving the cue ball safe for your next shot.',
-    reward: 'Ball-in-hand respot practice.'
-  },
-  {
-    level: 3,
-    title: 'Run the table',
-    objective: 'Sink three balls in one visit without scratching.',
-    reward: 'Pro tip overlays for long pots.'
-  },
-  {
-    level: 4,
-    title: 'Finishing shot',
-    objective: 'Clear the final ball under pressure to close the frame.',
-    reward: 'Celebration banners and XP boost.'
-  }
-];
-
-export function describeTrainingLevel(level) {
-  const numeric = Number(level);
-  const fallback = Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 1;
-  const preset = TRAINING_LEVELS.find((entry) => entry.level === fallback);
-  if (preset) return preset;
-  return {
-    level: fallback,
-    title: `Level ${fallback}`,
-    objective: 'Complete drills to unlock new cues and tips.',
-    reward: 'Progress boost'
-  };
+const clampLevel = (value, fallback = 1) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return fallback
+  return Math.max(1, Math.min(TRAINING_LEVEL_COUNT, Math.floor(numeric)))
 }
 
-export function loadTrainingProgress() {
-  if (typeof window === 'undefined') return { completed: [], lastLevel: 1 };
+const rotate = (arr, offset) => {
+  if (!Array.isArray(arr) || arr.length === 0) return []
+  const shift = ((offset % arr.length) + arr.length) % arr.length
+  return [...arr.slice(shift), ...arr.slice(0, shift)]
+}
+
+const buildTrainingLayout = (level) => {
+  const ring = [
+    { x: -0.52, z: -0.18 },
+    { x: -0.36, z: 0.12 },
+    { x: -0.14, z: -0.08 },
+    { x: 0.08, z: 0.2 },
+    { x: 0.24, z: -0.15 },
+    { x: 0.38, z: 0.11 },
+    { x: 0.54, z: -0.06 },
+    { x: -0.46, z: 0.32 },
+    { x: -0.22, z: 0.33 },
+    { x: 0.03, z: 0.36 },
+    { x: 0.26, z: 0.31 },
+    { x: 0.49, z: 0.28 },
+    { x: -0.33, z: -0.33 },
+    { x: -0.07, z: -0.35 },
+    { x: 0.2, z: -0.32 }
+  ]
+  const targetCount = Math.min(15, Math.max(1, level))
+  const rotated = rotate(ring, level - 1)
+  const spacingOffset = (level % 5) * 0.01
+  const balls = rotated.slice(0, targetCount).map((pos, idx) => ({
+    rackIndex: idx,
+    x: pos.x + (idx % 2 === 0 ? spacingOffset : -spacingOffset),
+    z: pos.z
+  }))
+
+  return {
+    cue: { x: -0.68 + (level % 3) * 0.05, z: 0.52 - (level % 4) * 0.08 },
+    balls
+  }
+}
+
+const buildTrainingDefinition = (level) => {
+  const discipline =
+    level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'American Billiards'
+  const targetCount = Math.min(15, level)
+  const reward =
+    level % 5 === 0
+      ? 'Free random table setup item unlocked.'
+      : 'Progress toward next free table setup item.'
+
+  return {
+    level,
+    discipline,
+    title: `${discipline} Drill ${String(level).padStart(2, '0')}`,
+    objective:
+      level <= 15
+        ? `Pot ${targetCount} ball${targetCount > 1 ? 's' : ''} without scratching.`
+        : `Clear ${targetCount} planned balls from a mixed ${discipline} layout.`,
+    reward,
+    layout: buildTrainingLayout(level)
+  }
+}
+
+export const TRAINING_LEVELS = Array.from(
+  { length: TRAINING_LEVEL_COUNT },
+  (_, idx) => buildTrainingDefinition(idx + 1)
+)
+
+export function describeTrainingLevel (level) {
+  const normalized = clampLevel(level)
+  return TRAINING_LEVELS[normalized - 1] || buildTrainingDefinition(normalized)
+}
+
+export function getTrainingLayout (level) {
+  return describeTrainingLevel(level).layout
+}
+
+export function loadTrainingProgress () {
+  if (typeof window === 'undefined') { return { completed: [], lastLevel: 1, carryShots: 3 } }
   try {
-    const stored = window.localStorage.getItem(TRAINING_PROGRESS_KEY);
-    if (!stored) return { completed: [], lastLevel: 1 };
-    const parsed = JSON.parse(stored);
+    const stored = window.localStorage.getItem(TRAINING_PROGRESS_KEY)
+    if (!stored) return { completed: [], lastLevel: 1, carryShots: 3 }
+    const parsed = JSON.parse(stored)
     const completed = Array.isArray(parsed?.completed)
       ? parsed.completed
-          .map((lvl) => Number(lvl))
-          .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
-          .sort((a, b) => a - b)
-      : [];
-    const lastLevel = Number.isFinite(parsed?.lastLevel) ? Number(parsed.lastLevel) : 1;
-    return { completed, lastLevel };
+        .map((lvl) => Number(lvl))
+        .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+        .sort((a, b) => a - b)
+      : []
+    const lastLevel = clampLevel(parsed?.lastLevel, 1)
+    const carryShots = Math.max(0, Math.floor(Number(parsed?.carryShots) || 3))
+    return { completed, lastLevel, carryShots }
   } catch (err) {
-    console.warn('Failed to load Pool Royale training progress', err);
-    return { completed: [], lastLevel: 1 };
+    console.warn('Failed to load Pool Royale training progress', err)
+    return { completed: [], lastLevel: 1, carryShots: 3 }
   }
 }
 
-export function persistTrainingProgress(progress) {
-  if (typeof window === 'undefined') return;
+export function persistTrainingProgress (progress) {
+  if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(TRAINING_PROGRESS_KEY, JSON.stringify(progress));
+    window.localStorage.setItem(
+      TRAINING_PROGRESS_KEY,
+      JSON.stringify(progress)
+    )
   } catch (err) {
-    console.warn('Failed to persist Pool Royale training progress', err);
+    console.warn('Failed to persist Pool Royale training progress', err)
   }
 }
 
-export function getNextIncompleteLevel(completedLevels) {
-  const completedSet = new Set((completedLevels || []).map((lvl) => Number(lvl)));
-  for (let level = 1; level <= 50; level++) {
-    if (!completedSet.has(level)) return level;
+export function getNextIncompleteLevel (completedLevels) {
+  const completedSet = new Set(
+    (completedLevels || []).map((lvl) => Number(lvl))
+  )
+  for (let level = 1; level <= TRAINING_LEVEL_COUNT; level++) {
+    if (!completedSet.has(level)) return level
   }
-  return null;
+  return null
 }
 
-export function resolvePlayableTrainingLevel(requestedLevel, progress) {
-  const completed = progress?.completed || [];
-  const nextIncomplete = getNextIncompleteLevel(completed);
-  const lastLevel = Number.isFinite(progress?.lastLevel) ? progress.lastLevel : 1;
-  const desired = Number.isFinite(requestedLevel) && requestedLevel > 0 ? requestedLevel : nextIncomplete || lastLevel || 1;
+export function resolvePlayableTrainingLevel (requestedLevel, progress) {
+  const completed = progress?.completed || []
+  const nextIncomplete = getNextIncompleteLevel(completed)
+  const lastLevel = clampLevel(progress?.lastLevel, 1)
+  const desired =
+    Number.isFinite(requestedLevel) && requestedLevel > 0
+      ? requestedLevel
+      : nextIncomplete || lastLevel || 1
 
-  // Let players replay any unlocked task while still preventing them from skipping ahead
-  // of the current progression. This fixes the flow where selecting a specific task
-  // from the lobby could redirect back to the first incomplete level and render a
-  // blank screen before the redirect finishes.
   if (nextIncomplete !== null) {
-    const cappedDesired = Math.max(1, Math.min(50, Math.floor(desired)));
+    const cappedDesired = clampLevel(desired)
     if (cappedDesired <= nextIncomplete) {
-      return cappedDesired;
+      return cappedDesired
     }
-    return Math.max(1, Math.min(50, nextIncomplete));
+    return clampLevel(nextIncomplete)
   }
 
-  return Math.max(1, Math.min(desired, lastLevel || 50));
+  return clampLevel(desired, lastLevel || TRAINING_LEVEL_COUNT)
 }


### PR DESCRIPTION
### Motivation
- Provide a full Training match type so players can practice progressively through 50 drills spanning 8-Ball, 9-Ball and American Billiards.
- Give players a limited number of attempts per round (3 baseline) that can accumulate/carry over and be used across rounds to encourage repeated practice without needing to re-enter the lobby.
- Reward players periodically (every 5 levels) with a free random table-setup item to incentivize progression.

### Description
- Added a generated 50-level training system and helper API in `webapp/src/utils/poolRoyaleTrainingProgress.js` including level metadata, rotating ball layouts (`getTrainingLayout`), discipline assignment (8-Ball / 9-Ball / American), and reward text that grants a free table item every 5 levels.
- Exposed `Training` as a match type in the Pool Royale lobby (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) and forced training to offline/AI mode while disabling online matchmaking for training (with updated UI messaging).
- Integrated training into the Pool Royale game loop (`webapp/src/pages/Games/PoolRoyale.jsx`) so level-specific layouts are applied at frame start, training misses decrement a per-session shot bank, level completion persists remaining shots plus a +3 baseline into the next level (`carryShots`), and progression is saved via localStorage.
- Updated the in-game training HUD and training menu to show current discipline, objective, reward text and the player’s `Shots bank` (remaining attempts) and adjusted the training progression logic to compute next-playable level correctly.

### Testing
- Ran code formatting: `npx prettier --write webapp/src/utils/poolRoyaleTrainingProgress.js webapp/src/pages/Games/PoolRoyaleLobby.jsx webapp/src/pages/Games/PoolRoyale.jsx` (succeeded).
- Ran lint checks: `npx eslint --no-ignore webapp/src/utils/poolRoyaleTrainingProgress.js` (ran and fixed formatting issues), and project eslint checks (some files are ignored by project config as expected).
- Launched dev server (`npm --prefix webapp run dev`) and verified the lobby page at `/games/poolroyale/lobby?type=training` by capturing a screenshot via Playwright (artifact produced).
- Basic runtime verification performed by loading the training lobby and confirming the new Training option, UI labels and the training HUD appear as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c53265c483298628a3f1ceb3dce0)