### PR TITLE
Harden store TPC purchase flow against timeout retries

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1407,7 +1407,8 @@ export default function Store() {
           price: item.price
         }))
       };
-      const purchase = await buyBundle(resolvedAccountId, bundle);
+      const purchaseId = `store-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+      const purchase = await buyBundle(resolvedAccountId, bundle, purchaseId);
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -704,8 +704,10 @@ export function depositAccount(accountId, amount, extra = {}) {
   );
 }
 
-export function buyBundle(accountId, bundle) {
-  return post('/api/store/purchase', { accountId, bundle });
+export function buyBundle(accountId, bundle, purchaseId) {
+  const body = { accountId, bundle };
+  if (purchaseId) body.purchaseId = purchaseId;
+  return post('/api/store/purchase', body);
 }
 
 export function claimPurchase(accountId, txHash) {


### PR DESCRIPTION
### Motivation
- Store purchases could appear to time out while the server had already debited TPC, making retries unsafe and leaving user balances inconsistent.
- The store checkout needed the same atomic, idempotent debit behavior used for TPC transfers so retries do not double-charge users.

### Description
- Added optional `purchaseId` support to `POST /api/store/purchase` and normalize it to a `requestId` on storefront transactions to act as an idempotency key (`bot/routes/store.js`).
- Switch priced store-item debits to an atomic `findOneAndUpdate` that performs balance check + decrement + transaction push in one operation and rejects duplicate `requestId`s to avoid double-deducts (`bot/routes/store.js`).
- If a retry with the same `purchaseId` is detected, the API now returns `alreadyProcessed` with the stable balance/date instead of charging again (`bot/routes/store.js`).
- Moved voice-language unlock processing to a best-effort async step after the successful debit so the checkout response remains fast, and updated the frontend to generate and include a per-purchase `purchaseId` (`webapp/src/pages/Store.jsx`, `webapp/src/utils/api.js`).

### Testing
- Ran `node --check bot/routes/store.js && node --check webapp/src/utils/api.js` and both files passed syntax checks (success).
- Ran `npx eslint bot/routes/store.js webapp/src/pages/Store.jsx webapp/src/utils/api.js`; linter reported only warnings and the project eslint config currently ignores these files (no blocking errors).
- Ran the repository `npm run -s lint` which fails due to pre-existing, repo-wide lint issues in generated/dist files unrelated to these changes (reported and not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995def3ad8c832998f0e80eacdd8423)