### PR TITLE
Fix Pool Royale training attempt deduction on missed shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12624,6 +12624,7 @@ function PoolRoyaleGame({
     return 1;
   });
   const [trainingShotsRemaining, setTrainingShotsRemaining] = useState(0);
+  const trainingShotsRemainingRef = useRef(trainingShotsRemaining);
   const trainingProgressRef = useRef(trainingProgress);
   const trainingLevelRef = useRef(trainingLevel);
   const trainingLayoutExpectedBallsRef = useRef(0);
@@ -12662,6 +12663,9 @@ function PoolRoyaleGame({
   useEffect(() => {
     trainingLevelRef.current = trainingLevel;
   }, [trainingLevel]);
+  useEffect(() => {
+    trainingShotsRemainingRef.current = Math.max(0, Number(trainingShotsRemaining) || 0);
+  }, [trainingShotsRemaining]);
   useEffect(() => {
     const stored = loadTrainingProgress();
     const requestedTrainingLevel = Number(initialTrainingLevel);
@@ -27155,7 +27159,7 @@ const powerRef = useRef(hud.power);
             meta: nextTrainingMeta ?? safeState?.meta
           };
         }
-        let remainingTrainingShots = Math.max(0, Number(trainingShotsRemaining) || 0);
+        let remainingTrainingShots = Math.max(0, Number(trainingShotsRemainingRef.current) || 0);
         let trainingOutOfAttempts = false;
         if (isTraining && !safeState?.frameOver) {
           const penalty = cueBallPotted
@@ -27170,6 +27174,7 @@ const powerRef = useRef(hud.power);
             };
             const nextShots = Math.max(0, remainingTrainingShots - penalty);
             remainingTrainingShots = nextShots;
+            trainingShotsRemainingRef.current = nextShots;
             setTrainingShotsRemaining(nextShots);
             setTrainingProgress((progressPrev) => {
               const updated = { ...(progressPrev || {}), carryShots: nextShots };


### PR DESCRIPTION
### Motivation
- Training shot-resolution logic was reading a potentially stale `trainingShotsRemaining` state inside the shot closure, causing a single missed shot to collapse the attempts bank instead of deducting exactly one attempt.
- The intended rule is `1 missed shot = 1 ❤️ attempt` (and scratch costs remain unchanged), so the code must always consult the latest attempts value when applying penalties.

### Description
- Added a ref `trainingShotsRemainingRef` in `webapp/src/pages/Games/PoolRoyale.jsx` to hold the live attempts count and keep it synced with state via a `useEffect`.
- Updated the shot-resolution penalty path to read from `trainingShotsRemainingRef.current` and immediately write back to the ref when deducting (`trainingShotsRemainingRef.current = nextShots`) before calling `setTrainingShotsRemaining` and persisting progress.
- This preserves existing penalty constants (`TRAINING_MISS_ATTEMPT_COST = 1`, `TRAINING_SCRATCH_ATTEMPT_COST = 2`) and prevents stale-closure bugs that previously zeroed the attempts bank.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build passed; only non-blocking chunk-size/dynamic-import warnings were emitted).
- No additional automated unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ef0795688329840a684081d655e2)