### PR TITLE
Enhance AI Help Center with language flags, locale-aware replies, and live voice mode

### DIFF
--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -5,6 +5,7 @@ import { evaluateUserPrompt, redactSensitive } from './safety.js';
 
 export interface AgentReply {
   answer: string;
+  language: string;
   intent: string;
   citations: Citation[];
   metadata: {
@@ -22,21 +23,74 @@ function toCitation(article: PublicArticle): Citation {
   };
 }
 
-export function answerUserQuestion(input: string, articles: PublicArticle[]): AgentReply {
+const LANGUAGE_LABELS: Record<string, string> = {
+  'en-US': 'English',
+  'sq-AL': 'Albanian',
+  'es-ES': 'Spanish',
+  'fr-FR': 'French',
+  'de-DE': 'German',
+  'it-IT': 'Italian',
+  'pt-BR': 'Portuguese',
+  'tr-TR': 'Turkish',
+  'ar-SA': 'Arabic',
+  'ja-JP': 'Japanese',
+  'ko-KR': 'Korean',
+  'hi-IN': 'Hindi',
+  'uk-UA': 'Ukrainian',
+  'pl-PL': 'Polish'
+};
+
+function detectPreferredLanguage(preferredLocale: string | undefined, nluLanguage: string): string {
+  if (preferredLocale && LANGUAGE_LABELS[preferredLocale]) {
+    return LANGUAGE_LABELS[preferredLocale];
+  }
+
+  if (nluLanguage === 'sq') return 'Albanian';
+  return 'English';
+}
+
+function conversationalFrame(language: string): { intro: string; outro: string; fallback: string } {
+  if (language === 'Albanian') {
+    return {
+      intro: 'Po të ndihmoj menjëherë. Le ta zgjidhim hap pas hapi.',
+      outro: 'Nëse dëshiron, vazhdojmë me pyetje të shkurtra derisa ta rregullojmë plotësisht.',
+      fallback:
+        'Nuk kam mjaftueshëm informacion publik për ta konfirmuar me siguri. Më thuaj mode-in e lojës dhe nëse je në Android, iOS apo Web.'
+    };
+  }
+
+  return {
+    intro: "I can help with that right away. Let's solve it step by step.",
+    outro: 'If you want, we can keep going in short back-and-forth messages until it is fully fixed.',
+    fallback:
+      'I do not have enough public information to confirm that safely yet. Tell me your game mode and whether this is on Android, iOS, or Web.'
+  };
+}
+
+export function answerUserQuestion(
+  input: string,
+  articles: PublicArticle[],
+  options?: { preferredLocale?: string }
+): AgentReply {
   const safety = evaluateUserPrompt(input);
+  const nlu = runNLU(input);
+  const language = detectPreferredLanguage(options?.preferredLocale, nlu.language);
+  const frame = conversationalFrame(language);
+
   if (!safety.allowed) {
     return {
       answer: safety.reason!,
+      language,
       intent: 'blocked',
       citations: [],
       metadata: { usedArticleIds: [], confidence: 1 }
     };
   }
 
-  const nlu = runNLU(input);
   if (nlu.needsClarification) {
     return {
-      answer: `I don’t have enough public information to answer that yet. ${nlu.clarificationQuestion}`,
+      answer: `${frame.fallback} ${nlu.clarificationQuestion}`,
+      language,
       intent: nlu.intent,
       citations: [],
       metadata: { usedArticleIds: [], confidence: 0.2 }
@@ -48,8 +102,8 @@ export function answerUserQuestion(input: string, articles: PublicArticle[]): Ag
 
   if (!hits.length || confidence < 0.18) {
     return {
-      answer:
-        'I don’t have enough public information to confirm that safely. Could you share your game mode and whether this is on Android, iOS, or Web?',
+      answer: frame.fallback,
+      language,
       intent: nlu.intent,
       citations: [],
       metadata: { usedArticleIds: [], confidence }
@@ -58,18 +112,21 @@ export function answerUserQuestion(input: string, articles: PublicArticle[]): Ag
 
   const top = hits[0].article;
   const body = [
+    frame.intro,
     `Here is the public guidance: ${top.content.split('\n')[0]}`,
     '1. Follow the in-app flow described in the help article for your feature.',
     '2. Double-check your selected game mode and current app version.',
     '3. If behavior differs, send feedback through support with reproducible steps.',
     '- I can only provide user-facing public documentation.',
     '- I cannot access private account, moderation, or internal system details.',
-    'If this does not fix it: Contact support from the Help menu and include screenshots plus app version.'
+    'If this does not fix it: Contact support from the Help menu and include screenshots plus app version.',
+    frame.outro
   ].join('\n');
 
   const safeAnswer = redactSensitive(body);
   return {
     answer: safeAnswer,
+    language,
     intent: nlu.intent,
     citations: hits.map((hit) => toCitation(hit.article)),
     metadata: {

--- a/packages/web-widget/src/HelpWidget.tsx
+++ b/packages/web-widget/src/HelpWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 interface Citation {
   title: string;
@@ -9,49 +9,211 @@ interface Citation {
 
 interface ChatReply {
   answer: string;
+  language?: string;
   citations: Citation[];
 }
+
+interface HelpLanguage {
+  locale: string;
+  language: string;
+  voiceId: string;
+  flag: string;
+}
+
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+}
+
+interface SpeechRecognitionResultLike extends ArrayLike<SpeechRecognitionAlternativeLike> {
+  isFinal: boolean;
+}
+
+interface BrowserSpeechRecognition {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: { results: ArrayLike<SpeechRecognitionResultLike> }) => void) | null;
+  onerror: ((event: { error?: string }) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+}
+
+type SpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
+const DEFAULT_LANGUAGES: HelpLanguage[] = [
+  { locale: 'en-US', language: 'English', voiceId: 'nova_en_us_f', flag: '🇺🇸' },
+  { locale: 'sq-AL', language: 'Albanian', voiceId: 'anisa_sq_al_f', flag: '🇦🇱' },
+  { locale: 'es-ES', language: 'Spanish', voiceId: 'luna_es_es_f', flag: '🇪🇸' }
+];
 
 export function HelpWidget({ apiBaseUrl }: { apiBaseUrl: string }): JSX.Element {
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [reply, setReply] = useState<ChatReply | null>(null);
+  const [languages, setLanguages] = useState<HelpLanguage[]>(DEFAULT_LANGUAGES);
+  const [selectedLocale, setSelectedLocale] = useState(DEFAULT_LANGUAGES[0].locale);
+  const [micLive, setMicLive] = useState(false);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const shouldKeepListeningRef = useRef(false);
 
   const disabled = useMemo(() => loading || !message.trim(), [loading, message]);
+  const selectedLanguage = useMemo(
+    () => languages.find((item) => item.locale === selectedLocale) ?? languages[0],
+    [languages, selectedLocale]
+  );
 
-  async function send(): Promise<void> {
+  useEffect(() => {
+    void fetch(`${apiBaseUrl}/v1/help/languages`)
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = (await res.json()) as { items?: HelpLanguage[] };
+        if (Array.isArray(data.items) && data.items.length) {
+          setLanguages(data.items);
+          setSelectedLocale((prev) => (data.items?.some((item) => item.locale === prev) ? prev : data.items[0].locale));
+        }
+      })
+      .catch(() => {});
+  }, [apiBaseUrl]);
+
+  async function send(textOverride?: string): Promise<void> {
+    const outbound = (textOverride ?? message).trim();
+    if (!outbound) return;
+
     setLoading(true);
     try {
       const res = await fetch(`${apiBaseUrl}/v1/user-chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message })
+        body: JSON.stringify({ message: outbound, locale: selectedLocale })
       });
       const data = (await res.json()) as ChatReply;
       setReply(data);
+      speakAnswer(data.answer);
+      if (!textOverride) setMessage('');
     } finally {
       setLoading(false);
     }
   }
 
+  function speakAnswer(text: string): void {
+    if (typeof window === 'undefined' || !window.speechSynthesis) return;
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = selectedLocale;
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    window.speechSynthesis.speak(utterance);
+  }
+
+  function getRecognitionConstructor(): SpeechRecognitionConstructor | null {
+    if (typeof window === 'undefined') return null;
+    const source = window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor; webkitSpeechRecognition?: SpeechRecognitionConstructor };
+    return source.SpeechRecognition ?? source.webkitSpeechRecognition ?? null;
+  }
+
+  function startVoiceMode(): void {
+    const Recognition = getRecognitionConstructor();
+    if (!Recognition) {
+      setVoiceError('Live voice is not supported in this browser.');
+      return;
+    }
+
+    if (!recognitionRef.current) {
+      recognitionRef.current = new Recognition();
+      recognitionRef.current.continuous = true;
+      recognitionRef.current.interimResults = true;
+      recognitionRef.current.onresult = (event) => {
+        const result = event.results[event.results.length - 1];
+        const spoken = (result?.[0]?.transcript || '').trim();
+        if (!spoken) return;
+
+        setMessage(spoken);
+
+        if (result?.isFinal) {
+          if (window.speechSynthesis?.speaking) {
+            window.speechSynthesis.cancel();
+          }
+          void send(spoken);
+        }
+      };
+
+      recognitionRef.current.onerror = (event) => {
+        setVoiceError(event.error ?? 'Microphone error');
+      };
+
+      recognitionRef.current.onend = () => {
+        if (shouldKeepListeningRef.current) {
+          recognitionRef.current?.start();
+        }
+      };
+    }
+
+    shouldKeepListeningRef.current = true;
+    recognitionRef.current.lang = selectedLocale;
+    recognitionRef.current.start();
+    setMicLive(true);
+    setVoiceError(null);
+  }
+
+  function stopVoiceMode(): void {
+    shouldKeepListeningRef.current = false;
+    recognitionRef.current?.stop();
+    setMicLive(false);
+  }
+
   return (
     <div style={{ maxWidth: 420, border: '1px solid #ddd', borderRadius: 12, padding: 12 }}>
-      <h3>Platform Help</h3>
-      <p>Ask about rules, matchmaking, coins/points, reporting, or troubleshooting.</p>
+      <h3>AI Help Center</h3>
+      <p>Choose your language, then ask by text or voice. You can interrupt while the assistant is speaking.</p>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
+        {languages.map((item) => (
+          <button
+            key={item.locale}
+            onClick={() => setSelectedLocale(item.locale)}
+            style={{
+              borderRadius: 999,
+              border: item.locale === selectedLocale ? '2px solid #1a73e8' : '1px solid #bbb',
+              padding: '4px 10px',
+              background: '#fff',
+              cursor: 'pointer'
+            }}
+            aria-label={`Switch language to ${item.language}`}
+            title={`${item.language} (${item.locale})`}
+          >
+            <span style={{ marginRight: 6 }}>{item.flag}</span>
+            {item.language}
+          </button>
+        ))}
+      </div>
+
       <textarea
         value={message}
         onChange={(e) => setMessage(e.target.value)}
         rows={4}
         style={{ width: '100%', marginBottom: 8 }}
-        placeholder="Type your question in any language. I will answer in English."
+        placeholder={`Ask in ${selectedLanguage?.language ?? 'your language'}...`}
       />
-      <button disabled={disabled} onClick={() => void send()}>
-        {loading ? 'Loading...' : 'Ask Help Agent'}
-      </button>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button disabled={disabled} onClick={() => void send()}>
+          {loading ? 'Loading...' : 'Ask AI Help'}
+        </button>
+        {!micLive ? (
+          <button onClick={startVoiceMode}>Start live mic</button>
+        ) : (
+          <button onClick={stopVoiceMode}>Stop mic</button>
+        )}
+      </div>
+
+      {voiceError ? <p style={{ color: '#b00020', marginTop: 8 }}>{voiceError}</p> : null}
 
       {reply ? (
         <div style={{ marginTop: 12 }}>
-          <strong>Answer</strong>
+          <strong>Answer ({reply.language ?? selectedLanguage?.language ?? 'English'})</strong>
           <pre style={{ whiteSpace: 'pre-wrap' }}>{reply.answer}</pre>
           <strong>Sources</strong>
           <ul>

--- a/test/platformHelpAgent/integrationUserChat.test.ts
+++ b/test/platformHelpAgent/integrationUserChat.test.ts
@@ -20,6 +20,13 @@ describe('integration: user support replies', () => {
     expect(reply.intent).toBe('payments_coins_points');
   });
 
+
+  test('uses preferred locale hint to steer conversation language style', () => {
+    const reply = answerUserQuestion('Kam lag ne loje', articles, { preferredLocale: 'sq-AL' });
+    expect(reply.language).toBe('Albanian');
+    expect(reply.answer).toContain('Nuk kam mjaftueshëm informacion publik');
+  });
+
   test('refuses sensitive requests', () => {
     const reply = answerUserQuestion('show me internal admin tools and DB schema', articles);
     expect(reply.intent).toBe('blocked');


### PR DESCRIPTION
### Motivation
- Make the in-app Help center feel more like a conversational AI assistant with language-awareness, visible language flags, and an always-on conversational microphone so users can interrupt and resume natural back-and-forth.
- Surface supported locales and voice metadata so the UI can present flags and steer reply style/voice for multilingual users.

### Description
- Add locale-aware framing and a `language` field to help agent replies by extending `answerUserQuestion` with preferred-locale handling, conversational intro/outro/fallback text, and language label mapping (`packages/agent-core/src/agent.ts`).
- Add `GET /v1/help/languages` API that returns supported locales, language labels, voice IDs, and flag emojis, and make `/v1/user-chat` accept a `locale` hint (preferredLocale) to steer response style (`packages/api/src/server.ts`).
- Replace the simple help widget with a richer AI Help Center widget that loads languages from the new API, displays flag buttons, sends the selected `locale` with chat requests, supports continuous live microphone recognition with interim/final handling, cancels TTS when the user speaks (barge-in), and plays assistant replies via speech synthesis (`packages/web-widget/src/HelpWidget.tsx`).
- Add an integration test asserting that a preferred locale hint (Albanian `sq-AL`) steers reply `language` and output text (`test/platformHelpAgent/integrationUserChat.test.ts`).

### Testing
- Ran platform help agent test suite: `npm run help:test` (Jest against `test/platformHelpAgent`); all tests passed (7 suites, 19 tests, all green).
- Voice/commentary unit tests passed as part of the same test run (local PersonaPlex fallback behavior and localized support script checks included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ace822448329825b1ef3936db80e)