### PR TITLE
Keep Career tasks in-session, fix Practice layout, add penalty spot marking

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -133,7 +133,6 @@ const buildTrainingLayout = (level) => {
   }
 }
 
-
 const buildTrainingDefinition = (level) => {
   const discipline = level <= 17 ? '8-Ball' : level <= 34 ? '9-Ball' : 'Pool Position Play'
   const targetCount = getTrainingTargetCount(level)
@@ -168,25 +167,25 @@ export function getTrainingLayout (level) {
 
 export function getPracticeLayout () {
   const triangleRows = 5
-  const triangleSpacingX = 0.086
-  const triangleSpacingZ = 0.094
-  const apexX = 0.2
-  const maxX = 0.44
-  const maxZ = 0.31
+  const triangleSpacingX = 0.094
+  const triangleSpacingZ = 0.086
+  const apexZ = 0.42
+  const maxX = 0.31
+  const maxZ = 0.44
   const balls = []
 
   for (let row = 0; row < triangleRows; row += 1) {
     const rowBallCount = row + 1
-    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
-    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    const z = clampLayoutCoord(apexZ - row * triangleSpacingZ, -maxZ, maxZ)
+    const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
     for (let col = 0; col < rowBallCount; col += 1) {
-      const z = clampLayoutCoord(rowStartZ + col * triangleSpacingZ, -maxZ, maxZ)
+      const x = clampLayoutCoord(rowStartX + col * triangleSpacingX, -maxX, maxX)
       balls.push({ rackIndex: balls.length, x, z })
     }
   }
 
   return {
-    cue: { x: -0.7, z: 0 },
+    cue: { x: 0, z: -0.62 },
     balls
   }
 }


### PR DESCRIPTION
### Motivation
- Avoid reloading the whole game when advancing Career training tasks so the player stays in the active match and the scene remains loaded. 
- Correct Practice-mode initial setup so the cue ball sits behind the baulk/white line and the object-ball rack is placed straight ahead with a clear penalty spot marking on the table.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to track an `activeCareerStageId` state and use it when awarding attempts and marking stages completed. 
- Implemented in-session continuation in `handleTrainingRoadmapContinue` so the next career stage/training level is resolved, match state is reset, the new training layout is applied, URL query params are updated with `navigate(..., { replace: true })`, and the scene is not reloaded. 
- Replaced usages of the previous `careerStageId` where appropriate so completion and attempt logic now reference the active in-session stage (e.g. post-completion and tournament wrap-up flows). 
- Adjusted `webapp/src/utils/poolRoyaleTrainingProgress.js` `getPracticeLayout()` to rotate/align the rack and cue placement so the cue ball starts behind the white/baulk line and the rack is straight ahead (changed spacing and cue coordinates). 
- Added a `PENALTY_SPOT_Z` constant and wired an extra table marking into the table scaling/`Table3D` marking generation so a visible penalty spot is positioned and updated with table scaling.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCareerProgress.test.js` — PASS (5 tests passed). 
- Ran lint checks: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/utils/poolRoyaleTrainingProgress.js` (normal project lint ignores these files) and `npx eslint --no-ignore ...` which surfaced pre-existing lint issues in `poolRoyaleTrainingProgress.js` (unused vars and style rules); one whitespace fix was applied but other linter findings remain unrelated to the feature change. 
- Started local dev server with `npm --prefix webapp run dev` to validate the build; attempted to capture a Playwright screenshot of the practice scene but screenshot capture timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69997bb0a4508329913b0dc78713d069)