### PR TITLE
fix(voice): enforce PersonaPlex-first synthesis and disable silent fallback

### DIFF
--- a/bot/routes/voiceCommentary.js
+++ b/bot/routes/voiceCommentary.js
@@ -147,9 +147,130 @@ async function synthesizeWithPersonaplex({ text, voiceId, locale, metadata = {} 
   };
 }
 
+async function synthesizeWithPersonaPlexService({ text, voiceId, locale, metadata = {} }) {
+  const endpoint = process.env.PERSONAPLEX_SERVICE_URL || 'http://127.0.0.1:8090';
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}/tts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text,
+      voiceId,
+      personaPrompt: metadata?.personaPrompt,
+      format: 'wav',
+      sampleRate: 22050,
+      locale,
+      metadata
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`PersonaPlex service failed (${response.status}): ${details}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('audio/wav') || contentType.includes('application/octet-stream')) {
+    const audioBuffer = Buffer.from(await response.arrayBuffer());
+    return {
+      provider: 'nvidia-personaplex',
+      audioBase64: audioBuffer.toString('base64'),
+      mimeType: 'audio/wav'
+    };
+  }
+
+  const payload = await response.json();
+  return {
+    provider: 'nvidia-personaplex',
+    audioBase64: payload.audioBase64 || payload.audio_base64 || null,
+    audioUrl: payload.audioUrl || payload.audio_url || null,
+    mimeType: payload.mimeType || payload.mime_type || 'audio/wav',
+    raw: payload
+  };
+}
+
+function resolvePersonaPlexModes() {
+  const configured = String(process.env.PERSONAPLEX_MODE || 'auto').toLowerCase();
+  if (configured === 'service') return ['service'];
+  if (configured === 'remote-api') return ['remote-api'];
+
+  const modes = [];
+  if (process.env.PERSONAPLEX_API_URL) modes.push('remote-api');
+  if (process.env.PERSONAPLEX_SERVICE_URL) modes.push('service');
+  if (!modes.length) modes.push('service');
+  return modes;
+}
+
+
+function allowClientFallback() {
+  return String(process.env.VOICE_ALLOW_CLIENT_FALLBACK || '0') === '1';
+}
+
+async function synthesizeVoice(args) {
+  const provider = String(process.env.VOICE_PROVIDER || 'personaplex').toLowerCase();
+  if (provider !== 'personaplex') {
+    throw new Error('Current provider selected; using client-side speech fallback.');
+  }
+
+  const modes = resolvePersonaPlexModes();
+  let lastError = null;
+  for (const mode of modes) {
+    try {
+      return mode === 'remote-api' ? await synthesizeWithPersonaplex(args) : await synthesizeWithPersonaPlexService(args);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('PersonaPlex synthesis unavailable');
+}
+
+export { synthesizeVoice };
+
 router.get('/catalog', async (_req, res) => {
   const catalog = await getVoiceCatalog();
   res.json({ ...catalog, defaultVoiceId: DEFAULT_FREE_VOICE_ID, storeItems: buildVoiceStoreItems(catalog) });
+});
+
+router.get('/health', async (_req, res) => {
+  const provider = String(process.env.VOICE_PROVIDER || 'personaplex').toLowerCase();
+  if (provider !== 'personaplex') {
+    return res.json({ ok: true, provider: 'current', modelLoaded: false, fallback: 'web-speech' });
+  }
+
+  const modes = resolvePersonaPlexModes();
+
+  if (modes.includes('service')) {
+    try {
+      const endpoint = process.env.PERSONAPLEX_SERVICE_URL || 'http://127.0.0.1:8090';
+      const response = await fetch(`${endpoint.replace(/\/$/, '')}/health`);
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      const payload = await response.json();
+      return res.json({ ok: true, provider: 'personaplex', mode: 'service', ...payload });
+    } catch {
+      // try next mode
+    }
+  }
+
+  if (modes.includes('remote-api') && process.env.PERSONAPLEX_API_URL) {
+    try {
+      const endpoint = process.env.PERSONAPLEX_API_URL;
+      const healthPath = process.env.PERSONAPLEX_HEALTH_PATH || '/health';
+      const headers = {};
+      if (process.env.PERSONAPLEX_API_KEY) {
+        headers.Authorization = `Bearer ${process.env.PERSONAPLEX_API_KEY}`;
+      }
+      const response = await fetch(`${endpoint.replace(/\/$/, '')}${healthPath.startsWith('/') ? healthPath : `/${healthPath}`}`, {
+        headers
+      });
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      const payload = await response.json().catch(() => ({}));
+      return res.json({ ok: true, provider: 'personaplex', mode: 'remote-api', modelLoaded: payload.modelLoaded ?? true });
+    } catch (error) {
+      return res.status(503).json({ ok: false, provider: 'personaplex', mode: 'remote-api', error: error.message });
+    }
+  }
+
+  return res.status(503).json({ ok: false, provider: 'personaplex', error: 'No healthy PersonaPlex mode available' });
 });
 
 router.post('/catalog/refresh', authenticate, async (_req, res) => {
@@ -214,7 +335,7 @@ router.post('/help', async (req, res) => {
 
   const answer = buildHelpAnswer(question);
   try {
-    const synthesis = await synthesizeWithPersonaplex({
+    const synthesis = await synthesizeVoice({
       text: answer,
       voiceId: selected.id,
       locale: selected.locale,
@@ -229,17 +350,20 @@ router.post('/help', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.json({
-      provider: 'web-speech-fallback',
-      voice: selected,
-      answer,
-      warning: `PersonaPlex synthesis unavailable: ${error.message}`
-    });
+    if (allowClientFallback()) {
+      return res.json({
+        provider: 'web-speech-fallback',
+        voice: selected,
+        answer,
+        warning: `PersonaPlex synthesis unavailable: ${error.message}`
+      });
+    }
+    return res.status(503).json({ error: `PersonaPlex synthesis unavailable: ${error.message}` });
   }
 });
 
 router.post('/speak', async (req, res) => {
-  const { text, accountId, voiceId, locale, speaker } = req.body || {};
+  const { text, accountId, voiceId, locale, speaker, personaPrompt, context, gameId } = req.body || {};
   const message = String(text || '').trim();
   if (!message) return res.status(400).json({ error: 'text is required' });
 
@@ -258,13 +382,15 @@ router.post('/speak', async (req, res) => {
   }
 
   try {
-    const synthesis = await synthesizeWithPersonaplex({
+    const synthesis = await synthesizeVoice({
       text: message,
       voiceId: selected.id,
       locale: selected.locale,
       metadata: {
-        channel: 'game_commentary',
-        speaker: String(speaker || 'host')
+        channel: context === 'help' ? 'help_center' : 'game_commentary',
+        speaker: String(speaker || 'host'),
+        gameId: String(gameId || ''),
+        personaPrompt: String(personaPrompt || '')
       }
     });
 
@@ -275,13 +401,16 @@ router.post('/speak', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.json({
-      provider: 'web-speech-fallback',
-      voice: selected,
-      inventory,
-      text: message,
-      warning: `PersonaPlex synthesis unavailable: ${error.message}`
-    });
+    if (allowClientFallback()) {
+      return res.json({
+        provider: 'web-speech-fallback',
+        voice: selected,
+        inventory,
+        text: message,
+        warning: `PersonaPlex synthesis unavailable: ${error.message}`
+      });
+    }
+    return res.status(503).json({ error: `PersonaPlex synthesis unavailable: ${error.message}` });
   }
 });
 

--- a/docs/voice-personaplex.md
+++ b/docs/voice-personaplex.md
@@ -1,0 +1,109 @@
+# PersonaPlex Voice Setup (Strict, No Silent Fallback)
+
+This integration is now configured to prioritize **real PersonaPlex audio output**.
+
+- `VOICE_PROVIDER=personaplex` is required.
+- Browser Web Speech fallback is **disabled by default**.
+- If PersonaPlex is down/misconfigured, API returns an explicit error instead of silently playing another voice.
+
+---
+
+## 1) Install and run PersonaPlex backend (NVIDIA OSS)
+
+Use the official `nvidia/personaplex` project as your synthesis backend.
+
+### Option A — run PersonaPlex directly (recommended if you already have it)
+
+1. Start PersonaPlex server from `nvidia/personaplex` according to upstream docs.
+2. Confirm it exposes synthesis endpoint compatible with:
+   - `POST /v1/speech/synthesize`
+3. Confirm health endpoint:
+   - `GET /health`
+
+### Option B — use your existing PersonaPlex deployment URL
+
+Set:
+
+```bash
+export PERSONAPLEX_API_URL="https://<your-personaplex-host>"
+export PERSONAPLEX_SYNTHESIS_PATH="/v1/speech/synthesize"
+export PERSONAPLEX_HEALTH_PATH="/health"
+# if needed
+export PERSONAPLEX_API_KEY="<token>"
+```
+
+---
+
+## 2) Run local wrapper service (Python)
+
+The wrapper proxies to PersonaPlex and returns `audio/wav`.
+
+```bash
+export PERSONAPLEX_API_URL="https://<your-personaplex-host>"
+export PERSONAPLEX_STRICT_REMOTE=1
+npm run voice:service
+```
+
+Wrapper API:
+
+- `GET /health`
+- `POST /tts` `{ text, voiceId, personaPrompt?, format?, sampleRate?, locale? }`
+
+### Strict mode
+
+- `PERSONAPLEX_STRICT_REMOTE=1` (default): return `503` when PersonaPlex fails.
+- No synthetic tone is generated anymore.
+
+---
+
+## 3) App env configuration (backend + webapp)
+
+Backend (`bot/server.js` process):
+
+```bash
+export VOICE_PROVIDER=personaplex
+export PERSONAPLEX_MODE=service
+export PERSONAPLEX_SERVICE_URL="http://127.0.0.1:8090"
+# keep this 0 unless you explicitly want browser fallback
+export VOICE_ALLOW_CLIENT_FALLBACK=0
+```
+
+Webapp:
+
+```bash
+export VITE_VOICE_PROVIDER=personaplex
+# keep this 0 unless you explicitly want browser fallback
+export VITE_VOICE_ALLOW_FALLBACK=0
+```
+
+---
+
+## 4) Defaults and personas
+
+Configured in `webapp/src/voice/voiceConfig.ts`:
+
+- Help Center voice: `NATF0`
+- Commentary voice: `NATM1`
+- Persona prompts centralized for both contexts.
+
+---
+
+## 5) Verify PersonaPlex is actually used
+
+1. Start PersonaPlex backend.
+2. Start wrapper: `npm run voice:service`.
+3. Check wrapper health:
+   - `curl http://127.0.0.1:8090/health`
+4. Start app API + webapp with env vars above.
+5. Open Help Center and run speak.
+6. Open several Games entries and trigger commentary.
+
+If PersonaPlex fails, you should now get explicit error responses (not hidden Web Speech), which makes setup issues visible and fixable quickly.
+
+---
+
+## 6) Troubleshooting
+
+- **503 from `/api/voice-commentary/speak`**: PersonaPlex endpoint is not reachable or credentials invalid.
+- **`/health` fails**: check `PERSONAPLEX_API_URL` and path envs.
+- **No audio on mobile after success response**: tap once to unlock audio playback (mobile autoplay policy).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "thumbs:pool-table-finishes": "node scripts/generatePoolRoyaleTableFinishThumbs.mjs",
     "help:ingest": "node --loader ts-node/esm packages/ingestion-public/src/cli.ts",
     "help:api": "node --loader ts-node/esm packages/api/src/server.ts",
-    "help:test": "jest test/platformHelpAgent --runInBand"
+    "help:test": "jest test/platformHelpAgent --runInBand",
+    "voice:service": "python3 services/personaplex/service.py"
   },
   "engines": {
     "node": ">=18"

--- a/services/personaplex/service.py
+++ b/services/personaplex/service.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import io
+import json
+import os
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+HOST = os.getenv('PERSONAPLEX_SERVICE_HOST', '0.0.0.0')
+PORT = int(os.getenv('PERSONAPLEX_SERVICE_PORT', '8090'))
+REMOTE_URL = os.getenv('PERSONAPLEX_API_URL', '').rstrip('/')
+REMOTE_PATH = os.getenv('PERSONAPLEX_SYNTHESIS_PATH', '/v1/speech/synthesize')
+HEALTH_PATH = os.getenv('PERSONAPLEX_HEALTH_PATH', '/health')
+REMOTE_KEY = os.getenv('PERSONAPLEX_API_KEY', '')
+STRICT_REMOTE = os.getenv('PERSONAPLEX_STRICT_REMOTE', '1') != '0'
+
+MODEL_LOADED = False
+LAST_ERROR = ''
+
+
+def _remote_endpoint(path: str) -> str:
+  normalized = path if path.startswith('/') else f'/{path}'
+  return f"{REMOTE_URL}{normalized}"
+
+
+def _request_json(url: str, method: str = 'GET', payload: dict | None = None, timeout: int = 45):
+  headers = {
+    'Content-Type': 'application/json'
+  }
+  if REMOTE_KEY:
+    headers['Authorization'] = f'Bearer {REMOTE_KEY}'
+  data = json.dumps(payload).encode('utf-8') if payload is not None else None
+  req = urllib.request.Request(url, data=data, headers=headers, method=method)
+  with urllib.request.urlopen(req, timeout=timeout) as res:
+    body = res.read()
+    content_type = res.headers.get('Content-Type', '')
+  return content_type, body
+
+
+def call_remote_tts(payload: dict) -> bytes:
+  global MODEL_LOADED, LAST_ERROR
+  if not REMOTE_URL:
+    raise RuntimeError('PERSONAPLEX_API_URL is not configured')
+
+  text = str(payload.get('text') or '').strip()
+  if not text:
+    raise RuntimeError('text is required')
+
+  tts_payload_candidates = [
+    {
+      'input': text,
+      'voice': payload.get('voiceId', 'NATF0'),
+      'locale': payload.get('locale'),
+      'metadata': {
+        'personaPrompt': payload.get('personaPrompt') or '',
+        **(payload.get('metadata') or {})
+      }
+    },
+    {
+      'text': text,
+      'voice_id': payload.get('voiceId', 'NATF0'),
+      'language': payload.get('locale'),
+      'metadata': {
+        'personaPrompt': payload.get('personaPrompt') or '',
+        **(payload.get('metadata') or {})
+      }
+    }
+  ]
+
+  final_error = None
+  for req_payload in tts_payload_candidates:
+    try:
+      content_type, body = _request_json(_remote_endpoint(REMOTE_PATH), method='POST', payload=req_payload)
+      MODEL_LOADED = True
+      LAST_ERROR = ''
+      if 'audio/wav' in content_type or 'application/octet-stream' in content_type:
+        return body
+      parsed = json.loads(body.decode('utf-8')) if body else {}
+      audio_base64 = parsed.get('audioBase64') or parsed.get('audio_base64')
+      if audio_base64:
+        return base64.b64decode(audio_base64)
+      raise RuntimeError('PersonaPlex response missing wav payload')
+    except Exception as err:
+      final_error = err
+
+  LAST_ERROR = str(final_error or 'PersonaPlex synthesis failed')
+  raise RuntimeError(LAST_ERROR)
+
+
+def probe_remote_health() -> tuple[bool, dict]:
+  global MODEL_LOADED, LAST_ERROR
+  if not REMOTE_URL:
+    return False, {'ok': False, 'error': 'PERSONAPLEX_API_URL is not configured'}
+  try:
+    content_type, body = _request_json(_remote_endpoint(HEALTH_PATH), method='GET', payload=None, timeout=20)
+    parsed = json.loads(body.decode('utf-8')) if 'json' in content_type and body else {}
+    MODEL_LOADED = bool(parsed.get('modelLoaded', MODEL_LOADED))
+    LAST_ERROR = ''
+    return True, {
+      'ok': True,
+      'provider': 'personaplex',
+      'modelLoaded': MODEL_LOADED,
+      'remote': _remote_endpoint(HEALTH_PATH)
+    }
+  except Exception as err:
+    LAST_ERROR = str(err)
+    return False, {'ok': False, 'provider': 'personaplex', 'error': LAST_ERROR}
+
+
+class Handler(BaseHTTPRequestHandler):
+  def _json(self, status: int, body: dict):
+    encoded = json.dumps(body).encode('utf-8')
+    self.send_response(status)
+    self.send_header('Content-Type', 'application/json')
+    self.send_header('Content-Length', str(len(encoded)))
+    self.end_headers()
+    self.wfile.write(encoded)
+
+  def do_GET(self):
+    if self.path != '/health':
+      self._json(404, {'ok': False, 'error': 'not found'})
+      return
+    healthy, payload = probe_remote_health()
+    if healthy:
+      self._json(200, payload)
+    else:
+      self._json(503, payload)
+
+  def do_POST(self):
+    if self.path != '/tts':
+      self._json(404, {'ok': False, 'error': 'not found'})
+      return
+    content_len = int(self.headers.get('Content-Length', '0'))
+    raw = self.rfile.read(content_len) if content_len > 0 else b'{}'
+    payload = json.loads(raw.decode('utf-8'))
+
+    try:
+      wav_data = call_remote_tts(payload)
+    except Exception as err:
+      if STRICT_REMOTE:
+        self._json(503, {'ok': False, 'provider': 'personaplex', 'error': str(err)})
+        return
+      self._json(503, {'ok': False, 'provider': 'personaplex', 'error': str(err), 'strictRemote': False})
+      return
+
+    self.send_response(200)
+    self.send_header('Content-Type', 'audio/wav')
+    self.send_header('Content-Length', str(len(wav_data)))
+    self.end_headers()
+    self.wfile.write(wav_data)
+
+
+def main():
+  parser = argparse.ArgumentParser(description='PersonaPlex wrapper service')
+  parser.add_argument('--check', action='store_true', help='perform health check and exit')
+  args = parser.parse_args()
+
+  if args.check:
+    healthy, payload = probe_remote_health()
+    print(json.dumps(payload))
+    raise SystemExit(0 if healthy else 1)
+
+  server = HTTPServer((HOST, PORT), Handler)
+  print(f'PersonaPlex wrapper listening on http://{HOST}:{PORT} (strict={STRICT_REMOTE})')
+  server.serve_forever()
+
+
+if __name__ == '__main__':
+  main()

--- a/test/personaplexServiceSmoke.test.js
+++ b/test/personaplexServiceSmoke.test.js
@@ -1,0 +1,86 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const WAV_BASE64 =
+  'UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA=';
+
+async function waitForHealth(url, timeoutMs = 10000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // retry
+    }
+    await wait(200);
+  }
+  throw new Error('health endpoint was not reachable in time');
+}
+
+describe('personaplex wrapper smoke', () => {
+  let proc;
+  let remoteServer;
+
+  beforeAll(async () => {
+    remoteServer = http.createServer((req, res) => {
+      if (req.url === '/health' && req.method === 'GET') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, modelLoaded: true }));
+        return;
+      }
+
+      if (req.url === '/v1/speech/synthesize' && req.method === 'POST') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ audioBase64: WAV_BASE64, mimeType: 'audio/wav' }));
+        return;
+      }
+
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: false }));
+    });
+
+    await new Promise((resolve) => remoteServer.listen(18091, resolve));
+
+    proc = spawn('python3', ['services/personaplex/service.py'], {
+      env: {
+        ...process.env,
+        PERSONAPLEX_SERVICE_PORT: '8092',
+        PERSONAPLEX_API_URL: 'http://127.0.0.1:18091',
+        PERSONAPLEX_STRICT_REMOTE: '1'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    await waitForHealth('http://127.0.0.1:8092/health');
+  });
+
+  afterAll(async () => {
+    if (proc) proc.kill('SIGTERM');
+    if (remoteServer) {
+      await new Promise((resolve) => remoteServer.close(resolve));
+    }
+  });
+
+  test('health is reachable and model is loaded', async () => {
+    const res = await fetch('http://127.0.0.1:8092/health');
+    expect(res.ok).toBe(true);
+    const payload = await res.json();
+    expect(payload.ok).toBe(true);
+    expect(payload.modelLoaded).toBe(true);
+  });
+
+  test('tts returns wav header from remote personaplex payload', async () => {
+    const res = await fetch('http://127.0.0.1:8092/tts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'short commentary line', voiceId: 'NATM1', format: 'wav' })
+    });
+    expect(res.ok).toBe(true);
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(buf.subarray(8, 12).toString('ascii')).toBe('WAVE');
+  });
+});

--- a/test/voiceProviderFallback.test.js
+++ b/test/voiceProviderFallback.test.js
@@ -1,0 +1,43 @@
+import { synthesizeVoice } from '../bot/routes/voiceCommentary.js';
+
+describe('voice provider fallback behavior', () => {
+  const priorProvider = process.env.VOICE_PROVIDER;
+  const priorMode = process.env.PERSONAPLEX_MODE;
+  const priorApi = process.env.PERSONAPLEX_API_URL;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    process.env.VOICE_PROVIDER = priorProvider;
+    process.env.PERSONAPLEX_MODE = priorMode;
+    process.env.PERSONAPLEX_API_URL = priorApi;
+    global.fetch = originalFetch;
+  });
+
+  test('uses current-provider fallback path when VOICE_PROVIDER=current', async () => {
+    process.env.VOICE_PROVIDER = 'current';
+    await expect(
+      synthesizeVoice({ text: 'hello', voiceId: 'NATF0', locale: 'en-US', metadata: {} })
+    ).rejects.toThrow('Current provider selected');
+  });
+
+  test('auto mode uses remote api when configured', async () => {
+    process.env.VOICE_PROVIDER = 'personaplex';
+    process.env.PERSONAPLEX_MODE = 'auto';
+    process.env.PERSONAPLEX_API_URL = 'https://personaplex.example';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ audioBase64: 'UklGRg==', mimeType: 'audio/wav' })
+    });
+
+    const result = await synthesizeVoice({
+      text: 'hello',
+      voiceId: 'NATF0',
+      locale: 'en-US',
+      metadata: {}
+    });
+
+    expect(result.provider).toBe('nvidia-personaplex');
+    expect(global.fetch).toHaveBeenCalled();
+  });
+});

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,4 +1,4 @@
-import { post } from './api.js'
+import { speakWithVoiceProvider, stopVoicePlayback } from '../voice/voiceProviderFactory.ts'
 
 let commentarySupport = true
 const listeners = new Set()
@@ -19,11 +19,6 @@ const emitSupport = (supported) => {
       // no-op
     }
   })
-}
-
-const getCurrentAccountId = () => {
-  if (typeof window === 'undefined') return 'guest'
-  return window.localStorage.getItem('accountId') || 'guest'
 }
 
 const unlockAudioPlayback = async () => {
@@ -50,43 +45,6 @@ const unlockAudioPlayback = async () => {
   await unlockPromise
 }
 
-const playAudioPayload = async (payload) => {
-  const synthesis = payload?.synthesis || {}
-  const audioUrl = synthesis.audioUrl
-  const audioBase64 = synthesis.audioBase64
-  const mimeType = synthesis.mimeType || 'audio/mpeg'
-  if (!audioUrl && !audioBase64) {
-    throw new Error('PersonaPlex response missing audio payload')
-  }
-
-  await unlockAudioPlayback()
-
-  const source = audioUrl || `data:${mimeType};base64,${audioBase64}`
-  const audio = new Audio(source)
-  await new Promise((resolve, reject) => {
-    const onDone = () => {
-      audio.removeEventListener('ended', onDone)
-      audio.removeEventListener('error', onError)
-      resolve()
-    }
-    const onError = () => {
-      audio.removeEventListener('ended', onDone)
-      audio.removeEventListener('error', onError)
-      reject(new Error('Audio playback failed'))
-    }
-    audio.addEventListener('ended', onDone)
-    audio.addEventListener('error', onError)
-    audio.play().catch(async (error) => {
-      if ((error && error.name === 'NotAllowedError') || !audioUnlocked) {
-        await unlockAudioPlayback()
-        audio.play().catch(onError)
-        return
-      }
-      onError()
-    })
-  })
-}
-
 export const installSpeechSynthesisUnlock = () => {
   if (typeof window === 'undefined') return
   const onUserGesture = () => {
@@ -99,7 +57,8 @@ export const installSpeechSynthesisUnlock = () => {
   })
 }
 
-export const getSpeechSynthesis = () => null
+export const getSpeechSynthesis = () =>
+  typeof window !== 'undefined' && window.speechSynthesis ? window.speechSynthesis : null
 
 export const getSpeechSupport = () =>
   commentarySupport &&
@@ -120,66 +79,11 @@ export const primeSpeechSynthesis = () => {
 
 export const resolveVoiceForSpeaker = () => null
 
-const pickSpeechSynthesisVoice = (hints = []) => {
-  if (typeof window === 'undefined' || !window.speechSynthesis) return null
-  const voices = window.speechSynthesis.getVoices?.() || []
-  if (!voices.length) return null
-
-  const normalizedHints = hints.map((hint) => String(hint || '').toLowerCase()).filter(Boolean)
-  for (const hint of normalizedHints) {
-    const byLang = voices.find((voice) => String(voice.lang || '').toLowerCase() === hint)
-    if (byLang) return byLang
-    const byPrefix = voices.find((voice) => String(voice.lang || '').toLowerCase().startsWith(`${hint}-`))
-    if (byPrefix) return byPrefix
-    const byName = voices.find((voice) => String(voice.name || '').toLowerCase().includes(hint))
-    if (byName) return byName
-  }
-
-  return voices.find((voice) => voice.default) || voices[0]
-}
-
-const speakWithBrowserTts = async (text, hints = []) => {
-  if (
-    typeof window === 'undefined' ||
-    !window.speechSynthesis ||
-    !window.SpeechSynthesisUtterance ||
-    !String(text || '').trim()
-  ) {
-    throw new Error('Web Speech is unavailable')
-  }
-
-  await unlockAudioPlayback()
-
-  await new Promise((resolve, reject) => {
-    const utterance = new window.SpeechSynthesisUtterance(String(text || '').trim())
-    const preferredVoice = pickSpeechSynthesisVoice(hints)
-    if (preferredVoice) {
-      utterance.voice = preferredVoice
-      if (preferredVoice.lang) utterance.lang = preferredVoice.lang
-    }
-
-    utterance.rate = 1
-    utterance.pitch = 1
-    utterance.volume = 1
-    utterance.onend = () => resolve()
-    utterance.onerror = () => reject(new Error('Web Speech playback failed'))
-
-    try {
-      window.speechSynthesis.cancel()
-      window.speechSynthesis.speak(utterance)
-    } catch {
-      reject(new Error('Web Speech playback failed'))
-    }
-  })
-}
-
 export const speakCommentaryLines = async (
   lines,
-  { voiceHints = {}, speakerSettings = {} } = {}
+  { voiceHints = {}, speakerSettings = {}, context = 'commentary', gameId } = {}
 ) => {
   if (!Array.isArray(lines) || !lines.length || typeof window === 'undefined') return
-
-  const accountId = getCurrentAccountId()
 
   for (const line of lines) {
     const text = String(line?.text || '').trim()
@@ -187,31 +91,22 @@ export const speakCommentaryLines = async (
 
     const speaker = line?.speaker || 'Host'
     const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : []
-    const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')))
-
-    const payload = await post('/api/voice-commentary/speak', {
-      accountId,
-      text,
-      speaker,
-      locale: localeHint,
-      style: speakerSettings[speaker] || null
-    })
-
-    if (payload?.error) {
-      emitSupport(false)
-      throw new Error(payload.error)
-    }
 
     try {
-      if (payload?.provider === 'web-speech-fallback' || !payload?.synthesis?.audioUrl && !payload?.synthesis?.audioBase64) {
-        await speakWithBrowserTts(payload?.text || text, hints)
-      } else {
-        await playAudioPayload(payload)
-      }
+      await speakWithVoiceProvider(text, {
+        context,
+        gameId,
+        persona: speakerSettings[speaker] || undefined,
+        hints
+      })
       emitSupport(true)
     } catch (error) {
       emitSupport(false)
       throw error
     }
   }
+}
+
+export const cancelSpeechQueue = () => {
+  stopVoicePlayback()
 }

--- a/webapp/src/utils/voiceHelpAssistant.js
+++ b/webapp/src/utils/voiceHelpAssistant.js
@@ -1,5 +1,7 @@
 import { post } from './api.js';
 import { primeSpeechSynthesis } from './textToSpeech.js';
+import { speakWithVoiceProvider } from '../voice/voiceProviderFactory.ts';
+import { PERSONA_DEFAULTS } from '../voice/voiceConfig.ts';
 
 const SPEECH_RECOGNITION =
   typeof window !== 'undefined'
@@ -25,31 +27,22 @@ function speakWithWebSpeech(text, locale = 'en-US') {
 
 async function playSynthesis(payload, locale = 'en-US') {
   primeSpeechSynthesis();
-  const synthesis = payload?.synthesis || {};
   const fallbackText = payload?.answer || payload?.text || '';
-  const source = synthesis.audioUrl || (synthesis.audioBase64 ? `data:${synthesis.mimeType || 'audio/mpeg'};base64,${synthesis.audioBase64}` : '');
-  if (!source) {
-    await speakWithWebSpeech(fallbackText, locale);
-    return;
-  }
-  const audio = new Audio(source);
-  await new Promise((resolve) => {
-    const finish = () => {
-      audio.removeEventListener('ended', finish);
-      audio.removeEventListener('error', fail);
-      resolve();
-    };
-    const fail = () => {
-      audio.removeEventListener('ended', finish);
-      audio.removeEventListener('error', fail);
-      resolve();
-    };
-    audio.addEventListener('ended', finish);
-    audio.addEventListener('error', fail);
-    audio.play().catch(fail);
-  });
-  if (payload?.provider === 'web-speech-fallback' && fallbackText) {
-    await speakWithWebSpeech(fallbackText, locale);
+  if (!fallbackText) return;
+  try {
+    await speakWithVoiceProvider(fallbackText, {
+      context: 'help',
+      voiceId: payload?.voice?.id || PERSONA_DEFAULTS.help.voiceId,
+      persona: PERSONA_DEFAULTS.help.persona,
+      hints: [locale]
+    });
+  } catch {
+    const allowFallback = String(import.meta.env.VITE_VOICE_ALLOW_FALLBACK || '0') === '1';
+    if (allowFallback) {
+      await speakWithWebSpeech(fallbackText, locale);
+      return;
+    }
+    throw new Error('PersonaPlex help synthesis failed and fallback is disabled');
   }
 }
 

--- a/webapp/src/voice/VoiceProvider.ts
+++ b/webapp/src/voice/VoiceProvider.ts
@@ -1,0 +1,13 @@
+export type VoiceSpeakOptions = {
+  voiceId: string;
+  persona?: string;
+  context?: 'help' | 'commentary';
+  gameId?: string;
+  hints?: string[];
+};
+
+export interface VoiceProvider {
+  speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement>;
+  stop(): void;
+  healthCheck?(): Promise<boolean>;
+}

--- a/webapp/src/voice/providers/CurrentVoiceProvider.ts
+++ b/webapp/src/voice/providers/CurrentVoiceProvider.ts
@@ -1,0 +1,70 @@
+import type { VoiceProvider, VoiceSpeakOptions } from '../VoiceProvider';
+
+const pickSpeechSynthesisVoice = (hints: string[] = []) => {
+  if (typeof window === 'undefined' || !window.speechSynthesis) return null;
+  const voices = window.speechSynthesis.getVoices?.() || [];
+  if (!voices.length) return null;
+
+  const normalizedHints = hints.map((hint) => String(hint || '').toLowerCase()).filter(Boolean);
+  for (const hint of normalizedHints) {
+    const byLang = voices.find((voice) => String(voice.lang || '').toLowerCase() === hint);
+    if (byLang) return byLang;
+    const byPrefix = voices.find((voice) => String(voice.lang || '').toLowerCase().startsWith(`${hint}-`));
+    if (byPrefix) return byPrefix;
+    const byName = voices.find((voice) => String(voice.name || '').toLowerCase().includes(hint));
+    if (byName) return byName;
+  }
+
+  return voices.find((voice) => voice.default) || voices[0] || null;
+};
+
+export class CurrentVoiceProvider implements VoiceProvider {
+  private currentAudio: HTMLAudioElement | null = null;
+
+  async speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement> {
+    if (
+      typeof window === 'undefined' ||
+      !window.speechSynthesis ||
+      !window.SpeechSynthesisUtterance ||
+      !String(text || '').trim()
+    ) {
+      throw new Error('Web Speech is unavailable');
+    }
+
+    const utterance = new window.SpeechSynthesisUtterance(String(text || '').trim());
+    const preferredVoice = pickSpeechSynthesisVoice(opts.hints || []);
+    if (preferredVoice) {
+      utterance.voice = preferredVoice;
+      if (preferredVoice.lang) utterance.lang = preferredVoice.lang;
+    }
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    utterance.volume = 1;
+
+    const audio = new Audio();
+    await new Promise<void>((resolve, reject) => {
+      utterance.onend = () => resolve();
+      utterance.onerror = () => reject(new Error('Web Speech playback failed'));
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    });
+
+    this.currentAudio = audio;
+    return audio;
+  }
+
+  stop() {
+    if (typeof window !== 'undefined' && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.currentTime = 0;
+      this.currentAudio = null;
+    }
+  }
+
+  async healthCheck() {
+    return typeof window !== 'undefined' && typeof window.SpeechSynthesisUtterance !== 'undefined';
+  }
+}

--- a/webapp/src/voice/providers/PersonaPlexVoiceProvider.ts
+++ b/webapp/src/voice/providers/PersonaPlexVoiceProvider.ts
@@ -1,0 +1,100 @@
+import { post } from '../../utils/api.js';
+import type { VoiceProvider, VoiceSpeakOptions } from '../VoiceProvider';
+import { VOICE_CACHE_PREFIX } from '../voiceConfig';
+
+const memoryCache = new Map<string, string>();
+
+const makeCacheKey = (text: string, opts: VoiceSpeakOptions) =>
+  [opts.voiceId, opts.persona || '', opts.context || '', opts.gameId || '', text].join('::');
+
+const loadCachedAudio = (key: string): string | null => {
+  if (memoryCache.has(key)) return memoryCache.get(key) || null;
+  if (typeof window === 'undefined') return null;
+  const local = window.localStorage.getItem(`${VOICE_CACHE_PREFIX}:${key}`);
+  if (local) {
+    memoryCache.set(key, local);
+    return local;
+  }
+  return null;
+};
+
+const storeCachedAudio = (key: string, source: string) => {
+  memoryCache.set(key, source);
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(`${VOICE_CACHE_PREFIX}:${key}`, source);
+    } catch {
+      // ignore quota failures
+    }
+  }
+};
+
+export class PersonaPlexVoiceProvider implements VoiceProvider {
+  private currentAudio: HTMLAudioElement | null = null;
+
+  async speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement> {
+    const normalizedText = String(text || '').trim();
+    if (!normalizedText) throw new Error('text is required');
+
+    const key = makeCacheKey(normalizedText, opts);
+    const cachedSource = loadCachedAudio(key);
+    const source = cachedSource || (await this.fetchAudioSource(normalizedText, opts));
+    if (!cachedSource) storeCachedAudio(key, source);
+
+    const audio = new Audio(source);
+    this.currentAudio = audio;
+    await new Promise<void>((resolve, reject) => {
+      const done = () => {
+        audio.removeEventListener('ended', done);
+        audio.removeEventListener('error', fail);
+        resolve();
+      };
+      const fail = () => {
+        audio.removeEventListener('ended', done);
+        audio.removeEventListener('error', fail);
+        reject(new Error('Audio playback failed'));
+      };
+      audio.addEventListener('ended', done);
+      audio.addEventListener('error', fail);
+      audio.play().catch(fail);
+    });
+
+    return audio;
+  }
+
+  private async fetchAudioSource(text: string, opts: VoiceSpeakOptions): Promise<string> {
+    const accountId = typeof window === 'undefined' ? 'guest' : window.localStorage.getItem('accountId') || 'guest';
+    const payload = await post('/api/voice-commentary/speak', {
+      accountId,
+      text,
+      voiceId: opts.voiceId,
+      personaPrompt: opts.persona,
+      gameId: opts.gameId,
+      context: opts.context
+    });
+
+    const synthesis = payload?.synthesis || {};
+    if (synthesis.audioUrl) return synthesis.audioUrl;
+    if (synthesis.audioBase64) {
+      return `data:${synthesis.mimeType || 'audio/wav'};base64,${synthesis.audioBase64}`;
+    }
+    throw new Error(payload?.warning || payload?.error || 'PersonaPlex response missing audio payload');
+  }
+
+  stop() {
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.currentTime = 0;
+      this.currentAudio = null;
+    }
+  }
+
+  async healthCheck() {
+    try {
+      const response = await fetch('/api/voice-commentary/health');
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/webapp/src/voice/voiceConfig.ts
+++ b/webapp/src/voice/voiceConfig.ts
@@ -1,0 +1,16 @@
+export type VoiceContext = 'help' | 'commentary';
+
+export const VOICE_PROVIDER = (import.meta.env.VITE_VOICE_PROVIDER || 'personaplex').toLowerCase();
+
+export const PERSONA_DEFAULTS: Record<VoiceContext, { voiceId: string; persona: string }> = {
+  help: {
+    voiceId: 'NATF0',
+    persona: 'Concise, helpful, instructional tone. Keep guidance practical and clear.'
+  },
+  commentary: {
+    voiceId: 'NATM1',
+    persona: 'Energetic game commentator style. Keep lines short, exciting, and easy to follow.'
+  }
+};
+
+export const VOICE_CACHE_PREFIX = 'tonplaygram.voice.cache.v1';

--- a/webapp/src/voice/voiceProviderFactory.ts
+++ b/webapp/src/voice/voiceProviderFactory.ts
@@ -1,0 +1,75 @@
+import type { VoiceProvider, VoiceSpeakOptions } from './VoiceProvider';
+import { PERSONA_DEFAULTS, VOICE_PROVIDER } from './voiceConfig';
+import { CurrentVoiceProvider } from './providers/CurrentVoiceProvider';
+import { PersonaPlexVoiceProvider } from './providers/PersonaPlexVoiceProvider';
+
+let activeProvider: VoiceProvider | null = null;
+let queue: Array<{ text: string; opts: VoiceSpeakOptions; resolve: () => void; reject: (error: Error) => void }> = [];
+let speaking = false;
+
+const ensureProvider = (): VoiceProvider => {
+  if (activeProvider) return activeProvider;
+  activeProvider = VOICE_PROVIDER === 'personaplex' ? new PersonaPlexVoiceProvider() : new CurrentVoiceProvider();
+  return activeProvider;
+};
+
+const next = async () => {
+  if (speaking || !queue.length) return;
+  speaking = true;
+  const item = queue.shift();
+  if (!item) {
+    speaking = false;
+    return;
+  }
+
+  try {
+    const provider = ensureProvider();
+    await provider.speak(item.text, item.opts);
+    item.resolve();
+  } catch (error) {
+    const allowFallback = String(import.meta.env.VITE_VOICE_ALLOW_FALLBACK || '0') === '1';
+    if (VOICE_PROVIDER === 'personaplex' && allowFallback) {
+      try {
+        const fallback = new CurrentVoiceProvider();
+        await fallback.speak(item.text, item.opts);
+        item.resolve();
+      } catch (fallbackError) {
+        item.reject(fallbackError as Error);
+      }
+    } else {
+      item.reject(error as Error);
+    }
+  } finally {
+    speaking = false;
+    if (queue.length) void next();
+  }
+};
+
+export const speakWithVoiceProvider = (text: string, opts: Partial<VoiceSpeakOptions> = {}) => {
+  const context = opts.context || 'commentary';
+  const defaults = PERSONA_DEFAULTS[context];
+  const mergedOpts: VoiceSpeakOptions = {
+    context,
+    voiceId: opts.voiceId || defaults.voiceId,
+    persona: opts.persona || defaults.persona,
+    gameId: opts.gameId,
+    hints: opts.hints || []
+  };
+
+  return new Promise<void>((resolve, reject) => {
+    queue.push({ text, opts: mergedOpts, resolve, reject });
+    void next();
+  });
+};
+
+export const stopVoicePlayback = () => {
+  queue = [];
+  speaking = false;
+  ensureProvider().stop();
+};
+
+export const checkVoiceProviderHealth = async () => {
+  const provider = ensureProvider();
+  if (typeof provider.healthCheck === 'function') return provider.healthCheck();
+  return true;
+};


### PR DESCRIPTION
### Motivation
- PersonaPlex audio was being silently masked by browser Web Speech or a generated tone when the PersonaPlex backend was misconfigured or down, making failures invisible and preventing verification that real PersonaPlex audio is used. 
- The goal is to make PersonaPlex the authoritative source for TTS and to surface explicit errors when PersonaPlex is unavailable so setup issues can be diagnosed and fixed.

### Description
- Implemented a strict PersonaPlex wrapper service at `services/personaplex/service.py` that proxies to a configured `PERSONAPLEX_API_URL`, probes remote health, supports multiple request payload shapes, and returns explicit `503` errors on synthesis failures (configurable via `PERSONAPLEX_STRICT_REMOTE`).
- Updated backend routes in `bot/routes/voiceCommentary.js` to use a unified `synthesizeVoice()` flow, add `resolvePersonaPlexModes()` and a `VOICE_ALLOW_CLIENT_FALLBACK` toggle (default off), make `/health` perform real service/remote-api checks, and return `503` when PersonaPlex is unavailable unless fallback is explicitly enabled.
- Frontend changes introduce a `VoiceProvider` abstraction and concrete providers (`PersonaPlexVoiceProvider`, `CurrentVoiceProvider`), a queued `voiceProviderFactory` with opt-in fallback controlled via `VITE_VOICE_ALLOW_FALLBACK`, and updated help/commentary playback to use the provider API; voice defaults and caching are in `webapp/src/voice/*` and `voiceConfig.ts`.
- Documentation and tooling: added `docs/voice-personaplex.md` with PersonaPlex-first setup and troubleshooting steps and added an npm script `voice:service` to run the local wrapper (`python3 services/personaplex/service.py`).

### Testing
- Ran focused Jest suites: `test/personaplexServiceSmoke.test.js` and `test/voiceProviderFallback.test.js` via `npm test -- --runInBand test/voiceProviderFallback.test.js test/personaplexServiceSmoke.test.js`, and both test suites passed. 
- The smoke test boots a mock remote PersonaPlex server and the Python wrapper and verifies `/health` and `/tts` return a valid WAV payload, and the fallback/auto resolution test verifies `auto` mode uses the remote API when `PERSONAPLEX_API_URL` is set; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e32e43548329aaafef7955ebb181)