### PR TITLE
Align store purchase auth/storage with NFT gifts/account APIs

### DIFF
--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -4,6 +4,11 @@ import User from '../models/User.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
 import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
+import {
+  findMemoryUser,
+  saveMemoryUser,
+  shouldUseMemoryUserStore
+} from '../utils/memoryUserStore.js';
 import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
 import { SNOOKER_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/snookerRoyalInventoryConfig.js';
 
@@ -87,9 +92,26 @@ function resolveUserBalance(user) {
   return Math.max(derived, persisted);
 }
 
+function isPrivileged(req) {
+  return req.auth?.apiToken === true;
+}
+
+function canAccessUser(req, user) {
+  if (isPrivileged(req)) return true;
+  if (!user) return false;
+  if (user.telegramId && req.auth?.telegramId && user.telegramId === req.auth.telegramId) return true;
+  if (user.googleId && req.auth?.googleId && user.googleId === req.auth.googleId) return true;
+  if (user.accountId && req.auth?.accountId && user.accountId === req.auth.accountId) return true;
+  return !user.telegramId && !user.googleId;
+}
+
 async function handleTpcPurchase(req, res) {
   const { accountId, bundle, txHash } = req.body;
-  const authId = req.auth?.telegramId;
+  const useMemoryStore = shouldUseMemoryUserStore();
+  const findUser = async (query) =>
+    useMemoryStore ? findMemoryUser(query) : User.findOne(query);
+  const persistUser = async (user) =>
+    useMemoryStore ? saveMemoryUser(user) : user.save();
 
   if (!accountId) {
     return res.status(400).json({ error: 'accountId required' });
@@ -109,9 +131,9 @@ async function handleTpcPurchase(req, res) {
     return res.status(400).json({ error: 'items bundle required' });
   }
 
-  const user = await User.findOne({ accountId });
+  const user = await findUser({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (authId && user.telegramId && authId !== user.telegramId) {
+  if (!canAccessUser(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
@@ -157,7 +179,7 @@ async function handleTpcPurchase(req, res) {
     items
   });
   user.balance = balance - totalPrice;
-  await user.save();
+  await persistUser(user);
 
   return res.json({
     balance: user.balance,


### PR DESCRIPTION
### Motivation
- Ensure Store purchases (including Pool Royale training-attempt bundles) use the same auth and user-storage behavior as the existing NFT gifts/account APIs so in-game store flows match a proven pattern.
- Support both Mongo-backed and memory-backed user stores to make store purchases work consistently across environments (local tests, CI, and production).

### Description
- Updated `bot/routes/store.js` to use `shouldUseMemoryUserStore`, `findMemoryUser`, and `saveMemoryUser` for user lookup and persistence so store purchases support the same memory/Mongo behavior as account endpoints.
- Introduced `canAccessUser` (and helper `isPrivileged`) to enforce the same authorization checks used by account/gift APIs (API token, Telegram init data, Google id, or matching `accountId`).
- Kept the existing public endpoints and payload contract intact by continuing to expose `POST /purchase-v2` and `POST /purchase` while replacing direct `User.findOne`/`user.save()` calls with the new lookup/persist helpers.

### Testing
- Ran `npm test -- test/storeDelivery.test.js --runInBand` to validate delivery logic and ensure no regressions in `applyStoreItemDelivery`, and the test suite passed.
- The store delivery unit tests reported: 2 tests passed (test suite `test/storeDelivery.test.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe6603448329a3aae8519891ff29)