### PR TITLE
Add Texas Hold'em 2D camera quick-action button

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2666,7 +2666,7 @@ function TexasHoldemArena({ search }) {
   const commentaryEventRef = useRef({ handId: null, lastActionId: null, stage: null, showdown: false });
   const [chipSelection, setChipSelection] = useState([]);
   const [sliderValue, setSliderValue] = useState(0);
-  const overheadView = false;
+  const [overheadView, setOverheadView] = useState(false);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -5440,9 +5440,13 @@ function TexasHoldemArena({ search }) {
         <BottomLeftIcons
           onChat={() => setShowChat(true)}
           onGift={() => setShowGift(true)}
+          onCamera2d={() => setOverheadView((prev) => !prev)}
           showInfo={false}
           showMute={false}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-row gap-2.5 z-20"
+          showCamera2d
+          camera2dActive={overheadView}
+          order={['chat', 'gift', 'camera2d']}
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Provide a quick 2D/top-down camera toggle in the Texas Hold'em arena that matches the Domino Battle Royal UX, placed directly under the Gift icon in portrait layout. 
- Reuse the existing `BottomLeftIcons` component to keep the quick-action bar consistent across arenas and simplify the UI wiring.

### Description
- Converted the local `overheadView` constant into React state via `const [overheadView, setOverheadView] = useState(false)` so the view can be toggled from UI controls (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Wired the left quick-actions rail to toggle the new state by passing `onCamera2d={() => setOverheadView(prev => !prev)}` and `showCamera2d`, `camera2dActive={overheadView}` into `BottomLeftIcons`.
- Reordered and restyled the left rail to a vertical stack and explicit order `['chat', 'gift', 'camera2d']` so the 2D button sits directly under the Gift icon and aligns visually on mobile/portrait.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`, which reported the file is ignored by current lint settings (warning, no lint errors in modified code reported).
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` successfully and verified the app served the Texas Hold'em page.
- Automated UI validation: used a Playwright script to navigate to `/games/texasholdem` in a mobile-portrait viewport and captured a screenshot showing the new vertical quick-action layout and the 2D camera button under Gift (artifact: `artifacts/texas-holdem-camera-button.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a1feb68083298b553b2c3f571ba0)