### PR TITLE
Route store purchases via account gift-style API and align auth/storage behavior

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -14,6 +14,7 @@ import {
   sendGiftNotification
 } from '../utils/notifications.js';
 import NFT_GIFTS from '../utils/nftGifts.js';
+import { handleTpcPurchase } from './store.js';
 
 import { mintGiftNFT } from '../utils/nftService.js';
 import { generateWalletAddress } from '../utils/wallet.js';
@@ -549,6 +550,10 @@ router.post('/gift', authenticate, async (req, res) => {
 
   res.json({ balance: sender.balance, transaction: senderTx });
 });
+
+
+// Store purchase endpoint under account API to match gift API auth/path behavior
+router.post('/store-purchase', authenticate, handleTpcPurchase);
 
 // Convert received gifts to TPC
 router.post('/convert-gifts', authenticate, async (req, res) => {

--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -4,6 +4,11 @@ import User from '../models/User.js';
 import { ensureTransactionArray, calculateBalance } from '../utils/userUtils.js';
 import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
 import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
+import {
+  findMemoryUser,
+  saveMemoryUser,
+  shouldUseMemoryUserStore
+} from '../utils/memoryUserStore.js';
 import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
 import { SNOOKER_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/snookerRoyalInventoryConfig.js';
 
@@ -87,9 +92,26 @@ function resolveUserBalance(user) {
   return Math.max(derived, persisted);
 }
 
-async function handleTpcPurchase(req, res) {
+function isPrivileged(req) {
+  return req.auth?.apiToken === true;
+}
+
+function canAccessUser(req, user) {
+  if (isPrivileged(req)) return true;
+  if (!user) return false;
+  if (user.telegramId && req.auth?.telegramId && user.telegramId === req.auth.telegramId) return true;
+  if (user.googleId && req.auth?.googleId && user.googleId === req.auth.googleId) return true;
+  if (user.accountId && req.auth?.accountId && user.accountId === req.auth.accountId) return true;
+  return !user.telegramId && !user.googleId;
+}
+
+export async function handleTpcPurchase(req, res) {
   const { accountId, bundle, txHash } = req.body;
-  const authId = req.auth?.telegramId;
+  const useMemoryStore = shouldUseMemoryUserStore();
+  const findUser = async (query) =>
+    useMemoryStore ? findMemoryUser(query) : User.findOne(query);
+  const persistUser = async (user) =>
+    useMemoryStore ? saveMemoryUser(user) : user.save();
 
   if (!accountId) {
     return res.status(400).json({ error: 'accountId required' });
@@ -109,9 +131,9 @@ async function handleTpcPurchase(req, res) {
     return res.status(400).json({ error: 'items bundle required' });
   }
 
-  const user = await User.findOne({ accountId });
+  const user = await findUser({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  if (authId && user.telegramId && authId !== user.telegramId) {
+  if (!canAccessUser(req, user)) {
     return res.status(403).json({ error: 'forbidden' });
   }
 
@@ -157,7 +179,7 @@ async function handleTpcPurchase(req, res) {
     items
   });
   user.balance = balance - totalPrice;
-  await user.save();
+  await persistUser(user);
 
   return res.json({
     balance: user.balance,

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -705,12 +705,20 @@ export function depositAccount(accountId, amount, extra = {}) {
 }
 
 export function buyBundle(accountId, bundle) {
-  return post('/api/store/purchase-v2', { accountId, bundle }).then((response) => {
+  return post('/api/account/store-purchase', { accountId, bundle }).then((response) => {
     if (
       response?.error &&
       /not found|404/i.test(String(response.error))
     ) {
-      return post('/api/store/purchase', { accountId, bundle });
+      return post('/api/store/purchase-v2', { accountId, bundle }).then((legacyResponse) => {
+        if (
+          legacyResponse?.error &&
+          /not found|404/i.test(String(legacyResponse.error))
+        ) {
+          return post('/api/store/purchase', { accountId, bundle });
+        }
+        return legacyResponse;
+      });
     }
     return response;
   });


### PR DESCRIPTION
### Motivation
- Make Store purchases (including Pool Royale training-attempt bundles) use the exact same request, authorization and user-storage behavior as the working NFT gifts/account APIs so store flows behave identically to gifts. 
- Support both Mongo-backed and memory-backed user stores like the account/gift flows to ensure parity across local, CI and production environments.

### Description
- Exported the existing store handler as `handleTpcPurchase` and reused it from the account routes by adding `POST /api/account/store-purchase` wired with `authenticate` so store purchases can be invoked under the `account` API family. 
- Recreated the account/gift-style access checks in the Store handler by adding `isPrivileged`/`canAccessUser` logic and using that check before allowing purchases. 
- Aligned user lookup/persistence with the gift/account APIs by using `shouldUseMemoryUserStore`, `findMemoryUser` and `saveMemoryUser` (falling back to `User.findOne`/`user.save()`), and replaced direct `User.findOne`/`user.save()` calls accordingly. 
- Updated frontend `buyBundle` in `webapp/src/utils/api.js` to call `POST /api/account/store-purchase` first, with fallbacks to the legacy `/api/store/purchase-v2` and `/api/store/purchase` endpoints for compatibility.

### Testing
- Ran `npm test -- test/storeDelivery.test.js --runInBand` and the test suite passed (`2 tests passed`).
- Ran a smoke import `node -e "import('./bot/routes/account.js').then(()=>console.log('ok'))"` which printed `ok` indicating routes load without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe6603448329a3aae8519891ff29)