### PR TITLE
Improve PersonaPlex voice commentary compatibility and help audio playback

### DIFF
--- a/bot/utils/voiceCommentaryCatalog.js
+++ b/bot/utils/voiceCommentaryCatalog.js
@@ -12,7 +12,20 @@ const FALLBACK_VOICE_CATALOG = [
   { id: 'amir_ar_sa_m', locale: 'ar-SA', language: 'Arabic', gender: 'male', style: 'calm', provider: 'nvidia-personaplex' },
   { id: 'anisa_sq_al_f', locale: 'sq-AL', language: 'Albanian', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
   { id: 'ivo_pt_br_m', locale: 'pt-BR', language: 'Portuguese', gender: 'male', style: 'energetic', provider: 'nvidia-personaplex' },
-  { id: 'olena_uk_ua_f', locale: 'uk-UA', language: 'Ukrainian', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' }
+  { id: 'olena_uk_ua_f', locale: 'uk-UA', language: 'Ukrainian', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'bartek_pl_pl_m', locale: 'pl-PL', language: 'Polish', gender: 'male', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'elif_tr_tr_f', locale: 'tr-TR', language: 'Turkish', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'ida_sv_se_f', locale: 'sv-SE', language: 'Swedish', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'nils_nb_no_m', locale: 'nb-NO', language: 'Norwegian', gender: 'male', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'aino_fi_fi_f', locale: 'fi-FI', language: 'Finnish', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'lia_nl_nl_f', locale: 'nl-NL', language: 'Dutch', gender: 'female', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'petra_cs_cz_f', locale: 'cs-CZ', language: 'Czech', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'marko_sr_rs_m', locale: 'sr-RS', language: 'Serbian', gender: 'male', style: 'energetic', provider: 'nvidia-personaplex' },
+  { id: 'farah_fa_ir_f', locale: 'fa-IR', language: 'Persian', gender: 'female', style: 'calm', provider: 'nvidia-personaplex' },
+  { id: 'kaito_zh_hk_m', locale: 'zh-HK', language: 'Chinese (Hong Kong)', gender: 'male', style: 'professional', provider: 'nvidia-personaplex' },
+  { id: 'thao_vi_vn_f', locale: 'vi-VN', language: 'Vietnamese', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'rani_id_id_f', locale: 'id-ID', language: 'Indonesian', gender: 'female', style: 'friendly', provider: 'nvidia-personaplex' },
+  { id: 'kai_th_th_m', locale: 'th-TH', language: 'Thai', gender: 'male', style: 'energetic', provider: 'nvidia-personaplex' }
 ];
 
 const CATALOG_TTL_MS = 5 * 60 * 1000;
@@ -53,10 +66,15 @@ async function fetchProviderCatalog() {
   const endpoint = process.env.PERSONAPLEX_API_URL;
   const apiKey = process.env.PERSONAPLEX_API_KEY;
   const path = process.env.PERSONAPLEX_VOICES_PATH || '/v1/voices';
-  if (!endpoint || !apiKey) return null;
+  if (!endpoint) return null;
+
+  const headers = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
 
   const response = await fetch(`${endpoint.replace(/\/$/, '')}${path.startsWith('/') ? path : `/${path}`}`, {
-    headers: { Authorization: `Bearer ${apiKey}` }
+    headers
   });
 
   if (!response.ok) {

--- a/docs/personaplex-voice-commentary.md
+++ b/docs/personaplex-voice-commentary.md
@@ -38,5 +38,8 @@ Purchases with item type `voiceLanguage` are applied server-side in `/api/store/
 ## Environment variables
 
 - `PERSONAPLEX_API_URL` - PersonaPlex API base URL
-- `PERSONAPLEX_API_KEY` - Bearer token
+- `PERSONAPLEX_API_KEY` - optional Bearer token (not required for local/open PersonaPlex deployments)
 - `PERSONAPLEX_VOICES_PATH` - optional voices path (default `/v1/voices`)
+- `PERSONAPLEX_SYNTHESIS_PATH` - optional synthesis path (default `/v1/speech/synthesize`)
+
+The server now tries multiple PersonaPlex-compatible payload formats automatically so you can run against NVIDIA PersonaPlex OSS endpoints without custom code changes.


### PR DESCRIPTION
### Motivation
- Make voice commentary and the in-app voice help work reliably with NVIDIA PersonaPlex OSS/self-hosted deployments that may use different request shapes or not require a bearer token. 
- Provide broader fallback voice coverage so games have commentary voices available before a remote catalog is fetched. 
- Improve help audio playback reliability on first play and support locale-aware speech recognition for user questions.

### Description
- Added many fallback voices/locales to the built-in catalog to increase language coverage used by store inventory and default commentary (`bot/utils/voiceCommentaryCatalog.js`).
- Made catalog fetching tolerant of PersonaPlex endpoints without auth by reading `PERSONAPLEX_API_KEY` optionally and passing headers only when present (`bot/utils/voiceCommentaryCatalog.js`).
- Reworked synthesis calls in `synthesizeWithPersonaplex` to accept a configurable synthesis path via `PERSONAPLEX_SYNTHESIS_PATH`, try multiple PersonaPlex-compatible payload formats, and optionally use a bearer token when provided (`bot/routes/voiceCommentary.js`).
- Primed audio before help playback and made speech recognition locale-aware by calling `primeSpeechSynthesis()` and using the incoming `locale` for `SpeechRecognition` (`webapp/src/utils/voiceHelpAssistant.js`).
- Updated documentation to mention `PERSONAPLEX_API_KEY` is optional, added `PERSONAPLEX_SYNTHESIS_PATH`, and noted the server's compatibility behavior (`docs/personaplex-voice-commentary.md`).

### Testing
- Ran syntax checks with `node --check` for `bot/routes/voiceCommentary.js`, `bot/utils/voiceCommentaryCatalog.js`, and `webapp/src/utils/voiceHelpAssistant.js`, all passing.
- Executed a catalog fetch script (`getVoiceCatalog({ forceRefresh: true })`) which returned the expanded fallback catalog (provider `nvidia-personaplex`, `source: fallback`, and the expected voice count), confirming the fallback voices are available.
- Verified the server-side synthesis code loads and parses successful responses and exposes `audioBase64`/`audioUrl` fields via the existing API contract in test runs (no runtime errors observed during local validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699598d31e8c832989269aa7ddd259d7)