### PR TITLE
PersonaPlex-only commentary, voice-first Home help, and faster store purchases

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -143,7 +143,10 @@ const userSchema = new mongoose.Schema({
   poolRoyalInventory: { type: Object, default: undefined },
 
   // Persist Snooker Royal unlocks server-side for cross-device sync
-  snookerRoyalInventory: { type: Object, default: undefined }
+  snookerRoyalInventory: { type: Object, default: undefined },
+
+  // Shared voice commentary unlocks apply across all games
+  voiceCommentaryInventory: { type: Object, default: undefined }
 
 });
 

--- a/bot/routes/voiceCommentary.js
+++ b/bot/routes/voiceCommentary.js
@@ -1,0 +1,270 @@
+import { Router } from 'express';
+import authenticate from '../middleware/auth.js';
+import User from '../models/User.js';
+import {
+  DEFAULT_FREE_VOICE_ID,
+  buildVoiceStoreItems,
+  createDefaultVoiceInventory,
+  getVoiceCatalog,
+  normalizeVoiceInventory
+} from '../utils/voiceCommentaryCatalog.js';
+
+const router = Router();
+
+const HELP_RESPONSES = [
+  {
+    keywords: ['wallet', 'send', 'receive', 'deposit', 'withdraw'],
+    answer:
+      'To use wallet, open Wallet, then choose send or receive. Keep enough T P C balance before paid matches and confirm your linked account.'
+  },
+  {
+    keywords: ['store', 'buy', 'purchase', 'voice', 'commentary'],
+    answer:
+      'Open Store, choose your item, then confirm purchase. Voice language packs unlock commentary across all games after payment.'
+  },
+  {
+    keywords: ['game', 'play', 'match', 'start'],
+    answer:
+      'Open Games, select a game mode, then join a lobby or start a match. For paid games, make sure your T P C balance is ready.'
+  },
+  {
+    keywords: ['account', 'telegram', 'google', 'connect'],
+    answer:
+      'From Home, connect Telegram, Google, or wallet. Linking your account helps sync inventory and protects your progress.'
+  }
+];
+
+export function buildHelpAnswer(question = '') {
+  const normalized = String(question || '').toLowerCase();
+  if (!normalized) {
+    return 'Hello, I am TonPlaygram voice help. How can I help you today?';
+  }
+  const match = HELP_RESPONSES.find((entry) => entry.keywords.some((keyword) => normalized.includes(keyword)));
+  if (match) return match.answer;
+  return 'I can help with wallet, games, store purchases, voice commentary, and account setup. Please ask one of these topics.';
+}
+
+async function loadUser(accountId) {
+  if (!accountId) return null;
+  return User.findOne({ accountId });
+}
+
+function resolveSelectedVoice({ catalogVoices = [], inventory, overrideVoiceId, overrideLocale }) {
+  const voices = Array.isArray(catalogVoices) ? catalogVoices : [];
+  if (!voices.length) return null;
+
+  if (overrideVoiceId) {
+    const byId = voices.find((voice) => String(voice.id) === String(overrideVoiceId));
+    if (byId) return byId;
+  }
+
+  const normalizedInventory = normalizeVoiceInventory(inventory);
+
+  const selectedOwned = voices.find((voice) =>
+    normalizedInventory.ownedVoiceIds.includes(String(voice.id)) &&
+    String(voice.id) === String(normalizedInventory.selectedVoiceId)
+  );
+  if (selectedOwned) return selectedOwned;
+
+  if (overrideLocale) {
+    const byLocale = voices.find((voice) => String(voice.locale).toLowerCase() === String(overrideLocale).toLowerCase());
+    if (byLocale) return byLocale;
+  }
+
+  const firstOwned = voices.find((voice) => normalizedInventory.ownedVoiceIds.includes(String(voice.id)));
+  if (firstOwned) return firstOwned;
+
+  return voices.find((voice) => String(voice.id) === DEFAULT_FREE_VOICE_ID) || voices[0];
+}
+
+async function synthesizeWithPersonaplex({ text, voiceId, locale, metadata = {} }) {
+  const endpoint = process.env.PERSONAPLEX_API_URL;
+  const apiKey = process.env.PERSONAPLEX_API_KEY;
+  if (!endpoint || !apiKey) {
+    throw new Error('PersonaPlex is not configured. Set PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY.');
+  }
+
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}/v1/speech/synthesize`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      input: text,
+      voice: voiceId,
+      locale,
+      metadata
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`PersonaPlex synthesis failed (${response.status}): ${details}`);
+  }
+
+  const payload = await response.json();
+  return {
+    provider: 'nvidia-personaplex',
+    audioBase64: payload.audioBase64 || payload.audio_base64 || null,
+    audioUrl: payload.audioUrl || payload.audio_url || null,
+    mimeType: payload.mimeType || payload.mime_type || 'audio/mpeg',
+    raw: payload
+  };
+}
+
+router.get('/catalog', async (_req, res) => {
+  const catalog = await getVoiceCatalog();
+  res.json({ ...catalog, defaultVoiceId: DEFAULT_FREE_VOICE_ID, storeItems: buildVoiceStoreItems(catalog) });
+});
+
+router.post('/catalog/refresh', authenticate, async (_req, res) => {
+  const catalog = await getVoiceCatalog({ forceRefresh: true });
+  res.json({ ...catalog, defaultVoiceId: DEFAULT_FREE_VOICE_ID, storeItems: buildVoiceStoreItems(catalog) });
+});
+
+router.get('/inventory/:accountId', async (req, res) => {
+  const { accountId } = req.params;
+  const user = await loadUser(accountId);
+  if (!user) return res.status(404).json({ error: 'account not found' });
+
+  const inventory = normalizeVoiceInventory(user.voiceCommentaryInventory);
+  if (JSON.stringify(user.voiceCommentaryInventory || {}) !== JSON.stringify(inventory)) {
+    user.voiceCommentaryInventory = inventory;
+    await user.save();
+  }
+  return res.json({ accountId, inventory });
+});
+
+router.post('/select', authenticate, async (req, res) => {
+  const { accountId, voiceId } = req.body || {};
+  if (!accountId || !voiceId) {
+    return res.status(400).json({ error: 'accountId and voiceId are required' });
+  }
+
+  const user = await loadUser(accountId);
+  if (!user) return res.status(404).json({ error: 'account not found' });
+  if (req.auth?.telegramId && user.telegramId && req.auth.telegramId !== user.telegramId) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
+  const inventory = normalizeVoiceInventory(user.voiceCommentaryInventory);
+  if (!inventory.ownedVoiceIds.includes(voiceId)) {
+    return res.status(400).json({ error: 'voice not owned' });
+  }
+
+  inventory.selectedVoiceId = voiceId;
+  inventory.updatedAt = new Date().toISOString();
+  user.voiceCommentaryInventory = inventory;
+  await user.save();
+
+  return res.json({ accountId, inventory });
+});
+
+
+router.post('/help', async (req, res) => {
+  const { accountId, question, voiceId, locale } = req.body || {};
+  const user = accountId ? await loadUser(accountId) : null;
+  const inventory = normalizeVoiceInventory(user?.voiceCommentaryInventory);
+  const catalog = await getVoiceCatalog();
+  const selected = resolveSelectedVoice({
+    catalogVoices: catalog.voices,
+    inventory,
+    overrideVoiceId: voiceId,
+    overrideLocale: locale
+  });
+
+  if (!selected) {
+    return res.status(503).json({ error: 'No PersonaPlex voices available in catalog' });
+  }
+
+  const answer = buildHelpAnswer(question);
+  try {
+    const synthesis = await synthesizeWithPersonaplex({
+      text: answer,
+      voiceId: selected.id,
+      locale: selected.locale,
+      metadata: {
+        channel: 'help_center'
+      }
+    });
+    return res.json({
+      provider: 'nvidia-personaplex',
+      voice: selected,
+      answer,
+      synthesis
+    });
+  } catch (error) {
+    return res.status(502).json({ error: error.message, provider: 'nvidia-personaplex' });
+  }
+});
+
+router.post('/speak', async (req, res) => {
+  const { text, accountId, voiceId, locale, speaker } = req.body || {};
+  const message = String(text || '').trim();
+  if (!message) return res.status(400).json({ error: 'text is required' });
+
+  const user = accountId ? await loadUser(accountId) : null;
+  const inventory = normalizeVoiceInventory(user?.voiceCommentaryInventory);
+  const catalog = await getVoiceCatalog();
+  const selected = resolveSelectedVoice({
+    catalogVoices: catalog.voices,
+    inventory,
+    overrideVoiceId: voiceId,
+    overrideLocale: locale
+  });
+
+  if (!selected) {
+    return res.status(503).json({ error: 'No PersonaPlex voices available in catalog' });
+  }
+
+  try {
+    const synthesis = await synthesizeWithPersonaplex({
+      text: message,
+      voiceId: selected.id,
+      locale: selected.locale,
+      metadata: {
+        channel: 'game_commentary',
+        speaker: String(speaker || 'host')
+      }
+    });
+
+    return res.json({
+      provider: 'nvidia-personaplex',
+      voice: selected,
+      inventory,
+      synthesis
+    });
+  } catch (error) {
+    return res.status(502).json({ error: error.message, provider: 'nvidia-personaplex' });
+  }
+});
+
+export function applyVoiceCommentaryUnlocks(user, purchasedItems = [], catalogVoices = []) {
+  const inventory = normalizeVoiceInventory(user.voiceCommentaryInventory || createDefaultVoiceInventory());
+  const localeToVoiceIds = catalogVoices.reduce((acc, voice) => {
+    const locale = String(voice.locale || '').toLowerCase();
+    if (!locale) return acc;
+    acc[locale] = acc[locale] || [];
+    acc[locale].push(String(voice.id));
+    return acc;
+  }, {});
+
+  purchasedItems.forEach((item) => {
+    if (item.type !== 'voiceLanguage') return;
+    const localeRaw = String(item.optionId || '');
+    const localeKey = localeRaw.toLowerCase();
+    const unlockedVoiceIds = localeToVoiceIds[localeKey] || [];
+    if (localeRaw && !inventory.ownedLocales.includes(localeRaw)) inventory.ownedLocales.push(localeRaw);
+    unlockedVoiceIds.forEach((voiceId) => {
+      if (!inventory.ownedVoiceIds.includes(voiceId)) {
+        inventory.ownedVoiceIds.push(voiceId);
+      }
+    });
+  });
+
+  inventory.updatedAt = new Date().toISOString();
+  user.voiceCommentaryInventory = inventory;
+}
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -29,6 +29,7 @@ import poolRoyaleRoutes from './routes/poolRoyale.js';
 import snookerRoyaleRoutes from './routes/snookerRoyal.js';
 import exchangeRoutes from './routes/exchange.js';
 import pushRoutes from './routes/push.js';
+import voiceCommentaryRoutes from './routes/voiceCommentary.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -255,6 +256,7 @@ app.use('/api/online', onlineRoutes);
 app.use('/api/pool-royale', poolRoyaleRoutes);
 app.use('/api/snooker-royale', snookerRoyaleRoutes);
 app.use('/api/exchange', exchangeRoutes);
+app.use('/api/voice-commentary', voiceCommentaryRoutes);
 
 app.post('/api/goal-rush/calibration', authenticate, async (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/bot/utils/voiceCommentaryCatalog.js
+++ b/bot/utils/voiceCommentaryCatalog.js
@@ -1,0 +1,165 @@
+const FALLBACK_VOICE_CATALOG = [
+  { id: 'nova_en_us_f', locale: 'en-US', language: 'English', gender: 'female', style: 'energetic', provider: 'nvidia-personaplex', isDefault: true, isFree: true },
+  { id: 'atlas_en_us_m', locale: 'en-US', language: 'English', gender: 'male', style: 'professional', provider: 'nvidia-personaplex', isFree: true },
+  { id: 'luna_es_es_f', locale: 'es-ES', language: 'Spanish', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'orion_es_mx_m', locale: 'es-MX', language: 'Spanish', gender: 'male', style: 'energetic', provider: 'nvidia-personaplex' },
+  { id: 'selene_fr_fr_f', locale: 'fr-FR', language: 'French', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'leo_de_de_m', locale: 'de-DE', language: 'German', gender: 'male', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'sofia_it_it_f', locale: 'it-IT', language: 'Italian', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'sakura_ja_jp_f', locale: 'ja-JP', language: 'Japanese', gender: 'female', style: 'energetic', provider: 'nvidia-personaplex' },
+  { id: 'jin_ko_kr_m', locale: 'ko-KR', language: 'Korean', gender: 'male', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'maya_hi_in_f', locale: 'hi-IN', language: 'Hindi', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'amir_ar_sa_m', locale: 'ar-SA', language: 'Arabic', gender: 'male', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'anisa_sq_al_f', locale: 'sq-AL', language: 'Albanian', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'ivo_pt_br_m', locale: 'pt-BR', language: 'Portuguese', gender: 'male', style: 'energetic', provider: 'nvidia-personaplex' },
+  { id: 'olena_uk_ua_f', locale: 'uk-UA', language: 'Ukrainian', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' }
+];
+
+const CATALOG_TTL_MS = 5 * 60 * 1000;
+let cache = {
+  voices: FALLBACK_VOICE_CATALOG,
+  source: 'fallback',
+  fetchedAt: 0
+};
+
+const normalizeLanguage = (voice) => {
+  if (voice.language) return String(voice.language);
+  if (voice.locale) {
+    const [base] = String(voice.locale).split('-');
+    return base.toUpperCase();
+  }
+  return 'Unknown';
+};
+
+const normalizeVoice = (voice, index = 0) => ({
+  id: String(voice.id || voice.voice_id || voice.voice || `voice_${index}`),
+  locale: String(voice.locale || voice.language_code || voice.lang || 'en-US'),
+  language: normalizeLanguage(voice),
+  gender: String(voice.gender || 'neutral').toLowerCase(),
+  style: String(voice.style || 'professional').toLowerCase(),
+  provider: 'nvidia-personaplex',
+  isDefault: Boolean(voice.isDefault),
+  isFree: Boolean(voice.isFree)
+});
+
+const fallbackCatalog = () => ({
+  provider: 'nvidia-personaplex',
+  source: 'fallback',
+  voices: FALLBACK_VOICE_CATALOG,
+  languages: Array.from(new Set(FALLBACK_VOICE_CATALOG.map((voice) => voice.language))).sort()
+});
+
+async function fetchProviderCatalog() {
+  const endpoint = process.env.PERSONAPLEX_API_URL;
+  const apiKey = process.env.PERSONAPLEX_API_KEY;
+  const path = process.env.PERSONAPLEX_VOICES_PATH || '/v1/voices';
+  if (!endpoint || !apiKey) return null;
+
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}${path.startsWith('/') ? path : `/${path}`}`, {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  });
+
+  if (!response.ok) {
+    throw new Error(`PersonaPlex voices endpoint failed (${response.status})`);
+  }
+
+  const body = await response.json();
+  const rows = Array.isArray(body?.voices) ? body.voices : Array.isArray(body) ? body : [];
+  if (!rows.length) return null;
+
+  const voices = rows.map((voice, index) => normalizeVoice(voice, index));
+  return {
+    provider: 'nvidia-personaplex',
+    source: 'remote',
+    voices,
+    languages: Array.from(new Set(voices.map((voice) => voice.language))).sort()
+  };
+}
+
+export async function getVoiceCatalog({ forceRefresh = false } = {}) {
+  const now = Date.now();
+  if (!forceRefresh && now - cache.fetchedAt < CATALOG_TTL_MS) {
+    return {
+      provider: 'nvidia-personaplex',
+      source: cache.source,
+      voices: cache.voices,
+      languages: Array.from(new Set(cache.voices.map((voice) => voice.language))).sort()
+    };
+  }
+
+  try {
+    const remoteCatalog = await fetchProviderCatalog();
+    if (remoteCatalog?.voices?.length) {
+      cache = { voices: remoteCatalog.voices, source: 'remote', fetchedAt: now };
+      return remoteCatalog;
+    }
+  } catch (error) {
+    console.warn('voice-catalog-fetch-failed', error.message);
+  }
+
+  const fallback = fallbackCatalog();
+  cache = { voices: fallback.voices, source: 'fallback', fetchedAt: now };
+  return fallback;
+}
+
+export const DEFAULT_FREE_VOICE_ID = 'nova_en_us_f';
+
+export function createDefaultVoiceInventory() {
+  return {
+    ownedVoiceIds: [DEFAULT_FREE_VOICE_ID],
+    ownedLocales: ['en-US'],
+    selectedVoiceId: DEFAULT_FREE_VOICE_ID,
+    updatedAt: new Date().toISOString()
+  };
+}
+
+export function normalizeVoiceInventory(rawInventory) {
+  const base = createDefaultVoiceInventory();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+
+  const ownedSet = new Set([DEFAULT_FREE_VOICE_ID]);
+  if (Array.isArray(rawInventory.ownedVoiceIds)) {
+    rawInventory.ownedVoiceIds.forEach((voiceId) => {
+      if (voiceId) ownedSet.add(String(voiceId));
+    });
+  }
+
+  const ownedLocales = new Set(['en-US']);
+  if (Array.isArray(rawInventory.ownedLocales)) {
+    rawInventory.ownedLocales.forEach((locale) => {
+      if (locale) ownedLocales.add(String(locale));
+    });
+  }
+
+  const selectedVoiceId = ownedSet.has(rawInventory.selectedVoiceId)
+    ? rawInventory.selectedVoiceId
+    : DEFAULT_FREE_VOICE_ID;
+
+  return {
+    ownedVoiceIds: Array.from(ownedSet),
+    ownedLocales: Array.from(ownedLocales),
+    selectedVoiceId,
+    updatedAt: rawInventory.updatedAt || base.updatedAt
+  };
+}
+
+export function buildVoiceStoreItems(catalog) {
+  const languageMap = new Map();
+  for (const voice of catalog.voices) {
+    const key = `${voice.language}|${voice.locale.split('-')[0]}`;
+    if (!languageMap.has(key)) {
+      languageMap.set(key, {
+        id: `voice-${voice.locale.toLowerCase()}`,
+        type: 'voiceLanguage',
+        optionId: voice.locale,
+        name: `${voice.language} Commentary Pack`,
+        description: `${voice.language} commentary voices for all games`,
+        price: voice.locale.toLowerCase().startsWith('en-') ? 0 : 2200,
+        voiceIds: []
+      });
+    }
+    languageMap.get(key).voiceIds.push(voice.id);
+  }
+
+  return Array.from(languageMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/docs/personaplex-voice-commentary.md
+++ b/docs/personaplex-voice-commentary.md
@@ -1,0 +1,42 @@
+# NVIDIA PersonaPlex Voice Commentary Integration
+
+This project now supports **cross-game voice commentary** using NVIDIA PersonaPlex.
+
+## What changed
+
+- Voice catalog can be fetched from PersonaPlex dynamically (`PERSONAPLEX_API_URL` + `PERSONAPLEX_API_KEY`), with fallback catalog when credentials are not configured.
+- English commentary is free by default for all users.
+- Voice language packs are modeled as **global store entitlements** (`voiceLanguage`) and apply to all games, not just one game.
+- Selected commentary voice is shared across games via `voiceCommentaryInventory`.
+
+## API routes
+
+### Platform help API (`packages/api/src/server.ts`)
+
+- `GET /v1/voice/catalog`
+- `POST /v1/voice/commentary`
+- `POST /v1/voice/support`
+
+When PersonaPlex credentials are missing, synthesis endpoints fail fast with a clear configuration error.
+
+### Main game API (`bot/server.js`)
+
+- `GET /api/voice-commentary/catalog` — returns provider catalog + generated voice language store items.
+- `POST /api/voice-commentary/catalog/refresh` — refreshes remote voice catalog.
+- `GET /api/voice-commentary/inventory/:accountId` — returns normalized cross-game owned/selected voices.
+- `POST /api/voice-commentary/select` — selects an owned voice.
+
+## Store integration
+
+`/store/voicecommentary` now includes commentary language packs:
+
+- English (`en-US`) pack is free by default.
+- Purchased language packs unlock voice commentary usage in all games.
+
+Purchases with item type `voiceLanguage` are applied server-side in `/api/store/purchase` and persisted to `user.voiceCommentaryInventory`.
+
+## Environment variables
+
+- `PERSONAPLEX_API_URL` - PersonaPlex API base URL
+- `PERSONAPLEX_API_KEY` - Bearer token
+- `PERSONAPLEX_VOICES_PATH` - optional voices path (default `/v1/voices`)

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -3,6 +3,14 @@ import crypto from 'crypto';
 import { answerUserQuestion } from '../../agent-core/src/agent.js';
 import { loadKnowledgeIndex } from '../../agent-core/src/knowledgeBase.js';
 import { evaluateUserPrompt } from '../../agent-core/src/safety.js';
+import {
+  VOICE_PROFILES,
+  buildCommentaryText,
+  buildSupportSpeech,
+  findVoiceProfile,
+  isGameKey,
+  requestPersonaplexSynthesis
+} from './voiceCommentary.js';
 
 const app = express();
 app.use(express.json());
@@ -110,6 +118,59 @@ app.post('/v1/feedback', requireBasicUserAuth, (req, res) => {
   };
 
   res.status(202).json({ accepted: true, payload });
+});
+
+app.get('/v1/voice/catalog', (_req, res) => {
+  const languages = Array.from(new Set(VOICE_PROFILES.map((voice) => voice.language))).sort();
+  res.json({ provider: 'nvidia-personaplex', languages, voices: VOICE_PROFILES });
+});
+
+app.post('/v1/voice/commentary', requireBasicUserAuth, async (req, res) => {
+  const game = String(req.body?.game || '');
+  if (!isGameKey(game)) {
+    res.status(400).json({ error: 'Unsupported game key', supportedGames: [
+      'pool_royale', 'snooker_royal', 'snake_multiplayer', 'texas_holdem', 'domino_royal',
+      'chess_battle_royal', 'air_hockey', 'goal_rush', 'ludo_battle_royal', 'table_tennis_royal',
+      'murlan_royale', 'dice_duel', 'snake_and_ladder'
+    ] });
+    return;
+  }
+
+  const eventType = String(req.body?.eventType || 'player_turn') as Parameters<typeof buildCommentaryText>[1];
+  const playerName = String(req.body?.playerName || 'Player');
+  const score = typeof req.body?.score === 'string' ? req.body.score : undefined;
+  const voice = findVoiceProfile(req.body?.voiceId, req.body?.locale);
+  const text = buildCommentaryText(game, eventType, playerName, score);
+
+  try {
+    const synthesis = await requestPersonaplexSynthesis({
+      text,
+      locale: voice.locale,
+      voiceId: voice.id,
+      metadata: { game, eventType }
+    });
+    res.json({ text, voice, synthesis });
+  } catch (error) {
+    res.status(502).json({ error: (error as Error).message, text, voice });
+  }
+});
+
+app.post('/v1/voice/support', requireBasicUserAuth, async (req, res) => {
+  const voice = findVoiceProfile(req.body?.voiceId, req.body?.locale);
+  const ticketContext = String(req.body?.ticketContext || 'General account support');
+  const text = buildSupportSpeech(ticketContext, voice);
+
+  try {
+    const synthesis = await requestPersonaplexSynthesis({
+      text,
+      locale: voice.locale,
+      voiceId: voice.id,
+      metadata: { channel: 'customer_support' }
+    });
+    res.json({ text, voice, synthesis });
+  } catch (error) {
+    res.status(502).json({ error: (error as Error).message, text, voice });
+  }
 });
 
 if (process.env.NODE_ENV !== 'test') {

--- a/packages/api/src/voiceCommentary.ts
+++ b/packages/api/src/voiceCommentary.ts
@@ -1,0 +1,165 @@
+export type CommentaryEventType =
+  | 'match_start'
+  | 'player_turn'
+  | 'score_update'
+  | 'streak'
+  | 'powerup'
+  | 'match_end'
+  | 'customer_support';
+
+export type GameKey =
+  | 'pool_royale'
+  | 'snooker_royal'
+  | 'snake_multiplayer'
+  | 'texas_holdem'
+  | 'domino_royal'
+  | 'chess_battle_royal'
+  | 'air_hockey'
+  | 'goal_rush'
+  | 'ludo_battle_royal'
+  | 'table_tennis_royal'
+  | 'murlan_royale'
+  | 'dice_duel'
+  | 'snake_and_ladder';
+
+export interface VoiceProfile {
+  id: string;
+  provider: 'nvidia-personaplex';
+  locale: string;
+  language: string;
+  gender: 'female' | 'male' | 'neutral';
+  style: 'energetic' | 'calm' | 'professional' | 'friendly';
+  isDefault?: boolean;
+}
+
+export const VOICE_PROFILES: VoiceProfile[] = [
+  { id: 'nova_en_us_f', provider: 'nvidia-personaplex', locale: 'en-US', language: 'English', gender: 'female', style: 'energetic', isDefault: true },
+  { id: 'atlas_en_us_m', provider: 'nvidia-personaplex', locale: 'en-US', language: 'English', gender: 'male', style: 'professional' },
+  { id: 'luna_es_es_f', provider: 'nvidia-personaplex', locale: 'es-ES', language: 'Spanish', gender: 'female', style: 'friendly' },
+  { id: 'orion_es_mx_m', provider: 'nvidia-personaplex', locale: 'es-MX', language: 'Spanish', gender: 'male', style: 'energetic' },
+  { id: 'selene_fr_fr_f', provider: 'nvidia-personaplex', locale: 'fr-FR', language: 'French', gender: 'female', style: 'calm' },
+  { id: 'leo_de_de_m', provider: 'nvidia-personaplex', locale: 'de-DE', language: 'German', gender: 'male', style: 'professional' },
+  { id: 'sofia_it_it_f', provider: 'nvidia-personaplex', locale: 'it-IT', language: 'Italian', gender: 'female', style: 'friendly' },
+  { id: 'sakura_ja_jp_f', provider: 'nvidia-personaplex', locale: 'ja-JP', language: 'Japanese', gender: 'female', style: 'energetic' },
+  { id: 'jin_ko_kr_m', provider: 'nvidia-personaplex', locale: 'ko-KR', language: 'Korean', gender: 'male', style: 'professional' },
+  { id: 'maya_hi_in_f', provider: 'nvidia-personaplex', locale: 'hi-IN', language: 'Hindi', gender: 'female', style: 'friendly' },
+  { id: 'amir_ar_sa_m', provider: 'nvidia-personaplex', locale: 'ar-SA', language: 'Arabic', gender: 'male', style: 'calm' },
+  { id: 'eda_tr_tr_f', provider: 'nvidia-personaplex', locale: 'tr-TR', language: 'Turkish', gender: 'female', style: 'professional' },
+  { id: 'anisa_sq_al_f', provider: 'nvidia-personaplex', locale: 'sq-AL', language: 'Albanian', gender: 'female', style: 'friendly' },
+  { id: 'ivo_pt_br_m', provider: 'nvidia-personaplex', locale: 'pt-BR', language: 'Portuguese', gender: 'male', style: 'energetic' },
+  { id: 'olena_uk_ua_f', provider: 'nvidia-personaplex', locale: 'uk-UA', language: 'Ukrainian', gender: 'female', style: 'calm' },
+  { id: 'marek_pl_pl_m', provider: 'nvidia-personaplex', locale: 'pl-PL', language: 'Polish', gender: 'male', style: 'professional' }
+];
+
+const GAME_LABELS: Record<GameKey, string> = {
+  pool_royale: 'Pool Royale',
+  snooker_royal: 'Snooker Royal',
+  snake_multiplayer: 'Snake Multiplayer',
+  texas_holdem: 'Texas Holdem',
+  domino_royal: 'Domino Royal',
+  chess_battle_royal: 'Chess Battle Royal',
+  air_hockey: 'Air Hockey',
+  goal_rush: 'Goal Rush',
+  ludo_battle_royal: 'Ludo Battle Royal',
+  table_tennis_royal: 'Table Tennis Royal',
+  murlan_royale: 'Murlan Royale',
+  dice_duel: 'Dice Duel',
+  snake_and_ladder: 'Snake and Ladder'
+};
+
+export function isGameKey(value: string): value is GameKey {
+  return value in GAME_LABELS;
+}
+
+function getGameLabel(game: GameKey): string {
+  return GAME_LABELS[game];
+}
+
+function supportReplyTemplate(language: string, ticketContext: string): string {
+  if (language.toLowerCase().startsWith('albanian')) {
+    return `Përshëndetje! Ky është asistenti zanor i mbështetjes. E kuptova kërkesën tuaj: ${ticketContext}. Po e shqyrtojmë tani dhe do t'ju përgjigjemi me hapa të qartë.`;
+  }
+
+  return `Hello! This is your voice support assistant. I understood your request: ${ticketContext}. We are checking it now and will send you clear next steps.`;
+}
+
+export function buildCommentaryText(game: GameKey, eventType: CommentaryEventType, playerName: string, score?: string): string {
+  const gameLabel = getGameLabel(game);
+  const safePlayer = playerName || 'Player';
+
+  switch (eventType) {
+    case 'match_start':
+      return `Welcome to ${gameLabel}! The match is live. ${safePlayer}, bring your best move.`;
+    case 'player_turn':
+      return `${safePlayer}, it's your turn in ${gameLabel}. Focus, aim, and execute.`;
+    case 'score_update':
+      return `Score update in ${gameLabel}: ${score ?? 'new score available'}. Momentum is shifting.`;
+    case 'streak':
+      return `${safePlayer} is on a streak in ${gameLabel}! What a dominant run.`;
+    case 'powerup':
+      return `Power play activated in ${gameLabel}. ${safePlayer} is changing the pace.`;
+    case 'match_end':
+      return `${gameLabel} match complete. Great game by ${safePlayer}. Thanks for playing.`;
+    case 'customer_support':
+      return supportReplyTemplate('English', score ?? 'General support request');
+    default:
+      return `Live update from ${gameLabel}.`;
+  }
+}
+
+export async function requestPersonaplexSynthesis(input: {
+  text: string;
+  voiceId: string;
+  locale: string;
+  metadata?: Record<string, string>;
+}): Promise<{ mode: 'remote'; provider: 'nvidia-personaplex'; response: unknown }> {
+  const endpoint = process.env.PERSONAPLEX_API_URL;
+  const apiKey = process.env.PERSONAPLEX_API_KEY;
+
+  const ssml = `<speak><lang xml:lang="${input.locale}">${input.text}</lang></speak>`;
+
+  if (!endpoint || !apiKey) {
+    throw new Error('PersonaPlex is not configured. Set PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY.');
+  }
+
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}/v1/speech/synthesize`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      input: input.text,
+      ssml,
+      voice: input.voiceId,
+      locale: input.locale,
+      metadata: input.metadata ?? {}
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`PersonaPlex synthesis failed (${response.status}): ${details}`);
+  }
+
+  const payload = await response.json();
+  return { mode: 'remote', provider: 'nvidia-personaplex', response: payload };
+}
+
+export function findVoiceProfile(voiceId?: string, locale?: string): VoiceProfile {
+  if (voiceId) {
+    const match = VOICE_PROFILES.find((voice) => voice.id === voiceId);
+    if (match) return match;
+  }
+
+  if (locale) {
+    const localeMatch = VOICE_PROFILES.find((voice) => voice.locale.toLowerCase() === locale.toLowerCase());
+    if (localeMatch) return localeMatch;
+  }
+
+  return VOICE_PROFILES.find((voice) => voice.isDefault) ?? VOICE_PROFILES[0];
+}
+
+export function buildSupportSpeech(ticketContext: string, voice: VoiceProfile): string {
+  return supportReplyTemplate(voice.language, ticketContext);
+}

--- a/test/platformHelpAgent/voiceCommentaryApi.test.ts
+++ b/test/platformHelpAgent/voiceCommentaryApi.test.ts
@@ -1,0 +1,29 @@
+import {
+  VOICE_PROFILES,
+  buildCommentaryText,
+  buildSupportSpeech,
+  findVoiceProfile,
+  requestPersonaplexSynthesis
+} from '../../packages/api/src/voiceCommentary';
+
+describe('voice commentary module', () => {
+  test('contains multilingual nvidia voice catalog', () => {
+    expect(VOICE_PROFILES.length).toBeGreaterThanOrEqual(12);
+    expect(VOICE_PROFILES.some((voice) => voice.locale === 'sq-AL')).toBe(true);
+  });
+
+  test('requires PersonaPlex credentials for synthesis', async () => {
+    const voice = findVoiceProfile(undefined, 'sq-AL');
+    const text = buildCommentaryText('pool_royale', 'match_start', 'Arben');
+
+    await expect(
+      requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id })
+    ).rejects.toThrow('PersonaPlex is not configured');
+  });
+
+  test('builds localized support script', () => {
+    const voice = findVoiceProfile(undefined, 'sq-AL');
+    const support = buildSupportSpeech('Nuk po më hapet loja', voice);
+    expect(support).toContain('Përshëndetje');
+  });
+});

--- a/test/voiceCommentaryUnlocks.test.js
+++ b/test/voiceCommentaryUnlocks.test.js
@@ -1,0 +1,56 @@
+import { test } from '@jest/globals';
+import assert from 'node:assert/strict';
+import {
+  buildVoiceStoreItems,
+  createDefaultVoiceInventory,
+  normalizeVoiceInventory
+} from '../bot/utils/voiceCommentaryCatalog.js';
+import { applyVoiceCommentaryUnlocks, buildHelpAnswer } from '../bot/routes/voiceCommentary.js';
+
+test('default voice commentary inventory includes free English voice', () => {
+  const inventory = createDefaultVoiceInventory();
+  assert.equal(inventory.selectedVoiceId, 'nova_en_us_f');
+  assert.ok(inventory.ownedVoiceIds.includes('nova_en_us_f'));
+  assert.ok(inventory.ownedLocales.includes('en-US'));
+});
+
+test('voice unlock grants locale voices for all games', () => {
+  const user = {
+    voiceCommentaryInventory: createDefaultVoiceInventory()
+  };
+  const catalog = [
+    { id: 'nova_en_us_f', locale: 'en-US' },
+    { id: 'atlas_en_us_m', locale: 'en-US' },
+    { id: 'sofia_it_it_f', locale: 'it-IT' }
+  ];
+
+  applyVoiceCommentaryUnlocks(
+    user,
+    [{ type: 'voiceLanguage', optionId: 'it-IT' }],
+    catalog
+  );
+
+  const normalized = normalizeVoiceInventory(user.voiceCommentaryInventory);
+  assert.ok(normalized.ownedVoiceIds.includes('sofia_it_it_f'));
+  assert.ok(normalized.ownedLocales.includes('it-IT'));
+});
+
+test('store item builder keeps English free and paid multilingual packs', () => {
+  const items = buildVoiceStoreItems({
+    voices: [
+      { id: 'nova_en_us_f', locale: 'en-US', language: 'English' },
+      { id: 'atlas_en_us_m', locale: 'en-US', language: 'English' },
+      { id: 'sofia_it_it_f', locale: 'it-IT', language: 'Italian' }
+    ]
+  });
+  const en = items.find((item) => item.optionId === 'en-US');
+  const it = items.find((item) => item.optionId === 'it-IT');
+  assert.equal(en.price, 0);
+  assert.ok(it.price > 0);
+});
+
+
+test('voice help answer routes key app topics', () => {
+  assert.match(buildHelpAnswer('How do I buy commentary in the store?'), /Store/i);
+  assert.match(buildHelpAnswer(''), /How can I help you today/i);
+});

--- a/webapp/src/config/voiceCommentaryInventoryConfig.js
+++ b/webapp/src/config/voiceCommentaryInventoryConfig.js
@@ -1,0 +1,36 @@
+export const VOICE_COMMENTARY_DEFAULT_VOICE_ID = 'nova_en_us_f';
+
+const VOICE_LANGUAGE_PACKS = [
+  { locale: 'en-US', language: 'English', price: 0 },
+  { locale: 'es-ES', language: 'Spanish', price: 2200 },
+  { locale: 'fr-FR', language: 'French', price: 2200 },
+  { locale: 'de-DE', language: 'German', price: 2200 },
+  { locale: 'it-IT', language: 'Italian', price: 2200 },
+  { locale: 'ja-JP', language: 'Japanese', price: 2600 },
+  { locale: 'ko-KR', language: 'Korean', price: 2600 },
+  { locale: 'hi-IN', language: 'Hindi', price: 2200 },
+  { locale: 'ar-SA', language: 'Arabic', price: 2200 },
+  { locale: 'sq-AL', language: 'Albanian', price: 1800 },
+  { locale: 'pt-BR', language: 'Portuguese', price: 2200 },
+  { locale: 'uk-UA', language: 'Ukrainian', price: 2200 }
+];
+
+export const VOICE_COMMENTARY_OPTION_LABELS = {
+  voiceLanguage: VOICE_LANGUAGE_PACKS.reduce((acc, pack) => {
+    acc[pack.locale] = `${pack.language} (${pack.locale})`;
+    return acc;
+  }, {})
+};
+
+export const VOICE_COMMENTARY_STORE_ITEMS = VOICE_LANGUAGE_PACKS.map((pack) => ({
+  id: `voice-${pack.locale.toLowerCase()}`,
+  type: 'voiceLanguage',
+  optionId: pack.locale,
+  name: `${pack.language} Commentary Pack`,
+  description:
+    pack.price === 0
+      ? 'Default free English commentary for all games.'
+      : `${pack.language} commentary voice unlock for all games.`,
+  price: pack.price,
+  rarity: pack.price === 0 ? 'free' : 'premium'
+}));

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -5,7 +5,7 @@ import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
 import HomeSocialHub from '../components/HomeSocialHub.jsx';
 import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
 
-import { FaArrowUp, FaArrowDown, FaWallet } from 'react-icons/fa';
+import { FaArrowUp, FaArrowDown, FaWallet, FaQuestionCircle } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
 import { useTonAddress } from '@tonconnect/ui-react';
@@ -30,11 +30,13 @@ import useTokenBalances from '../hooks/useTokenBalances.js';
 import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { loadGoogleProfile } from '../utils/google.js';
+import { runVoiceHelpSession } from '../utils/voiceHelpAssistant.js';
 
 export default function Home() {
   const [status, setStatus] = useState('checking');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
+  const [helpBusy, setHelpBusy] = useState(false);
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
   const walletAddress = useTonAddress();
@@ -114,6 +116,20 @@ export default function Home() {
     return () =>
       window.removeEventListener('profilePhotoUpdated', handleUpdate);
   }, []);
+
+
+  const handleVoiceHelp = async () => {
+    if (helpBusy) return;
+    setHelpBusy(true);
+    try {
+      const accountId = window.localStorage.getItem('accountId') || 'guest';
+      await runVoiceHelpSession({ accountId, locale: 'en-US' });
+    } catch (error) {
+      console.warn('voice-help-session-failed', error);
+    } finally {
+      setHelpBusy(false);
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -359,6 +375,16 @@ export default function Home() {
           <IoLogoTiktok className="text-pink-500 w-6 h-6" />
         </a>
       </div>
+
+      <button
+        type="button"
+        onClick={handleVoiceHelp}
+        className={`fixed bottom-20 right-4 z-40 flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-white shadow-lg ${helpBusy ? 'opacity-70' : ''}`}
+        aria-label="Open help guide"
+      >
+        <FaQuestionCircle className="h-4 w-4 text-yellow-300" />
+        <span>{helpBusy ? 'Listening…' : 'Help'}</span>
+      </button>
     </div>
   );
 }

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -88,7 +88,7 @@ function buildHeaders(base = {}) {
   return headers;
 }
 
-async function post(path, body, token) {
+export async function post(path, body, token) {
   const headers = buildHeaders({ 'Content-Type': 'application/json' });
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
@@ -126,7 +126,7 @@ async function post(path, body, token) {
   return data;
 }
 
-async function put(path, body, token) {
+export async function put(path, body, token) {
   const headers = buildHeaders({ 'Content-Type': 'application/json' });
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
@@ -162,7 +162,7 @@ async function put(path, body, token) {
   return data;
 }
 
-async function get(path, token) {
+export async function get(path, token) {
   const headers = buildHeaders();
   if (token) headers['Authorization'] = `Bearer ${token}`;
 

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,375 +1,102 @@
-const DEFAULT_VOICE_HINTS = {
-  Mason: ['en-US', 'English', 'Male', 'Google US English Male', 'David', 'Guy'],
-  Lena: ['en-GB', 'English', 'Female', 'Google UK English Female', 'Sonia', 'Hazel']
-};
+import { post } from './api.js';
 
-const DEFAULT_SPEAKER_SETTINGS = {
-  Mason: { rate: 1, pitch: 0.95, volume: 1 },
-  Lena: { rate: 1.02, pitch: 1.05, volume: 1 }
-};
+let commentarySupport = true;
+const listeners = new Set();
 
-let audioContext;
-let audioContextUnlocked = false;
-let speechUnlockInstalled = false;
-let speechUnlockHandler;
-let speechUnlockVisibilityHandler;
-let speechSupportMonitorInstalled = false;
-let speechSupportListenerAttached = false;
-let speechSupportState = false;
-
-const SPEECH_SUPPORT_EVENT = 'tonplaygram:speech-support';
-const TELEGRAM_EVENT_OPTIONS = { passive: true };
-
-const getSpeechUtteranceClass = () => {
-  if (typeof SpeechSynthesisUtterance !== 'undefined') return SpeechSynthesisUtterance;
-  if (typeof window !== 'undefined' && window.SpeechSynthesisUtterance) {
-    return window.SpeechSynthesisUtterance;
-  }
-  if (typeof window !== 'undefined' && window.webkitSpeechSynthesisUtterance) {
-    return window.webkitSpeechSynthesisUtterance;
-  }
-  return null;
-};
-
-const emitSpeechSupport = (supported) => {
-  if (typeof window === 'undefined') return;
-  if (speechSupportState === supported) return;
-  speechSupportState = supported;
-  if (typeof window.CustomEvent === 'function') {
-    window.dispatchEvent(new CustomEvent(SPEECH_SUPPORT_EVENT, { detail: { supported } }));
-  } else {
-    window.dispatchEvent(new Event(SPEECH_SUPPORT_EVENT));
-  }
-};
-
-const ensureAudioContext = () => {
-  if (typeof window === 'undefined') return null;
-  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
-  if (!AudioContextClass) return null;
-  if (!audioContext) {
+const emitSupport = (supported) => {
+  if (commentarySupport === supported) return;
+  commentarySupport = supported;
+  listeners.forEach((listener) => {
     try {
-      audioContext = new AudioContextClass();
-    } catch (error) {
-      audioContext = null;
+      listener(supported);
+    } catch {
+      // no-op
     }
+  });
+};
+
+const getCurrentAccountId = () => {
+  if (typeof window === 'undefined') return 'guest';
+  return window.localStorage.getItem('accountId') || 'guest';
+};
+
+const playAudioPayload = async (payload) => {
+  const synthesis = payload?.synthesis || {};
+  const audioUrl = synthesis.audioUrl;
+  const audioBase64 = synthesis.audioBase64;
+  const mimeType = synthesis.mimeType || 'audio/mpeg';
+  if (!audioUrl && !audioBase64) {
+    throw new Error('PersonaPlex response missing audio payload');
   }
-  return audioContext;
-};
-
-const unlockAudioContext = () => {
-  const ctx = ensureAudioContext();
-  if (!ctx || audioContextUnlocked) return;
-  const resumeContext = typeof ctx.resume === 'function' ? ctx.resume() : Promise.resolve();
-  Promise.resolve(resumeContext)
-    .catch(() => {})
-    .finally(() => {
-      if (!ctx || audioContextUnlocked) return;
-      try {
-        const buffer = ctx.createBuffer(1, 1, 22050);
-        const source = ctx.createBufferSource();
-        source.buffer = buffer;
-        source.connect(ctx.destination);
-        source.start(0);
-        if (typeof source.stop === 'function') {
-          source.stop(0);
-        }
-        audioContextUnlocked = true;
-      } catch {
-        audioContextUnlocked = false;
-      }
-    });
-};
-
-const createSpeechUnlockHandler = () => {
-  if (speechUnlockHandler) return speechUnlockHandler;
-  speechUnlockHandler = () => {
-    const synth = getSpeechSynthesis();
-    if (!synth) return;
-    ensureSpeechUnlocked(synth);
-    primeSpeechSynthesis();
-    evaluateSpeechSupport();
-  };
-  return speechUnlockHandler;
-};
-
-const evaluateSpeechSupport = () => {
-  const synth = getSpeechSynthesis();
-  const supported = Boolean(synth && getSpeechUtteranceClass());
-  if (supported && !speechSupportListenerAttached) {
-    speechSupportListenerAttached = true;
-    const handler = () => evaluateSpeechSupport();
-    if (typeof synth.addEventListener === 'function') {
-      synth.addEventListener('voiceschanged', handler);
-    } else {
-      synth.onvoiceschanged = handler;
-    }
-  }
-  emitSpeechSupport(supported);
-  return supported;
-};
-
-const installSpeechSupportMonitor = () => {
-  if (typeof window === 'undefined' || speechSupportMonitorInstalled) return;
-  speechSupportMonitorInstalled = true;
-  const handler = () => evaluateSpeechSupport();
-  window.addEventListener('focus', handler, { passive: true });
-  document.addEventListener('visibilitychange', handler, { passive: true });
-  evaluateSpeechSupport();
+  const source = audioUrl || `data:${mimeType};base64,${audioBase64}`;
+  const audio = new Audio(source);
+  await new Promise((resolve, reject) => {
+    const onDone = () => {
+      audio.removeEventListener('ended', onDone);
+      audio.removeEventListener('error', onError);
+      resolve();
+    };
+    const onError = () => {
+      audio.removeEventListener('ended', onDone);
+      audio.removeEventListener('error', onError);
+      reject(new Error('Audio playback failed'));
+    };
+    audio.addEventListener('ended', onDone);
+    audio.addEventListener('error', onError);
+    audio.play().catch(onError);
+  });
 };
 
 export const installSpeechSynthesisUnlock = () => {
-  if (typeof window === 'undefined' || speechUnlockInstalled) return;
-  speechUnlockInstalled = true;
-  installSpeechSupportMonitor();
-  const handler = createSpeechUnlockHandler();
-  const isTelegram = typeof window !== 'undefined' && Boolean(window.Telegram?.WebApp);
-  const options = { once: !isTelegram, passive: true };
-  window.addEventListener('pointerdown', handler, options);
-  window.addEventListener('pointerup', handler, options);
-  window.addEventListener('touchstart', handler, options);
-  window.addEventListener('touchend', handler, options);
-  window.addEventListener('click', handler, options);
-  window.addEventListener('keydown', handler, options);
-  if (typeof document !== 'undefined') {
-    document.addEventListener('touchend', handler, options);
-  }
-  if (isTelegram) {
-    speechUnlockVisibilityHandler = () => {
-      if (document.visibilityState === 'visible') {
-        handler();
-      }
-    };
-    window.addEventListener('focus', handler, TELEGRAM_EVENT_OPTIONS);
-    document.addEventListener('visibilitychange', speechUnlockVisibilityHandler, TELEGRAM_EVENT_OPTIONS);
-  }
+  // No-op: commentary now uses PersonaPlex audio streaming only.
 };
 
-export const getSpeechSynthesis = () => {
-  if (typeof window === 'undefined') return null;
-  let synth = null;
-  try {
-    synth = window.speechSynthesis;
-  } catch {
-    synth = null;
-  }
-  if (!synth) {
-    try {
-      synth = window.webkitSpeechSynthesis;
-    } catch {
-      synth = null;
-    }
-  }
-  return synth || null;
-};
+export const getSpeechSynthesis = () => null;
 
-export const getSpeechSupport = () => {
-  if (speechSupportState) return true;
-  return Boolean(getSpeechSynthesis() && getSpeechUtteranceClass());
-};
+export const getSpeechSupport = () => commentarySupport;
 
 export const onSpeechSupportChange = (callback) => {
-  if (typeof window === 'undefined') return () => {};
-  const handler = (event) => {
-    if (event?.detail && typeof event.detail.supported === 'boolean') {
-      callback(event.detail.supported);
-    } else {
-      callback(getSpeechSupport());
-    }
-  };
-  window.addEventListener(SPEECH_SUPPORT_EVENT, handler);
-  return () => window.removeEventListener(SPEECH_SUPPORT_EVENT, handler);
-};
-
-const ensureSpeechUnlocked = (synth) => {
-  if (!synth) return;
-  unlockAudioContext();
-  if (typeof synth.resume === 'function') {
-    try {
-      synth.resume();
-    } catch {}
-  }
-  if (typeof synth.getVoices === 'function') {
-    try {
-      synth.getVoices();
-    } catch {}
-  }
+  if (typeof callback !== 'function') return () => {};
+  listeners.add(callback);
+  return () => listeners.delete(callback);
 };
 
 export const primeSpeechSynthesis = () => {
-  const synth = getSpeechSynthesis();
-  const UtteranceClass = getSpeechUtteranceClass();
-  if (!synth || synth.speaking || synth.pending || !UtteranceClass) return;
-  ensureSpeechUnlocked(synth);
-  const utterance = new UtteranceClass('.');
-  utterance.volume = 0.01;
-  utterance.rate = 1;
-  utterance.pitch = 1;
-  if (typeof navigator !== 'undefined' && navigator.language) {
-    utterance.lang = navigator.language;
-  }
-  utterance.onend = () => {
-    if (typeof synth.cancel === 'function') {
-      try {
-        synth.cancel();
-      } catch {}
-    }
-  };
-  utterance.onerror = utterance.onend;
-  try {
-    synth.speak(utterance);
-  } catch {
-    if (typeof synth.cancel === 'function') {
-      try {
-        synth.cancel();
-      } catch {}
-    }
-  }
+  // No-op: commentary now uses PersonaPlex audio streaming only.
 };
 
-const loadVoices = (synth, timeoutMs = 3500) =>
-  new Promise((resolve) => {
-    if (!synth) {
-      resolve([]);
-      return;
-    }
-    ensureSpeechUnlocked(synth);
-    const existing = synth.getVoices();
-    if (existing.length) {
-      resolve(existing);
-      return;
-    }
-    let settled = false;
-    let intervalId = null;
-    const finalize = (voices) => {
-      if (settled) return;
-      settled = true;
-      if (intervalId) clearInterval(intervalId);
-      resolve(voices);
-    };
-    const handleVoices = () => {
-      const next = synth.getVoices();
-      if (next.length) finalize(next);
-    };
-    if (typeof synth.addEventListener === 'function') {
-      synth.addEventListener('voiceschanged', handleVoices, { once: true });
-    } else {
-      synth.onvoiceschanged = handleVoices;
-    }
-    intervalId = setInterval(handleVoices, 250);
-    setTimeout(() => finalize(synth.getVoices()), timeoutMs);
-  });
-
-const findVoiceMatch = (voices, hints = []) => {
-  const normalizedHints = hints.map((hint) => hint.toLowerCase());
-  return (
-    voices.find((voice) => normalizedHints.some((hint) => voice.name.toLowerCase().includes(hint))) ||
-    voices.find((voice) => normalizedHints.some((hint) => voice.lang.toLowerCase().includes(hint))) ||
-    voices[0] ||
-    null
-  );
-};
-
-const findDistinctVoice = (voices, hints = [], usedVoices = new Set()) => {
-  if (!voices.length) return null;
-  const normalizedHints = hints.map((hint) => hint.toLowerCase());
-  const matchesByName = voices.filter((voice) =>
-    normalizedHints.some((hint) => voice.name.toLowerCase().includes(hint))
-  );
-  const matchesByLang = voices.filter((voice) =>
-    normalizedHints.some((hint) => voice.lang.toLowerCase().includes(hint))
-  );
-  const candidateLists = [matchesByName, matchesByLang, voices];
-  for (const candidates of candidateLists) {
-    const match = candidates.find((voice) => !usedVoices.has(voice));
-    if (match) return match;
-  }
-  return voices[0] || null;
-};
-
-const resolveHintedLanguage = (hints = [], fallback) => {
-  const normalizedHints = hints.map((hint) => String(hint || '').trim()).filter(Boolean);
-  const matched = normalizedHints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(hint));
-  if (matched) return matched;
-  if (fallback) return fallback;
-  if (typeof navigator !== 'undefined' && navigator.language) return navigator.language;
-  return 'en-US';
-};
-
-export const resolveVoiceForSpeaker = (speaker, voices = []) => {
-  if (!voices.length) return null;
-  const hints = DEFAULT_VOICE_HINTS[speaker] || DEFAULT_VOICE_HINTS.Mason;
-  return findVoiceMatch(voices, hints);
-};
+export const resolveVoiceForSpeaker = () => null;
 
 export const speakCommentaryLines = async (
   lines,
-  { speakerSettings = DEFAULT_SPEAKER_SETTINGS, voiceHints = DEFAULT_VOICE_HINTS } = {}
+  { voiceHints = {}, speakerSettings = {} } = {}
 ) => {
-  const synth = getSpeechSynthesis();
-  const UtteranceClass = getSpeechUtteranceClass();
-  if (!synth || !UtteranceClass || !Array.isArray(lines) || lines.length === 0) return;
+  if (!Array.isArray(lines) || !lines.length || typeof window === 'undefined') return;
 
-  const voices = await loadVoices(synth);
-  const uniqueSpeakers = [...new Set(lines.map((line) => line.speaker || 'Mason'))];
-  const usedVoices = new Set();
-  const speakerVoices = uniqueSpeakers.reduce((acc, speaker) => {
-    const voice = findDistinctVoice(voices, voiceHints[speaker] || voiceHints.Mason, usedVoices);
-    if (voice) {
-      usedVoices.add(voice);
-      acc[speaker] = voice;
-    }
-    return acc;
-  }, {});
-
-  ensureSpeechUnlocked(synth);
+  const accountId = getCurrentAccountId();
 
   for (const line of lines) {
-    ensureSpeechUnlocked(synth);
-    const speaker = line.speaker || 'Mason';
-    const settings = speakerSettings[speaker] || DEFAULT_SPEAKER_SETTINGS.Mason;
-    const utterance = new UtteranceClass(line.text);
-    const voice = speakerVoices[speaker] || findVoiceMatch(voices, voiceHints[speaker] || voiceHints.Mason);
-    const fallbackLang = resolveHintedLanguage(voiceHints[speaker] || voiceHints.Mason);
+    const text = String(line?.text || '').trim();
+    if (!text) continue;
 
-    if (voice) {
-      utterance.voice = voice;
-      if (voice.lang) utterance.lang = voice.lang;
-    } else {
-      utterance.lang = fallbackLang;
-    }
-    utterance.rate = settings.rate;
-    utterance.pitch = settings.pitch;
-    utterance.volume = settings.volume;
+    const speaker = line?.speaker || 'Host';
+    const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : [];
+    const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')));
 
-    await new Promise((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        resolve();
-      };
-      const fallbackMs = Math.max(1800, line.text.length * 60);
-      const timeoutId = setTimeout(finish, fallbackMs);
-      utterance.onend = () => {
-        clearTimeout(timeoutId);
-        finish();
-      };
-      utterance.onerror = () => {
-        clearTimeout(timeoutId);
-        finish();
-      };
-      if (synth.speaking || synth.pending) {
-        try {
-          synth.cancel();
-        } catch {}
-      }
-      try {
-        synth.speak(utterance);
-        setTimeout(() => ensureSpeechUnlocked(synth), 0);
-      } catch {
-        clearTimeout(timeoutId);
-        finish();
-      }
+    const payload = await post('/api/voice-commentary/speak', {
+      accountId,
+      text,
+      speaker,
+      locale: localeHint,
+      style: speakerSettings[speaker] || null
     });
+
+    if (payload?.error) {
+      emitSupport(false);
+      throw new Error(payload.error);
+    }
+
+    emitSupport(true);
+    await playAudioPayload(payload);
   }
 };

--- a/webapp/src/utils/voiceCommentaryInventory.js
+++ b/webapp/src/utils/voiceCommentaryInventory.js
@@ -1,0 +1,95 @@
+import { get, post } from './api.js';
+import { VOICE_COMMENTARY_DEFAULT_VOICE_ID } from '../config/voiceCommentaryInventoryConfig.js';
+
+const STORAGE_PREFIX = 'tpg.voiceCommentary';
+const DEFAULT_LOCALE = 'en-US';
+
+const buildStorageKey = (accountId = 'guest') => `${STORAGE_PREFIX}.${accountId || 'guest'}`;
+
+const createDefault = () => ({
+  ownedVoiceIds: [VOICE_COMMENTARY_DEFAULT_VOICE_ID],
+  ownedLocales: [DEFAULT_LOCALE],
+  selectedVoiceId: VOICE_COMMENTARY_DEFAULT_VOICE_ID,
+  updatedAt: new Date().toISOString()
+});
+
+export const normalizeVoiceInventory = (inventory) => {
+  const base = createDefault();
+  if (!inventory || typeof inventory !== 'object') return base;
+  const ownedVoiceIds = new Set([VOICE_COMMENTARY_DEFAULT_VOICE_ID]);
+  const ownedLocales = new Set([DEFAULT_LOCALE]);
+  if (Array.isArray(inventory.ownedVoiceIds)) {
+    inventory.ownedVoiceIds.forEach((voiceId) => {
+      if (voiceId) ownedVoiceIds.add(String(voiceId));
+    });
+  }
+  if (Array.isArray(inventory.ownedLocales)) {
+    inventory.ownedLocales.forEach((locale) => {
+      if (locale) ownedLocales.add(String(locale));
+    });
+  }
+  const selectedVoiceId = ownedVoiceIds.has(inventory.selectedVoiceId)
+    ? inventory.selectedVoiceId
+    : VOICE_COMMENTARY_DEFAULT_VOICE_ID;
+  return {
+    ownedVoiceIds: Array.from(ownedVoiceIds),
+    ownedLocales: Array.from(ownedLocales),
+    selectedVoiceId,
+    updatedAt: inventory.updatedAt || base.updatedAt
+  };
+};
+
+export const getVoiceCommentaryInventory = (accountId = 'guest') => {
+  if (typeof window === 'undefined') return createDefault();
+  try {
+    const raw = window.localStorage.getItem(buildStorageKey(accountId));
+    if (!raw) return createDefault();
+    return normalizeVoiceInventory(JSON.parse(raw));
+  } catch {
+    return createDefault();
+  }
+};
+
+export const saveVoiceCommentaryInventory = (accountId = 'guest', inventory) => {
+  const normalized = normalizeVoiceInventory(inventory);
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(buildStorageKey(accountId), JSON.stringify(normalized));
+  }
+  return normalized;
+};
+
+export const isVoiceCommentaryUnlocked = (_type, optionId, inventory) =>
+  normalizeVoiceInventory(inventory).ownedLocales.includes(String(optionId || ''));
+
+export async function loadVoiceCommentaryCatalog() {
+  return get('/api/voice-commentary/catalog');
+}
+
+export async function syncVoiceCommentaryInventory(accountId) {
+  if (!accountId || accountId === 'guest') return getVoiceCommentaryInventory(accountId);
+  const res = await get(`/api/voice-commentary/inventory/${accountId}`);
+  if (res?.inventory) return saveVoiceCommentaryInventory(accountId, res.inventory);
+  return getVoiceCommentaryInventory(accountId);
+}
+
+export async function selectVoiceCommentary(accountId, voiceId) {
+  if (!accountId || accountId === 'guest') {
+    const current = getVoiceCommentaryInventory(accountId);
+    if (!current.ownedVoiceIds.includes(voiceId)) return current;
+    return saveVoiceCommentaryInventory(accountId, { ...current, selectedVoiceId: voiceId });
+  }
+  const res = await post('/api/voice-commentary/select', { accountId, voiceId });
+  if (res?.inventory) return saveVoiceCommentaryInventory(accountId, res.inventory);
+  return getVoiceCommentaryInventory(accountId);
+}
+
+export async function addVoiceCommentaryUnlock(_type, _optionId, accountId) {
+  return syncVoiceCommentaryInventory(accountId);
+}
+
+export const listOwnedVoiceCommentaryOptions = (inventory) =>
+  normalizeVoiceInventory(inventory).ownedLocales.map((locale) => ({
+    type: 'voiceLanguage',
+    optionId: locale,
+    label: locale
+  }));

--- a/webapp/src/utils/voiceHelpAssistant.js
+++ b/webapp/src/utils/voiceHelpAssistant.js
@@ -1,0 +1,73 @@
+import { post } from './api.js';
+
+const SPEECH_RECOGNITION =
+  typeof window !== 'undefined'
+    ? window.SpeechRecognition || window.webkitSpeechRecognition || null
+    : null;
+
+async function playSynthesis(payload) {
+  const synthesis = payload?.synthesis || {};
+  const source = synthesis.audioUrl || (synthesis.audioBase64 ? `data:${synthesis.mimeType || 'audio/mpeg'};base64,${synthesis.audioBase64}` : '');
+  if (!source) throw new Error('Missing help audio');
+  const audio = new Audio(source);
+  await new Promise((resolve, reject) => {
+    const finish = () => {
+      audio.removeEventListener('ended', finish);
+      audio.removeEventListener('error', fail);
+      resolve();
+    };
+    const fail = () => {
+      audio.removeEventListener('ended', finish);
+      audio.removeEventListener('error', fail);
+      reject(new Error('Help audio playback failed'));
+    };
+    audio.addEventListener('ended', finish);
+    audio.addEventListener('error', fail);
+    audio.play().catch(fail);
+  });
+}
+
+function listenOnce(timeoutMs = 9000) {
+  if (!SPEECH_RECOGNITION) return Promise.resolve('');
+  return new Promise((resolve) => {
+    const recognition = new SPEECH_RECOGNITION();
+    recognition.lang = 'en-US';
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    let done = false;
+    const finish = (value = '') => {
+      if (done) return;
+      done = true;
+      try {
+        recognition.stop();
+      } catch {
+        // ignore
+      }
+      resolve(value);
+    };
+    recognition.onresult = (event) => {
+      const transcript = event?.results?.[0]?.[0]?.transcript || '';
+      finish(String(transcript || '').trim());
+    };
+    recognition.onerror = () => finish('');
+    recognition.onend = () => finish('');
+    recognition.start();
+    setTimeout(() => finish(''), timeoutMs);
+  });
+}
+
+export async function runVoiceHelpSession({ accountId, locale = 'en-US' }) {
+  const first = await post('/api/voice-commentary/help', { accountId, locale, question: '' });
+  if (first?.error) throw new Error(first.error);
+  await playSynthesis(first);
+
+  const spokenQuestion = await listenOnce();
+  const answer = await post('/api/voice-commentary/help', {
+    accountId,
+    locale,
+    question: spokenQuestion || 'general app help'
+  });
+  if (answer?.error) throw new Error(answer.error);
+  await playSynthesis(answer);
+  return { question: spokenQuestion, answer: answer.answer || '' };
+}


### PR DESCRIPTION
### Motivation
- Replace fragile in-browser TTS with a single server-side NVIDIA PersonaPlex pipeline for consistent cross-game commentary and voice help. 
- Fix store checkout failures and long processing times when buying voice packs or multiple items. 
- Provide a voice-first Home help experience for mobile users that speaks and listens instead of showing a text modal.

### Description
- Added a PersonaPlex subsystem with a server route `bot/routes/voiceCommentary.js` and a catalog helper `bot/utils/voiceCommentaryCatalog.js` to fetch/normalize/cache voices, synthesize speech, return catalogs/inventory, apply unlocks, and expose `/api/voice-commentary/*` endpoints. 
- Integrated PersonaPlex into the platform API via new `packages/api/src/voiceCommentary.ts` and route additions in `packages/api/src/server.ts` to request synthesis for game commentary and support replies. 
- Fixed storefront handling so zero-price bundles are accepted and balances are only decremented when `totalPrice > 0`, and applied voice-language unlocks server-side in `bot/routes/store.js`. 
- Optimized the web store UI (`webapp/src/pages/Store.jsx`) by parallelizing per-slug unlock operations to speed bulk purchases and avoid the reported “stuck on processing” behavior. 
- Replaced direct browser Web Speech usage with PersonaPlex calls by rewriting `webapp/src/utils/textToSpeech.js` to request `/api/voice-commentary/speak`, adding client-side voice inventory utilities (`webapp/src/utils/voiceCommentaryInventory.js`), config (`webapp/src/config/voiceCommentaryInventoryConfig.js`), and store wiring, and updated game code (example: `webapp/src/pages/Games/TableTennisRoyal.tsx`) to use the shared `speakCommentaryLines` pipeline. 
- Added a voice-first Home help assistant: `webapp/src/utils/voiceHelpAssistant.js` plus Home button wiring in `webapp/src/pages/Home.jsx` to request a PersonaPlex greeting, listen once, and return a spoken answer via the new `POST /api/voice-commentary/help` endpoint. 
- Added tests and documentation: `test/voiceCommentaryUnlocks.test.js`, `test/platformHelpAgent/voiceCommentaryApi.test.ts`, and `docs/personaplex-voice-commentary.md`.

### Testing
- Ran the unit test suites with `npm test -- test/voiceCommentaryUnlocks.test.js test/platformHelpAgent/voiceCommentaryApi.test.ts --runInBand` and both tests passed. 
- Built the web client with `npm --prefix webapp run build` and the production build completed successfully. 
- Verified removal of direct Web Speech API usage with `rg "speechSynthesis|SpeechSynthesisUtterance|webkitSpeechSynthesis" webapp/src -n` which returned no hits. 
- Launched the dev server and captured a mobile-portrait screenshot of the Home page to validate the voice help button UI; the dev server started and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c7f44e2c83299478cbd12a64c9b4)