### PR TITLE
Align Telegram receipt assets with storefront logo and TPC icon

### DIFF
--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -6,11 +6,14 @@ import { fetchTelegramInfo } from './telegram.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicPath = path.join(__dirname, '../../webapp/public');
-// Keep Telegram receipt branding aligned with the live app visuals.
+// Keep Telegram receipt branding aligned with the same assets used in:
+// - wallet/store/task TPC icon: `/assets/icons/ezgif-54c96d8a9b9236.webp`
+// - storefront/home/mining TonPlaygram logo: `/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp`
 const TPC_ICON_ASSET = '/assets/icons/ezgif-54c96d8a9b9236.webp';
-const TPC_ICON_ASSET_FALLBACK = '/assets/icons/file_00000000ce2461f7a5c5347320c3167c.webp';
+const TPC_ICON_ASSET_FALLBACK = '/assets/icons/ezgif-54c96d8a9b9236.webp';
 const TONPLAYGRAM_LOGO_ASSET = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
 const TONPLAYGRAM_LOGO_ASSET_FALLBACK = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
+const TONPLAYGRAM_STORE_AVATAR_ASSET = TONPLAYGRAM_LOGO_ASSET;
 const RECEIPT_BRAND_ICON_FALLBACKS = [
   TONPLAYGRAM_LOGO_ASSET_FALLBACK,
   TPC_ICON_ASSET_FALLBACK,
@@ -448,7 +451,7 @@ export async function sendStorePurchaseNotification(bot, toId, payload) {
     fromName: `${toInfo?.firstName || ''}${toInfo?.lastName ? ` ${toInfo.lastName}` : ''}`.trim() || 'You',
     toName: 'TonPlaygram Store',
     fromPhoto: toInfo?.photoUrl,
-    toPhoto: TONPLAYGRAM_LOGO_ASSET,
+    toPhoto: TONPLAYGRAM_STORE_AVATAR_ASSET,
     itemThumbnail: resolveReceiptItemThumbnail(payload),
     itemLabel: payload.itemLabel,
   });


### PR DESCRIPTION
### Motivation
- Telegram receipt images were resolving to alternate assets and needed to use the same TPC icon and TonPlaygram logo/avatar used across the webapp (wallet, store, tasks, storefront, home, mining) to keep branding consistent.

### Description
- Updated receipt branding constants in `bot/utils/notifications.js` to use the same TPC icon (`/assets/icons/ezgif-54c96d8a9b9236.webp`) and TonPlaygram logo (`/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp`).
- Made the TPC fallback point to the canonical TPC icon so receipts resolve to the wallet/store/tasks icon consistently by default.
- Added `TONPLAYGRAM_STORE_AVATAR_ASSET` and wired `sendStorePurchaseNotification` to pass that asset into `generateReceiptImage` as the store avatar.
- Updated inline comment to document the intended asset mapping and kept all path resolution logic in `bot/utils/notifications.js`.

### Testing
- Ran `node bot/scripts/generate-receipt-preview.js` to verify receipt image generation and the preview was produced successfully (`bot/tmp/receipt-preview.png`).
- No unit tests were modified; change is limited to receipt-branding constants and usage in `bot/utils/notifications.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b49d3f648329a0a467634644c7b4)