### PR TITLE
Isolate Pool Royale career progression and move hearts to career mode

### DIFF
--- a/test/poolRoyaleCareerProgress.test.js
+++ b/test/poolRoyaleCareerProgress.test.js
@@ -1,0 +1,34 @@
+import {
+  CAREER_STAGES,
+  getCareerRoadmap,
+  getNextCareerStage,
+  syncCareerProgressWithTraining
+} from '../webapp/src/utils/poolRoyaleCareerProgress.js';
+
+describe('pool royale career progression isolation', () => {
+  test('does not auto-complete career training stages from standalone training progress', () => {
+    const trainingProgress = { completed: [1, 2, 3, 4, 5] };
+    const careerProgress = { completedStageIds: [], updatedAt: Date.now() };
+    const synced = syncCareerProgressWithTraining(trainingProgress, careerProgress);
+    expect(synced.completedStageIds).toEqual([]);
+  });
+
+  test('roadmap only marks stages completed from career progress state', () => {
+    const firstTrainingStage = CAREER_STAGES.find((stage) => stage.type === 'training');
+    const roadmap = getCareerRoadmap({ completed: [firstTrainingStage.trainingLevel] }, {
+      completedStageIds: [],
+      updatedAt: Date.now()
+    });
+    const firstNode = roadmap.find((stage) => stage.id === firstTrainingStage.id);
+    expect(firstNode.completed).toBe(false);
+    expect(firstNode.playable).toBe(true);
+  });
+
+  test('next stage selection ignores standalone training completions', () => {
+    const nextStage = getNextCareerStage(
+      { completed: [1, 2, 3] },
+      { completedStageIds: [], updatedAt: Date.now() }
+    );
+    expect(nextStage?.id).toBe(CAREER_STAGES[0].id);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -30,8 +30,7 @@ import {
   CAREER_LEVEL_COUNT,
   getCareerRoadmap,
   getNextCareerStage,
-  loadCareerProgress,
-  syncCareerProgressWithTraining
+  loadCareerProgress
 } from '../../utils/poolRoyaleCareerProgress.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
@@ -408,9 +407,7 @@ export default function PoolRoyaleLobby() {
     setUkBallSet('uk');
     const loadedTraining = loadTrainingProgress();
     setTrainingProgress(loadedTraining);
-    setCareerProgress(
-      syncCareerProgressWithTraining(loadedTraining, loadCareerProgress())
-    );
+    setCareerProgress(loadCareerProgress());
   }, [playType]);
 
   useEffect(() => {
@@ -478,13 +475,6 @@ export default function PoolRoyaleLobby() {
     () => getNextCareerStage(trainingProgress, careerProgress),
     [trainingProgress, careerProgress]
   );
-
-  useEffect(() => {
-    if (playType !== 'career') return;
-    setCareerProgress((prev) =>
-      syncCareerProgressWithTraining(trainingProgress, prev)
-    );
-  }, [playType, trainingProgress]);
 
   const tournamentKey = getTelegramId() || 'anon';
   const tournamentStateKey = `poolRoyaleTournamentState_${tournamentKey}`;

--- a/webapp/src/utils/poolRoyaleCareerProgress.js
+++ b/webapp/src/utils/poolRoyaleCareerProgress.js
@@ -141,43 +141,21 @@ export function markCareerStageCompleted (stageId) {
 }
 
 export function syncCareerProgressWithTraining (
-  trainingProgress,
+  _trainingProgress,
   careerProgress = loadCareerProgress()
 ) {
-  const completedTraining = new Set(
-    Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []
-  )
-  const completedCareer = new Set(careerProgress.completedStageIds || [])
-  let dirty = false
-  for (const stage of CAREER_STAGES) {
-    if (stage.type !== 'training') continue
-    if (!completedTraining.has(stage.trainingLevel)) continue
-    if (completedCareer.has(stage.id)) continue
-    completedCareer.add(stage.id)
-    dirty = true
-  }
-  if (!dirty) return normalizeProgress(careerProgress)
-  return persistCareerProgress({
-    ...careerProgress,
-    completedStageIds: [...completedCareer],
-    updatedAt: Date.now()
-  })
+  return normalizeProgress(careerProgress)
 }
 
 export function getCareerRoadmap (
-  trainingProgress,
+  _trainingProgress,
   careerProgress = loadCareerProgress()
 ) {
-  const completedTraining = new Set(
-    Array.isArray(trainingProgress?.completed) ? trainingProgress.completed : []
-  )
   const completedCareer = new Set(careerProgress.completedStageIds || [])
 
   let previousLocked = false
   return CAREER_STAGES.map((stage) => {
-    const completed =
-      completedCareer.has(stage.id) ||
-      (stage.type === 'training' && completedTraining.has(stage.trainingLevel))
+    const completed = completedCareer.has(stage.id)
     const locked = previousLocked
     const playable = !locked && !completed
     if (!completed) previousLocked = true


### PR DESCRIPTION
### Motivation
- Ensure career progression is independent from standalone training so unlocking in `training` does not auto-complete career stages, and make training free while moving heart (❤️) attempts to career-mode tasks only.

### Description
- Stop auto-syncing training -> career: `syncCareerProgressWithTraining` is now a no-op and `getCareerRoadmap` no longer treats standalone training completions as career completions (changes in `webapp/src/utils/poolRoyaleCareerProgress.js`).
- Load career state independently in the lobby: the Pool Royale lobby no longer auto-applies training progress to career progress (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`).
- Move heart attempts to career mode: added career attempt persistence and helpers (`CAREER_ATTEMPTS_KEY`, `loadCareerAttemptsProgress`, `persistCareerAttemptsProgress`) and introduced `usesCareerAttempts` to gate awarding, purchasing and penalty consumption so only career training consumes/awards hearts (`webapp/src/pages/Games/PoolRoyale.jsx`).
- UI and purchase flow updates: training HUD, commentary text and attempts store were updated to show free standalone training vs career hearts, and purchase flow now credits the career heart bank instead of training-only state (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tests: added regression tests to assert career roadmap and next-stage selection ignore standalone training completions (`test/poolRoyaleCareerProgress.test.js`).

### Testing
- Ran Jest for the modified/related suites with `npm test -- test/poolRoyaleCareerProgress.test.js test/poolRoyaleTrainingProgress.test.js --runInBand`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998036b94f08329b9c9d622eb187aaf)