### PR TITLE
Anchor discard pile to top-seat area and stabilise Murlan Royale stacking

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1907,6 +1907,11 @@ const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const CARD_H = 0.56 * MODEL_SCALE * CARD_SCALE;
 const CARD_D = 0.02 * MODEL_SCALE * CARD_SCALE;
 const CARD_SURFACE_OFFSET = CARD_D * 4;
+const DISCARD_PILE_OFFSET = Object.freeze({
+  x: 0,
+  y: CARD_H * 0.96,
+  z: -TABLE_RADIUS * 0.84
+});
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -2814,7 +2819,11 @@ export default function MurlanRoyaleArena({ search }) {
     animations: [],
     raycaster: new THREE.Raycaster(),
     tableAnchor: new THREE.Vector3(0, TABLE_HEIGHT + CARD_SURFACE_OFFSET, 0),
-    discardAnchor: new THREE.Vector3(-TABLE_RADIUS * 0.76, TABLE_HEIGHT - CARD_H * 0.3, -TABLE_RADIUS * 0.62),
+    discardAnchor: new THREE.Vector3(
+      DISCARD_PILE_OFFSET.x,
+      TABLE_HEIGHT + DISCARD_PILE_OFFSET.y,
+      DISCARD_PILE_OFFSET.z
+    ),
     scoreboard: null,
     tableInfo: null,
     tableThemeId: null,
@@ -3135,9 +3144,14 @@ export default function MurlanRoyaleArena({ search }) {
 
     const discardCount = state.discardPile.length;
     const discardSpacing = CARD_W * 0.08;
-    const discardAnchor = tableAnchor
-      .clone()
-      .add(new THREE.Vector3(0, CARD_H * 0.95, -CARD_H * 0.22));
+    const discardAnchor = three.discardAnchor?.clone() ??
+      tableAnchor.clone().add(
+        new THREE.Vector3(
+          DISCARD_PILE_OFFSET.x,
+          DISCARD_PILE_OFFSET.y,
+          DISCARD_PILE_OFFSET.z
+        )
+      );
     state.discardPile.forEach((card, idx) => {
       const entry = cardMap.get(card.id);
       if (!entry) return;
@@ -3145,7 +3159,7 @@ export default function MurlanRoyaleArena({ search }) {
       mesh.visible = true;
       mesh.scale.setScalar(1);
       updateCardFace(mesh, 'back');
-      const layer = discardCount - idx - 1;
+      const layer = idx;
       const target = discardAnchor.clone();
       target.x += layer * discardSpacing;
       target.y += layer * 0.0015;
@@ -3253,9 +3267,9 @@ export default function MurlanRoyaleArena({ search }) {
       three.tableFinishId = finish?.id ?? null;
       three.tableAnchor = new THREE.Vector3(0, tableInfo.surfaceY + CARD_SURFACE_OFFSET, 0);
       three.discardAnchor = new THREE.Vector3(
-        -TABLE_RADIUS * 0.76,
-        tableInfo.surfaceY - CARD_H * 0.3,
-        -TABLE_RADIUS * 0.62
+        DISCARD_PILE_OFFSET.x,
+        tableInfo.surfaceY + DISCARD_PILE_OFFSET.y,
+        DISCARD_PILE_OFFSET.z
       );
       return tableInfo;
     },
@@ -4348,7 +4362,11 @@ export default function MurlanRoyaleArena({ search }) {
         animations: [],
         raycaster: new THREE.Raycaster(),
         tableAnchor: new THREE.Vector3(0, TABLE_HEIGHT + CARD_SURFACE_OFFSET, 0),
-        discardAnchor: new THREE.Vector3(-TABLE_RADIUS * 0.76, TABLE_HEIGHT - CARD_H * 0.3, -TABLE_RADIUS * 0.62),
+        discardAnchor: new THREE.Vector3(
+          DISCARD_PILE_OFFSET.x,
+          TABLE_HEIGHT + DISCARD_PILE_OFFSET.y,
+          DISCARD_PILE_OFFSET.z
+        ),
         scoreboard: null,
         tableInfo: null,
         tableThemeId: null,


### PR DESCRIPTION
### Motivation
- The discard/used-card pile in Murlan Royale was visually placed over the community area in 2D/top-down camera view, causing the pile to move and look wrong when community cards are revealed.
- The goal is to keep the pile anchored near the top-seat player, have community cards move into the pile and flip there, and avoid previously stacked cards shifting when new cards are added.

### Description
- Added a shared `DISCARD_PILE_OFFSET` constant and applied it to the scene discard anchor so the pile sits closer to the top-seat side of the table (file changed: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Initialized `threeStateRef.current.discardAnchor` and the reset state to use the new offset so the anchor is stable across rebuilds and resets.
- Changed discard placement to prefer the scene `three.discardAnchor` (if present) and fall back to the configured offset, so cards move into a fixed pile location instead of the pile moving itself.
- Switched discard stacking arithmetic from reverse-indexing to forward indexing (`layer = idx`) so existing cards remain in place and newly finished community cards are added without shifting older cards.

### Testing
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` (file matched repo ignore patterns; lint ran but reported file ignored).
- Attempted full repo build with `npm run build` but the run failed due to a pre-existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts`, so the production build was not validated here.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a validation screenshot of `/games/murlanroyale` (dev server started successfully and a screenshot was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699959c0d0d48329b0b92890872c2c64)