### PR TITLE
Increase Pool Royale training ball progression to 25 and add overflow layout slots

### DIFF
--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -18,18 +18,18 @@ describe('resolvePlayableTrainingLevel', () => {
 });
 
 describe('pool royale training layout progression', () => {
-  test('increases object-ball count by one from task 1 to task 20', () => {
-    for (let level = 1; level <= 20; level++) {
+  test('increases object-ball count by one from task 1 to task 25', () => {
+    for (let level = 1; level <= 25; level++) {
       const layout = getTrainingLayout(level);
       expect(Array.isArray(layout.balls)).toBe(true);
       expect(layout.balls.length).toBe(level);
     }
   });
 
-  test('keeps 20 object balls from task 21 to task 50', () => {
-    for (let level = 21; level <= 50; level++) {
+  test('keeps 25 object balls from task 26 to task 50', () => {
+    for (let level = 26; level <= 50; level++) {
       const layout = getTrainingLayout(level);
-      expect(layout.balls.length).toBe(20);
+      expect(layout.balls.length).toBe(25);
     }
   });
 


### PR DESCRIPTION
### Motivation
- Allow training tasks to scale their target object-ball count up to level 25 instead of stopping at 20 so drills can progress more gradually.
- Ensure layout generation still produces valid ball positions for levels that exceed the original pattern length.

### Description
- Raised the layout cap by changing `TRAINING_MAX_LAYOUT_BALLS` from `20` to `25` in `webapp/src/utils/poolRoyaleTrainingProgress.js`.
- Added `clampLayoutCoord` and `resolveLayoutSlot` helpers to deterministically generate extra ball positions beyond the base pattern when needed.
- Updated `buildTrainingLayout` to use `resolveLayoutSlot` so `balls` are produced for any target count up to the new cap.
- Updated tests in `test/poolRoyaleTrainingProgress.test.js` to expect growth by one ball through task 25 and to assert a 25-ball cap afterwards.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js` and the suite passed with 6 tests (all passing).
- Verified layout progression: tasks 1..25 produce 1..25 object balls respectively, and tasks 26..50 are capped at 25 balls via automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e74b070883299ee8fef7c9f4e560)