### PR TITLE
Voice-only multilingual help UI and PersonaPlex speak endpoint

### DIFF
--- a/webapp/src/components/PlatformHelpAgentCard.jsx
+++ b/webapp/src/components/PlatformHelpAgentCard.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getSpeechSupport, speakCommentaryLines } from '../utils/textToSpeech.js';
 import {
   buildStructuredResponse,
@@ -7,15 +7,33 @@ import {
 } from '../utils/platformHelpLocalSearch.js';
 
 const SPEECH_RECOGNITION_ERROR =
-  'Voice input is unavailable on this device/browser. You can still type your question.';
+  'Voice input is unavailable on this device/browser. Please use a supported browser for voice help.';
 
-const SUPPORTED_HELP_LANGUAGES = [
-  { label: 'English', locale: 'en-US', flag: '🇺🇸' },
-  { label: 'Shqip', locale: 'sq-AL', flag: '🇦🇱' },
-  { label: 'Español', locale: 'es-ES', flag: '🇪🇸' },
-  { label: 'Português', locale: 'pt-PT', flag: '🇵🇹' },
-  { label: 'Türkçe', locale: 'tr-TR', flag: '🇹🇷' }
+const DEFAULT_LANGUAGES = [
+  { locale: 'en-US', language: 'English' },
+  { locale: 'sq-AL', language: 'Albanian' },
+  { locale: 'es-ES', language: 'Spanish' },
+  { locale: 'pt-BR', language: 'Portuguese' },
+  { locale: 'tr-TR', language: 'Turkish' }
 ];
+
+const LOCALE_TO_FLAG = {
+  'en-US': '🇺🇸',
+  'sq-AL': '🇦🇱',
+  'es-ES': '🇪🇸',
+  'es-MX': '🇲🇽',
+  'fr-FR': '🇫🇷',
+  'de-DE': '🇩🇪',
+  'it-IT': '🇮🇹',
+  'ja-JP': '🇯🇵',
+  'ko-KR': '🇰🇷',
+  'hi-IN': '🇮🇳',
+  'ar-SA': '🇸🇦',
+  'tr-TR': '🇹🇷',
+  'pt-BR': '🇧🇷',
+  'uk-UA': '🇺🇦',
+  'pl-PL': '🇵🇱'
+};
 
 function createSpeechRecognition(locale = 'en-US') {
   if (typeof window === 'undefined') return null;
@@ -30,18 +48,17 @@ function createSpeechRecognition(locale = 'en-US') {
 }
 
 export default function PlatformHelpAgentCard({ onClose = null }) {
-  const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState(
-    'Hi! I can help with wallet, games, NFTs, matchmaking, roadmap, tasks, and troubleshooting. Pick your language and ask naturally.'
+    'Voice help is ready. Tap your language flag, then tap Open Mic and speak.'
   );
   const [citations, setCitations] = useState([]);
   const [isListening, setIsListening] = useState(false);
-  const [isSpeakingEnabled, setIsSpeakingEnabled] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedLocale, setSelectedLocale] = useState('en-US');
+  const [supportedLanguages, setSupportedLanguages] = useState(DEFAULT_LANGUAGES);
 
   const recognitionRef = useRef(null);
-  const liveTranscriptRef = useRef('');
+  const isListeningRef = useRef(false);
 
   const canUseSpeechInput = useMemo(() => {
     if (typeof window === 'undefined') return false;
@@ -50,10 +67,58 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
 
   const canUseSpeechOutput = useMemo(() => Boolean(getSpeechSupport()), []);
 
+  useEffect(() => {
+    isListeningRef.current = isListening;
+  }, [isListening]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadVoiceLanguages = async () => {
+      try {
+        const response = await fetch('/v1/voice/catalog');
+        if (!response.ok) return;
+        const payload = await response.json();
+        const voices = Array.isArray(payload?.voices) ? payload.voices : [];
+        const uniqueByLocale = new Map();
+        voices.forEach((voice) => {
+          const locale = String(voice?.locale || '').trim();
+          const language = String(voice?.language || '').trim();
+          if (!locale || !language || uniqueByLocale.has(locale)) return;
+          uniqueByLocale.set(locale, { locale, language });
+        });
+
+        const items = Array.from(uniqueByLocale.values());
+        if (!cancelled && items.length) {
+          setSupportedLanguages(items);
+          if (!items.some((item) => item.locale === selectedLocale)) {
+            setSelectedLocale(items[0].locale);
+          }
+        }
+      } catch {
+        // Keep local defaults if catalog call fails.
+      }
+    };
+
+    void loadVoiceLanguages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedLocale]);
+
   const stopAgentVoice = () => {
     if (typeof window !== 'undefined' && window.speechSynthesis) {
       window.speechSynthesis.cancel();
     }
+  };
+
+  const speakAnswer = async (text) => {
+    if (!canUseSpeechOutput || !String(text || '').trim()) return;
+    await speakCommentaryLines([{ speaker: 'Help Host', text }], {
+      voiceHints: { 'Help Host': [selectedLocale] },
+      speakerSettings: { 'Help Host': 'personaplex' }
+    });
   };
 
   const runLocalFallback = async (text) => {
@@ -61,11 +126,7 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
     const reply = buildStructuredResponse(text, matches, selectedLocale);
     setAnswer(reply.answer);
     setCitations(reply.citations);
-    if (isSpeakingEnabled && canUseSpeechOutput) {
-      await speakCommentaryLines([{ speaker: 'Lena', text: reply.answer }], {
-        voiceHints: { Lena: [selectedLocale] }
-      });
-    }
+    await speakAnswer(reply.answer);
   };
 
   const runAgentReply = async (text) => {
@@ -74,11 +135,7 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
         'I can’t help with sensitive, private, or abuse-related requests. I can share public user guidance and official support steps.';
       setAnswer(blocked);
       setCitations([]);
-      if (isSpeakingEnabled && canUseSpeechOutput) {
-        await speakCommentaryLines([{ speaker: 'Lena', text: blocked }], {
-          voiceHints: { Lena: [selectedLocale] }
-        });
-      }
+      await speakAnswer(blocked);
       return;
     }
 
@@ -90,13 +147,14 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
         body: JSON.stringify({
           message: text,
           locale: selectedLocale,
-          mode: 'live-help',
+          mode: 'live-help-voice-only',
           systemContext:
-            'You are TonPlaygram live help. Be warm, concise, natural, and conversational. Ask follow-up questions. Avoid robotic responses. Reply in the user locale when possible.',
+            'You are TonPlaygram live help. Keep answers clear and voice-friendly. Reply in the selected locale.',
           capabilities: {
             interruptionAware: true,
             keepMicOpen: true,
-            bargeIn: true
+            bargeIn: true,
+            voiceOnly: true
           }
         })
       });
@@ -116,22 +174,12 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
 
       setAnswer(nextAnswer);
       setCitations(nextCitations);
-      if (isSpeakingEnabled && canUseSpeechOutput) {
-        await speakCommentaryLines([{ speaker: 'Lena', text: nextAnswer }], {
-          voiceHints: { Lena: [selectedLocale] }
-        });
-      }
+      await speakAnswer(nextAnswer);
     } catch {
       await runLocalFallback(text);
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const askQuestion = async () => {
-    const text = question.trim();
-    if (!text) return;
-    await runAgentReply(text);
   };
 
   const stopVoiceInput = () => {
@@ -164,34 +212,22 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
     }
 
     recognition.onresult = (event) => {
-      let partial = '';
       for (let i = event.resultIndex; i < event.results.length; i += 1) {
         const result = event.results[i];
-        const transcript = result?.[0]?.transcript || '';
-        if (result.isFinal) {
-          const finalText = String(transcript || '').trim();
-          if (!finalText) continue;
-          liveTranscriptRef.current = '';
-          setQuestion(finalText);
-          stopAgentVoice();
-          void runAgentReply(finalText);
-        } else {
-          partial += transcript;
-        }
-      }
-      if (partial.trim()) {
-        liveTranscriptRef.current = partial.trim();
-        setQuestion(liveTranscriptRef.current);
+        const transcript = String(result?.[0]?.transcript || '').trim();
+        if (!result.isFinal || !transcript) continue;
+        stopAgentVoice();
+        void runAgentReply(transcript);
       }
     };
 
     recognition.onerror = () => {
-      setAnswer('Voice input failed. Please try again or type your question.');
+      setAnswer('Voice input failed. Please try again.');
       setIsListening(false);
     };
 
     recognition.onend = () => {
-      if (isListening) {
+      if (isListeningRef.current) {
         try {
           recognition.start();
         } catch {
@@ -209,62 +245,38 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
       <div className="flex items-center justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-white">TonPlaygram AI Help Center</h3>
-          <p className="text-xs text-subtext">Real-time conversation • Voice interruption enabled • Public guidance only</p>
+          <p className="text-xs text-subtext">Voice-only help • PersonaPlex voices • Tap a flag to change language</p>
         </div>
-        <div className="flex items-center gap-2">
+        {onClose ? (
           <button
             type="button"
             className="px-2 py-1 text-xs rounded-md border border-border text-white"
-            onClick={() => setIsSpeakingEnabled((prev) => !prev)}
+            onClick={onClose}
           >
-            {isSpeakingEnabled ? 'Voice: ON' : 'Voice: OFF'}
+            Close
           </button>
-          {onClose ? (
-            <button
-              type="button"
-              className="px-2 py-1 text-xs rounded-md border border-border text-white"
-              onClick={onClose}
-            >
-              Close
-            </button>
-          ) : null}
-        </div>
+        ) : null}
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-semibold text-subtext">Choose help language</p>
+        <p className="text-xs font-semibold text-subtext">Supported languages</p>
         <div className="flex flex-wrap gap-2">
-          {SUPPORTED_HELP_LANGUAGES.map((language) => (
+          {supportedLanguages.map((language) => (
             <button
               key={language.locale}
               type="button"
               onClick={() => setSelectedLocale(language.locale)}
-              className={`px-2.5 py-1.5 rounded-lg border text-sm ${selectedLocale === language.locale ? 'border-primary bg-primary/20 text-white' : 'border-border text-subtext'}`}
+              className={`h-10 w-10 rounded-lg border text-xl leading-none ${selectedLocale === language.locale ? 'border-primary bg-primary/20' : 'border-border'}`}
+              aria-label={language.language}
+              title={`${language.language} (${language.locale})`}
             >
-              <span className="mr-1" role="img" aria-label={language.label}>{language.flag}</span>
-              {language.label}
+              {LOCALE_TO_FLAG[language.locale] || '🌐'}
             </button>
           ))}
         </div>
       </div>
 
-      <textarea
-        value={question}
-        onChange={(event) => setQuestion(event.target.value)}
-        rows={3}
-        className="w-full rounded-lg bg-background border border-border px-3 py-2 text-sm text-white"
-        placeholder="Ask naturally. You can interrupt voice and ask follow-up questions anytime..."
-      />
-
       <div className="flex items-center gap-2 flex-wrap">
-        <button
-          type="button"
-          className="px-3 py-2 rounded-lg bg-primary text-black text-sm font-semibold disabled:opacity-60"
-          onClick={() => void askQuestion()}
-          disabled={isLoading}
-        >
-          {isLoading ? 'Thinking…' : 'Ask'}
-        </button>
         <button
           type="button"
           className="px-3 py-2 rounded-lg border border-border text-sm text-white disabled:opacity-60"

--- a/webapp/src/utils/textToSpeech.js
+++ b/webapp/src/utils/textToSpeech.js
@@ -189,12 +189,13 @@ export const speakCommentaryLines = async (
     const hints = Array.isArray(voiceHints[speaker]) ? voiceHints[speaker] : []
     const localeHint = hints.find((hint) => /^[a-z]{2}(?:-[a-z]{2})?$/i.test(String(hint || '')))
 
-    const payload = await post('/api/voice-commentary/speak', {
+    const payload = await post('/v1/voice/speak', {
       accountId,
       text,
       speaker,
       locale: localeHint,
-      style: speakerSettings[speaker] || null
+      style: speakerSettings[speaker] || null,
+      channel: 'commentary'
     })
 
     if (payload?.error) {
@@ -203,7 +204,7 @@ export const speakCommentaryLines = async (
     }
 
     try {
-      if (payload?.provider === 'web-speech-fallback' || !payload?.synthesis?.audioUrl && !payload?.synthesis?.audioBase64) {
+      if (payload?.provider === 'web-speech-fallback' || (!payload?.synthesis?.audioUrl && !payload?.synthesis?.audioBase64)) {
         await speakWithBrowserTts(payload?.text || text, hints)
       } else {
         try {


### PR DESCRIPTION
### Motivation
- Provide a voice-only help experience where users pick their language by tapping a flag and receive spoken answers. 
- Use PersonaPlex (PersonaPlex / NVIDIA) voice personalities for both help and in-game commentary to ensure consistent, natural TTS.
- Expose a single, reusable backend synthesis endpoint to centralize PersonaPlex calls and support help/commentary producers.

### Description
- Reworked the help UI in `webapp/src/components/PlatformHelpAgentCard.jsx` to a voice-only flow, removed the typed-question textarea, and replaced language labels with flag-only selection buttons wired to a dynamic voice catalog. The card now loads supported locales from `GET /v1/voice/catalog` and lets users tap flags to switch `selectedLocale`.
- Added a new API endpoint `POST /v1/voice/speak` in `packages/api/src/server.ts` which resolves a PersonaPlex voice profile via `findVoiceProfile(...)` and delegates synthesis to `requestPersonaplexSynthesis(...)`; the endpoint returns `{ text, voice, synthesis }` and accepts `voiceId`, `locale`, `channel`, and `speaker` fields.
- Updated client TTS usage to call the new endpoint: `webapp/src/utils/textToSpeech.js` now posts to `POST /v1/voice/speak` (with `channel: 'commentary'` for commentary), and chooses browser TTS fallback if no audio payload is present.
- Introduced `personaplex` speaker setting hints in help playback and cleaned up a mixed-operator lint issue in the TTS client (`(!payload?.synthesis?.audioUrl && !payload?.synthesis?.audioBase64)`).

### Testing
- Lint check: `npx eslint --no-ignore webapp/src/utils/textToSpeech.js` — succeeded after fixing the mixed-operator expression.
- Dev server smoke run: `npm run dev -- --host 0.0.0.0 --port 4173` — Vite dev server started successfully.
- Playwright screenshot attempt to validate UI visually — failed due to Chromium in-container crash (SIGSEGV) in this environment, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996c2b70a848329a2f0c670be5cda56)