### PR TITLE
Fix Pool Royale training Continue flow to advance to next task and reset layout

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12547,6 +12547,28 @@ function PoolRoyaleGame({
     setHud((prev) => ({ ...prev, over: false, turn: 0 }));
   }, []);
 
+  const handleTrainingRoadmapContinue = useCallback(() => {
+    const completedLevel = Number(lastCompletedLevel) || trainingLevelRef.current || trainingLevel;
+    const nextLevel = resolvePlayableTrainingLevel(
+      completedLevel + 1,
+      trainingProgressRef.current
+    );
+    setTrainingLevel(nextLevel);
+    setTrainingRoadmapOpen(false);
+    setTrainingMenuOpen(false);
+    setRuleToast(null);
+    setTurnCycle((value) => value + 1);
+    setFrameState((prev) => ({
+      ...prev,
+      frameOver: false,
+      winner: undefined,
+      foul: undefined,
+      activePlayer: 'A'
+    }));
+    setHud((prev) => ({ ...prev, over: false, turn: 0, inHand: false }));
+    applyTrainingLayoutForLevel(nextLevel);
+  }, [applyTrainingLayoutForLevel, lastCompletedLevel, trainingLevel]);
+
   const awardTrainingTaskPayout = useCallback(async (level, rewardAmount) => {
     const account = resolvedAccountId;
     const amount = Math.max(0, Number(rewardAmount) || 0);
@@ -31028,21 +31050,7 @@ const powerRef = useRef(hud.power);
               </div>
               <button
                 type="button"
-                onClick={() => {
-                  setTrainingRoadmapOpen(false);
-                  setTrainingMenuOpen(false);
-                  setRuleToast(null);
-                  setTurnCycle((value) => value + 1);
-                  setFrameState((prev) => ({
-                    ...prev,
-                    frameOver: false,
-                    winner: undefined,
-                    foul: undefined,
-                    activePlayer: 'A'
-                  }));
-                  setHud((prev) => ({ ...prev, over: false, turn: 0 }));
-                  applyTrainingLayoutForLevel(trainingLevelRef.current || trainingLevel);
-                }}
+                onClick={handleTrainingRoadmapContinue}
                 className="rounded-full border border-white/30 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
               >
                 Continue


### PR DESCRIPTION
### Motivation
- Users who completed a Pool Royale training task could get credit but remain stuck when tapping Continue; the flow needed to advance to the proper next task and ensure the table is set up for the new level.
- The intent is to centralize the Continue behavior and guarantee the HUD/frame and ball layout are reset for the next playable training level.

### Description
- Added a `handleTrainingRoadmapContinue` callback in `webapp/src/pages/Games/PoolRoyale.jsx` which resolves the next playable training level using `resolvePlayableTrainingLevel` and current progress.
- The handler closes the roadmap/menu, clears UI toast, advances the turn cycle, resets frame/hud training flags (including `inHand`), sets the resolved `trainingLevel`, and reapplies the training ball layout for that level via `applyTrainingLayoutForLevel` so balls are ready immediately.
- Replaced the inline Continue button logic in the training roadmap UI with the new `handleTrainingRoadmapContinue` callback to centralize behavior and avoid stale state issues.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleTrainingProgress.test.js` and all tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956ee9d73883298a8d1b0b35fbc877)