### PR TITLE
Fix Pool Royale training ball visibility after early tasks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12634,8 +12634,7 @@ function PoolRoyaleGame({
       const rid = Number.isFinite(entry?.rackIndex)
         ? Math.max(0, Math.floor(entry.rackIndex))
         : idx % Math.max(1, variantConfig?.objectColors?.length || objectBalls.length || 1);
-      const targetBallId = getPoolBallId(variantConfig, rid);
-      const objectBall = balls.find((ball) => ball?.id === targetBallId) || objectBalls[idx];
+      const objectBall = objectBalls[rid] || objectBalls[idx];
       if (!objectBall) return;
       const ballState = stateById.get(objectBall.id);
       const x = normalize(entry?.x, limitX);
@@ -22030,7 +22029,14 @@ const powerRef = useRef(hud.power);
           ? variantConfig.objectColors
           : [];
         const entries = Array.isArray(layout.balls) ? layout.balls : [];
-        const trainingBallCount = Math.max(rackColors.length, entries.length);
+        const maxTrainingTargets = Array.isArray(TRAINING_LEVELS)
+          ? TRAINING_LEVELS.reduce(
+              (maxCount, levelDef) =>
+                Math.max(maxCount, Array.isArray(levelDef?.layout?.balls) ? levelDef.layout.balls.length : 0),
+              0
+            )
+          : 0;
+        const trainingBallCount = Math.max(rackColors.length, entries.length, maxTrainingTargets);
         const spawnedTrainingBalls = [];
         for (let rid = 0; rid < trainingBallCount; rid++) {
           const color = getPoolBallColor(variantConfig, rid);
@@ -22051,10 +22057,7 @@ const powerRef = useRef(hud.power);
           const rid = Number.isFinite(ball?.rackIndex)
             ? Math.max(0, Math.floor(ball.rackIndex))
             : idx % Math.max(1, rackColors.length || 15);
-          const ballId = getPoolBallId(variantConfig, rid);
-          const objectBall =
-            spawnedTrainingBalls.find((entryBall) => entryBall?.id === ballId) ||
-            spawnedTrainingBalls[idx];
+          const objectBall = spawnedTrainingBalls[rid] || spawnedTrainingBalls[idx];
           if (!objectBall) return;
           const px = normalize(ball?.x, limitX);
           const pz = normalize(ball?.z, limitZ);


### PR DESCRIPTION
### Motivation
- Players reported that training balls disappear after early tasks, preventing later tasks from showing targets, so the training system must guarantee enough spawned object balls for the full roadmap.
- The change ensures training layouts map reliably to spawned object balls regardless of variant-specific IDs to avoid mismatches when applying layouts.

### Description
- Precompute the maximum needed training targets from `TRAINING_LEVELS` and include that when determining `trainingBallCount` so we pre-spawn capacity for the largest layout. (updated in `webapp/src/pages/Games/PoolRoyale.jsx`).
- When placing training layouts, use index/rack-slot mapping (`spawnedTrainingBalls[rid]` / `objectBalls[rid]`) instead of searching by ID to avoid variant ID mismatches and ensure consistent placement across levels. (updated in `placeTrainingLayout` and `applyTrainingLayoutForLevel`).
- Keep existing cue placement and snapshot/apply logic intact while making ball spawning and assignment robust for all training levels.

### Testing
- Ran a quick node check `node --input-type=module -e "import { getTrainingLayout } from './webapp/src/utils/poolRoyaleTrainingProgress.js'; const counts=[1,2,3,4,10,25,50].map(l=>({l,c:getTrainingLayout(l).balls.length})); console.log(JSON.stringify(counts));"` which executed successfully and confirmed layout ball counts (level 50 caps at 25). 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed but reported the file is ignored by project lint patterns (no lint errors applied to this file). 
- Started the dev server with `npm --prefix webapp run dev` (Vite started and served the app) and executed a headless Playwright navigation that produced a screenshot artifact at `browser:/tmp/codex_browser_invocations/faae3e283b72aa66/artifacts/artifacts/poolroyale-training-fix.png`, confirming the training page renders with the updated layout logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fcdf6a748329bf47b48af5523e0d)