### PR TITLE
Support confirmed TPC txHash payments in store purchase API

### DIFF
--- a/bot/models/BurnedTPC.js
+++ b/bot/models/BurnedTPC.js
@@ -5,7 +5,9 @@ const burnedTPCSchema = new mongoose.Schema({
   amount: { type: Number, required: true },
   date: { type: Date, required: true },
   verified: { type: Boolean, default: false },
-  recipient: { type: String, required: true }
+  recipient: { type: String, required: true },
+  claimedByAccountId: { type: String, default: '' },
+  claimedAt: { type: Date, default: null }
 });
 
 export default mongoose.model('BurnedTPC', burnedTPCSchema);

--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import authenticate from '../middleware/auth.js';
 import User from '../models/User.js';
+import BurnedTPC from '../models/BurnedTPC.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
 import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
@@ -20,16 +21,74 @@ function resolveUserBalance(user) {
   return Math.max(derived, persisted);
 }
 
+function normalizeTxHash(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+async function resolvePayment({ user, accountId, totalPrice, txHash }) {
+  const normalizedTxHash = normalizeTxHash(txHash);
+  ensureTransactionArray(user);
+
+  if (normalizedTxHash) {
+    const alreadyClaimed = (user.transactions || []).some(
+      (tx) => normalizeTxHash(tx?.txHash) === normalizedTxHash
+    );
+    if (alreadyClaimed) {
+      return { error: 'payment already claimed', status: 409 };
+    }
+
+    const confirmedTransfer = await BurnedTPC.findOne({
+      txHash: normalizedTxHash,
+      verified: true,
+      recipient: accountId
+    });
+
+    if (!confirmedTransfer) {
+      return {
+        error: 'payment not confirmed yet. Wait for network confirmation and retry.',
+        status: 409
+      };
+    }
+
+    if (confirmedTransfer.claimedByAccountId && confirmedTransfer.claimedByAccountId !== accountId) {
+      return { error: 'payment already claimed', status: 409 };
+    }
+
+    const paidAmount = Number(confirmedTransfer.amount) || 0;
+    if (paidAmount < totalPrice) {
+      return { error: 'confirmed payment amount is below item total', status: 400 };
+    }
+
+    confirmedTransfer.claimedByAccountId = accountId;
+    confirmedTransfer.claimedAt = new Date();
+    await confirmedTransfer.save();
+
+    return {
+      kind: 'confirmed-transfer',
+      txHash: normalizedTxHash,
+      paymentToken: 'TPC',
+      balance: resolveUserBalance(user)
+    };
+  }
+
+  const balance = resolveUserBalance(user);
+  if (balance < totalPrice) {
+    return { error: 'insufficient balance', status: 400 };
+  }
+
+  return {
+    kind: 'balance',
+    paymentToken: 'TPC',
+    balance
+  };
+}
+
 router.post('/purchase', authenticate, async (req, res) => {
   const { accountId, bundle, txHash } = req.body;
   const authId = req.auth?.telegramId;
 
   if (!accountId) {
     return res.status(400).json({ error: 'accountId required' });
-  }
-
-  if (txHash) {
-    return res.status(400).json({ error: 'TON payments are disabled. Use TPC balance only.' });
   }
 
   const isItemBundle =
@@ -65,10 +124,9 @@ router.post('/purchase', authenticate, async (req, res) => {
     return res.status(400).json({ error: 'invalid bundle total' });
   }
 
-  ensureTransactionArray(user);
-  const balance = resolveUserBalance(user);
-  if (balance < totalPrice) {
-    return res.status(400).json({ error: 'insufficient balance' });
+  const payment = await resolvePayment({ user, accountId, totalPrice, txHash });
+  if (payment.error) {
+    return res.status(payment.status || 400).json({ error: payment.error });
   }
 
   const txDate = new Date();
@@ -81,20 +139,25 @@ router.post('/purchase', authenticate, async (req, res) => {
   user.transactions.push({
     amount: -totalPrice,
     type: 'storefront',
-    token: 'TPC',
+    token: payment.paymentToken,
     status: 'delivered',
     date: txDate,
     detail: 'Storefront purchase',
+    txHash: payment.txHash || undefined,
     items
   });
-  user.balance = balance - totalPrice;
+  if (payment.kind === 'balance') {
+    user.balance = payment.balance - totalPrice;
+  }
   await user.save();
 
   return res.json({
     balance: user.balance,
     date: txDate,
-    paymentToken: 'TPC'
+    paymentToken: payment.paymentToken,
+    txHash: payment.txHash || undefined
   });
 });
 
+export { resolvePayment };
 export default router;

--- a/test/storePaymentResolution.test.js
+++ b/test/storePaymentResolution.test.js
@@ -1,0 +1,53 @@
+import { test, afterEach } from '@jest/globals';
+import assert from 'node:assert/strict';
+import BurnedTPC from '../bot/models/BurnedTPC.js';
+import { resolvePayment } from '../bot/routes/store.js';
+
+const originalFindOne = BurnedTPC.findOne;
+
+afterEach(() => {
+  BurnedTPC.findOne = originalFindOne;
+});
+
+test('resolvePayment uses account balance when txHash is not provided', async () => {
+  const user = { balance: 150, transactions: [] };
+  const result = await resolvePayment({ user, accountId: 'acc-1', totalPrice: 100, txHash: '' });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.kind, 'balance');
+  assert.equal(result.balance, 150);
+  assert.equal(result.paymentToken, 'TPC');
+});
+
+test('resolvePayment accepts confirmed txHash payment and does not require balance', async () => {
+  let saveCalls = 0;
+  BurnedTPC.findOne = async (query) => {
+    assert.equal(query.txHash, '0xabc');
+    assert.equal(query.verified, true);
+    assert.equal(query.recipient, 'acc-2');
+    return {
+      amount: 220,
+      async save() {
+        saveCalls += 1;
+      }
+    };
+  };
+
+  const user = { balance: 0, transactions: [] };
+  const result = await resolvePayment({ user, accountId: 'acc-2', totalPrice: 200, txHash: ' 0xabc ' });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.kind, 'confirmed-transfer');
+  assert.equal(result.txHash, '0xabc');
+  assert.equal(saveCalls, 1);
+});
+
+test('resolvePayment rejects unconfirmed txHash payments', async () => {
+  BurnedTPC.findOne = async () => null;
+
+  const user = { balance: 0, transactions: [] };
+  const result = await resolvePayment({ user, accountId: 'acc-3', totalPrice: 90, txHash: '0xdead' });
+
+  assert.equal(result.status, 409);
+  assert.match(result.error, /not confirmed yet/i);
+});


### PR DESCRIPTION
### Motivation
- The store purchase endpoint previously rejected any request with `txHash`, preventing wallet-driven TPC payments from being accepted and delivered.
- Allowing confirmed on-chain TPC transfers (tx hashes) to be claimed lets users pay from external wallets and still receive store items.

### Description
- Remove the hard rejection of `txHash` in `/api/store/purchase` and add a unified payment resolution flow via `resolvePayment` that accepts either an internal balance or a confirmed TPC transfer recorded in `BurnedTPC`.
- Add guarded handling for tx-hash purchases: verify the `BurnedTPC` record is `verified`, reject unconfirmed or already-claimed transfers, reject underpaid transfers, and mark a confirmed transfer as claimed (`claimedByAccountId`, `claimedAt`), and persist `txHash` on the storefront transaction for traceability.
- Extend the `BurnedTPC` model with `claimedByAccountId` and `claimedAt` fields to prevent replay/duplicate claims.
- Export and unit-test `resolvePayment`; add `test/storePaymentResolution.test.js` covering balance payments, confirmed tx-hash acceptance, and rejection of unconfirmed tx-hash payments.

### Testing
- Ran the new unit tests: `npm test -- test/storePaymentResolution.test.js` and they passed (3/3 tests passed).
- Re-ran a related suite to ensure no regressions: `npm test -- test/voiceCommentaryUnlocks.test.js` and it passed (4/4 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e9fb54648329aa9bb2f24ab002cf)