### PR TITLE
Pool Royale: fix black-screen on exit, preserve pre-impact spin, and adjust training penalties

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -115,6 +115,7 @@ const BASIS_TRANSCODER_PATH =
 
 
 const TRAINING_MISS_ATTEMPT_COST = 1;
+const TRAINING_CUEBALL_POT_ATTEMPT_COST = 2;
 const TRAINING_ATTEMPT_BUNDLES = Object.freeze([
   Object.freeze({ id: 'training-attempts-1', attempts: 1, price: 100, label: 'Starter heart' }),
   Object.freeze({ id: 'training-attempts-5', attempts: 5, price: 450, label: 'Pocket run deal' }),
@@ -14722,16 +14723,18 @@ const powerRef = useRef(hud.power);
   const goToLobby = useCallback(() => {
     const winnerId = frameRef.current?.winner ?? frameState.winner;
     const winnerParam = winnerId === 'A' ? '1' : winnerId === 'B' ? '0' : '';
-    if (tournamentMode) {
-      const search = location.search && location.search.length ? location.search : '';
-      window.location.assign(`/pool-royale-bracket.html${search}`);
-      return;
+    const lobbyUrl = tournamentMode
+      ? '/games/poolroyale/lobby?type=tournament'
+      : winnerParam
+        ? `/games/poolroyale/lobby?winner=${winnerParam}`
+        : '/games/poolroyale/lobby';
+    try {
+      navigate(lobbyUrl, { replace: true });
+    } catch (error) {
+      console.warn('Pool Royale lobby navigation fallback triggered', error);
+      window.location.assign(lobbyUrl);
     }
-    const lobbyUrl = winnerParam
-      ? `/games/poolroyale/lobby?winner=${winnerParam}`
-      : '/games/poolroyale/lobby';
-    window.location.assign(lobbyUrl);
-  }, [frameState.winner, location.search, tournamentMode]);
+  }, [frameState.winner, navigate, tournamentMode]);
   const resetTableLayoutForRematch = useCallback(() => {
     if (skipReplayRef.current) {
       skipReplayRef.current();
@@ -23493,6 +23496,9 @@ const powerRef = useRef(hud.power);
       // In-hand placement
 
       const allowFullTableInHand = () => {
+        if (hudRef.current?.inHand && cue && !cue.active) {
+          return true;
+        }
         const frameSnapshot = frameRef.current ?? frameState;
         const variant =
           frameSnapshot?.meta?.variant ?? activeVariantRef.current?.id ?? variantKey;
@@ -27157,7 +27163,11 @@ const powerRef = useRef(hud.power);
         let remainingTrainingShots = Math.max(0, Number(trainingShotsRemaining) || 0);
         let trainingOutOfAttempts = false;
         if (isTraining && !safeState?.frameOver) {
-          const penalty = pottedObjectCount === 0 ? TRAINING_MISS_ATTEMPT_COST : 0;
+          const penalty = cueBallPotted
+            ? TRAINING_CUEBALL_POT_ATTEMPT_COST
+            : pottedObjectCount === 0
+              ? TRAINING_MISS_ATTEMPT_COST
+              : 0;
           if (penalty > 0) {
             const nextShots = Math.max(0, remainingTrainingShots - penalty);
             remainingTrainingShots = nextShots;
@@ -28789,12 +28799,14 @@ const powerRef = useRef(hud.power);
             if (
               isCue &&
               !b.impacted &&
-              b.launchDir &&
-              (b.spin?.y ?? 0) < -1e-4
+              b.launchDir
             ) {
-              const forwardDot = b.vel.dot(b.launchDir);
-              if (forwardDot < 0) {
-                b.vel.addScaledVector(b.launchDir, -forwardDot);
+              const launchDir = b.launchDir.clone().normalize();
+              const forwardSpeed = b.vel.dot(launchDir);
+              if (forwardSpeed <= 0) {
+                b.vel.set(0, 0);
+              } else {
+                b.vel.copy(launchDir.multiplyScalar(forwardSpeed));
               }
             }
             if (!hasLift) {
@@ -30877,7 +30889,7 @@ const powerRef = useRef(hud.power);
             ) : null}
             {tournamentMode && !winnerOverlay.userWon ? (
               <div className="max-w-md rounded-2xl border border-rose-300/55 bg-rose-400/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-rose-100">
-                You’ve been disqualified. Try a new tournament or return to lobby.
+                You’ve been disqualified. Return to lobby to continue.
               </div>
             ) : null}
             {finalPotLabel ? (
@@ -30946,18 +30958,7 @@ const powerRef = useRef(hud.power);
                 >
                   Continue tournament
                 </button>
-              ) : tournamentMode && !winnerOverlay.userWon ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    resetTournamentState();
-                    navigate('/games/poolroyale/lobby?type=tournament');
-                  }}
-                  className="rounded-full border border-rose-300 bg-rose-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.22em] text-black shadow-[0_8px_24px_rgba(0,0,0,0.35)] transition hover:bg-rose-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300"
-                >
-                  New tournament
-                </button>
-              ) : (
+              ) : tournamentMode && !winnerOverlay.userWon ? null : (
                 <button
                   type="button"
                   onClick={handlePlayAgain}
@@ -31778,6 +31779,7 @@ const powerRef = useRef(hud.power);
               </p>
               <p className="mt-1 text-xs text-white/80">{currentTrainingInfo.objective}</p>
               <p className="mt-1 text-[11px] text-rose-200">Missed-shot cost: ❤️ -{TRAINING_MISS_ATTEMPT_COST} attempt.</p>
+              <p className="mt-1 text-[11px] text-rose-200">Cue-ball potted cost: ❤️ -{TRAINING_CUEBALL_POT_ATTEMPT_COST} attempts.</p>
             </div>
           )}
           <div className="pointer-events-auto rounded-full border border-emerald-300/70 bg-black/65 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100 shadow-[0_10px_24px_rgba(0,0,0,0.45)] backdrop-blur">
@@ -32673,7 +32675,7 @@ export default function PoolRoyale() {
   useTelegramBackButton(() => {
     confirmExit().then((confirmed) => {
       if (confirmed) {
-        navigate('/games/poolroyale/lobby');
+        goToLobby();
       }
     });
   });
@@ -32688,7 +32690,7 @@ export default function PoolRoyale() {
         if (!confirmed) {
           window.history.pushState(null, '', window.location.href);
         } else {
-          navigate('/games/poolroyale/lobby');
+          goToLobby();
         }
       });
     };
@@ -32699,7 +32701,7 @@ export default function PoolRoyale() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [confirmExit, exitMessage, navigate]);
+  }, [confirmExit, exitMessage, goToLobby]);
   const opponentName = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('opponent') || '';


### PR DESCRIPTION
### Motivation
- Prevent a black page when exiting Pool Royale by keeping navigation inside the SPA runtime instead of forcing a hard reload.
- Preserve cue-ball spin behavior while removing unintended lateral deflection before the first impact.
- Charge sensible training attempt penalties for misses and cue-ball pots and surface the costs in the HUD.
- Improve ball-in-hand placement UX after cue-ball pots by allowing full-table placement when the cue ball is inactive.

### Description
- Replaced the previous hard-reload exit flow with a unified `goToLobby` that resolves a `lobbyUrl` and uses `navigate(lobbyUrl, { replace: true })` with a `try/catch` fallback to `window.location.assign(lobbyUrl)`, and updated the hook deps to include `navigate`/`goToLobby` as appropriate.
- Updated exit handlers (`useTelegramBackButton` and `popstate`/beforeunload flows) to call the shared `goToLobby` instead of invoking `navigate`/hard reload directly so all back/exit flows use the same stable logic.
- Added `TRAINING_CUEBALL_POT_ATTEMPT_COST = 2`, updated training penalty logic to deduct `2` attempts when the cue-ball is potted and `1` attempt for a missed shot, and updated the training HUD copy to display both costs (using `TRAINING_MISS_ATTEMPT_COST` and `TRAINING_CUEBALL_POT_ATTEMPT_COST`).
- Constrained pre-impact cue-ball velocity in the physics loop so when the cue ball has a `launchDir` and hasn't impacted it will be projected onto the `launchDir` (or zeroed) to avoid lateral deflection while preserving spin; tweaked `allowFullTableInHand` to allow full-table placement when `hudRef.current?.inHand && cue && !cue.active`.
- Removed the “New tournament” button on disqualification overlay and adjusted disqualification copy to show only the `Return lobby` action for consistent exit behavior.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975407d3fc83299d5dfad6dfeba797)