### PR TITLE
Restore store payment flow to yesterday morning behavior

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -90,15 +90,18 @@ router.post('/purchase', authenticate, async (req, res) => {
       return res.status(400).json({ error: 'invalid bundle total' });
     }
     ensureTransactionArray(user);
-    const availableBalance = Number.isFinite(user.balance)
-      ? user.balance
-      : calculateBalance(user);
-    if (availableBalance < totalPrice) {
+    const balance = calculateBalance(user);
+    if (balance < totalPrice) {
       return res.status(400).json({ error: 'insufficient balance' });
     }
     const txDate = new Date();
     const hasVoiceItem = items.some((item) => item.type === 'voiceLanguage');
-    const transaction = {
+    if (hasVoiceItem) {
+      const catalog = await getVoiceCatalog();
+      applyVoiceCommentaryUnlocks(user, items, catalog.voices || []);
+    }
+
+    user.transactions.push({
       amount: -totalPrice,
       type: 'storefront',
       token: 'TPC',
@@ -106,36 +109,9 @@ router.post('/purchase', authenticate, async (req, res) => {
       date: txDate,
       detail: 'Storefront purchase',
       items
-    };
-
-    // Fast path for normal item bundles: avoid full document save + validation
-    // and perform an atomic balance check/debit to reduce checkout latency.
-    if (totalPrice > 0 && !hasVoiceItem) {
-      const updated = await User.findOneAndUpdate(
-        { _id: user._id, balance: { $gte: totalPrice } },
-        {
-          $inc: { balance: -totalPrice },
-          $push: { transactions: transaction }
-        },
-        { new: true, projection: { balance: 1 } }
-      );
-      if (!updated) {
-        return res.status(400).json({ error: 'insufficient balance' });
-      }
-      return res.json({ balance: updated.balance, date: txDate });
-    }
-
-    if (hasVoiceItem) {
-      const catalog = await Promise.race([
-        getVoiceCatalog(),
-        new Promise((resolve) => setTimeout(() => resolve({ voices: [] }), 1500))
-      ]);
-      applyVoiceCommentaryUnlocks(user, items, catalog?.voices || []);
-    }
-
-    user.transactions.push(transaction);
+    });
     if (totalPrice > 0) {
-      user.balance = availableBalance - totalPrice;
+      user.balance = balance - totalPrice;
     }
     await user.save();
     return res.json({ balance: user.balance, date: txDate });

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -245,7 +245,6 @@ const VOICE_TYPE_LABELS = {
 const TON_ICON = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TON_PRICE_MIN = 100;
 const TON_PRICE_MAX = 5000;
-const PURCHASE_REQUEST_TIMEOUT_MS = 30000;
 const THUMBNAIL_SIZE = 256;
 const ZOOM_PREVIEW_SIZE = 1024;
 const POLYHAVEN_THUMBNAIL_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs/';
@@ -1266,11 +1265,6 @@ export default function Store() {
     return allMarketplaceItems.filter((item) => keySet.has(selectionKey(item)));
   }, [allMarketplaceItems, selectedKeys]);
 
-  const visiblePurchasableItems = useMemo(
-    () => visibleItems.filter((item) => !item.owned),
-    [visibleItems]
-  );
-
   const selectedPurchasable = useMemo(
     () => selectedItems.filter((item) => !item.owned),
     [selectedItems]
@@ -1308,21 +1302,6 @@ export default function Store() {
   }, []);
 
   const clearSelection = useCallback(() => setSelectedKeys([]), []);
-
-  const selectVisibleItems = useCallback(() => {
-    if (!visiblePurchasableItems.length) return;
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      visiblePurchasableItems.forEach((item) => next.add(selectionKey(item)));
-      return Array.from(next);
-    });
-  }, [visiblePurchasableItems]);
-
-  const quickBuyVisible = useCallback(() => {
-    if (!visiblePurchasableItems.length || processing) return;
-    setConfirmItem(null);
-    setConfirmItems(visiblePurchasableItems);
-  }, [processing, visiblePurchasableItems]);
 
   const userListingStats = useMemo(() => {
     const total = decoratedUserListings.length;
@@ -1475,14 +1454,7 @@ export default function Store() {
           price: item.price
         }))
       };
-      const purchasePromise = buyBundle(resolvedAccountId, bundle);
-      const timeoutPromise = new Promise((_, reject) => {
-        window.setTimeout(
-          () => reject(new Error('TPC transfer request timed out')),
-          PURCHASE_REQUEST_TIMEOUT_MS
-        );
-      });
-      const purchase = await Promise.race([purchasePromise, timeoutPromise]);
+      const purchase = await buyBundle(resolvedAccountId, bundle);
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');
@@ -1601,18 +1573,9 @@ export default function Store() {
       await loadAccountBalance();
     } catch (err) {
       console.error('Purchase failed', err);
-      const timedOut = err instanceof Error && err.message === 'TPC transfer request timed out';
-      setInfo(
-        timedOut
-          ? 'TPC transfer timed out. Your balance was not changed. Please try again.'
-          : 'Failed to process purchase.'
-      );
+      setInfo('Failed to process purchase.');
       setTransactionState('error');
-      setTransactionStatus(
-        timedOut
-          ? 'Payment request timed out. Please retry checkout.'
-          : 'Purchase failed. Please try again.'
-      );
+      setTransactionStatus('Purchase failed. Please try again.');
     } finally {
       setProcessing('');
       setConfirmItem(null);
@@ -2738,22 +2701,6 @@ export default function Store() {
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="button"
-                    onClick={selectVisibleItems}
-                    className="rounded-2xl border border-sky-300/30 bg-sky-400/10 px-3 py-2 text-xs font-semibold text-sky-100 hover:bg-sky-400/20 disabled:cursor-not-allowed disabled:opacity-50"
-                    disabled={!visiblePurchasableItems.length || Boolean(processing)}
-                  >
-                    Select visible ({visiblePurchasableItems.length})
-                  </button>
-                  <button
-                    type="button"
-                    onClick={quickBuyVisible}
-                    className="rounded-2xl border border-emerald-300/30 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100 hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-50"
-                    disabled={!visiblePurchasableItems.length || Boolean(processing)}
-                  >
-                    Quick buy visible
-                  </button>
-                  <button
-                    type="button"
                     onClick={clearSelection}
                     className="rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-xs font-semibold text-white/80 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
                     disabled={!selectedKeys.length}
@@ -2777,7 +2724,7 @@ export default function Store() {
                 <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5">
                   Green + Blue cloth bundles ready for Pool Royale
                 </span>
-                <span>Use “Select visible” or “Quick buy visible” to purchase large filtered sets faster.</span>
+                <span>Pick multiple NFTs, confirm once, and unlock them together.</span>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- Recent changes introduced a fast-path atomic debit + timeout-based client flow intended to reduce checkout latency but changed the payment behavior and UX.
- We need to restore the exact prior payment flow used yesterday morning so client and server behavior match the previous, stable checkout semantics.

### Description
- Reverted server-side fast-path logic and atomic `findOneAndUpdate` branch and restored the original balance calculation, transaction push and `user.save()` flow in `bot/routes/store.js`.
- Restored original voice commentary unlock handling flow by using the direct `getVoiceCatalog()` path for voice items in `bot/routes/store.js`.
- Reverted client-side timeout/race logic and timeout-specific messaging by removing the `PURCHASE_REQUEST_TIMEOUT_MS` constant and the `Promise.race` timeout wrapper around `buyBundle` in `webapp/src/pages/Store.jsx`.
- Removed the quick-selection/quick-buy UI additions and related code paths so the Store UI and multi-select checkout match the previous implementation in `webapp/src/pages/Store.jsx`.

### Testing
- Ran `git diff --cached --check` with no reported issues.
- Successfully built the web frontend using `npm --prefix webapp run build` which completed without errors.
- Launched the dev server (`vite`) and captured a Store page screenshot to validate the restored UI and flow visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a027f90883298288c880b9a7cfde)