### PR TITLE
Pool Royale: stabilize training — 40 tasks, layout nudging, per-task attempts & rewards

### DIFF
--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -12,7 +12,7 @@ describe('resolvePlayableTrainingLevel', () => {
   });
 
   test('falls back to the last level when every task is already complete', () => {
-    const progress = { completed: Array.from({ length: 50 }, (_, i) => i + 1), lastLevel: 4 };
+    const progress = { completed: Array.from({ length: 40 }, (_, i) => i + 1), lastLevel: 4 };
     expect(resolvePlayableTrainingLevel(null, progress)).toBe(4);
   });
 });
@@ -26,8 +26,8 @@ describe('pool royale training layout progression', () => {
     }
   });
 
-  test('keeps 25 object balls from task 26 to task 50', () => {
-    for (let level = 26; level <= 50; level++) {
+  test('keeps 25 object balls from task 26 to task 40', () => {
+    for (let level = 26; level <= 40; level++) {
       const layout = getTrainingLayout(level);
       expect(layout.balls.length).toBe(25);
     }
@@ -39,6 +39,22 @@ describe('pool royale training layout progression', () => {
     expect(level1).not.toEqual(level2);
   });
 
+
+  test('avoids overlapping balls so roadmap preview can start', () => {
+    const minDistance = 0.001;
+    for (let level = 1; level <= 40; level++) {
+      const layout = getTrainingLayout(level);
+      const balls = Array.isArray(layout?.balls) ? layout.balls : [];
+      for (let i = 0; i < balls.length; i++) {
+        for (let j = i + 1; j < balls.length; j++) {
+          const dx = Number(balls[i].x) - Number(balls[j].x);
+          const dz = Number(balls[i].z) - Number(balls[j].z);
+          const distance = Math.sqrt((dx * dx) + (dz * dz));
+          expect(distance).toBeGreaterThanOrEqual(minDistance);
+        }
+      }
+    }
+  });
   test('keeps early training balls away from pocket-edge dead zones', () => {
     for (let level = 1; level <= 12; level++) {
       const layout = getTrainingLayout(level);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12454,6 +12454,7 @@ function PoolRoyaleGame({
     tableFinishId
   ]);
   const isTraining = playType === 'training';
+  const TRAINING_TASK_COUNT = TRAINING_LEVELS.length || 40;
   const [trainingMenuOpen, setTrainingMenuOpen] = useState(false);
   const [trainingModeState, setTrainingModeState] = useState('solo');
   const [trainingRulesOn, setTrainingRulesOn] = useState(true);
@@ -12510,10 +12511,10 @@ function PoolRoyaleGame({
     const next = getNextIncompleteLevel(trainingProgress?.completed || []);
     if (next != null) return next;
     if (Number.isFinite(trainingProgress?.lastLevel)) {
-      return Math.min(50, Math.max(1, Number(trainingProgress.lastLevel) + 1));
+      return Math.min(TRAINING_TASK_COUNT, Math.max(1, Number(trainingProgress.lastLevel) + 1));
     }
-    return Math.min(50, trainingLevel + 1);
-  }, [trainingProgress?.completed, trainingProgress?.lastLevel, trainingLevel]);
+    return Math.min(TRAINING_TASK_COUNT, trainingLevel + 1);
+  }, [TRAINING_TASK_COUNT, trainingProgress?.completed, trainingProgress?.lastLevel, trainingLevel]);
   const nextTrainingInfo = useMemo(
     () => describeTrainingLevel(nextTrainingLevel ?? trainingLevel),
     [nextTrainingLevel, trainingLevel]
@@ -12538,10 +12539,15 @@ function PoolRoyaleGame({
   }, [isTraining]);
 
   const handleTrainingLevelPick = useCallback((level) => {
-    const levelNum = Math.min(50, Math.max(1, Number(level) || 1));
+    const levelNum = Math.min(TRAINING_TASK_COUNT, Math.max(1, Number(level) || 1));
     const unlockedLevel = resolvePlayableTrainingLevel(levelNum, trainingProgressRef.current);
     if (levelNum > unlockedLevel) return;
+    aiShotPreviewRef.current = false;
+    aiShotCueViewRef.current = false;
+    setReplayActive(false);
+    setShotActive(false);
     setTrainingLevel(unlockedLevel);
+    setTrainingShotsRemaining(BASE_ATTEMPTS_PER_LEVEL);
     setPendingTrainingLevel(null);
     setTrainingRoadmapOpen(false);
     setTrainingMenuOpen(false);
@@ -12553,13 +12559,13 @@ function PoolRoyaleGame({
       activePlayer: 'A'
     }));
     setHud((prev) => ({ ...prev, over: false, turn: 0 }));
-  }, []);
+  }, [TRAINING_TASK_COUNT]);
 
   const awardTrainingTaskPayout = useCallback(async (level, rewardAmount) => {
     const account = resolvedAccountId;
     const amount = Math.max(0, Number(rewardAmount) || 0);
     if (!account || amount <= 0) return;
-    const safeLevel = Math.max(1, Math.min(50, Number(level) || 1));
+    const safeLevel = Math.max(1, Math.min(TRAINING_TASK_COUNT, Number(level) || 1));
     try {
       const receipt = await depositAccount(account, amount, {
         source: 'pool-royale-training',
@@ -12576,7 +12582,7 @@ function PoolRoyaleGame({
     } catch (error) {
       console.warn('Pool Royale training payout request failed:', error);
     }
-  }, [resolvedAccountId]);
+  }, [TRAINING_TASK_COUNT, resolvedAccountId]);
 
   const ensureTrainingBallPoolForLayout = useCallback((trainingLayout) => {
     if (!isTraining) return;
@@ -12714,6 +12720,7 @@ function PoolRoyaleGame({
         ? Number(pendingTrainingLevel)
         : computedNextLevel;
     setTrainingLevel(nextLevel);
+    setTrainingShotsRemaining(BASE_ATTEMPTS_PER_LEVEL);
     setPendingTrainingLevel(null);
     setTrainingRoadmapOpen(false);
     setTrainingMenuOpen(false);
@@ -12745,8 +12752,8 @@ function PoolRoyaleGame({
     []
   );
   const unlockedTrainingCap = useMemo(
-    () => resolvePlayableTrainingLevel(50, trainingProgress),
-    [trainingProgress]
+    () => resolvePlayableTrainingLevel(TRAINING_TASK_COUNT, trainingProgress),
+    [TRAINING_TASK_COUNT, trainingProgress]
   );
   const completedTrainingSet = useMemo(
     () => new Set(Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []),
@@ -13931,7 +13938,7 @@ const powerRef = useRef(hud.power);
       const completed = Array.from(completedSet).sort((a, b) => a - b);
       const rewarded = Array.from(rewardedSet).sort((a, b) => a - b);
       const lastLevel = Math.max(prev?.lastLevel ?? 1, completedLevel);
-      const carryShots = Math.max(0, trainingShotsRemaining) + BASE_ATTEMPTS_PER_LEVEL;
+      const carryShots = BASE_ATTEMPTS_PER_LEVEL;
       const updated = { completed, rewarded, lastLevel, carryShots };
       persistTrainingProgress(updated);
       const nextPlayable = resolvePlayableTrainingLevel(completedLevel + 1, updated);
@@ -13945,6 +13952,23 @@ const powerRef = useRef(hud.power);
       awardTrainingTaskPayout(completedLevel, completedRewardAmount);
     }
   }, [applyTrainingLayoutForLevel, awardTrainingTaskPayout, frameState.frameOver, isTraining, setTrainingProgress, setTrainingLevel, trainingShotsRemaining]);
+
+  useEffect(() => {
+    if (!isTraining || frameState.frameOver) return;
+    if (trainingShotsRemaining > 0) return;
+    showRuleToast('Attempt ended on miss. Task restarted with 3 fresh attempts.');
+    setTrainingShotsRemaining(BASE_ATTEMPTS_PER_LEVEL);
+    setHud((prev) => ({ ...prev, over: false, turn: 0, inHand: false }));
+    setFrameState((prev) => ({
+      ...prev,
+      frameOver: false,
+      winner: undefined,
+      foul: undefined,
+      activePlayer: 'A'
+    }));
+    applyTrainingLayoutForLevel(trainingLevelRef.current || 1);
+  }, [applyTrainingLayoutForLevel, frameState.frameOver, isTraining, showRuleToast, trainingShotsRemaining]);
+
   const cueBallPlacedFromHandRef = useRef(false);
   const wasInHandRef = useRef(false);
   useEffect(() => {
@@ -31080,7 +31104,7 @@ const powerRef = useRef(hud.power);
             </div>
           )}
           <div className="pointer-events-auto rounded-full border border-emerald-300/70 bg-black/65 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100 shadow-[0_10px_24px_rgba(0,0,0,0.45)] backdrop-blur">
-            L{currentTrainingInfo.level} • {completedTrainingCount}/50 done • {trainingShotsRemaining} shots
+            L{currentTrainingInfo.level} • {completedTrainingCount}/{TRAINING_TASK_COUNT} done • {trainingShotsRemaining} attempts
           </div>
           <button
             type="button"
@@ -31124,7 +31148,7 @@ const powerRef = useRef(hud.power);
                     Next: Level {nextTrainingInfo.level} — {nextTrainingInfo.objective}
                   </p>
                   <p className="mt-1 text-[11px] text-white/60">Discipline: {currentTrainingInfo.discipline}</p>
-                  <p className="mt-1 text-[11px] text-white/60">Attempts bank: {trainingShotsRemaining}</p>
+                  <p className="mt-1 text-[11px] text-white/60">Attempts left for this task: {trainingShotsRemaining}</p>
                   <p className="mt-1 text-[11px] text-white/60">Reward: {currentTrainingInfo.reward}</p>
                 </div>
                 <div className="rounded-xl border border-emerald-400/30 bg-white/5 p-3 text-xs text-white/80">
@@ -31135,7 +31159,7 @@ const powerRef = useRef(hud.power);
                   onClick={() => setTrainingRoadmapOpen(true)}
                   className="w-full rounded-full border border-emerald-300 bg-emerald-400/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100 transition hover:bg-emerald-400/30"
                 >
-                  Open 50-level roadmap
+                  Open training roadmap
                 </button>
               </div>
             </div>
@@ -31149,7 +31173,7 @@ const powerRef = useRef(hud.power);
             <div className="flex items-center justify-between gap-2">
               <div>
                 <p className="text-[11px] uppercase tracking-[0.24em] text-emerald-200">Training roadmap</p>
-                <p className="text-sm text-white/80">{lastCompletedLevel ? `Level ${lastCompletedLevel} cleared.` : 'Track your 50-level progression.'}</p>
+                <p className="text-sm text-white/80">{lastCompletedLevel ? `Level ${lastCompletedLevel} cleared.` : `Track your ${TRAINING_TASK_COUNT}-task progression.`}</p>
               </div>
               <button
                 type="button"

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,7 +1,9 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
-const TRAINING_LEVEL_COUNT = 50
+const TRAINING_LEVEL_COUNT = 40
 const BASE_ATTEMPTS_PER_LEVEL = 3
 const TRAINING_MAX_LAYOUT_BALLS = 25
+const TRAINING_MIN_BALL_SPACING = 0.072
+const TRAINING_CUE_SAFE_RADIUS = 0.11
 
 const clampLevel = (value, fallback = 1) => {
   const numeric = Number(value)
@@ -101,6 +103,38 @@ const resolveLayoutSlot = (pattern, index, level) => {
   }
 }
 
+const nudgeToSafeSlot = (slot, usedSlots, levelSeed, indexSeed) => {
+  const adjusted = { ...slot }
+  const maxPasses = 36
+  const minSpacingSq = TRAINING_MIN_BALL_SPACING * TRAINING_MIN_BALL_SPACING
+  const jitterBase = (levelSeed * 0.91) + (indexSeed * 1.73)
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let overlapFound = false
+    usedSlots.forEach((placed, placedIdx) => {
+      const dx = adjusted.x - placed.x
+      const dz = adjusted.z - placed.z
+      const distanceSq = (dx * dx) + (dz * dz)
+      if (distanceSq >= minSpacingSq) return
+      overlapFound = true
+      const distance = Math.sqrt(distanceSq) || 0.0001
+      const push = (TRAINING_MIN_BALL_SPACING - distance) + 0.003
+      const normalX = dx / distance
+      const normalZ = dz / distance
+      const fallbackAngle = jitterBase + (placedIdx * 0.63) + (pass * 0.27)
+      const pushX = Number.isFinite(normalX) ? normalX : Math.cos(fallbackAngle)
+      const pushZ = Number.isFinite(normalZ) ? normalZ : Math.sin(fallbackAngle)
+      adjusted.x = clampLayoutCoord(adjusted.x + (pushX * push), -0.44, 0.44)
+      adjusted.z = clampLayoutCoord(adjusted.z + (pushZ * push), -0.31, 0.31)
+      if (Math.abs(adjusted.x) > 0.4 && Math.abs(adjusted.z) > 0.24) {
+        adjusted.x = Math.sign(adjusted.x || 1) * 0.39
+        adjusted.z = Math.sign(adjusted.z || 1) * 0.22
+      }
+    })
+    if (!overlapFound) break
+  }
+  return adjusted
+}
+
 const buildTrainingLayout = (level) => {
   const pattern = PATTERN_LIBRARY[(level - 1) % PATTERN_LIBRARY.length] || PATTERN_LIBRARY[0]
   const targetCount = getTrainingTargetCount(level)
@@ -120,10 +154,47 @@ const buildTrainingLayout = (level) => {
       x,
       z
     }
+  }).reduce((acc, slot, idx) => {
+    const nudged = nudgeToSafeSlot(slot, acc, level, idx)
+    acc.push({ ...slot, ...nudged })
+    return acc
+  }, []).map((slot, idx, all) => {
+    let x = slot.x
+    let z = slot.z
+    let guard = 0
+    while (guard < 12) {
+      const duplicated = all.some((other, otherIdx) => {
+        if (otherIdx === idx) return false
+        const dx = x - other.x
+        const dz = z - other.z
+        return (dx * dx) + (dz * dz) < 0.0025
+      })
+      if (!duplicated) break
+      const nudgeAngle = (level * 0.7) + (idx * 1.1) + (guard * 0.53)
+      x = clampLayoutCoord(x + (Math.cos(nudgeAngle) * 0.024), -0.44, 0.44)
+      z = clampLayoutCoord(z + (Math.sin(nudgeAngle) * 0.024), -0.31, 0.31)
+      guard += 1
+    }
+    return { ...slot, x, z }
   })
 
+  const cue = {
+    x: clampLayoutCoord(-0.7 + (level % 5) * 0.045, -0.78, 0.78),
+    z: clampLayoutCoord(0.5 - (level % 6) * 0.065, -0.55, 0.55)
+  }
+
+  const cueTooClose = balls.some((ball) => {
+    const dx = cue.x - ball.x
+    const dz = cue.z - ball.z
+    return (dx * dx) + (dz * dz) < TRAINING_CUE_SAFE_RADIUS * TRAINING_CUE_SAFE_RADIUS
+  })
+  if (cueTooClose) {
+    cue.x = -0.76
+    cue.z = 0
+  }
+
   return {
-    cue: { x: -0.7 + (level % 5) * 0.045, z: 0.5 - (level % 6) * 0.065 },
+    cue,
     balls
   }
 }
@@ -170,12 +241,14 @@ export function loadTrainingProgress () {
       ? parsed.completed
         .map((lvl) => Number(lvl))
         .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+        .map((lvl) => clampLevel(lvl))
         .sort((a, b) => a - b)
       : []
     const rewarded = Array.isArray(parsed?.rewarded)
       ? parsed.rewarded
         .map((lvl) => Number(lvl))
         .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+        .map((lvl) => clampLevel(lvl))
         .sort((a, b) => a - b)
       : []
     const lastLevel = clampLevel(parsed?.lastLevel, 1)


### PR DESCRIPTION
### Motivation
- Reduce training roadmap to a deterministic set of tasks and prevent roadmap preview / training freezes caused by overlapping ball layouts. 
- Make training attempts and payouts behave per-task (one-time reward per task and attempts consumed on misses) instead of banking/awarding on every login. 
- Ensure each task layout reliably places object balls and the cue so training scenes initialize without errors.

### Description
- Reduced the training roadmap to 40 tasks and clamped persisted progress to the valid range in `webapp/src/utils/poolRoyaleTrainingProgress.js` (added `TRAINING_LEVEL_COUNT = 40`).
- Implemented layout-stability logic: added `TRAINING_MIN_BALL_SPACING` and `TRAINING_CUE_SAFE_RADIUS`, a `nudgeToSafeSlot` collision-avoidance pass, a small dedupe/nudge post-pass, and cue-safe repositioning so generated layouts avoid overlaps and pocket-edge dead zones. 
- Normalized persisted progress entries by clamping completed/rewarded levels when loading from storage to avoid out-of-range values. 
- Updated gameplay flow in `webapp/src/pages/Games/PoolRoyale.jsx` to use `TRAINING_TASK_COUNT`, reset per-task attempts to `BASE_ATTEMPTS_PER_LEVEL` when selecting/continuing tasks, clear active preview/ai/replay state before switching tasks, and handle misses by decrementing attempts and resetting the task when attempts reach zero with a toast message. 
- Updated HUD / menu copy to reflect the task count and “attempts left for this task” wording. 
- Extended and adjusted tests in `test/poolRoyaleTrainingProgress.test.js` to validate the 40-task roadmap and to assert layouts avoid overlapping balls.

### Testing
- Ran unit tests for the training progression: `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js` (test file: `test/poolRoyaleTrainingProgress.test.js`), all tests passed. 
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` successfully to smoke-test the app boot. 
- Attempted an automated Playwright screenshot of the training page to visually validate the roadmap, but `page.screenshot` timed out in this environment (Playwright runs timed out), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960a8bd33083298488630006f5670c)