### PR TITLE
Add idempotency to storefront purchases to prevent duplicate TPC deductions

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -17,6 +17,7 @@ const transactionSchema = new mongoose.Schema(
     detail: String,
     category: String,
     txHash: String,
+    requestId: String,
     giftId: String,
     items: {
       type: [

--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -57,7 +57,7 @@ export const BUNDLES = {
 };
 
 router.post('/purchase', authenticate, async (req, res) => {
-  const { accountId, txHash, bundle } = req.body;
+  const { accountId, txHash, bundle, requestId } = req.body;
   const authId = req.auth?.telegramId;
   if (!accountId) {
     return res.status(400).json({ error: 'accountId required' });
@@ -75,6 +75,27 @@ router.post('/purchase', authenticate, async (req, res) => {
   }
 
   if (isItemBundle) {
+    const safeRequestId =
+      typeof requestId === 'string' && requestId.trim()
+        ? requestId.trim().slice(0, 120)
+        : undefined;
+
+    if (safeRequestId) {
+      const existingByRequestId = (user.transactions || []).find(
+        (tx) => tx.type === 'storefront' && tx.requestId === safeRequestId
+      );
+      if (existingByRequestId) {
+        const currentBalance = Number.isFinite(user.balance)
+          ? user.balance
+          : calculateBalance(user);
+        return res.json({
+          alreadyClaimed: true,
+          balance: currentBalance,
+          date: existingByRequestId.date
+        });
+      }
+    }
+
     const rawItems = bundle.items.filter(Boolean);
     if (!rawItems.length) {
       return res.status(400).json({ error: 'items required' });
@@ -109,6 +130,7 @@ router.post('/purchase', authenticate, async (req, res) => {
       status: 'delivered',
       date: txDate,
       detail: 'Storefront purchase',
+      ...(safeRequestId ? { requestId: safeRequestId } : {}),
       items
     };
 
@@ -116,7 +138,22 @@ router.post('/purchase', authenticate, async (req, res) => {
     // and perform an atomic balance check/debit to reduce checkout latency.
     if (totalPrice > 0 && !hasVoiceItem) {
       const updated = await User.findOneAndUpdate(
-        { _id: user._id, balance: { $gte: totalPrice } },
+        {
+          _id: user._id,
+          balance: { $gte: totalPrice },
+          ...(safeRequestId
+            ? {
+                transactions: {
+                  $not: {
+                    $elemMatch: {
+                      type: 'storefront',
+                      requestId: safeRequestId
+                    }
+                  }
+                }
+              }
+            : {})
+        },
         {
           $inc: { balance: -totalPrice },
           $push: { transactions: transaction }
@@ -124,6 +161,22 @@ router.post('/purchase', authenticate, async (req, res) => {
         { new: true, projection: { balance: 1 } }
       );
       if (!updated) {
+        if (safeRequestId) {
+          const reloaded = await User.findById(user._id, {
+            balance: 1,
+            transactions: 1
+          });
+          const existingByRequestId = (reloaded?.transactions || []).find(
+            (tx) => tx.type === 'storefront' && tx.requestId === safeRequestId
+          );
+          if (existingByRequestId) {
+            return res.json({
+              alreadyClaimed: true,
+              balance: reloaded.balance,
+              date: existingByRequestId.date
+            });
+          }
+        }
         return res.status(400).json({ error: 'insufficient balance' });
       }
       return res.json({ balance: updated.balance, date: txDate });


### PR DESCRIPTION
### Motivation
- Storefront checkout retries after client/network timeouts could charge users multiple times because each retry was treated as a new purchase. 
- The transfer flow used elsewhere already handles retries safely; the storefront flow needed equivalent idempotency and atomic checks.

### Description
- Added optional `requestId` support to `POST /store/purchase` and sanitize/limit it to 120 chars before use. 
- Persist `requestId` on transactions by adding `requestId` to the transaction schema in `bot/models/User.js`. 
- Short-circuit requests when an existing `storefront` transaction with the same `requestId` is found and return `alreadyClaimed: true` with the balance and date. 
- Protected the fast-path atomic debit (`findOneAndUpdate`) by adding a `$not: { $elemMatch: { type: 'storefront', requestId } }` clause and reloading the document on contention to detect already-processed requests.

### Testing
- Static syntax checks with `node --check bot/routes/store.js` succeeded. 
- Static syntax checks with `node --check bot/models/User.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995def3ad8c832998f0e80eacdd8423)