### PR TITLE
Fix training scratch flow, add training commentary, and implement active tournament lobby with improved bracket layout

### DIFF
--- a/webapp/public/pool-royale-bracket.html
+++ b/webapp/public/pool-royale-bracket.html
@@ -34,6 +34,23 @@
       radial-gradient(1000px 300px at 50% -50px, rgba(37,99,235,.25), transparent 70%),
       radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
   }
+  body.embed-mode {
+    gap: 0;
+    background: transparent;
+  }
+  body.embed-mode .canvas-wrap {
+    border: 0;
+    background: transparent;
+  }
+  body.embed-mode #continueBtn {
+    display: none;
+  }
+  @media (max-width: 600px) {
+    .canvas-wrap {
+      border-top: 0;
+      border-bottom: 0;
+    }
+  }
   canvas{ display:block; margin:0 auto; }
   .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
   details{margin-left:auto}
@@ -61,6 +78,10 @@
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
   const params = new URLSearchParams(window.location.search);
+  const embedMode = params.get('embed') === '1';
+  if (embedMode) {
+    document.body.classList.add('embed-mode');
+  }
   const tgKey = params.get("tgId") || "anon";
   const STATE_KEY = `poolRoyaleTournamentState_${tgKey}`;
   const OPP_KEY = `poolRoyaleTournamentOpponent_${tgKey}`;
@@ -135,17 +156,18 @@
 
   function layoutAndDraw(){
     const rounds = state.rounds.length;
-    const colW = 220;
-    const colGap = 64;
-    const padX = 24;
-    const padY = 24;
+    const portraitMobile = window.innerHeight > window.innerWidth && window.innerWidth <= 520;
+    const colW = portraitMobile ? 164 : 220;
+    const colGap = portraitMobile ? 36 : 64;
+    const padX = portraitMobile ? 12 : 24;
+    const padY = portraitMobile ? 12 : 24;
     const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
 
     const matches0 = state.rounds[0].length;
 
-    const boxH = 56;
+    const boxH = portraitMobile ? 46 : 56;
     const slotH = boxH/2;
-    const baseGap = 28;
+    const baseGap = portraitMobile ? 18 : 28;
 
     const centers = [];
     centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
@@ -160,7 +182,7 @@
     }
 
     const lastCenter = centers[rounds-1][0] || padY + boxH/2;
-    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+    const heightCSS = Math.max(portraitMobile ? 420 : 600, lastCenter + padY + boxH/2);
 
     canvas.style.width = widthCSS + 'px';
     canvas.style.height = heightCSS + 'px';
@@ -459,7 +481,8 @@
   }
 
   (function init(){
-    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const requestedPlayers = parseInt(params.get('players') || '8', 10);
+    const totalPlayers = Math.max(2, Math.floor((Number.isFinite(requestedPlayers) ? requestedPlayers : 8) / 2) * 2);
     const saved = localStorage.getItem(STATE_KEY);
     if(saved){
       try{


### PR DESCRIPTION
### Motivation
- Prevent training sessions from freezing when the cue ball is potted and make training UX explicit (ball-in-hand placement, clear aiming color, and commentary). 
- Allow players to continue an unfinished tournament from the lobby and simplify the lobby UI while an active bracket exists. 
- Improve the bracket page layout for mobile portrait and embedded uses and ensure tournament sizes are even.

### Description
- Training fixes: when the cue ball is potted in training the code now respawns the cue ball behind the baulk line and ensures the player keeps ball-in-hand placement (no stalled flow). (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Aiming visuals: the main aiming guide is forced to the training-safe color (yellow) while in training so the guide never shows the foul/red tone during training. (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Training commentary: added an automatic commentary announcement that reads the current training task and how many attempts remain (deduplicated by key to avoid repeats). (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Lobby: detect an unfinished tournament stored in localStorage and, when present, hide the regular match configuration controls and show an embedded bracket panel with `Continue` and `Start New Tournament` buttons; starting a new tournament clears the stored tournament and restores the normal lobby options. (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) 
- Tournament presets: changed the lobby bracket presets to even options (now [8, 16, 32]) to reduce odd-player situations. (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) 
- Bracket page: added an `embed` mode, compacted layout for portrait mobile (smaller columns/boxes and gaps), hid the CTA when embedded, and normalized requested tournament player counts to an even number. (`webapp/public/pool-royale-bracket.html`) 

### Testing
- Ran `npx eslint` on the modified files (paths were reported as ignored by the current lint config; no new lint errors introduced). — warning results only. 
- Built the webapp with `npm run -s build` in `webapp/` and the production bundle built successfully. 
- Performed an automated browser check (Playwright) to seed an active tournament in localStorage and captured a mobile-portrait screenshot of the lobby showing the embedded bracket panel; the screenshot was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ab2c01c883299993ee7dab596ccb)