### PR TITLE
Improve Telegram receipt images with branding, avatars and NFT thumbnails

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "receipt:preview": "node scripts/generate-receipt-preview.js"
   },
   "dependencies": {
     "canvas": "^2.11.2",

--- a/bot/scripts/generate-receipt-preview.js
+++ b/bot/scripts/generate-receipt-preview.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { writeReceiptPreview } from '../utils/notifications.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outPath = path.join(__dirname, '../tmp/receipt-preview.png');
+
+await writeReceiptPreview(outPath, {
+  title: 'Store Purchase Completed',
+  subtitle: 'Receipt preview',
+  amount: -1250,
+  fromName: 'Alice Sender',
+  toName: 'Bob Receiver',
+  fromPhoto: '/assets/icons/AlbaniaLeader.webp',
+  toPhoto: '/assets/icons/CanadaLeader.webp',
+  itemThumbnail: '/store-thumbs/poolRoyale/tableFinish/oakVeneer01.png',
+  itemLabel: 'Oak Veneer Table Finish'
+});
+
+console.log(`Receipt preview generated at: ${outPath}`);


### PR DESCRIPTION
### Motivation
- Provide richer, branded Telegram transaction receipts (deposits, transfers, gifts, store purchases) as screenshot-like images that include the TonPlaygram logo, a TPC icon, sender/receiver avatars and optional NFT/store thumbnails.

### Description
- Added a reusable canvas renderer `generateReceiptImage` in `bot/utils/notifications.js` which draws the TonPlaygram logo, TPC icon, amount box, sender/receiver avatars and an optional item/NFT thumbnail block, plus helper functions `safeLoadImage`, `normalizeAssetPath`, `roundedRect` and `drawAvatar`.
- Introduced dedicated notification senders in `bot/utils/notifications.js`: `sendDepositNotification`, `sendStorePurchaseNotification`, and updated `sendTransferNotification` and `sendGiftNotification` to use the new renderer and include avatar/thumbnail context.
- Wired server flows in `bot/routes/account.js` to the new notifications: `/deposit` now calls `sendDepositNotification`, `/store-purchase` resolves store item preview (imports store item configs) and calls `sendStorePurchaseNotification`, and `/gift` forwards sender photo to `sendGiftNotification`.
- Added a local preview helper `bot/scripts/generate-receipt-preview.js` and an npm script `receipt:preview` in `bot/package.json` to generate sample receipt images for visual validation.

### Testing
- Ran static checks `node --check bot/utils/notifications.js` and `node --check bot/routes/account.js`, both succeeded without syntax errors.
- Generated a sample receipt with `cd bot && npm run receipt:preview`, which produced a preview image successfully.
- Executed the preview generation script end-to-end (`node scripts/generate-receipt-preview.js`) and validated image creation; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f48ff5548329b7c5879a373abef2)