### PR TITLE
Fix Pool Royale training progression to increase balls per task up to 20

### DIFF
--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -1,4 +1,4 @@
-import { resolvePlayableTrainingLevel } from '../webapp/src/utils/poolRoyaleTrainingProgress.js';
+import { describeTrainingLevel, getTrainingLayout, resolvePlayableTrainingLevel } from '../webapp/src/utils/poolRoyaleTrainingProgress.js';
 
 describe('resolvePlayableTrainingLevel', () => {
   test('caps requested levels to the next incomplete slot', () => {
@@ -14,5 +14,28 @@ describe('resolvePlayableTrainingLevel', () => {
   test('falls back to the last level when every task is already complete', () => {
     const progress = { completed: Array.from({ length: 50 }, (_, i) => i + 1), lastLevel: 4 };
     expect(resolvePlayableTrainingLevel(null, progress)).toBe(4);
+  });
+});
+
+describe('pool royale training layout progression', () => {
+  test('increases object-ball count by one from task 1 to task 20', () => {
+    for (let level = 1; level <= 20; level++) {
+      const layout = getTrainingLayout(level);
+      expect(Array.isArray(layout.balls)).toBe(true);
+      expect(layout.balls.length).toBe(level);
+    }
+  });
+
+  test('keeps 20 object balls from task 21 to task 50', () => {
+    for (let level = 21; level <= 50; level++) {
+      const layout = getTrainingLayout(level);
+      expect(layout.balls.length).toBe(20);
+    }
+  });
+
+  test('does not repeat the same exact rack between early consecutive tasks', () => {
+    const level1 = describeTrainingLevel(1).layout.balls;
+    const level2 = describeTrainingLevel(2).layout.balls;
+    expect(level1).not.toEqual(level2);
   });
 });

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,6 +1,7 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
 const TRAINING_LEVEL_COUNT = 50
 const BASE_ATTEMPTS_PER_LEVEL = 3
+const TRAINING_MAX_LAYOUT_BALLS = 20
 
 const clampLevel = (value, fallback = 1) => {
   const numeric = Number(value)
@@ -29,40 +30,50 @@ const STRATEGY_DRILLS = [
 
 const PATTERN_LIBRARY = [
   [
-    { x: -0.54, z: -0.28 }, { x: -0.38, z: -0.16 }, { x: -0.22, z: -0.04 }, { x: -0.06, z: 0.08 },
-    { x: 0.1, z: 0.2 }, { x: 0.26, z: 0.3 }, { x: 0.43, z: 0.33 }, { x: 0.53, z: 0.12 },
-    { x: 0.41, z: -0.08 }, { x: 0.25, z: -0.2 }, { x: 0.09, z: -0.3 }, { x: -0.09, z: -0.35 },
-    { x: -0.28, z: -0.3 }, { x: -0.45, z: -0.18 }, { x: -0.51, z: 0.02 }
+    { x: -0.56, z: -0.34 }, { x: -0.43, z: -0.24 }, { x: -0.3, z: -0.15 }, { x: -0.16, z: -0.06 },
+    { x: -0.02, z: 0.03 }, { x: 0.12, z: 0.12 }, { x: 0.27, z: 0.2 }, { x: 0.41, z: 0.27 },
+    { x: 0.53, z: 0.14 }, { x: 0.49, z: -0.02 }, { x: 0.36, z: -0.12 }, { x: 0.23, z: -0.22 },
+    { x: 0.08, z: -0.31 }, { x: -0.08, z: -0.33 }, { x: -0.24, z: -0.31 }, { x: -0.38, z: -0.23 },
+    { x: -0.5, z: -0.11 }, { x: -0.52, z: 0.05 }, { x: -0.45, z: 0.19 }, { x: -0.3, z: 0.29 }
   ],
   [
-    { x: -0.5, z: 0.26 }, { x: -0.38, z: 0.12 }, { x: -0.26, z: -0.02 }, { x: -0.14, z: -0.18 },
-    { x: -0.02, z: -0.32 }, { x: 0.13, z: -0.24 }, { x: 0.27, z: -0.12 }, { x: 0.42, z: -0.03 },
-    { x: 0.54, z: 0.14 }, { x: 0.36, z: 0.25 }, { x: 0.18, z: 0.34 }, { x: 0.02, z: 0.27 },
-    { x: -0.17, z: 0.2 }, { x: -0.31, z: 0.32 }, { x: 0.05, z: 0.06 }
+    { x: -0.52, z: 0.3 }, { x: -0.39, z: 0.22 }, { x: -0.25, z: 0.13 }, { x: -0.1, z: 0.04 },
+    { x: 0.04, z: -0.06 }, { x: 0.18, z: -0.15 }, { x: 0.33, z: -0.22 }, { x: 0.48, z: -0.27 },
+    { x: 0.56, z: -0.11 }, { x: 0.5, z: 0.03 }, { x: 0.37, z: 0.12 }, { x: 0.22, z: 0.2 },
+    { x: 0.06, z: 0.28 }, { x: -0.1, z: 0.33 }, { x: -0.26, z: 0.33 }, { x: -0.4, z: 0.28 },
+    { x: -0.51, z: 0.16 }, { x: -0.55, z: 0.01 }, { x: -0.48, z: -0.13 }, { x: -0.33, z: -0.24 }
   ],
   [
-    { x: -0.48, z: -0.01 }, { x: -0.32, z: 0.08 }, { x: -0.32, z: -0.12 }, { x: -0.15, z: 0.18 },
-    { x: -0.15, z: -0.22 }, { x: 0.03, z: 0.27 }, { x: 0.03, z: -0.31 }, { x: 0.19, z: 0.14 },
-    { x: 0.19, z: -0.18 }, { x: 0.34, z: 0.03 }, { x: 0.48, z: 0.2 }, { x: 0.5, z: -0.24 },
-    { x: -0.01, z: -0.06 }, { x: 0.34, z: 0.33 }, { x: -0.47, z: 0.28 }
+    { x: -0.5, z: -0.02 }, { x: -0.36, z: 0.08 }, { x: -0.36, z: -0.12 }, { x: -0.22, z: 0.17 },
+    { x: -0.22, z: -0.21 }, { x: -0.07, z: 0.24 }, { x: -0.07, z: -0.28 }, { x: 0.08, z: 0.3 },
+    { x: 0.08, z: -0.34 }, { x: 0.23, z: 0.23 }, { x: 0.23, z: -0.27 }, { x: 0.37, z: 0.14 },
+    { x: 0.37, z: -0.18 }, { x: 0.49, z: 0.04 }, { x: 0.49, z: -0.05 }, { x: -0.5, z: 0.21 },
+    { x: -0.5, z: -0.24 }, { x: 0.21, z: 0.33 }, { x: 0.21, z: -0.35 }, { x: 0.53, z: 0.24 }
   ],
   [
-    { x: -0.54, z: 0.34 }, { x: -0.38, z: 0.24 }, { x: -0.22, z: 0.16 }, { x: -0.04, z: 0.12 },
-    { x: 0.14, z: 0.08 }, { x: 0.31, z: 0.02 }, { x: 0.47, z: -0.07 }, { x: 0.55, z: -0.22 },
-    { x: 0.37, z: -0.27 }, { x: 0.2, z: -0.3 }, { x: 0.02, z: -0.34 }, { x: -0.16, z: -0.31 },
-    { x: -0.33, z: -0.25 }, { x: -0.49, z: -0.12 }, { x: -0.44, z: 0.07 }
+    { x: -0.56, z: 0.35 }, { x: -0.43, z: 0.28 }, { x: -0.29, z: 0.2 }, { x: -0.14, z: 0.13 },
+    { x: 0.01, z: 0.06 }, { x: 0.16, z: -0.01 }, { x: 0.31, z: -0.08 }, { x: 0.45, z: -0.16 },
+    { x: 0.56, z: -0.27 }, { x: 0.43, z: -0.31 }, { x: 0.28, z: -0.34 }, { x: 0.12, z: -0.35 },
+    { x: -0.04, z: -0.34 }, { x: -0.2, z: -0.3 }, { x: -0.35, z: -0.24 }, { x: -0.49, z: -0.16 },
+    { x: -0.55, z: -0.02 }, { x: -0.52, z: 0.12 }, { x: -0.41, z: 0.22 }, { x: -0.25, z: 0.3 }
   ],
   [
-    { x: -0.45, z: 0.33 }, { x: -0.27, z: 0.31 }, { x: -0.08, z: 0.34 }, { x: 0.11, z: 0.32 },
-    { x: 0.3, z: 0.28 }, { x: 0.47, z: 0.21 }, { x: 0.53, z: 0.01 }, { x: 0.43, z: -0.15 },
-    { x: 0.26, z: -0.25 }, { x: 0.07, z: -0.31 }, { x: -0.11, z: -0.34 }, { x: -0.29, z: -0.3 },
-    { x: -0.46, z: -0.21 }, { x: -0.53, z: -0.03 }, { x: -0.01, z: 0.04 }
+    { x: -0.47, z: 0.34 }, { x: -0.31, z: 0.33 }, { x: -0.15, z: 0.34 }, { x: 0.01, z: 0.34 },
+    { x: 0.17, z: 0.33 }, { x: 0.33, z: 0.29 }, { x: 0.48, z: 0.23 }, { x: 0.56, z: 0.1 },
+    { x: 0.54, z: -0.05 }, { x: 0.46, z: -0.18 }, { x: 0.32, z: -0.27 }, { x: 0.16, z: -0.33 },
+    { x: 0, z: -0.35 }, { x: -0.16, z: -0.35 }, { x: -0.32, z: -0.31 }, { x: -0.46, z: -0.24 },
+    { x: -0.54, z: -0.11 }, { x: -0.55, z: 0.04 }, { x: -0.5, z: 0.18 }, { x: -0.39, z: 0.28 }
   ]
 ]
 
+const getTrainingTargetCount = (level) => {
+  const normalized = clampLevel(level)
+  return normalized <= TRAINING_MAX_LAYOUT_BALLS ? normalized : TRAINING_MAX_LAYOUT_BALLS
+}
+
 const buildTrainingLayout = (level) => {
   const pattern = PATTERN_LIBRARY[(level - 1) % PATTERN_LIBRARY.length] || PATTERN_LIBRARY[0]
-  const targetCount = Math.max(3, Math.min(15, 3 + Math.floor((level - 1) / 2)))
+  const targetCount = getTrainingTargetCount(level)
   const rotated = rotate(pattern, (level * 2) % pattern.length)
   const microShift = ((level % 4) - 1.5) * 0.008
   const balls = rotated.slice(0, targetCount).map((pos, idx) => ({
@@ -79,7 +90,7 @@ const buildTrainingLayout = (level) => {
 
 const buildTrainingDefinition = (level) => {
   const discipline = level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'Pool Position Play'
-  const targetCount = Math.max(3, Math.min(15, 3 + Math.floor((level - 1) / 2)))
+  const targetCount = getTrainingTargetCount(level)
   const strategy = STRATEGY_DRILLS[(level - 1) % STRATEGY_DRILLS.length]
   const rewardAmount = level * 100
   const reward = `${rewardAmount.toLocaleString('en-US')} TPC`


### PR DESCRIPTION
### Motivation
- Restore the intended training progression so each training task increases the number of object balls compared to the previous task up to task 20, then caps at 20 through task 50.
- Prevent early tasks from reusing the same small rack (task 2 matching task 1) by providing more placement slots and stable selection logic.
- Ensure the scene can spawn as many training object-balls as required by the layout (up to 20) instead of being limited to the base rack size.

### Description
- Added `TRAINING_MAX_LAYOUT_BALLS = 20` and a helper `getTrainingTargetCount(level)` in `webapp/src/utils/poolRoyaleTrainingProgress.js` and replaced the old target-count formula with this function so levels 1..20 grow to 1..20 and 21..50 stay at 20.
- Expanded the `PATTERN_LIBRARY` to provide 20 placement slots per pattern so early consecutive tasks produce visually distinct racks.
- Updated `buildTrainingLayout` and `buildTrainingDefinition` to use `getTrainingTargetCount(level)` for layout and objective generation.
- Modified scene spawning and layout application in `webapp/src/pages/Games/PoolRoyale.jsx` to instantiate enough training object-balls (`trainingBallCount = Math.max(rackColors.length, entries.length)`), added a pending-layout mechanism (`pendingTrainingLayoutLevelRef` + `flushPendingTrainingLayout`) and guarded application when ball meshes are not yet ready.
- Added/updated unit tests in `test/poolRoyaleTrainingProgress.test.js` to verify monotonic increase for tasks 1..20, cap at 20 for tasks 21..50, and that early consecutive tasks are not identical.

### Testing
- Ran the unit tests with `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js`, and all tests passed (6/6).
- Started the dev server (`npm --prefix webapp run dev`) and used an automated Playwright script to capture a screenshot of the training layout to validate the change; the run completed and the artifact was produced.
- Confirmed the training layout functions (`describeTrainingLevel` / `getTrainingLayout`) behave as expected via the new tests and local verification, with no failing automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d4dedcd48329924b9421f899b843)