### PR TITLE
Revamp Pool Royale career roadmap with 100-stage progression

### DIFF
--- a/webapp/src/utils/poolRoyaleCareerProgress.js
+++ b/webapp/src/utils/poolRoyaleCareerProgress.js
@@ -1,0 +1,200 @@
+const CAREER_PROGRESS_KEY = 'poolRoyaleCareerProgress'
+export const CAREER_LEVEL_COUNT = 100
+
+const TRAINING_TITLES = [
+  'Cue Fundamentals',
+  'Spin Stability',
+  'Line Control',
+  'Rail Geometry',
+  'Pattern Break',
+  'Pressure Shots'
+]
+
+const FRIENDLY_TITLES = [
+  'Scout Friendly',
+  'Club Exhibition',
+  'Prime Time Friendly',
+  'Captain Challenge'
+]
+
+const TOURNAMENT_TITLES = [
+  'Rookie Cup',
+  'Regional Clash',
+  'National Masters',
+  'Continental Open',
+  'Legend Circuit'
+]
+
+const getStageType = (level) => {
+  if (level % 10 === 0) return 'tournament'
+  if (level % 4 === 0) return 'friendly'
+  return 'training'
+}
+
+const getTournamentPlayers = (level) => {
+  if (level <= 20) return 8
+  if (level <= 60) return 16
+  return 32
+}
+
+const getTrainingLevel = (level) => ((level - 1) % 50) + 1
+
+const buildReward = (level, type) => {
+  const tpc =
+    120 +
+    level * 22 +
+    (type === 'tournament' ? 380 : type === 'friendly' ? 160 : 0)
+  const hasGift = level % 5 === 0
+  return {
+    tpc,
+    hasGift,
+    label: `${tpc.toLocaleString('en-US')} TPC${hasGift ? ' + 🎁 Bonus Crate' : ''}`
+  }
+}
+
+const buildStage = (level) => {
+  const type = getStageType(level)
+  const phaseIndex = Math.min(4, Math.floor((level - 1) / 20))
+  const trainingLevel = type === 'training' ? getTrainingLevel(level) : null
+  const reward = buildReward(level, type)
+  const titleSource =
+    type === 'training'
+      ? TRAINING_TITLES
+      : type === 'friendly'
+        ? FRIENDLY_TITLES
+        : TOURNAMENT_TITLES
+  const titleBase = titleSource[(level - 1) % titleSource.length]
+  return {
+    id: `career-stage-${String(level).padStart(3, '0')}`,
+    level,
+    phase: phaseIndex + 1,
+    title: `${titleBase} ${String(level).padStart(2, '0')}`,
+    type,
+    icon: type === 'training' ? '🎯' : type === 'friendly' ? '🤝' : '🏆',
+    objective:
+      type === 'training'
+        ? `Complete advanced drill pattern #${trainingLevel} with controlled cue-ball shape.`
+        : type === 'friendly'
+          ? 'Win a tactical friendly against an adaptive AI rival.'
+          : `Win a ${getTournamentPlayers(level)}-player bracket and secure promotion.`,
+    reward: reward.label,
+    rewardTpc: reward.tpc,
+    hasGift: reward.hasGift,
+    trainingLevel,
+    players: type === 'tournament' ? getTournamentPlayers(level) : null
+  }
+}
+
+export const CAREER_STAGES = Array.from(
+  { length: CAREER_LEVEL_COUNT },
+  (_, idx) => buildStage(idx + 1)
+)
+
+const normalizeProgress = (value) => {
+  const completed = Array.isArray(value?.completedStageIds)
+    ? value.completedStageIds.filter(
+      (entry) => typeof entry === 'string' && entry.trim()
+    )
+    : []
+  return {
+    completedStageIds: [...new Set(completed)],
+    updatedAt: Number(value?.updatedAt) || Date.now()
+  }
+}
+
+export function loadCareerProgress () {
+  if (typeof window === 'undefined') return normalizeProgress(null)
+  try {
+    const raw = window.localStorage.getItem(CAREER_PROGRESS_KEY)
+    if (!raw) return normalizeProgress(null)
+    return normalizeProgress(JSON.parse(raw))
+  } catch (err) {
+    console.warn('Failed to load Pool Royale career progress', err)
+    return normalizeProgress(null)
+  }
+}
+
+export function persistCareerProgress (progress) {
+  const normalized = normalizeProgress(progress)
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(
+        CAREER_PROGRESS_KEY,
+        JSON.stringify(normalized)
+      )
+    } catch (err) {
+      console.warn('Failed to save Pool Royale career progress', err)
+    }
+  }
+  return normalized
+}
+
+export function markCareerStageCompleted (stageId) {
+  if (!stageId) return loadCareerProgress()
+  const current = loadCareerProgress()
+  if (current.completedStageIds.includes(stageId)) return current
+  return persistCareerProgress({
+    ...current,
+    completedStageIds: [...current.completedStageIds, stageId],
+    updatedAt: Date.now()
+  })
+}
+
+export function syncCareerProgressWithTraining (
+  trainingProgress,
+  careerProgress = loadCareerProgress()
+) {
+  const completedTraining = new Set(
+    Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []
+  )
+  const completedCareer = new Set(careerProgress.completedStageIds || [])
+  let dirty = false
+  for (const stage of CAREER_STAGES) {
+    if (stage.type !== 'training') continue
+    if (!completedTraining.has(stage.trainingLevel)) continue
+    if (completedCareer.has(stage.id)) continue
+    completedCareer.add(stage.id)
+    dirty = true
+  }
+  if (!dirty) return normalizeProgress(careerProgress)
+  return persistCareerProgress({
+    ...careerProgress,
+    completedStageIds: [...completedCareer],
+    updatedAt: Date.now()
+  })
+}
+
+export function getCareerRoadmap (
+  trainingProgress,
+  careerProgress = loadCareerProgress()
+) {
+  const completedTraining = new Set(
+    Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []
+  )
+  const completedCareer = new Set(careerProgress.completedStageIds || [])
+
+  let previousLocked = false
+  return CAREER_STAGES.map((stage) => {
+    const completed =
+      completedCareer.has(stage.id) ||
+      (stage.type === 'training' && completedTraining.has(stage.trainingLevel))
+    const locked = previousLocked
+    const playable = !locked && !completed
+    if (!completed) previousLocked = true
+    return {
+      ...stage,
+      completed,
+      locked,
+      playable,
+      statusLabel: completed ? 'Completed' : locked ? 'Locked' : 'Active'
+    }
+  })
+}
+
+export function getNextCareerStage (
+  trainingProgress,
+  careerProgress = loadCareerProgress()
+) {
+  const roadmap = getCareerRoadmap(trainingProgress, careerProgress)
+  return roadmap.find((stage) => stage.playable) || null
+}


### PR DESCRIPTION
### Motivation
- Create a full-featured single-player Career that mirrors the training roadmap style but scales to 100 progressive stages (drills, friendlies, tournaments) to give players a clear, long-form advancement path. 
- Surface stage metadata (icons, TPC rewards, gift crates) and wire career flow so training completions count toward career drills while match/tournament stages are completed explicitly.

### Description
- Added a generated 100-stage career system in `webapp/src/utils/poolRoyaleCareerProgress.js` with `CAREER_LEVEL_COUNT` and stage builders that produce `title`, `type` (`training|friendly|tournament`), `icon`, `objective`, `rewardTpc`, `hasGift`, `trainingLevel` and `players` metadata. 
- Implemented progression helpers: `getCareerRoadmap`, `getNextCareerStage`, `syncCareerProgressWithTraining`, `markCareerStageCompleted`, `loadCareerProgress` and `persistCareerProgress` to normalize storage and to auto-sync training completions into career progress. 
- Updated lobby UI in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` to add a stylish vertical timeline-style Career roadmap matching the training view, show per-stage icons (`🎯` / `🤝` / `🏆`), TPC coin icon, and `🎁` markers, plus counters and a CTA to launch the next career match. 
- Extended career orchestration in lobby `startGame` and routing so career stages map to underlying play types (training/regular/tournament), set `career=1` and `careerStageId`/`careerStageTitle` query params, and pass tournament sizing when applicable. 
- Hooked career completion in the game wrap-up: when `careerMode` and `careerStageId` are present, winning a stage (and completion for tournament stages) calls `markCareerStageCompleted(stageId)`. 
- Minor UI and plumbing improvements: fallback icons for the Career card, auto-sync career progress when loading training progress, and timeline styling for the career list.

### Testing
- Ran `npx eslint --no-ignore webapp/src/utils/poolRoyaleCareerProgress.js` and fixed lint issues; final lint run completed successfully. 
- Launched the dev server via Vite and captured a Playwright screenshot for visual verification of the career lobby at `?type=career` (artifact: `artifacts/pool-career-mode-v2.png`). 
- Attempted full build with `npm run -s build` which failed due to a pre-existing unrelated TypeScript type error in `src/rules/SnookerRoyalRules.ts`, so end-to-end build validation remains blocked by that unrelated issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f26cb4a88329b32faf80f71f953a)