### PR TITLE
Fix Pool Royale practice rack layout; isolate career progress and improve career reward reveal

### DIFF
--- a/webapp/src/utils/poolRoyaleCareerProgress.js
+++ b/webapp/src/utils/poolRoyaleCareerProgress.js
@@ -3,7 +3,7 @@ import {
   describeTrainingLevel
 } from './poolRoyaleTrainingProgress.js'
 
-const CAREER_PROGRESS_KEY = 'poolRoyaleCareerProgress'
+const CAREER_PROGRESS_KEY = 'poolRoyaleCareerProgress_v2'
 export const CAREER_LEVEL_COUNT = 100
 
 const FRIENDLY_TITLES = [

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -166,6 +166,31 @@ export function getTrainingLayout (level) {
   return describeTrainingLevel(level).layout
 }
 
+export function getPracticeLayout () {
+  const triangleRows = 5
+  const triangleSpacingX = 0.086
+  const triangleSpacingZ = 0.094
+  const apexX = 0.2
+  const maxX = 0.44
+  const maxZ = 0.31
+  const balls = []
+
+  for (let row = 0; row < triangleRows; row += 1) {
+    const rowBallCount = row + 1
+    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
+    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    for (let col = 0; col < rowBallCount; col += 1) {
+      const z = clampLayoutCoord(rowStartZ + col * triangleSpacingZ, -maxZ, maxZ)
+      balls.push({ rackIndex: balls.length, x, z })
+    }
+  }
+
+  return {
+    cue: { x: -0.7, z: 0 },
+    balls
+  }
+}
+
 export function loadTrainingProgress () {
   if (typeof window === 'undefined') { return { completed: [], rewarded: [], lastLevel: 1, carryShots: 0, attemptsAwardedLevels: [] } }
   try {


### PR DESCRIPTION
### Motivation
- Practice was spawning with incorrect/taken-from-career layouts and could leak completion state into Career, causing unexpected completed tasks and incorrect ball placements.
- Career rewards needed a clearer reveal flow (explicit open action, larger NFT presentation and celebratory effects) and persisted thumbnail metadata for consistent thumbnails in the lobby.

### Description
- Add a dedicated practice rack generator `getPracticeLayout()` to `webapp/src/utils/poolRoyaleTrainingProgress.js` and use it for free Practice so Practice always starts with a clean 15-ball triangle and cue position.
- Make Pool Royale use the Practice layout when `usesCareerAttempts` is false by wiring `getPracticeLayout()` into `applyTrainingLayoutForLevel` and the initial table placement in `webapp/src/pages/Games/PoolRoyale.jsx` and include `usesCareerAttempts` in relevant effect deps.
- Reset carrier of previous Career progress by moving the storage key to `poolRoyaleCareerProgress_v2` in `webapp/src/utils/poolRoyaleCareerProgress.js` so Career progression is isolated and older completions do not carry over.
- Improve Career NFT reward UX by persisting `thumbnail` in reward history, adding a shared `openRewardGift()` handler that triggers coin bursts, replacing direct reveal calls with this handler, adding an explicit 🎁 “Open” button in the career-complete modal, and adding a larger reveal view with fireworks-style burst animation and adjusted CSS keyframes (all in `PoolRoyale.jsx`).

### Testing
- Ran `npx eslint webapp/src/utils/poolRoyaleTrainingProgress.js webapp/src/utils/poolRoyaleCareerProgress.js webapp/src/pages/Games/PoolRoyale.jsx` which completed (repo ignore-pattern warnings only) and did not introduce new lint failures.
- Ran `npx eslint --no-ignore ...` which surfaced pre-existing lint errors in legacy files unrelated to these changes (reported but not caused by this PR).
- Ran `npm run build` which failed due to an unrelated, pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` and not because of the modifications here.
- Launched the webapp dev server with `npm --prefix webapp run dev` and captured a visual verification screenshot of the Pool Royale career lobby using Playwright; the live UI served successfully for visual validation (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996116646c83298e2ca6aab3941206)