### PR TITLE
Adjust Telegram receipt branding and TPC amount badge

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -90,13 +90,20 @@ function drawAvatar(ctx, image, x, y, size, borderColor = '#67e8f9') {
 function isTonPlaygramAccount(label = '') {
   if (!label) return false;
   const normalized = String(label).trim().toLowerCase();
-  return normalized.includes('tonplaygram') || normalized === 'store' || normalized === 'treasury';
+  return (
+    normalized.includes('tonplaygram') ||
+    normalized.includes('store') ||
+    normalized.includes('shop') ||
+    normalized === 'treasury'
+  );
 }
 
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
+  const prefersBrandAvatar = isTonPlaygramAccount(label);
+  if (prefersBrandAvatar) candidates.push(logoPath);
   if (photo) candidates.push(photo);
-  if (isTonPlaygramAccount(label)) candidates.push(logoPath);
+  if (!prefersBrandAvatar) candidates.push(logoPath);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];
 }
@@ -157,12 +164,12 @@ export async function generateReceiptImage({
 
   const logo = await safeLoadImage(logoPath, { attempts: 8, delayMs: 220 });
   if (logo) {
-    roundedRect(ctx, width / 2 - 110, 84, 220, 110, 26);
+    roundedRect(ctx, width / 2 - 120, 72, 240, 120, 28);
     ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
     ctx.fill();
 
-    const logoSize = 92;
-    ctx.drawImage(logo, width / 2 - logoSize / 2, 94, logoSize, logoSize);
+    const logoSize = 96;
+    ctx.drawImage(logo, width / 2 - logoSize / 2, 84, logoSize, logoSize);
   }
 
   ctx.fillStyle = '#e2e8f0';
@@ -189,19 +196,35 @@ export async function generateReceiptImage({
   ctx.fill();
 
   const coin = await safeLoadImage(coinPath, { attempts: 8, delayMs: 220 });
-  if (coin) {
-    ctx.drawImage(coin, amountBoxX + 32, amountBoxY + 31, 84, 84);
-  }
 
   const sign = amount > 0 ? '+' : '';
   const formatted = Number(amount || 0).toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
+  const amountValue = `${sign}${formatted}`;
+
   ctx.fillStyle = '#f8fafc';
   ctx.font = '700 52px Sans';
+  ctx.textAlign = 'center';
+  ctx.fillText(amountValue, width / 2 - 60, amountBoxY + 92);
+
+  const tpcBadgeX = width / 2 + 95;
+  const tpcBadgeY = amountBoxY + 44;
+  const tpcBadgeW = 170;
+  const tpcBadgeH = 68;
+  roundedRect(ctx, tpcBadgeX, tpcBadgeY, tpcBadgeW, tpcBadgeH, 20);
+  ctx.fillStyle = 'rgba(51, 65, 85, 0.95)';
+  ctx.fill();
+
+  if (coin) {
+    ctx.drawImage(coin, tpcBadgeX + 12, tpcBadgeY + 10, 48, 48);
+  }
+
+  ctx.fillStyle = '#a5f3fc';
+  ctx.font = '700 30px Sans';
   ctx.textAlign = 'left';
-  ctx.fillText(`${sign}${formatted} TPC`, amountBoxX + 132, amountBoxY + 92);
+  ctx.fillText('TPC', tpcBadgeX + 72, tpcBadgeY + 44);
 
   const fromAvatar = await resolveReceiptAvatar(fromPhoto, fromName);
   const toAvatar = await resolveReceiptAvatar(toPhoto, toName);


### PR DESCRIPTION
### Motivation
- Ensure the TonPlaygram logo is visible at the top of Telegram receipt images so branding is clear.  
- Make store receipts consistently use the brand avatar instead of a user photo for `store`/`shop`/`tonplaygram`/`treasury` accounts.  
- Present the TPC amount with an explicit icon+text badge so the token icon and `TPC` label appear next to the numeric value.

### Description
- Updated avatar resolution logic in `bot/utils/notifications.js` so labels matching `tonplaygram`, `store`, or `shop` (and `treasury`) prefer the TonPlaygram logo when resolving receipt avatars.  
- Reordered avatar candidate list to prioritize the brand logo for store accounts while still falling back to user photo and a default avatar.  
- Moved and enlarged the top logo card in `generateReceiptImage` and increased the drawn logo size so the TonPlaygram mark appears higher and more prominent.  
- Reworked the amount area to render the numeric value centered and added a right-side TPC badge that draws the token icon and `TPC` text next to the amount.

### Testing
- Ran `npm run receipt:preview` from the `bot/` folder to generate a receipt preview image and the command completed successfully.  
- The generated preview file was created (receipt preview generation succeeded without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699806333b6c832989d326387d1af6f7)