### PR TITLE
Pool Royale: move guided training into Career and make Training free-practice

### DIFF
--- a/test/poolRoyaleCareerProgress.test.js
+++ b/test/poolRoyaleCareerProgress.test.js
@@ -3,32 +3,47 @@ import {
   getCareerRoadmap,
   getNextCareerStage,
   syncCareerProgressWithTraining
-} from '../webapp/src/utils/poolRoyaleCareerProgress.js';
+} from '../webapp/src/utils/poolRoyaleCareerProgress.js'
 
 describe('pool royale career progression isolation', () => {
   test('does not auto-complete career training stages from standalone training progress', () => {
-    const trainingProgress = { completed: [1, 2, 3, 4, 5] };
-    const careerProgress = { completedStageIds: [], updatedAt: Date.now() };
-    const synced = syncCareerProgressWithTraining(trainingProgress, careerProgress);
-    expect(synced.completedStageIds).toEqual([]);
-  });
+    const trainingProgress = { completed: [1, 2, 3, 4, 5] }
+    const careerProgress = { completedStageIds: [], updatedAt: Date.now() }
+    const synced = syncCareerProgressWithTraining(trainingProgress, careerProgress)
+    expect(synced.completedStageIds).toEqual([])
+  })
 
   test('roadmap only marks stages completed from career progress state', () => {
-    const firstTrainingStage = CAREER_STAGES.find((stage) => stage.type === 'training');
+    const firstTrainingStage = CAREER_STAGES.find((stage) => stage.type === 'training')
     const roadmap = getCareerRoadmap({ completed: [firstTrainingStage.trainingLevel] }, {
       completedStageIds: [],
       updatedAt: Date.now()
-    });
-    const firstNode = roadmap.find((stage) => stage.id === firstTrainingStage.id);
-    expect(firstNode.completed).toBe(false);
-    expect(firstNode.playable).toBe(true);
-  });
+    })
+    const firstNode = roadmap.find((stage) => stage.id === firstTrainingStage.id)
+    expect(firstNode.completed).toBe(false)
+    expect(firstNode.playable).toBe(true)
+  })
 
   test('next stage selection ignores standalone training completions', () => {
     const nextStage = getNextCareerStage(
       { completed: [1, 2, 3] },
       { completedStageIds: [], updatedAt: Date.now() }
-    );
-    expect(nextStage?.id).toBe(CAREER_STAGES[0].id);
-  });
-});
+    )
+    expect(nextStage?.id).toBe(CAREER_STAGES[0].id)
+  })
+
+  test('career starts with the full training task set', () => {
+    const openingStages = CAREER_STAGES.slice(0, 50)
+    expect(openingStages.every((stage) => stage.type === 'training')).toBe(true)
+    expect(openingStages[0].title).toContain('Task 01')
+    expect(openingStages[49].title).toContain('Task 50')
+  })
+
+  test('career training stages use training objectives and rewards', () => {
+    const firstStage = CAREER_STAGES[0]
+    expect(firstStage.objective).toContain('Clear')
+    expect(firstStage.reward).toContain('TPC')
+    expect(firstStage.rewardTpc).toBeGreaterThan(0)
+  })
+
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12758,8 +12758,11 @@ function PoolRoyaleGame({
   useEffect(() => {
     if (!isTraining) return;
     if (trainingModeState !== 'solo') setTrainingModeState('solo');
-    if (!trainingRulesOn) setTrainingRulesOn(true);
-  }, [isTraining, trainingModeState, trainingRulesOn]);
+    const shouldEnableRules = careerMode;
+    if (trainingRulesOn !== shouldEnableRules) {
+      setTrainingRulesOn(shouldEnableRules);
+    }
+  }, [careerMode, isTraining, trainingModeState, trainingRulesOn]);
   const currentTrainingInfo = useMemo(
     () => describeTrainingLevel(trainingLevel),
     [trainingLevel]
@@ -13961,7 +13964,7 @@ function PoolRoyaleGame({
     return params.get('starter') === 'B' ? 'B' : 'A';
   }, [location.search]);
   const isOnlineMatch = mode === 'online';
-  const aiOpponentEnabled = !isOnlineMatch;
+  const aiOpponentEnabled = !isOnlineMatch && !isTraining;
   const framePlayerAName = localSeat === 'A' ? playerLabel : opponentLabel;
   const framePlayerBName = localSeat === 'A' ? opponentLabel : playerLabel;
   const initialFrame = useMemo(() => {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -20,11 +20,8 @@ import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon, getVariantThumbnail } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import {
-  TRAINING_LEVELS,
   TRAINING_LEVEL_COUNT,
-  describeTrainingLevel,
-  loadTrainingProgress,
-  resolvePlayableTrainingLevel
+  loadTrainingProgress
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import {
   CAREER_LEVEL_COUNT,
@@ -403,8 +400,6 @@ export default function PoolRoyaleLobby() {
 
   useEffect(() => {
     if (playType !== 'training' && playType !== 'career') return;
-    setVariant('uk');
-    setUkBallSet('uk');
     const loadedTraining = loadTrainingProgress();
     setTrainingProgress(loadedTraining);
     setCareerProgress(loadCareerProgress());
@@ -434,39 +429,6 @@ export default function PoolRoyaleLobby() {
     () => new Set((readyList || []).map((id) => String(id))),
     [readyList]
   );
-  const unlockedTrainingCap = useMemo(
-    () => resolvePlayableTrainingLevel(TRAINING_LEVEL_COUNT, trainingProgress),
-    [trainingProgress]
-  );
-  const completedTrainingSet = useMemo(
-    () =>
-      new Set(
-        Array.isArray(trainingProgress?.completed)
-          ? trainingProgress.completed
-          : []
-      ),
-    [trainingProgress]
-  );
-  const trainingRoadmapNodes = useMemo(
-    () =>
-      TRAINING_LEVELS.map((levelDef) => {
-        const levelNum = Number(levelDef.level);
-        return {
-          ...levelDef,
-          levelNum,
-          rewardAmount: Number(levelDef.rewardAmount) || 0,
-          hasGift: levelNum % 5 === 0
-        };
-      }),
-    []
-  );
-  const currentTrainingTask = useMemo(() => {
-    const unlocked = resolvePlayableTrainingLevel(
-      trainingProgress?.lastLevel || 1,
-      trainingProgress
-    );
-    return describeTrainingLevel(unlocked);
-  }, [trainingProgress]);
   const careerRoadmapNodes = useMemo(
     () => getCareerRoadmap(trainingProgress, careerProgress),
     [trainingProgress, careerProgress]
@@ -739,9 +701,7 @@ export default function PoolRoyaleLobby() {
             </div>
           )}
 
-        {playType !== 'training' &&
-          playType !== 'career' &&
-          !hasActiveTournament && (
+        {playType !== 'career' && !hasActiveTournament && (
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <h3 className="font-semibold text-white">Game Variant</h3>
@@ -787,10 +747,7 @@ export default function PoolRoyaleLobby() {
             </div>
           )}
 
-        {playType !== 'training' &&
-          playType !== 'career' &&
-          !hasActiveTournament &&
-          variant === 'uk' && (
+        {playType !== 'career' && !hasActiveTournament && variant === 'uk' && (
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <h3 className="font-semibold text-white">Ball Colors</h3>
@@ -841,132 +798,22 @@ export default function PoolRoyaleLobby() {
 
         {playType === 'training' && (
           <div className="space-y-3 rounded-2xl border border-emerald-300/30 bg-gradient-to-br from-emerald-500/10 via-black/35 to-cyan-500/10 p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h3 className="font-semibold text-white">Training Roadmap</h3>
-                <p className="text-xs text-white/60">
-                  Same path view as in-game. Tap unlocked tasks to jump in.
-                </p>
-              </div>
-              <span className="text-xs font-semibold text-emerald-200">
-                {completedTrainingSet.size}/{TRAINING_LEVEL_COUNT}
-              </span>
+            <div>
+              <h3 className="font-semibold text-white">Free Practice</h3>
+              <p className="text-xs text-white/60">
+                Training is now open-table practice: no AI and no rule penalties.
+                Choose any variant, set your preferred ball colors, then start and
+                practice shots freely.
+              </p>
             </div>
             <div className="rounded-xl border border-white/10 bg-black/25 p-3 text-xs text-white/70">
               <p>
-                Next suggested task:{' '}
-                <span className="font-semibold text-white">
-                  {String(currentTrainingTask.level).padStart(2, '0')}
-                </span>
+                All guided training tasks were moved to Career mode as progression
+                stages.
               </p>
               <p className="mt-1 text-white/60">
-                {currentTrainingTask.objective}
+                Open Career when you want structured objectives and rewards.
               </p>
-            </div>
-            <div className="max-h-96 overflow-y-auto pr-1">
-              <div className="relative pl-2">
-                <div className="absolute left-[1.35rem] top-2 bottom-2 w-[2px] rounded-full bg-gradient-to-b from-emerald-300/60 via-cyan-300/45 to-emerald-300/20" />
-                <div className="space-y-2.5">
-                  {trainingRoadmapNodes.map((levelDef) => {
-                    const levelNum = levelDef.levelNum;
-                    const completed = completedTrainingSet.has(levelNum);
-                    const active = levelNum === currentTrainingTask.level;
-                    const unlocked = levelNum <= unlockedTrainingCap;
-                    return (
-                      <div
-                        key={levelNum}
-                        className="relative flex items-start gap-3"
-                      >
-                        <button
-                          type="button"
-                          onClick={() =>
-                            startGame({ trainingLevelOverride: levelNum })
-                          }
-                          disabled={!unlocked}
-                          className={`relative z-10 mt-1 flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 text-sm font-semibold shadow-[0_10px_22px_rgba(0,0,0,0.45)] transition ${
-                            completed
-                              ? 'border-emerald-200 bg-emerald-300/20 text-emerald-50'
-                              : active
-                                ? 'border-cyan-200 bg-cyan-300/20 text-cyan-50'
-                                : unlocked
-                                  ? 'border-white/35 bg-black/45 text-white/90 hover:border-white/65'
-                                  : 'cursor-not-allowed border-white/15 bg-black/35 text-white/35'
-                          }`}
-                          aria-label={`Play training level ${levelNum}`}
-                        >
-                          {active ? (
-                            <img
-                              src={avatar || '/assets/icons/profile.svg'}
-                              alt="Player avatar"
-                              className="h-full w-full object-cover"
-                            />
-                          ) : (
-                            levelNum
-                          )}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            startGame({ trainingLevelOverride: levelNum })
-                          }
-                          disabled={!unlocked}
-                          className={`flex min-w-0 flex-1 flex-col items-start gap-2 rounded-2xl border px-3 py-3 text-left transition ${
-                            active
-                              ? 'border-cyan-300/60 bg-cyan-400/12 shadow-[0_10px_24px_rgba(34,211,238,0.18)]'
-                              : completed
-                                ? 'border-emerald-300/50 bg-emerald-400/10'
-                                : unlocked
-                                  ? 'border-white/20 bg-white/[0.03] hover:bg-white/[0.06]'
-                                  : 'cursor-not-allowed border-white/10 bg-white/[0.01]'
-                          }`}
-                        >
-                          <div className="flex w-full min-w-0 items-start justify-between gap-2">
-                            <div className="min-w-0">
-                              <p className="truncate text-xs font-semibold text-white">
-                                Task {String(levelNum).padStart(2, '0')} ·{' '}
-                                {levelDef.title.replace(/^Task\s\d+\s·\s/, '')}
-                              </p>
-                              <p className="mt-0.5 truncate text-[10px] text-white/70">
-                                {levelDef.objective}
-                              </p>
-                            </div>
-                            <span
-                              className={`ml-2 shrink-0 text-[10px] font-semibold uppercase tracking-[0.15em] ${completed ? 'text-emerald-200' : unlocked ? 'text-cyan-100/90' : 'text-white/35'}`}
-                            >
-                              {completed
-                                ? 'Done'
-                                : unlocked
-                                  ? active
-                                    ? 'Now'
-                                    : 'Play'
-                                  : 'Locked'}
-                            </span>
-                          </div>
-                          <div className="flex w-full flex-wrap items-center gap-1.5">
-                            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200/40 bg-emerald-300/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-100">
-                              <img
-                                src="/assets/icons/ezgif-54c96d8a9b9236.webp"
-                                alt="TPC"
-                                className="h-3.5 w-3.5"
-                              />
-                              {Number(
-                                levelDef.rewardAmount || 0
-                              ).toLocaleString('en-US')}{' '}
-                              TPC
-                            </span>
-                            {levelDef.hasGift ? (
-                              <span className="inline-flex items-center gap-1 rounded-full border border-amber-200/50 bg-amber-300/12 px-2 py-0.5 text-[10px] font-semibold text-amber-100">
-                                <span>🎁</span>
-                                NFT task
-                              </span>
-                            ) : null}
-                          </div>
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
             </div>
           </div>
         )}
@@ -1288,9 +1135,7 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
-        {playType !== 'training' &&
-          playType !== 'career' &&
-          !hasActiveTournament && (
+        {playType !== 'career' && !hasActiveTournament && (
             <button
               onClick={startGame}
               className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"

--- a/webapp/src/utils/poolRoyaleCareerProgress.js
+++ b/webapp/src/utils/poolRoyaleCareerProgress.js
@@ -1,14 +1,10 @@
+import {
+  TRAINING_LEVEL_COUNT,
+  describeTrainingLevel
+} from './poolRoyaleTrainingProgress.js'
+
 const CAREER_PROGRESS_KEY = 'poolRoyaleCareerProgress'
 export const CAREER_LEVEL_COUNT = 100
-
-const TRAINING_TITLES = [
-  'Cue Fundamentals',
-  'Spin Stability',
-  'Line Control',
-  'Rail Geometry',
-  'Pattern Break',
-  'Pressure Shots'
-]
 
 const FRIENDLY_TITLES = [
   'Scout Friendly',
@@ -25,7 +21,10 @@ const TOURNAMENT_TITLES = [
   'Legend Circuit'
 ]
 
+const CAREER_TRAINING_STAGE_COUNT = TRAINING_LEVEL_COUNT
+
 const getStageType = (level) => {
+  if (level <= CAREER_TRAINING_STAGE_COUNT) return 'training'
   if (level % 10 === 0) return 'tournament'
   if (level % 4 === 0) return 'friendly'
   return 'training'
@@ -37,7 +36,7 @@ const getTournamentPlayers = (level) => {
   return 32
 }
 
-const getTrainingLevel = (level) => ((level - 1) % 50) + 1
+const getTrainingLevel = (level) => ((level - 1) % TRAINING_LEVEL_COUNT) + 1
 
 const buildReward = (level, type) => {
   const tpc =
@@ -57,26 +56,42 @@ const buildStage = (level) => {
   const phaseIndex = Math.min(4, Math.floor((level - 1) / 20))
   const trainingLevel = type === 'training' ? getTrainingLevel(level) : null
   const reward = buildReward(level, type)
+
+  if (type === 'training') {
+    const trainingTask = describeTrainingLevel(trainingLevel || 1)
+    return {
+      id: `career-stage-${String(level).padStart(3, '0')}`,
+      level,
+      phase: phaseIndex + 1,
+      title: trainingTask.title,
+      type,
+      icon: '🎯',
+      objective: trainingTask.objective,
+      reward: trainingTask.reward,
+      rewardTpc: Number(trainingTask.rewardAmount) || reward.tpc,
+      hasGift: reward.hasGift,
+      trainingLevel,
+      players: null
+    }
+  }
+
   const titleSource =
-    type === 'training'
-      ? TRAINING_TITLES
-      : type === 'friendly'
-        ? FRIENDLY_TITLES
-        : TOURNAMENT_TITLES
+    type === 'friendly'
+      ? FRIENDLY_TITLES
+      : TOURNAMENT_TITLES
   const titleBase = titleSource[(level - 1) % titleSource.length]
+
   return {
     id: `career-stage-${String(level).padStart(3, '0')}`,
     level,
     phase: phaseIndex + 1,
     title: `${titleBase} ${String(level).padStart(2, '0')}`,
     type,
-    icon: type === 'training' ? '🎯' : type === 'friendly' ? '🤝' : '🏆',
+    icon: type === 'friendly' ? '🤝' : '🏆',
     objective:
-      type === 'training'
-        ? `Complete advanced drill pattern #${trainingLevel} with controlled cue-ball shape.`
-        : type === 'friendly'
-          ? 'Win a tactical friendly against an adaptive AI rival.'
-          : `Win a ${getTournamentPlayers(level)}-player bracket and secure promotion.`,
+      type === 'friendly'
+        ? 'Win a tactical friendly against an adaptive AI rival.'
+        : `Win a ${getTournamentPlayers(level)}-player bracket and secure promotion.`,
     reward: reward.label,
     rewardTpc: reward.tpc,
     hasGift: reward.hasGift,


### PR DESCRIPTION
### Motivation
- Consolidate guided training tasks into Career mode so the Career roadmap contains the canonical Task 01–Task 50 drills and their metadata. 
- Make the Training lobby a free practice sandbox where players can pick variant and ball colors and practice without AI or rule penalties. 

### Description
- Career stage generation now imports and reuses training definitions (`TRAINING_LEVEL_COUNT` / `describeTrainingLevel`) so the first 50 career stages are the real training tasks (titles, objectives, rewards). (`webapp/src/utils/poolRoyaleCareerProgress.js`)
- Lobby UI changes present Training as "Free Practice" (remove the in-lobby training roadmap and guided task list), keep variant selection and UK ball-color options available in the training lobby, and stop forcing the variant/ball-set when entering training/career. (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`)
- In-match training behavior updated so free practice runs solo with rules disabled while career-linked training stages preserve rules and rewards; AI opponent logic is disabled for free practice sessions. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Tests extended to validate that Career starts with the full set of training tasks and that career training stages use training objective/reward data. (`test/poolRoyaleCareerProgress.test.js`) 

### Testing
- Ran unit tests with Jest: `test/poolRoyaleCareerProgress.test.js` and `test/poolRoyaleTrainingProgress.test.js` — all tests passed (total 12 tests across the two suites). 
- Ran ESLint on the modified career progress util: `npx eslint --no-ignore webapp/src/utils/poolRoyaleCareerProgress.js` — no errors reported. 
- Captured a headless Playwright screenshot of the updated training lobby to validate the free-practice messaging and variant controls (script completed and generated an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998606e9be88329b1725325acf3d52b)