### PR TITLE
Improve Telegram receipt branding: show TonPlaygram logo, use logo for system avatars, and improve NFT thumbnails

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -70,6 +70,29 @@ function drawAvatar(ctx, image, x, y, size, borderColor = '#67e8f9') {
   ctx.stroke();
 }
 
+function isTonPlaygramAccount(label = '') {
+  if (!label) return false;
+  const normalized = String(label).trim().toLowerCase();
+  return normalized.includes('tonplaygram') || normalized === 'store' || normalized === 'treasury';
+}
+
+function resolveReceiptAvatar(photo, label) {
+  if (photo) return photo;
+  if (isTonPlaygramAccount(label)) return logoPath;
+  return fallbackAvatarPath;
+}
+
+function resolveReceiptItemThumbnail(item = {}) {
+  return (
+    item?.itemThumbnail ||
+    item?.thumbnail ||
+    item?.icon ||
+    item?.image ||
+    item?.imageUrl ||
+    null
+  );
+}
+
 export async function generateReceiptImage({
   title,
   subtitle,
@@ -106,8 +129,12 @@ export async function generateReceiptImage({
 
   const logo = await safeLoadImage(logoPath);
   if (logo) {
-    const logoSize = 88;
-    ctx.drawImage(logo, width / 2 - logoSize / 2, 96, logoSize, logoSize);
+    roundedRect(ctx, width / 2 - 110, 84, 220, 110, 26);
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
+    ctx.fill();
+
+    const logoSize = 92;
+    ctx.drawImage(logo, width / 2 - logoSize / 2, 94, logoSize, logoSize);
   }
 
   ctx.fillStyle = '#e2e8f0';
@@ -148,8 +175,8 @@ export async function generateReceiptImage({
   ctx.textAlign = 'left';
   ctx.fillText(`${sign}${formatted} TPC`, amountBoxX + 132, amountBoxY + 92);
 
-  const fromAvatar = (await safeLoadImage(fromPhoto)) || (await safeLoadImage(fallbackAvatarPath));
-  const toAvatar = (await safeLoadImage(toPhoto)) || (await safeLoadImage(fallbackAvatarPath));
+  const fromAvatar = await safeLoadImage(resolveReceiptAvatar(fromPhoto, fromName));
+  const toAvatar = await safeLoadImage(resolveReceiptAvatar(toPhoto, toName));
 
   const blockY = 590;
   const avatarSize = 120;
@@ -189,7 +216,7 @@ export async function generateReceiptImage({
     ctx.fillStyle = '#f8fafc';
     ctx.textAlign = 'left';
     ctx.font = '700 30px Sans';
-    ctx.fillText('Item included', 374, itemBoxY + 98);
+    ctx.fillText('NFT included', 374, itemBoxY + 98);
     ctx.font = '500 26px Sans';
     ctx.fillStyle = '#cbd5e1';
     ctx.fillText(itemLabel || 'Store / NFT item', 374, itemBoxY + 150);
@@ -269,7 +296,7 @@ export async function sendGiftNotification(bot, toId, gift, senderName, date, op
     toName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     fromPhoto: options.senderPhoto,
     toPhoto: toInfo?.photoUrl,
-    itemThumbnail: gift?.icon,
+    itemThumbnail: resolveReceiptItemThumbnail(gift),
     itemLabel: `${gift?.name || 'Gift'} • ${gift?.price || 0} TPC`,
   });
 
@@ -288,7 +315,7 @@ export async function sendStorePurchaseNotification(bot, toId, payload) {
     fromName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     toName: 'TonPlaygram Store',
     fromPhoto: toInfo?.photoUrl,
-    itemThumbnail: payload.thumbnail,
+    itemThumbnail: resolveReceiptItemThumbnail(payload),
     itemLabel: payload.itemLabel,
   });
 


### PR DESCRIPTION
### Motivation
- Make Telegram receipt images clearly branded and more informative by surfacing the TonPlaygram logo at the top of receipts. 
- Ensure system-linked accounts (store/treasury/TonPlaygram) show the TonPlaygram logo as their avatar when no profile photo is available. 
- Increase reliability of NFT/store thumbnails shown in receipts by accepting common thumbnail field variants.

### Description
- Added a dedicated logo container and stronger top-area rendering so the TonPlaygram app icon is visible and centered on the receipt card in `generateReceiptImage` (`bot/utils/notifications.js`).
- Implemented `isTonPlaygramAccount` and `resolveReceiptAvatar` to default avatars for labels like `TonPlaygram`, `store`, or `treasury` to the app logo when no photo is provided (`bot/utils/notifications.js`).
- Introduced `resolveReceiptItemThumbnail` to normalize thumbnail sources (`itemThumbnail`, `thumbnail`, `icon`, `image`, `imageUrl`) and wired it into gift and store receipt generation so NFT thumbnails are shown more reliably.
- Updated the item section copy from `Item included` to `NFT included` for clearer context when an NFT thumbnail is present.

### Testing
- Generated a receipt preview with `npm --prefix bot run receipt:preview` and the script completed successfully producing a preview image.
- The change was limited to `bot/utils/notifications.js` and the preview script exercised the modified rendering path without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997fe04f6c4832985fd285dca21cd0d)