### PR TITLE
Fix Pool Royale career continue flow to avoid black screen and keep table loaded

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -166,6 +166,14 @@ function persistCareerAttemptsProgress(progress) {
 const POOL_ROYALE_REWARDABLE_NFT_IDS = Object.freeze(['surprise_box', 'magic_trick', 'bullseye']);
 const POOL_ROYALE_REWARD_NFT_KEY_PREFIX = 'poolRoyaleRewardNfts_';
 
+function parseCareerStageLevel(stageId) {
+  if (typeof stageId !== 'string' || !stageId.trim()) return null;
+  const match = stageId.match(/(\d+)$/);
+  if (!match) return null;
+  const level = Number(match[1]);
+  return Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
+}
+
 function pickPoolRoyaleRewardNft() {
   const mediumTier = NFT_GIFTS.filter(
     (item) =>
@@ -11979,6 +11987,7 @@ function PoolRoyaleGame({
   const [isTournamentFinalMatch, setIsTournamentFinalMatch] = useState(false);
   const [showTournamentFinalWelcome, setShowTournamentFinalWelcome] = useState(false);
   const [revealedRewardNft, setRevealedRewardNft] = useState(null);
+  const [revealedRewardMeta, setRevealedRewardMeta] = useState(null);
   const [rewardFireworkSeed, setRewardFireworkSeed] = useState(0);
   const tournamentLastResult = useMemo(() => {
     if (!tournamentMode || typeof window === 'undefined') return null;
@@ -12107,8 +12116,8 @@ function PoolRoyaleGame({
       }
       @keyframes prGiftReveal {
         0% { transform: scale(0.48); opacity: 0.2; }
-        45% { transform: scale(1.85); opacity: 1; }
-        100% { transform: scale(1.45); opacity: 1; }
+        45% { transform: scale(2.05); opacity: 1; }
+        100% { transform: scale(1.75); opacity: 1; }
       }
       .pr-coin-burst {
         position: fixed;
@@ -12727,12 +12736,27 @@ function PoolRoyaleGame({
   );
 
 
-  const openRewardGift = useCallback((nft) => {
+  const openRewardGift = useCallback((nft, options = {}) => {
     if (!nft) return;
+    setRevealedRewardMeta({
+      autoCloseMs: Math.max(0, Number(options?.autoCloseMs) || 0),
+      receipt: options?.receipt || null
+    });
     setRevealedRewardNft(nft);
     setRewardFireworkSeed((prev) => prev + 1);
     triggerCoinBurst(28);
   }, [triggerCoinBurst]);
+
+  useEffect(() => {
+    if (!revealedRewardNft) return undefined;
+    const autoCloseMs = Math.max(0, Number(revealedRewardMeta?.autoCloseMs) || 0);
+    if (!autoCloseMs) return undefined;
+    const timeoutId = window.setTimeout(() => {
+      setRevealedRewardNft(null);
+      setRevealedRewardMeta(null);
+    }, autoCloseMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [revealedRewardMeta, revealedRewardNft]);
 
   useEffect(() => {
     trainingProgressRef.current = trainingProgress;
@@ -14422,7 +14446,18 @@ const powerRef = useRef(hud.power);
     const completedLevel = trainingLevelRef.current || 1;
     const completedLevelInfo = describeTrainingLevel(completedLevel);
     const completedRewardAmount = Number(completedLevelInfo?.rewardAmount) || 0;
-    const nftReward = completedLevel % 5 === 0 ? pickPoolRoyaleRewardNft() : null;
+    const careerStageLevel = parseCareerStageLevel(careerStageId) || completedLevel;
+    const nftMilestoneReached = usesCareerAttempts
+      ? careerStageLevel % 5 === 0
+      : completedLevel % 5 === 0;
+    const nftReward = nftMilestoneReached ? pickPoolRoyaleRewardNft() : null;
+    const nftReceipt = nftReward
+      ? {
+        id: `PR-${String(careerStageLevel).padStart(3, '0')}-${Date.now().toString(36).toUpperCase()}`,
+        taskLabel: `Task ${careerStageLevel}`,
+        issuedAt: new Date().toISOString()
+      }
+      : null;
     const previous = trainingProgressRef.current || { completed: [], rewarded: [] };
     const previousRewardedSet = new Set(
       (previous?.rewarded || []).map((lvl) => Number(lvl)).filter((lvl) => Number.isFinite(lvl) && lvl > 0)
@@ -14451,6 +14486,7 @@ const powerRef = useRef(hud.power);
         status: 'won',
         rewardAmount: shouldAwardReward ? completedRewardAmount : 0,
         nftReward,
+        nftReceipt,
         nextLabel: 'Continue to next task'
       });
     } else {
@@ -14497,7 +14533,12 @@ const powerRef = useRef(hud.power);
     }
     if (nftReward) {
       persistRewardNft(nftReward);
-      openRewardGift(nftReward);
+      if (!usesCareerAttempts) {
+        openRewardGift(nftReward, {
+          autoCloseMs: 0,
+          receipt: nftReceipt
+        });
+      }
     }
     triggerCoinBurst(nftReward ? 26 : 18);
   }, [
@@ -31250,18 +31291,46 @@ const powerRef = useRef(hud.power);
             <p className="mt-3 text-sm font-black uppercase tracking-[0.22em] text-amber-100">Congratulations 👏</p>
             <p className="mt-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/80">NFT unlocked</p>
             <p className="mt-1 text-lg font-semibold text-white">{revealedRewardNft.name}</p>
+            {revealedRewardMeta?.receipt?.id ? (
+              <p className="mt-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-amber-100/90">
+                Receipt: {revealedRewardMeta.receipt.id}
+              </p>
+            ) : null}
             <div className="mt-4 flex items-center justify-center gap-2 text-xs text-white/75">
               <img src={resolvedPlayerAvatar || '/assets/icons/profile.svg'} alt="Player avatar" className="h-8 w-8 rounded-full border border-amber-200/60 object-cover" />
               <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="h-5 w-5 animate-bounce" />
               <span>Career reward opened</span>
             </div>
-            <button
-              type="button"
-              onClick={() => setRevealedRewardNft(null)}
-              className="mt-5 rounded-full border border-emerald-300 bg-emerald-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.2em] text-black"
-            >
-              Awesome
-            </button>
+            {usesCareerAttempts ? (
+              <p className="mt-3 text-[10px] uppercase tracking-[0.2em] text-white/70">
+                Closing automatically… choose your next step below.
+              </p>
+            ) : null}
+            <div className="mt-5 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setRevealedRewardNft(null);
+                  setRevealedRewardMeta(null);
+                  if (usesCareerAttempts) {
+                    setCareerTaskResultModal(null);
+                    handleTrainingRoadmapContinue();
+                  }
+                }}
+                className="rounded-full border border-emerald-300 bg-emerald-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.2em] text-black"
+              >
+                {usesCareerAttempts ? 'Continue task' : 'Awesome'}
+              </button>
+              {usesCareerAttempts ? (
+                <button
+                  type="button"
+                  onClick={goToLobby}
+                  className="rounded-full border border-white/40 bg-white/10 px-5 py-2 text-xs font-bold uppercase tracking-[0.2em] text-white"
+                >
+                  Return to lobby
+                </button>
+              ) : null}
+            </div>
           </div>
         </div>
       ) : null}
@@ -32188,13 +32257,21 @@ const powerRef = useRef(hud.power);
                   {careerTaskResultModal.nftReward ? (
                     <button
                       type="button"
-                      onClick={() => openRewardGift(careerTaskResultModal.nftReward)}
+                      onClick={() => openRewardGift(careerTaskResultModal.nftReward, {
+                        autoCloseMs: 3200,
+                        receipt: careerTaskResultModal.nftReceipt || null
+                      })}
                       className="inline-flex min-w-[10rem] flex-col items-center rounded-2xl border border-amber-200/70 bg-amber-300/10 px-4 py-2 text-amber-100 transition hover:bg-amber-300/20"
                     >
                       <span className="text-2xl">🎁</span>
                       <span className="mt-1 text-[10px] font-semibold uppercase tracking-[0.2em]">Open</span>
                       <span className="mt-1 text-[11px] font-semibold">{careerTaskResultModal.nftReward.name}</span>
                     </button>
+                  ) : null}
+                  {careerTaskResultModal.nftReceipt ? (
+                    <div className="rounded-xl border border-amber-200/45 bg-amber-300/10 px-3 py-2 text-[10px] uppercase tracking-[0.18em] text-amber-100/90">
+                      Receipt sent · {careerTaskResultModal.nftReceipt.id}
+                    </div>
                   ) : null}
                 </div>
                 <div className="mt-4 grid grid-cols-2 gap-2">


### PR DESCRIPTION
### Motivation
- Automatically opening the full-screen NFT reveal during career task completion could conflict with the in-scene continue transition and leave the player on a black/empty overlay instead of advancing the task in-place. 
- The intent is to keep the 3D table/HDRI and game scene loaded and only show the reveal when the player explicitly opens the gift.

### Description
- Prevent automatic reveal on career sessions by gating the in-code reveal call so the NFT is persisted but `openRewardGift` is only invoked automatically for non-career flows (training freeplay). 
- Add `parseCareerStageLevel` to extract a numeric career stage from `careerStageId` and use that to determine milestone NFTs every 5th career stage, and generate a compact `nftReceipt` object for awarded NFTs. 
- Extend `openRewardGift` to accept `options` (`autoCloseMs`, `receipt`) and track `revealedRewardMeta` for auto-close behavior and receipt display, plus a timed `useEffect` to auto-close when requested. 
- Update UI: the career completion card now only opens the gift when the user taps `Open` (and passes `autoCloseMs` and `receipt`), the reveal modal shows the receipt id and presents explicit `Continue task` and `Return to lobby` actions, and `Continue` advances the next task in-place via the existing `handleTrainingRoadmapContinue` flow. 
- Tweak reveal animation scale (`prGiftReveal` keyframes) to increase growth on reveal for a stronger visual effect.

### Testing
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which produced the repository ignore warning but no blocking errors. 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully. 
- Captured a mobile-portrait screenshot of the career flow using an automated Playwright script which executed and produced an artifact for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999881940648329a81f552f5d8f20f4)