### PR TITLE
Render Murlan Royale center community cards face-up

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3171,7 +3171,7 @@ export default function MurlanRoyaleArena({ search }) {
         mesh,
         target,
         tableLookBase,
-        { face: 'front', flat: true, flatTiltX: COMMUNITY_CARD_TOP_TILT, flatYawY: Math.PI },
+        { face: 'front', flat: true, flatTiltX: COMMUNITY_CARD_TOP_TILT },
         immediate,
         three.animations
       );


### PR DESCRIPTION
### Motivation
- Community cards in the center were appearing face-down because an extra 180° yaw was applied when positioning table/community cards, reducing legibility; the intent is to show the community pile face-up while keeping a slight top tilt for readability.

### Description
- Removed the `flatYawY: Math.PI` argument from the `setMeshPosition` call that places `state.tableCards` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, so the cards are positioned with `{ face: 'front', flat: true, flatTiltX: COMMUNITY_CARD_TOP_TILT }` and render face-up.

### Testing
- Ran the unit tests with `npm test -- --runInBand test/murlan.test.js` and the suite passed (all tests successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0c2cd014832982cba9bc623ee873)