### PR TITLE
Align Pool Royale training attempts purchase with store API configuration

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12674,8 +12674,8 @@ function PoolRoyaleGame({
     try {
       const purchase = await buyBundle(resolvedAccountId, {
         items: [{
-          slug: bundle.id,
-          type: 'pool-training-attempt',
+          slug: 'poolroyale',
+          type: 'poolTrainingAttempt',
           optionId: String(bundle.attempts),
           price: Number(bundle.price) || 0
         }]


### PR DESCRIPTION
### Motivation
- Training-attempt purchases from the Pool Royale popup were using a different item shape than the main Store flow, causing delivery mismatches with the backend store handling.
- The store backend routes deliveries by `slug` and expects the item `type` to match inventory config, so the popup must send the same shape as the Store UI.

### Description
- Updated the Pool Royale training purchase payload in `webapp/src/pages/Games/PoolRoyale.jsx` to use `slug: 'poolroyale'` and `type: 'poolTrainingAttempt'` when calling `buyBundle` so it matches the store item configuration.
- This replaces the previous `slug: bundle.id` and `type: 'pool-training-attempt'` values to ensure the backend `applyStoreItemDelivery` logic and `STORE_INVENTORY_TARGETS` mapping receive the expected fields.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; the command completed successfully but reported the file is ignored by repository lint ignore patterns (no errors observed).
- Verified the file diff shows the intended 2-line change to the `buyBundle` call and no other modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe6603448329a3aae8519891ff29)