### PR TITLE
Expand leaderboard player popup with full game list and live spectator status

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -15,18 +15,18 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
 import InvitePopup from './InvitePopup.jsx';
 import PlayerInvitePopup from './PlayerInvitePopup.jsx';
+import gamesCatalog from '../config/gamesCatalog.js';
 
 function getGameFromTableId(id) {
   if (!id) return 'snake';
-  const prefix = id.split('-')[0];
-  if (
-    [
-      'snake',
-      'goalrush',
-      'poolroyale',
-    ].includes(prefix)
-  )
-    return prefix;
+  const lowerId = String(id).toLowerCase();
+  const matched = gamesCatalog.find((game) => {
+    const slug = String(game.slug || '').toLowerCase();
+    if (!slug) return false;
+    const normalizedSlug = slug.replace(/[^a-z0-9]/g, '');
+    return lowerId.startsWith(`${slug}-`) || lowerId.startsWith(`${normalizedSlug}-`);
+  });
+  if (matched?.slug) return matched.slug;
   return 'snake';
 }
 
@@ -489,6 +489,7 @@ export default function LeaderboardCard() {
       <PlayerInvitePopup
         open={!!inviteTarget}
         player={inviteTarget}
+        onlineStatus={inviteTarget ? onlineUsers[String(inviteTarget.accountId)] : 'offline'}
         stake={stake}
         onStakeChange={setStake}
         onInvite={(game) => {


### PR DESCRIPTION
### Motivation
- Ensure the leaderboard user popup shows the full set of games (matching the Games page) and routes spectator links correctly for any catalog game.
- Surface accurate online presence (online/busy/offline) and a desktop icon when a player is actively playing so viewers can join as spectators.

### Description
- Replace the small hardcoded table-id → game mapping with a catalog-driven resolver using `gamesCatalog` so table IDs map to the correct `slug` for all games.
- Pass the selected player online state from `LeaderboardCard` into `PlayerInvitePopup` so the popup can display real-time status and color indicator.
- Add a small status row to the popup showing a colored `FaCircle` and a `FaDesktop` icon when the player is in-game; clicking the desktop icon navigates to the game's spectator URL (`/games/{game}?table={table}&watch=1`).
- Replace the popup's hardcoded invite game list with a dynamic list sourced from `gamesCatalog` and thumbnails via `getGameThumbnail` so the invite selector matches the Games lobby.

### Testing
- Ran `npm --prefix webapp run build` (Vite production build) which completed successfully and produced the dist bundle.
- Ran `npx eslint` on the modified files which produced repository ignore warnings (lint run did not fail but paths are ignored by workspace config). 
- Launched the dev server and captured a mobile-viewport screenshot of `/games` via Playwright to validate the updated popup UI (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981b0cbfac8329b0a822278efd9554)