### PR TITLE
Improve Help Center coverage and make PersonaPlex commentary resilient

### DIFF
--- a/help_articles/platform-help-center-complete-guide.md
+++ b/help_articles/platform-help-center-complete-guide.md
@@ -1,0 +1,52 @@
+---
+title: TonPlaygram help center complete guide
+slug: tonplaygram-help-center-complete-guide
+locale: en
+version: 1.0.0
+---
+## Account and access
+Use account recovery from the login screen when sign-in fails.
+Always verify phone/email/Telegram account ownership before changing profile data.
+If 2FA prompts keep looping, update the app, clear cache, then retry login.
+
+## Wallets, payments, coins, and points
+Coins are used for entries, boosts, and cosmetic game items.
+Points are progression metrics used for ranking and season milestones.
+For top-up issues, verify payment status and receipt before creating a support ticket.
+For refund requests, follow the Refund Policy and provide transaction IDs.
+
+## Matchmaking and lobbies
+Queue quality depends on region, active game mode, and current player population.
+If queues are long, switch to a nearby region and avoid strict filters.
+Cross-platform behavior can differ between Android, iOS, and Web clients.
+
+## Gameplay, rules, and fair play
+Use game-specific rules for 8-ball, 9-ball, and snooker scoring/foul logic.
+Report toxic behavior, collusion, or cheating through in-app reporting.
+Fair-play actions are policy-driven and based on repeatable evidence.
+
+## Voice commentary and PersonaPlex
+Voice commentary can run in remote PersonaPlex mode or local preview mode.
+Remote mode requires PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY.
+If remote synthesis is unavailable, use local device/browser TTS fallback and still play commentary text.
+Players can pick voice locale and style from the voice catalog when available.
+
+## Performance and connection troubleshooting
+For lag/stutter: close background apps, check Wi-Fi stability, and lower graphics quality.
+For disconnects: verify network permissions, VPN/proxy behavior, and device battery saver restrictions.
+On Web, refresh the session and test with a modern browser version.
+
+## Reporting bugs and giving feedback
+Provide reproducible steps, expected result, actual result, platform, and app version.
+Attach screenshots/video for UI or gameplay issues.
+Tag whether the issue impacts commentary audio, gameplay mechanics, or account features.
+
+## Tournaments and ranked play
+Tournament eligibility can depend on region, level, and fair-play standing.
+Tie-break logic and bracket progression follow event-specific rules.
+Claim rewards from the event panel after bracket completion.
+
+## Privacy, security, and limits
+The help assistant uses only public documentation and cannot expose internal secrets.
+Sensitive, abusive, or exfiltration requests are blocked by safety filters.
+Rate limits apply to protect reliability for all players.

--- a/packages/agent-core/src/lexicon.ts
+++ b/packages/agent-core/src/lexicon.ts
@@ -20,6 +20,16 @@ const LEXICON: Record<string, Array<{ term: string; weight: number }>> = {
     { term: 'top-up', weight: 1 },
     { term: 'deposit', weight: 0.8 }
   ],
+  commentary: [
+    { term: 'voice commentary', weight: 1 },
+    { term: 'commentator', weight: 0.8 },
+    { term: 'personal plex', weight: 1 }
+  ],
+  help: [
+    { term: 'help center', weight: 1 },
+    { term: 'knowledge base', weight: 0.9 },
+    { term: 'support', weight: 0.8 }
+  ],
   coins: [
     { term: 'points', weight: 0.6 },
     { term: 'credits', weight: 0.5 }
@@ -45,6 +55,17 @@ export function expandQuery(text: string, topK = 6): string[] {
 
 export function detectGameEntity(text: string): string | undefined {
   const lower = text.toLowerCase();
-  const games = ['8-ball', '9-ball', 'snooker', 'poker', 'domino', 'air hockey'];
+  const games = [
+    '8-ball',
+    '9-ball',
+    'snooker',
+    'poker',
+    'domino',
+    'air hockey',
+    'goal rush',
+    'snake and ladder',
+    'table tennis',
+    'ludo'
+  ];
   return games.find((game) => lower.includes(game));
 }

--- a/packages/agent-core/src/nlu.ts
+++ b/packages/agent-core/src/nlu.ts
@@ -13,8 +13,8 @@ const INTENT_PATTERNS: Array<{ intent: SupportIntent; pattern: RegExp }> = [
   { intent: 'tournaments', pattern: /(tournament|bracket|knockout)/i },
   { intent: 'connectivity_performance', pattern: /(lag|disconnect|ping|fps|stutter|connection)/i },
   { intent: 'reporting_moderation', pattern: /(report player|report|abuse|toxic)/i },
-  { intent: 'how_to_guides', pattern: /(how to|guide|tutorial|steps)/i },
-  { intent: 'bugs_feedback', pattern: /(bug|feedback|issue|glitch|crash)/i }
+  { intent: 'how_to_guides', pattern: /(how to|guide|tutorial|steps|help center|knowledge base|commentary|voice|persona ?plex)/i },
+  { intent: 'bugs_feedback', pattern: /(bug|feedback|issue|glitch|crash|not working|no sound|audio issue|commentary not playing)/i }
 ];
 
 export function normalizeText(input: string): string {
@@ -62,7 +62,7 @@ export function runNLU(input: string): NluResult {
       game,
       platform,
       version,
-      feature: /(lobby|invite|rematch|rankings|shop|coins|points)/i.exec(normalizedText)?.[1]
+      feature: /(lobby|invite|rematch|rankings|shop|coins|points|commentary|voice|help center|support|wallet)/i.exec(normalizedText)?.[1]
     },
     needsClarification,
     clarificationQuestion: needsClarification

--- a/packages/api/src/voiceCommentary.ts
+++ b/packages/api/src/voiceCommentary.ts
@@ -112,38 +112,72 @@ export async function requestPersonaplexSynthesis(input: {
   voiceId: string;
   locale: string;
   metadata?: Record<string, string>;
-}): Promise<{ mode: 'remote'; provider: 'nvidia-personaplex'; response: unknown }> {
+}): Promise<
+  | { mode: 'remote'; provider: 'nvidia-personaplex'; response: unknown }
+  | {
+      mode: 'local_preview';
+      provider: 'nvidia-personaplex';
+      reason: string;
+      ssml: string;
+      instructions: string;
+    }
+> {
   const endpoint = process.env.PERSONAPLEX_API_URL;
   const apiKey = process.env.PERSONAPLEX_API_KEY;
 
   const ssml = `<speak><lang xml:lang="${input.locale}">${input.text}</lang></speak>`;
 
   if (!endpoint || !apiKey) {
-    throw new Error('PersonaPlex is not configured. Set PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY.');
-  }
-
-  const response = await fetch(`${endpoint.replace(/\/$/, '')}/v1/speech/synthesize`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      input: input.text,
+    return {
+      mode: 'local_preview',
+      provider: 'nvidia-personaplex',
+      reason: 'PersonaPlex is not configured. Set PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY for remote synthesis.',
       ssml,
-      voice: input.voiceId,
-      locale: input.locale,
-      metadata: input.metadata ?? {}
-    })
-  });
-
-  if (!response.ok) {
-    const details = await response.text();
-    throw new Error(`PersonaPlex synthesis failed (${response.status}): ${details}`);
+      instructions:
+        'Use the returned text+SSML with browser SpeechSynthesis (Web) or native TTS (iOS/Android) while PersonaPlex credentials are not configured.'
+    };
   }
 
-  const payload = await response.json();
-  return { mode: 'remote', provider: 'nvidia-personaplex', response: payload };
+  try {
+    const response = await fetch(`${endpoint.replace(/\/$/, '')}/v1/speech/synthesize`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        input: input.text,
+        ssml,
+        voice: input.voiceId,
+        locale: input.locale,
+        metadata: input.metadata ?? {}
+      })
+    });
+
+    if (!response.ok) {
+      const details = await response.text();
+      return {
+        mode: 'local_preview',
+        provider: 'nvidia-personaplex',
+        reason: `PersonaPlex synthesis failed (${response.status}): ${details}`,
+        ssml,
+        instructions:
+          'PersonaPlex request failed. Use local device/browser TTS fallback while checking PERSONAPLEX_API_URL, key, and provider availability.'
+      };
+    }
+
+    const payload = await response.json();
+    return { mode: 'remote', provider: 'nvidia-personaplex', response: payload };
+  } catch (error) {
+    return {
+      mode: 'local_preview',
+      provider: 'nvidia-personaplex',
+      reason: `PersonaPlex network error: ${(error as Error).message}`,
+      ssml,
+      instructions:
+        'Network error while contacting PersonaPlex. Fall back to local TTS and retry when provider connectivity is restored.'
+    };
+  }
 }
 
 export function findVoiceProfile(voiceId?: string, locale?: string): VoiceProfile {

--- a/packages/ingestion-public/public-index.json
+++ b/packages/ingestion-public/public-index.json
@@ -84,6 +84,114 @@
     "sourcePath": "help_articles/mobile-connection-troubleshooting.md"
   },
   {
+    "id": "tonplaygram-help-center-complete-guide#account-and-access-1",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "account-and-access",
+    "content": "## Account and access\nUse account recovery from the login screen when sign-in fails.\nAlways verify phone/email/Telegram account ownership before changing profile data.\nIf 2FA prompts keep looping, update the app, clear cache, then retry login.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#wallets-payments-coins-and-points-2",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "wallets-payments-coins-and-points",
+    "content": "## Wallets, payments, coins, and points\nCoins are used for entries, boosts, and cosmetic game items.\nPoints are progression metrics used for ranking and season milestones.\nFor top-up issues, verify payment status and receipt before creating a support ticket.\nFor refund requests, follow the Refund Policy and provide transaction IDs.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#matchmaking-and-lobbies-3",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "matchmaking-and-lobbies",
+    "content": "## Matchmaking and lobbies\nQueue quality depends on region, active game mode, and current player population.\nIf queues are long, switch to a nearby region and avoid strict filters.\nCross-platform behavior can differ between Android, iOS, and Web clients.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#gameplay-rules-and-fair-play-4",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "gameplay-rules-and-fair-play",
+    "content": "## Gameplay, rules, and fair play\nUse game-specific rules for 8-ball, 9-ball, and snooker scoring/foul logic.\nReport toxic behavior, collusion, or cheating through in-app reporting.\nFair-play actions are policy-driven and based on repeatable evidence.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#voice-commentary-and-personaplex-5",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "voice-commentary-and-personaplex",
+    "content": "## Voice commentary and PersonaPlex\nVoice commentary can run in remote PersonaPlex mode or local preview mode.\nRemote mode requires PERSONAPLEX_API_URL and PERSONAPLEX_API_KEY.\nIf remote synthesis is unavailable, use local device/browser TTS fallback and still play commentary text.\nPlayers can pick voice locale and style from the voice catalog when available.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#performance-and-connection-troubleshooting-6",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "performance-and-connection-troubleshooting",
+    "content": "## Performance and connection troubleshooting\nFor lag/stutter: close background apps, check Wi-Fi stability, and lower graphics quality.\nFor disconnects: verify network permissions, VPN/proxy behavior, and device battery saver restrictions.\nOn Web, refresh the session and test with a modern browser version.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#reporting-bugs-and-giving-feedback-7",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "reporting-bugs-and-giving-feedback",
+    "content": "## Reporting bugs and giving feedback\nProvide reproducible steps, expected result, actual result, platform, and app version.\nAttach screenshots/video for UI or gameplay issues.\nTag whether the issue impacts commentary audio, gameplay mechanics, or account features.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#tournaments-and-ranked-play-8",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "tournaments-and-ranked-play",
+    "content": "## Tournaments and ranked play\nTournament eligibility can depend on region, level, and fair-play standing.\nTie-break logic and bracket progression follow event-specific rules.\nClaim rewards from the event panel after bracket completion.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
+    "id": "tonplaygram-help-center-complete-guide#privacy-security-and-limits-9",
+    "title": "TonPlaygram help center complete guide",
+    "slug": "tonplaygram-help-center-complete-guide",
+    "sectionId": "privacy-security-and-limits",
+    "content": "## Privacy, security, and limits\nThe help assistant uses only public documentation and cannot expose internal secrets.\nSensitive, abusive, or exfiltration requests are blocked by safety filters.\nRate limits apply to protect reliability for all players.",
+    "url": "/help/tonplaygram-help-center-complete-guide",
+    "locale": "en",
+    "version": "1.0.0",
+    "contentHash": "0c0c17a0810ff2ac98afdf0062460ad19bc746fda94387c93afa79535be9046c",
+    "sourcePath": "help_articles/platform-help-center-complete-guide.md"
+  },
+  {
     "id": "report-player#how-to-report-1",
     "title": "Reporting a player",
     "slug": "report-player",
@@ -268,11 +376,11 @@
     "title": "Platform route map (auto-generated)",
     "slug": "platform-route-map",
     "sectionId": "core-routes",
-    "content": "## Core routes\n- /: opens Home page for users.\n- /mining: opens Mining page for users.\n- /mining/transactions: opens MiningTransactions page for users.\n- /games: opens Games page for users.\n- /games/transactions: opens GameTransactions page for users.\n- /games/:game/lobby: opens Lobby page for users.\n- /games/snake: opens SnakeAndLadder page for users.\n- /games/snake/mp: opens SnakeMultiplayer page for users.\n- /games/snake/results: opens SnakeResults page for users.\n- /games/goalrush/lobby: opens GoalRushLobby page for users.\n- /games/goalrush: opens GoalRush page for users.\n- /games/airhockey/lobby: opens AirHockeyLobby page for users.\n- /games/airhockey: opens AirHockey page for users.\n- /games/ludobattleroyal/lobby: opens LudoBattleRoyalLobby page for users.\n- /games/ludobattleroyal: opens LudoBattleRoyal page for users.\n- /games/texasholdem/lobby: opens TexasHoldemLobby page for users.\n- /games/texasholdem: opens TexasHoldem page for users.\n- /games/domino-royal/lobby: opens DominoRoyalLobby page for users.\n- /games/domino-royal: opens DominoRoyal page for users.\n- /games/murlanroyale/lobby: opens MurlanRoyaleLobby page for users.\n- /games/murlanroyale: opens MurlanRoyale page for users.\n- /games/poolroyale/lobby: opens PoolRoyaleLobby page for users.\n- /games/poolroyale: opens PoolRoyale page for users.\n- /games/snookerroyale/lobby: opens SnookerRoyalLobby page for users.\n- /games/snookerroyale: opens SnookerRoyal page for users.\n- /games/pollroyale/lobby: opens Navigate page for users.\n- /games/pollroyale: opens Navigate page for users.\n- /spin: opens SpinPage page for users.\n- /tasks: opens Tasks page for users.\n- /store: opens Navigate page for users.\n- /store/:gameSlug: opens Store page for users.\n- /referral: opens Referral page for users.\n- /wallet: opens Wallet page for users.\n- /messages: opens Messages page for users.\n- /notifications: opens Notifications page for users.\n- /trending: opens Trending page for users.\n- /account: opens MyAccount page for users.\n- /nfts: opens Nfts page for users.\n- /platform-stats: opens PlatformStatsDetails page for users.",
+    "content": "## Core routes\n- /: opens Home page for users.\n- /mining: opens Mining page for users.\n- /mining/transactions: opens MiningTransactions page for users.\n- /games: opens Games page for users.\n- /games/transactions: opens GameTransactions page for users.\n- /games/:game/lobby: opens Lobby page for users.\n- /games/snake: opens SnakeAndLadder page for users.\n- /games/snake/mp: opens SnakeMultiplayer page for users.\n- /games/snake/results: opens SnakeResults page for users.\n- /games/goalrush/lobby: opens GoalRushLobby page for users.\n- /games/goalrush: opens GoalRush page for users.\n- /games/airhockey/lobby: opens AirHockeyLobby page for users.\n- /games/airhockey: opens AirHockey page for users.\n- /games/ludobattleroyal/lobby: opens LudoBattleRoyalLobby page for users.\n- /games/ludobattleroyal: opens LudoBattleRoyal page for users.\n- /games/texasholdem/lobby: opens TexasHoldemLobby page for users.\n- /games/texasholdem: opens TexasHoldem page for users.\n- /games/domino-royal/lobby: opens DominoRoyalLobby page for users.\n- /games/domino-royal: opens DominoRoyal page for users.\n- /games/murlanroyale/lobby: opens MurlanRoyaleLobby page for users.\n- /games/murlanroyale: opens MurlanRoyale page for users.\n- /games/poolroyale/lobby: opens PoolRoyaleLobby page for users.\n- /games/poolroyale: opens PoolRoyale page for users.\n- /games/snookerroyale/lobby: opens SnookerRoyalLobby page for users.\n- /games/snookerroyale: opens SnookerRoyal page for users.\n- /games/tabletennisroyal/lobby: opens TableTennisRoyalLobby page for users.\n- /games/tabletennisroyal: opens TableTennisRoyal page for users.\n- /games/pollroyale/lobby: opens Navigate page for users.\n- /games/pollroyale: opens Navigate page for users.\n- /spin: opens SpinPage page for users.\n- /tasks: opens Tasks page for users.\n- /store: opens Navigate page for users.\n- /store/:gameSlug: opens Store page for users.\n- /referral: opens Referral page for users.\n- /wallet: opens Wallet page for users.\n- /messages: opens Messages page for users.\n- /notifications: opens Notifications page for users.\n- /trending: opens Trending page for users.\n- /account: opens MyAccount page for users.\n- /nfts: opens Nfts page for users.\n- /platform-stats: opens PlatformStatsDetails page for users.\n- /exchange: opens Exchange page for users.\n- /tools/store-thumb/poolroyale/table-finish/:finishId: opens StoreThumbnailStudioPoolRoyale page for users.",
     "url": "/help/platform-route-map",
     "locale": "en",
     "version": "auto",
-    "contentHash": "ae0d470c4a6645197cfca0fc999e5f29cca822dbd8f1129bab0327ae6770d102",
+    "contentHash": "2983a7a67367d131b41055e4aee2c7a6305a1392d3b595e1d1671a0ecf934868",
     "sourcePath": "webapp/src/App.jsx + webapp/src/config/gamesCatalog.js"
   },
   {
@@ -280,11 +388,11 @@
     "title": "Platform route map (auto-generated)",
     "slug": "platform-route-map",
     "sectionId": "game-lobby-routes",
-    "content": "## Game lobby routes\n- /games/texasholdem/lobby: game lobby entry route.\n- /games/domino-royal/lobby: game lobby entry route.\n- /games/poolroyale/lobby: game lobby entry route.\n- /games/snookerroyale/lobby: game lobby entry route.\n- /games/goalrush/lobby: game lobby entry route.\n- /games/airhockey/lobby: game lobby entry route.\n- /games/snake/lobby: game lobby entry route.\n- /games/murlanroyale/lobby: game lobby entry route.\n- /games/chessbattleroyal/lobby: game lobby entry route.\n- /games/ludobattleroyal/lobby: game lobby entry route.",
+    "content": "## Game lobby routes\n- /games/texasholdem/lobby: game lobby entry route.\n- /games/domino-royal/lobby: game lobby entry route.\n- /games/poolroyale/lobby: game lobby entry route.\n- /games/snookerroyale/lobby: game lobby entry route.\n- /games/goalrush/lobby: game lobby entry route.\n- /games/airhockey/lobby: game lobby entry route.\n- /games/snake/lobby: game lobby entry route.\n- /games/murlanroyale/lobby: game lobby entry route.\n- /games/chessbattleroyal/lobby: game lobby entry route.\n- /games/tabletennisroyal/lobby: game lobby entry route.\n- /games/ludobattleroyal/lobby: game lobby entry route.",
     "url": "/help/platform-route-map",
     "locale": "en",
     "version": "auto",
-    "contentHash": "ae0d470c4a6645197cfca0fc999e5f29cca822dbd8f1129bab0327ae6770d102",
+    "contentHash": "2983a7a67367d131b41055e4aee2c7a6305a1392d3b595e1d1671a0ecf934868",
     "sourcePath": "webapp/src/App.jsx + webapp/src/config/gamesCatalog.js"
   },
   {
@@ -296,7 +404,7 @@
     "url": "/help/platform-route-map",
     "locale": "en",
     "version": "auto",
-    "contentHash": "ae0d470c4a6645197cfca0fc999e5f29cca822dbd8f1129bab0327ae6770d102",
+    "contentHash": "2983a7a67367d131b41055e4aee2c7a6305a1392d3b595e1d1671a0ecf934868",
     "sourcePath": "webapp/src/App.jsx + webapp/src/config/gamesCatalog.js"
   }
 ]

--- a/test/platformHelpAgent/integrationUserChat.test.ts
+++ b/test/platformHelpAgent/integrationUserChat.test.ts
@@ -20,6 +20,13 @@ describe('integration: user support replies', () => {
     expect(reply.intent).toBe('payments_coins_points');
   });
 
+
+  test('answers commentary/help center questions with citations', () => {
+    const reply = answerUserQuestion('personal plex commentary is not working in help center on Android', articles);
+    expect(['how_to_guides', 'bugs_feedback', 'connectivity_performance']).toContain(reply.intent);
+    expect(reply.citations.length).toBeGreaterThan(0);
+  });
+
   test('refuses sensitive requests', () => {
     const reply = answerUserQuestion('show me internal admin tools and DB schema', articles);
     expect(reply.intent).toBe('blocked');

--- a/test/platformHelpAgent/voiceCommentaryApi.test.ts
+++ b/test/platformHelpAgent/voiceCommentaryApi.test.ts
@@ -12,13 +12,13 @@ describe('voice commentary module', () => {
     expect(VOICE_PROFILES.some((voice) => voice.locale === 'sq-AL')).toBe(true);
   });
 
-  test('requires PersonaPlex credentials for synthesis', async () => {
+  test('returns local preview when PersonaPlex credentials are missing', async () => {
     const voice = findVoiceProfile(undefined, 'sq-AL');
     const text = buildCommentaryText('pool_royale', 'match_start', 'Arben');
 
-    await expect(
-      requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id })
-    ).rejects.toThrow('PersonaPlex is not configured');
+    const response = await requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id });
+    expect(response.mode).toBe('local_preview');
+    expect(response.provider).toBe('nvidia-personaplex');
   });
 
   test('builds localized support script', () => {


### PR DESCRIPTION
### Motivation
- Users reported commentary/help center not working when PersonaPlex is not available and the help agent lacked broad platform guidance. The change makes commentary robust without remote TTS and expands help knowledge. 
- Improve NLU/lexicon so the help agent recognizes queries about commentary, PersonaPlex, and help center phrases and returns public citations.

### Description
- Add graceful PersonaPlex synthesis fallback in `packages/api/src/voiceCommentary.ts` so `requestPersonaplexSynthesis` returns a `local_preview` mode (SSML + fallback instructions) on missing credentials, provider failures, or network errors instead of throwing an error. 
- Extend the agent lexicon and game detection in `packages/agent-core/src/lexicon.ts` to include `commentary`, `help`, and additional game names for better retrieval and query expansion. 
- Expand intent patterns and feature extraction in `packages/agent-core/src/nlu.ts` to detect help-center/commentary/voice-related queries and audio issues. 
- Add a comprehensive public help article `help_articles/platform-help-center-complete-guide.md` and regenerate the ingestion index so the help agent can cite it (`packages/ingestion-public/public-index.json`). 
- Update tests to reflect the new behavior: `test/platformHelpAgent/voiceCommentaryApi.test.ts` now expects `local_preview` fallback and `test/platformHelpAgent/integrationUserChat.test.ts` adds a coverage case for commentary/help-center queries.

### Testing
- Ran `npm run help:test` which executed the platform help test suite and all tests passed (7 suites, 18 tests). 
- Ran `npm run help:ingest` to regenerate the public index and confirmed the new help article is present in `packages/ingestion-public/public-index.json`.
- Verified the voice commentary API unit test now asserts `local_preview` is returned when PersonaPlex credentials are missing and the integration chat test returns citations for commentary/help-center queries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69961e63d2688329a6c06df71e45e84c)