### PR TITLE
Murlan Royale: increase community card visibility, flip discard pile, and make Red Joker beat Black Joker

### DIFF
--- a/lib/murlan.js
+++ b/lib/murlan.js
@@ -14,7 +14,7 @@ export const ComboType = {
 };
 
 export const DEFAULT_CONFIG = {
-  RANK_ORDER: ['3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A', '2', 'JR', 'JB'],
+  RANK_ORDER: ['3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A', '2', 'JB', 'JR'],
   USE_JOKER_AS_WILD: false,
   STRAIGHTS_REQUIRE_SAME_SUIT: false,
   MIN_STRAIGHT_LENGTH: 5,

--- a/test/murlan.test.js
+++ b/test/murlan.test.js
@@ -17,8 +17,14 @@ test('detect single/joker', () => {
   const singleJR = detectCombo([card('JR')], DEFAULT_CONFIG);
   const single2 = detectCombo([card('2')], DEFAULT_CONFIG);
   assert.equal(singleJB.type, ComboType.SINGLE);
-  assert(singleJB.strength > singleJR.strength);
-  assert(singleJR.strength > single2.strength);
+  assert(singleJR.strength > singleJB.strength);
+  assert(singleJB.strength > single2.strength);
+});
+
+test('red joker beats black joker', () => {
+  const table = detectCombo([card('JB')], DEFAULT_CONFIG);
+  const red = detectCombo([card('JR')], DEFAULT_CONFIG);
+  assert.equal(canBeat(red, table, DEFAULT_CONFIG), true);
 });
 
 test('detect pair/trips', () => {

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3117,10 +3117,11 @@ export default function MurlanRoyaleArena({ search }) {
       if (!entry) return;
       const mesh = entry.mesh;
       mesh.visible = true;
+      mesh.scale.setScalar(1.16);
       updateCardFace(mesh, 'front');
       const target = tableAnchor.clone();
       target.x += tableStartX + idx * tableSpacing;
-      target.y += 0.05 * MODEL_SCALE;
+      target.y += 0.075 * MODEL_SCALE;
       target.z += 0;
       setMeshPosition(
         mesh,
@@ -3136,13 +3137,14 @@ export default function MurlanRoyaleArena({ search }) {
     const discardSpacing = CARD_W * 0.08;
     const discardAnchor = tableAnchor
       .clone()
-      .add(new THREE.Vector3(tableStartX + Math.max(tableCount - 1, 0) * tableSpacing + CARD_W * 1.18, -CARD_H * 0.04, 0));
+      .add(new THREE.Vector3(0, CARD_H * 0.95, -CARD_H * 0.22));
     state.discardPile.forEach((card, idx) => {
       const entry = cardMap.get(card.id);
       if (!entry) return;
       const mesh = entry.mesh;
       mesh.visible = true;
-      updateCardFace(mesh, 'front');
+      mesh.scale.setScalar(1);
+      updateCardFace(mesh, 'back');
       const layer = discardCount - idx - 1;
       const target = discardAnchor.clone();
       target.x += layer * discardSpacing;
@@ -3151,7 +3153,7 @@ export default function MurlanRoyaleArena({ search }) {
         mesh,
         target,
         tableLookBase,
-        { face: 'front', flat: true },
+        { face: 'back', flat: true },
         immediate,
         three.animations
       );
@@ -3159,6 +3161,7 @@ export default function MurlanRoyaleArena({ search }) {
 
     three.cardMap.forEach(({ mesh }, id) => {
       if (handsVisible.has(id) || tableSet.has(id) || discardSet.has(id)) return;
+      mesh.scale.setScalar(1);
       mesh.visible = false;
       if (mesh.userData?.animation) {
         mesh.userData.animation.cancelled = true;


### PR DESCRIPTION
### Motivation
- Improve visual clarity of the active community/table cards so they stand out during play. 
- Make the used/discard pile behave visually like a traditional face-down discard pile and position it so it does not obscure community cards. 
- Adjust game ranking so the Red Joker (`JR`) ranks higher than the Black Joker (`JB`) and can beat it in single-card comparisons.

### Description
- Raised and slightly enlarged community/table card meshes in the 3D arena by setting `mesh.scale.setScalar(1.16)` and increasing the table Y offset. (modified `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Moved the discard/used pile above the community cards and render discard cards face-down by changing the discard anchor and using the back face when placing discard meshes. (modified `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Restored/reset mesh scale for discard/hidden cards to avoid unintended scaling changes when hidden. (modified `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Swapped the order of jokers in the rank ordering so `JR` (Red Joker) is higher than `JB` (Black Joker) by updating `DEFAULT_CONFIG.RANK_ORDER`. (modified `lib/murlan.js`).
- Updated unit tests to reflect the new joker ordering and added a test that explicitly verifies Red Joker beats Black Joker. (modified `test/murlan.test.js`).

### Testing
- Ran the unit test suite for Murlan logic with `npm test -- test/murlan.test.js`, and all tests passed (`12 passed, 12 total`).
- Executed an automated visual check via a Playwright script that loaded the local dev server and produced a screenshot artifact to confirm layout changes (screenshot artifact generated during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699954b7e1348329b67c8fdeb9177064)