### PR TITLE
Fix Telegram receipt logo/icon rendering with non‑WebP fallbacks

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -9,6 +9,14 @@ const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const TPC_ICON_FALLBACKS = [
+  TPC_ICON_ASSET,
+  '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
+];
+const TONPLAYGRAM_LOGO_FALLBACKS = [
+  TONPLAYGRAM_LOGO_ASSET,
+  '/assets/icons/generated/app-icon-512.png',
+];
 
 function resolvePublicAssetPath(assetPath) {
   if (!assetPath || typeof assetPath !== 'string') return null;
@@ -49,6 +57,14 @@ function getBrandAssetCandidates(assetPath) {
     }
   }
   return [...new Set(candidates)];
+}
+
+function getBrandAssetCandidatesList(assetPaths = []) {
+  const candidates = [];
+  for (const assetPath of assetPaths) {
+    candidates.push(...getBrandAssetCandidates(assetPath));
+  }
+  return [...new Set(candidates.filter(Boolean))];
 }
 
 const RECEIPT_IMAGE_RETRY_ATTEMPTS = 6;
@@ -215,10 +231,7 @@ export async function generateReceiptImage({
   ctx.stroke();
 
   const logo = await resolveReceiptBrandImage(
-    [
-      TONPLAYGRAM_LOGO_ASSET,
-      ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
-    ],
+    getBrandAssetCandidatesList(TONPLAYGRAM_LOGO_FALLBACKS),
     { attempts: 8, delayMs: 220 }
   );
   roundedRect(ctx, width / 2 - 130, 58, 260, 130, 30);
@@ -258,17 +271,11 @@ export async function generateReceiptImage({
 
   const coin =
     (await resolveReceiptBrandImage(
-      [
-        TPC_ICON_ASSET,
-        ...getBrandAssetCandidates(TPC_ICON_ASSET),
-      ],
+      getBrandAssetCandidatesList(TPC_ICON_FALLBACKS),
       { attempts: 8, delayMs: 220 }
     )) ||
     (await resolveReceiptBrandImage(
-      [
-        TONPLAYGRAM_LOGO_ASSET,
-        ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
-      ],
+      getBrandAssetCandidatesList(TONPLAYGRAM_LOGO_FALLBACKS),
       { attempts: 8, delayMs: 220 }
     ));
 


### PR DESCRIPTION
### Motivation

- Telegram receipt images sometimes rendered without the TonPlaygram logo or TPC icon because the bot runtime's `canvas` cannot decode the provided WebP assets.  
- The receipt generator already uses retry/candidate loading for avatars and thumbnails, so receipts should reuse the same multi-candidate approach to ensure a visible brand/logo image.

### Description

- Added ordered fallback lists for the TPC icon and TonPlaygram logo (`TPC_ICON_FALLBACKS`, `TONPLAYGRAM_LOGO_FALLBACKS`) in `bot/utils/notifications.js` and wired those into the receipt image loader.  
- Introduced `getBrandAssetCandidatesList` helper to build deduplicated candidate URLs/paths for multiple assets and reuse the existing `safeLoadImage`/`resolveReceiptBrandImage` flow.  
- Updated `generateReceiptImage` to load the logo and coin via the candidate lists so PNG fallbacks are attempted when WebP cannot be decoded.  
- Kept existing normalization, remote/local candidate resolution and retry behavior used elsewhere for avatars/thumbnails.

### Testing

- Ran `writeReceiptPreview` via `writeReceiptPreview('./tmp/receipt-preview.png', {...})` in `bot/` and it produced `./tmp/receipt-preview.png` successfully.  
- Verified `canvas.loadImage` can load the fallback PNGs (`../webapp/public/assets/icons/generated/app-icon-512.png` and `../webapp/public/assets/icons/file_00000000123071f4a91766ac58320bce.png`) in the bot runtime; image loading succeeded.  
- Both automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699876a6f49883299d0fe0f6d7c6bad9)