### PR TITLE
Restore store payment confirmations to prior flow

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1419,10 +1419,7 @@ export default function Store() {
           price: item.price
         }))
       };
-      const purchaseId = `store-${resolvedAccountId}-${Date.now()}-${Math.random()
-        .toString(36)
-        .slice(2, 10)}`;
-      const purchase = await buyBundle(resolvedAccountId, bundle, purchaseId);
+      const purchase = await buyBundle(resolvedAccountId, bundle);
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -704,10 +704,8 @@ export function depositAccount(accountId, amount, extra = {}) {
   );
 }
 
-export function buyBundle(accountId, bundle, purchaseId) {
-  const body = { accountId, bundle };
-  if (purchaseId) body.purchaseId = purchaseId;
-  return post('/api/store/purchase', body);
+export function buyBundle(accountId, bundle) {
+  return post('/api/store/purchase', { accountId, bundle });
 }
 
 export function claimPurchase(accountId, txHash) {


### PR DESCRIPTION
### Motivation
- The store payment flow was changed recently to use request-level idempotency and a generated `purchaseId`, which altered confirmation semantics and caused purchases to fail for some linked TPC accounts. 
- The intent is to restore the storefront payment confirmations to the behavior used one week ago so purchases complete when the user has sufficient TPC and the account is linked. 
- The change is scoped to store checkout/payment handling only, avoiding unrelated UI/game logic changes.

### Description
- Reverted the client checkout shape by removing the generated `purchaseId` from the call to `buyBundle(...)` and restored `buyBundle(accountId, bundle)` in `webapp/src/utils/api.js` and `webapp/src/pages/Store.jsx` so requests match the prior stable flow. 
- Restored the previous server-side item-bundle handling in `bot/routes/store.js` by reverting the idempotent/find-and-update debit logic and returning to the earlier sequence: compute balance via `calculateBalance(...)`, append a `storefront` transaction, then deduct `user.balance` if needed. 
- Preserved voice-item unlock behavior and per-game unlock syncs while keeping the overall change narrowly focused on store purchase confirmation and accounting logic (`bot/routes/store.js`, `webapp/src/pages/Store.jsx`, `webapp/src/utils/api.js`).

### Testing
- Ran `npx eslint bot/routes/store.js webapp/src/utils/api.js webapp/src/pages/Store.jsx` and `npx eslint --no-ignore ...` to surface style issues; lint reported many existing style-rule violations but these are repo-wide pre-existing issues and not blockers for runtime behavior. (Lint run completed; errors are stylistic.)
- Ran `node --check bot/routes/store.js && node --check webapp/src/utils/api.js` to validate syntax; this check succeeded. 
- Verified changes were committed (`Restore store payment confirmations to prior flow`) and the modified files are `bot/routes/store.js`, `webapp/src/pages/Store.jsx`, and `webapp/src/utils/api.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ae2109748329b2efd101291e4062)