### PR TITLE
Fix Telegram receipt branding assets

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -8,10 +8,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.png';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_000000008ab462439ff27618691146eb.png';
 const RECEIPT_BRAND_ICON_FALLBACKS = [
-  '/assets/icons/generated/app-icon-192.png',
-  '/assets/icons/generated/app-icon-512.png',
+  TONPLAYGRAM_LOGO_ASSET_FALLBACK,
+  TPC_ICON_ASSET_FALLBACK,
 ];
 
 function resolvePublicAssetPath(assetPath) {
@@ -272,11 +274,11 @@ export async function generateReceiptImage({
 
   const coin =
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TPC_ICON_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
+      getReceiptBrandCandidates(TPC_ICON_ASSET, [TPC_ICON_ASSET_FALLBACK]),
       { attempts: 8, delayMs: 220 }
     )) ||
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
+      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, [TONPLAYGRAM_LOGO_ASSET_FALLBACK]),
       { attempts: 8, delayMs: 220 }
     ));
 


### PR DESCRIPTION
### Motivation
- Telegram receipt images were using fallback app icons that did not match the live site branding, causing incorrect logo/icon rendering in generated receipts. 
- The goal is to ensure the receipt header logo and the TPC token icon match the same assets used by the webapp UI, using files already present in `webapp/public/assets/icons`.

### Description
- Added dedicated fallback constants `TPC_ICON_ASSET_FALLBACK` and `TONPLAYGRAM_LOGO_ASSET_FALLBACK` in `bot/utils/notifications.js` that point to existing PNG assets under `/assets/icons`.
- Replaced the previous generic generated-app-icon fallbacks with the new TonPlaygram-specific fallbacks and scoped the brand resolution so the amount-row coin prefers the TPC asset (and its fallback) before falling back to the logo asset (and its fallback).
- Kept the primary asset paths unchanged so the receipt generation now uses the same branding assets as the site while reliably resolving a PNG fallback when needed.

### Testing
- Ran the receipt preview generator with `cd bot && npm run -s receipt:preview` and confirmed it successfully produced `bot/tmp/receipt-preview.png`.
- Verified the generated preview visually to ensure the TonPlaygram logo and TPC icon appear in the receipt header and amount row respectively.
- Confirmed the code diff with `git status`/`git diff` to ensure only `bot/utils/notifications.js` was modified and no binary assets were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988413fb88832997ca3d1dd3cdbe2f)