### PR TITLE
Fix Pool Royale practice rack orientation to match 8-ball setup

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -106,7 +106,9 @@ const buildTrainingLayout = (level) => {
   const targetCount = getTrainingTargetCount(level)
   const triangleSpacingX = 0.085
   const triangleSpacingZ = 0.09
-  const apexX = 0.18
+  // Keep practice racks oriented exactly like the main 8-ball rack:
+  // apex up-table and rows opening left/right from center.
+  const apexZ = 0.18
   const maxX = 0.44
   const maxZ = 0.31
 
@@ -114,10 +116,10 @@ const buildTrainingLayout = (level) => {
   let row = 0
   while (balls.length < targetCount) {
     const rowBallCount = row + 1
-    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
-    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    const z = clampLayoutCoord(apexZ + row * triangleSpacingZ, -maxZ, maxZ)
+    const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
     for (let column = 0; column < rowBallCount && balls.length < targetCount; column += 1) {
-      const z = clampLayoutCoord(rowStartZ + column * triangleSpacingZ, -maxZ, maxZ)
+      const x = clampLayoutCoord(rowStartX + column * triangleSpacingX, -maxX, maxX)
       balls.push({
         rackIndex: balls.length,
         x,


### PR DESCRIPTION
### Motivation
- Practice training racks were generated with the wrong orientation so object balls near the middle pockets were placed incorrectly compared to the 8-ball variant.
- The change makes practice layouts visually and spatially consistent with the normal 8-ball rack facing (apex up-table, rows opening left/right). 

### Description
- Adjusted the training layout generation in `webapp/src/utils/poolRoyaleTrainingProgress.js` by swapping the rack axis so rows advance down-table (`z`) and columns spread left/right (`x`).
- Introduced `apexZ` and updated the row/column normalization to keep the same `triangleSpacing` and clamping envelope while correcting orientation. 
- The change is localized to `buildTrainingLayout` and preserves existing spacing, counts and safety clamping logic.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTrainingProgress.test.js`, and all tests passed (`1 test suite, 7 tests` passed).
- Attempted an automated Playwright render to capture a screenshot, but the headless Chromium process crashed (SIGSEGV) in this environment so the visual smoke check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999551597f8832984077ef2ad76b374)