### PR TITLE
Server-side delivery for TPC store purchases: apply unlocks and add tests

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -4,11 +4,78 @@ import User from '../models/User.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
 import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
+import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
+import { SNOOKER_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/snookerRoyalInventoryConfig.js';
 
 const router = Router();
 
 
 export const BUNDLES = {};
+
+const STORE_INVENTORY_TARGETS = {
+  poolroyale: 'pool',
+  tabletennisroyal: 'pool',
+  snookerroyale: 'snooker'
+};
+
+function copyDefaults(defaults = {}) {
+  return Object.entries(defaults).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...new Set(values.filter(Boolean))] : [];
+    return acc;
+  }, {});
+}
+
+function normalizeInventory(rawInventory, defaults) {
+  const normalized = copyDefaults(defaults);
+  if (!rawInventory || typeof rawInventory !== 'object') return normalized;
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    normalized[key] = [...new Set([...(normalized[key] || []), ...value.filter(Boolean)])];
+  });
+  return normalized;
+}
+
+export function applyStoreItemDelivery(user, items = []) {
+  const poolInventory = normalizeInventory(user.poolRoyalInventory, POOL_ROYALE_DEFAULT_UNLOCKS);
+  const snookerInventory = normalizeInventory(user.snookerRoyalInventory, SNOOKER_ROYALE_DEFAULT_UNLOCKS);
+  const delivery = {
+    pool: [],
+    snooker: [],
+    unsupported: []
+  };
+
+  items.forEach((item) => {
+    const target = STORE_INVENTORY_TARGETS[item.slug];
+    if (!target || !item.type || !item.optionId) {
+      delivery.unsupported.push(item);
+      return;
+    }
+
+    if (target === 'pool') {
+      const current = new Set(poolInventory[item.type] || []);
+      const sizeBefore = current.size;
+      current.add(item.optionId);
+      poolInventory[item.type] = [...current];
+      if (current.size !== sizeBefore) delivery.pool.push(item);
+      return;
+    }
+
+    const current = new Set(snookerInventory[item.type] || []);
+    const sizeBefore = current.size;
+    current.add(item.optionId);
+    snookerInventory[item.type] = [...current];
+    if (current.size !== sizeBefore) delivery.snooker.push(item);
+  });
+
+  user.poolRoyalInventory = poolInventory;
+  user.snookerRoyalInventory = snookerInventory;
+
+  return {
+    ...delivery,
+    poolInventory,
+    snookerInventory
+  };
+}
 
 function safeNumericBalance(value) {
   return Number.isFinite(value) ? value : 0;
@@ -78,6 +145,8 @@ router.post('/purchase', authenticate, async (req, res) => {
     applyVoiceCommentaryUnlocks(user, items, catalog.voices || []);
   }
 
+  const delivery = applyStoreItemDelivery(user, items);
+
   user.transactions.push({
     amount: -totalPrice,
     type: 'storefront',
@@ -93,7 +162,12 @@ router.post('/purchase', authenticate, async (req, res) => {
   return res.json({
     balance: user.balance,
     date: txDate,
-    paymentToken: 'TPC'
+    paymentToken: 'TPC',
+    delivery: {
+      pool: delivery.pool.length,
+      snooker: delivery.snooker.length,
+      unsupported: delivery.unsupported.length
+    }
   });
 });
 

--- a/test/storeDelivery.test.js
+++ b/test/storeDelivery.test.js
@@ -1,0 +1,41 @@
+import { applyStoreItemDelivery } from '../bot/routes/store.js';
+
+describe('applyStoreItemDelivery', () => {
+  test('delivers Pool and Snooker unlocks and tracks unsupported items', () => {
+    const user = {
+      poolRoyalInventory: { tableFinish: ['classic_green'] },
+      snookerRoyalInventory: { cueStyle: ['stock'] }
+    };
+
+    const result = applyStoreItemDelivery(user, [
+      { slug: 'poolroyale', type: 'tableFinish', optionId: 'neo_carbon' },
+      { slug: 'snookerroyale', type: 'cueStyle', optionId: 'pro_black' },
+      { slug: 'airhockey', type: 'table', optionId: 'ice_blue' }
+    ]);
+
+    expect(result.pool).toHaveLength(1);
+    expect(result.snooker).toHaveLength(1);
+    expect(result.unsupported).toHaveLength(1);
+    expect(user.poolRoyalInventory.tableFinish).toEqual(
+      expect.arrayContaining(['classic_green', 'neo_carbon'])
+    );
+    expect(user.snookerRoyalInventory.cueStyle).toEqual(
+      expect.arrayContaining(['stock', 'pro_black'])
+    );
+  });
+
+  test('does not duplicate already owned items', () => {
+    const user = {
+      poolRoyalInventory: { tableFinish: ['neo_carbon'] },
+      snookerRoyalInventory: { cueStyle: [] }
+    };
+
+    const result = applyStoreItemDelivery(user, [
+      { slug: 'poolroyale', type: 'tableFinish', optionId: 'neo_carbon' }
+    ]);
+
+    expect(result.pool).toHaveLength(0);
+    expect(user.poolRoyalInventory.tableFinish).toContain('neo_carbon');
+    expect(user.poolRoyalInventory.tableFinish.filter((entry) => entry === 'neo_carbon')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- The purchase endpoint deducted TPC and recorded transactions but relied on client-side follow-up calls to apply non-voice item unlocks, which could leave users charged without delivered items. 
- Move delivery into the server purchase flow to guarantee atomic payment + delivery for supported inventories.

### Description
- Added server-side delivery logic in `bot/routes/store.js` via `applyStoreItemDelivery` to apply unlocks idempotently for supported slugs (`poolroyale`, `tabletennisroyal`, `snookerroyale`) and normalize inventories against default unlock sets. 
- Kept voice commentary handling unchanged and still applied by `applyVoiceCommentaryUnlocks`. 
- The purchase handler now calls `applyStoreItemDelivery(user, items)` before persisting the user and returns a `delivery` summary in the response with counts for `pool`, `snooker`, and `unsupported` items. 
- Added unit tests at `test/storeDelivery.test.js` that validate pool/snooker deliveries, unsupported tracking, and duplicate-prevention.

### Testing
- Added `test/storeDelivery.test.js` covering delivery behavior and duplicate prevention. 
- Ran the test command `npm test -- test/storeDelivery.test.js --runInBand`, and it passed: 2 tests, 2 passed.
- No other automated tests were modified; the change is constrained to `bot/routes/store.js` and the new unit test file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e9fb54648329aa9bb2f24ab002cf)