### PR TITLE
Fix NVIDIA PersonaPlex commentary audio parsing

### DIFF
--- a/packages/api/src/voiceCommentary.ts
+++ b/packages/api/src/voiceCommentary.ts
@@ -112,7 +112,14 @@ export async function requestPersonaplexSynthesis(input: {
   voiceId: string;
   locale: string;
   metadata?: Record<string, string>;
-}): Promise<{ mode: 'remote'; provider: 'nvidia-personaplex'; response: unknown }> {
+}): Promise<{
+  mode: 'remote';
+  provider: 'nvidia-personaplex';
+  response: unknown;
+  audioUrl: string | null;
+  audioBase64: string | null;
+  mimeType: string;
+}> {
   const endpoint = process.env.PERSONAPLEX_API_URL;
   const apiKey = process.env.PERSONAPLEX_API_KEY;
 
@@ -143,7 +150,68 @@ export async function requestPersonaplexSynthesis(input: {
   }
 
   const payload = await response.json();
-  return { mode: 'remote', provider: 'nvidia-personaplex', response: payload };
+  return {
+    mode: 'remote',
+    provider: 'nvidia-personaplex',
+    response: payload,
+    ...normalizeSynthesisPayload(payload)
+  };
+}
+
+const AUDIO_URL_KEYS = ['audioUrl', 'audio_url', 'url', 'audio_url_signed', 'signed_url'] as const;
+const AUDIO_BASE64_KEYS = ['audioBase64', 'audio_base64', 'audioContent', 'audio_content', 'content', 'audio'] as const;
+const MIME_TYPE_KEYS = ['mimeType', 'mime_type', 'contentType', 'content_type', 'audioMimeType'] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function findFirstValue(input: unknown, keys: readonly string[]): string | null {
+  if (!input) return null;
+
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      const match = findFirstValue(item, keys);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  if (!isRecord(input)) return null;
+
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  for (const nested of Object.values(input)) {
+    if (!nested || typeof nested === 'string' || typeof nested === 'number' || typeof nested === 'boolean') {
+      continue;
+    }
+    const match = findFirstValue(nested, keys);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function normalizeAudioBase64(value: string | null): string | null {
+  if (!value) return null;
+  if (value.startsWith('data:')) {
+    const [, payload] = value.split(',', 2);
+    return payload || null;
+  }
+  return value;
+}
+
+export function normalizeSynthesisPayload(payload: unknown): { audioUrl: string | null; audioBase64: string | null; mimeType: string } {
+  return {
+    audioUrl: findFirstValue(payload, AUDIO_URL_KEYS),
+    audioBase64: normalizeAudioBase64(findFirstValue(payload, AUDIO_BASE64_KEYS)),
+    mimeType: findFirstValue(payload, MIME_TYPE_KEYS) || 'audio/mpeg'
+  };
 }
 
 export function findVoiceProfile(voiceId?: string, locale?: string): VoiceProfile {

--- a/test/platformHelpAgent/voiceCommentaryApi.test.ts
+++ b/test/platformHelpAgent/voiceCommentaryApi.test.ts
@@ -3,6 +3,7 @@ import {
   buildCommentaryText,
   buildSupportSpeech,
   findVoiceProfile,
+  normalizeSynthesisPayload,
   requestPersonaplexSynthesis
 } from '../../packages/api/src/voiceCommentary';
 
@@ -25,5 +26,18 @@ describe('voice commentary module', () => {
     const voice = findVoiceProfile(undefined, 'sq-AL');
     const support = buildSupportSpeech('Nuk po më hapet loja', voice);
     expect(support).toContain('Përshëndetje');
+  });
+
+  test('normalizes data-uri base64 synthesis payload', () => {
+    const synthesis = normalizeSynthesisPayload({
+      output: {
+        audio: 'data:audio/wav;base64,QUJDREVGRw==',
+        mimeType: 'audio/wav'
+      }
+    });
+
+    expect(synthesis.audioBase64).toBe('QUJDREVGRw==');
+    expect(synthesis.mimeType).toBe('audio/wav');
+    expect(synthesis.audioUrl).toBeNull();
   });
 });

--- a/test/voiceCommentaryUnlocks.test.js
+++ b/test/voiceCommentaryUnlocks.test.js
@@ -5,7 +5,7 @@ import {
   createDefaultVoiceInventory,
   normalizeVoiceInventory
 } from '../bot/utils/voiceCommentaryCatalog.js';
-import { applyVoiceCommentaryUnlocks, buildHelpAnswer } from '../bot/routes/voiceCommentary.js';
+import { applyVoiceCommentaryUnlocks, buildHelpAnswer, normalizeSynthesisPayload } from '../bot/routes/voiceCommentary.js';
 
 test('default voice commentary inventory includes free English voice', () => {
   const inventory = createDefaultVoiceInventory();
@@ -53,4 +53,19 @@ test('store item builder keeps English free and paid multilingual packs', () => 
 test('voice help answer routes key app topics', () => {
   assert.match(buildHelpAnswer('How do I buy commentary in the store?'), /Store/i);
   assert.match(buildHelpAnswer(''), /How can I help you today/i);
+});
+
+test('normalizes nested PersonaPlex synthesis payloads', () => {
+  const normalized = normalizeSynthesisPayload({
+    data: {
+      result: {
+        audio_url: 'https://cdn.example.com/commentary.mp3',
+        content_type: 'audio/mp3'
+      }
+    }
+  });
+
+  assert.equal(normalized.audioUrl, 'https://cdn.example.com/commentary.mp3');
+  assert.equal(normalized.mimeType, 'audio/mp3');
+  assert.equal(normalized.audioBase64, null);
 });


### PR DESCRIPTION
### Motivation
- Commentary audio sometimes fell back to silence because PersonaPlex (NVIDIA PersonaPlex) returned audio fields in nested or alternate keys that the backend did not handle. 
- The change aims to reliably extract playable audio (URL or base64) and mime-type from varied provider response shapes so in-game commentary and voice-help playback works consistently.

### Description
- Added a recursive payload normalization function `normalizeSynthesisPayload` that searches nested objects/arrays for common audio URL, base64 and mime-type keys and strips `data:` URI prefixes when present. 
- Updated `synthesizeWithPersonaplex` in `bot/routes/voiceCommentary.js` to use the normalization and return `audioUrl`, `audioBase64`, and `mimeType` alongside the raw provider payload. 
- Updated the TypeScript helper `requestPersonaplexSynthesis` in `packages/api/src/voiceCommentary.ts` to return the normalized audio fields together with the provider response. 
- Added regression tests that assert nested `audio_url` extraction and `data:`-URI base64 extraction to `test/voiceCommentaryUnlocks.test.js` and `test/platformHelpAgent/voiceCommentaryApi.test.ts`.

### Testing
- Ran the targeted test command `npm test -- test/voiceCommentaryUnlocks.test.js test/platformHelpAgent/voiceCommentaryApi.test.ts --runInBand` and all tests passed. 
- Test results: 2 test suites executed and 9 tests passed with no failures. 
- The changes were validated by new unit tests that confirm nested URL extraction and data-URI base64 normalization behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c0d9278483298a84c0ffc2d410b7)