### PR TITLE
Restore Store page to pre-5am state

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -642,6 +642,14 @@ const storeMeta = {
     typeLabels: TYPE_LABELS,
     accountId: POOL_STORE_ACCOUNT_ID
   },
+  tabletennisroyal: {
+    name: 'Table Tennis Royal',
+    items: POOL_ROYALE_STORE_ITEMS,
+    defaults: POOL_ROYALE_DEFAULT_LOADOUT,
+    labels: POOL_ROYALE_OPTION_LABELS,
+    typeLabels: TYPE_LABELS,
+    accountId: POOL_STORE_ACCOUNT_ID
+  },
   snookerroyale: {
     name: 'Snooker Royal',
     items: SNOOKER_ROYALE_STORE_ITEMS,
@@ -868,6 +876,7 @@ export default function Store() {
   const storeItemsBySlug = useMemo(
     () => ({
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'poolroyale' })),
+      tabletennisroyal: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tabletennisroyal' })),
       snookerroyale: SNOOKER_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'snookerroyale' })),
       airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
@@ -883,6 +892,7 @@ export default function Store() {
   const ownedCheckers = useMemo(
     () => ({
       poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
+      tabletennisroyal: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
       snookerroyale: (type, optionId) => isSnookerOptionUnlocked(type, optionId, snookerOwned),
       airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
@@ -898,6 +908,7 @@ export default function Store() {
   const labelResolvers = useMemo(
     () => ({
       poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      tabletennisroyal: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       snookerroyale: (item) => SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
@@ -913,6 +924,7 @@ export default function Store() {
   const typeLabelResolver = useMemo(
     () => ({
       poolroyale: TYPE_LABELS,
+      tabletennisroyal: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
@@ -1407,8 +1419,7 @@ export default function Store() {
           price: item.price
         }))
       };
-      const purchaseId = `store-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
-      const purchase = await buyBundle(resolvedAccountId, bundle, purchaseId);
+      const purchase = await buyBundle(resolvedAccountId, bundle);
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');
@@ -1419,7 +1430,7 @@ export default function Store() {
 
       for (const [slug, group] of Object.entries(groupedBySlug)) {
         for (const entry of group.items) {
-          if (slug === 'poolroyale') {
+          if (slug === 'poolroyale' || slug === 'tabletennisroyal') {
             const updated = await addPoolRoyalUnlock(entry.type, entry.optionId, resolvedAccountId);
             setPoolOwned(updated);
           } else if (slug === 'snookerroyale') {


### PR DESCRIPTION
### Motivation
- The Store page wiring was unintentionally changed during morning edits and needs to be reverted so the store behaves the same as it did at ~5am while keeping item definitions unchanged.

### Description
- Restored `webapp/src/pages/Store.jsx` to the prior store page behavior and wiring while leaving store item data files untouched.
- Reintroduced `tabletennisroyal` mappings into `storeMeta`, `storeItemsBySlug`, `ownedCheckers`, `labelResolvers`, and `typeLabelResolver` so it uses the same option sets as Pool Royale.
- Reverted the purchase flow to call `buyBundle(resolvedAccountId, bundle)` (removed the custom `purchaseId` parameter) and treated `tabletennisroyal` unlocks the same as `poolroyale` when updating inventories.
- Kept all other store item definitions and assets unchanged and scoped the change only to the Store page wiring and purchase/unlock flow.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (warnings only for large chunks but build succeeded).
- Started the dev server with `npm --prefix webapp run dev` and verified the Store UI by taking a Playwright-driven screenshot of the running site, which completed successfully.
- No unit tests were present or run for this change; automated build and basic UI validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ec245f7c8329a7bd0096dc9bc619)