### PR TITLE
Improve PersonaPlex synthesis compatibility and audio handling

### DIFF
--- a/bot/routes/voiceCommentary.js
+++ b/bot/routes/voiceCommentary.js
@@ -80,7 +80,7 @@ function resolveSelectedVoice({ catalogVoices = [], inventory, overrideVoiceId, 
 async function synthesizeWithPersonaplex({ text, voiceId, locale, metadata = {} }) {
   const endpoint = process.env.PERSONAPLEX_API_URL;
   const apiKey = process.env.PERSONAPLEX_API_KEY;
-  const synthPath = process.env.PERSONAPLEX_SYNTHESIS_PATH || '/v1/speech/synthesize';
+  const configuredPath = process.env.PERSONAPLEX_SYNTHESIS_PATH || '/v1/speech/synthesize';
   if (!endpoint) {
     throw new Error('PersonaPlex is not configured. Set PERSONAPLEX_API_URL.');
   }
@@ -117,34 +117,73 @@ async function synthesizeWithPersonaplex({ text, voiceId, locale, metadata = {} 
     }
   ];
 
+  const pathCandidates = [
+    configuredPath,
+    '/v1/voice/commentary',
+    '/v1/voice/synthesize',
+    '/v1/audio/speech',
+    '/v1/speech/synthesize'
+  ].filter((path, index, arr) => path && arr.indexOf(path) === index);
+
   let response = null;
   let details = '';
-  for (const body of candidates) {
-    response = await fetch(`${endpoint.replace(/\/$/, '')}${synthPath.startsWith('/') ? synthPath : `/${synthPath}`}`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body)
-    });
+  for (const path of pathCandidates) {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    for (const body of candidates) {
+      response = await fetch(`${endpoint.replace(/\/$/, '')}${normalizedPath}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body)
+      });
 
-    if (response.ok) break;
-    details = await response.text();
-    if (![400, 404, 422].includes(response.status)) {
-      break;
+      if (response.ok) break;
+      details = await response.text();
+      if (![400, 404, 405, 415, 422].includes(response.status)) {
+        break;
+      }
     }
+
+    if (response?.ok) break;
   }
 
   if (!response?.ok) {
     throw new Error(`PersonaPlex synthesis failed (${response.status}): ${details}`);
   }
 
+  const contentType = String(response.headers.get('content-type') || '').toLowerCase();
+  if (contentType.startsWith('audio/')) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    return {
+      provider: 'nvidia-personaplex',
+      audioBase64: buffer.toString('base64'),
+      audioUrl: null,
+      mimeType: contentType,
+      raw: null
+    };
+  }
+
   const payload = await response.json();
-  return {
+  const nestedAudio = payload.audio || payload.synthesis || payload.data || {};
+  const normalized = {
     provider: 'nvidia-personaplex',
-    audioBase64: payload.audioBase64 || payload.audio_base64 || null,
-    audioUrl: payload.audioUrl || payload.audio_url || null,
-    mimeType: payload.mimeType || payload.mime_type || 'audio/mpeg',
+    audioBase64:
+      payload.audioBase64 ||
+      payload.audio_base64 ||
+      nestedAudio.audioBase64 ||
+      nestedAudio.audio_base64 ||
+      nestedAudio.base64 ||
+      nestedAudio.content ||
+      null,
+    audioUrl: payload.audioUrl || payload.audio_url || nestedAudio.audioUrl || nestedAudio.audio_url || nestedAudio.url || null,
+    mimeType: payload.mimeType || payload.mime_type || nestedAudio.mimeType || nestedAudio.mime_type || contentType || 'audio/mpeg',
     raw: payload
   };
+
+  if (!normalized.audioBase64 && !normalized.audioUrl) {
+    throw new Error('PersonaPlex synthesis response did not include audio content');
+  }
+
+  return normalized;
 }
 
 router.get('/catalog', async (_req, res) => {


### PR DESCRIPTION
### Motivation
- PersonaPlex / NVIDIA voice endpoints vary across deployments and sometimes return audio in non-standard shapes or raw `audio/*` responses, which caused commentary to fail or fall back to non-NVIDIA voices. 
- The change aims to make synthesis robust to multiple endpoint paths and payload formats so voice commentary reliably plays the intended NVIDIA/personaplex voices.

### Description
- Try multiple known synthesis paths (configured path plus `/v1/voice/commentary`, `/v1/voice/synthesize`, `/v1/audio/speech`, `/v1/speech/synthesize`) when contacting the PersonaPlex endpoint to improve route compatibility. (updated `bot/routes/voiceCommentary.js`).
- Attempt several candidate request body shapes for compatibility with different PersonaPlex / OSS payload formats.
- Support binary `audio/*` responses by reading the response bytes and converting them to base64 for client playback.
- Broaden JSON parsing to extract audio from nested keys (`audio`, `synthesis`, `data`) and alternate key names (`audioBase64`, `audio_base64`, `base64`, `content`, URL variants). 
- Fail fast with a clear error when synthesis returns success but contains no usable audio payload to avoid silent no-op commentary.

### Testing
- Ran `node --check bot/routes/voiceCommentary.js` to validate there are no syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c0d9278483298a84c0ffc2d410b7)