### PR TITLE
Adjust Pool Royale practice UI and cue/rack behavior

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1464,7 +1464,7 @@ input:focus {
 }
 
 .lobby-option-icon {
-  @apply h-20 w-20;
+  @apply h-24 w-24;
 }
 
 .lobby-option-thumb-sm {

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -103,53 +103,36 @@ const resolveLayoutSlot = (pattern, index, level) => {
 }
 
 const buildTrainingLayout = (level) => {
-  const pattern = PATTERN_LIBRARY[(level - 1) % PATTERN_LIBRARY.length] || PATTERN_LIBRARY[0]
   const targetCount = getTrainingTargetCount(level)
-  const rotated = rotate(pattern, (level * 2) % pattern.length)
-  const microShift = ((level % 4) - 1.5) * 0.008
-  const balls = Array.from({ length: targetCount }, (_, idx) => {
-    const rawPos = resolveLayoutSlot(rotated, idx, level)
-    const pos = stabilizeTrainingSlot(rawPos)
-    let x = clampLayoutCoord(pos.x + (idx % 2 === 0 ? microShift : -microShift), -0.44, 0.44)
-    let z = clampLayoutCoord(pos.z + (idx % 3 === 0 ? microShift : 0), -0.31, 0.31)
-    if (Math.abs(x) > 0.4 && Math.abs(z) > 0.24) {
-      x = Math.sign(x || 1) * 0.39
-      z = Math.sign(z || 1) * 0.22
-    }
-    return {
-      rackIndex: idx,
-      x,
-      z
-    }
-  })
+  const triangleSpacingX = 0.085
+  const triangleSpacingZ = 0.09
+  const apexX = 0.18
+  const maxX = 0.44
+  const maxZ = 0.31
 
-  // Stabilize every task layout so each ball has enough separation and never spawns overlapping.
-  for (let i = 0; i < balls.length; i++) {
-    const anchor = balls[i]
-    for (let j = 0; j < i; j++) {
-      const other = balls[j]
-      const dx = anchor.x - other.x
-      const dz = anchor.z - other.z
-      const distSq = (dx * dx) + (dz * dz)
-      if (distSq >= MIN_LAYOUT_GAP * MIN_LAYOUT_GAP) continue
-      const dist = Math.max(1e-6, Math.sqrt(distSq))
-      const push = (MIN_LAYOUT_GAP - dist) + 0.004
-      const nx = dx / dist
-      const nz = dz / dist
-      anchor.x = clampLayoutCoord(anchor.x + (nx * push), -0.44, 0.44)
-      anchor.z = clampLayoutCoord(anchor.z + (nz * push), -0.31, 0.31)
-      if (Math.abs(anchor.x) > 0.4 && Math.abs(anchor.z) > 0.24) {
-        anchor.x = Math.sign(anchor.x || 1) * 0.39
-        anchor.z = Math.sign(anchor.z || 1) * 0.22
-      }
+  const balls = []
+  let row = 0
+  while (balls.length < targetCount) {
+    const rowBallCount = row + 1
+    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
+    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    for (let column = 0; column < rowBallCount && balls.length < targetCount; column += 1) {
+      const z = clampLayoutCoord(rowStartZ + column * triangleSpacingZ, -maxZ, maxZ)
+      balls.push({
+        rackIndex: balls.length,
+        x,
+        z
+      })
     }
+    row += 1
   }
 
   return {
-    cue: { x: -0.7 + (level % 5) * 0.045, z: 0.5 - (level % 6) * 0.065 },
+    cue: { x: -0.68, z: 0 },
     balls
   }
 }
+
 
 const buildTrainingDefinition = (level) => {
   const discipline = level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'Pool Position Play'


### PR DESCRIPTION
### Motivation
- Improve portrait layout and UX by moving the table setup control to the top-left where it's easier to reach on mobile. 
- Simplify the Practice (training) experience by removing the large practice menu and keeping a compact level/progress HUD. 
- Make lobby game-mode icons better fit their option cards. 
- Make training layouts match the official triangle rack visual and ensure the cue ball is restored when scratched in practice.

### Description
- Moved the in-match table setup control cluster to the top-left and changed its transform origin to `top left` (updated UI container positioning in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Removed the practice menu toggle and the large practice menu panel and the associated `trainingMenuOpen` state so practice shows only the compact level/progress text in the top-right (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Increased the lobby option icon sizing by updating `.lobby-option-icon` from `h-20 w-20` to `h-24 w-24` (changed `webapp/src/index.css`) so mode artwork fills the boxes better.
- Reworked training ball placement to place object balls in a triangle/rack formation and set a consistent cue start position for practice (`buildTrainingLayout` in `webapp/src/utils/poolRoyaleTrainingProgress.js`).
- When the cue ball is pocketed during practice, auto-respawn and place it at table center (restore mesh and shadow, zero velocity, clear spin) and clear the in-hand state instead of leaving it in the pocket (changes in pocket-capture handling in `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished, assets emitted). ✅
- Launched the dev server (`npm --prefix webapp run dev`) and captured a lobby screenshot to validate the lobby icon sizing and layout; the screenshot was produced. ✅
- A Playwright screenshot run targeting the training page timed out in this environment and did not complete. ⚠️
- Ran ESLint on the modified files which reported file-ignore warnings due to repository ignore configuration rather than code errors. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993c489bd483298773418b2da3ad95)