### PR TITLE
Restore store payment flow to yesterday morning implementation

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -4,8 +4,6 @@ import User from '../models/User.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { withProxy } from '../utils/proxyAgent.js';
 import TonWeb from 'tonweb';
-import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
-import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
 
 const router = Router();
 
@@ -86,19 +84,16 @@ router.post('/purchase', authenticate, async (req, res) => {
       price: Number(item.price) || 0
     }));
     const totalPrice = items.reduce((sum, item) => sum + (Number(item.price) || 0), 0);
-    if (!Number.isFinite(totalPrice) || totalPrice < 0) {
+    if (!Number.isFinite(totalPrice) || totalPrice <= 0) {
       return res.status(400).json({ error: 'invalid bundle total' });
     }
     ensureTransactionArray(user);
-    const availableBalance = Number.isFinite(user.balance)
-      ? user.balance
-      : calculateBalance(user);
-    if (availableBalance < totalPrice) {
+    const balance = calculateBalance(user);
+    if (balance < totalPrice) {
       return res.status(400).json({ error: 'insufficient balance' });
     }
     const txDate = new Date();
-    const hasVoiceItem = items.some((item) => item.type === 'voiceLanguage');
-    const transaction = {
+    user.transactions.push({
       amount: -totalPrice,
       type: 'storefront',
       token: 'TPC',
@@ -106,37 +101,8 @@ router.post('/purchase', authenticate, async (req, res) => {
       date: txDate,
       detail: 'Storefront purchase',
       items
-    };
-
-    // Fast path for normal item bundles: avoid full document save + validation
-    // and perform an atomic balance check/debit to reduce checkout latency.
-    if (totalPrice > 0 && !hasVoiceItem) {
-      const updated = await User.findOneAndUpdate(
-        { _id: user._id, balance: { $gte: totalPrice } },
-        {
-          $inc: { balance: -totalPrice },
-          $push: { transactions: transaction }
-        },
-        { new: true, projection: { balance: 1 } }
-      );
-      if (!updated) {
-        return res.status(400).json({ error: 'insufficient balance' });
-      }
-      return res.json({ balance: updated.balance, date: txDate });
-    }
-
-    if (hasVoiceItem) {
-      const catalog = await Promise.race([
-        getVoiceCatalog(),
-        new Promise((resolve) => setTimeout(() => resolve({ voices: [] }), 1500))
-      ]);
-      applyVoiceCommentaryUnlocks(user, items, catalog?.voices || []);
-    }
-
-    user.transactions.push(transaction);
-    if (totalPrice > 0) {
-      user.balance = availableBalance - totalPrice;
-    }
+    });
+    user.balance = balance - totalPrice;
     await user.save();
     return res.json({ balance: user.balance, date: txDate });
   }


### PR DESCRIPTION
### Motivation
- Revert recent checkout optimizations so the store purchase route behaves exactly like the prior morning implementation used for payments. 
- Avoid the newer fast-path atomic debit and voice-catalog side-effects which changed payment timing and behavior.

### Description
- Restored `bot/routes/store.js` purchase handling to push a transaction into `user.transactions`, update `user.balance` from `calculateBalance(user)`, then call `user.save()` for item bundles. 
- Removed the fast-path `User.findOneAndUpdate` atomic debit path and the voice-catalog imports/side-effects (`applyVoiceCommentaryUnlocks` / `getVoiceCatalog`).
- Reinstated strict positive bundle validation by treating `totalPrice <= 0` as invalid and using `calculateBalance(user)` for balance checks.
- Change is limited to `bot/routes/store.js` payment logic and does not alter the TX-claim (`txHash`) flow.

### Testing
- Ran `node --check bot/routes/store.js` and it completed successfully. 
- No additional automated tests were modified or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a027f90883298288c880b9a7cfde)