### PR TITLE
Training: 50-level solo drills, attempts bank, roadmap UI, and varied layouts

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,5 +1,6 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
 const TRAINING_LEVEL_COUNT = 50
+const BASE_ATTEMPTS_PER_LEVEL = 3
 
 const clampLevel = (value, fallback = 1) => {
   const numeric = Number(value)
@@ -13,43 +14,73 @@ const rotate = (arr, offset) => {
   return [...arr.slice(shift), ...arr.slice(0, shift)]
 }
 
-const buildTrainingLayout = (level) => {
-  const ring = [
-    { x: -0.52, z: -0.18 },
-    { x: -0.36, z: 0.12 },
-    { x: -0.14, z: -0.08 },
-    { x: 0.08, z: 0.2 },
-    { x: 0.24, z: -0.15 },
-    { x: 0.38, z: 0.11 },
-    { x: 0.54, z: -0.06 },
-    { x: -0.46, z: 0.32 },
-    { x: -0.22, z: 0.33 },
-    { x: 0.03, z: 0.36 },
-    { x: 0.26, z: 0.31 },
-    { x: 0.49, z: 0.28 },
-    { x: -0.33, z: -0.33 },
-    { x: -0.07, z: -0.35 },
-    { x: 0.2, z: -0.32 }
+const STRATEGY_DRILLS = [
+  { title: 'Straight-in stop shot', objective: 'Pot all balls using a controlled stop-shot finish.' },
+  { title: 'Half-ball cuts', objective: 'Clear the table by controlling medium cut angles.' },
+  { title: 'Rail-first recovery', objective: 'Use at least one rail route to stay on sequence.' },
+  { title: 'Two-rail position play', objective: 'Run out while planning two-rail cue-ball paths.' },
+  { title: 'Stun-to-draw ladder', objective: 'Mix stun and draw so each next ball is high percentage.' },
+  { title: 'Inside spin navigation', objective: 'Use inside english to hold lines on cut shots.' },
+  { title: 'Outside spin escapes', objective: 'Apply outside spin to widen pocket approach windows.' },
+  { title: 'Breakout pattern drill', objective: 'Open clustered balls and preserve an easy insurance shot.' },
+  { title: 'Safety-to-attack conversion', objective: 'Recover from a tight leave and continue the runout.' },
+  { title: 'End-game precision', objective: 'Finish the final balls with conservative cue-ball speed.' }
+]
+
+const PATTERN_LIBRARY = [
+  [
+    { x: -0.54, z: -0.28 }, { x: -0.38, z: -0.16 }, { x: -0.22, z: -0.04 }, { x: -0.06, z: 0.08 },
+    { x: 0.1, z: 0.2 }, { x: 0.26, z: 0.3 }, { x: 0.43, z: 0.33 }, { x: 0.53, z: 0.12 },
+    { x: 0.41, z: -0.08 }, { x: 0.25, z: -0.2 }, { x: 0.09, z: -0.3 }, { x: -0.09, z: -0.35 },
+    { x: -0.28, z: -0.3 }, { x: -0.45, z: -0.18 }, { x: -0.51, z: 0.02 }
+  ],
+  [
+    { x: -0.5, z: 0.26 }, { x: -0.38, z: 0.12 }, { x: -0.26, z: -0.02 }, { x: -0.14, z: -0.18 },
+    { x: -0.02, z: -0.32 }, { x: 0.13, z: -0.24 }, { x: 0.27, z: -0.12 }, { x: 0.42, z: -0.03 },
+    { x: 0.54, z: 0.14 }, { x: 0.36, z: 0.25 }, { x: 0.18, z: 0.34 }, { x: 0.02, z: 0.27 },
+    { x: -0.17, z: 0.2 }, { x: -0.31, z: 0.32 }, { x: 0.05, z: 0.06 }
+  ],
+  [
+    { x: -0.48, z: -0.01 }, { x: -0.32, z: 0.08 }, { x: -0.32, z: -0.12 }, { x: -0.15, z: 0.18 },
+    { x: -0.15, z: -0.22 }, { x: 0.03, z: 0.27 }, { x: 0.03, z: -0.31 }, { x: 0.19, z: 0.14 },
+    { x: 0.19, z: -0.18 }, { x: 0.34, z: 0.03 }, { x: 0.48, z: 0.2 }, { x: 0.5, z: -0.24 },
+    { x: -0.01, z: -0.06 }, { x: 0.34, z: 0.33 }, { x: -0.47, z: 0.28 }
+  ],
+  [
+    { x: -0.54, z: 0.34 }, { x: -0.38, z: 0.24 }, { x: -0.22, z: 0.16 }, { x: -0.04, z: 0.12 },
+    { x: 0.14, z: 0.08 }, { x: 0.31, z: 0.02 }, { x: 0.47, z: -0.07 }, { x: 0.55, z: -0.22 },
+    { x: 0.37, z: -0.27 }, { x: 0.2, z: -0.3 }, { x: 0.02, z: -0.34 }, { x: -0.16, z: -0.31 },
+    { x: -0.33, z: -0.25 }, { x: -0.49, z: -0.12 }, { x: -0.44, z: 0.07 }
+  ],
+  [
+    { x: -0.45, z: 0.33 }, { x: -0.27, z: 0.31 }, { x: -0.08, z: 0.34 }, { x: 0.11, z: 0.32 },
+    { x: 0.3, z: 0.28 }, { x: 0.47, z: 0.21 }, { x: 0.53, z: 0.01 }, { x: 0.43, z: -0.15 },
+    { x: 0.26, z: -0.25 }, { x: 0.07, z: -0.31 }, { x: -0.11, z: -0.34 }, { x: -0.29, z: -0.3 },
+    { x: -0.46, z: -0.21 }, { x: -0.53, z: -0.03 }, { x: -0.01, z: 0.04 }
   ]
-  const targetCount = Math.min(15, Math.max(1, level))
-  const rotated = rotate(ring, level - 1)
-  const spacingOffset = (level % 5) * 0.01
+]
+
+const buildTrainingLayout = (level) => {
+  const pattern = PATTERN_LIBRARY[(level - 1) % PATTERN_LIBRARY.length] || PATTERN_LIBRARY[0]
+  const targetCount = Math.max(3, Math.min(15, 3 + Math.floor((level - 1) / 2)))
+  const rotated = rotate(pattern, (level * 2) % pattern.length)
+  const microShift = ((level % 4) - 1.5) * 0.008
   const balls = rotated.slice(0, targetCount).map((pos, idx) => ({
     rackIndex: idx,
-    x: pos.x + (idx % 2 === 0 ? spacingOffset : -spacingOffset),
-    z: pos.z
+    x: pos.x + (idx % 2 === 0 ? microShift : -microShift),
+    z: pos.z + (idx % 3 === 0 ? microShift : 0)
   }))
 
   return {
-    cue: { x: -0.68 + (level % 3) * 0.05, z: 0.52 - (level % 4) * 0.08 },
+    cue: { x: -0.7 + (level % 5) * 0.045, z: 0.5 - (level % 6) * 0.065 },
     balls
   }
 }
 
 const buildTrainingDefinition = (level) => {
-  const discipline =
-    level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'American Billiards'
-  const targetCount = Math.min(15, level)
+  const discipline = level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'Pool Position Play'
+  const targetCount = Math.max(3, Math.min(15, 3 + Math.floor((level - 1) / 2)))
+  const strategy = STRATEGY_DRILLS[(level - 1) % STRATEGY_DRILLS.length]
   const reward =
     level % 5 === 0
       ? 'Free random table setup item unlocked.'
@@ -58,11 +89,8 @@ const buildTrainingDefinition = (level) => {
   return {
     level,
     discipline,
-    title: `${discipline} Drill ${String(level).padStart(2, '0')}`,
-    objective:
-      level <= 15
-        ? `Pot ${targetCount} ball${targetCount > 1 ? 's' : ''} without scratching.`
-        : `Clear ${targetCount} planned balls from a mixed ${discipline} layout.`,
+    title: `${strategy.title} #${String(level).padStart(2, '0')}`,
+    objective: `${strategy.objective} Clear ${targetCount} planned ball${targetCount > 1 ? 's' : ''}.`,
     reward,
     layout: buildTrainingLayout(level)
   }
@@ -83,10 +111,10 @@ export function getTrainingLayout (level) {
 }
 
 export function loadTrainingProgress () {
-  if (typeof window === 'undefined') { return { completed: [], lastLevel: 1, carryShots: 3 } }
+  if (typeof window === 'undefined') { return { completed: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL } }
   try {
     const stored = window.localStorage.getItem(TRAINING_PROGRESS_KEY)
-    if (!stored) return { completed: [], lastLevel: 1, carryShots: 3 }
+    if (!stored) return { completed: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL }
     const parsed = JSON.parse(stored)
     const completed = Array.isArray(parsed?.completed)
       ? parsed.completed
@@ -95,13 +123,15 @@ export function loadTrainingProgress () {
         .sort((a, b) => a - b)
       : []
     const lastLevel = clampLevel(parsed?.lastLevel, 1)
-    const carryShots = Math.max(0, Math.floor(Number(parsed?.carryShots) || 3))
+    const carryShots = Math.max(0, Math.floor(Number(parsed?.carryShots) || BASE_ATTEMPTS_PER_LEVEL))
     return { completed, lastLevel, carryShots }
   } catch (err) {
     console.warn('Failed to load Pool Royale training progress', err)
-    return { completed: [], lastLevel: 1, carryShots: 3 }
+    return { completed: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL }
   }
 }
+
+export { BASE_ATTEMPTS_PER_LEVEL }
 
 export function persistTrainingProgress (progress) {
   if (typeof window === 'undefined') return


### PR DESCRIPTION
### Motivation

- Provide a full 50-level solo training experience with varied, realistic drill setups and persistent attempts so players can train sequentially without AI or break-dice interference. 
- Make training progression visible and returnable in-session via a roadmap popup and preserve player's attempts between levels/sessions. 

### Description

- Added `BASE_ATTEMPTS_PER_LEVEL` and richer level generation in `webapp/src/utils/poolRoyaleTrainingProgress.js`, including `STRATEGY_DRILLS`, a `PATTERN_LIBRARY`, varied ball counts (3–15), and exported `TRAINING_LEVELS` so each of the 50 levels has distinct objectives and layouts. 
- Standardized carry-over attempts and persistence fallbacks by switching defaults to `BASE_ATTEMPTS_PER_LEVEL` and updating `loadTrainingProgress`/`persistTrainingProgress` behavior. 
- Enforced solo-only training flow and always-on training rules inside `PoolRoyaleGame` by defaulting training state to solo, preventing break-dice logic during training, and locking training UI options accordingly in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added a 50-level roadmap popup and menu updates that show an attempts bank and open the roadmap on level completion, plus minor UI label changes ("Shots" → "Attempts"). 

Files changed: `webapp/src/utils/poolRoyaleTrainingProgress.js`, `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing

- Ran a node import check that validated `TRAINING_LEVELS` contains 50 entries and that layouts use between 3 and 15 balls (succeeded). 
- Built the web app bundle with `npm --prefix webapp run build` to verify the frontend compiles (succeeded with existing Vite chunk-size warnings). 
- Ran the repository-level `npm run build` which failed due to a pre-existing, unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (failure unrelated to these changes). 
- Ran `eslint` on the modified files which produced non-blocking warnings only, and attempted a Playwright screenshot of the training UI which timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699542b340d88329ba3407bf03daaa3b)