### PR TITLE
Fix Pool Royale career Continue to advance to next stage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -97,7 +97,10 @@ import {
   TRAINING_LEVELS,
   TRAINING_LEVEL_COUNT
 } from '../../utils/poolRoyaleTrainingProgress.js';
-import { markCareerStageCompleted } from '../../utils/poolRoyaleCareerProgress.js';
+import {
+  getNextCareerStage,
+  markCareerStageCompleted
+} from '../../utils/poolRoyaleCareerProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
   clampToUnitCircle,
@@ -13119,6 +13122,55 @@ function PoolRoyaleGame({
     handleTrainingLevelPick(trainingLevelRef.current || trainingLevel);
   }, [handleTrainingLevelPick, trainingLevel]);
 
+  const handleCareerTaskContinue = useCallback(() => {
+    if (!careerMode || !careerStageId) {
+      setCareerTaskResultModal(null);
+      handleTrainingRoadmapContinue();
+      return;
+    }
+    const updatedCareerProgress = markCareerStageCompleted(careerStageId);
+    const nextCareerStage = getNextCareerStage(
+      trainingProgressRef.current,
+      updatedCareerProgress
+    );
+    if (!nextCareerStage) {
+      setCareerTaskResultModal(null);
+      goToLobby();
+      return;
+    }
+    const params = new URLSearchParams(location.search);
+    const nextPlayType =
+      nextCareerStage.type === 'friendly' ? 'regular' : nextCareerStage.type;
+    params.set('type', nextPlayType || 'training');
+    params.set('career', '1');
+    params.set('careerStageId', nextCareerStage.id);
+    if (nextCareerStage.title) {
+      params.set('careerStageTitle', nextCareerStage.title);
+    } else {
+      params.delete('careerStageTitle');
+    }
+    if (nextCareerStage.type === 'training' && nextCareerStage.trainingLevel) {
+      params.set('trainingLevel', String(nextCareerStage.trainingLevel));
+      params.delete('players');
+    } else {
+      params.delete('trainingLevel');
+      if (nextCareerStage.type === 'tournament' && nextCareerStage.players) {
+        params.set('players', String(nextCareerStage.players));
+      } else {
+        params.delete('players');
+      }
+    }
+    setCareerTaskResultModal(null);
+    navigate(`/games/poolroyale?${params.toString()}`);
+  }, [
+    careerMode,
+    careerStageId,
+    goToLobby,
+    handleTrainingRoadmapContinue,
+    location.search,
+    navigate
+  ]);
+
   useEffect(() => {
     applyTrainingLayoutForLevel(trainingLevel);
     const retryA = window.setTimeout(() => {
@@ -14358,13 +14410,17 @@ const powerRef = useRef(hud.power);
       : !previousRewardedSet.has(completedLevel) && completedRewardAmount > 0;
 
     if (isCareerTrainingSession) {
+      const nextPlayable = resolvePlayableTrainingLevel(
+        completedLevel + 1,
+        trainingProgressRef.current
+      );
       const carryShots = Math.max(0, trainingShotsRemaining);
       setTrainingShotsRemaining(carryShots);
-      setPendingTrainingLevel(completedLevel);
+      setPendingTrainingLevel(nextPlayable);
       setLastCompletedLevel(completedLevel);
       setTrainingTaskTransition({
         fromLevel: completedLevel,
-        toLevel: completedLevel,
+        toLevel: nextPlayable,
         rewardAmount: shouldAwardReward ? completedRewardAmount : 0,
         nftReward
       });
@@ -32111,10 +32167,7 @@ const powerRef = useRef(hud.power);
                 <div className="mt-4 grid grid-cols-2 gap-2">
                   <button
                     type="button"
-                    onClick={() => {
-                      setCareerTaskResultModal(null);
-                      handleTrainingRoadmapContinue();
-                    }}
+                    onClick={handleCareerTaskContinue}
                     className="rounded-full border border-emerald-300/70 bg-emerald-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100 transition hover:bg-emerald-500/30"
                   >
                     Continue next task


### PR DESCRIPTION
### Motivation
- Fix a progression bug where pressing Continue after completing a career task would replay the same stage instead of advancing the player to the next career task.
- Keep career progression consistent with the training roadmap behavior so career sessions move forward correctly.

### Description
- Import `getNextCareerStage` and use it alongside `markCareerStageCompleted` to resolve the next career stage after a win.
- Add a new `handleCareerTaskContinue` callback that marks the current stage complete, computes the next stage, updates query params (`career`, `careerStageId`, `type`, `trainingLevel` / `players`) and navigates to the correct next task or returns to the lobby when no stage remains.
- Wire the career success modal’s Continue button to `handleCareerTaskContinue` so the UI now triggers the new flow.
- For career training sessions, compute and store the next playable training level (`nextPlayable`) and set `trainingTaskTransition.toLevel` and `pendingTrainingLevel` to that value instead of reusing the just-completed level.

### Testing
- Ran the unit test `test/poolRoyaleCareerProgress.test.js` via `npm test -- test/poolRoyaleCareerProgress.test.js --runInBand`, and the suite passed (`5 tests, 5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699872c1584c8329b1154adbfd2bccb8)