### PR TITLE
Fix store purchase auth header fallback for TPC checkout

### DIFF
--- a/test/storePurchaseAuthHeaders.test.js
+++ b/test/storePurchaseAuthHeaders.test.js
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, test } from '@jest/globals';
+import assert from 'node:assert/strict';
+
+const originalWindow = global.window;
+const originalFetch = global.fetch;
+
+function createStorage() {
+  const map = new Map();
+  return {
+    getItem: (key) => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => map.set(key, String(value)),
+    removeItem: (key) => map.delete(key)
+  };
+}
+
+beforeEach(() => {
+  global.window = {
+    localStorage: createStorage(),
+    location: { origin: 'https://example.test' }
+  };
+});
+
+afterEach(() => {
+  global.window = originalWindow;
+  global.fetch = originalFetch;
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('store purchase forwards accountId in auth header when local storage is empty', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ ok: true })
+  });
+
+  const { buyBundle } = await import('../webapp/src/utils/api.js');
+
+  const accountId = 'acc_test_123';
+  await buyBundle(accountId, {
+    items: [{ slug: 'poolroyale', type: 'cue', optionId: 'starter', price: 100 }]
+  });
+
+  assert.equal(global.fetch.mock.calls.length, 1);
+  const [, request] = global.fetch.mock.calls[0];
+  assert.equal(request.headers['X-Tpc-Account-Id'], accountId);
+});

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -73,13 +73,15 @@ async function fetchWithRetry(url, options = {}, retries = 3, backoff = 500) {
   }
 }
 
-function buildHeaders(base = {}) {
+function buildHeaders(base = {}, body = null) {
   const headers = { ...base };
   const initData = window?.Telegram?.WebApp?.initData;
   if (initData) headers['X-Telegram-Init-Data'] = initData;
-  const accountId = window?.localStorage?.getItem('accountId');
+  const bodyAccountId = body && typeof body === 'object' ? body.accountId : null;
+  const accountId = window?.localStorage?.getItem('accountId') || bodyAccountId;
   if (accountId) headers['X-Tpc-Account-Id'] = accountId;
-  const googleId = window?.localStorage?.getItem('googleId');
+  const bodyGoogleId = body && typeof body === 'object' ? body.googleId : null;
+  const googleId = window?.localStorage?.getItem('googleId') || bodyGoogleId;
   if (googleId) headers['X-Google-Id'] = googleId;
   const bridgeHeaders = getNativeBridgeHeaders();
   Object.entries(bridgeHeaders).forEach(([key, value]) => {
@@ -89,7 +91,7 @@ function buildHeaders(base = {}) {
 }
 
 export async function post(path, body, token) {
-  const headers = buildHeaders({ 'Content-Type': 'application/json' });
+  const headers = buildHeaders({ 'Content-Type': 'application/json' }, body);
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
   let res;
@@ -127,7 +129,7 @@ export async function post(path, body, token) {
 }
 
 export async function put(path, body, token) {
-  const headers = buildHeaders({ 'Content-Type': 'application/json' });
+  const headers = buildHeaders({ 'Content-Type': 'application/json' }, body);
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
   let res;


### PR DESCRIPTION
### Motivation
- Store purchases using TPC were failing because `/api/store/purchase` requires non-Telegram auth via `X-Tpc-Account-Id`/`X-Google-Id` headers and some frontend sessions send `accountId` only in the request body, causing `401 unauthorized` and blocking payments. 

### Description
- Update `webapp/src/utils/api.js` so `buildHeaders(base, body)` falls back to `body.accountId` and `body.googleId` when `localStorage` values are missing and those headers are required.  
- Pass the request `body` into `buildHeaders` for `post` and `put` calls so `buyBundle(accountId, bundle)` forwards `X-Tpc-Account-Id` from the call when needed.  
- Add a regression test `test/storePurchaseAuthHeaders.test.js` that asserts `buyBundle(accountId, bundle)` sets `X-Tpc-Account-Id` when localStorage is empty.  

### Testing
- Added and ran the new unit test with `npm test -- --runInBand test/storePurchaseAuthHeaders.test.js`, which passed.  
- Re-ran related voice/commentary tests with `npm test -- --runInBand test/voiceCommentaryUnlocks.test.js`, which also passed.  
- All automated tests mentioned above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e9fb54648329aa9bb2f24ab002cf)