### PR TITLE
Add Personaplex TTS fallback API and webapp remote TTS for game commentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
    - `VITE_API_AUTH_TOKEN` – (optional) token used when calling privileged API
      endpoints outside Telegram.
    - `VITE_LAUNCHER_URL` – HTTPS link to the signed `tonplaygram-launcher.apk` hosted on your CDN/object storage (or GitHub Releases) so `Home.jsx` links to the correct binary.
+  - `VITE_API_BASE_URL` + backend `PERSONAPLEX_API_URL` – configure these to enable server-side NVIDIA Personaplex voice streaming for commentary fallback when browser speech synthesis voices are unavailable.
 
    This value is required for the Google button to appear on the login and
    profile pages. When provided, the webapp lets users sign in with Google and
@@ -407,6 +408,19 @@ To move from the start you must roll at least one six when rolling two dice. Any
 - **Capturing** – Finish your move on a tile already occupied by another player to send that token back to start.
 - **Winning and extra turns** – You must land exactly on the final pot tile. From tile 100 you need to roll a single one. Rolling double six gives an extra turn.
 - **In‑app help** – A help button in game opens an info popup implemented in [`SnakeAndLadder.jsx`](webapp/src/pages/Games/SnakeAndLadder.jsx).
+
+
+### NVIDIA Personaplex voice commentary
+
+The backend now exposes `GET /api/voice/catalog` and `POST /api/voice/speak` to proxy text-to-speech through a Personaplex-compatible endpoint.
+
+Set these environment variables on the bot service:
+
+- `PERSONAPLEX_API_URL` – upstream HTTP endpoint that accepts JSON `{ text, language, voice, format, sample_rate }` and returns audio bytes
+- `PERSONAPLEX_API_KEY` – optional bearer token for the upstream provider
+- `PERSONAPLEX_PROVIDER_NAME` – optional display name returned by `/api/voice/catalog`
+
+The webapp auto-falls back to this API if Web Speech synthesis is not available, so multilingual commentary can still play for supported game languages.
 
 ## Troubleshooting
 

--- a/bot/routes/voice.js
+++ b/bot/routes/voice.js
@@ -1,0 +1,78 @@
+import { Router } from 'express';
+
+const router = Router();
+
+const SUPPORTED_GAME_COMMENTARY = Object.freeze([
+  { id: 'air-hockey', name: 'Air Hockey', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'snake-ladder', name: 'Snake & Ladder', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'murlan-royale', name: 'Murlan Royale', locales: ['en', 'hi', 'ru', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'pool-royale', name: 'Pool Royale', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'snooker-royale', name: 'Snooker Royale', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'chess-battle', name: 'Chess Battle', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'ludo-battle-royale', name: 'Ludo Battle Royale', locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] },
+  { id: 'texas-holdem', name: "Texas Hold'em", locales: ['en', 'zh', 'hi', 'es', 'fr', 'ar', 'sq'] }
+]);
+
+router.get('/catalog', (_req, res) => {
+  res.json({
+    provider: process.env.PERSONAPLEX_PROVIDER_NAME || 'nvidia-personaplex',
+    configured: Boolean(process.env.PERSONAPLEX_API_URL),
+    games: SUPPORTED_GAME_COMMENTARY
+  });
+});
+
+router.post('/speak', async (req, res) => {
+  const endpoint = process.env.PERSONAPLEX_API_URL;
+  if (!endpoint) {
+    return res.status(503).json({
+      error: 'PERSONAPLEX_API_URL is not configured. Set it to enable NVIDIA Personaplex voice synthesis.'
+    });
+  }
+
+  const { text, language = 'en', voice, format = 'mp3', sampleRate = 24000 } = req.body || {};
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ error: 'text is required' });
+  }
+
+  const payload = {
+    text,
+    language,
+    voice,
+    format,
+    sample_rate: sampleRate
+  };
+
+  try {
+    const upstream = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.PERSONAPLEX_API_KEY
+          ? { Authorization: `Bearer ${process.env.PERSONAPLEX_API_KEY}` }
+          : {})
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!upstream.ok) {
+      const message = await upstream.text();
+      return res.status(502).json({
+        error: 'Voice provider request failed',
+        detail: message.slice(0, 500)
+      });
+    }
+
+    const audioBuffer = Buffer.from(await upstream.arrayBuffer());
+    const mimeType = upstream.headers.get('content-type') || 'audio/mpeg';
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Cache-Control', 'no-store');
+    return res.send(audioBuffer);
+  } catch (error) {
+    return res.status(502).json({
+      error: 'Failed to reach voice provider',
+      detail: error instanceof Error ? error.message : String(error)
+    });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -29,6 +29,7 @@ import poolRoyaleRoutes from './routes/poolRoyale.js';
 import snookerRoyaleRoutes from './routes/snookerRoyal.js';
 import exchangeRoutes from './routes/exchange.js';
 import pushRoutes from './routes/push.js';
+import voiceRoutes from './routes/voice.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -255,6 +256,7 @@ app.use('/api/online', onlineRoutes);
 app.use('/api/pool-royale', poolRoyaleRoutes);
 app.use('/api/snooker-royale', snookerRoyaleRoutes);
 app.use('/api/exchange', exchangeRoutes);
+app.use('/api/voice', voiceRoutes);
 
 app.post('/api/goal-rush/calibration', authenticate, async (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/webapp/src/utils/remoteTextToSpeech.js
+++ b/webapp/src/utils/remoteTextToSpeech.js
@@ -1,0 +1,35 @@
+import { API_BASE_URL } from './api.js';
+
+const REMOTE_TTS_PATH = '/api/voice/speak';
+
+const buildUrl = () => `${API_BASE_URL}${REMOTE_TTS_PATH}`;
+
+const playBlobAudio = (blob, volume = 1) =>
+  new Promise((resolve) => {
+    const audio = new Audio(URL.createObjectURL(blob));
+    audio.volume = volume;
+    const cleanup = () => {
+      URL.revokeObjectURL(audio.src);
+      resolve();
+    };
+    audio.onended = cleanup;
+    audio.onerror = cleanup;
+    audio.play().catch(cleanup);
+  });
+
+export const speakRemoteLine = async ({ text, lang = 'en', voice, volume = 1 }) => {
+  if (!text) return false;
+  try {
+    const response = await fetch(buildUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, language: lang, voice, format: 'mp3' })
+    });
+    if (!response.ok) return false;
+    const blob = await response.blob();
+    await playBlobAudio(blob, volume);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,3 +1,4 @@
+import { speakRemoteLine } from './remoteTextToSpeech.js';
 const DEFAULT_VOICE_HINTS = {
   Mason: ['en-US', 'English', 'Male', 'Google US English Male', 'David', 'Guy'],
   Lena: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia', 'Hazel']
@@ -295,6 +296,13 @@ const resolveHintedLanguage = (hints = [], fallback) => {
   return 'en-US';
 };
 
+
+const normalizeRemoteLang = (hints = []) => {
+  const matched = hints.find((hint) => /^[a-z]{2}(?:-[A-Z]{2})?$/i.test(String(hint || '').trim()));
+  if (!matched) return 'en';
+  return String(matched).split('-')[0].toLowerCase();
+};
+
 export const resolveVoiceForSpeaker = (speaker, voices = []) => {
   if (!voices.length) return null;
   const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Mason;
@@ -307,7 +315,23 @@ export const speakCommentaryLines = async (
 ) => {
   const synth = getSpeechSynthesis();
   const UtteranceClass = getSpeechUtteranceClass();
-  if (!synth || !UtteranceClass || !Array.isArray(lines) || lines.length === 0) return;
+  if (!Array.isArray(lines) || lines.length === 0) return;
+
+  const useRemoteOnly = !synth || !UtteranceClass;
+  if (useRemoteOnly) {
+    for (const line of lines) {
+      const speaker = line.speaker || 'Mason';
+      const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
+      const hints = voiceHints[speaker] || voiceHints.Mason || [];
+      await speakRemoteLine({
+        text: line.text,
+        lang: normalizeRemoteLang(hints),
+        voice: speaker,
+        volume: settings.volume ?? 1
+      });
+    }
+    return;
+  }
 
   const voices = await loadVoices(synth);
   const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Mason'))];


### PR DESCRIPTION
### Motivation

- Ensure voice commentary works across browsers/devices that lack or restrict Web Speech voices by providing a server-side TTS fallback. 
- Centralize multilingual voice coverage for game commentary using a Personaplex-compatible upstream so the app can serve consistent voices and languages. 

### Description

- Added a new Express router `bot/routes/voice.js` exposing `GET /api/voice/catalog` and `POST /api/voice/speak` to proxy Personaplex-style TTS requests and report configured game locales. 
- Wired the new router into the API by mounting it at `app.use('/api/voice', voiceRoutes)` in `bot/server.js`. 
- Added a client helper `webapp/src/utils/remoteTextToSpeech.js` that posts text to the backend, receives audio bytes, and plays them as blob audio in the browser. 
- Updated `webapp/src/utils/textToSpeech.js` so `speakCommentaryLines` automatically falls back to the remote TTS path when `SpeechSynthesis`/`SpeechSynthesisUtterance` are not available, preserving the existing local-speech path when supported. 
- Documented required environment variables and endpoints in `README.md` (`PERSONAPLEX_API_URL`, `PERSONAPLEX_API_KEY`, `PERSONAPLEX_PROVIDER_NAME`, and `VITE_API_BASE_URL` usage). 

### Testing

- Ran `node --check` on `bot/routes/voice.js`, `webapp/src/utils/remoteTextToSpeech.js`, `webapp/src/utils/textToSpeech.js` and `bot/server.js`, and all checks passed. 
- Attempted repository lint with `npm run -s lint`, which reported many pre-existing errors in unrelated/generated artifacts and so is considered a known unrelated failure for this change. 
- Verified the new endpoints and client code are added and referenced without syntax errors via basic static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c7f44e2c83299478cbd12a64c9b4)