### PR TITLE
Add 2D camera toggle button to Snake & Ladder quick actions

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1187,6 +1187,7 @@ export default function SnakeAndLadder() {
   const [forfeitMsg, setForfeitMsg] = useState(false);
   const [cheatMsg, setCheatMsg] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
+  const [cameraViewMode, setCameraViewMode] = useState('3d');
   const [showExactHelp, setShowExactHelp] = useState(false);
   const [muted, setMuted] = useState(isGameMuted());
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
@@ -3501,6 +3502,7 @@ export default function SnakeAndLadder() {
           appearance={resolvedAppearance}
           appearanceKey={appearanceKey}
           frameRate={frameRateValue}
+          cameraViewMode={cameraViewMode}
         />
       </div>
       <div
@@ -3748,6 +3750,7 @@ export default function SnakeAndLadder() {
           <BottomLeftIcons
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
+            onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
             style={{
               left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
               bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
@@ -3755,7 +3758,10 @@ export default function SnakeAndLadder() {
             className="fixed z-20 flex flex-col items-center gap-2"
             showInfo={false}
             showMute={false}
-            order={['chat', 'gift']}
+            showCamera2d
+            camera2dActive={cameraViewMode === '2d'}
+            cameraLabel="2D"
+            order={['chat', 'gift', 'camera2d']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation
- Provide a quick 2D top-down camera toggle for the Snake & Ladder game to match the Domino Battle Royal behavior and align the camera control vertically under the Gift icon. 
- Improve UX by offering a single-tap switch between 3D and locked 2D top-down views for portrait mobile play.

### Description
- Added a `cameraViewMode` UI state in `SnakeAndLadder.jsx` and passed it into the 3D board as `cameraViewMode`.
- Extended the bottom-left quick-action rail to include a camera action (`camera2d`) placed under `gift`, wired via an `onCamera2d` handler and exposing `camera2dActive` and `cameraLabel` to `BottomLeftIcons`.
- Implemented camera mode switching in `SnakeBoard3D.jsx` by accepting a `cameraViewMode` prop and using an effect to snap to a top-down locked camera in `2d` mode while storing/restoring the previous camera and control state when returning to `3d` mode.
- Kept frame-rate and other existing behaviors untouched and used conservative constraints (disable rotation, lock polar angles) for the 2D mode to maintain a stable top-down presentation.

### Testing
- Ran `npx eslint --no-ignore webapp/src/pages/Games/SnakeAndLadder.jsx webapp/src/components/SnakeBoard3D.jsx` which completed but reported repository ignore-pattern warnings for these files. 
- Ran `npm test -- --runInBand test/snakeGame.test.js` and the test suite passed (all assertions passed), while the test runner emitted an existing environment warning about an open-handle related to mongoose teardown. 
- Launched the dev server and executed an automated Playwright script to navigate to `/games/snake` on a portrait viewport and capture a screenshot showing the new camera button, which completed and produced an artifact (`artifacts/snake-camera-button.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a22938188329af172a47785a1a8f)