### PR TITLE
fix(voice): enforce PersonaPlex-first synthesis and remove silent fallbacks

### DIFF
--- a/bot/routes/voiceCommentary.js
+++ b/bot/routes/voiceCommentary.js
@@ -147,9 +147,110 @@ async function synthesizeWithPersonaplex({ text, voiceId, locale, metadata = {} 
   };
 }
 
+async function synthesizeWithPersonaPlexService({ text, voiceId, locale, metadata = {} }) {
+  const endpoint = process.env.PERSONAPLEX_SERVICE_URL || 'http://127.0.0.1:8090';
+  const response = await fetch(`${endpoint.replace(/\/$/, '')}/tts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text,
+      voiceId,
+      personaPrompt: metadata?.personaPrompt,
+      format: 'wav',
+      sampleRate: 22050,
+      locale,
+      metadata
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`PersonaPlex service failed (${response.status}): ${details}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('audio/wav') || contentType.includes('application/octet-stream')) {
+    const audioBuffer = Buffer.from(await response.arrayBuffer());
+    return {
+      provider: 'nvidia-personaplex',
+      audioBase64: audioBuffer.toString('base64'),
+      mimeType: 'audio/wav'
+    };
+  }
+
+  const payload = await response.json();
+  return {
+    provider: 'nvidia-personaplex',
+    audioBase64: payload.audioBase64 || payload.audio_base64 || null,
+    audioUrl: payload.audioUrl || payload.audio_url || null,
+    mimeType: payload.mimeType || payload.mime_type || 'audio/wav',
+    raw: payload
+  };
+}
+
+function resolvePersonaPlexModes() {
+  const configured = String(process.env.PERSONAPLEX_MODE || 'auto').toLowerCase();
+  if (configured === 'service') return ['service'];
+  if (configured === 'remote-api') return ['remote-api'];
+
+  const modes = [];
+  if (process.env.PERSONAPLEX_API_URL) modes.push('remote-api');
+  if (process.env.PERSONAPLEX_SERVICE_URL) modes.push('service');
+  if (!modes.length) modes.push('service');
+  return modes;
+}
+
+async function synthesizeVoice(args) {
+  const provider = String(process.env.VOICE_PROVIDER || 'personaplex').toLowerCase();
+  if (provider !== 'personaplex') {
+    throw new Error('Current provider selected; using client-side speech fallback.');
+  }
+
+  const modes = resolvePersonaPlexModes();
+  let lastError = null;
+  for (const mode of modes) {
+    try {
+      return mode === 'remote-api' ? await synthesizeWithPersonaplex(args) : await synthesizeWithPersonaPlexService(args);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('PersonaPlex synthesis unavailable');
+}
+
+export { synthesizeVoice };
+
 router.get('/catalog', async (_req, res) => {
   const catalog = await getVoiceCatalog();
   res.json({ ...catalog, defaultVoiceId: DEFAULT_FREE_VOICE_ID, storeItems: buildVoiceStoreItems(catalog) });
+});
+
+router.get('/health', async (_req, res) => {
+  const provider = String(process.env.VOICE_PROVIDER || 'personaplex').toLowerCase();
+  if (provider !== 'personaplex') {
+    return res.json({ ok: true, provider: 'current', modelLoaded: false, fallback: 'web-speech' });
+  }
+
+  const modes = resolvePersonaPlexModes();
+
+  if (modes.includes('service')) {
+    try {
+      const endpoint = process.env.PERSONAPLEX_SERVICE_URL || 'http://127.0.0.1:8090';
+      const response = await fetch(`${endpoint.replace(/\/$/, '')}/health`);
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      const payload = await response.json();
+      return res.json({ ok: true, provider: 'personaplex', mode: 'service', ...payload });
+    } catch {
+      // try next mode
+    }
+  }
+
+  if (modes.includes('remote-api') && process.env.PERSONAPLEX_API_URL) {
+    return res.json({ ok: true, provider: 'personaplex', mode: 'remote-api', modelLoaded: true });
+  }
+
+  return res.status(503).json({ ok: false, provider: 'personaplex', error: 'No healthy PersonaPlex mode available' });
 });
 
 router.post('/catalog/refresh', authenticate, async (_req, res) => {
@@ -214,7 +315,7 @@ router.post('/help', async (req, res) => {
 
   const answer = buildHelpAnswer(question);
   try {
-    const synthesis = await synthesizeWithPersonaplex({
+    const synthesis = await synthesizeVoice({
       text: answer,
       voiceId: selected.id,
       locale: selected.locale,
@@ -229,17 +330,15 @@ router.post('/help', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.json({
-      provider: 'web-speech-fallback',
-      voice: selected,
-      answer,
-      warning: `PersonaPlex synthesis unavailable: ${error.message}`
+    return res.status(503).json({
+      error: `PersonaPlex synthesis unavailable: ${error.message}`,
+      provider: 'nvidia-personaplex'
     });
   }
 });
 
 router.post('/speak', async (req, res) => {
-  const { text, accountId, voiceId, locale, speaker } = req.body || {};
+  const { text, accountId, voiceId, locale, speaker, personaPrompt, context, gameId } = req.body || {};
   const message = String(text || '').trim();
   if (!message) return res.status(400).json({ error: 'text is required' });
 
@@ -258,13 +357,15 @@ router.post('/speak', async (req, res) => {
   }
 
   try {
-    const synthesis = await synthesizeWithPersonaplex({
+    const synthesis = await synthesizeVoice({
       text: message,
       voiceId: selected.id,
       locale: selected.locale,
       metadata: {
-        channel: 'game_commentary',
-        speaker: String(speaker || 'host')
+        channel: context === 'help' ? 'help_center' : 'game_commentary',
+        speaker: String(speaker || 'host'),
+        gameId: String(gameId || ''),
+        personaPrompt: String(personaPrompt || '')
       }
     });
 
@@ -275,12 +376,9 @@ router.post('/speak', async (req, res) => {
       synthesis
     });
   } catch (error) {
-    return res.json({
-      provider: 'web-speech-fallback',
-      voice: selected,
-      inventory,
-      text: message,
-      warning: `PersonaPlex synthesis unavailable: ${error.message}`
+    return res.status(503).json({
+      error: `PersonaPlex synthesis unavailable: ${error.message}`,
+      provider: 'nvidia-personaplex'
     });
   }
 });

--- a/docs/voice-personaplex.md
+++ b/docs/voice-personaplex.md
@@ -1,0 +1,86 @@
+# PersonaPlex Voice Integration (Strict Mode)
+
+This setup is now **PersonaPlex-first**. When `VOICE_PROVIDER=personaplex`, the app should play PersonaPlex audio, not browser fallback audio.
+
+## 1) Install PersonaPlex model/runtime (official open-source flow)
+
+From NVIDIA PersonaPlex README (`nvidia/personaplex`):
+
+```bash
+sudo apt install -y libopus-dev
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install moshi/.
+```
+
+Accept the HF model license for `nvidia/personaplex-7b-v1`, then:
+
+```bash
+export HF_TOKEN="<your_huggingface_token>"
+```
+
+## 2) Run PersonaPlex server (upstream)
+
+```bash
+SSL_DIR=$(mktemp -d)
+python -m moshi.server --ssl "$SSL_DIR"
+```
+
+If VRAM is low:
+
+```bash
+python -m moshi.server --ssl "$SSL_DIR" --cpu-offload
+```
+
+## 3) Run this repo’s wrapper service
+
+Wrapper script:
+
+```bash
+npm run voice:service
+```
+
+Required env vars for wrapper:
+
+```bash
+export PERSONAPLEX_API_URL="https://<moshi-server-host>:8998"
+export PERSONAPLEX_API_KEY=""              # set only if your gateway needs auth
+export PERSONAPLEX_SYNTHESIS_PATH="/v1/speech/synthesize"
+export PERSONAPLEX_HEALTH_PATH="/health"
+```
+
+Wrapper endpoints:
+- `GET /health`
+- `POST /tts` with `{ text, voiceId, personaPrompt?, format?: "wav", sampleRate? }`
+
+## 4) App env vars (strict PersonaPlex)
+
+Backend (`bot/server.js`):
+
+```bash
+export VOICE_PROVIDER=personaplex
+export PERSONAPLEX_MODE=service
+export PERSONAPLEX_SERVICE_URL="http://127.0.0.1:8090"
+```
+
+Webapp build:
+
+```bash
+export VITE_VOICE_PROVIDER=personaplex
+```
+
+## 5) Behavior guarantees in current code
+
+- `/api/voice-commentary/help` and `/api/voice-commentary/speak` return **503** when PersonaPlex synthesis fails.
+- No synthetic tone fallback in the wrapper.
+- No automatic browser Web Speech fallback when PersonaPlex provider is selected.
+
+## 6) Troubleshooting
+
+- If you hear no voice, check these in order:
+  1. `curl http://127.0.0.1:8090/health`
+  2. `curl -X POST http://127.0.0.1:8090/tts -H 'content-type: application/json' -d '{"text":"test","voiceId":"NATM1"}' --output /tmp/test.wav`
+  3. Confirm API env uses `VOICE_PROVIDER=personaplex`.
+  4. Confirm webapp env uses `VITE_VOICE_PROVIDER=personaplex`.
+- Mobile autoplay requires one user tap to unlock audio output.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "thumbs:pool-table-finishes": "node scripts/generatePoolRoyaleTableFinishThumbs.mjs",
     "help:ingest": "node --loader ts-node/esm packages/ingestion-public/src/cli.ts",
     "help:api": "node --loader ts-node/esm packages/api/src/server.ts",
-    "help:test": "jest test/platformHelpAgent --runInBand"
+    "help:test": "jest test/platformHelpAgent --runInBand",
+    "voice:service": "python3 services/personaplex/service.py"
   },
   "engines": {
     "node": ">=18"

--- a/services/personaplex/service.py
+++ b/services/personaplex/service.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import base64
+import json
+import os
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+HOST = os.getenv('PERSONAPLEX_SERVICE_HOST', '0.0.0.0')
+PORT = int(os.getenv('PERSONAPLEX_SERVICE_PORT', '8090'))
+REMOTE_URL = os.getenv('PERSONAPLEX_API_URL', '').rstrip('/')
+REMOTE_PATH = os.getenv('PERSONAPLEX_SYNTHESIS_PATH', '/v1/speech/synthesize')
+REMOTE_HEALTH_PATH = os.getenv('PERSONAPLEX_HEALTH_PATH', '/health')
+REMOTE_KEY = os.getenv('PERSONAPLEX_API_KEY', '')
+MODEL_LOADED = False
+LAST_ERROR = None
+
+
+def build_remote_request(payload: dict) -> list[dict]:
+  text = str(payload.get('text', '')).strip()
+  voice_id = str(payload.get('voiceId', 'NATF0')).strip() or 'NATF0'
+  persona_prompt = payload.get('personaPrompt') or ''
+  metadata = payload.get('metadata') or {}
+
+  return [
+    {
+      'input': text,
+      'voice': voice_id,
+      'metadata': {'personaPrompt': persona_prompt, **metadata}
+    },
+    {
+      'text': text,
+      'voice_id': voice_id,
+      'metadata': {'personaPrompt': persona_prompt, **metadata}
+    },
+    {
+      'input': {'text': text},
+      'voice': {'id': voice_id},
+      'metadata': {'personaPrompt': persona_prompt, **metadata}
+    }
+  ]
+
+
+def call_remote_tts(payload: dict) -> bytes:
+  global MODEL_LOADED, LAST_ERROR
+  if not REMOTE_URL:
+    raise RuntimeError('PERSONAPLEX_API_URL is not configured')
+
+  headers = {
+    'Content-Type': 'application/json',
+    **({'Authorization': f'Bearer {REMOTE_KEY}'} if REMOTE_KEY else {})
+  }
+
+  last_error = None
+  for body in build_remote_request(payload):
+    req = urllib.request.Request(
+      f"{REMOTE_URL}{REMOTE_PATH if REMOTE_PATH.startswith('/') else '/' + REMOTE_PATH}",
+      data=json.dumps(body).encode('utf-8'),
+      headers=headers,
+      method='POST'
+    )
+
+    try:
+      with urllib.request.urlopen(req, timeout=60) as res:
+        content_type = res.headers.get('Content-Type', '')
+        response_body = res.read()
+    except Exception as error:
+      last_error = error
+      continue
+
+    if 'audio/wav' in content_type or 'application/octet-stream' in content_type:
+      MODEL_LOADED = True
+      LAST_ERROR = None
+      return response_body
+
+    parsed = json.loads(response_body.decode('utf-8')) if response_body else {}
+    audio_base64 = parsed.get('audioBase64') or parsed.get('audio_base64')
+    if audio_base64:
+      MODEL_LOADED = True
+      LAST_ERROR = None
+      return base64.b64decode(audio_base64)
+
+    last_error = RuntimeError('PersonaPlex response missing wav payload')
+
+  LAST_ERROR = str(last_error) if last_error else 'unknown error'
+  raise RuntimeError(f'PersonaPlex synthesis failed: {LAST_ERROR}')
+
+
+def check_remote_health() -> tuple[bool, str]:
+  if not REMOTE_URL:
+    return False, 'PERSONAPLEX_API_URL is not configured'
+  headers = {
+    **({'Authorization': f'Bearer {REMOTE_KEY}'} if REMOTE_KEY else {})
+  }
+  req = urllib.request.Request(
+    f"{REMOTE_URL}{REMOTE_HEALTH_PATH if REMOTE_HEALTH_PATH.startswith('/') else '/' + REMOTE_HEALTH_PATH}",
+    headers=headers,
+    method='GET'
+  )
+  try:
+    with urllib.request.urlopen(req, timeout=15) as res:
+      if 200 <= res.status < 300:
+        return True, 'ok'
+      return False, f'status {res.status}'
+  except Exception as error:
+    return False, str(error)
+
+
+class Handler(BaseHTTPRequestHandler):
+  def _json(self, status: int, body: dict):
+    encoded = json.dumps(body).encode('utf-8')
+    self.send_response(status)
+    self.send_header('Content-Type', 'application/json')
+    self.send_header('Content-Length', str(len(encoded)))
+    self.end_headers()
+    self.wfile.write(encoded)
+
+  def do_GET(self):
+    if self.path != '/health':
+      self._json(404, {'ok': False, 'error': 'not found'})
+      return
+
+    remote_ok, detail = check_remote_health()
+    status = 200 if remote_ok else 503
+    self._json(status, {
+      'ok': remote_ok,
+      'provider': 'personaplex',
+      'modelLoaded': MODEL_LOADED,
+      'remoteConfigured': bool(REMOTE_URL),
+      'remoteHealth': detail,
+      'lastError': LAST_ERROR
+    })
+
+  def do_POST(self):
+    if self.path != '/tts':
+      self._json(404, {'ok': False, 'error': 'not found'})
+      return
+
+    content_len = int(self.headers.get('Content-Length', '0'))
+    raw = self.rfile.read(content_len) if content_len > 0 else b'{}'
+    try:
+      payload = json.loads(raw.decode('utf-8'))
+    except json.JSONDecodeError:
+      self._json(400, {'ok': False, 'error': 'invalid json'})
+      return
+
+    text = str(payload.get('text', '')).strip()
+    if not text:
+      self._json(400, {'ok': False, 'error': 'text is required'})
+      return
+
+    try:
+      wav_data = call_remote_tts(payload)
+    except Exception as error:
+      self._json(503, {'ok': False, 'error': str(error)})
+      return
+
+    self.send_response(200)
+    self.send_header('Content-Type', 'audio/wav')
+    self.send_header('Content-Length', str(len(wav_data)))
+    self.end_headers()
+    self.wfile.write(wav_data)
+
+
+def main():
+  server = HTTPServer((HOST, PORT), Handler)
+  print(f'PersonaPlex wrapper listening on http://{HOST}:{PORT}')
+  server.serve_forever()
+
+
+if __name__ == '__main__':
+  main()

--- a/test/personaplexServiceSmoke.test.js
+++ b/test/personaplexServiceSmoke.test.js
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForHealth(url, timeoutMs = 12000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // retry
+    }
+    await wait(200);
+  }
+  throw new Error('health endpoint was not reachable in time');
+}
+
+const MINIMAL_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA=';
+
+describe('personaplex wrapper smoke', () => {
+  let proc;
+  let remote;
+
+  beforeAll(async () => {
+    remote = http.createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      if (req.url === '/v1/speech/synthesize' && req.method === 'POST') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ audioBase64: MINIMAL_WAV_BASE64, mimeType: 'audio/wav' }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    await new Promise((resolve) => remote.listen(18093, '127.0.0.1', resolve));
+
+    proc = spawn('python3', ['services/personaplex/service.py'], {
+      env: {
+        ...process.env,
+        PERSONAPLEX_SERVICE_PORT: '8092',
+        PERSONAPLEX_API_URL: 'http://127.0.0.1:18093',
+        PERSONAPLEX_SYNTHESIS_PATH: '/v1/speech/synthesize',
+        PERSONAPLEX_HEALTH_PATH: '/health'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    await waitForHealth('http://127.0.0.1:8092/health');
+  });
+
+  afterAll(async () => {
+    if (proc) proc.kill('SIGTERM');
+    if (remote) await new Promise((resolve) => remote.close(resolve));
+  });
+
+  test('health is reachable', async () => {
+    const res = await fetch('http://127.0.0.1:8092/health');
+    expect(res.ok).toBe(true);
+    const payload = await res.json();
+    expect(payload.ok).toBe(true);
+  });
+
+  test('tts returns wav header', async () => {
+    const res = await fetch('http://127.0.0.1:8092/tts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'short commentary line', voiceId: 'NATM1', format: 'wav' })
+    });
+    expect(res.ok).toBe(true);
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.subarray(0, 4).toString('ascii')).toBe('RIFF');
+    expect(buf.subarray(8, 12).toString('ascii')).toBe('WAVE');
+  });
+});

--- a/test/voiceProviderFallback.test.js
+++ b/test/voiceProviderFallback.test.js
@@ -1,0 +1,43 @@
+import { synthesizeVoice } from '../bot/routes/voiceCommentary.js';
+
+describe('voice provider fallback behavior', () => {
+  const priorProvider = process.env.VOICE_PROVIDER;
+  const priorMode = process.env.PERSONAPLEX_MODE;
+  const priorApi = process.env.PERSONAPLEX_API_URL;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    process.env.VOICE_PROVIDER = priorProvider;
+    process.env.PERSONAPLEX_MODE = priorMode;
+    process.env.PERSONAPLEX_API_URL = priorApi;
+    global.fetch = originalFetch;
+  });
+
+  test('uses current-provider fallback path when VOICE_PROVIDER=current', async () => {
+    process.env.VOICE_PROVIDER = 'current';
+    await expect(
+      synthesizeVoice({ text: 'hello', voiceId: 'NATF0', locale: 'en-US', metadata: {} })
+    ).rejects.toThrow('Current provider selected');
+  });
+
+  test('auto mode uses remote api when configured', async () => {
+    process.env.VOICE_PROVIDER = 'personaplex';
+    process.env.PERSONAPLEX_MODE = 'auto';
+    process.env.PERSONAPLEX_API_URL = 'https://personaplex.example';
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ audioBase64: 'UklGRg==', mimeType: 'audio/wav' })
+    });
+
+    const result = await synthesizeVoice({
+      text: 'hello',
+      voiceId: 'NATF0',
+      locale: 'en-US',
+      metadata: {}
+    });
+
+    expect(result.provider).toBe('nvidia-personaplex');
+    expect(global.fetch).toHaveBeenCalled();
+  });
+});

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -1,4 +1,4 @@
-import { post } from './api.js'
+import { speakWithVoiceProvider, stopVoicePlayback } from '../voice/voiceProviderFactory.ts'
 
 let commentarySupport = true
 const listeners = new Set()
@@ -19,11 +19,6 @@ const emitSupport = (supported) => {
       // no-op
     }
   })
-}
-
-const getCurrentAccountId = () => {
-  if (typeof window === 'undefined') return 'guest'
-  return window.localStorage.getItem('accountId') || 'guest'
 }
 
 const unlockAudioPlayback = async () => {
@@ -50,43 +45,6 @@ const unlockAudioPlayback = async () => {
   await unlockPromise
 }
 
-const playAudioPayload = async (payload) => {
-  const synthesis = payload?.synthesis || {}
-  const audioUrl = synthesis.audioUrl
-  const audioBase64 = synthesis.audioBase64
-  const mimeType = synthesis.mimeType || 'audio/mpeg'
-  if (!audioUrl && !audioBase64) {
-    throw new Error('PersonaPlex response missing audio payload')
-  }
-
-  await unlockAudioPlayback()
-
-  const source = audioUrl || `data:${mimeType};base64,${audioBase64}`
-  const audio = new Audio(source)
-  await new Promise((resolve, reject) => {
-    const onDone = () => {
-      audio.removeEventListener('ended', onDone)
-      audio.removeEventListener('error', onError)
-      resolve()
-    }
-    const onError = () => {
-      audio.removeEventListener('ended', onDone)
-      audio.removeEventListener('error', onError)
-      reject(new Error('Audio playback failed'))
-    }
-    audio.addEventListener('ended', onDone)
-    audio.addEventListener('error', onError)
-    audio.play().catch(async (error) => {
-      if ((error && error.name === 'NotAllowedError') || !audioUnlocked) {
-        await unlockAudioPlayback()
-        audio.play().catch(onError)
-        return
-      }
-      onError()
-    })
-  })
-}
-
 export const installSpeechSynthesisUnlock = () => {
   if (typeof window === 'undefined') return
   const onUserGesture = () => {
@@ -99,7 +57,8 @@ export const installSpeechSynthesisUnlock = () => {
   })
 }
 
-export const getSpeechSynthesis = () => null
+export const getSpeechSynthesis = () =>
+  typeof window !== 'undefined' && window.speechSynthesis ? window.speechSynthesis : null
 
 export const getSpeechSupport = () =>
   commentarySupport &&
@@ -120,66 +79,11 @@ export const primeSpeechSynthesis = () => {
 
 export const resolveVoiceForSpeaker = () => null
 
-const pickSpeechSynthesisVoice = (hints = []) => {
-  if (typeof window === 'undefined' || !window.speechSynthesis) return null
-  const voices = window.speechSynthesis.getVoices?.() || []
-  if (!voices.length) return null
-
-  const normalizedHints = hints.map((hint) => String(hint || '').toLowerCase()).filter(Boolean)
-  for (const hint of normalizedHints) {
-    const byLang = voices.find((voice) => String(voice.lang || '').toLowerCase() === hint)
-    if (byLang) return byLang
-    const byPrefix = voices.find((voice) => String(voice.lang || '').toLowerCase().startsWith(`${hint}-`))
-    if (byPrefix) return byPrefix
-    const byName = voices.find((voice) => String(voice.name || '').toLowerCase().includes(hint))
-    if (byName) return byName
-  }
-
-  return voices.find((voice) => voice.default) || voices[0]
-}
-
-const speakWithBrowserTts = async (text, hints = []) => {
-  if (
-    typeof window === 'undefined' ||
-    !window.speechSynthesis ||
-    !window.SpeechSynthesisUtterance ||
-    !String(text || '').trim()
-  ) {
-    throw new Error('Web Speech is unavailable')
-  }
-
-  await unlockAudioPlayback()
-
-  await new Promise((resolve, reject) => {
-    const utterance = new window.SpeechSynthesisUtterance(String(text || '').trim())
-    const preferredVoice = pickSpeechSynthesisVoice(hints)
-    if (preferredVoice) {
-      utterance.voice = preferredVoice
-      if (preferredVoice.lang) utterance.lang = preferredVoice.lang
-    }
-
-    utterance.rate = 1
-    utterance.pitch = 1
-    utterance.volume = 1
-    utterance.onend = () => resolve()
-    utterance.onerror = () => reject(new Error('Web Speech playback failed'))
-
-    try {
-      window.speechSynthesis.cancel()
-      window.speechSynthesis.speak(utterance)
-    } catch {
-      reject(new Error('Web Speech playback failed'))
-    }
-  })
-}
-
 export const speakCommentaryLines = async (
   lines,
-  { voiceHints = {}, speakerSettings = {} } = {}
+  { voiceHints = {}, speakerSettings = {}, context = 'commentary', gameId } = {}
 ) => {
   if (!Array.isArray(lines) || !lines.length || typeof window === 'undefined') return
-
-  const accountId = getCurrentAccountId()
 
   for (const line of lines) {
     const text = String(line?.text || '').trim()
@@ -187,31 +91,22 @@ export const speakCommentaryLines = async (
 
     const speaker = line?.speaker || 'Host'
     const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : []
-    const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')))
-
-    const payload = await post('/api/voice-commentary/speak', {
-      accountId,
-      text,
-      speaker,
-      locale: localeHint,
-      style: speakerSettings[speaker] || null
-    })
-
-    if (payload?.error) {
-      emitSupport(false)
-      throw new Error(payload.error)
-    }
 
     try {
-      if (payload?.provider === 'web-speech-fallback' || !payload?.synthesis?.audioUrl && !payload?.synthesis?.audioBase64) {
-        await speakWithBrowserTts(payload?.text || text, hints)
-      } else {
-        await playAudioPayload(payload)
-      }
+      await speakWithVoiceProvider(text, {
+        context,
+        gameId,
+        persona: speakerSettings[speaker] || undefined,
+        hints
+      })
       emitSupport(true)
     } catch (error) {
       emitSupport(false)
       throw error
     }
   }
+}
+
+export const cancelSpeechQueue = () => {
+  stopVoicePlayback()
 }

--- a/webapp/src/voice/VoiceProvider.ts
+++ b/webapp/src/voice/VoiceProvider.ts
@@ -1,0 +1,13 @@
+export type VoiceSpeakOptions = {
+  voiceId: string;
+  persona?: string;
+  context?: 'help' | 'commentary';
+  gameId?: string;
+  hints?: string[];
+};
+
+export interface VoiceProvider {
+  speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement>;
+  stop(): void;
+  healthCheck?(): Promise<boolean>;
+}

--- a/webapp/src/voice/providers/CurrentVoiceProvider.ts
+++ b/webapp/src/voice/providers/CurrentVoiceProvider.ts
@@ -1,0 +1,70 @@
+import type { VoiceProvider, VoiceSpeakOptions } from '../VoiceProvider';
+
+const pickSpeechSynthesisVoice = (hints: string[] = []) => {
+  if (typeof window === 'undefined' || !window.speechSynthesis) return null;
+  const voices = window.speechSynthesis.getVoices?.() || [];
+  if (!voices.length) return null;
+
+  const normalizedHints = hints.map((hint) => String(hint || '').toLowerCase()).filter(Boolean);
+  for (const hint of normalizedHints) {
+    const byLang = voices.find((voice) => String(voice.lang || '').toLowerCase() === hint);
+    if (byLang) return byLang;
+    const byPrefix = voices.find((voice) => String(voice.lang || '').toLowerCase().startsWith(`${hint}-`));
+    if (byPrefix) return byPrefix;
+    const byName = voices.find((voice) => String(voice.name || '').toLowerCase().includes(hint));
+    if (byName) return byName;
+  }
+
+  return voices.find((voice) => voice.default) || voices[0] || null;
+};
+
+export class CurrentVoiceProvider implements VoiceProvider {
+  private currentAudio: HTMLAudioElement | null = null;
+
+  async speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement> {
+    if (
+      typeof window === 'undefined' ||
+      !window.speechSynthesis ||
+      !window.SpeechSynthesisUtterance ||
+      !String(text || '').trim()
+    ) {
+      throw new Error('Web Speech is unavailable');
+    }
+
+    const utterance = new window.SpeechSynthesisUtterance(String(text || '').trim());
+    const preferredVoice = pickSpeechSynthesisVoice(opts.hints || []);
+    if (preferredVoice) {
+      utterance.voice = preferredVoice;
+      if (preferredVoice.lang) utterance.lang = preferredVoice.lang;
+    }
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    utterance.volume = 1;
+
+    const audio = new Audio();
+    await new Promise<void>((resolve, reject) => {
+      utterance.onend = () => resolve();
+      utterance.onerror = () => reject(new Error('Web Speech playback failed'));
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    });
+
+    this.currentAudio = audio;
+    return audio;
+  }
+
+  stop() {
+    if (typeof window !== 'undefined' && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.currentTime = 0;
+      this.currentAudio = null;
+    }
+  }
+
+  async healthCheck() {
+    return typeof window !== 'undefined' && typeof window.SpeechSynthesisUtterance !== 'undefined';
+  }
+}

--- a/webapp/src/voice/providers/PersonaPlexVoiceProvider.ts
+++ b/webapp/src/voice/providers/PersonaPlexVoiceProvider.ts
@@ -1,0 +1,100 @@
+import { post } from '../../utils/api.js';
+import type { VoiceProvider, VoiceSpeakOptions } from '../VoiceProvider';
+import { VOICE_CACHE_PREFIX } from '../voiceConfig';
+
+const memoryCache = new Map<string, string>();
+
+const makeCacheKey = (text: string, opts: VoiceSpeakOptions) =>
+  [opts.voiceId, opts.persona || '', opts.context || '', opts.gameId || '', text].join('::');
+
+const loadCachedAudio = (key: string): string | null => {
+  if (memoryCache.has(key)) return memoryCache.get(key) || null;
+  if (typeof window === 'undefined') return null;
+  const local = window.localStorage.getItem(`${VOICE_CACHE_PREFIX}:${key}`);
+  if (local) {
+    memoryCache.set(key, local);
+    return local;
+  }
+  return null;
+};
+
+const storeCachedAudio = (key: string, source: string) => {
+  memoryCache.set(key, source);
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(`${VOICE_CACHE_PREFIX}:${key}`, source);
+    } catch {
+      // ignore quota failures
+    }
+  }
+};
+
+export class PersonaPlexVoiceProvider implements VoiceProvider {
+  private currentAudio: HTMLAudioElement | null = null;
+
+  async speak(text: string, opts: VoiceSpeakOptions): Promise<HTMLAudioElement> {
+    const normalizedText = String(text || '').trim();
+    if (!normalizedText) throw new Error('text is required');
+
+    const key = makeCacheKey(normalizedText, opts);
+    const cachedSource = loadCachedAudio(key);
+    const source = cachedSource || (await this.fetchAudioSource(normalizedText, opts));
+    if (!cachedSource) storeCachedAudio(key, source);
+
+    const audio = new Audio(source);
+    this.currentAudio = audio;
+    await new Promise<void>((resolve, reject) => {
+      const done = () => {
+        audio.removeEventListener('ended', done);
+        audio.removeEventListener('error', fail);
+        resolve();
+      };
+      const fail = () => {
+        audio.removeEventListener('ended', done);
+        audio.removeEventListener('error', fail);
+        reject(new Error('Audio playback failed'));
+      };
+      audio.addEventListener('ended', done);
+      audio.addEventListener('error', fail);
+      audio.play().catch(fail);
+    });
+
+    return audio;
+  }
+
+  private async fetchAudioSource(text: string, opts: VoiceSpeakOptions): Promise<string> {
+    const accountId = typeof window === 'undefined' ? 'guest' : window.localStorage.getItem('accountId') || 'guest';
+    const payload = await post('/api/voice-commentary/speak', {
+      accountId,
+      text,
+      voiceId: opts.voiceId,
+      personaPrompt: opts.persona,
+      gameId: opts.gameId,
+      context: opts.context
+    });
+
+    const synthesis = payload?.synthesis || {};
+    if (synthesis.audioUrl) return synthesis.audioUrl;
+    if (synthesis.audioBase64) {
+      return `data:${synthesis.mimeType || 'audio/wav'};base64,${synthesis.audioBase64}`;
+    }
+    throw new Error(payload?.warning || payload?.error || 'PersonaPlex response missing audio payload');
+  }
+
+  stop() {
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.currentTime = 0;
+      this.currentAudio = null;
+    }
+  }
+
+  async healthCheck() {
+    try {
+      const response = await fetch('/api/voice-commentary/health');
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/webapp/src/voice/voiceConfig.ts
+++ b/webapp/src/voice/voiceConfig.ts
@@ -1,0 +1,16 @@
+export type VoiceContext = 'help' | 'commentary';
+
+export const VOICE_PROVIDER = (import.meta.env.VITE_VOICE_PROVIDER || 'personaplex').toLowerCase();
+
+export const PERSONA_DEFAULTS: Record<VoiceContext, { voiceId: string; persona: string }> = {
+  help: {
+    voiceId: 'NATF0',
+    persona: 'Concise, helpful, instructional tone. Keep guidance practical and clear.'
+  },
+  commentary: {
+    voiceId: 'NATM1',
+    persona: 'Energetic game commentator style. Keep lines short, exciting, and easy to follow.'
+  }
+};
+
+export const VOICE_CACHE_PREFIX = 'tonplaygram.voice.cache.v1';

--- a/webapp/src/voice/voiceProviderFactory.ts
+++ b/webapp/src/voice/voiceProviderFactory.ts
@@ -1,0 +1,64 @@
+import type { VoiceProvider, VoiceSpeakOptions } from './VoiceProvider';
+import { PERSONA_DEFAULTS, VOICE_PROVIDER } from './voiceConfig';
+import { CurrentVoiceProvider } from './providers/CurrentVoiceProvider';
+import { PersonaPlexVoiceProvider } from './providers/PersonaPlexVoiceProvider';
+
+let activeProvider: VoiceProvider | null = null;
+let queue: Array<{ text: string; opts: VoiceSpeakOptions; resolve: () => void; reject: (error: Error) => void }> = [];
+let speaking = false;
+
+const ensureProvider = (): VoiceProvider => {
+  if (activeProvider) return activeProvider;
+  activeProvider = VOICE_PROVIDER === 'personaplex' ? new PersonaPlexVoiceProvider() : new CurrentVoiceProvider();
+  return activeProvider;
+};
+
+const next = async () => {
+  if (speaking || !queue.length) return;
+  speaking = true;
+  const item = queue.shift();
+  if (!item) {
+    speaking = false;
+    return;
+  }
+
+  try {
+    const provider = ensureProvider();
+    await provider.speak(item.text, item.opts);
+    item.resolve();
+  } catch (error) {
+    item.reject(error as Error);
+  } finally {
+    speaking = false;
+    if (queue.length) void next();
+  }
+};
+
+export const speakWithVoiceProvider = (text: string, opts: Partial<VoiceSpeakOptions> = {}) => {
+  const context = opts.context || 'commentary';
+  const defaults = PERSONA_DEFAULTS[context];
+  const mergedOpts: VoiceSpeakOptions = {
+    context,
+    voiceId: opts.voiceId || defaults.voiceId,
+    persona: opts.persona || defaults.persona,
+    gameId: opts.gameId,
+    hints: opts.hints || []
+  };
+
+  return new Promise<void>((resolve, reject) => {
+    queue.push({ text, opts: mergedOpts, resolve, reject });
+    void next();
+  });
+};
+
+export const stopVoicePlayback = () => {
+  queue = [];
+  speaking = false;
+  ensureProvider().stop();
+};
+
+export const checkVoiceProviderHealth = async () => {
+  const provider = ensureProvider();
+  if (typeof provider.healthCheck === 'function') return provider.healthCheck();
+  return true;
+};


### PR DESCRIPTION
### Motivation

- Ensure the app actually plays PersonaPlex audio when `VOICE_PROVIDER=personaplex` instead of silently falling back to browser Web Speech. 
- Make PersonaPlex health and synthesis failures explicit so setup problems are visible and debuggable.

### Description

- API changes: `/api/voice-commentary/help` and `/api/voice-commentary/speak` now call `synthesizeVoice()` and return `503` on PersonaPlex synthesis failure instead of returning a `web-speech-fallback` payload. 
- Wrapper service: added `services/personaplex/service.py` which proxies to an upstream PersonaPlex server, removes the dev tone fallback, exposes `GET /health` with `remoteHealth`/`lastError` details, and returns `503` for `/tts` when upstream fails. 
- Client changes: introduced a `VoiceProvider` abstraction with `PersonaPlexVoiceProvider` and `CurrentVoiceProvider`, added `voiceProviderFactory.ts` queueing, removed automatic client-side fallback from the PersonaPlex execution path, and updated `textToSpeech.js`/`voiceHelpAssistant.js` to use the provider API. 
- Docs & scripts: added `docs/voice-personaplex.md` with setup/troubleshooting steps and a `package.json` script `voice:service` to run the wrapper (`python3 services/personaplex/service.py`). 

### Testing

- Ran unit/smoke tests with `npm test -- --runInBand test/voiceProviderFallback.test.js test/personaplexServiceSmoke.test.js` and both suites passed. 
- The smoke test starts a mock PersonaPlex upstream and the local Python wrapper and verifies `GET /health` is reachable and `POST /tts` returns a valid WAV payload. 
- The fallback behavior test validates `synthesizeVoice()` respects `VOICE_PROVIDER` and that `PERSONAPLEX_MODE=auto` prefers the remote API when `PERSONAPLEX_API_URL` is set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e32e43548329aaafef7955ebb181)