### PR TITLE
Pool Royale: reduce roadmap to 40 tasks, persist attempts and stabilize training layout loading

### DIFF
--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -12,7 +12,7 @@ describe('resolvePlayableTrainingLevel', () => {
   });
 
   test('falls back to the last level when every task is already complete', () => {
-    const progress = { completed: Array.from({ length: 50 }, (_, i) => i + 1), lastLevel: 4 };
+    const progress = { completed: Array.from({ length: 40 }, (_, i) => i + 1), lastLevel: 4 };
     expect(resolvePlayableTrainingLevel(null, progress)).toBe(4);
   });
 });
@@ -26,8 +26,8 @@ describe('pool royale training layout progression', () => {
     }
   });
 
-  test('keeps 25 object balls from task 26 to task 50', () => {
-    for (let level = 26; level <= 50; level++) {
+  test('keeps 25 object balls from task 26 to task 40', () => {
+    for (let level = 26; level <= 40; level++) {
       const layout = getTrainingLayout(level);
       expect(layout.balls.length).toBe(25);
     }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12454,6 +12454,7 @@ function PoolRoyaleGame({
     tableFinishId
   ]);
   const isTraining = playType === 'training';
+  const trainingLevelCount = TRAINING_LEVELS.length || 1;
   const [trainingMenuOpen, setTrainingMenuOpen] = useState(false);
   const [trainingModeState, setTrainingModeState] = useState('solo');
   const [trainingRulesOn, setTrainingRulesOn] = useState(true);
@@ -12494,7 +12495,10 @@ function PoolRoyaleGame({
     const playableLevel = resolvePlayableTrainingLevel(stored.lastLevel, stored);
     trainingProgressRef.current = stored;
     setTrainingProgress(stored);
-    setTrainingShotsRemaining(Math.max(0, Number(stored?.carryShots) || BASE_ATTEMPTS_PER_LEVEL));
+    const storedCarryShots = Number(stored?.carryShots);
+    setTrainingShotsRemaining(
+      Number.isFinite(storedCarryShots) ? Math.max(0, storedCarryShots) : BASE_ATTEMPTS_PER_LEVEL
+    );
     setTrainingLevel(playableLevel);
   }, []);
   useEffect(() => {
@@ -12510,10 +12514,10 @@ function PoolRoyaleGame({
     const next = getNextIncompleteLevel(trainingProgress?.completed || []);
     if (next != null) return next;
     if (Number.isFinite(trainingProgress?.lastLevel)) {
-      return Math.min(50, Math.max(1, Number(trainingProgress.lastLevel) + 1));
+      return Math.min(trainingLevelCount, Math.max(1, Number(trainingProgress.lastLevel) + 1));
     }
-    return Math.min(50, trainingLevel + 1);
-  }, [trainingProgress?.completed, trainingProgress?.lastLevel, trainingLevel]);
+    return Math.min(trainingLevelCount, trainingLevel + 1);
+  }, [trainingLevelCount, trainingProgress?.completed, trainingProgress?.lastLevel, trainingLevel]);
   const nextTrainingInfo = useMemo(
     () => describeTrainingLevel(nextTrainingLevel ?? trainingLevel),
     [nextTrainingLevel, trainingLevel]
@@ -12538,9 +12542,11 @@ function PoolRoyaleGame({
   }, [isTraining]);
 
   const handleTrainingLevelPick = useCallback((level) => {
-    const levelNum = Math.min(50, Math.max(1, Number(level) || 1));
+    const levelNum = Math.min(trainingLevelCount, Math.max(1, Number(level) || 1));
     const unlockedLevel = resolvePlayableTrainingLevel(levelNum, trainingProgressRef.current);
     if (levelNum > unlockedLevel) return;
+    trainingCompletionHandledRef.current = false;
+    gameOverHandledRef.current = false;
     setTrainingLevel(unlockedLevel);
     setPendingTrainingLevel(null);
     setTrainingRoadmapOpen(false);
@@ -12553,13 +12559,14 @@ function PoolRoyaleGame({
       activePlayer: 'A'
     }));
     setHud((prev) => ({ ...prev, over: false, turn: 0 }));
-  }, []);
+    applyTrainingLayoutForLevel(unlockedLevel);
+  }, [applyTrainingLayoutForLevel, trainingLevelCount]);
 
   const awardTrainingTaskPayout = useCallback(async (level, rewardAmount) => {
     const account = resolvedAccountId;
     const amount = Math.max(0, Number(rewardAmount) || 0);
     if (!account || amount <= 0) return;
-    const safeLevel = Math.max(1, Math.min(50, Number(level) || 1));
+    const safeLevel = Math.max(1, Math.min(trainingLevelCount, Number(level) || 1));
     try {
       const receipt = await depositAccount(account, amount, {
         source: 'pool-royale-training',
@@ -12576,7 +12583,23 @@ function PoolRoyaleGame({
     } catch (error) {
       console.warn('Pool Royale training payout request failed:', error);
     }
-  }, [resolvedAccountId]);
+  }, [resolvedAccountId, trainingLevelCount]);
+
+  const consumeTrainingAttempt = useCallback(() => {
+    setTrainingShotsRemaining((prev) => {
+      const nextShots = Math.max(0, (Number(prev) || 0) - 1);
+      setTrainingProgress((current) => {
+        const updated = {
+          ...(current || {}),
+          carryShots: nextShots
+        };
+        trainingProgressRef.current = updated;
+        persistTrainingProgress(updated);
+        return updated;
+      });
+      return nextShots;
+    });
+  }, []);
 
   const ensureTrainingBallPoolForLayout = useCallback((trainingLayout) => {
     if (!isTraining) return;
@@ -12745,8 +12768,8 @@ function PoolRoyaleGame({
     []
   );
   const unlockedTrainingCap = useMemo(
-    () => resolvePlayableTrainingLevel(50, trainingProgress),
-    [trainingProgress]
+    () => resolvePlayableTrainingLevel(trainingLevelCount, trainingProgress),
+    [trainingLevelCount, trainingProgress]
   );
   const completedTrainingSet = useMemo(
     () => new Set(Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []),
@@ -13923,6 +13946,7 @@ const powerRef = useRef(hud.power);
       const completedSet = new Set(
         (prev?.completed || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
       );
+      const wasCompletedBefore = completedSet.has(completedLevel);
       const rewardedSet = new Set(
         (prev?.rewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
       );
@@ -13931,7 +13955,9 @@ const powerRef = useRef(hud.power);
       const completed = Array.from(completedSet).sort((a, b) => a - b);
       const rewarded = Array.from(rewardedSet).sort((a, b) => a - b);
       const lastLevel = Math.max(prev?.lastLevel ?? 1, completedLevel);
-      const carryShots = Math.max(0, trainingShotsRemaining) + BASE_ATTEMPTS_PER_LEVEL;
+      const carryShots = wasCompletedBefore
+        ? Math.max(0, trainingShotsRemaining)
+        : Math.max(0, trainingShotsRemaining) + BASE_ATTEMPTS_PER_LEVEL;
       const updated = { completed, rewarded, lastLevel, carryShots };
       persistTrainingProgress(updated);
       const nextPlayable = resolvePlayableTrainingLevel(completedLevel + 1, updated);
@@ -13944,7 +13970,7 @@ const powerRef = useRef(hud.power);
     if (shouldAwardReward) {
       awardTrainingTaskPayout(completedLevel, completedRewardAmount);
     }
-  }, [applyTrainingLayoutForLevel, awardTrainingTaskPayout, frameState.frameOver, isTraining, setTrainingProgress, setTrainingLevel, trainingShotsRemaining]);
+  }, [awardTrainingTaskPayout, frameState.frameOver, isTraining, trainingShotsRemaining]);
   const cueBallPlacedFromHandRef = useRef(false);
   const wasInHandRef = useRef(false);
   useEffect(() => {
@@ -26625,7 +26651,7 @@ const powerRef = useRef(hud.power);
           };
         }
         if (isTraining && !safeState?.frameOver && pottedObjectCount === 0) {
-          setTrainingShotsRemaining((prev) => Math.max(0, (Number(prev) || 0) - 1));
+          consumeTrainingAttempt();
         }
         if (!isTraining && cueBallPotted) {
           const nextPlayer = currentState?.activePlayer === 'B' ? 'A' : 'B';
@@ -31080,7 +31106,7 @@ const powerRef = useRef(hud.power);
             </div>
           )}
           <div className="pointer-events-auto rounded-full border border-emerald-300/70 bg-black/65 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100 shadow-[0_10px_24px_rgba(0,0,0,0.45)] backdrop-blur">
-            L{currentTrainingInfo.level} • {completedTrainingCount}/50 done • {trainingShotsRemaining} shots
+            L{currentTrainingInfo.level} • {completedTrainingCount}/{trainingLevelCount} done • {trainingShotsRemaining} shots
           </div>
           <button
             type="button"
@@ -31135,7 +31161,7 @@ const powerRef = useRef(hud.power);
                   onClick={() => setTrainingRoadmapOpen(true)}
                   className="w-full rounded-full border border-emerald-300 bg-emerald-400/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100 transition hover:bg-emerald-400/30"
                 >
-                  Open 50-level roadmap
+                  Open {trainingLevelCount}-level roadmap
                 </button>
               </div>
             </div>
@@ -31149,7 +31175,7 @@ const powerRef = useRef(hud.power);
             <div className="flex items-center justify-between gap-2">
               <div>
                 <p className="text-[11px] uppercase tracking-[0.24em] text-emerald-200">Training roadmap</p>
-                <p className="text-sm text-white/80">{lastCompletedLevel ? `Level ${lastCompletedLevel} cleared.` : 'Track your 50-level progression.'}</p>
+                <p className="text-sm text-white/80">{lastCompletedLevel ? `Level ${lastCompletedLevel} cleared.` : `Track your ${trainingLevelCount}-level progression.`}</p>
               </div>
               <button
                 type="button"

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,5 +1,5 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
-const TRAINING_LEVEL_COUNT = 50
+const TRAINING_LEVEL_COUNT = 40
 const BASE_ATTEMPTS_PER_LEVEL = 3
 const TRAINING_MAX_LAYOUT_BALLS = 25
 
@@ -179,7 +179,10 @@ export function loadTrainingProgress () {
         .sort((a, b) => a - b)
       : []
     const lastLevel = clampLevel(parsed?.lastLevel, 1)
-    const carryShots = Math.max(0, Math.floor(Number(parsed?.carryShots) || BASE_ATTEMPTS_PER_LEVEL))
+    const parsedCarryShots = Number(parsed?.carryShots)
+    const carryShots = Number.isFinite(parsedCarryShots)
+      ? Math.max(0, Math.floor(parsedCarryShots))
+      : BASE_ATTEMPTS_PER_LEVEL
     return { completed, rewarded, lastLevel, carryShots }
   } catch (err) {
     console.warn('Failed to load Pool Royale training progress', err)


### PR DESCRIPTION
### Motivation
- Prevent players from being re-granted training attempts on every login and make the training roadmap stable and consistent in UI and logic.
- Ensure each training task behaves independently so layouts load correctly when previewing/choosing a task and misses consume attempts immediately.

### Description
- Reduced the shared training level constant from 50 to 40 and made various consumers use the dynamic `trainingLevelCount` so progression and UI copy are consistent with the new roadmap size.
- Fixed `carryShots` parsing in `loadTrainingProgress` so a stored `0` is preserved instead of falling back to the base attempts value. 
- Added `consumeTrainingAttempt` to decrement `trainingShotsRemaining` on a training miss and persist the updated progress immediately. 
- Adjusted completion handling to only add bonus attempts on first-time completion (preventing repeated grants) and reset completion/game-over refs and immediately apply the selected layout when picking a roadmap node to reduce frozen/stale previews. 
- Updated the training HUD/menu text and unit tests to reflect the 40-task flow.

### Testing
- Ran the targeted unit test suite with `npm test -- test/poolRoyaleTrainingProgress.test.js --runInBand` and all tests passed. 
- Ran `npx eslint` against the modified files; the standard lint run reported repository ignore warnings, and forcing `--no-ignore` surfaced existing test-file lint issues (Jest globals) unrelated to the behavioral changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960a8bd33083298488630006f5670c)