### PR TITLE
Add 2D camera quick-action to Murlan Royale (button under Gift)

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -5,12 +5,15 @@ export default function BottomLeftIcons({
   onInfo,
   onChat,
   onGift,
+  onCamera2d,
   style,
   className = 'fixed left-1 bottom-4 flex flex-col items-center space-y-2 z-20',
   showInfo = true,
   showChat = true,
   showGift = true,
   showMute = true,
+  showCamera2d = false,
+  camera2dActive = false,
   buttonClassName = 'p-1 flex flex-col items-center',
   iconClassName = 'text-xl',
   labelClassName = 'text-xs',
@@ -19,6 +22,8 @@ export default function BottomLeftIcons({
   infoIcon,
   muteIconOn,
   muteIconOff,
+  cameraIcon,
+  cameraLabel = '2D',
   order = ['chat', 'gift', 'info', 'mute']
 }) {
   const [muted, setMuted] = useState(isGameMuted());
@@ -74,6 +79,14 @@ export default function BottomLeftIcons({
               {muted ? muteIconOn ?? '🔇' : muteIconOff ?? '🔊'}
             </span>
             <span className={labelClassName}>{muted ? 'Unmute' : 'Mute'}</span>
+          </button>
+        )
+      : null,
+    camera2d: showCamera2d && onCamera2d
+      ? (
+          <button type="button" onClick={onCamera2d} className={buttonClassName} aria-pressed={camera2dActive}>
+            <span className={iconClassName}>{cameraIcon ?? '🎥'}</span>
+            <span className={labelClassName}>{camera2dActive ? '3D' : cameraLabel}</span>
           </button>
         )
       : null


### PR DESCRIPTION
### Motivation
- Expose a portrait-friendly 2D/top-down camera toggle in Murlan Royale so the camera button sits in the same vertical rail and alignment as the existing Gift/Info/Chat icons. 

### Description
- Added a reusable `camera2d` quick-action to `BottomLeftIcons` with props `onCamera2d`, `showCamera2d`, `camera2dActive`, `cameraIcon` and `cameraLabel` so games can opt-in to render a camera toggle in the same icon column. (`webapp/src/components/BottomLeftIcons.jsx`)
- Wired the new camera action into Murlan Royale by adding `isCamera2d` state and `handleToggleCamera2d`, exposing the `camera2d` button under the Gift icon in the same order and passing `camera2dActive`. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)
- Implemented view switching logic that saves the current orbit camera/controls state into `cameraViewRestoreRef`, moves the camera to a locked top-down position while 2D is active, disables rotate/pan, and restores the previous camera state when toggled off; seat anchors are updated after toggles. (`MurlanRoyaleArena.jsx` changes)
- Kept the API surface small and accessible: `BottomLeftIcons` presents the action in the `order` array and uses `aria-pressed` on the toggle for accessibility.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (no errors). ✅
- Launched a preview and ran an automated Playwright script (mobile viewport 390×844) that loaded `/games/murlanroyale` and verified the rendered quick-action labels contained: `Info`, `Mute`, `Chat`, `Gift`, `2D`; a screenshot was captured for visual validation. ✅
- Manual smoke checked the Murlan arena UI to confirm the new button appears directly under Gift and toggles the camera into a locked top-down view and back. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989f54f8088329a4a8a9a60c2c06ba)