### PR TITLE
Add NVIDIA PersonaPlex-ready voice commentary and support endpoints

### DIFF
--- a/docs/personaplex-voice-commentary.md
+++ b/docs/personaplex-voice-commentary.md
@@ -1,0 +1,71 @@
+# NVIDIA PersonaPlex Voice Commentary Integration
+
+This project now includes a reusable voice layer for:
+
+- real-time game commentary across core games
+- multilingual voice catalog selection
+- spoken customer support responses
+
+## Environment variables
+
+Configure the API server (`packages/api/src/server.ts`) with:
+
+- `PERSONAPLEX_API_URL` - PersonaPlex API base URL
+- `PERSONAPLEX_API_KEY` - Bearer token for synthesis requests
+
+If these values are not set, voice endpoints return **preview mode** (`ssml`) so you can validate scripts without spending API credits.
+
+## Endpoints
+
+### `GET /v1/voice/catalog`
+Returns supported languages and voice profiles.
+
+### `POST /v1/voice/commentary`
+Builds commentary text for game events and optionally synthesizes speech.
+
+Payload example:
+
+```json
+{
+  "game": "pool_royale",
+  "eventType": "match_start",
+  "playerName": "Arben",
+  "score": "5-3",
+  "locale": "sq-AL",
+  "voiceId": "anisa_sq_al_f"
+}
+```
+
+### `POST /v1/voice/support`
+Builds customer-support voice messages and optionally synthesizes speech.
+
+Payload example:
+
+```json
+{
+  "ticketContext": "Nuk po më hapet loja",
+  "locale": "sq-AL",
+  "voiceId": "anisa_sq_al_f"
+}
+```
+
+## Included game keys
+
+- `pool_royale`
+- `snooker_royal`
+- `snake_multiplayer`
+- `texas_holdem`
+- `domino_royal`
+- `chess_battle_royal`
+- `air_hockey`
+- `goal_rush`
+- `ludo_battle_royal`
+- `table_tennis_royal`
+- `murlan_royale`
+- `dice_duel`
+- `snake_and_ladder`
+
+## Notes
+
+- Voice IDs in the catalog are provider-facing identifiers used by this app.
+- Keep commentary generation modular (`buildCommentaryText`, `buildSupportSpeech`) so game systems can call it from UI, server events, or bot flows.

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -3,6 +3,14 @@ import crypto from 'crypto';
 import { answerUserQuestion } from '../../agent-core/src/agent.js';
 import { loadKnowledgeIndex } from '../../agent-core/src/knowledgeBase.js';
 import { evaluateUserPrompt } from '../../agent-core/src/safety.js';
+import {
+  VOICE_PROFILES,
+  buildCommentaryText,
+  buildSupportSpeech,
+  findVoiceProfile,
+  isGameKey,
+  requestPersonaplexSynthesis
+} from './voiceCommentary.js';
 
 const app = express();
 app.use(express.json());
@@ -110,6 +118,59 @@ app.post('/v1/feedback', requireBasicUserAuth, (req, res) => {
   };
 
   res.status(202).json({ accepted: true, payload });
+});
+
+app.get('/v1/voice/catalog', (_req, res) => {
+  const languages = Array.from(new Set(VOICE_PROFILES.map((voice) => voice.language))).sort();
+  res.json({ provider: 'nvidia-personaplex', languages, voices: VOICE_PROFILES });
+});
+
+app.post('/v1/voice/commentary', requireBasicUserAuth, async (req, res) => {
+  const game = String(req.body?.game || '');
+  if (!isGameKey(game)) {
+    res.status(400).json({ error: 'Unsupported game key', supportedGames: [
+      'pool_royale', 'snooker_royal', 'snake_multiplayer', 'texas_holdem', 'domino_royal',
+      'chess_battle_royal', 'air_hockey', 'goal_rush', 'ludo_battle_royal', 'table_tennis_royal',
+      'murlan_royale', 'dice_duel', 'snake_and_ladder'
+    ] });
+    return;
+  }
+
+  const eventType = String(req.body?.eventType || 'player_turn') as Parameters<typeof buildCommentaryText>[1];
+  const playerName = String(req.body?.playerName || 'Player');
+  const score = typeof req.body?.score === 'string' ? req.body.score : undefined;
+  const voice = findVoiceProfile(req.body?.voiceId, req.body?.locale);
+  const text = buildCommentaryText(game, eventType, playerName, score);
+
+  try {
+    const synthesis = await requestPersonaplexSynthesis({
+      text,
+      locale: voice.locale,
+      voiceId: voice.id,
+      metadata: { game, eventType }
+    });
+    res.json({ text, voice, synthesis });
+  } catch (error) {
+    res.status(502).json({ error: (error as Error).message, text, voice });
+  }
+});
+
+app.post('/v1/voice/support', requireBasicUserAuth, async (req, res) => {
+  const voice = findVoiceProfile(req.body?.voiceId, req.body?.locale);
+  const ticketContext = String(req.body?.ticketContext || 'General account support');
+  const text = buildSupportSpeech(ticketContext, voice);
+
+  try {
+    const synthesis = await requestPersonaplexSynthesis({
+      text,
+      locale: voice.locale,
+      voiceId: voice.id,
+      metadata: { channel: 'customer_support' }
+    });
+    res.json({ text, voice, synthesis });
+  } catch (error) {
+    res.status(502).json({ error: (error as Error).message, text, voice });
+  }
 });
 
 if (process.env.NODE_ENV !== 'test') {

--- a/packages/api/src/voiceCommentary.ts
+++ b/packages/api/src/voiceCommentary.ts
@@ -1,0 +1,165 @@
+export type CommentaryEventType =
+  | 'match_start'
+  | 'player_turn'
+  | 'score_update'
+  | 'streak'
+  | 'powerup'
+  | 'match_end'
+  | 'customer_support';
+
+export type GameKey =
+  | 'pool_royale'
+  | 'snooker_royal'
+  | 'snake_multiplayer'
+  | 'texas_holdem'
+  | 'domino_royal'
+  | 'chess_battle_royal'
+  | 'air_hockey'
+  | 'goal_rush'
+  | 'ludo_battle_royal'
+  | 'table_tennis_royal'
+  | 'murlan_royale'
+  | 'dice_duel'
+  | 'snake_and_ladder';
+
+export interface VoiceProfile {
+  id: string;
+  provider: 'nvidia-personaplex';
+  locale: string;
+  language: string;
+  gender: 'female' | 'male' | 'neutral';
+  style: 'energetic' | 'calm' | 'professional' | 'friendly';
+  isDefault?: boolean;
+}
+
+export const VOICE_PROFILES: VoiceProfile[] = [
+  { id: 'nova_en_us_f', provider: 'nvidia-personaplex', locale: 'en-US', language: 'English', gender: 'female', style: 'energetic', isDefault: true },
+  { id: 'atlas_en_us_m', provider: 'nvidia-personaplex', locale: 'en-US', language: 'English', gender: 'male', style: 'professional' },
+  { id: 'luna_es_es_f', provider: 'nvidia-personaplex', locale: 'es-ES', language: 'Spanish', gender: 'female', style: 'friendly' },
+  { id: 'orion_es_mx_m', provider: 'nvidia-personaplex', locale: 'es-MX', language: 'Spanish', gender: 'male', style: 'energetic' },
+  { id: 'selene_fr_fr_f', provider: 'nvidia-personaplex', locale: 'fr-FR', language: 'French', gender: 'female', style: 'calm' },
+  { id: 'leo_de_de_m', provider: 'nvidia-personaplex', locale: 'de-DE', language: 'German', gender: 'male', style: 'professional' },
+  { id: 'sofia_it_it_f', provider: 'nvidia-personaplex', locale: 'it-IT', language: 'Italian', gender: 'female', style: 'friendly' },
+  { id: 'sakura_ja_jp_f', provider: 'nvidia-personaplex', locale: 'ja-JP', language: 'Japanese', gender: 'female', style: 'energetic' },
+  { id: 'jin_ko_kr_m', provider: 'nvidia-personaplex', locale: 'ko-KR', language: 'Korean', gender: 'male', style: 'professional' },
+  { id: 'maya_hi_in_f', provider: 'nvidia-personaplex', locale: 'hi-IN', language: 'Hindi', gender: 'female', style: 'friendly' },
+  { id: 'amir_ar_sa_m', provider: 'nvidia-personaplex', locale: 'ar-SA', language: 'Arabic', gender: 'male', style: 'calm' },
+  { id: 'eda_tr_tr_f', provider: 'nvidia-personaplex', locale: 'tr-TR', language: 'Turkish', gender: 'female', style: 'professional' },
+  { id: 'anisa_sq_al_f', provider: 'nvidia-personaplex', locale: 'sq-AL', language: 'Albanian', gender: 'female', style: 'friendly' },
+  { id: 'ivo_pt_br_m', provider: 'nvidia-personaplex', locale: 'pt-BR', language: 'Portuguese', gender: 'male', style: 'energetic' },
+  { id: 'olena_uk_ua_f', provider: 'nvidia-personaplex', locale: 'uk-UA', language: 'Ukrainian', gender: 'female', style: 'calm' },
+  { id: 'marek_pl_pl_m', provider: 'nvidia-personaplex', locale: 'pl-PL', language: 'Polish', gender: 'male', style: 'professional' }
+];
+
+const GAME_LABELS: Record<GameKey, string> = {
+  pool_royale: 'Pool Royale',
+  snooker_royal: 'Snooker Royal',
+  snake_multiplayer: 'Snake Multiplayer',
+  texas_holdem: 'Texas Holdem',
+  domino_royal: 'Domino Royal',
+  chess_battle_royal: 'Chess Battle Royal',
+  air_hockey: 'Air Hockey',
+  goal_rush: 'Goal Rush',
+  ludo_battle_royal: 'Ludo Battle Royal',
+  table_tennis_royal: 'Table Tennis Royal',
+  murlan_royale: 'Murlan Royale',
+  dice_duel: 'Dice Duel',
+  snake_and_ladder: 'Snake and Ladder'
+};
+
+export function isGameKey(value: string): value is GameKey {
+  return value in GAME_LABELS;
+}
+
+function getGameLabel(game: GameKey): string {
+  return GAME_LABELS[game];
+}
+
+function supportReplyTemplate(language: string, ticketContext: string): string {
+  if (language.toLowerCase().startsWith('albanian')) {
+    return `Përshëndetje! Ky është asistenti zanor i mbështetjes. E kuptova kërkesën tuaj: ${ticketContext}. Po e shqyrtojmë tani dhe do t'ju përgjigjemi me hapa të qartë.`;
+  }
+
+  return `Hello! This is your voice support assistant. I understood your request: ${ticketContext}. We are checking it now and will send you clear next steps.`;
+}
+
+export function buildCommentaryText(game: GameKey, eventType: CommentaryEventType, playerName: string, score?: string): string {
+  const gameLabel = getGameLabel(game);
+  const safePlayer = playerName || 'Player';
+
+  switch (eventType) {
+    case 'match_start':
+      return `Welcome to ${gameLabel}! The match is live. ${safePlayer}, bring your best move.`;
+    case 'player_turn':
+      return `${safePlayer}, it's your turn in ${gameLabel}. Focus, aim, and execute.`;
+    case 'score_update':
+      return `Score update in ${gameLabel}: ${score ?? 'new score available'}. Momentum is shifting.`;
+    case 'streak':
+      return `${safePlayer} is on a streak in ${gameLabel}! What a dominant run.`;
+    case 'powerup':
+      return `Power play activated in ${gameLabel}. ${safePlayer} is changing the pace.`;
+    case 'match_end':
+      return `${gameLabel} match complete. Great game by ${safePlayer}. Thanks for playing.`;
+    case 'customer_support':
+      return supportReplyTemplate('English', score ?? 'General support request');
+    default:
+      return `Live update from ${gameLabel}.`;
+  }
+}
+
+export async function requestPersonaplexSynthesis(input: {
+  text: string;
+  voiceId: string;
+  locale: string;
+  metadata?: Record<string, string>;
+}): Promise<{ mode: 'remote'; provider: 'nvidia-personaplex'; response: unknown } | { mode: 'preview'; ssml: string }> {
+  const endpoint = process.env.PERSONAPLEX_API_URL;
+  const apiKey = process.env.PERSONAPLEX_API_KEY;
+
+  const ssml = `<speak><lang xml:lang="${input.locale}">${input.text}</lang></speak>`;
+
+  if (!endpoint || !apiKey) {
+    return { mode: 'preview', ssml };
+  }
+
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}/v1/speech/synthesize`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      input: input.text,
+      ssml,
+      voice: input.voiceId,
+      locale: input.locale,
+      metadata: input.metadata ?? {}
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`PersonaPlex synthesis failed (${response.status}): ${details}`);
+  }
+
+  const payload = await response.json();
+  return { mode: 'remote', provider: 'nvidia-personaplex', response: payload };
+}
+
+export function findVoiceProfile(voiceId?: string, locale?: string): VoiceProfile {
+  if (voiceId) {
+    const match = VOICE_PROFILES.find((voice) => voice.id === voiceId);
+    if (match) return match;
+  }
+
+  if (locale) {
+    const localeMatch = VOICE_PROFILES.find((voice) => voice.locale.toLowerCase() === locale.toLowerCase());
+    if (localeMatch) return localeMatch;
+  }
+
+  return VOICE_PROFILES.find((voice) => voice.isDefault) ?? VOICE_PROFILES[0];
+}
+
+export function buildSupportSpeech(ticketContext: string, voice: VoiceProfile): string {
+  return supportReplyTemplate(voice.language, ticketContext);
+}

--- a/test/platformHelpAgent/voiceCommentaryApi.test.ts
+++ b/test/platformHelpAgent/voiceCommentaryApi.test.ts
@@ -1,0 +1,32 @@
+import {
+  VOICE_PROFILES,
+  buildCommentaryText,
+  buildSupportSpeech,
+  findVoiceProfile,
+  requestPersonaplexSynthesis
+} from '../../packages/api/src/voiceCommentary';
+
+describe('voice commentary module', () => {
+  test('contains multilingual nvidia voice catalog', () => {
+    expect(VOICE_PROFILES.length).toBeGreaterThanOrEqual(12);
+    expect(VOICE_PROFILES.some((voice) => voice.locale === 'sq-AL')).toBe(true);
+  });
+
+  test('builds game commentary text and preview synthesis', async () => {
+    const voice = findVoiceProfile(undefined, 'sq-AL');
+    const text = buildCommentaryText('pool_royale', 'match_start', 'Arben');
+    const synthesis = await requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id });
+
+    expect(text).toContain('Pool Royale');
+    expect(synthesis.mode).toBe('preview');
+    if (synthesis.mode === 'preview') {
+      expect(synthesis.ssml).toContain('xml:lang="sq-AL"');
+    }
+  });
+
+  test('builds localized support script', () => {
+    const voice = findVoiceProfile(undefined, 'sq-AL');
+    const support = buildSupportSpeech('Nuk po më hapet loja', voice);
+    expect(support).toContain('Përshëndetje');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide in-game spoken commentary and multilingual customer-support speech using NVIDIA PersonaPlex so games can produce voiced feedback and support messages. 
- Centralize voice profiles and script generation to keep commentary modular and callable from UI, server events, or bots. 
- Allow safe validation without API credentials by returning an SSML preview mode when PersonaPlex env vars are not set. 

### Description
- Added a new module `packages/api/src/voiceCommentary.ts` exporting voice catalog (`VOICE_PROFILES`), types, `buildCommentaryText`, `buildSupportSpeech`, `findVoiceProfile`, and `requestPersonaplexSynthesis` with SSML preview fallback. 
- Extended the API server (`packages/api/src/server.ts`) with endpoints `GET /v1/voice/catalog`, `POST /v1/voice/commentary`, and `POST /v1/voice/support`, including game-key validation and integration with the synthesis helper. 
- Included a multilingual default catalog (Albanian included) and concise game-key list for supported games. 
- Added documentation `docs/personaplex-voice-commentary.md` and tests `test/platformHelpAgent/voiceCommentaryApi.test.ts` demonstrating catalog coverage, preview synthesis SSML, and localized support wording. 

### Testing
- Ran the focused test file with `npm test -- test/platformHelpAgent/voiceCommentaryApi.test.ts --runInBand`. 
- Test suite passed: 3 tests passed covering voice catalog presence, preview-mode synthesis SSML, and Albanian support message. 
- The tests validated `requestPersonaplexSynthesis` preview behavior and `buildSupportSpeech` localized output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c7f44e2c83299478cbd12a64c9b4)