### PR TITLE
fix(pool-royale): restore cue-ball in-hand placement after scratches in training

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26976,7 +26976,7 @@ const powerRef = useRef(hud.power);
           cushionAfterContact: false,
           spin: { x: 0, y: 0 }
         };
-        let nextInHand = isTraining ? false : cueBallPotted;
+        let nextInHand = cueBallPotted;
         try {
           if (shotResolved) {
             if (safeState.foul) {
@@ -27061,7 +27061,7 @@ const powerRef = useRef(hud.power);
               cue.impacted = false;
               cue.launchDir = null;
               cueBallPlacedFromHandRef.current = false;
-              pendingInHandResetRef.current = !isTraining;
+              pendingInHandResetRef.current = true;
             }
             if (shouldStartReplay) {
               postShotSnapshot = captureBallSnapshot();


### PR DESCRIPTION
### Motivation
- Training-mode scratches did not re-enter the ball-in-hand placement flow, so when the cue ball was potted during training it wasn't being repositioned like in normal gameplay.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` so `nextInHand` is derived from `cueBallPotted` in all modes, allowing cue-ball pocketing to drive the in-hand state consistently.
- Always set `pendingInHandResetRef.current = true` when the cue is pocketed to prime the in-hand reset/placement flow after a scratch.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; the command completed but the file is ignored by the current ESLint configuration (no lint errors emitted).
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`; the command completed and showed the same ignore warning with no reported lint errors for the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a07aba5c83299e0241f4202670d1)