### PR TITLE
Align Telegram receipt and Store header branding with TonPlaygram logo

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,8 +6,9 @@ import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
+// Keep Telegram receipt branding aligned with the live app visuals.
 const coinPath = path.join(publicPath, 'assets/icons/ezgif-54c96d8a9b9236.webp');
-const logoPath = path.join(publicPath, 'assets/icons/generated/app-icon-512.png');
+const logoPath = path.join(publicPath, 'assets/icons/file_00000000bc2862439eecffff3730bbe4.webp');
 const fallbackAvatarPath = path.join(publicPath, 'assets/icons/profile.svg');
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -2517,8 +2517,12 @@ export default function Store() {
       <header className="sticky top-0 z-30 border-b border-white/10 bg-zinc-950/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
           <div className="flex items-center gap-3">
-            <div className="grid h-10 w-10 place-items-center rounded-2xl bg-white/10 shadow-sm">
-              <span className="text-lg">🛍️</span>
+            <div className="grid h-10 w-10 place-items-center overflow-hidden rounded-2xl bg-white/10 shadow-sm">
+              <img
+                src="/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp"
+                alt="TonPlaygram store avatar"
+                className="h-full w-full object-cover"
+              />
             </div>
             <div className="leading-tight">
               <div className="text-sm font-semibold tracking-wide">TonPlaygram</div>


### PR DESCRIPTION
### Motivation
- Ensure Telegram notification receipts and the Store header use the same TonPlaygram logo asset as the homepage so branding is consistent.

### Description
- Updated `bot/utils/notifications.js` to point `logoPath` at `/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp` and added a clarifying comment, and replaced the shopping-bag emoji in the Store header with an `<img>` using the same logo in `webapp/src/pages/Store.jsx` (kept TPC coin path unchanged).

### Testing
- Built the web app with `npm --prefix webapp run build` which completed successfully (Vite emitted existing chunk-size warnings but no errors) and ran the dev server then captured a mobile-viewport screenshot of `/store` using Playwright to verify the header avatar; both automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981a08f304832982c361a29c6c87d0)