### PR TITLE
Show TV icon and embed live spectator frame in leaderboard popup

### DIFF
--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -15,18 +15,18 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
 import InvitePopup from './InvitePopup.jsx';
 import PlayerInvitePopup from './PlayerInvitePopup.jsx';
+import gamesCatalog from '../config/gamesCatalog.js';
 
 function getGameFromTableId(id) {
   if (!id) return 'snake';
-  const prefix = id.split('-')[0];
-  if (
-    [
-      'snake',
-      'goalrush',
-      'poolroyale',
-    ].includes(prefix)
-  )
-    return prefix;
+  const lowerId = String(id).toLowerCase();
+  const matched = gamesCatalog.find((game) => {
+    const slug = String(game.slug || '').toLowerCase();
+    if (!slug) return false;
+    const normalizedSlug = slug.replace(/[^a-z0-9]/g, '');
+    return lowerId.startsWith(`${slug}-`) || lowerId.startsWith(`${normalizedSlug}-`);
+  });
+  if (matched?.slug) return matched.slug;
   return 'snake';
 }
 
@@ -267,8 +267,12 @@ export default function LeaderboardCard() {
                     u.accountId === accountId ? 'bg-accent text-black' : 'cursor-pointer'
                   }`}
                   onClick={() => {
-                    if (u.accountId === accountId || u.currentTableId) return;
+                    if (u.accountId === accountId) return;
                     if (mode === 'group') {
+                      if (u.currentTableId) {
+                        setInviteTarget(u);
+                        return;
+                      }
                       setSelected((prev) => {
                         const exists = prev.find((p) => p.accountId === u.accountId);
                         if (exists) return prev.filter((p) => p.accountId !== u.accountId);
@@ -318,12 +322,19 @@ export default function LeaderboardCard() {
                           className="mr-1"
                         />
                       )}
-                      <span
-                        className="text-white"
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (u.accountId === accountId) return;
+                          setInviteTarget(u);
+                        }}
+                        className="text-white inline-flex items-center"
                         style={{ WebkitTextStroke: '1px black' }}
                       >
-                        {u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}
-                      </span>
+                        <span>{u.nickname || `${u.firstName} ${u.lastName}`.trim() || 'User'}</span>
+                        {u.currentTableId && <FaTv className="ml-1 text-red-500" size={10} />}
+                      </button>
                       {(() => {
                         const userStatus = u.currentTableId
                           ? 'playing'
@@ -489,6 +500,7 @@ export default function LeaderboardCard() {
       <PlayerInvitePopup
         open={!!inviteTarget}
         player={inviteTarget}
+        onlineStatus={inviteTarget ? onlineUsers[String(inviteTarget.accountId)] : 'offline'}
         stake={stake}
         onStakeChange={setStake}
         onInvite={(game) => {


### PR DESCRIPTION
### Motivation
- Make it obvious when a leaderboard user is actively playing by showing a TV icon next to their name and allow opening an in-page spectator view from the user popup. 
- Provide an embedded spectator frame (with chat/gifts context) so viewers can watch and interact without forcing a full-page navigation. 

### Description
- Stop blocking popup open for playing users so clicking a playing user still opens the `PlayerInvitePopup` and added a TV icon next to the username in leaderboard rows. 
- Add `openWatchFrame` in `LeaderboardCard.jsx` and `PlayerInvitePopup.jsx` to resolve the game slug from a `currentTableId` via `gamesCatalog` and open an embedded iframe modal at `/games/{game}?table={table}&watch=1`. 
- Replace hardcoded invite/game lists in the popup with a dynamic `gamesCatalog`-driven list and thumbnails via `getGameThumbnail`, and surface the player online/playing status (color indicator and label) in the popup. 
- Add an in-modal live broadcast frame with a close button and a short label indicating chat + gifts are available while watching. Files changed: `webapp/src/components/LeaderboardCard.jsx`, `webapp/src/components/PlayerInvitePopup.jsx`. 

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully and produced the production `dist` bundle. 
- Started the dev server via `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and it started successfully for UI verification. 
- Captured a mobile-viewport screenshot of `/games` with Playwright to validate the updated leaderboard/popup UI (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981b0cbfac8329b0a822278efd9554)