### PR TITLE
Enhance Pool Royale career roadmap with mixed stages and gift previews

### DIFF
--- a/test/poolRoyaleCareerProgress.test.js
+++ b/test/poolRoyaleCareerProgress.test.js
@@ -32,11 +32,15 @@ describe('pool royale career progression isolation', () => {
     expect(nextStage?.id).toBe(CAREER_STAGES[0].id)
   })
 
-  test('career starts with the full training task set', () => {
-    const openingStages = CAREER_STAGES.slice(0, 50)
-    expect(openingStages.every((stage) => stage.type === 'training')).toBe(true)
+  test('career roadmap mixes drills, matches, and tournaments after onboarding', () => {
+    const openingStages = CAREER_STAGES.slice(0, 20)
+    const uniqueTypes = new Set(openingStages.map((stage) => stage.type))
+    expect(uniqueTypes.has('training')).toBe(true)
+    expect(uniqueTypes.has('friendly')).toBe(true)
+    expect(uniqueTypes.has('tournament')).toBe(true)
+    expect(uniqueTypes.has('league')).toBe(true)
+    expect(uniqueTypes.has('showdown')).toBe(true)
     expect(openingStages[0].title).toContain('Task 01')
-    expect(openingStages[49].title).toContain('Task 50')
   })
 
   test('career training stages use training objectives and rewards', () => {
@@ -44,6 +48,12 @@ describe('pool royale career progression isolation', () => {
     expect(firstStage.objective).toContain('Clear')
     expect(firstStage.reward).toContain('TPC')
     expect(firstStage.rewardTpc).toBeGreaterThan(0)
+  })
+
+  test('gift milestones provide gift thumbnails for roadmap previews', () => {
+    const giftStage = CAREER_STAGES.find((stage) => stage.hasGift)
+    expect(giftStage).toBeTruthy()
+    expect(giftStage.giftThumbnail).toContain('/store-thumbs/poolRoyale/tableFinish/')
   })
 
 })

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -936,7 +936,11 @@ export default function PoolRoyaleLobby() {
                               ? '🎯 Drill'
                               : stage.type === 'friendly'
                                 ? '🤝 Match'
-                                : '🏆 Tournament'}
+                                : stage.type === 'league'
+                                  ? '🗓️ League'
+                                  : stage.type === 'showdown'
+                                    ? '⚡ Showdown'
+                                    : '🏆 Tournament'}
                           </span>
                           <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200/40 bg-emerald-300/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-100">
                             <img
@@ -953,6 +957,17 @@ export default function PoolRoyaleLobby() {
                             <span className="inline-flex items-center gap-1 rounded-full border border-amber-200/50 bg-amber-300/12 px-2 py-0.5 text-[10px] font-semibold text-amber-100">
                               <span>🎁</span>
                               Gift bonus
+                            </span>
+                          ) : null}
+                          {stage.hasGift && stage.giftThumbnail ? (
+                            <span className="inline-flex items-center gap-1 rounded-lg border border-amber-200/50 bg-black/25 px-1.5 py-1 text-[10px] font-semibold text-amber-50">
+                              <img
+                                src={stage.giftThumbnail}
+                                alt="Gift reward thumbnail"
+                                className="h-7 w-7 rounded object-cover"
+                                loading="lazy"
+                              />
+                              Gift preview
                             </span>
                           ) : null}
                         </div>


### PR DESCRIPTION
### Motivation
- Improve the Pool Royale career experience by moving from a mostly training-only progression to a true mixed Career flow with drills, friendlies, league fixtures, tournaments and rival showdowns. 
- Make milestone rewards more visible by surfacing gift thumbnails on the roadmap so players can preview NFT/store-item rewards before launching a stage. 
- Rebalance rewards by stage type so higher-stakes stages (tournaments/showdowns) yield appropriately larger TPC payouts. 

### Description
- Reworked career stage generation in `webapp/src/utils/poolRoyaleCareerProgress.js` by adding `CAREER_TYPE_SEQUENCE` and `stageMetaByType`, changing `getStageType` logic, rebalanced `buildReward`, and attaching `giftThumbnail` metadata for milestone stages. 
- Added `GIFT_THUMBNAILS` and logic to mark every 5th stage as a gift milestone and select a thumbnail from store thumbs. 
- Updated the Pool Royale lobby UI in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` to render new stage badges for `league` and `showdown` types and display gift thumbnail previews on roadmap cards when available. 
- Extended `test/poolRoyaleCareerProgress.test.js` to validate mixed-stage composition and that gift milestones include thumbnail metadata. 

### Testing
- Ran the focused unit tests with `npm test -- test/poolRoyaleCareerProgress.test.js --runInBand` and all tests passed (6 tests). 
- Started the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to verify the lobby UI builds and serves correctly. 
- Captured a mobile-portrait Playwright screenshot of the Pool Royale lobby with Career selected to confirm the roadmap renders and gift thumbnails appear: `browser:/tmp/codex_browser_invocations/00462fbfdff60b6a/artifacts/artifacts/pool-career-roadmap-career-selected.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f71b3d18832982924913e2986ed6)