### PR TITLE
Reveal player hands in 2D Murlan Royale and enable constrained camera zoom

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2901,7 +2901,10 @@ export default function MurlanRoyaleArena({ search }) {
         position: camera.position.clone(),
         target: controls.target.clone(),
         enablePan: controls.enablePan,
+        enableZoom: controls.enableZoom,
         enableRotate: controls.enableRotate,
+        minDistance: controls.minDistance,
+        maxDistance: controls.maxDistance,
         minPolarAngle: controls.minPolarAngle,
         maxPolarAngle: controls.maxPolarAngle,
         minAzimuthAngle: controls.minAzimuthAngle,
@@ -2909,9 +2912,14 @@ export default function MurlanRoyaleArena({ search }) {
       };
       const target = controls.target.clone();
       const radius = Math.max(controls.minDistance || 0, camera.position.distanceTo(target));
+      const min2dDistance = Math.max(0.2, radius * 0.9);
+      const max2dDistance = radius * 1.12;
       camera.position.set(target.x, target.y + radius, target.z);
       controls.enableRotate = false;
       controls.enablePan = false;
+      controls.enableZoom = true;
+      controls.minDistance = min2dDistance;
+      controls.maxDistance = max2dDistance;
       controls.minPolarAngle = 0.0001;
       controls.maxPolarAngle = 0.0001;
       controls.update();
@@ -2921,7 +2929,10 @@ export default function MurlanRoyaleArena({ search }) {
         camera.position.copy(restore.position);
         controls.target.copy(restore.target);
         controls.enablePan = restore.enablePan;
+        controls.enableZoom = restore.enableZoom;
         controls.enableRotate = restore.enableRotate;
+        controls.minDistance = restore.minDistance;
+        controls.maxDistance = restore.maxDistance;
         controls.minPolarAngle = restore.minPolarAngle;
         controls.maxPolarAngle = restore.maxPolarAngle;
         controls.minAzimuthAngle = restore.minAzimuthAngle;
@@ -3059,6 +3070,7 @@ export default function MurlanRoyaleArena({ search }) {
     const cardMap = three.cardMap;
 
     const humanTurn = state.status === 'PLAYING' && state.players[state.activePlayer]?.isHuman;
+    const revealAllHands = isCamera2d;
     humanTurnRef.current = humanTurn;
 
     const humanMeshes = [];
@@ -3086,7 +3098,7 @@ export default function MurlanRoyaleArena({ search }) {
         if (!entry) return;
         const mesh = entry.mesh;
         mesh.visible = true;
-        updateCardFace(mesh, player.isHuman ? 'front' : 'back');
+        updateCardFace(mesh, player.isHuman || revealAllHands ? 'front' : 'back');
         handsVisible.add(card.id);
         const offset = cards.length > 1 ? cardIdx - (cards.length - 1) / 2 : 0;
         const lateral = cards.length > 1 ? (offset * spread) / (cards.length - 1 || 1) : 0;
@@ -3097,7 +3109,7 @@ export default function MurlanRoyaleArena({ search }) {
           mesh,
           target,
           focus,
-          { face: player.isHuman ? 'front' : 'back' },
+          { face: player.isHuman || revealAllHands ? 'front' : 'back' },
           immediate,
           three.animations
         );
@@ -3176,7 +3188,7 @@ export default function MurlanRoyaleArena({ search }) {
     if (three.renderer?.domElement) {
       three.renderer.domElement.style.cursor = humanTurn ? 'pointer' : 'default';
     }
-  }, []);
+  }, [isCamera2d]);
 
   const rebuildTable = useCallback(
     async (tableTheme, tableFinish, tableCloth) => {
@@ -4123,14 +4135,14 @@ export default function MurlanRoyaleArena({ search }) {
       controls = new OrbitControls(camera, renderer.domElement);
       controls.enableDamping = true;
       controls.enablePan = true;
-      controls.enableZoom = false;
+      controls.enableZoom = true;
       controls.enableRotate = true;
       controls.minPolarAngle = ARENA_CAMERA_DEFAULTS.phiMin;
       controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
-      controls.minDistance = desiredRadius;
-      controls.maxDistance = desiredRadius;
+      controls.minDistance = desiredRadius * 0.9;
+      controls.maxDistance = desiredRadius * 1.15;
       controls.rotateSpeed = 0.6;
       controls.target.copy(target);
       controls.update();


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale 2D/table view more readable by showing players' hand cards face-up the same way community cards are visible in the domino game. 
- Allow a small, controlled zoom in 2D so mobile/portrait users can slightly zoom in/out for clarity without breaking the scene framing. 
- Preserve the existing hidden-hand behavior for normal 3D view and restore camera settings when toggling modes. 

### Description
- Added a `revealAllHands` (derived from `isCamera2d`) flag and changed `updateCardFace` and `setMeshPosition` calls so player hands render front-facing when 2D is active in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`. 
- Made the `applyStateToScene` callback depend on `isCamera2d` so hand visibility updates when toggling views. 
- Persisted zoom-related `OrbitControls` properties into `cameraViewRestoreRef` and enabled `controls.enableZoom` in 2D, setting constrained `minDistance`/`maxDistance` for a small zoom range. 
- Loosened the default 3D camera `minDistance`/`maxDistance` to a small window around the desired radius so slight zooming is possible in the regular view as well. 

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the build completed successfully. 
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which produced no errors (only a file-ignore warning). 
- Launched the dev server and captured a mobile-portrait screenshot of `/games/murlanroyale` via Playwright to validate the 2D hand reveal and zoom behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993dbbd8b08329940697e4285260e5)