### PR TITLE
Adjust Murlan Royale discard pile spacing and 2D camera height

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1910,7 +1910,7 @@ const CARD_SURFACE_OFFSET = CARD_D * 4;
 const DISCARD_PILE_OFFSET = Object.freeze({
   x: 0,
   y: CARD_H * 0.96,
-  z: -TABLE_RADIUS * 0.84
+  z: -TABLE_RADIUS * 0.42
 });
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -2918,7 +2918,7 @@ export default function MurlanRoyaleArena({ search }) {
       };
       const target = controls.target.clone();
       const radius = Math.max(controls.minDistance || 0, camera.position.distanceTo(target));
-      camera.position.set(target.x, target.y + radius, target.z);
+      camera.position.set(target.x, target.y + radius * 1.06, target.z);
       controls.enableRotate = false;
       controls.enablePan = false;
       controls.minPolarAngle = 0.0001;


### PR DESCRIPTION
### Motivation
- Bring the used/discard pile visually closer to the community cards and raise the 2D/top camera a small amount so the on-screen layout matches the requested portrait appearance.

### Description
- Update in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: reduce `DISCARD_PILE_OFFSET.z` from `-TABLE_RADIUS * 0.84` to `-TABLE_RADIUS * 0.42` and slightly raise the 2D camera by using `camera.position.set(target.x, target.y + radius * 1.06, target.z)`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` (warning: file is ignored by repo lint ignore rules). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully. 
- Captured a portrait screenshot of `/games/murlanroyale` with a Playwright script for visual verification and produced an artifact (screenshot) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995d8384ec8329b58b21aa098de5de)