### PR TITLE
Fix Telegram receipt branding assets to match storefront

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -8,12 +8,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
 // Keep Telegram receipt branding aligned with the live app visuals.
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const STORE_AVATAR_ASSET = TONPLAYGRAM_LOGO_ASSET;
 const RECEIPT_BRAND_ICON_FALLBACKS = [
-  TONPLAYGRAM_LOGO_ASSET_FALLBACK,
-  TPC_ICON_ASSET_FALLBACK,
+  TONPLAYGRAM_LOGO_ASSET,
+  TPC_ICON_ASSET,
 ];
 
 function resolvePublicAssetPath(assetPath) {
@@ -163,7 +162,7 @@ function isTonPlaygramAccount(label = '') {
 
 function getReceiptAvatarCandidates(photo, label) {
   if (isTonPlaygramAccount(label)) {
-    return [TONPLAYGRAM_LOGO_ASSET, TONPLAYGRAM_LOGO_ASSET_FALLBACK];
+    return [STORE_AVATAR_ASSET, TONPLAYGRAM_LOGO_ASSET];
   }
 
   const candidates = [];
@@ -275,11 +274,11 @@ export async function generateReceiptImage({
 
   const coin =
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TPC_ICON_ASSET, [TPC_ICON_ASSET_FALLBACK]),
+      getReceiptBrandCandidates(TPC_ICON_ASSET, [TPC_ICON_ASSET]),
       { attempts: 8, delayMs: 220 }
     )) ||
     (await resolveReceiptBrandImage(
-      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, [TONPLAYGRAM_LOGO_ASSET_FALLBACK]),
+      getReceiptBrandCandidates(TONPLAYGRAM_LOGO_ASSET, [STORE_AVATAR_ASSET]),
       { attempts: 8, delayMs: 220 }
     ));
 
@@ -448,7 +447,7 @@ export async function sendStorePurchaseNotification(bot, toId, payload) {
     fromName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     toName: 'TonPlaygram Store',
     fromPhoto: toInfo?.photoUrl,
-    toPhoto: TONPLAYGRAM_LOGO_ASSET,
+    toPhoto: STORE_AVATAR_ASSET,
     itemThumbnail: resolveReceiptItemThumbnail(payload),
     itemLabel: payload.itemLabel,
   });


### PR DESCRIPTION
### Motivation
- Ensure Telegram receipts use the same TonPlaygram storefront logo and TPC icon that are shown across the webapp so receipts match the live UI and avoid inconsistent branding.
- Replace fallback references that could surface alternate assets and force a consistent storefront avatar for store-related receipts.

### Description
- Updated `bot/utils/notifications.js` to prefer the canonical TPC icon (`/assets/icons/ezgif-54c96d8a9b9236.webp`) and the storefront logo (`/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp`) when generating receipt images.
- Introduced `STORE_AVATAR_ASSET` and adjusted receipt avatar candidate resolution so TonPlaygram/store accounts resolve to the storefront avatar asset.
- Simplified brand fallback list to the canonical storefront logo and TPC icon and wired `sendStorePurchaseNotification` to pass the storefront avatar as `toPhoto`.

### Testing
- Ran the receipt preview generator with `cd bot && npm run receipt:preview` and verified the preview image was produced at `bot/tmp/receipt-preview.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b49d3f648329a0a467634644c7b4)