### PR TITLE
Use existing Home/Store WebP assets for Telegram receipts (remove added PNGs)

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -9,8 +9,13 @@ const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-const coinPath = path.join(publicPath, TPC_ICON_ASSET);
-const logoPath = path.join(publicPath, TONPLAYGRAM_LOGO_ASSET);
+
+function resolvePublicAssetPath(assetPath) {
+  if (!assetPath || typeof assetPath !== 'string') return null;
+  return path.join(publicPath, assetPath.replace(/^\//, '').replace(/^\.\//, ''));
+}
+
+const coinPath = resolvePublicAssetPath(TPC_ICON_ASSET);
 const fallbackAvatarPath = path.join(publicPath, 'assets/icons/profile.svg');
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {
@@ -25,10 +30,13 @@ function normalizeAssetPath(assetPath) {
   if (assetPath.startsWith('http://') || assetPath.startsWith('https://')) {
     return assetPath;
   }
-  if (assetPath.startsWith('/')) {
-    return path.join(publicPath, assetPath);
+  if (assetPath.startsWith('/assets/') || assetPath.startsWith('/store-thumbs/')) {
+    return resolvePublicAssetPath(assetPath);
   }
-  return path.join(publicPath, assetPath.replace(/^\.\//, ''));
+  if (path.isAbsolute(assetPath)) {
+    return assetPath;
+  }
+  return resolvePublicAssetPath(assetPath);
 }
 
 function getBrandAssetCandidates(assetPath) {
@@ -44,7 +52,8 @@ function getBrandAssetCandidates(assetPath) {
 }
 
 async function loadBrandAsset(assetPath, options = {}) {
-  const candidates = getBrandAssetCandidates(assetPath);
+  const variants = Array.isArray(assetPath) ? assetPath : [assetPath];
+  const candidates = variants.flatMap((variant) => getBrandAssetCandidates(variant));
   for (const candidate of candidates) {
     const image = await safeLoadImage(candidate, options);
     if (image) return image;
@@ -145,7 +154,7 @@ function isTonPlaygramAccount(label = '') {
 
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
-  if (isTonPlaygramAccount(label)) candidates.push(logoPath);
+  if (isTonPlaygramAccount(label)) candidates.push(TONPLAYGRAM_LOGO_ASSET);
   if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];
@@ -410,7 +419,7 @@ export async function sendStorePurchaseNotification(bot, toId, payload) {
     fromName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     toName: 'TonPlaygram Store',
     fromPhoto: toInfo?.photoUrl,
-    toPhoto: logoPath,
+    toPhoto: TONPLAYGRAM_LOGO_ASSET,
     itemThumbnail: resolveReceiptItemThumbnail(payload),
     itemLabel: payload.itemLabel,
   });


### PR DESCRIPTION
### Motivation
- Ensure Telegram receipt visuals use the exact Home header logo and Store TPC icon already present in the webapp assets and avoid introducing binary files in the PR. 
- Make server-side asset resolution reliable so `canvas` can load the same assets the live webapp uses.

### Description
- Switched branding constants to the existing WebP files: `TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp'` and `TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp'` in `bot/utils/notifications.js`.
- Added `resolvePublicAssetPath()` and updated `normalizeAssetPath()` so web paths like `/assets/...` and `/store-thumbs/...` map to `webapp/public`, while absolute filesystem paths are preserved, improving server-side loading fidelity.
- Improved `getBrandAssetCandidates()`/`loadBrandAsset()` to accept variants and try HTTP variants when appropriate, and updated avatar selection to prefer `TONPLAYGRAM_LOGO_ASSET` for TonPlaygram/Store receipts and pass it as `toPhoto`.
- Removed the two PNG files that had been added previously from `webapp/public/assets/icons` so the PR contains no new binary assets.

### Testing
- Ran `node bot/scripts/generate-receipt-preview.js` and it completed successfully, producing the receipt preview image. (success)
- Ran `node --input-type=module -e "import { writeReceiptPreview } from './bot/utils/notifications.js'; await writeReceiptPreview('./bot/tmp/receipt-store-avatar.png', {...});"` to generate a store-avatar-specific preview and verified it rendered the store avatar and TPC icon correctly. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699839751df08329ac39bb6ab68858d9)