### PR TITLE
Use homepage logo and TPC burst icon assets in Telegram receipts

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -51,16 +51,6 @@ function getBrandAssetCandidates(assetPath) {
   return [...new Set(candidates)];
 }
 
-async function loadBrandAsset(assetPath, options = {}) {
-  const variants = Array.isArray(assetPath) ? assetPath : [assetPath];
-  const candidates = variants.flatMap((variant) => getBrandAssetCandidates(variant));
-  for (const candidate of candidates) {
-    const image = await safeLoadImage(candidate, options);
-    if (image) return image;
-  }
-  return null;
-}
-
 const RECEIPT_IMAGE_RETRY_ATTEMPTS = 6;
 const RECEIPT_IMAGE_RETRY_DELAY_MS = 180;
 
@@ -154,7 +144,9 @@ function isTonPlaygramAccount(label = '') {
 
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
-  if (isTonPlaygramAccount(label)) candidates.push(TONPLAYGRAM_LOGO_ASSET);
+  if (isTonPlaygramAccount(label)) {
+    candidates.push(TONPLAYGRAM_LOGO_ASSET);
+  }
   if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];
@@ -165,6 +157,14 @@ async function resolveReceiptAvatar(photo, label) {
   for (const candidate of candidates) {
     const avatar = await safeLoadImage(candidate);
     if (avatar) return avatar;
+  }
+  return null;
+}
+
+async function resolveReceiptBrandImage(candidates = [], options = {}) {
+  for (const candidate of candidates.filter(Boolean)) {
+    const image = await safeLoadImage(candidate, options);
+    if (image) return image;
   }
   return null;
 }
@@ -214,7 +214,13 @@ export async function generateReceiptImage({
   ctx.lineWidth = 3;
   ctx.stroke();
 
-  const logo = await loadBrandAsset(TONPLAYGRAM_LOGO_ASSET, { attempts: 8, delayMs: 220 });
+  const logo = await resolveReceiptBrandImage(
+    [
+      TONPLAYGRAM_LOGO_ASSET,
+      ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
+    ],
+    { attempts: 8, delayMs: 220 }
+  );
   roundedRect(ctx, width / 2 - 130, 58, 260, 130, 30);
   ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
   ctx.fill();
@@ -251,8 +257,20 @@ export async function generateReceiptImage({
   ctx.fill();
 
   const coin =
-    (await loadBrandAsset(TPC_ICON_ASSET, { attempts: 8, delayMs: 220 })) ||
-    (await loadBrandAsset(TONPLAYGRAM_LOGO_ASSET, { attempts: 8, delayMs: 220 }));
+    (await resolveReceiptBrandImage(
+      [
+        TPC_ICON_ASSET,
+        ...getBrandAssetCandidates(TPC_ICON_ASSET),
+      ],
+      { attempts: 8, delayMs: 220 }
+    )) ||
+    (await resolveReceiptBrandImage(
+      [
+        TONPLAYGRAM_LOGO_ASSET,
+        ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
+      ],
+      { attempts: 8, delayMs: 220 }
+    ));
 
   const sign = amount > 0 ? '+' : '';
   const formatted = Number(amount || 0).toLocaleString(undefined, {


### PR DESCRIPTION
### Motivation
- Previous fallback PNG/app-icon logic caused the TON-style icon to appear in receipts, so receipts must use the exact branding assets shown in the live app (homepage logo and the TPC coin burst) to match visuals and avoid decoding surprises.
- Maintain the resilient retry/loading flow used by avatars/thumbnails but ensure it resolves the intended UI assets rather than generic app-icon fallbacks.

### Description
- Updated receipt branding to use the homepage top logo and coin burst assets by setting `TPC_ICON_ASSET` to `/assets/icons/ezgif-54c96d8a9b9236.webp` and `TONPLAYGRAM_LOGO_ASSET` to `/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp` in `bot/utils/notifications.js`.
- Removed the previously-added PNG app-icon fallback constants and changed invite fallback `coinPath` to resolve the TPC burst asset so invites use the same coin image as the web UI.
- Simplified avatar candidate selection so TonPlaygram accounts now prioritize the actual homepage logo asset (via `getReceiptAvatarCandidates`) instead of app-icon fallbacks.
- Kept the resilient loader and candidate resolution by using `resolveReceiptBrandImage(...)` together with `safeLoadImage(...)` and `getBrandAssetCandidates(...)` when resolving the receipt header logo and amount coin.

### Testing
- Ran `npm --prefix bot run receipt:preview` and the script completed successfully creating `/bot/tmp/receipt-preview.png` (visual verification done).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699863cd2ef88329b855c3c70489c98e)