### PR TITLE
Enforce PersonaPlex TTS for help/commentary, normalize synthesis payloads, and align help languages

### DIFF
--- a/packages/api/src/voiceCommentary.ts
+++ b/packages/api/src/voiceCommentary.ts
@@ -77,10 +77,10 @@ function getGameLabel(game: GameKey): string {
 
 function supportReplyTemplate(language: string, ticketContext: string): string {
   if (language.toLowerCase().startsWith('albanian')) {
-    return `Përshëndetje! Ky është asistenti zanor i mbështetjes. E kuptova kërkesën tuaj: ${ticketContext}. Po e shqyrtojmë tani dhe do t'ju përgjigjemi me hapa të qartë.`;
+    return `Përshëndetje! Faleminderit që na kontaktuat. E kuptova kërkesën tuaj: ${ticketContext}. Po e kontrollojmë menjëherë dhe do t’ju japim hapa të qartë, një nga një.`;
   }
 
-  return `Hello! This is your voice support assistant. I understood your request: ${ticketContext}. We are checking it now and will send you clear next steps.`;
+  return `Hi there, thanks for reaching out. I understood your request: ${ticketContext}. We’re checking this now and I’ll walk you through the next steps clearly.`;
 }
 
 export function buildCommentaryText(game: GameKey, eventType: CommentaryEventType, playerName: string, score?: string): string {
@@ -89,17 +89,17 @@ export function buildCommentaryText(game: GameKey, eventType: CommentaryEventTyp
 
   switch (eventType) {
     case 'match_start':
-      return `Welcome to ${gameLabel}! The match is live. ${safePlayer}, bring your best move.`;
+      return `Welcome to ${gameLabel}. We’re live, the crowd is ready, and ${safePlayer} is stepping in with confidence.`;
     case 'player_turn':
-      return `${safePlayer}, it's your turn in ${gameLabel}. Focus, aim, and execute.`;
+      return `Your move, ${safePlayer}. Take a breath, line it up, and trust your timing in ${gameLabel}.`;
     case 'score_update':
-      return `Score update in ${gameLabel}: ${score ?? 'new score available'}. Momentum is shifting.`;
+      return `Score update in ${gameLabel}: ${score ?? 'new score available'}. This match just got a lot more interesting.`;
     case 'streak':
-      return `${safePlayer} is on a streak in ${gameLabel}! What a dominant run.`;
+      return `${safePlayer} is heating up in ${gameLabel}. That streak is putting real pressure on everyone else.`;
     case 'powerup':
-      return `Power play activated in ${gameLabel}. ${safePlayer} is changing the pace.`;
+      return `Power play activated in ${gameLabel}. ${safePlayer} just changed the rhythm of the game.`;
     case 'match_end':
-      return `${gameLabel} match complete. Great game by ${safePlayer}. Thanks for playing.`;
+      return `${gameLabel} is complete. Great performance by ${safePlayer}, and a strong finish from both sides.`;
     case 'customer_support':
       return supportReplyTemplate('English', score ?? 'General support request');
     default:

--- a/webapp/src/components/PlatformHelpAgentCard.jsx
+++ b/webapp/src/components/PlatformHelpAgentCard.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getSpeechSupport, speakCommentaryLines } from '../utils/textToSpeech.js';
 import {
   buildStructuredResponse,
@@ -7,15 +7,33 @@ import {
 } from '../utils/platformHelpLocalSearch.js';
 
 const SPEECH_RECOGNITION_ERROR =
-  'Voice input is unavailable on this device/browser. You can still type your question.';
+  'Voice input is unavailable on this device/browser. Please use a supported browser for voice help.';
 
-const SUPPORTED_HELP_LANGUAGES = [
-  { label: 'English', locale: 'en-US', flag: '🇺🇸' },
-  { label: 'Shqip', locale: 'sq-AL', flag: '🇦🇱' },
-  { label: 'Español', locale: 'es-ES', flag: '🇪🇸' },
-  { label: 'Português', locale: 'pt-PT', flag: '🇵🇹' },
-  { label: 'Türkçe', locale: 'tr-TR', flag: '🇹🇷' }
+const DEFAULT_LANGUAGES = [
+  { locale: 'en-US', language: 'English' },
+  { locale: 'sq-AL', language: 'Albanian' },
+  { locale: 'es-ES', language: 'Spanish' },
+  { locale: 'pt-BR', language: 'Portuguese' },
+  { locale: 'tr-TR', language: 'Turkish' }
 ];
+
+const LOCALE_TO_FLAG = {
+  'en-US': '🇺🇸',
+  'sq-AL': '🇦🇱',
+  'es-ES': '🇪🇸',
+  'es-MX': '🇲🇽',
+  'fr-FR': '🇫🇷',
+  'de-DE': '🇩🇪',
+  'it-IT': '🇮🇹',
+  'ja-JP': '🇯🇵',
+  'ko-KR': '🇰🇷',
+  'hi-IN': '🇮🇳',
+  'ar-SA': '🇸🇦',
+  'tr-TR': '🇹🇷',
+  'pt-BR': '🇧🇷',
+  'uk-UA': '🇺🇦',
+  'pl-PL': '🇵🇱'
+};
 
 function createSpeechRecognition(locale = 'en-US') {
   if (typeof window === 'undefined') return null;
@@ -30,18 +48,17 @@ function createSpeechRecognition(locale = 'en-US') {
 }
 
 export default function PlatformHelpAgentCard({ onClose = null }) {
-  const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState(
-    'Hi! I can help with wallet, games, NFTs, matchmaking, roadmap, tasks, and troubleshooting. Pick your language and ask naturally.'
+    'Voice help is ready. Tap your language flag, then tap Open Mic and speak.'
   );
   const [citations, setCitations] = useState([]);
   const [isListening, setIsListening] = useState(false);
-  const [isSpeakingEnabled, setIsSpeakingEnabled] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedLocale, setSelectedLocale] = useState('en-US');
+  const [supportedLanguages, setSupportedLanguages] = useState(DEFAULT_LANGUAGES);
 
   const recognitionRef = useRef(null);
-  const liveTranscriptRef = useRef('');
+  const isListeningRef = useRef(false);
 
   const canUseSpeechInput = useMemo(() => {
     if (typeof window === 'undefined') return false;
@@ -50,9 +67,64 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
 
   const canUseSpeechOutput = useMemo(() => Boolean(getSpeechSupport()), []);
 
+  useEffect(() => {
+    isListeningRef.current = isListening;
+  }, [isListening]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadVoiceLanguages = async () => {
+      try {
+        const response = await fetch('/v1/voice/catalog');
+        if (!response.ok) return;
+        const payload = await response.json();
+        const voices = Array.isArray(payload?.voices) ? payload.voices : [];
+        const uniqueByLocale = new Map();
+        voices.forEach((voice) => {
+          const locale = String(voice?.locale || '').trim();
+          const language = String(voice?.language || '').trim();
+          if (!locale || !language || uniqueByLocale.has(locale)) return;
+          uniqueByLocale.set(locale, { locale, language });
+        });
+
+        const items = Array.from(uniqueByLocale.values()).sort((a, b) => a.language.localeCompare(b.language));
+        if (!cancelled && items.length) {
+          setSupportedLanguages(items);
+          if (!items.some((item) => item.locale === selectedLocale)) {
+            setSelectedLocale(items[0].locale);
+          }
+        }
+      } catch {
+        // Keep local defaults if catalog call fails.
+      }
+    };
+
+    void loadVoiceLanguages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const stopAgentVoice = () => {
     if (typeof window !== 'undefined' && window.speechSynthesis) {
       window.speechSynthesis.cancel();
+    }
+  };
+
+  const speakAnswer = async (text) => {
+    if (!canUseSpeechOutput || !String(text || '').trim()) return;
+    try {
+      await speakCommentaryLines([{ speaker: 'Help Host', text }], {
+        voiceHints: { 'Help Host': [selectedLocale] },
+        speakerSettings: { 'Help Host': 'personaplex' },
+        channel: 'help'
+      });
+    } catch {
+      setAnswer((prev) => `${prev}
+
+(Voice unavailable right now. PersonaPlex synthesis did not return playable audio.)`);
     }
   };
 
@@ -61,11 +133,7 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
     const reply = buildStructuredResponse(text, matches, selectedLocale);
     setAnswer(reply.answer);
     setCitations(reply.citations);
-    if (isSpeakingEnabled && canUseSpeechOutput) {
-      await speakCommentaryLines([{ speaker: 'Lena', text: reply.answer }], {
-        voiceHints: { Lena: [selectedLocale] }
-      });
-    }
+    await speakAnswer(reply.answer);
   };
 
   const runAgentReply = async (text) => {
@@ -74,11 +142,7 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
         'I can’t help with sensitive, private, or abuse-related requests. I can share public user guidance and official support steps.';
       setAnswer(blocked);
       setCitations([]);
-      if (isSpeakingEnabled && canUseSpeechOutput) {
-        await speakCommentaryLines([{ speaker: 'Lena', text: blocked }], {
-          voiceHints: { Lena: [selectedLocale] }
-        });
-      }
+      await speakAnswer(blocked);
       return;
     }
 
@@ -90,13 +154,14 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
         body: JSON.stringify({
           message: text,
           locale: selectedLocale,
-          mode: 'live-help',
+          mode: 'live-help-voice-only',
           systemContext:
-            'You are TonPlaygram live help. Be warm, concise, natural, and conversational. Ask follow-up questions. Avoid robotic responses. Reply in the user locale when possible.',
+            'You are TonPlaygram live help. Keep answers clear and voice-friendly. Reply in the selected locale.',
           capabilities: {
             interruptionAware: true,
             keepMicOpen: true,
-            bargeIn: true
+            bargeIn: true,
+            voiceOnly: true
           }
         })
       });
@@ -116,22 +181,12 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
 
       setAnswer(nextAnswer);
       setCitations(nextCitations);
-      if (isSpeakingEnabled && canUseSpeechOutput) {
-        await speakCommentaryLines([{ speaker: 'Lena', text: nextAnswer }], {
-          voiceHints: { Lena: [selectedLocale] }
-        });
-      }
+      await speakAnswer(nextAnswer);
     } catch {
       await runLocalFallback(text);
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const askQuestion = async () => {
-    const text = question.trim();
-    if (!text) return;
-    await runAgentReply(text);
   };
 
   const stopVoiceInput = () => {
@@ -164,34 +219,22 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
     }
 
     recognition.onresult = (event) => {
-      let partial = '';
       for (let i = event.resultIndex; i < event.results.length; i += 1) {
         const result = event.results[i];
-        const transcript = result?.[0]?.transcript || '';
-        if (result.isFinal) {
-          const finalText = String(transcript || '').trim();
-          if (!finalText) continue;
-          liveTranscriptRef.current = '';
-          setQuestion(finalText);
-          stopAgentVoice();
-          void runAgentReply(finalText);
-        } else {
-          partial += transcript;
-        }
-      }
-      if (partial.trim()) {
-        liveTranscriptRef.current = partial.trim();
-        setQuestion(liveTranscriptRef.current);
+        const transcript = String(result?.[0]?.transcript || '').trim();
+        if (!result.isFinal || !transcript) continue;
+        stopAgentVoice();
+        void runAgentReply(transcript);
       }
     };
 
     recognition.onerror = () => {
-      setAnswer('Voice input failed. Please try again or type your question.');
+      setAnswer('Voice input failed. Please try again.');
       setIsListening(false);
     };
 
     recognition.onend = () => {
-      if (isListening) {
+      if (isListeningRef.current) {
         try {
           recognition.start();
         } catch {
@@ -209,62 +252,38 @@ export default function PlatformHelpAgentCard({ onClose = null }) {
       <div className="flex items-center justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-white">TonPlaygram AI Help Center</h3>
-          <p className="text-xs text-subtext">Real-time conversation • Voice interruption enabled • Public guidance only</p>
+          <p className="text-xs text-subtext">Voice-only help • PersonaPlex voices • Tap a flag to change language</p>
         </div>
-        <div className="flex items-center gap-2">
+        {onClose ? (
           <button
             type="button"
             className="px-2 py-1 text-xs rounded-md border border-border text-white"
-            onClick={() => setIsSpeakingEnabled((prev) => !prev)}
+            onClick={onClose}
           >
-            {isSpeakingEnabled ? 'Voice: ON' : 'Voice: OFF'}
+            Close
           </button>
-          {onClose ? (
-            <button
-              type="button"
-              className="px-2 py-1 text-xs rounded-md border border-border text-white"
-              onClick={onClose}
-            >
-              Close
-            </button>
-          ) : null}
-        </div>
+        ) : null}
       </div>
 
       <div className="space-y-2">
-        <p className="text-xs font-semibold text-subtext">Choose help language</p>
+        <p className="text-xs font-semibold text-subtext">Supported languages</p>
         <div className="flex flex-wrap gap-2">
-          {SUPPORTED_HELP_LANGUAGES.map((language) => (
+          {supportedLanguages.map((language) => (
             <button
               key={language.locale}
               type="button"
               onClick={() => setSelectedLocale(language.locale)}
-              className={`px-2.5 py-1.5 rounded-lg border text-sm ${selectedLocale === language.locale ? 'border-primary bg-primary/20 text-white' : 'border-border text-subtext'}`}
+              className={`h-10 w-10 rounded-lg border text-xl leading-none ${selectedLocale === language.locale ? 'border-primary bg-primary/20' : 'border-border'}`}
+              aria-label={language.language}
+              title={`${language.language} (${language.locale})`}
             >
-              <span className="mr-1" role="img" aria-label={language.label}>{language.flag}</span>
-              {language.label}
+              {LOCALE_TO_FLAG[language.locale] || '🌐'}
             </button>
           ))}
         </div>
       </div>
 
-      <textarea
-        value={question}
-        onChange={(event) => setQuestion(event.target.value)}
-        rows={3}
-        className="w-full rounded-lg bg-background border border-border px-3 py-2 text-sm text-white"
-        placeholder="Ask naturally. You can interrupt voice and ask follow-up questions anytime..."
-      />
-
       <div className="flex items-center gap-2 flex-wrap">
-        <button
-          type="button"
-          className="px-3 py-2 rounded-lg bg-primary text-black text-sm font-semibold disabled:opacity-60"
-          onClick={() => void askQuestion()}
-          disabled={isLoading}
-        >
-          {isLoading ? 'Thinking…' : 'Ask'}
-        </button>
         <button
           type="button"
           className="px-3 py-2 rounded-lg border border-border text-sm text-white disabled:opacity-60"


### PR DESCRIPTION
### Motivation
- Ensure commentary and help use PersonaPlex voices (no silent browser-TTS fallback) so in-game commentary and voice help sound natural and consistent. 
- Surface a stable, normalized audio payload from the backend so the web client can reliably play PersonaPlex audio. 
- Make the help UI language selector reflect the same voice locales available for commentary so flags and voices are in parity.

### Description
- Added `normalizeSynthesisPayload(...)` and updated `/v1/voice/speak`, `/v1/voice/commentary`, and `/v1/voice/support` to return normalized `synthesis` fields (`audioUrl` / `audioBase64` / `mimeType` and `mode` metadata) in `packages/api/src/server.ts` so the client sees a consistent audio shape. 
- Updated `requestPersonaplexSynthesis`/scripts in `packages/api/src/voiceCommentary.ts` to use friendlier, more conversational templates for commentary/support text. 
- Changed client TTS flow in `webapp/src/utils/textToSpeech.js` to call `/v1/voice/speak`, require PersonaPlex audio by default (no browser fallback unless `allowBrowserFallback` is true), surface explicit errors when PersonaPlex is unavailable, and keep commentary output-only (no mic activation). 
- Reworked help UI in `webapp/src/components/PlatformHelpAgentCard.jsx` to load deduplicated locales from `GET /v1/voice/catalog`, sort them, render flag-only language buttons, adopt a voice-only help flow (removed typed-question textarea/ask button), and call the centralized PersonaPlex-backed `speakCommentaryLines` (channel `'help'`).

### Testing
- Ran lint: `npx eslint --no-ignore webapp/src/components/PlatformHelpAgentCard.jsx webapp/src/utils/textToSpeech.js` which completed with a file-ignore warning but no errors. (succeeded with warning)
- Started dev server: `npm run dev -- --host 0.0.0.0 --port 4173` and Vite served the app (server started successfully). (succeeded)
- Executed a Playwright script to open the app and capture a mobile-portrait screenshot of the help flags to verify UI; an artifact was produced. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996c2b70a848329a2f0c670be5cda56)