### PR TITLE
Enable local PersonaPlex fallback for help voice API

### DIFF
--- a/README-platform-help-agent.md
+++ b/README-platform-help-agent.md
@@ -43,6 +43,8 @@ test/platformHelpAgent/
    - `npm run help:ingest`
 3. Start API
    - `npm run help:api`
+   - Voice endpoints now support a local development fallback when PersonaPlex credentials are missing.
+   - Optional strict mode: set `PERSONAPLEX_LOCAL_FALLBACK=0` to force real PersonaPlex credentials.
 4. Run tests
    - `npm run help:test`
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:offline-assets": "node scripts/buildOfflineAssets.mjs",
     "thumbs:pool-table-finishes": "node scripts/generatePoolRoyaleTableFinishThumbs.mjs",
     "help:ingest": "node --loader ts-node/esm packages/ingestion-public/src/cli.ts",
-    "help:api": "node --loader ts-node/esm packages/api/src/server.ts",
+    "help:api": "node --loader ts-node/esm/transpile-only packages/api/src/server.ts",
     "help:test": "jest test/platformHelpAgent --runInBand"
   },
   "engines": {

--- a/test/platformHelpAgent/voiceCommentaryApi.test.ts
+++ b/test/platformHelpAgent/voiceCommentaryApi.test.ts
@@ -12,13 +12,34 @@ describe('voice commentary module', () => {
     expect(VOICE_PROFILES.some((voice) => voice.locale === 'sq-AL')).toBe(true);
   });
 
-  test('requires PersonaPlex credentials for synthesis', async () => {
+  test('returns local fallback synthesis when PersonaPlex credentials are missing', async () => {
     const voice = findVoiceProfile(undefined, 'sq-AL');
     const text = buildCommentaryText('pool_royale', 'match_start', 'Arben');
 
-    await expect(
-      requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id })
-    ).rejects.toThrow('PersonaPlex is not configured');
+    const result = await requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id });
+    expect(result.mode).toBe('local-fallback');
+    if (result.mode === 'local-fallback') {
+      expect(result.reason).toBe('missing_credentials');
+      expect(result.payload.voiceId).toBe(voice.id);
+    }
+  });
+
+  test('still allows strict mode that requires PersonaPlex credentials', async () => {
+    const previous = process.env.PERSONAPLEX_LOCAL_FALLBACK;
+    process.env.PERSONAPLEX_LOCAL_FALLBACK = '0';
+
+    const voice = findVoiceProfile(undefined, 'sq-AL');
+    const text = buildCommentaryText('pool_royale', 'match_start', 'Arben');
+
+    await expect(requestPersonaplexSynthesis({ text, locale: voice.locale, voiceId: voice.id })).rejects.toThrow(
+      'PersonaPlex is not configured'
+    );
+
+    if (typeof previous === 'undefined') {
+      delete process.env.PERSONAPLEX_LOCAL_FALLBACK;
+    } else {
+      process.env.PERSONAPLEX_LOCAL_FALLBACK = previous;
+    }
   });
 
   test('builds localized support script', () => {


### PR DESCRIPTION
### Motivation

- Make the platform help voice/commentary endpoints usable in local development when external PersonaPlex credentials are not available. 
- Avoid blocking local API startup on unrelated TypeScript build errors in the monorepo so voice endpoints can be exercised locally.

### Description

- Added a local fallback path in `requestPersonaplexSynthesis` that returns a structured `mode: 'local-fallback'` payload when `PERSONAPLEX_API_URL` or `PERSONAPLEX_API_KEY` are missing. 
- Introduced `PERSONAPLEX_LOCAL_FALLBACK` toggle so strict mode can be enforced by setting it to `0`, which preserves the original error behavior. 
- Switched the help API run script to `ts-node` transpile-only mode for `help:api` so the API can start locally without a full monorepo TypeScript build. 
- Updated tests to validate both the local-fallback behavior and the strict (credential-required) mode, and documented the fallback+toggle in `README-platform-help-agent.md`.

### Testing

- Ran unit/integration tests with `npm run help:test -- --runInBand` and all help-agent suites passed (7 suites, 18 tests). 
- Started the local help API with the transpile-only runner and POSTed to `/v1/voice/support`, which returned `synthesis.mode = 'local-fallback'` and `reason = 'missing_credentials'` when credentials were absent. 
- Verified strict mode by setting `PERSONAPLEX_LOCAL_FALLBACK=0` and confirming `requestPersonaplexSynthesis` throws the original configuration error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969d2bc5088329897bddebeb17afd5)