### PR TITLE
Align Telegram receipt assets with Home header logo and Wallet TPC icon

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -7,13 +7,15 @@ import { fetchTelegramInfo } from './telegram.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
-const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.png';
-const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_000000008ab462439ff27618691146eb.png';
+// Same logo as the top header on Home page (Layout.jsx).
+const HOME_HEADER_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const HOME_HEADER_LOGO_ASSET_FALLBACK = '/assets/icons/file_000000008ab462439ff27618691146eb.png';
+// Same TPC icon as the Home wallet card.
+const HOME_WALLET_TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+const HOME_WALLET_TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.png';
 const RECEIPT_BRAND_ICON_FALLBACKS = [
-  TONPLAYGRAM_LOGO_ASSET_FALLBACK,
-  TPC_ICON_ASSET_FALLBACK,
+  HOME_HEADER_LOGO_ASSET_FALLBACK,
+  HOME_WALLET_TPC_ICON_ASSET_FALLBACK,
 ];
 
 function resolvePublicAssetPath(assetPath) {
@@ -21,7 +23,7 @@ function resolvePublicAssetPath(assetPath) {
   return path.join(publicPath, assetPath.replace(/^\//, '').replace(/^\.\//, ''));
 }
 
-const coinPath = resolvePublicAssetPath(TPC_ICON_ASSET);
+const coinPath = resolvePublicAssetPath(HOME_WALLET_TPC_ICON_ASSET);
 const fallbackAvatarPath = path.join(publicPath, 'assets/icons/profile.svg');
 
 export function getInviteUrl(roomId, token, amount, game = 'snake') {
@@ -164,7 +166,9 @@ function isTonPlaygramAccount(label = '') {
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
   if (isTonPlaygramAccount(label)) {
-    candidates.push(TONPLAYGRAM_LOGO_ASSET);
+    candidates.push(
+      ...getReceiptBrandCandidates(HOME_HEADER_LOGO_ASSET, [HOME_HEADER_LOGO_ASSET_FALLBACK])
+    );
   }
   if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
@@ -234,7 +238,7 @@ export async function generateReceiptImage({
   ctx.stroke();
 
   const logo = await resolveReceiptBrandImage(
-    getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
+    getReceiptBrandCandidates(HOME_HEADER_LOGO_ASSET, RECEIPT_BRAND_ICON_FALLBACKS),
     { attempts: 8, delayMs: 220 }
   );
   roundedRect(ctx, width / 2 - 130, 58, 260, 130, 30);
@@ -274,11 +278,11 @@ export async function generateReceiptImage({
 
   const coin =
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TPC_ICON_ASSET, [TPC_ICON_ASSET_FALLBACK]),
+      getReceiptBrandCandidates(HOME_WALLET_TPC_ICON_ASSET, [HOME_WALLET_TPC_ICON_ASSET_FALLBACK]),
       { attempts: 8, delayMs: 220 }
     )) ||
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, [TONPLAYGRAM_LOGO_ASSET_FALLBACK]),
+      getReceiptBrandCandidates(HOME_HEADER_LOGO_ASSET, [HOME_HEADER_LOGO_ASSET_FALLBACK]),
       { attempts: 8, delayMs: 220 }
     ));
 
@@ -447,7 +451,7 @@ export async function sendStorePurchaseNotification(bot, toId, payload) {
     fromName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     toName: 'TonPlaygram Store',
     fromPhoto: toInfo?.photoUrl,
-    toPhoto: TONPLAYGRAM_LOGO_ASSET,
+    toPhoto: HOME_HEADER_LOGO_ASSET,
     itemThumbnail: resolveReceiptItemThumbnail(payload),
     itemLabel: payload.itemLabel,
   });


### PR DESCRIPTION
### Motivation
- Ensure Telegram receipt visuals use the same logo and TPC icon shown on the app Home page and wallet card so receipts, store avatars and treasury avatars match the live UI while leaving delivery behavior unchanged.

### Description
- Replaced hard-coded receipt asset constants with `HOME_HEADER_LOGO_ASSET` and `HOME_WALLET_TPC_ICON_ASSET` and kept existing fallback assets.
- Updated avatar candidate resolution so TonPlaygram-branded accounts (including `store` and `treasury`) prioritize the Home header logo and its fallback.
- Wired coin/brand resolution and `toPhoto` for store purchase receipts to use the new Home assets while preserving attempts/retry behavior.
- Only `bot/utils/notifications.js` was modified; the receipt generation and send flows remain unchanged.

### Testing
- Ran `node --check bot/utils/notifications.js` which completed successfully.
- Ran a programmatic receipt preview generation via `node -e "import('./bot/utils/notifications.js').then(async m=>{await m.writeReceiptPreview('/tmp/receipt-preview.png', {title:'Test', subtitle:'Brand check', amount:12.34, fromName:'TonPlaygram Treasury', toName:'TonPlaygram Store'});console.log('ok');})"` which produced the preview without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989e6976888329b17b1c5a3dfb82f9)