### PR TITLE
Fix Telegram receipt logo and TPC icon rendering fallbacks

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -8,14 +8,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+const TPC_ICON_FALLBACK_ASSET = '/assets/icons/generated/app-icon-192.png';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const TONPLAYGRAM_LOGO_FALLBACK_ASSET = '/assets/icons/generated/app-icon-512.png';
 
 function resolvePublicAssetPath(assetPath) {
   if (!assetPath || typeof assetPath !== 'string') return null;
   return path.join(publicPath, assetPath.replace(/^\//, '').replace(/^\.\//, ''));
 }
 
-const coinPath = resolvePublicAssetPath(TPC_ICON_ASSET);
+const coinPath = resolvePublicAssetPath(TPC_ICON_FALLBACK_ASSET);
 const fallbackAvatarPath = path.join(publicPath, 'assets/icons/profile.svg');
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {
@@ -49,16 +51,6 @@ function getBrandAssetCandidates(assetPath) {
     }
   }
   return [...new Set(candidates)];
-}
-
-async function loadBrandAsset(assetPath, options = {}) {
-  const variants = Array.isArray(assetPath) ? assetPath : [assetPath];
-  const candidates = variants.flatMap((variant) => getBrandAssetCandidates(variant));
-  for (const candidate of candidates) {
-    const image = await safeLoadImage(candidate, options);
-    if (image) return image;
-  }
-  return null;
 }
 
 const RECEIPT_IMAGE_RETRY_ATTEMPTS = 6;
@@ -154,7 +146,9 @@ function isTonPlaygramAccount(label = '') {
 
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
-  if (isTonPlaygramAccount(label)) candidates.push(TONPLAYGRAM_LOGO_ASSET);
+  if (isTonPlaygramAccount(label)) {
+    candidates.push(TONPLAYGRAM_LOGO_ASSET, TONPLAYGRAM_LOGO_FALLBACK_ASSET);
+  }
   if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];
@@ -165,6 +159,14 @@ async function resolveReceiptAvatar(photo, label) {
   for (const candidate of candidates) {
     const avatar = await safeLoadImage(candidate);
     if (avatar) return avatar;
+  }
+  return null;
+}
+
+async function resolveReceiptBrandImage(candidates = [], options = {}) {
+  for (const candidate of candidates.filter(Boolean)) {
+    const image = await safeLoadImage(candidate, options);
+    if (image) return image;
   }
   return null;
 }
@@ -214,7 +216,15 @@ export async function generateReceiptImage({
   ctx.lineWidth = 3;
   ctx.stroke();
 
-  const logo = await loadBrandAsset(TONPLAYGRAM_LOGO_ASSET, { attempts: 8, delayMs: 220 });
+  const logo = await resolveReceiptBrandImage(
+    [
+      TONPLAYGRAM_LOGO_ASSET,
+      TONPLAYGRAM_LOGO_FALLBACK_ASSET,
+      ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
+      ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_FALLBACK_ASSET),
+    ],
+    { attempts: 8, delayMs: 220 }
+  );
   roundedRect(ctx, width / 2 - 130, 58, 260, 130, 30);
   ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
   ctx.fill();
@@ -251,8 +261,24 @@ export async function generateReceiptImage({
   ctx.fill();
 
   const coin =
-    (await loadBrandAsset(TPC_ICON_ASSET, { attempts: 8, delayMs: 220 })) ||
-    (await loadBrandAsset(TONPLAYGRAM_LOGO_ASSET, { attempts: 8, delayMs: 220 }));
+    (await resolveReceiptBrandImage(
+      [
+        TPC_ICON_ASSET,
+        TPC_ICON_FALLBACK_ASSET,
+        ...getBrandAssetCandidates(TPC_ICON_ASSET),
+        ...getBrandAssetCandidates(TPC_ICON_FALLBACK_ASSET),
+      ],
+      { attempts: 8, delayMs: 220 }
+    )) ||
+    (await resolveReceiptBrandImage(
+      [
+        TONPLAYGRAM_LOGO_ASSET,
+        TONPLAYGRAM_LOGO_FALLBACK_ASSET,
+        ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
+        ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_FALLBACK_ASSET),
+      ],
+      { attempts: 8, delayMs: 220 }
+    ));
 
   const sign = amount > 0 ? '+' : '';
   const formatted = Number(amount || 0).toLocaleString(undefined, {


### PR DESCRIPTION
### Motivation
- Receipt images used WEBP branding assets that may fail to decode in some runtimes, causing the TonPlaygram logo and TPC icon to not appear on Telegram receipts. 
- The avatar/thumbnail flows already use a resilient image-loading approach, so receipts should use the same technique and include guaranteed-decoding PNG fallbacks.

### Description
- Added PNG fallback constants `TPC_ICON_FALLBACK_ASSET` and `TONPLAYGRAM_LOGO_FALLBACK_ASSET` and switched invite fallback `coinPath` to the PNG fallback so notifications have a decodable fallback image. 
- Introduced `resolveReceiptBrandImage(...)` to attempt a prioritized list of brand asset candidates using the existing `safeLoadImage(...)` loader. 
- Updated receipt header `logo` and amount `coin` resolution to use `resolveReceiptBrandImage(...)` with both original and fallback assets plus URL variants from `getBrandAssetCandidates(...)`. 
- Added the PNG logo fallback as an extra candidate for TonPlaygram account avatars so store/treasury avatars resolve to branding instead of a generic placeholder when WEBP fails.

### Testing
- Ran `npm --prefix bot run receipt:preview` and the script completed successfully producing `bot/tmp/receipt-preview.png`. 
- Executed an image decode check which showed the WEBP sources failed to decode in this environment while the PNG fallbacks decoded successfully. 
- Visually inspected the generated `bot/tmp/receipt-preview.png` and confirmed the TonPlaygram logo and TPC icon are visible in the receipt preview.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699863cd2ef88329b855c3c70489c98e)