### PR TITLE
Fix Pool Royale practice rack, reset/isolate career progress, and improve career reward reveal UX

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -124,13 +124,19 @@ const TRAINING_ATTEMPT_BUNDLES = Object.freeze([
   Object.freeze({ id: 'training-attempts-30', attempts: 30, price: 2100, label: 'Champion heart vault' })
 ]);
 
-const CAREER_ATTEMPTS_KEY = 'poolRoyaleCareerAttempts';
+const CAREER_ATTEMPTS_STORAGE_VERSION = 2;
+const CAREER_ATTEMPTS_KEY = `poolRoyaleCareerAttempts_v${CAREER_ATTEMPTS_STORAGE_VERSION}`;
+const LEGACY_CAREER_ATTEMPTS_KEYS = ['poolRoyaleCareerAttempts', 'poolRoyaleCareerAttempts_v1'];
 
 function loadCareerAttemptsProgress() {
   if (typeof window === 'undefined') {
     return { carryShots: 0, attemptsAwardedStageIds: [] };
   }
   try {
+    LEGACY_CAREER_ATTEMPTS_KEYS.forEach((legacyKey) => {
+      if (!legacyKey || legacyKey === CAREER_ATTEMPTS_KEY) return;
+      window.localStorage.removeItem(legacyKey);
+    });
     const raw = window.localStorage.getItem(CAREER_ATTEMPTS_KEY);
     if (!raw) return { carryShots: 0, attemptsAwardedStageIds: [] };
     const parsed = JSON.parse(raw);
@@ -12112,6 +12118,30 @@ function PoolRoyaleGame({
     document.head.appendChild(style);
     coinStyleInjectedRef.current = true;
   }, []);
+  const triggerFireworksBurst = useCallback((count = 18) => {
+    if (typeof document === 'undefined') return;
+    ensureCoinBurstStyles();
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.inset = '0';
+    container.style.pointerEvents = 'none';
+    container.style.zIndex = '75';
+    document.body.appendChild(container);
+    const particles = ['✨', '🎆', '🎇', '💥'];
+    for (let i = 0; i < count; i += 1) {
+      const spark = document.createElement('span');
+      spark.textContent = particles[i % particles.length];
+      spark.style.position = 'fixed';
+      spark.style.left = `${8 + Math.random() * 84}vw`;
+      spark.style.top = `${12 + Math.random() * 58}vh`;
+      spark.style.fontSize = `${20 + Math.random() * 26}px`;
+      spark.style.opacity = '0';
+      spark.style.animation = `prRewardHalo ${0.95 + Math.random() * 0.5}s ease-out ${Math.random() * 0.45}s forwards`;
+      container.appendChild(spark);
+    }
+    window.setTimeout(() => container.remove(), 2100);
+  }, [ensureCoinBurstStyles]);
+
   const triggerCoinBurst = useCallback(
     (count = 20) => {
       if (typeof document === 'undefined') return;
@@ -12647,6 +12677,7 @@ function PoolRoyaleGame({
   const [trainingRulesOn, setTrainingRulesOn] = useState(true);
   const [trainingRoadmapOpen, setTrainingRoadmapOpen] = useState(false);
   const [careerTaskResultModal, setCareerTaskResultModal] = useState(null);
+  const [careerRewardRevealOpen, setCareerRewardRevealOpen] = useState(false);
   const [lastCompletedLevel, setLastCompletedLevel] = useState(null);
   const [pendingTrainingLevel, setPendingTrainingLevel] = useState(null);
   const [showTrainingIntroCard, setShowTrainingIntroCard] = useState(false);
@@ -12704,6 +12735,7 @@ function PoolRoyaleGame({
           id: nft.id,
           name: nft.name,
           icon: nft.icon,
+          thumbnail: nft.thumbnail,
           price: nft.price,
           wonAt: Date.now()
         });
@@ -14478,6 +14510,14 @@ const powerRef = useRef(hud.power);
     trainingShotsRemaining,
     triggerCoinBurst
   ]);
+
+  useEffect(() => {
+    if (careerTaskResultModal?.status === 'won' && careerTaskResultModal?.nftReward) {
+      setCareerRewardRevealOpen(false);
+    } else {
+      setCareerRewardRevealOpen(true);
+    }
+  }, [careerTaskResultModal]);
 
   useEffect(() => {
     if (!isTraining && trainingAutoAdvanceTimeoutRef.current) {
@@ -32132,7 +32172,35 @@ const powerRef = useRef(hud.power);
                     </p>
                   ) : null}
                   {careerTaskResultModal.nftReward ? (
-                    <p>🎁 Gift unlocked: {careerTaskResultModal.nftReward.name}</p>
+                    <div className="mt-2 flex flex-col items-center gap-2 rounded-2xl border border-amber-300/40 bg-amber-300/10 p-3">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (careerRewardRevealOpen) return;
+                          setCareerRewardRevealOpen(true);
+                          triggerFireworksBurst(24);
+                          triggerCoinBurst(14);
+                        }}
+                        className="group flex flex-col items-center gap-2"
+                      >
+                        {!careerRewardRevealOpen ? (
+                          <>
+                            <span className="inline-flex h-20 w-20 items-center justify-center rounded-2xl border border-amber-200/70 bg-black/35 text-5xl shadow-[0_10px_28px_rgba(245,158,11,0.35)]">🎁</span>
+                            <span className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-100 underline decoration-dotted underline-offset-4">Open</span>
+                          </>
+                        ) : (
+                          <span className="relative inline-flex h-24 w-24 items-center justify-center">
+                            <span className="absolute inset-0 rounded-full bg-amber-300/30 animate-[prRewardGlow_850ms_ease-out_forwards]" />
+                            <img
+                              src={careerTaskResultModal.nftReward.thumbnail || careerTaskResultModal.nftReward.icon || '/assets/icons/gift.png'}
+                              alt={careerTaskResultModal.nftReward.name}
+                              className="relative h-24 w-24 rounded-2xl border border-amber-100/80 object-cover shadow-[0_14px_36px_rgba(245,158,11,0.45)] animate-[prRewardPop_700ms_ease-out_forwards]"
+                            />
+                          </span>
+                        )}
+                      </button>
+                      <p className="text-center text-xs text-amber-100">🎁 Gift unlocked: {careerTaskResultModal.nftReward.name}</p>
+                    </div>
                   ) : null}
                 </div>
                 <div className="mt-4 grid grid-cols-2 gap-2">

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -400,8 +400,17 @@ export default function PoolRoyaleLobby() {
 
   useEffect(() => {
     if (playType !== 'training' && playType !== 'career') return;
-    const loadedTraining = loadTrainingProgress();
-    setTrainingProgress(loadedTraining);
+    if (playType === 'training') {
+      const loadedTraining = loadTrainingProgress();
+      setTrainingProgress(loadedTraining);
+    } else {
+      setTrainingProgress({
+        completed: [],
+        rewarded: [],
+        lastLevel: 1,
+        carryShots: 0
+      });
+    }
     setCareerProgress(loadCareerProgress());
   }, [playType]);
 

--- a/webapp/src/utils/poolRoyaleCareerProgress.js
+++ b/webapp/src/utils/poolRoyaleCareerProgress.js
@@ -3,7 +3,9 @@ import {
   describeTrainingLevel
 } from './poolRoyaleTrainingProgress.js'
 
-const CAREER_PROGRESS_KEY = 'poolRoyaleCareerProgress'
+const CAREER_PROGRESS_STORAGE_VERSION = 2
+const CAREER_PROGRESS_KEY = `poolRoyaleCareerProgress_v${CAREER_PROGRESS_STORAGE_VERSION}`
+const LEGACY_CAREER_PROGRESS_KEYS = ['poolRoyaleCareerProgress', 'poolRoyaleCareerProgress_v1']
 export const CAREER_LEVEL_COUNT = 100
 
 const FRIENDLY_TITLES = [
@@ -120,6 +122,10 @@ const normalizeProgress = (value) => {
 export function loadCareerProgress () {
   if (typeof window === 'undefined') return normalizeProgress(null)
   try {
+    LEGACY_CAREER_PROGRESS_KEYS.forEach((legacyKey) => {
+      if (!legacyKey || legacyKey === CAREER_PROGRESS_KEY) return
+      window.localStorage.removeItem(legacyKey)
+    })
     const raw = window.localStorage.getItem(CAREER_PROGRESS_KEY)
     if (!raw) return normalizeProgress(null)
     return normalizeProgress(JSON.parse(raw))

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -104,6 +104,38 @@ const resolveLayoutSlot = (pattern, index, level) => {
 
 const buildTrainingLayout = (level) => {
   const targetCount = getTrainingTargetCount(level)
+  const isPracticeFreePlayLayout = clampLevel(level) === 15
+
+  if (isPracticeFreePlayLayout) {
+    const triangleSpacingX = 0.082
+    const triangleSpacingZ = 0.086
+    const apexZ = -0.36
+    const maxX = 0.26
+    const maxZ = 0.34
+
+    const balls = []
+    let row = 0
+    while (balls.length < targetCount) {
+      const rowBallCount = row + 1
+      const z = clampLayoutCoord(apexZ + row * triangleSpacingZ, -maxZ, maxZ)
+      const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
+      for (let column = 0; column < rowBallCount && balls.length < targetCount; column += 1) {
+        const x = clampLayoutCoord(rowStartX + column * triangleSpacingX, -maxX, maxX)
+        balls.push({
+          rackIndex: balls.length,
+          x,
+          z
+        })
+      }
+      row += 1
+    }
+
+    return {
+      cue: { x: 0, z: 0.52 },
+      balls
+    }
+  }
+
   const triangleSpacingX = 0.085
   const triangleSpacingZ = 0.09
   const apexX = 0.18


### PR DESCRIPTION
### Motivation
- Fix the Practice (free-play) rack so the initial ball placement matches the intended reference photo instead of appearing skewed on load. 
- Ensure Career mode is isolated from Practice so training progress does not leak into Career and users can restart Career from the beginning. 
- Improve feedback when a Career task is completed by showing a clear congratulations flow, coin burst, and an interactive NFT gift reveal with a stronger visual reveal (thumbnail + fireworks). 

### Description
- Added a dedicated Practice/free-play layout for level 15 that generates a centered triangular rack and a cue-ball start at a stable position by updating `webapp/src/utils/poolRoyaleTrainingProgress.js` (new layout generation for practice). 
- Versioned and cleared legacy career storage to force a Career reset by default, and added legacy-key cleanup for attempts storage, in `webapp/src/utils/poolRoyaleCareerProgress.js` and `webapp/src/pages/Games/PoolRoyale.jsx` (storage key versioning + legacy removal). 
- Isolated Lobby loading so entering `career` no longer reuses Practice/training completion state by resetting in-memory training progress for Career in `webapp/src/pages/Games/PoolRoyaleLobby.jsx`. 
- Enhanced Career completion UI in `webapp/src/pages/Games/PoolRoyale.jsx` to: keep the coin burst, add a clickable `🎁` card with an `Open` label, reveal NFT thumbnail with pop/glow animations, trigger a fireworks burst on open, and persist `thumbnail` metadata for reward history. 

### Testing
- Built the web app with `npm --prefix webapp run build` which completed successfully (production build, warnings only about large chunks). 
- Run the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and exercised the Career lobby. 
- Captured a mobile-portrait screenshot of the Career lobby via a Playwright script to validate the reset/isolation UI (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996116646c83298e2ca6aab3941206)