### PR TITLE
Add avatar live-watch icon and embedded watch frame to Leaderboard

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -58,6 +58,13 @@ export default function LeaderboardCard() {
   const [mode, setMode] = useState('1v1');
   const [selected, setSelected] = useState([]);
   const [groupPopup, setGroupPopup] = useState(false);
+  const [watchFrame, setWatchFrame] = useState(null);
+
+  const openWatchFrame = (tableId) => {
+    if (!tableId) return;
+    const game = getGameFromTableId(tableId);
+    setWatchFrame({ tableId, game });
+  };
 
   useEffect(() => {
     const saved = loadAvatar();
@@ -282,7 +289,20 @@ export default function LeaderboardCard() {
                       alt="avatar"
                       className="w-12 h-12 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
                     />
-                    {u.accountId !== accountId && null}
+                    {u.currentTableId && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openWatchFrame(u.currentTableId);
+                        }}
+                        className="absolute -right-1 -bottom-1 h-5 w-5 rounded-full bg-black/80 text-white text-[11px] flex items-center justify-center border border-white/70 hover:bg-black"
+                        aria-label="Open live game frame"
+                        title="Watch live game"
+                      >
+                        🖥
+                      </button>
+                    )}
                   </td>
                   <td className="p-2 flex flex-col items-start">
                     <div className="flex items-center">
@@ -356,6 +376,26 @@ export default function LeaderboardCard() {
                       alt="avatar"
                       className="w-12 h-12 hexagon border-2 border-brand-gold object-cover shadow-[0_0_12px_rgba(241,196,15,0.8)]"
                     />
+                    {(() => {
+                      const myTable = leaderboard.find(
+                        (u) => u.accountId === accountId
+                      )?.currentTableId;
+                      if (!myTable) return null;
+                      return (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openWatchFrame(myTable);
+                          }}
+                          className="absolute -right-1 -bottom-1 h-5 w-5 rounded-full bg-black/80 text-white text-[11px] flex items-center justify-center border border-white/70 hover:bg-black"
+                          aria-label="Open live game frame"
+                          title="Watch live game"
+                        >
+                          🖥
+                        </button>
+                      );
+                    })()}
                   </td>
                   <td className="p-2 flex flex-col items-start">
                     <div className="flex items-center">
@@ -506,6 +546,46 @@ export default function LeaderboardCard() {
       >
         ☝️
       </button>
+
+      {watchFrame && (
+        <div
+          className="fixed inset-0 z-[70] bg-black/75 p-3 sm:p-6"
+          onClick={() => setWatchFrame(null)}
+        >
+          <div
+            className="h-full max-w-4xl mx-auto bg-surface border border-border rounded-xl overflow-hidden flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between p-2 border-b border-border">
+              <div className="text-sm sm:text-base font-semibold">🖥 Live Game</div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.location.href = `/games/${watchFrame.game}?table=${watchFrame.tableId}&watch=1`;
+                  }}
+                  className="px-2 py-1 text-xs rounded bg-primary hover:bg-primary-hover text-white"
+                >
+                  Open full
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setWatchFrame(null)}
+                  className="px-2 py-1 text-xs rounded border border-border hover:bg-black/20"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            <iframe
+              title="Live game frame"
+              src={`/games/${watchFrame.game}?table=${watchFrame.tableId}&watch=1&embed=1`}
+              className="w-full flex-1 bg-black"
+              allow="autoplay; fullscreen"
+            />
+          </div>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a quicker way for spectators to join live games from the leaderboard by adding a compact watch affordance on player avatars. 
- Let watchers view the live match inline and still use in-game interactions (chat/gifts) without forcing full-page navigation. 
- Keep existing watch controls intact while improving discoverability and reducing friction for casual viewers.

### Description
- Added `watchFrame` state and `openWatchFrame(tableId)` helper in `webapp/src/components/LeaderboardCard.jsx` to manage the in-page live-watch modal. 
- Rendered a small `🖥` button over avatars (including the "You" row) when a user has `currentTableId`, which calls `openWatchFrame` to open the modal. 
- Implemented a full-screen overlay modal that embeds the live page via an `<iframe>` using the URL format `/games/<game>?table=<id>&watch=1&embed=1`, with `Open full` and `Close` controls. 
- Preserved existing row-level "Watch" button and watch-counts; the new icon is a shortcut for inline viewing.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Started the dev server with `npm --prefix webapp run dev` (server started), and attempted an automated browser screenshot run, but the Playwright Chromium process crashed with a `SIGSEGV` in this environment so a headless verification screenshot could not be captured. 
- No unit tests were added or modified as this is a UI enhancement; build output indicates the change bundles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699804fa108883298dc6295b73565325)