### PR TITLE
Add 2D camera toggle to Snake & Ladder (2D/3D view switch)

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
 import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
-import { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
+import SnakeBoard, { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
 import {
   dropSound,
   snakeSound,
@@ -1208,6 +1208,7 @@ export default function SnakeAndLadder() {
   });
   const [showConfig, setShowConfig] = useState(false);
   const [showTrailEnabled, setShowTrailEnabled] = useState(true);
+  const [isCamera2d, setIsCamera2d] = useState(false);
   const [appearance, setAppearance] = useState(() => {
     try {
       if (typeof window === 'undefined') return DEFAULT_APPEARANCE;
@@ -1279,6 +1280,9 @@ export default function SnakeAndLadder() {
     [frameRateId]
   );
   const frameRateValue = activeFrameRateOption?.fps ?? DEFAULT_FRAME_RATE_OPTION?.fps ?? 90;
+  const handleToggleCamera2d = useCallback(() => {
+    setIsCamera2d((prev) => !prev);
+  }, []);
   const activeCommentaryPreset = useMemo(
     () =>
       SNAKE_COMMENTARY_PRESETS.find((preset) => preset.id === commentaryPresetId) ??
@@ -3478,30 +3482,53 @@ export default function SnakeAndLadder() {
   return (
     <div className="relative w-screen h-dvh overflow-hidden bg-[#05070f] text-text select-none">
       <div className="absolute inset-0">
-        <SnakeBoard3D
-          players={players}
-          highlight={highlight}
-          trail={showTrailEnabled ? trail : []}
-          pot={pot}
-          snakes={snakes}
-          ladders={ladders}
-          snakeOffsets={snakeOffsets}
-          ladderOffsets={ladderOffsets}
-          offsetPopup={offsetPopup}
-          celebrate={celebrate}
-          tokenType={tokenType}
-          rollingIndex={rollingIndex}
-          currentTurn={currentTurn}
-          burning={burning}
-          slide={slideAnimation}
-          onSlideComplete={handleSlideComplete}
-          diceEvent={diceBoardEvent}
-          onSeatPositionsChange={setSeatAnchors}
-          onDiceAnchorChange={setDiceAnchor}
-          appearance={resolvedAppearance}
-          appearanceKey={appearanceKey}
-          frameRate={frameRateValue}
-        />
+        {isCamera2d ? (
+          <div className="flex h-full w-full items-center justify-center overflow-auto px-2 py-16">
+            <SnakeBoard
+              players={players}
+              highlight={highlight}
+              trail={showTrailEnabled ? trail : []}
+              pot={pot}
+              snakes={snakes}
+              ladders={ladders}
+              snakeOffsets={snakeOffsets}
+              ladderOffsets={ladderOffsets}
+              offsetPopup={offsetPopup}
+              celebrate={celebrate}
+              token={token}
+              tokenType={tokenType}
+              diceCells={diceCells}
+              rollingIndex={rollingIndex}
+              currentTurn={currentTurn}
+              burning={burning}
+            />
+          </div>
+        ) : (
+          <SnakeBoard3D
+            players={players}
+            highlight={highlight}
+            trail={showTrailEnabled ? trail : []}
+            pot={pot}
+            snakes={snakes}
+            ladders={ladders}
+            snakeOffsets={snakeOffsets}
+            ladderOffsets={ladderOffsets}
+            offsetPopup={offsetPopup}
+            celebrate={celebrate}
+            tokenType={tokenType}
+            rollingIndex={rollingIndex}
+            currentTurn={currentTurn}
+            burning={burning}
+            slide={slideAnimation}
+            onSlideComplete={handleSlideComplete}
+            diceEvent={diceBoardEvent}
+            onSeatPositionsChange={setSeatAnchors}
+            onDiceAnchorChange={setDiceAnchor}
+            appearance={resolvedAppearance}
+            appearanceKey={appearanceKey}
+            frameRate={frameRateValue}
+          />
+        )}
       </div>
       <div
         className="absolute z-30 pointer-events-auto"
@@ -3748,6 +3775,7 @@ export default function SnakeAndLadder() {
           <BottomLeftIcons
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
+            onCamera2d={handleToggleCamera2d}
             style={{
               left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
               bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
@@ -3755,7 +3783,9 @@ export default function SnakeAndLadder() {
             className="fixed z-20 flex flex-col items-center gap-2"
             showInfo={false}
             showMute={false}
-            order={['chat', 'gift']}
+            showCamera2d
+            camera2dActive={isCamera2d}
+            order={['chat', 'gift', 'camera2d']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation

- Provide a 2D camera option for the Snake & Ladder game that matches the existing behavior used in other games (quick top-down 2D view alongside the 3D arena).
- Place the 2D camera toggle in the same icon stack as other quick actions so it sits directly beneath the gift button for consistent UI layout on portrait screens.
- Make the change non-destructive so the existing 3D experience (`SnakeBoard3D`) remains the default and the 2D view is an optional toggle.

### Description

- Imported the 2D board component with `import SnakeBoard, { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";` and kept the existing `SnakeBoard3D` import. 
- Added `isCamera2d` state and `handleToggleCamera2d` callback to `SnakeAndLadder.jsx` to track and toggle the camera mode using `useState`/`useCallback`.
- Conditionally render `SnakeBoard` (2D) when `isCamera2d` is true, otherwise render the existing `SnakeBoard3D`, passing the appropriate props to each view so game state remains synchronized.
- Wired the shared `BottomLeftIcons` control set by adding the `camera2d` action to the icon `order` and providing `onCamera2d` and `camera2dActive` props so the new button appears directly under the gift icon and toggles the view.

### Testing

- Built the web frontend with `npm --prefix webapp run build`, which completed successfully (Vite emitted non-blocking warnings about chunk sizes and mixed static/dynamic imports). ✅
- Started the dev server (`npm --prefix webapp run dev`) and verified the app served successfully on the development port. ✅
- Performed an automated UI capture with Playwright (mobile portrait viewport) to visually verify the new icon layout and 2D toggle, and the screenshot artifact was produced. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a22938188329af172a47785a1a8f)