### PR TITLE
Fix Pool Royale training Continue flow between tasks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12547,6 +12547,43 @@ function PoolRoyaleGame({
     setHud((prev) => ({ ...prev, over: false, turn: 0 }));
   }, []);
 
+  const handleTrainingContinue = useCallback(() => {
+    const nextPlayable = resolvePlayableTrainingLevel(
+      trainingLevelRef.current || trainingLevel,
+      trainingProgressRef.current
+    );
+    const nextLevelInfo = describeTrainingLevel(nextPlayable);
+    setTrainingLevel(nextPlayable);
+    setTrainingRoadmapOpen(false);
+    setTrainingMenuOpen(false);
+    setRuleToast(null);
+    setTurnCycle((value) => value + 1);
+    setFrameState((prev) => {
+      const nextMeta =
+        prev?.meta && typeof prev.meta === 'object'
+          ? { ...prev.meta }
+          : prev?.meta;
+      if (nextMeta && typeof nextMeta === 'object' && 'hud' in nextMeta) {
+        delete nextMeta.hud;
+      }
+      return {
+        ...prev,
+        frameOver: false,
+        winner: undefined,
+        foul: undefined,
+        activePlayer: 'A',
+        meta: nextMeta
+      };
+    });
+    setHud((prev) => ({
+      ...prev,
+      over: false,
+      turn: 0,
+      next: nextLevelInfo?.objective || prev.next
+    }));
+    applyTrainingLayoutForLevel(nextPlayable);
+  }, [applyTrainingLayoutForLevel, trainingLevel]);
+
   const awardTrainingTaskPayout = useCallback(async (level, rewardAmount) => {
     const account = resolvedAccountId;
     const amount = Math.max(0, Number(rewardAmount) || 0);
@@ -31028,21 +31065,7 @@ const powerRef = useRef(hud.power);
               </div>
               <button
                 type="button"
-                onClick={() => {
-                  setTrainingRoadmapOpen(false);
-                  setTrainingMenuOpen(false);
-                  setRuleToast(null);
-                  setTurnCycle((value) => value + 1);
-                  setFrameState((prev) => ({
-                    ...prev,
-                    frameOver: false,
-                    winner: undefined,
-                    foul: undefined,
-                    activePlayer: 'A'
-                  }));
-                  setHud((prev) => ({ ...prev, over: false, turn: 0 }));
-                  applyTrainingLayoutForLevel(trainingLevelRef.current || trainingLevel);
-                }}
+                onClick={handleTrainingContinue}
                 className="rounded-full border border-white/30 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
               >
                 Continue


### PR DESCRIPTION
### Motivation

- Players who completed a training task could press Continue and not be advanced cleanly into the next training task because stale HUD/meta or frame state prevented the next layout from being applied.

### Description

- Added a dedicated `handleTrainingContinue` callback in `PoolRoyale.jsx` that resolves the next playable level using `resolvePlayableTrainingLevel` and `trainingProgressRef`.
- The handler resets round state (`frameOver`, `winner`, `foul`, `activePlayer`), clears stale HUD metadata, updates the HUD (`over`, `turn`, `next`) and applies the next training layout via `applyTrainingLayoutForLevel` so the balls/table are prepared immediately.
- Wired the roadmap Continue button to the new `handleTrainingContinue` handler and preserved the existing `handleTrainingLevelPick` behavior for explicit level picks.

### Testing

- Ran the unit tests: `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js` and the suite passed (3 tests, all passing).
- Attempted an automated Playwright screenshot against the local Vite dev server to visually validate the flow, but the Playwright run timed out in this environment (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699594daec2c8329827e07aeefc2abf7)