### PR TITLE
Fix commentary and Help Center voice playback (audio unlock for autoplay-restricted browsers)

### DIFF
--- a/webapp/src/components/PlatformHelpAgentCard.jsx
+++ b/webapp/src/components/PlatformHelpAgentCard.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
-import { getSpeechSynthesis, speakCommentaryLines } from '../utils/textToSpeech.js';
+import { getSpeechSupport, speakCommentaryLines } from '../utils/textToSpeech.js';
 import {
   buildStructuredResponse,
   isSensitiveHelpRequest,
@@ -37,7 +37,7 @@ export default function PlatformHelpAgentCard() {
     return Boolean(window.SpeechRecognition || window.webkitSpeechRecognition);
   }, []);
 
-  const canUseSpeechOutput = useMemo(() => Boolean(getSpeechSynthesis()), []);
+  const canUseSpeechOutput = useMemo(() => Boolean(getSpeechSupport()), []);
 
   const runLocalFallback = async (text) => {
     const matches = searchLocalHelp(text, 3);

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,87 +1,136 @@
-import { post } from './api.js';
+import { post } from './api.js'
 
-let commentarySupport = true;
-const listeners = new Set();
+let commentarySupport = true
+const listeners = new Set()
+let audioUnlocked = false
+let unlockPromise = null
+
+const UNLOCK_EVENTS = ['pointerdown', 'touchstart', 'mousedown', 'keydown']
+const TINY_SILENCE_MP3 =
+  'data:audio/mpeg;base64,SUQzAwAAAAAAI1RTU0UAAAAPAAADTGF2ZjU2LjE1LjEwNAAAAAAAAAAAAAAA//tQxAADBzQASQAAABhAAAACAAACcQCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgP/7UMQAAwcoAEkAAABoAAAACAAADSAAAAAEAAANIAAAAAExhdmM1Ni4xNAAAAAAAAAAAAAAAACQCkAAAAAAAAAAAAAAAAAAAA//sQxAADAgAASAAAABgAAAACAAACcQCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg'
 
 const emitSupport = (supported) => {
-  if (commentarySupport === supported) return;
-  commentarySupport = supported;
+  if (commentarySupport === supported) return
+  commentarySupport = supported
   listeners.forEach((listener) => {
     try {
-      listener(supported);
+      listener(supported)
     } catch {
       // no-op
     }
-  });
-};
+  })
+}
 
 const getCurrentAccountId = () => {
-  if (typeof window === 'undefined') return 'guest';
-  return window.localStorage.getItem('accountId') || 'guest';
-};
+  if (typeof window === 'undefined') return 'guest'
+  return window.localStorage.getItem('accountId') || 'guest'
+}
+
+const unlockAudioPlayback = async () => {
+  if (audioUnlocked || typeof window === 'undefined') return
+  if (!unlockPromise) {
+    unlockPromise = (async () => {
+      try {
+        const audio = new Audio(TINY_SILENCE_MP3)
+        audio.muted = true
+        audio.volume = 0
+        audio.currentTime = 0
+        const playPromise = audio.play()
+        if (playPromise?.then) await playPromise
+        audio.pause()
+        audio.currentTime = 0
+        audioUnlocked = true
+      } catch {
+        audioUnlocked = false
+      } finally {
+        unlockPromise = null
+      }
+    })()
+  }
+  await unlockPromise
+}
 
 const playAudioPayload = async (payload) => {
-  const synthesis = payload?.synthesis || {};
-  const audioUrl = synthesis.audioUrl;
-  const audioBase64 = synthesis.audioBase64;
-  const mimeType = synthesis.mimeType || 'audio/mpeg';
+  const synthesis = payload?.synthesis || {}
+  const audioUrl = synthesis.audioUrl
+  const audioBase64 = synthesis.audioBase64
+  const mimeType = synthesis.mimeType || 'audio/mpeg'
   if (!audioUrl && !audioBase64) {
-    throw new Error('PersonaPlex response missing audio payload');
+    throw new Error('PersonaPlex response missing audio payload')
   }
-  const source = audioUrl || `data:${mimeType};base64,${audioBase64}`;
-  const audio = new Audio(source);
+
+  await unlockAudioPlayback()
+
+  const source = audioUrl || `data:${mimeType};base64,${audioBase64}`
+  const audio = new Audio(source)
   await new Promise((resolve, reject) => {
     const onDone = () => {
-      audio.removeEventListener('ended', onDone);
-      audio.removeEventListener('error', onError);
-      resolve();
-    };
+      audio.removeEventListener('ended', onDone)
+      audio.removeEventListener('error', onError)
+      resolve()
+    }
     const onError = () => {
-      audio.removeEventListener('ended', onDone);
-      audio.removeEventListener('error', onError);
-      reject(new Error('Audio playback failed'));
-    };
-    audio.addEventListener('ended', onDone);
-    audio.addEventListener('error', onError);
-    audio.play().catch(onError);
-  });
-};
+      audio.removeEventListener('ended', onDone)
+      audio.removeEventListener('error', onError)
+      reject(new Error('Audio playback failed'))
+    }
+    audio.addEventListener('ended', onDone)
+    audio.addEventListener('error', onError)
+    audio.play().catch(async (error) => {
+      if ((error && error.name === 'NotAllowedError') || !audioUnlocked) {
+        await unlockAudioPlayback()
+        audio.play().catch(onError)
+        return
+      }
+      onError()
+    })
+  })
+}
 
 export const installSpeechSynthesisUnlock = () => {
-  // No-op: commentary now uses PersonaPlex audio streaming only.
-};
+  if (typeof window === 'undefined') return
+  const onUserGesture = () => {
+    if (!audioUnlocked) {
+      unlockAudioPlayback().catch(() => {})
+    }
+  }
+  UNLOCK_EVENTS.forEach((eventName) => {
+    window.addEventListener(eventName, onUserGesture, { passive: true })
+  })
+}
 
-export const getSpeechSynthesis = () => null;
+export const getSpeechSynthesis = () => null
 
-export const getSpeechSupport = () => commentarySupport;
+export const getSpeechSupport = () =>
+  commentarySupport && typeof window !== 'undefined' && typeof window.Audio !== 'undefined'
 
 export const onSpeechSupportChange = (callback) => {
-  if (typeof callback !== 'function') return () => {};
-  listeners.add(callback);
-  return () => listeners.delete(callback);
-};
+  if (typeof callback !== 'function') return () => {}
+  listeners.add(callback)
+  return () => listeners.delete(callback)
+}
 
 export const primeSpeechSynthesis = () => {
-  // No-op: commentary now uses PersonaPlex audio streaming only.
-};
+  unlockAudioPlayback().catch(() => {})
+}
 
-export const resolveVoiceForSpeaker = () => null;
+export const resolveVoiceForSpeaker = () => null
 
 export const speakCommentaryLines = async (
   lines,
   { voiceHints = {}, speakerSettings = {} } = {}
 ) => {
-  if (!Array.isArray(lines) || !lines.length || typeof window === 'undefined') return;
+  if (!Array.isArray(lines) || !lines.length || typeof window === 'undefined') return
 
-  const accountId = getCurrentAccountId();
+  const accountId = getCurrentAccountId()
 
   for (const line of lines) {
-    const text = String(line?.text || '').trim();
-    if (!text) continue;
+    const text = String(line?.text || '').trim()
+    if (!text) continue
 
-    const speaker = line?.speaker || 'Host';
-    const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : [];
-    const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')));
+    const speaker = line?.speaker || 'Host'
+    const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : []
+    const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')))
 
     const payload = await post('/api/voice-commentary/speak', {
       accountId,
@@ -89,14 +138,14 @@ export const speakCommentaryLines = async (
       speaker,
       locale: localeHint,
       style: speakerSettings[speaker] || null
-    });
+    })
 
     if (payload?.error) {
-      emitSupport(false);
-      throw new Error(payload.error);
+      emitSupport(false)
+      throw new Error(payload.error)
     }
 
-    emitSupport(true);
-    await playAudioPayload(payload);
+    emitSupport(true)
+    await playAudioPayload(payload)
   }
-};
+}


### PR DESCRIPTION
### Motivation
- Voice commentary and Help Center spoken replies were failing on many browsers because playback gating relied on a `null` speech synthesis path and mobile autoplay policies prevented audio from starting without a user gesture.
- The change aims to reliably enable PersonaPlex-based audio streaming for game commentary and help replies while keeping support detection accurate.

### Description
- Replaced Help Center output gating to use `getSpeechSupport()` instead of the intentionally `null` `getSpeechSynthesis()` so voice replies are correctly enabled in the Help Agent UI (`webapp/src/components/PlatformHelpAgentCard.jsx`).
- Implemented a robust audio-unlock flow in `webapp/src/utils/textToSpeech.js` including user-gesture listeners, a tiny silent MP3 priming clip, an `unlockAudioPlayback` helper, and retry logic when playback fails with `NotAllowedError`.
- Updated `playAudioPayload` to prime/unlock audio before playing PersonaPlex payloads and to retry playback after unlock when necessary.
- Added `installSpeechSynthesisUnlock`, `primeSpeechSynthesis`, and refined `getSpeechSupport` so components can detect and prime playback capability without changing the server API.

### Testing
- Ran the platform help test suite with `npm run -s help:test` which passed (7 test suites, 17 tests) successfully.
- Ran lint checks with `npx eslint --no-ignore webapp/src/utils/textToSpeech.js` to validate the changed utility file and it completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956b4940808329bda756f3ba5a0ad4)