### PR TITLE
Pool Royale: final welcome + NFT reward celebration for tournament and training wins

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -75,7 +75,8 @@ import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP,
   POOL_ROYALE_BASE_VARIANTS,
-  POOL_ROYALE_OPTION_LABELS
+  POOL_ROYALE_OPTION_LABELS,
+  POOL_ROYALE_STORE_ITEMS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
 import {
@@ -120,6 +121,18 @@ const TRAINING_ATTEMPT_BUNDLES = Object.freeze([
   Object.freeze({ id: 'training-attempts-12', attempts: 12, price: 960, label: 'Table control deal' }),
   Object.freeze({ id: 'training-attempts-30', attempts: 30, price: 2100, label: 'Champion heart vault' })
 ]);
+
+const MEDIUM_NFT_REWARD_CANDIDATES = Object.freeze(
+  POOL_ROYALE_STORE_ITEMS.filter(
+    (item) =>
+      item?.type === 'environmentHdri' &&
+      Number.isFinite(Number(item?.price)) &&
+      Number(item.price) >= 1800 &&
+      Number(item.price) <= 2300
+  )
+);
+
+const TRAINING_NFT_MILESTONE = 5;
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -234,6 +247,27 @@ function detectHighRefreshDisplay() {
 }
 
 const randomPick = (list) => list[Math.floor(Math.random() * list.length)];
+
+const buildStoreNftReward = (item) => {
+  if (!item?.type || !item?.optionId) return null;
+  return {
+    type: item.type,
+    optionId: item.optionId,
+    label: item.name || item.optionId,
+    thumbnail: item.thumbnail || null,
+    price: Number(item.price) || 0,
+    source: 'poolRoyaleStore'
+  };
+};
+
+const pickMediumValueNftReward = (inventory) => {
+  const locked = MEDIUM_NFT_REWARD_CANDIDATES.filter(
+    (item) => !isPoolOptionUnlocked(item.type, item.optionId, inventory)
+  );
+  const pool = locked.length ? locked : MEDIUM_NFT_REWARD_CANDIDATES;
+  if (!pool.length) return null;
+  return buildStoreNftReward(randomPick(pool));
+};
 
 const wait = (ms = 0) =>
   new Promise((resolve) => {
@@ -11951,6 +11985,8 @@ function PoolRoyaleGame({
   }, [location.search]);
   const [winnerOverlay, setWinnerOverlay] = useState(null);
   const [finalPotLabel, setFinalPotLabel] = useState('');
+  const [rewardCelebration, setRewardCelebration] = useState(null);
+  const [rewardRevealOpen, setRewardRevealOpen] = useState(false);
   const [rematchStatus, setRematchStatus] = useState(null);
   const [incomingRematch, setIncomingRematch] = useState(null);
   const rematchRequestRef = useRef(null);
@@ -11977,6 +12013,11 @@ function PoolRoyaleGame({
         pointer-events: none;
         z-index: 70;
         will-change: transform, opacity;
+      }
+      @keyframes prGiftPop {
+        0% { transform: scale(0.25); opacity: 0; }
+        60% { transform: scale(1.14); opacity: 1; }
+        100% { transform: scale(1); opacity: 1; }
       }`;
     document.head.appendChild(style);
     coinStyleInjectedRef.current = true;
@@ -12008,6 +12049,14 @@ function PoolRoyaleGame({
     },
     [ensureCoinBurstStyles]
   );
+
+  const openRewardCelebration = useCallback((payload) => {
+    if (!payload) return;
+    setRewardCelebration(payload);
+    setRewardRevealOpen(false);
+    triggerCoinBurst(payload.burstCount || 28);
+  }, [triggerCoinBurst]);
+
   const [poolInventory, setPoolInventory] = useState(() =>
     getCachedPoolRoyalInventory(resolvedAccountId)
   );
@@ -12110,6 +12159,30 @@ function PoolRoyaleGame({
     }
     return rewards;
   }, [isCueFinishUnlocked, poolInventory, resolvedAccountId]);
+
+  const awardMediumValueNft = useCallback(async () => {
+    if (!resolvedAccountId) return null;
+    let inventory = poolInventory;
+    try {
+      const latest = await getPoolRoyalInventory(resolvedAccountId);
+      if (latest) inventory = latest;
+    } catch (err) {
+      console.warn('Pool Royale medium NFT fetch fallback to cache', err);
+    }
+    const reward = pickMediumValueNftReward(inventory);
+    if (!reward) return null;
+    let nextInventory = inventory;
+    try {
+      nextInventory = await addPoolRoyalUnlock(reward.type, reward.optionId, resolvedAccountId);
+    } catch (err) {
+      console.warn('Pool Royale medium NFT unlock failed', err);
+    }
+    if (nextInventory) {
+      setPoolInventory(nextInventory);
+    }
+    return reward;
+  }, [poolInventory, resolvedAccountId]);
+
   const resolveStoredSelection = useCallback(
     (type, storageKey, isValid, fallbackId) => {
       const inventory = poolInventory;
@@ -12777,6 +12850,15 @@ function PoolRoyaleGame({
       console.warn('Pool Royale training payout request failed:', error);
     }
   }, [resolvedAccountId]);
+
+
+  const awardTrainingMilestoneNft = useCallback(async (level) => {
+    const safeLevel = Math.max(1, Math.min(TRAINING_LEVEL_COUNT, Number(level) || 1));
+    if (safeLevel % TRAINING_NFT_MILESTONE !== 0) return null;
+    const reward = await awardMediumValueNft();
+    if (!reward) return null;
+    return { ...reward, trainingLevel: safeLevel };
+  }, [awardMediumValueNft]);
 
   const ensureTrainingBallPoolForLayout = useCallback((trainingLayout) => {
     if (!isTraining) return;
@@ -14152,11 +14234,17 @@ const powerRef = useRef(hud.power);
     const completedLevel = trainingLevelRef.current || 1;
     const completedLevelInfo = describeTrainingLevel(completedLevel);
     const completedRewardAmount = Number(completedLevelInfo?.rewardAmount) || 0;
-    const previous = trainingProgressRef.current || { completed: [], rewarded: [] };
+    const previous = trainingProgressRef.current || { completed: [], rewarded: [], nftRewarded: [] };
     const previousRewardedSet = new Set(
       (previous?.rewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
     );
+    const previousNftRewardedSet = new Set(
+      (previous?.nftRewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+    );
     const shouldAwardReward = !previousRewardedSet.has(completedLevel) && completedRewardAmount > 0;
+    const shouldAwardNft =
+      completedLevel % TRAINING_NFT_MILESTONE === 0 && !previousNftRewardedSet.has(completedLevel);
+    let nextPlayable = completedLevel;
     setTrainingProgress((prev) => {
       const completedSet = new Set(
         (prev?.completed || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
@@ -14164,16 +14252,22 @@ const powerRef = useRef(hud.power);
       const rewardedSet = new Set(
         (prev?.rewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
       );
+      const nftRewardedSet = new Set(
+        (prev?.nftRewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
+      );
       completedSet.add(completedLevel);
       if (shouldAwardReward) rewardedSet.add(completedLevel);
+      if (shouldAwardNft) nftRewardedSet.add(completedLevel);
       const completed = Array.from(completedSet).sort((a, b) => a - b);
       const rewarded = Array.from(rewardedSet).sort((a, b) => a - b);
+      const nftRewarded = Array.from(nftRewardedSet).sort((a, b) => a - b);
       const lastLevel = Math.max(prev?.lastLevel ?? 1, completedLevel);
       const carryShots = Math.max(0, trainingShotsRemaining);
       const updated = {
         ...prev,
         completed,
         rewarded,
+        nftRewarded,
         lastLevel,
         carryShots,
         attemptsAwardedLevels: Array.isArray(prev?.attemptsAwardedLevels)
@@ -14181,14 +14275,15 @@ const powerRef = useRef(hud.power);
           : []
       };
       persistTrainingProgress(updated);
-      const nextPlayable = resolvePlayableTrainingLevel(completedLevel + 1, updated);
+      nextPlayable = resolvePlayableTrainingLevel(completedLevel + 1, updated);
       setTrainingShotsRemaining(carryShots);
       setPendingTrainingLevel(nextPlayable);
       setLastCompletedLevel(completedLevel);
       setTrainingTaskTransition({
         fromLevel: completedLevel,
         toLevel: nextPlayable,
-        rewardAmount: shouldAwardReward ? completedRewardAmount : 0
+        rewardAmount: shouldAwardReward ? completedRewardAmount : 0,
+        nftReward: null
       });
       setTrainingRoadmapOpen(true);
       return updated;
@@ -14196,7 +14291,33 @@ const powerRef = useRef(hud.power);
     if (shouldAwardReward) {
       awardTrainingTaskPayout(completedLevel, completedRewardAmount);
     }
-  }, [applyTrainingLayoutForLevel, awardTrainingTaskPayout, frameState.frameOver, isTraining, setTrainingProgress, setTrainingLevel, trainingShotsRemaining]);
+    if (shouldAwardReward || shouldAwardNft) {
+      openRewardCelebration({
+        source: 'training',
+        title: `Task ${String(completedLevel).padStart(2, '0')} cleared`,
+        avatar: resolvedPlayerAvatar || '/assets/icons/profile.svg',
+        playerName: player.name || 'Player',
+        coinText: shouldAwardReward ? `+${completedRewardAmount.toLocaleString('en-US')} TPC` : '',
+        nftReward: null,
+        burstCount: shouldAwardNft ? 32 : 24
+      });
+    }
+    if (shouldAwardNft) {
+      void awardTrainingMilestoneNft(completedLevel).then((nftReward) => {
+        if (!nftReward) return;
+        setTrainingTaskTransition((prev) => (prev ? { ...prev, nftReward } : prev));
+        openRewardCelebration({
+          source: 'training',
+          title: `Task ${String(completedLevel).padStart(2, '0')} reward`,
+          avatar: resolvedPlayerAvatar || '/assets/icons/profile.svg',
+          playerName: player.name || 'Player',
+          coinText: shouldAwardReward ? `+${completedRewardAmount.toLocaleString('en-US')} TPC` : '',
+          nftReward,
+          burstCount: 34
+        });
+      });
+    }
+  }, [applyTrainingLayoutForLevel, awardTrainingMilestoneNft, awardTrainingTaskPayout, frameState.frameOver, isTraining, openRewardCelebration, player.name, resolvedPlayerAvatar, setTrainingProgress, setTrainingLevel, trainingShotsRemaining]);
 
   useEffect(() => {
     if (!isTraining && trainingAutoAdvanceTimeoutRef.current) {
@@ -14837,6 +14958,24 @@ const powerRef = useRef(hud.power);
       window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
     }
   }, [location.search, tournamentMode, tournamentOppKey, tournamentStateKey]);
+
+  useEffect(() => {
+    if (!tournamentMode || typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(tournamentStateKey);
+      if (!raw) return;
+      const st = JSON.parse(raw);
+      const pendingRound = Number(st?.pendingMatch?.round);
+      const totalRounds = Array.isArray(st?.rounds) ? st.rounds.length : 0;
+      if (!Number.isFinite(pendingRound) || totalRounds <= 0) return;
+      if (pendingRound === totalRounds - 1) {
+        showRuleToast('Welcome to the final 🏆');
+      }
+    } catch (err) {
+      console.warn('Pool Royale tournament final intro failed', err);
+    }
+  }, [showRuleToast, tournamentMode, tournamentStateKey]);
+
   useEffect(() => () => clearRematchTimers(), [clearRematchTimers]);
   const simulateRoundAI = useCallback((st, round) => {
     const next = st.rounds[round + 1];
@@ -14871,17 +15010,17 @@ const powerRef = useRef(hud.power);
   );
   const handleTournamentResult = useCallback(
     async ({ winnerSeat, scores }) => {
-      if (!tournamentMode) return { unlocks: [], complete: false };
+      if (!tournamentMode) return { unlocks: [], complete: false, nftReward: null };
       try {
         const raw = window.localStorage.getItem(tournamentStateKey);
         if (!raw) {
           window.location.assign(`/pool-royale-bracket.html${location.search}`);
-          return { unlocks: [], complete: false };
+          return { unlocks: [], complete: false, nftReward: null };
         }
         const st = JSON.parse(raw);
         if (!st?.pendingMatch) {
           window.location.assign(`/pool-royale-bracket.html${location.search}`);
-          return { unlocks: [], complete: false };
+          return { unlocks: [], complete: false, nftReward: null };
         }
         const r = st.pendingMatch.round;
         const m = st.pendingMatch.match;
@@ -14925,16 +15064,19 @@ const powerRef = useRef(hud.power);
           }
           if (winnerSeed === userSeed) {
             const unlocks = await awardTournamentLoot();
-            return { unlocks, complete: true };
+            const nftReward = aiOpponentEnabled ? await awardMediumValueNft() : null;
+            return { unlocks, complete: true, nftReward };
           }
         }
-        return { unlocks: [], complete: Boolean(st.complete) };
+        return { unlocks: [], complete: Boolean(st.complete), nftReward: null };
       } catch (err) {
         console.error('Pool Royale tournament result update failed', err);
       }
-      return { unlocks: [], complete: false };
+      return { unlocks: [], complete: false, nftReward: null };
     },
     [
+      aiOpponentEnabled,
+      awardMediumValueNft,
       awardTournamentLoot,
       localSeat,
       location.search,
@@ -15838,15 +15980,29 @@ const powerRef = useRef(hud.power);
           avatar: userWon ? resolvedPlayerAvatar : opponentDisplayAvatar || '/assets/icons/profile.svg',
           prizeText: prizeAmount > 0 ? `+${prizeAmount} ${stakeToken}` : '',
           rewards: tournamentOutcome?.unlocks || [],
+          nftReward: tournamentOutcome?.nftReward || null,
           userWon,
-          tournamentAdvance: tournamentMode && userWon && !tournamentOutcome?.complete
+          tournamentAdvance: tournamentMode && userWon && !tournamentOutcome?.complete,
+          tournamentChampion: tournamentMode && userWon && Boolean(tournamentOutcome?.complete)
         };
         setWinnerOverlay(overlayData);
-        const burstCount =
-          overlayData.prizeText || (overlayData.rewards && overlayData.rewards.length > 0)
-            ? 28
-            : 18;
-        triggerCoinBurst(burstCount);
+        if (userWon && (prizeAmount > 0 || overlayData.nftReward)) {
+          openRewardCelebration({
+            source: 'tournament',
+            title: overlayData.tournamentChampion ? 'Tournament Champion' : 'Match Reward',
+            avatar: overlayData.avatar,
+            playerName: overlayData.name,
+            coinText: prizeAmount > 0 ? `+${prizeAmount.toLocaleString('en-US')} ${stakeToken}` : '',
+            nftReward: overlayData.nftReward,
+            burstCount: overlayData.nftReward ? 34 : 28
+          });
+        } else {
+          const burstCount =
+            overlayData.prizeText || (overlayData.rewards && overlayData.rewards.length > 0)
+              ? 28
+              : 18;
+          triggerCoinBurst(burstCount);
+        }
       } catch (error) {
         console.error('Pool Royale match wrap-up failed:', error);
         if (cancelled) return;
@@ -15880,6 +16036,7 @@ const powerRef = useRef(hud.power);
     localSeat,
     opponentDisplayAvatar,
     opponentDisplayName,
+    openRewardCelebration,
     player.name,
     resetTableLayoutForRematch,
     resolvedPlayerAvatar,
@@ -30685,15 +30842,31 @@ const powerRef = useRef(hud.power);
                 Congratulations! You are moving to the next stage of the tournament.
               </div>
             ) : null}
+            {winnerOverlay.tournamentChampion ? (
+              <div className="max-w-md rounded-2xl border border-amber-300/60 bg-amber-400/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-amber-100">
+                Final complete — you are the champion.
+              </div>
+            ) : null}
             {finalPotLabel ? (
               <div className="rounded-full border border-white/30 bg-white/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-white/80">
                 Final pot: {finalPotLabel}
               </div>
             ) : null}
-            {winnerOverlay.prizeText ? (
+            {winnerOverlay.prizeText || winnerOverlay.nftReward ? (
               <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-emerald-300 px-4 py-2 text-sm font-bold uppercase tracking-[0.22em] text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]">
                 <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC prize" className="h-6 w-6" />
-                <span>{winnerOverlay.prizeText}</span>
+                <span>{winnerOverlay.prizeText || 'Reward unlocked'}</span>
+                <span aria-hidden="true">💥</span>
+                {winnerOverlay.nftReward ? (
+                  <button
+                    type="button"
+                    onClick={() => setRewardRevealOpen(true)}
+                    className="rounded-full border border-black/30 bg-amber-200/70 px-2 py-0.5 text-sm"
+                    aria-label="Open won NFT"
+                  >
+                    🎁
+                  </button>
+                ) : null}
               </div>
             ) : null}
             {winnerOverlay.rewards?.length ? (
@@ -30759,6 +30932,69 @@ const powerRef = useRef(hud.power);
           </div>
         </div>
       )}
+      {rewardCelebration && (
+        <div className="absolute inset-0 z-[123] flex items-center justify-center bg-black/75 px-4">
+          <div className="w-full max-w-sm rounded-3xl border border-amber-300/60 bg-slate-950/95 p-5 text-center text-white shadow-[0_24px_48px_rgba(0,0,0,0.65)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-amber-200">{rewardCelebration.title || 'Reward'}</p>
+            <div className="mt-3 flex items-center justify-center gap-3">
+              <img
+                src={rewardCelebration.avatar || '/assets/icons/profile.svg'}
+                alt="winner avatar"
+                className="h-16 w-16 rounded-full border-2 border-emerald-200 object-cover"
+              />
+              <span className="text-2xl" aria-hidden="true">💥</span>
+              {rewardCelebration.coinText ? (
+                <span className="rounded-full border border-emerald-200/70 bg-emerald-400/20 px-3 py-1 text-sm font-semibold text-emerald-100">
+                  {rewardCelebration.coinText}
+                </span>
+              ) : null}
+              {rewardCelebration.nftReward ? (
+                <button
+                  type="button"
+                  onClick={() => setRewardRevealOpen(true)}
+                  className="rounded-full border border-amber-200 bg-amber-300/25 px-3 py-1 text-lg shadow-[0_0_14px_rgba(251,191,36,0.4)]"
+                  aria-label="Open NFT reward"
+                >
+                  🎁
+                </button>
+              ) : null}
+            </div>
+            <p className="mt-3 text-xs text-white/75">{rewardCelebration.playerName || 'Player'} reward summary ready.</p>
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={() => setRewardCelebration(null)}
+                className="rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.2em]"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {rewardRevealOpen && rewardCelebration?.nftReward ? (
+        <div className="absolute inset-0 z-[124] flex items-center justify-center bg-black/80 px-4" onClick={() => setRewardRevealOpen(false)}>
+          <div
+            className="w-full max-w-xs rounded-3xl border border-amber-300/70 bg-slate-900/95 p-5 text-center text-white"
+            style={{ animation: 'prGiftPop 420ms ease-out both' }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <p className="text-lg font-black text-amber-200">Congratulations 👏</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.22em] text-amber-100">You won a NFT</p>
+            {rewardCelebration.nftReward.thumbnail ? (
+              <img
+                src={rewardCelebration.nftReward.thumbnail}
+                alt={rewardCelebration.nftReward.label}
+                className="mx-auto mt-4 h-24 w-24 rounded-2xl border border-amber-200/60 object-cover"
+              />
+            ) : (
+              <div className="mx-auto mt-4 flex h-24 w-24 items-center justify-center rounded-2xl border border-amber-200/60 text-4xl">🎁</div>
+            )}
+            <p className="mt-3 text-sm font-semibold text-white">{rewardCelebration.nftReward.label}</p>
+          </div>
+        </div>
+      ) : null}
+
       {incomingRematch && (
         <div className="absolute inset-0 z-[125] flex items-center justify-center bg-black/75 px-4">
           <div className="w-full max-w-sm rounded-3xl border border-emerald-300/70 bg-slate-950/95 p-5 text-center text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)]">
@@ -31718,11 +31954,31 @@ const powerRef = useRef(hud.power);
                 <p className="mt-2 text-xs text-white/80">
                   Cleaning pocket holders, setting balls, and opening the next task automatically…
                 </p>
-                {trainingTaskTransition.rewardAmount > 0 && (
-                  <p className="mt-1 text-[11px] text-emerald-200">
-                    Reward added: {Number(trainingTaskTransition.rewardAmount).toLocaleString('en-US')} TPC
-                  </p>
-                )}
+                <div className="mt-2 flex items-center justify-center gap-3">
+                  <img
+                    src={resolvedPlayerAvatar || '/assets/icons/profile.svg'}
+                    alt="training avatar"
+                    className="h-10 w-10 rounded-full border-2 border-emerald-200/80 object-cover shadow-[0_0_18px_rgba(16,185,129,0.45)]"
+                  />
+                  <span className="text-lg" aria-hidden="true">💥</span>
+                  {trainingTaskTransition.rewardAmount > 0 ? (
+                    <p className="text-[11px] text-emerald-200">
+                      Reward added: {Number(trainingTaskTransition.rewardAmount).toLocaleString('en-US')} TPC
+                    </p>
+                  ) : (
+                    <p className="text-[11px] text-white/70">Task cleared. Keep the run going.</p>
+                  )}
+                  {trainingTaskTransition.nftReward ? (
+                    <button
+                      type="button"
+                      onClick={() => setRewardRevealOpen(true)}
+                      className="rounded-full border border-amber-200/80 bg-amber-300/20 px-2 py-1 text-sm text-amber-100 shadow-[0_0_14px_rgba(251,191,36,0.45)]"
+                      aria-label="Open won NFT"
+                    >
+                      🎁
+                    </button>
+                  ) : null}
+                </div>
               </div>
             )}
             {trainingTaskTransition?.toLevel && (


### PR DESCRIPTION
### Motivation
- Fix a reported issue where winning the tournament final produced no visible reward and provide clearer final-stage UX. 
- Grant a medium-value Pool Royale store NFT to players who win the tournament final vs AI and surface the unlock to the player. 
- Provide consistent reward feedback (avatar + TPC coin burst + 🎁 reveal animation) for both tournament wins and training milestone rewards. 

### Description
- Added selection and reward plumbing for medium-value store NFTs by filtering `POOL_ROYALE_STORE_ITEMS` and introducing `buildStoreNftReward`, `pickMediumValueNftReward`, and `awardMediumValueNft` helpers; integrated these into the tournament reward path. (file changed: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Modified tournament flow (`handleTournamentResult` + match wrap-up) to return and display `nftReward` metadata when available, and to trigger a reusable reward celebration overlay instead of silently ending. 
- Added a start-of-final toast when entering the championship match (`showRuleToast('Welcome to the final 🏆')`).
- Implemented a reusable reward celebration UI and an animated NFT reveal modal (small->large pop via `prGiftPop` keyframes) with copy: “Congratulations 👏 you won a NFT” and the NFT name/thumbnail; wired the 🎁 button to open the reveal. 
- Extended training completion logic to award milestone NFTs every 5th task (`TRAINING_NFT_MILESTONE = 5`), call `awardTrainingMilestoneNft`, and reuse the same celebration + reveal UI; updated training roadmap panel to show avatar + coin burst + 🎁 control when an NFT is awarded. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported only repository ignore warnings (lint ran but file is matched by ignore pattern). (warning)
- Attempted `npm run build` for full repo; the build failed due to a pre-existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (failure unrelated to these changes). (failed)
- Launched the webapp dev server with Vite and performed a visual verification using Playwright to open the Pool Royale tournament URL and capture a screenshot of the new reward UI; the dev server and screenshot flow completed successfully and an artifact was produced. (success)

Files changed: `webapp/src/pages/Games/PoolRoyale.jsx` (UI, reward logic, and training/tournament flow).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971ca423208329b79875de20108b35)