### PR TITLE
Add browser TTS fallback and retry for voice Help playback

### DIFF
--- a/webapp/src/utils/voiceHelpAssistant.js
+++ b/webapp/src/utils/voiceHelpAssistant.js
@@ -1,75 +1,120 @@
-import { post } from './api.js';
-import { primeSpeechSynthesis } from './textToSpeech.js';
+import { post } from './api.js'
+import { primeSpeechSynthesis } from './textToSpeech.js'
 
 const SPEECH_RECOGNITION =
   typeof window !== 'undefined'
     ? window.SpeechRecognition || window.webkitSpeechRecognition || null
-    : null;
+    : null
 
-async function playSynthesis(payload) {
-  primeSpeechSynthesis();
-  const synthesis = payload?.synthesis || {};
-  const source = synthesis.audioUrl || (synthesis.audioBase64 ? `data:${synthesis.mimeType || 'audio/mpeg'};base64,${synthesis.audioBase64}` : '');
-  if (!source) throw new Error('Missing help audio');
-  const audio = new Audio(source);
-  await new Promise((resolve, reject) => {
-    const finish = () => {
-      audio.removeEventListener('ended', finish);
-      audio.removeEventListener('error', fail);
-      resolve();
-    };
-    const fail = () => {
-      audio.removeEventListener('ended', finish);
-      audio.removeEventListener('error', fail);
-      reject(new Error('Help audio playback failed'));
-    };
-    audio.addEventListener('ended', finish);
-    audio.addEventListener('error', fail);
-    audio.play().catch(fail);
-  });
+const HELP_GREETING = 'Hello, I am TonPlaygram voice help. How can I help you today?'
+
+const buildSynthesisSource = (payload) => {
+  const synthesis = payload?.synthesis || {}
+  return (
+    synthesis.audioUrl ||
+    (synthesis.audioBase64
+      ? `data:${synthesis.mimeType || 'audio/mpeg'};base64,${synthesis.audioBase64}`
+      : '')
+  )
 }
 
-function listenOnce(locale = 'en-US', timeoutMs = 9000) {
-  if (!SPEECH_RECOGNITION) return Promise.resolve('');
+async function playBrowserSpeech (text, locale = 'en-US') {
+  if (typeof window === 'undefined' || typeof window.SpeechSynthesisUtterance === 'undefined') {
+    return
+  }
+
+  await new Promise((resolve, reject) => {
+    try {
+      const utterance = new window.SpeechSynthesisUtterance(String(text || '').trim())
+      utterance.lang = locale || 'en-US'
+      utterance.onend = () => resolve()
+      utterance.onerror = () => reject(new Error('Help speech synthesis failed'))
+      window.speechSynthesis.cancel()
+      window.speechSynthesis.speak(utterance)
+    } catch {
+      reject(new Error('Help speech synthesis failed'))
+    }
+  })
+}
+
+async function playSynthesis (payload) {
+  primeSpeechSynthesis()
+  const source = buildSynthesisSource(payload)
+  if (!source) throw new Error('Missing help audio')
+  const audio = new Audio(source)
+  await new Promise((resolve, reject) => {
+    const finish = () => {
+      audio.removeEventListener('ended', finish)
+      audio.removeEventListener('error', fail)
+      resolve()
+    }
+    const fail = () => {
+      audio.removeEventListener('ended', finish)
+      audio.removeEventListener('error', fail)
+      reject(new Error('Help audio playback failed'))
+    }
+    audio.addEventListener('ended', finish)
+    audio.addEventListener('error', fail)
+    audio.play().catch(async (error) => {
+      if (error?.name === 'NotAllowedError') {
+        primeSpeechSynthesis()
+        audio.play().catch(fail)
+        return
+      }
+      fail()
+    })
+  })
+}
+
+function listenOnce (locale = 'en-US', timeoutMs = 9000) {
+  if (!SPEECH_RECOGNITION) return Promise.resolve('')
   return new Promise((resolve) => {
-    const recognition = new SPEECH_RECOGNITION();
-    recognition.lang = locale || 'en-US';
-    recognition.continuous = false;
-    recognition.interimResults = false;
-    let done = false;
+    const recognition = new SPEECH_RECOGNITION()
+    recognition.lang = locale || 'en-US'
+    recognition.continuous = false
+    recognition.interimResults = false
+    let done = false
     const finish = (value = '') => {
-      if (done) return;
-      done = true;
+      if (done) return
+      done = true
       try {
-        recognition.stop();
+        recognition.stop()
       } catch {
         // ignore
       }
-      resolve(value);
-    };
+      resolve(value)
+    }
     recognition.onresult = (event) => {
-      const transcript = event?.results?.[0]?.[0]?.transcript || '';
-      finish(String(transcript || '').trim());
-    };
-    recognition.onerror = () => finish('');
-    recognition.onend = () => finish('');
-    recognition.start();
-    setTimeout(() => finish(''), timeoutMs);
-  });
+      const transcript = event?.results?.[0]?.[0]?.transcript || ''
+      finish(String(transcript || '').trim())
+    }
+    recognition.onerror = () => finish('')
+    recognition.onend = () => finish('')
+    recognition.start()
+    setTimeout(() => finish(''), timeoutMs)
+  })
 }
 
-export async function runVoiceHelpSession({ accountId, locale = 'en-US' }) {
-  const first = await post('/api/voice-commentary/help', { accountId, locale, question: '' });
-  if (first?.error) throw new Error(first.error);
-  await playSynthesis(first);
+export async function runVoiceHelpSession ({ accountId, locale = 'en-US' }) {
+  const first = await post('/api/voice-commentary/help', { accountId, locale, question: '' })
+  if (first?.error) throw new Error(first.error)
+  try {
+    await playSynthesis(first)
+  } catch {
+    await playBrowserSpeech(first?.answer || HELP_GREETING, locale)
+  }
 
-  const spokenQuestion = await listenOnce(locale);
+  const spokenQuestion = await listenOnce(locale)
   const answer = await post('/api/voice-commentary/help', {
     accountId,
     locale,
     question: spokenQuestion || 'general app help'
-  });
-  if (answer?.error) throw new Error(answer.error);
-  await playSynthesis(answer);
-  return { question: spokenQuestion, answer: answer.answer || '' };
+  })
+  if (answer?.error) throw new Error(answer.error)
+  try {
+    await playSynthesis(answer)
+  } catch {
+    await playBrowserSpeech(answer?.answer || 'I can help with wallet, games, store purchases, voice commentary, and account setup.', locale)
+  }
+  return { question: spokenQuestion, answer: answer.answer || '' }
 }


### PR DESCRIPTION
### Motivation
- Ensure pressing Help always produces a spoken greeting and spoken response even when remote PersonaPlex/NVIDIA audio fails or browser autoplay restrictions block playback.
- Make the voice-help flow resilient on mobile and browsers that require a user gesture to unlock audio so users hear a vocal greeting instead of nothing.

### Description
- Updated `webapp/src/utils/voiceHelpAssistant.js` to resolve audio payloads through `buildSynthesisSource` and to retry playback after calling `primeSpeechSynthesis` when a `NotAllowedError` occurs.
- Added `HELP_GREETING` constant and `playBrowserSpeech` which uses `SpeechSynthesisUtterance` as a browser TTS fallback when remote audio is missing or playback fails.
- Kept the original voice-first flow in `runVoiceHelpSession` but wrapped both the initial greeting and the follow-up answer in try/catch blocks that fall back to browser TTS on error.
- Small formatting and lint-friendly adjustments to match project style.

### Testing
- Ran `npm test -- test/platformHelpAgent/voiceCommentaryApi.test.ts --runInBand` and the suite passed (3 tests, 1 suite). 
- Ran `npx eslint --no-ignore webapp/src/utils/voiceHelpAssistant.js` and fixed lint issues with `--fix`, after which ESLint reported clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a1dcc0b48329bb31efb2ca1b3941)