### PR TITLE
Fix Pool Royale training freeze when cue ball is potted

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -23590,6 +23590,7 @@ const powerRef = useRef(hud.power);
 
       // Shot lifecycle
       let potted = [];
+      const pottedIds = new Set();
       let firstHit = null;
 
       const alignStandingCameraToAim = (cueBall, aimDir) => {
@@ -23863,6 +23864,7 @@ const powerRef = useRef(hud.power);
         queuedPocketView = null;
         aimFocusRef.current = null;
         potted = [];
+        pottedIds.clear();
         firstHit = null;
         clearInterval(timerRef.current);
         const aimDir = aimDirRef.current.clone();
@@ -27231,6 +27233,7 @@ const powerRef = useRef(hud.power);
             });
           }
           potted = [];
+          pottedIds.clear();
           firstHit = null;
       lastShotPower = 0;
     }
@@ -28964,6 +28967,9 @@ const powerRef = useRef(hud.power);
                   }
                 }
               }
+              if (pottedIds.has(b.id)) {
+                continue;
+              }
               if (shotRecording) {
                 recordReplayFrame(performance.now());
               }
@@ -28999,6 +29005,7 @@ const powerRef = useRef(hud.power);
                 const colorId =
                   mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
                 potted.push({ id: b.id, color: colorId, pocket: pocketId });
+                pottedIds.add(b.id);
                 if (
                   activeShotView?.mode === 'pocket' &&
                   activeShotView.ballId === b.id
@@ -29148,6 +29155,7 @@ const powerRef = useRef(hud.power);
               const colorId =
                 mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
               potted.push({ id: b.id, color: colorId, pocket: pocketId });
+              pottedIds.add(b.id);
               if (
                 activeShotView?.mode === 'pocket' &&
                 activeShotView.ballId === b.id


### PR DESCRIPTION
### Motivation
- Training sessions could freeze when the cue ball was potted because the pocket handler repeatedly re-processed the same cue-ball each frame while it remained active for in-hand respawn.

### Description
- Add a per-shot dedupe set `pottedIds` to the shot lifecycle to track which ball IDs have already been processed for the current shot.
- Clear `pottedIds` when a shot starts and during shot cleanup so the dedupe is scoped to a single shot.
- Guard the pocket-processing loop with `if (pottedIds.has(b.id)) continue;` and add `pottedIds.add(b.id)` when pushing a ball into `potted`, at both cue-ball and object-ball code paths.
- Change is localized to `webapp/src/pages/Games/PoolRoyale.jsx` and does not alter game rules, only prevents duplicate per-frame pocket events during resolution.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which reported the file is ignored by repo eslint patterns (no lint errors for the executed scope).
- Ran `npm --prefix webapp run build` and the project successfully built (Vite build completed with warnings about large chunks but no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996b04578688329978446b24ee72ab4)