### PR TITLE
Align store purchase flow with gifts API and fix Mongo transaction validation

### DIFF
--- a/test/storePurchaseRoute.test.js
+++ b/test/storePurchaseRoute.test.js
@@ -1,0 +1,92 @@
+import { test } from '@jest/globals';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import path from 'node:path';
+
+const distDir = path.resolve(process.cwd(), 'webapp', 'dist');
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+async function createAccount(port, telegramId) {
+  const res = await fetch(`http://localhost:${port}/api/account/create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiToken}`
+    },
+    body: JSON.stringify({ telegramId })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  return data.accountId;
+}
+
+async function deposit(port, accountId, amount) {
+  const res = await fetch(`http://localhost:${port}/api/account/deposit`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiToken}`
+    },
+    body: JSON.stringify({ accountId, amount, game: 'test' })
+  });
+  assert.equal(res.status, 200);
+}
+
+test('account store-purchase accepts gift-style fromAccount payload', async () => {
+  fs.mkdirSync(path.join(distDir, 'assets'), { recursive: true });
+  fs.writeFileSync(path.join(distDir, 'index.html'), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3215',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  try {
+    const accountId = await createAccount(3215, 999992);
+    await deposit(3215, accountId, 500);
+
+    const purchaseRes = await fetch('http://localhost:3215/api/account/store-purchase', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiToken}`
+      },
+      body: JSON.stringify({
+        fromAccount: accountId,
+        bundle: {
+          items: [{ slug: 'poolroyale', type: 'cueStyle', optionId: 'carbon-matrix', price: 100 }]
+        }
+      })
+    });
+
+    assert.equal(purchaseRes.status, 200);
+    const purchaseData = await purchaseRes.json();
+    assert.equal(purchaseData.balance, 400);
+    assert.equal(purchaseData.transaction?.type, 'storefront');
+  } finally {
+    server.kill();
+  }
+}, 20000);

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -705,12 +705,20 @@ export function depositAccount(accountId, amount, extra = {}) {
 }
 
 export function buyBundle(accountId, bundle) {
-  return post('/api/store/purchase-v2', { accountId, bundle }).then((response) => {
+  return post('/api/account/store-purchase', { accountId, fromAccount: accountId, bundle }).then((response) => {
     if (
       response?.error &&
       /not found|404/i.test(String(response.error))
     ) {
-      return post('/api/store/purchase', { accountId, bundle });
+      return post('/api/store/purchase-v2', { accountId, bundle }).then((legacyResponse) => {
+        if (
+          legacyResponse?.error &&
+          /not found|404/i.test(String(legacyResponse.error))
+        ) {
+          return post('/api/store/purchase', { accountId, bundle });
+        }
+        return legacyResponse;
+      });
     }
     return response;
   });


### PR DESCRIPTION
### Motivation
- Storefront purchases were failing at runtime and did not match the account/gifts access and persistence model, causing client rollbacks during rollout.  The intent is to make store purchases behave exactly like gifts/account APIs. 
- The root cause was `transactions.items` being saved as object arrays which triggered Mongoose cast/validation failures in some runtime paths. 
- Support both Mongo-backed and in-memory user stores so purchases work in local tests, CI, and production while preserving backward compatibility.

### Description
- Added an account-scoped handler `POST /api/account/store-purchase` that accepts `fromAccount` (gift-style payload) with an `accountId` fallback and uses the same auth/access guard (`canAccessUser`) as other account routes. 
- Aligned purchase flow to the gifts-style debit path: validate bundle, check balance, apply voice/unlock deliveries using `applyStoreItemDelivery` and `applyVoiceCommentaryUnlocks`, then deduct balance (`sender.balance -= totalPrice`) and record a `storefront` transaction. 
- Fixed Mongo validation by persisting transaction `items` as serialized strings (`items.map(item => JSON.stringify(item))`) in both the account handler and legacy `handleTpcPurchase` path to avoid Mongoose cast errors. 
- Updated legacy store handler to use memory-store helpers (`shouldUseMemoryUserStore`, `findMemoryUser`, `saveMemoryUser`) and the same `canAccessUser` logic, and updated the frontend `buyBundle` in `webapp/src/utils/api.js` to send `fromAccount` along with `accountId` while retaining fallback calls to legacy endpoints. 
- Added an integration test `test/storePurchaseRoute.test.js` which boots the server in-memory, creates an account, deposits TPC, and verifies a gifts-style `fromAccount` purchase succeeds and debits the balance.

### Testing
- Ran `npm test -- test/storePurchaseRoute.test.js --runInBand` and it passed. 
- Ran `npm test -- test/storeDelivery.test.js --runInBand` and it passed (2 tests). 
- Ran `npm test -- test/poolRoyalInventoryRoutes.test.js --runInBand` and it passed (1 test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe6603448329a3aae8519891ff29)