### PR TITLE
Align Telegram receipt branding with Home UI (logo & TPC icon)

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -8,9 +8,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.png';
+const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_000000008ab462439ff27618691146eb.png';
+const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
 const RECEIPT_BRAND_ICON_FALLBACKS = [
   TONPLAYGRAM_LOGO_ASSET_FALLBACK,
   TPC_ICON_ASSET_FALLBACK,
@@ -162,10 +162,11 @@ function isTonPlaygramAccount(label = '') {
 }
 
 function getReceiptAvatarCandidates(photo, label) {
-  const candidates = [];
   if (isTonPlaygramAccount(label)) {
-    candidates.push(TONPLAYGRAM_LOGO_ASSET);
+    return [TONPLAYGRAM_LOGO_ASSET, TONPLAYGRAM_LOGO_ASSET_FALLBACK];
   }
+
+  const candidates = [];
   if (photo) candidates.push(photo);
   candidates.push(fallbackAvatarPath);
   return [...new Set(candidates.filter(Boolean))];


### PR DESCRIPTION
### Motivation
- Make Telegram receipt visuals use the same TonPlaygram logo and TPC icon as the live Home UI so receipts match the app branding and TonPlaygram-owned accounts render the correct avatar.

### Description
- Updated receipt asset constants in `bot/utils/notifications.js` to use the Home header logo as the primary and fallback logo and to use the wallet-family TPC icon as the TPC fallback.
- Changed `getReceiptAvatarCandidates` so TonPlaygram-owned labels (`tonplaygram*`, `store`, `treasury`) return the TonPlaygram logo as the avatar candidate before user photos or generic fallback.
- Kept receipt generation logic and delivery flow unchanged; only avatar/brand image selection and fallback assets were modified.

### Testing
- Ran `node bot/scripts/generate-receipt-preview.js` to validate receipt image generation, and the script completed successfully producing a preview image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989e6976888329b17b1c5a3dfb82f9)