### PR TITLE
Force practice sessions to use 8‑ball (UK) table layout in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32810,11 +32810,21 @@ const powerRef = useRef(hud.power);
 export default function PoolRoyale() {
   const navigate = useNavigate();
   const location = useLocation();
+  const playType = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('type');
+    if (requested === 'training') return 'training';
+    if (requested === 'tournament') return 'tournament';
+    return 'regular';
+  }, [location.search]);
   const variantKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('variant');
+    if (playType === 'training') {
+      return 'uk';
+    }
     return resolvePoolVariant(requested).id;
-  }, [location.search]);
+  }, [location.search, playType]);
   const ballSetKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('ballSet');
@@ -32825,13 +32835,6 @@ export default function PoolRoyale() {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableSize');
     return resolveTableSize(requested).id;
-  }, [location.search]);
-  const playType = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('type');
-    if (requested === 'training') return 'training';
-    if (requested === 'tournament') return 'tournament';
-    return 'regular';
   }, [location.search]);
   const mode = useMemo(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
### Motivation
- Practice/training scenarios were inheriting the active variant from query params, which caused middle-pocket ball placement/orientation to differ from the 8‑ball (UK) layout used in practice expectations.
- Ensure training (practice) always uses the same pocket/ball orientation as the 8‑ball variant so drills and pocket visuals match the intended design.

### Description
- When `type=training` the route parsing now forces the pool variant key to `uk` by returning `'uk'` from the `variantKey` `useMemo` in `PoolRoyale`, ensuring practice sessions use the 8‑ball layout.
- Reordered memoized URL parsing so `playType` is computed before `variantKey` to make the training-specific override deterministic; the change is in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed with no lint errors (only repository ignore/warning messages reported). ✅
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` to check with ignores disabled, which produced the same ignore-related warning but no errors. ✅
- Attempted a Playwright navigation + screenshot to `http://127.0.0.1:5173/games/poolroyale?type=training` to validate visual behavior, but the local dev server was not responding (`ERR_EMPTY_RESPONSE`) so a runtime screenshot could not be captured. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999551597f8832984077ef2ad76b374)