### PR TITLE
Fix Pool Royale freeze when cue ball is potted

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -29087,7 +29087,7 @@ const powerRef = useRef(hud.power);
               const pocketId = POCKET_IDS[pocketIndex] ?? 'TM';
               if (isCueBall && inHandActive) {
                 if (b.mesh) {
-                  b.mesh.visible = true;
+                  b.mesh.visible = false;
                 }
                 b.vel.set(0, 0);
                 b.spin?.set(0, 0);
@@ -29096,7 +29096,7 @@ const powerRef = useRef(hud.power);
                 b.swerveStrength = 0;
                 b.swervePowerStrength = 0;
                 b.impacted = false;
-                b.active = true;
+                b.active = false;
                 if (!hudRef.current?.inHand) {
                   hudRef.current = { ...hudRef.current, inHand: true };
                   setHud((prev) => ({ ...prev, inHand: true }));
@@ -29171,7 +29171,7 @@ const powerRef = useRef(hud.power);
               if (b.id === 'cue') b.impacted = false;
               if (isCueBall) {
                 if (b.mesh) {
-                  b.mesh.visible = true;
+                  b.mesh.visible = false;
                 }
                 b.vel.set(0, 0);
                 b.spin?.set(0, 0);
@@ -29180,7 +29180,7 @@ const powerRef = useRef(hud.power);
                 b.swerveStrength = 0;
                 b.swervePowerStrength = 0;
                 b.impacted = false;
-                b.active = true;
+                b.active = false;
                 removePocketDropEntry(b.id);
                 if (isTraining && table) {
                   const scratchPopup = createTrainingScratchPopupMesh();


### PR DESCRIPTION
### Motivation
- Potting the cue ball could leave it active and visible inside the pocket trigger which caused repeated per-frame recapture and effectively froze shot progression. 

### Description
- Updated pocket-capture handling in `webapp/src/pages/Games/PoolRoyale.jsx` to hide the cue-ball mesh (`b.mesh.visible = false`) and mark the cue ball inactive (`b.active = false`) in both the in-hand branch and the general potted branch. 
- This prevents the cue ball from being repeatedly processed by the pocket trigger while preserving the existing in-hand respawn and HUD flow. 
- Change is limited to pocket capture logic and does not alter foul/hud state computation or other ball handling.

### Testing
- Ran the unit tests for pool rules with `npm test -- --runInBand test/poolRoyaleRules.test.ts`, and the suite passed.
- `jest` reported: 1 test suite passed, 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e51037748329b0eb5d85c5625367)