### PR TITLE
Align Telegram receipt branding with Home header and wallet-card assets

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,11 +6,13 @@ import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
-// Keep Telegram receipt branding aligned with the live app visuals.
-const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.png';
-const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_000000008ab462439ff27618691146eb.png';
+// Keep Telegram receipt branding aligned with the same assets used on Home.
+const HOME_TOP_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const HOME_WALLET_CARD_TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+const TPC_ICON_ASSET = HOME_WALLET_CARD_TPC_ICON_ASSET;
+const TPC_ICON_ASSET_FALLBACK = HOME_WALLET_CARD_TPC_ICON_ASSET;
+const TONPLAYGRAM_LOGO_ASSET = HOME_TOP_LOGO_ASSET;
+const TONPLAYGRAM_LOGO_ASSET_FALLBACK = HOME_TOP_LOGO_ASSET;
 const RECEIPT_BRAND_ICON_FALLBACKS = [
   TONPLAYGRAM_LOGO_ASSET_FALLBACK,
   TPC_ICON_ASSET_FALLBACK,
@@ -164,9 +166,11 @@ function isTonPlaygramAccount(label = '') {
 function getReceiptAvatarCandidates(photo, label) {
   const candidates = [];
   if (isTonPlaygramAccount(label)) {
-    candidates.push(TONPLAYGRAM_LOGO_ASSET);
+    // Store / Treasury avatars must always match the home header logo.
+    candidates.push(TONPLAYGRAM_LOGO_ASSET, TONPLAYGRAM_LOGO_ASSET_FALLBACK);
+  } else if (photo) {
+    candidates.push(photo);
   }
-  if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];
 }


### PR DESCRIPTION
### Motivation
- Ensure Telegram notification receipts use the exact same visual branding as the Home UI so logos/icons and store/treasury avatars remain consistent across the product.

### Description
- Updated `bot/utils/notifications.js` to reference `HOME_TOP_LOGO_ASSET` and `HOME_WALLET_CARD_TPC_ICON_ASSET` and reuse those values for receipt logo and TPC icon fallbacks.
- Changed avatar selection in `getReceiptAvatarCandidates` so `Store`/`Treasury`/`TonPlaygram` receipts prefer the Home header logo (then its fallback), while other receipts still prefer the user's photo and then the generic profile fallback.
- No changes were made to the receipt transport or delivery logic; only asset selection and avatar resolution priority were adjusted.

### Testing
- Ran `npm --prefix bot run receipt:preview` to generate a receipt preview image and verified the script completed successfully.
- Verified receipt image generation still produces output with the new asset selection (preview generated at runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989e6976888329b17b1c5a3dfb82f9)