### PR TITLE
Fix Pool Royale training Continue black screen and next-task progression

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12638,6 +12638,28 @@ function PoolRoyaleGame({
     initialLayoutRef.current = snapshot;
   }, [isTraining]);
 
+  const handleTrainingRoadmapContinue = useCallback(() => {
+    const completedLevel = Number(lastCompletedLevel) || trainingLevelRef.current || trainingLevel;
+    const nextLevel = resolvePlayableTrainingLevel(
+      completedLevel + 1,
+      trainingProgressRef.current
+    );
+    setTrainingLevel(nextLevel);
+    setTrainingRoadmapOpen(false);
+    setTrainingMenuOpen(false);
+    setRuleToast(null);
+    setTurnCycle((value) => value + 1);
+    setFrameState((prev) => ({
+      ...prev,
+      frameOver: false,
+      winner: undefined,
+      foul: undefined,
+      activePlayer: 'A'
+    }));
+    setHud((prev) => ({ ...prev, over: false, turn: 0, inHand: false }));
+    applyTrainingLayoutForLevel(nextLevel);
+  }, [applyTrainingLayoutForLevel, lastCompletedLevel, trainingLevel]);
+
   useEffect(() => {
     applyTrainingLayoutForLevel(trainingLevel);
   }, [applyTrainingLayoutForLevel, trainingLevel]);
@@ -31028,21 +31050,7 @@ const powerRef = useRef(hud.power);
               </div>
               <button
                 type="button"
-                onClick={() => {
-                  setTrainingRoadmapOpen(false);
-                  setTrainingMenuOpen(false);
-                  setRuleToast(null);
-                  setTurnCycle((value) => value + 1);
-                  setFrameState((prev) => ({
-                    ...prev,
-                    frameOver: false,
-                    winner: undefined,
-                    foul: undefined,
-                    activePlayer: 'A'
-                  }));
-                  setHud((prev) => ({ ...prev, over: false, turn: 0 }));
-                  applyTrainingLayoutForLevel(trainingLevelRef.current || trainingLevel);
-                }}
+                onClick={handleTrainingRoadmapContinue}
                 className="rounded-full border border-white/30 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
               >
                 Continue


### PR DESCRIPTION
### Motivation
- Tapping Continue from the Pool Royale training roadmap could produce a black/blank page because of a runtime initialization error during component setup.  
- The Continue action must advance to the next playable training task and reset the table/HUD so the next task is immediately playable.

### Description
- Reordered the `handleTrainingRoadmapContinue` declaration so it is defined after `applyTrainingLayoutForLevel` to avoid a temporal-dead-zone/runtime init crash.  
- Kept the centralized Continue behavior which uses `resolvePlayableTrainingLevel` to pick the next level, sets `trainingLevel`, closes the roadmap/menu, clears `ruleToast`, increments `turnCycle`, and resets `frameState` and `hud` (including `inHand`).  
- Ensured the handler calls `applyTrainingLayoutForLevel(nextLevel)` so the ball layout for the next level is applied immediately.  
- Replaced the previous inline Continue logic in the roadmap UI with `onClick={handleTrainingRoadmapContinue}` to avoid duplicated/stale inline code.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleTrainingProgress.test.js` and the test suite passed.  
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956ee9d73883298a8d1b0b35fbc877)