### PR TITLE
Adjust Pool Royale training: require full pot, grant attempts once per task, center Play Next, avatar route downwards

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -184,10 +184,10 @@ export function getTrainingLayout (level) {
 }
 
 export function loadTrainingProgress () {
-  if (typeof window === 'undefined') { return { completed: [], rewarded: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL } }
+  if (typeof window === 'undefined') { return { completed: [], rewarded: [], lastLevel: 1, carryShots: 0, attemptsAwardedLevels: [] } }
   try {
     const stored = window.localStorage.getItem(TRAINING_PROGRESS_KEY)
-    if (!stored) return { completed: [], rewarded: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL }
+    if (!stored) return { completed: [], rewarded: [], lastLevel: 1, carryShots: 0, attemptsAwardedLevels: [] }
     const parsed = JSON.parse(stored)
     const completed = Array.isArray(parsed?.completed)
       ? parsed.completed
@@ -205,11 +205,17 @@ export function loadTrainingProgress () {
     const rawCarryShots = Number(parsed?.carryShots)
     const carryShots = Number.isFinite(rawCarryShots)
       ? Math.max(0, Math.floor(rawCarryShots))
-      : BASE_ATTEMPTS_PER_LEVEL
-    return { completed, rewarded, lastLevel, carryShots }
+      : 0
+    const attemptsAwardedLevels = Array.isArray(parsed?.attemptsAwardedLevels)
+      ? parsed.attemptsAwardedLevels
+        .map((lvl) => Number(lvl))
+        .filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+        .sort((a, b) => a - b)
+      : []
+    return { completed, rewarded, lastLevel, carryShots, attemptsAwardedLevels }
   } catch (err) {
     console.warn('Failed to load Pool Royale training progress', err)
-    return { completed: [], rewarded: [], lastLevel: 1, carryShots: BASE_ATTEMPTS_PER_LEVEL }
+    return { completed: [], rewarded: [], lastLevel: 1, carryShots: 0, attemptsAwardedLevels: [] }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Make training behavior match the game design: a task is only finished when all object balls on the table are potted (not when rules mark frameOver).  
- Ensure attempts are granted once per task (3 attempts per task), unused attempts carry forward between tasks, and attempts are not re-awarded on every login.  
- Improve roadmap UX by centering the `Play next` CTA and changing the avatar route animation to move downward.  

### Description

- Add persistent tracking of which levels have had their attempts awarded by adding `attemptsAwardedLevels` to the training progress payload stored by `loadTrainingProgress`/`persistTrainingProgress`.  
- Stop defaulting to an attempts bank on load; training carry-attempts default to `0` and are only increased when a level is first entered. (`webapp/src/utils/poolRoyaleTrainingProgress.js`)  
- Add `grantTrainingAttemptsForLevel` in `PoolRoyale.jsx` which grants `BASE_ATTEMPTS_PER_LEVEL` once per level and persists the updated `carryShots` + `attemptsAwardedLevels`. This is invoked on initial playable-level load and when the player picks or continues a level.  
- Make training completion depend on the number of remaining active object balls on the table (`remainingTrainingObjectBalls === 0`) so the task is only considered finished when all object balls are potted. (`PoolRoyale.jsx`)  
- Persist decrements of the attempts bank immediately when a training shot is consumed (miss) so the bank survives reload/session resets. (`PoolRoyale.jsx`)  
- Remove the automatic roadmap auto-advance timer and introduce a centered `Play next` CTA inside the roadmap overlay transition; adjust the avatar route visual to a vertical/downward representation. (`PoolRoyale.jsx`)  

### Testing

- Ran the unit tests for training layout/progression with `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js`, all tests passed (`7 passed`).  
- Ran `npx eslint` against the changed files (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/utils/poolRoyaleTrainingProgress.js`); linter produced warnings related to repository ignore patterns but no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969b2d84c48329886c7b947b96e56f)