### PR TITLE
Improve Pool Royale training progression continuity

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12459,6 +12459,7 @@ function PoolRoyaleGame({
   const [trainingRulesOn, setTrainingRulesOn] = useState(true);
   const [trainingRoadmapOpen, setTrainingRoadmapOpen] = useState(false);
   const [lastCompletedLevel, setLastCompletedLevel] = useState(null);
+  const [pendingTrainingLevel, setPendingTrainingLevel] = useState(null);
   const [showTrainingIntroCard, setShowTrainingIntroCard] = useState(false);
   const trainingModeRef = useRef(trainingModeState);
   const trainingRulesRef = useRef(trainingRulesOn);
@@ -12535,6 +12536,7 @@ function PoolRoyaleGame({
     const unlockedLevel = resolvePlayableTrainingLevel(levelNum, trainingProgressRef.current);
     if (levelNum > unlockedLevel) return;
     setTrainingLevel(unlockedLevel);
+    setPendingTrainingLevel(null);
     setTrainingRoadmapOpen(false);
     setTrainingMenuOpen(false);
     setFrameState((prev) => ({
@@ -12640,11 +12642,16 @@ function PoolRoyaleGame({
 
   const handleTrainingRoadmapContinue = useCallback(() => {
     const completedLevel = Number(lastCompletedLevel) || trainingLevelRef.current || trainingLevel;
-    const nextLevel = resolvePlayableTrainingLevel(
+    const computedNextLevel = resolvePlayableTrainingLevel(
       completedLevel + 1,
       trainingProgressRef.current
     );
+    const nextLevel =
+      Number.isFinite(Number(pendingTrainingLevel)) && Number(pendingTrainingLevel) > 0
+        ? Number(pendingTrainingLevel)
+        : computedNextLevel;
     setTrainingLevel(nextLevel);
+    setPendingTrainingLevel(null);
     setTrainingRoadmapOpen(false);
     setTrainingMenuOpen(false);
     setRuleToast(null);
@@ -12657,7 +12664,7 @@ function PoolRoyaleGame({
     }));
     setHud((prev) => ({ ...prev, over: false, turn: 0, inHand: false }));
     applyTrainingLayoutForLevel(nextLevel);
-  }, [applyTrainingLayoutForLevel, lastCompletedLevel, trainingLevel]);
+  }, [applyTrainingLayoutForLevel, lastCompletedLevel, pendingTrainingLevel, trainingLevel]);
 
   useEffect(() => {
     applyTrainingLayoutForLevel(trainingLevel);
@@ -13862,8 +13869,7 @@ const powerRef = useRef(hud.power);
       persistTrainingProgress(updated);
       const nextPlayable = resolvePlayableTrainingLevel(completedLevel + 1, updated);
       setTrainingShotsRemaining(carryShots);
-      setTrainingLevel(nextPlayable);
-      applyTrainingLayoutForLevel(nextPlayable);
+      setPendingTrainingLevel(nextPlayable);
       setLastCompletedLevel(completedLevel);
       setTrainingRoadmapOpen(true);
       return updated;


### PR DESCRIPTION
### Motivation
- Prevent a full table reload when a training task completes so the table rendering remains active and only ball positions are updated for the next task.
- Let the roadmap/Continue flow control when the next level layout is applied so players see an immediate, lightweight transition instead of a perceived reload.

### Description
- Add `pendingTrainingLevel` state to queue the next playable training level after task completion instead of immediately advancing the active `trainingLevel` and reapplying layout. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- When a training task completes, persist progress and rewards and set `pendingTrainingLevel` and open the roadmap modal, deferring layout changes until the player taps Continue. (changed completion handler to set `pendingTrainingLevel` rather than `trainingLevel` + layout application)
- Update the roadmap interactions so manual level selection clears any queued `pendingTrainingLevel`, and the roadmap Continue button prefers the queued level when applying the layout and advancing `trainingLevel`.
- Keep existing `applyTrainingLayoutForLevel` usage on explicit Continue to update ball snapshots without reinitializing the renderer or full scene lifecycle.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; it completed (the file is ignored by repo eslint config so no lint errors were reported). — Success.
- Started the dev server with `npm --prefix webapp run dev` to validate the app bundle and serve the page; Vite reported readiness and served on the configured ports. — Success.
- Attempted an automated Playwright script to open the training page and capture a screenshot, but Chromium crashed in the container (SIGSEGV), so the headless browser check failed; the change itself was not exercised end-to-end by Playwright in this environment. — Failed (Playwright run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995be2d26688329adbfa578c5d5216b)