### PR TITLE
Store: add quick actions to speed multi-item checkout

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1265,6 +1265,11 @@ export default function Store() {
     return allMarketplaceItems.filter((item) => keySet.has(selectionKey(item)));
   }, [allMarketplaceItems, selectedKeys]);
 
+  const visiblePurchasableItems = useMemo(
+    () => visibleItems.filter((item) => !item.owned),
+    [visibleItems]
+  );
+
   const selectedPurchasable = useMemo(
     () => selectedItems.filter((item) => !item.owned),
     [selectedItems]
@@ -1302,6 +1307,21 @@ export default function Store() {
   }, []);
 
   const clearSelection = useCallback(() => setSelectedKeys([]), []);
+
+  const selectVisibleItems = useCallback(() => {
+    if (!visiblePurchasableItems.length) return;
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      visiblePurchasableItems.forEach((item) => next.add(selectionKey(item)));
+      return Array.from(next);
+    });
+  }, [visiblePurchasableItems]);
+
+  const quickBuyVisible = useCallback(() => {
+    if (!visiblePurchasableItems.length || processing) return;
+    setConfirmItem(null);
+    setConfirmItems(visiblePurchasableItems);
+  }, [processing, visiblePurchasableItems]);
 
   const userListingStats = useMemo(() => {
     const total = decoratedUserListings.length;
@@ -2701,6 +2721,22 @@ export default function Store() {
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="button"
+                    onClick={selectVisibleItems}
+                    className="rounded-2xl border border-sky-300/30 bg-sky-400/10 px-3 py-2 text-xs font-semibold text-sky-100 hover:bg-sky-400/20 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={!visiblePurchasableItems.length || Boolean(processing)}
+                  >
+                    Select visible ({visiblePurchasableItems.length})
+                  </button>
+                  <button
+                    type="button"
+                    onClick={quickBuyVisible}
+                    className="rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100 hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={!visiblePurchasableItems.length || Boolean(processing)}
+                  >
+                    Quick buy visible
+                  </button>
+                  <button
+                    type="button"
                     onClick={clearSelection}
                     className="rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-xs font-semibold text-white/80 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
                     disabled={!selectedKeys.length}
@@ -2724,7 +2760,7 @@ export default function Store() {
                 <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5">
                   Green + Blue cloth bundles ready for Pool Royale
                 </span>
-                <span>Pick multiple NFTs, confirm once, and unlock them together.</span>
+                <span>Use “Select visible” or “Quick buy visible” to purchase large filtered sets faster.</span>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation

- Make multi-item purchases much faster by allowing users to act on the entire filtered result set instead of selecting items one-by-one.

### Description

- Added a memo `visiblePurchasableItems` to derive the currently visible, unowned listings and drive bulk actions. (modified `webapp/src/pages/Store.jsx`).
- Added `selectVisibleItems` to select all visible purchasable items in one tap. (UI control added to the bulk-purchase toolbar).
- Added `quickBuyVisible` to open the bulk confirmation for the visible purchasable set immediately, skipping manual per-card selection.
- Updated the store UI copy to mention the new fast actions and show visible counts in the button labels.

### Testing

- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Started the dev server and captured a mobile-viewport screenshot using Playwright to validate the new buttons render correctly; screenshot artifact: `browser:/tmp/codex_browser_invocations/ab8175aa035a38d3/artifacts/artifacts/store-fast-bulk-purchase.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956d2ffa148329bb7e1a3f45b556ac)