### PR TITLE
Align Telegram receipt branding assets with app visuals

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,8 +6,9 @@ import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
+// Keep Telegram receipts aligned with the same assets used in the webapp UI.
 const coinPath = path.join(publicPath, 'assets/icons/ezgif-54c96d8a9b9236.webp');
-const logoPath = path.join(publicPath, 'assets/icons/generated/app-icon-512.png');
+const logoPath = path.join(publicPath, 'assets/icons/file_00000000bc2862439eecffff3730bbe4.webp');
 const fallbackAvatarPath = path.join(publicPath, 'assets/icons/profile.svg');
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {
@@ -64,6 +65,16 @@ function roundedRect(ctx, x, y, width, height, radius) {
   ctx.arcTo(x, y + height, x, y, r);
   ctx.arcTo(x, y, x + width, y, r);
   ctx.closePath();
+}
+
+function drawImageContain(ctx, image, x, y, width, height) {
+  if (!image || !image.width || !image.height) return;
+  const scale = Math.min(width / image.width, height / image.height);
+  const drawWidth = image.width * scale;
+  const drawHeight = image.height * scale;
+  const drawX = x + (width - drawWidth) / 2;
+  const drawY = y + (height - drawHeight) / 2;
+  ctx.drawImage(image, drawX, drawY, drawWidth, drawHeight);
 }
 
 
@@ -184,10 +195,11 @@ export async function generateReceiptImage({
   ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
   ctx.fill();
 
-  const logoSize = 108;
+  const logoBounds = { x: width / 2 - 118, y: 66, width: 236, height: 114 };
   if (logo) {
-    ctx.drawImage(logo, width / 2 - logoSize / 2, 68, logoSize, logoSize);
+    drawImageContain(ctx, logo, logoBounds.x, logoBounds.y, logoBounds.width, logoBounds.height);
   } else {
+    const logoSize = 108;
     drawTonPlaygramMark(ctx, width / 2 - logoSize / 2, 68, logoSize, { label: 'TP' });
   }
 


### PR DESCRIPTION
### Motivation
- Make Telegram-generated receipts visually consistent with the webapp by using the same TonPlaygram logo that appears in the header and homepage. 
- Ensure the TPC coin used in receipts matches the TPC icon used in coin bursts and other UI places. 
- Prevent logo distortion in receipts by fitting the logo proportionally into the header area and ensure the Store avatar uses the same logo asset.

### Description
- Switch `logoPath` in `bot/utils/notifications.js` to the homepage header asset (`assets/icons/file_00000000bc2862439eecffff3730bbe4.webp`).
- Add a `drawImageContain` helper to scale-and-center images while preserving aspect ratio and use it to render the top logo inside the receipt header container.
- Keep `coinPath` pointed at the existing TPC asset (`assets/icons/ezgif-54c96d8a9b9236.webp`) so receipt coin matches in-app coin bursts.
- Make store receipts resolve `toPhoto` to the updated `logoPath` so store avatar in messages uses the same logo.

### Testing
- Ran `node --check bot/utils/notifications.js` to verify there are no syntax errors, which succeeded. 
- Executed a small smoke test using the module `writeReceiptPreview` to generate `artifacts/receipt-preview.png`, which completed successfully and produced a preview image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981a08f304832982c361a29c6c87d0)