### PR TITLE
Fix Pool Royale career task progression and make Practice use full 15-ball rack

### DIFF
--- a/test/poolRoyaleTrainingProgress.test.js
+++ b/test/poolRoyaleTrainingProgress.test.js
@@ -1,4 +1,10 @@
-import { describeTrainingLevel, getTrainingLayout, resolvePlayableTrainingLevel } from '../webapp/src/utils/poolRoyaleTrainingProgress.js';
+import {
+  describeTrainingLevel,
+  getPracticeLayout,
+  getTrainingLayout,
+  PRACTICE_OBJECT_BALL_COUNT,
+  resolvePlayableTrainingLevel
+} from '../webapp/src/utils/poolRoyaleTrainingProgress.js';
 
 describe('resolvePlayableTrainingLevel', () => {
   test('caps requested levels to the next incomplete slot', () => {
@@ -14,6 +20,14 @@ describe('resolvePlayableTrainingLevel', () => {
   test('falls back to the last level when every task is already complete', () => {
     const progress = { completed: Array.from({ length: 50 }, (_, i) => i + 1), lastLevel: 4 };
     expect(resolvePlayableTrainingLevel(null, progress)).toBe(4);
+  });
+});
+
+describe('pool royale practice layout', () => {
+  test('uses a full 15-ball rack without roadmap task scaling', () => {
+    const layout = getPracticeLayout();
+    expect(Array.isArray(layout.balls)).toBe(true);
+    expect(layout.balls.length).toBe(PRACTICE_OBJECT_BALL_COUNT);
   });
 });
 

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -1,5 +1,6 @@
 const TRAINING_PROGRESS_KEY = 'poolRoyaleTrainingProgress'
 export const TRAINING_LEVEL_COUNT = 50
+export const PRACTICE_OBJECT_BALL_COUNT = 15
 const BASE_ATTEMPTS_PER_LEVEL = 3
 const TRAINING_MAX_LAYOUT_BALLS = 25
 const MIN_LAYOUT_GAP = 0.08
@@ -181,6 +182,32 @@ export function describeTrainingLevel (level) {
 
 export function getTrainingLayout (level) {
   return describeTrainingLevel(level).layout
+}
+
+export function getPracticeLayout () {
+  const baseX = 0.24
+  const baseZ = 0
+  const spacing = 0.056
+  const balls = []
+  let rackIndex = 0
+
+  for (let row = 0; row < 5; row++) {
+    const rowX = baseX + (row * spacing)
+    const rowStartZ = baseZ - ((row * spacing) / 2)
+    for (let col = 0; col <= row; col++) {
+      balls.push({
+        rackIndex,
+        x: rowX,
+        z: rowStartZ + (col * spacing)
+      })
+      rackIndex += 1
+    }
+  }
+
+  return {
+    cue: { x: -0.68, z: 0 },
+    balls
+  }
 }
 
 export function loadTrainingProgress () {


### PR DESCRIPTION
### Motivation
- Career training tasks could leave players stuck on the same task after completion and the Practice mode used the roadmap/task layouts instead of a normal 15-ball rack; this change fixes progression and simplifies practice behavior.

### Description
- Add a reusable `getPracticeLayout` helper and `PRACTICE_OBJECT_BALL_COUNT` in `webapp/src/utils/poolRoyaleTrainingProgress.js` that returns a 15-ball rack layout for practice sessions.
- Switch training layout selection in `webapp/src/pages/Games/PoolRoyale.jsx` so non-career practice uses `getPracticeLayout()` while career training continues to use task layouts.
- When a career training task is completed, immediately mark the career stage done via `markCareerStageCompleted` and compute/advance to the next task (so `Continue next task` moves forward rather than reopening the same task).
- Prevent the practice roadmap modal from interrupting free practice by auto-advancing/applying the next layout for non-career practice flows and avoid opening the roadmap in free practice.
- Add unit test coverage (`test/poolRoyaleTrainingProgress.test.js`) validating the practice layout contains 15 object balls and export the practice constant for assertions.

### Testing
- Ran `npm test -- test/poolRoyaleTrainingProgress.test.js` and the suite passed (new practice layout test plus existing training layout tests: all green).
- Ran `npm test -- test/poolRoyaleCareerProgress.test.js` and the career progression tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989c15aa5c8329845461ccb623f031)