### PR TITLE
Add PNG fallbacks & candidate resolver for Telegram receipt logos/icons

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -9,6 +9,10 @@ const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const RECEIPT_BRAND_ICON_FALLBACKS = [
+  '/assets/icons/generated/app-icon-192.png',
+  '/assets/icons/generated/app-icon-512.png',
+];
 
 function resolvePublicAssetPath(assetPath) {
   if (!assetPath || typeof assetPath !== 'string') return null;
@@ -49,6 +53,19 @@ function getBrandAssetCandidates(assetPath) {
     }
   }
   return [...new Set(candidates)];
+}
+
+function getReceiptBrandCandidates(primaryAsset, fallbackAssets = []) {
+  const candidates = [
+    primaryAsset,
+    ...getBrandAssetCandidates(primaryAsset),
+  ];
+
+  for (const fallback of fallbackAssets.filter(Boolean)) {
+    candidates.push(fallback, ...getBrandAssetCandidates(fallback));
+  }
+
+  return [...new Set(candidates.filter(Boolean))];
 }
 
 const RECEIPT_IMAGE_RETRY_ATTEMPTS = 6;
@@ -215,10 +232,7 @@ export async function generateReceiptImage({
   ctx.stroke();
 
   const logo = await resolveReceiptBrandImage(
-    [
-      TONPLAYGRAM_LOGO_ASSET,
-      ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
-    ],
+    getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
     { attempts: 8, delayMs: 220 }
   );
   roundedRect(ctx, width / 2 - 130, 58, 260, 130, 30);
@@ -258,17 +272,11 @@ export async function generateReceiptImage({
 
   const coin =
     (await resolveReceiptBrandImage(
-      [
-        TPC_ICON_ASSET,
-        ...getBrandAssetCandidates(TPC_ICON_ASSET),
-      ],
+      getReceiptBrandCandidates(TPC_ICON_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
       { attempts: 8, delayMs: 220 }
     )) ||
     (await resolveReceiptBrandImage(
-      [
-        TONPLAYGRAM_LOGO_ASSET,
-        ...getBrandAssetCandidates(TONPLAYGRAM_LOGO_ASSET),
-      ],
+      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
       { attempts: 8, delayMs: 220 }
     ));
 


### PR DESCRIPTION
### Motivation
- The receipt image generator could fail to show the brand logo/icon when the server canvas runtime cannot decode WebP assets, so receipts lacked the expected logo/avatar visuals.
- Use the same resilient candidate/resolution approach as thumbnails/avatars to ensure receipts always show a brand icon where possible.

### Description
- Added `RECEIPT_BRAND_ICON_FALLBACKS` pointing to `/assets/icons/generated/app-icon-192.png` and `/assets/icons/generated/app-icon-512.png` as PNG fallbacks.
- Introduced `getReceiptBrandCandidates(primaryAsset, fallbackAssets)` to build a unified list of local and absolute candidates for brand images.
- Rewired logo and token-icon resolution in `generateReceiptImage` to use the new candidate resolver so the generator will try PNG fallbacks when WebP assets fail to load.
- Changes are contained in `bot/utils/notifications.js` and preserve the existing retry/attempt semantics used by `safeLoadImage`.

### Testing
- Ran `npm --prefix bot run receipt:preview` which completed successfully and produced a receipt preview image.
- Executed a Node `loadImage` check (from the `canvas` package) that confirmed PNG fallback assets can be loaded while the original WebP assets show `Unsupported image type` in this runtime, validating the fallback behavior.
- All automated checks above passed and the receipt preview rendered with a brand image when fallbacks were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699876a6f49883299d0fe0f6d7c6bad9)