### PR TITLE
Add 2D camera toggle to Texas Hold'em HUD

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2666,7 +2666,7 @@ function TexasHoldemArena({ search }) {
   const commentaryEventRef = useRef({ handId: null, lastActionId: null, stage: null, showdown: false });
   const [chipSelection, setChipSelection] = useState([]);
   const [sliderValue, setSliderValue] = useState(0);
-  const overheadView = false;
+  const [overheadView, setOverheadView] = useState(false);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -5143,6 +5143,10 @@ function TexasHoldemArena({ search }) {
     handleAction(action, sliderMax);
   };
 
+  const handleToggleCamera2d = useCallback(() => {
+    setOverheadView((prev) => !prev);
+  }, []);
+
   useEffect(() => {
     interactionsRef.current = {
       onChip: (value) => handleChipClick(value),
@@ -5440,9 +5444,13 @@ function TexasHoldemArena({ search }) {
         <BottomLeftIcons
           onChat={() => setShowChat(true)}
           onGift={() => setShowGift(true)}
+          onCamera2d={handleToggleCamera2d}
           showInfo={false}
           showMute={false}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-row gap-2.5 z-20"
+          showCamera2d
+          camera2dActive={overheadView}
+          order={['chat', 'gift', 'camera2d']}
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Add a 2D / top-down camera toggle to the Texas Hold'em HUD and place it under the Gift icon so the HUD matches the vertical icon layout used in Domino Battle Royal.

### Description
- Replace the hardcoded `overheadView` flag with React state via `const [overheadView, setOverheadView] = useState(false)` so the view can be toggled at runtime.
- Add `handleToggleCamera2d` which flips `overheadView` and is wired into the existing camera transition flow that calls `applyOverheadCamera` / `applySeatedCamera`.
- Update the left HUD `BottomLeftIcons` usage to expose the `2D` camera button by passing `onCamera2d={handleToggleCamera2d}`, `showCamera2d`, `camera2dActive={overheadView}`, `order={['chat','gift','camera2d']}`, and change the layout to a vertical stack so the camera button sits directly under Gift.

### Testing
- Ran `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx` which produced a repo-ignore warning but no errors (warning only).
- Built the webapp with `npm --prefix webapp run build` which completed successfully.
- Launched the dev server and captured an automated portrait screenshot using Playwright to visually validate the new `2D` button placement, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a1feb68083298b553b2c3f571ba0)