### PR TITLE
Speed up wallet send and multi-item store checkout

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -245,7 +245,7 @@ const VOICE_TYPE_LABELS = {
 const TON_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TON_PRICE_MIN = 100;
 const TON_PRICE_MAX = 5000;
-const PURCHASE_REQUEST_TIMEOUT_MS = 20000;
+const PURCHASE_REQUEST_TIMEOUT_MS = 30000;
 const THUMBNAIL_SIZE = 256;
 const ZOOM_PREVIEW_SIZE = 1024;
 const POLYHAVEN_THUMBNAIL_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs/';
@@ -1475,15 +1475,14 @@ export default function Store() {
           price: item.price
         }))
       };
-      const purchase = await Promise.race([
-        buyBundle(resolvedAccountId, bundle),
-        new Promise((_, reject) => {
-          window.setTimeout(
-            () => reject(new Error('TPC transfer request timed out')),
-            PURCHASE_REQUEST_TIMEOUT_MS
-          );
-        })
-      ]);
+      const purchasePromise = buyBundle(resolvedAccountId, bundle);
+      const timeoutPromise = new Promise((_, reject) => {
+        window.setTimeout(
+          () => reject(new Error('TPC transfer request timed out')),
+          PURCHASE_REQUEST_TIMEOUT_MS
+        );
+      });
+      const purchase = await Promise.race([purchasePromise, timeoutPromise]);
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');


### PR DESCRIPTION
### Motivation

- Users experienced slow or timed-out multi-item purchases and laggy send-card input while composing transfers, causing poor UX during checkout and transfers.
- The goal is to ensure single-transaction purchases complete quickly and make sending TPC as responsive as other fast operations in the app.

### Description

- Parallelized lookups and saves in the TPC transfer flow and returned the API response before delivering Telegram notifications to make `/api/account/send` faster (`bot/routes/account.js`).
- Made notification delivery fire-and-forget by calling `sendTransferNotification(...).catch(...)` so notification errors don't delay responses (`bot/routes/account.js`).
- Use persisted `user.balance` as the primary balance source with fallback to `calculateBalance(user)` and bound voice-catalog fetch to 1.5s to avoid blocking bundled checkout processing in `/api/store/purchase` (`bot/routes/store.js`).
- Increase the client-side purchase timeout window from 20s to 30s and convert the buy+timeout into an explicit `purchasePromise` + `timeoutPromise` race to reduce premature timeouts for larger bundles (`webapp/src/pages/Store.jsx`).
- Memoized transaction-derived computations (`txTypes`, filtered list and sorted list) in the Wallet page to prevent expensive recomputation on every keystroke while typing recipient/amount/note (`webapp/src/pages/Wallet.jsx`).

### Testing

- Ran unit/integration tests: `npm test -- --runInBand test/walletRoutes.test.js test/poolRoyalInventoryRoutes.test.js`, and both test suites passed (2 test suites, 3 tests total passed). 
- Ran lint check with `npx eslint` for edited files; lint warnings are from repo ignore patterns and no blocking errors were reported. 
- Smoke-validated store checkout and wallet send code paths locally during testing harness runs; timeouts and memoization behaved as expected in those flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699578dd70148329bb48865efb5c9a24)