### PR TITLE
Add robust voice fallback for help and commentary responses

### DIFF
--- a/bot/routes/voiceCommentary.js
+++ b/bot/routes/voiceCommentary.js
@@ -229,7 +229,12 @@ router.post('/help', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.status(502).json({ error: error.message, provider: 'nvidia-personaplex' });
+    return res.json({
+      provider: 'web-speech-fallback',
+      voice: selected,
+      answer,
+      warning: `PersonaPlex synthesis unavailable: ${error.message}`
+    });
   }
 });
 
@@ -270,7 +275,13 @@ router.post('/speak', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.status(502).json({ error: error.message, provider: 'nvidia-personaplex' });
+    return res.json({
+      provider: 'web-speech-fallback',
+      voice: selected,
+      inventory,
+      text: message,
+      warning: `PersonaPlex synthesis unavailable: ${error.message}`
+    });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Ensure users hear the help greeting and vocal responses even when the NVIDIA PersonaPlex TTS service is unavailable or playback fails. 
- Avoid silent failures when pressing the Help button or requesting commentary so the app remains voice-first.

### Description
- Modified `POST /api/voice-commentary/help` and `POST /api/voice-commentary/speak` to return a successful `provider: 'web-speech-fallback'` response with `answer`/`text` and voice context when PersonaPlex synthesis errors occur instead of returning HTTP 502. 
- Added a browser-side fallback in `webapp/src/utils/voiceHelpAssistant.js` that uses `speechSynthesis` (`SpeechSynthesisUtterance`) to speak `answer`/`text` when no audio URL/base64 is provided or when playback fails. 
- Kept the help flow intact so the greeting is played, the session listens for the spoken question, then the follow-up answer is spoken using either backend synthesis or the Web Speech fallback.

### Testing
- Ran basic runtime checks with `node --check bot/routes/voiceCommentary.js && node --check webapp/src/utils/voiceHelpAssistant.js` which completed successfully. 
- Executed `npx eslint bot/routes/voiceCommentary.js webapp/src/utils/voiceHelpAssistant.js` which produced warnings due to repo ignore rules but no new lint errors. 
- Ran `npm run build` which failed due to a pre-existing, unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a1dcc0b48329bb31efb2ca1b3941)