### PR TITLE
Harden production env validation and fix webapp audit findings

### DIFF
--- a/bot/env.js
+++ b/bot/env.js
@@ -22,18 +22,26 @@ function warnMissing(key, hint) {
 
 export function validateEnv() {
   const isProd = process.env.NODE_ENV === 'production';
+  const allowInsecureDefaults = isTruthy(process.env.ALLOW_INSECURE_DEFAULTS);
 
   // Required for production runtime.
   if (isProd) {
     requireEnv('BOT_TOKEN');
     // MONGO_URI can be set later by server.js fallback, but in production we want it explicit.
     requireEnv('MONGO_URI');
+
+    if (!allowInsecureDefaults) {
+      requireEnv('ALLOWED_ORIGINS');
+      requireEnv('API_AUTH_TOKEN');
+    }
   }
 
   // Optional but recommended.
   warnMissing(
     'ALLOWED_ORIGINS',
-    'comma-separated list, e.g. https://tonplaygram-bot.onrender.com,https://web.telegram.org'
+    isProd
+      ? 'set this in production (or ALLOW_INSECURE_DEFAULTS=true only temporarily)'
+      : 'comma-separated list, e.g. https://tonplaygram-bot.onrender.com,https://web.telegram.org'
   );
 
   // TON claim / withdraw requirements.
@@ -45,10 +53,16 @@ export function validateEnv() {
   }
 
   // Token used for privileged server-to-server calls (optional but useful).
-  warnMissing('API_AUTH_TOKEN');
+  warnMissing(
+    'API_AUTH_TOKEN',
+    isProd
+      ? 'set this in production (or ALLOW_INSECURE_DEFAULTS=true only temporarily)'
+      : undefined
+  );
 
   return {
     isProd,
-    withdrawEnabled
+    withdrawEnabled,
+    allowInsecureDefaults
   };
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -43,12 +43,17 @@
     "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
-    "vite": "^4.4.9"
+    "vite": "^5.4.20"
   },
   "devDependencies": {
     "@capacitor/cli": "6.1.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "typescript": "^5.4.0"
+  },
+  "overrides": {
+    "esbuild": "^0.25.10",
+    "minimatch": "^10.2.1",
+    "tar": "^7.5.8"
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent insecure default deployments by requiring critical production variables and making safety expectations explicit. 
- Provide a temporary escape hatch for rollouts that need to relax the new checks (`ALLOW_INSECURE_DEFAULTS`).
- Eliminate transitive package vulnerabilities reported by `npm audit` in the `webapp` package.

### Description
- Updated `bot/env.js` to add `ALLOW_INSECURE_DEFAULTS`, require `ALLOWED_ORIGINS` and `API_AUTH_TOKEN` in production when the escape hatch is not enabled, improve warning text, and return `allowInsecureDefaults` from `validateEnv`.
- Updated `webapp/package.json` to bump `vite` to `^5.4.20` and add `overrides` for `esbuild`, `minimatch`, and `tar` to force patched transitive versions.
- No application logic behavior was changed beyond environment validation and dependency policy updates.

### Testing
- Ran `npm audit` in `webapp` and confirmed `found 0 vulnerabilities` after the changes.
- Ran `npm run build` in `webapp` and confirmed the production build completed successfully using Vite `5.4.x`.
- No additional automated unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f7b8f20c832983f04d3c5c29791d)