### PR TITLE
Fix Pool Royale training continue flow and disable fouls in training

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12648,7 +12648,6 @@ function PoolRoyaleGame({
     setTrainingRoadmapOpen(false);
     setTrainingMenuOpen(false);
     setRuleToast(null);
-    setTurnCycle((value) => value + 1);
     setFrameState((prev) => ({
       ...prev,
       frameOver: false,
@@ -26510,17 +26509,14 @@ const powerRef = useRef(hud.power);
           console.error('Pool Royale shot resolution failed:', err);
         }
         if (isTraining) {
-          if (!trainingRulesRef.current) {
-            safeState = {
-              ...safeState,
-              foul: undefined,
-              frameOver: false,
-              winner: undefined
-            };
-          }
-          if (trainingModeRef.current === 'solo') {
-            safeState = { ...safeState, activePlayer: 'A' };
-          }
+          const disableRuleEnding = !trainingRulesRef.current;
+          safeState = {
+            ...safeState,
+            foul: undefined,
+            activePlayer: trainingModeRef.current === 'solo' ? 'A' : safeState?.activePlayer,
+            frameOver: disableRuleEnding ? false : safeState?.frameOver,
+            winner: disableRuleEnding ? undefined : safeState?.winner
+          };
         }
         if (isTraining && !safeState?.frameOver && pottedObjectCount === 0) {
           setTrainingShotsRemaining((prev) => Math.max(0, (Number(prev) || 0) - 1));
@@ -26543,7 +26539,7 @@ const powerRef = useRef(hud.power);
             meta: nextMeta ?? safeState.meta
           };
         }
-        if (safeState?.foul) {
+        if (!isTraining && safeState?.foul) {
           const foulNextPlayer = currentState?.activePlayer === 'B' ? 'A' : 'B';
           const nextMeta =
             safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
@@ -26735,7 +26731,7 @@ const powerRef = useRef(hud.power);
           cushionAfterContact: false,
           spin: { x: 0, y: 0 }
         };
-        let nextInHand = cueBallPotted;
+        let nextInHand = isTraining ? false : cueBallPotted;
         try {
           if (shotResolved) {
             if (safeState.foul) {
@@ -26820,7 +26816,7 @@ const powerRef = useRef(hud.power);
               cue.impacted = false;
               cue.launchDir = null;
               cueBallPlacedFromHandRef.current = false;
-              pendingInHandResetRef.current = true;
+              pendingInHandResetRef.current = !isTraining;
             }
             if (shouldStartReplay) {
               postShotSnapshot = captureBallSnapshot();


### PR DESCRIPTION
### Motivation
- Training tasks must advance smoothly without reloading the whole session or causing extra turn-cycle churn when the player taps Continue. 
- Training should not punish learners with fouls so tasks can be completed by potting any available balls.

### Description
- Updated the training roadmap Continue handler to advance levels and reset only training frame/hud/layout (no `turnCycle` bump) in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Modified shot resolution when `isTraining` to always clear foul state and keep solo training active on player A, while preserving normal foul behavior outside training.
- Prevented foul-driven turn/ball-in-hand handoff during training by gating that logic behind `!isTraining`.
- Adjusted cue-ball scratch handling so training does not force in-hand mode by setting `nextInHand` and `pendingInHandResetRef` based on `isTraining`.

### Testing
- Ran unit tests with `npx jest test/poolRoyaleRules.test.ts --runInBand`, and the suite passed (3 tests, 0 failures).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; the command executed but the file is ignored by the repository ESLint ignore configuration (warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a2460dec83298a7369bffe4f9990)