### PR TITLE
Improve Murlan Royale community card legibility under arena lighting

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -5491,19 +5491,33 @@ function updateCardFace(mesh, mode) {
 function setCommunityCardLegibility(mesh, highlighted) {
   const frontMaterial = mesh?.userData?.frontMaterial;
   if (!frontMaterial) return;
+  if (!mesh.userData.frontMaterialDefaults) {
+    mesh.userData.frontMaterialDefaults = {
+      roughness: frontMaterial.roughness,
+      metalness: frontMaterial.metalness,
+      emissiveIntensity: frontMaterial.emissiveIntensity ?? 0,
+      envMapIntensity: frontMaterial.envMapIntensity ?? 1,
+      toneMapped: frontMaterial.toneMapped ?? true
+    };
+  }
+  const defaults = mesh.userData.frontMaterialDefaults;
   if (!frontMaterial.emissive) {
     frontMaterial.emissive = new THREE.Color('#000000');
   }
   if (highlighted) {
-    frontMaterial.roughness = 0.22;
-    frontMaterial.metalness = 0.04;
-    frontMaterial.emissive.set('#2c2c2c');
-    frontMaterial.emissiveIntensity = 0.14;
-  } else {
-    frontMaterial.roughness = 0.35;
-    frontMaterial.metalness = 0.08;
+    frontMaterial.roughness = 0.96;
+    frontMaterial.metalness = 0;
+    frontMaterial.envMapIntensity = 0;
+    frontMaterial.toneMapped = false;
     frontMaterial.emissive.set('#000000');
     frontMaterial.emissiveIntensity = 0;
+  } else {
+    frontMaterial.roughness = defaults.roughness;
+    frontMaterial.metalness = defaults.metalness;
+    frontMaterial.envMapIntensity = defaults.envMapIntensity;
+    frontMaterial.toneMapped = defaults.toneMapped;
+    frontMaterial.emissive.set('#000000');
+    frontMaterial.emissiveIntensity = defaults.emissiveIntensity;
   }
   frontMaterial.needsUpdate = true;
 }


### PR DESCRIPTION
### Motivation
- Community/table cards were too reflective under arena lighting which washed out the card faces and made them hard to read. 
- The change should only affect community/table cards (not player hand or discard cards) and be reversible when a card leaves the table.

### Description
- Updated `setCommunityCardLegibility` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to capture per-card front material defaults into `mesh.userData.frontMaterialDefaults` so original material state can be restored. 
- When a card is marked as a community/table card (`highlighted`), the front material is made non-reflective by setting `roughness = 0.96`, `metalness = 0`, `envMapIntensity = 0`, and `toneMapped = false`, and emissive is cleared. 
- When the card is no longer a community card the stored defaults are restored and `frontMaterial.needsUpdate` is set so hand/discard cards keep their original appearance. 
- Change is scoped to the community-legibility helper only and does not alter card creation paths or in-hand rendering logic.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which returned the project ignore warning and no lint errors. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/MurlanRoyaleArena.jsx` which returned the same ignore warning and no lint errors. 
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite became ready (Local/Network URLs served). 
- Ran automated Playwright snapshots that loaded the Murlan Royale pages and produced screenshots successfully at `browser:/tmp/codex_browser_invocations/33bcc346b228f464/artifacts/artifacts/murlan-community-cards.png` and `browser:/tmp/codex_browser_invocations/d16fa19b3010af5e/artifacts/artifacts/murlan-royale-screen.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999abd7df9483299b52fc2aff497b5d)