### PR TITLE
Pool Royale: grant 3 attempts per task once and stage NFT gifts from store (scaled every 3 tasks)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -51,7 +51,6 @@ import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import { giftSounds } from '../../utils/giftSounds.js';
-import { NFT_GIFTS } from '../../utils/nftGifts.js';
 import {
   createBallPreviewDataUrl,
   getBallMaterial as getBilliardBallMaterial
@@ -76,7 +75,8 @@ import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP,
   POOL_ROYALE_BASE_VARIANTS,
-  POOL_ROYALE_OPTION_LABELS
+  POOL_ROYALE_OPTION_LABELS,
+  POOL_ROYALE_STORE_ITEMS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
 import {
@@ -163,7 +163,6 @@ function persistCareerAttemptsProgress(progress) {
   return normalized;
 }
 
-const POOL_ROYALE_REWARDABLE_NFT_IDS = Object.freeze(['surprise_box', 'magic_trick', 'bullseye']);
 const POOL_ROYALE_REWARD_NFT_KEY_PREFIX = 'poolRoyaleRewardNfts_';
 
 function parseCareerStageLevel(stageId) {
@@ -174,24 +173,42 @@ function parseCareerStageLevel(stageId) {
   return Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 
-function pickPoolRoyaleRewardNft() {
-  const mediumTier = NFT_GIFTS.filter(
-    (item) =>
-      Number(item?.tier) === 2 &&
-      POOL_ROYALE_REWARDABLE_NFT_IDS.includes(item?.id) &&
+const POOL_ROYALE_CAREER_GIFT_CANDIDATES = Object.freeze(
+  POOL_ROYALE_STORE_ITEMS
+    .filter((item) =>
       typeof item?.thumbnail === 'string' &&
-      item.thumbnail.trim().length > 0
-  );
-  const source = mediumTier.length
-    ? mediumTier
-    : NFT_GIFTS.filter(
-      (item) =>
-        Number(item?.tier) === 2 &&
-        typeof item?.thumbnail === 'string' &&
-        item.thumbnail.trim().length > 0
-    );
-  if (!source.length) return null;
-  return source[Math.floor(Math.random() * source.length)] || null;
+      item.thumbnail.trim().length > 0 &&
+      Number(item?.price) > 0 &&
+      item?.type !== 'poolTrainingAttempt'
+    )
+    .sort((a, b) => (Number(a?.price) || 0) - (Number(b?.price) || 0))
+);
+
+function pickPoolRoyaleRewardNft(level = 1) {
+  if (!POOL_ROYALE_CAREER_GIFT_CANDIDATES.length) {
+    return null;
+  }
+  const normalizedLevel = Math.max(1, Math.min(TRAINING_LEVEL_COUNT, Number(level) || 1));
+  const progress = (normalizedLevel - 1) / Math.max(1, TRAINING_LEVEL_COUNT - 1);
+  const maxIndex = POOL_ROYALE_CAREER_GIFT_CANDIDATES.length - 1;
+  const targetIndex = Math.min(maxIndex, Math.max(0, Math.round(progress * maxIndex)));
+  const source = [
+    POOL_ROYALE_CAREER_GIFT_CANDIDATES[targetIndex - 1],
+    POOL_ROYALE_CAREER_GIFT_CANDIDATES[targetIndex],
+    POOL_ROYALE_CAREER_GIFT_CANDIDATES[targetIndex + 1]
+  ].filter(Boolean);
+  const selected = source[Math.floor(Math.random() * source.length)] || POOL_ROYALE_CAREER_GIFT_CANDIDATES[targetIndex];
+  if (!selected) return null;
+  return {
+    id: `pool-career-${selected.id}`,
+    name: selected.name,
+    icon: selected.thumbnail,
+    price: Number(selected.price) || 0,
+    tier: 1,
+    thumbnail: selected.thumbnail,
+    storeItemId: selected.id,
+    storeType: selected.type
+  };
 }
 
 function safePolygonUnion(...parts) {
@@ -14448,9 +14465,11 @@ const powerRef = useRef(hud.power);
     const completedRewardAmount = Number(completedLevelInfo?.rewardAmount) || 0;
     const careerStageLevel = parseCareerStageLevel(careerStageId) || completedLevel;
     const nftMilestoneReached = usesCareerAttempts
-      ? careerStageLevel % 5 === 0
-      : completedLevel % 5 === 0;
-    const nftReward = nftMilestoneReached ? pickPoolRoyaleRewardNft() : null;
+      ? careerStageLevel % 3 === 0
+      : completedLevel % 3 === 0;
+    const nftReward = nftMilestoneReached
+      ? pickPoolRoyaleRewardNft(usesCareerAttempts ? careerStageLevel : completedLevel)
+      : null;
     const nftReceipt = nftReward
       ? {
         id: `PR-${String(careerStageLevel).padStart(3, '0')}-${Date.now().toString(36).toUpperCase()}`,
@@ -31294,23 +31313,16 @@ const powerRef = useRef(hud.power);
               <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="h-5 w-5 animate-bounce" />
               <span>Career reward opened</span>
             </div>
-            {usesCareerAttempts ? (
-              <p className="mt-3 text-[10px] uppercase tracking-[0.2em] text-white/70">
-                Closing automatically… then choose continue or lobby in task panel.
-              </p>
-            ) : null}
-            {!usesCareerAttempts ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setRevealedRewardNft(null);
-                  setRevealedRewardMeta(null);
-                }}
-                className="mt-5 rounded-full border border-emerald-300 bg-emerald-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.2em] text-black"
-              >
-                Awesome
-              </button>
-            ) : null}
+            <button
+              type="button"
+              onClick={() => {
+                setRevealedRewardNft(null);
+                setRevealedRewardMeta(null);
+              }}
+              className="mt-5 rounded-full border border-emerald-300 bg-emerald-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.2em] text-black"
+            >
+              Close
+            </button>
           </div>
         </div>
       ) : null}
@@ -32238,7 +32250,6 @@ const powerRef = useRef(hud.power);
                     <button
                       type="button"
                       onClick={() => openRewardGift(careerTaskResultModal.nftReward, {
-                        autoCloseMs: 3200,
                         receipt: careerTaskResultModal.nftReceipt || null
                       })}
                       className="inline-flex min-w-[10rem] flex-col items-center rounded-2xl border border-amber-200/70 bg-amber-300/10 px-4 py-2 text-amber-100 transition hover:bg-amber-300/20"


### PR DESCRIPTION
### Motivation
- Make Career mode award hearts (attempts) exactly once per task and add a predictable, visible NFT gift flow that uses real Pool Royale store items and scales with player progression.
- Keep the existing task-by-task career flow and UX (do not load whole game state), while improving reward sourcing and reveal behavior.

### Description
- Use `POOL_ROYALE_STORE_ITEMS` as the source of career gift candidates, filtering out training-attempt bundles and items without thumbnails, and sorting by price so gifts scale from low to higher value as level increases (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add `pickPoolRoyaleRewardNft(level)` which selects a store item-based reward near the progression index so early levels get lower-value items and later levels trend higher. 
- Keep the existing per-stage grant guard (`attemptsAwardedStageIds`) so each career task issues the base attempts only once and preserve `BASE_ATTEMPTS_PER_LEVEL` behavior.
- Change career NFT bonus cadence from every 5 tasks to every 3 tasks, and pass the completed/career level into the reward picker so the gift is stage-appropriate.
- Update the reward reveal UI/flow so the gift is shown centered with thumbnail, fireworks and coin burst, and provide a persistent bottom `Close` button instead of auto-closing for career reveals.

### Testing
- Started dev server (`npm --prefix webapp run dev`) and confirmed the app serves; used Playwright to capture a portrait screenshot of the Pool Royale training/career page (artifact produced). — succeeded.
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported the file is ignored by repo lint config (no file-level lint signal in this environment). — informational.
- Ran `npm run lint -- --no-warn-ignored webapp/src/pages/Games/PoolRoyale.jsx` which failed due to many pre-existing lint errors across unrelated files in the repository, not introduced by this change. — pre-existing failures (not blocking functional validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c9773e7c8329b8da1535f7a6ec94)