### PR TITLE
Adjust Texas Hold'em 3D camera pacing, card layout, and showdown focus

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -349,7 +349,7 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
 const COMMUNITY_SPACING = CARD_W * 0.62;
 const COMMUNITY_CARD_FORWARD_OFFSET = 0;
-const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
+const COMMUNITY_CARD_LIFT = CARD_D * 3.45;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
 const COMMUNITY_ROW_ROTATION = 0;
@@ -361,7 +361,6 @@ const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
   )
 );
 const HOLE_SPACING = CARD_W * 0.65;
-const HUMAN_CARD_SPREAD = HOLE_SPACING * 1.32;
 const HUMAN_CARD_FORWARD_OFFSET = CARD_W * 0.04;
 const HUMAN_CARD_VERTICAL_OFFSET = CARD_H * 0.52;
 const HUMAN_CARD_LOOK_LIFT = CARD_H * 0.24;
@@ -383,8 +382,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.82, landscape: 1.16 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.6, landscape: 1.18 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.98, landscape: 1.26 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.66, landscape: 1.24 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
@@ -398,7 +397,7 @@ const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 1.12;
 const HUMAN_CARD_CHIP_BLEND = 0.08;
 const HUMAN_CARD_SCALE = 1;
-const COMMUNITY_CARD_SCALE = 1.08;
+const COMMUNITY_CARD_SCALE = 1.16;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
@@ -410,7 +409,10 @@ const TURN_INDICATOR_OUTER_RADIUS = CARD_W * 0.36;
 const TURN_INDICATOR_HEIGHT = 0.008 * MODEL_SCALE;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const CAMERA_TURN_SNAP_EPSILON = THREE.MathUtils.degToRad(0.25);
-const CAMERA_TURN_DURATION_MS = 240;
+const CAMERA_TURN_DURATION_MS = 460;
+const AI_ACTION_DELAY_MS = 3600;
+const CAMERA_CHIP_VIEW_DELAY_MS = 1000;
+const CAMERA_PASS_VIEW_DELAY_MS = 1500;
 
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
@@ -2586,6 +2588,8 @@ function TexasHoldemArena({ search }) {
   const threeRef = useRef(null);
   const animationRef = useRef(null);
   const cameraTurnAnimRef = useRef(null);
+  const cameraHoldTimeoutRef = useRef(null);
+  const delayedFocusActionRef = useRef({ actionId: null, seatIndex: null });
   const headAnglesRef = useRef({ yaw: 0, pitch: 0 });
   const humanSeatRef = useRef(null);
   const seatTopPointRef = useRef(null);
@@ -3291,6 +3295,14 @@ function TexasHoldemArena({ search }) {
     [applyHeadOrientation, stopCameraTurnAnimation]
   );
 
+
+  useEffect(() => () => {
+    if (cameraHoldTimeoutRef.current) {
+      clearTimeout(cameraHoldTimeoutRef.current);
+      cameraHoldTimeoutRef.current = null;
+    }
+  }, []);
+
   const findSeatWithAvatar = useCallback((startIndex = 0, options = {}) => {
     const state = gameStateRef.current;
     const players = state?.players ?? [];
@@ -3850,10 +3862,7 @@ function TexasHoldemArena({ search }) {
     const humanSeat = seatLayout.find((seat) => seat.isHuman) ?? seatLayout[0];
     humanSeatRef.current = humanSeat;
     seatTopPointRef.current = seatTopPoint;
-    const communityRowRotation = Math.atan2(humanSeat.right.z, humanSeat.right.x);
-    const resolvedCommunityRowRotation = Number.isFinite(communityRowRotation)
-      ? communityRowRotation
-      : COMMUNITY_ROW_ROTATION;
+    const resolvedCommunityRowRotation = COMMUNITY_ROW_ROTATION;
     const raiseControls = createRaiseControls({ arena: arenaGroup, seat: humanSeat, chipFactory, tableInfo });
     const cameraTarget = new THREE.Vector3(0, TABLE_HEIGHT + CAMERA_TARGET_LIFT, 0);
 
@@ -4680,6 +4689,25 @@ function TexasHoldemArena({ search }) {
 
     const showdownState = showdownAnimationRef.current;
     const winningCommunity = new Set(state.winningCommunityCards ?? []);
+    const winnerIndices = state.showdown
+      ? Array.from(
+          new Set(
+            (state.winners ?? []).flatMap((entry) =>
+              (entry?.winners ?? []).map((winner) => winner?.index).filter((idx) => Number.isInteger(idx) && idx >= 0)
+            )
+          )
+        )
+      : [];
+    const winnerShowcaseAnchors = winnerIndices.map((seatIdx, winnerOrder) => {
+      const centerOffset = (winnerIndices.length - 1) / 2;
+      const xOffset = (winnerOrder - centerOffset) * (CARD_W * 1.9);
+      const anchor = new THREE.Vector3(
+        xOffset,
+        TABLE_HEIGHT + CARD_SURFACE_OFFSET + COMMUNITY_CARD_LIFT - CARD_H * 0.82,
+        COMMUNITY_CARD_FORWARD_OFFSET + CARD_W * 0.16
+      );
+      return { seatIdx, winnerOrder, anchor };
+    });
 
     state.players.forEach((player, idx) => {
       const seat = seatGroups[idx];
@@ -4726,27 +4754,33 @@ function TexasHoldemArena({ search }) {
         }
         const position = baseAnchor
           .clone()
-          .addScaledVector(forward, seat.isHuman ? HUMAN_CARD_FORWARD_OFFSET : CARD_FORWARD_OFFSET)
-          .add(right.clone().multiplyScalar((cardIdx - 0.5) * (seat.isHuman ? HOLE_SPACING : HUMAN_CARD_SPREAD)));
+          .addScaledVector(forward, HUMAN_CARD_FORWARD_OFFSET)
+          .add(right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING));
         position.y = (seat.isHuman ? baseAnchor.y : seat.cardRailAnchor.y) + CARD_D * 0.6;
         mesh.position.copy(position);
-        const lookOrigin = seat.isHuman ? baseAnchor : seat.stoolAnchor;
-        const lookTarget = seat.isHuman
-          ? three.camera.position
-              .clone()
-              .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
-              .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
-          : lookOrigin
-              .clone()
-              .add(new THREE.Vector3(0, seat.stoolHeight * 0.5 + CARD_LOOK_LIFT, 0))
-              .add(right.clone().multiplyScalar((cardIdx - 0.5) * CARD_LOOK_SPLAY))
-              .addScaledVector(forward, 0);
+        const lookTarget = three.camera.position
+          .clone()
+          .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
+          .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0));
         const face = overheadView || seat.isHuman || state.showdown ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: seat.isHuman });
+        orientCard(mesh, lookTarget, { face, flat: true });
         setCardFace(mesh, face);
-        if (seat.isHuman) {
+        mesh.rotation.x = 0;
+
+        const winnerShowcase = state.showdown
+          ? winnerShowcaseAnchors.find((entry) => entry.seatIdx === idx)
+          : null;
+        if (winnerShowcase) {
+          const showcasePos = winnerShowcase.anchor
+            .clone()
+            .add(right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING * 0.96));
+          mesh.position.copy(showcasePos);
+          const showcaseLook = showcasePos.clone().add(new THREE.Vector3(0, COMMUNITY_CARD_LOOK_LIFT, CARD_W));
+          orientCard(mesh, showcaseLook, { face: 'front', flat: true });
+          setCardFace(mesh, 'front');
           mesh.rotation.x = 0;
         }
+
         const key = cardKey(card);
         setCardHighlight(mesh, state.showdown && winningCardSet.has(key));
       });
@@ -4812,6 +4846,14 @@ function TexasHoldemArena({ search }) {
         seat.lastAvatar = labelAvatar;
         label.userData.update(player.name, chipsAmount, highlight, status, labelAvatar);
         label.userData.texture.needsUpdate = true;
+        const winnerShowcase = state.showdown
+          ? winnerShowcaseAnchors.find((entry) => entry.seatIdx === idx)
+          : null;
+        if (winnerShowcase) {
+          label.position.copy(winnerShowcase.anchor.clone().add(new THREE.Vector3(0, CARD_H * -0.58, 0)));
+        } else {
+          label.position.copy(seat.labelAnchor);
+        }
       }
 
       if (player.folded && !(prevPlayer?.folded)) {
@@ -4902,6 +4944,10 @@ function TexasHoldemArena({ search }) {
   const currentStage = gameState?.stage;
   useEffect(() => {
     if (typeof currentActionIndex !== 'number') return;
+    if (cameraHoldTimeoutRef.current) {
+      clearTimeout(cameraHoldTimeoutRef.current);
+      cameraHoldTimeoutRef.current = null;
+    }
     if (currentStage === 'showdown') {
       const indicator = threeRef.current?.turnIndicator;
       if (indicator) {
@@ -4932,23 +4978,49 @@ function TexasHoldemArena({ search }) {
       }
     }
     if (typeof focusIndex !== 'number') return;
-    const seat = three.seatGroups?.[focusIndex];
-    if (seat?.isHuman) {
-      stopCameraTurnAnimation();
-      if (Math.abs(headAnglesRef.current.yaw) > CAMERA_TURN_SNAP_EPSILON) {
-        headAnglesRef.current.yaw = 0;
-        headAnglesRef.current.pitch = 0;
-        applyHeadOrientation();
+    const focusActionId = gameState?.lastActionId ?? null;
+    const focusAction = gameState?.lastAction?.action ?? '';
+    const hasFreshAction =
+      focusActionId != null &&
+      delayedFocusActionRef.current.actionId !== focusActionId;
+    const holdDelay = hasFreshAction
+      ? ['call', 'raise', 'bet', 'allIn'].includes(focusAction)
+        ? CAMERA_CHIP_VIEW_DELAY_MS
+        : CAMERA_PASS_VIEW_DELAY_MS
+      : 0;
+
+    const focusSeat = () => {
+      delayedFocusActionRef.current = { actionId: focusActionId, seatIndex: focusIndex };
+      const seat = three.seatGroups?.[focusIndex];
+      if (seat?.isHuman) {
+        stopCameraTurnAnimation();
+        if (Math.abs(headAnglesRef.current.yaw) > CAMERA_TURN_SNAP_EPSILON) {
+          headAnglesRef.current.yaw = 0;
+          headAnglesRef.current.pitch = 0;
+          applyHeadOrientation();
+        }
+        playSound('knock');
+        return;
       }
-      playSound('knock');
+      turnCameraTowardsSeat(focusIndex, { animate: true });
+    };
+
+    if (holdDelay > 0) {
+      cameraHoldTimeoutRef.current = setTimeout(() => {
+        cameraHoldTimeoutRef.current = null;
+        focusSeat();
+      }, holdDelay);
       return;
     }
-    turnCameraTowardsSeat(focusIndex, { animate: true });
+
+    focusSeat();
   }, [
     applyHeadOrientation,
     currentActionIndex,
     currentStage,
     findSeatWithAvatar,
+    gameState?.lastAction?.action,
+    gameState?.lastActionId,
     playSound,
     stopCameraTurnAnimation,
     turnCameraTowardsSeat
@@ -5065,6 +5137,17 @@ function TexasHoldemArena({ search }) {
     });
   }, [gameState, findSeatWithAvatar]);
 
+
+  useEffect(() => {
+    if (gameState?.stage !== 'showdown') {
+      return;
+    }
+    const focusWinner = gameState?.winnerFocusIndex;
+    if (typeof focusWinner === 'number') {
+      turnCameraTowardsSeat(focusWinner, { animate: true, durationMs: 620 });
+    }
+  }, [gameState?.stage, gameState?.winnerFocusIndex, turnCameraTowardsSeat]);
+
   useEffect(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
@@ -5107,7 +5190,7 @@ function TexasHoldemArena({ search }) {
             performAiAction(next);
             return next;
           });
-        }, 3000);
+        }, AI_ACTION_DELAY_MS);
       }
     }
     return () => {


### PR DESCRIPTION
### Motivation
- Improve 3D table readability by zooming out slightly and slowing camera motion so players can see chip placements and actions before the view moves on. 
- Slow down AI and per-turn pacing to make the game feel less rushed and match expectations from other 3D games (e.g. Domino Royale). 
- Make community/player cards more readable and present winners at the center of the table at showdown. 

### Description
- Tuned camera and card layout constants: increased `COMMUNITY_CARD_LIFT` and `COMMUNITY_CARD_SCALE`, adjusted `CAMERA_RETREAT_OFFSETS` and `CAMERA_ELEVATION_OFFSETS` for a slightly wider view, and increased `CAMERA_TURN_DURATION_MS` for slower camera turns. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Introduced explicit pacing constants `AI_ACTION_DELAY_MS`, `CAMERA_CHIP_VIEW_DELAY_MS`, and `CAMERA_PASS_VIEW_DELAY_MS` and used them to slow AI decisions and add camera hold durations after actions. (file: `TexasHoldemArena.jsx`)
- Added camera hold state and cleanup (`cameraHoldTimeoutRef`, `delayedFocusActionRef`) and changed the turn-focus effect so the camera waits (1.0s for chip actions like `call`/`raise`/`bet`/`all-in`, 1.5s for pass actions like `check`/`fold`) before turning to the next seat. (file: `TexasHoldemArena.jsx`)
- Aligned hole-card placement/orientation so all seats use the bottom-player visual style (consistent spacing/orientation) and simplified look-targets to improve readability. (file: `TexasHoldemArena.jsx`)
- Added showdown winner showcase: compute center anchors for winner(s), move winner cards and nameplate/avatar into a centered showcase under community cards, and refocus the camera toward the winning seat during showdown. (file: `TexasHoldemArena.jsx`)

### Testing
- Ran unit tests with Jest using `npm test -- test/texasHoldemGame.test.js test/texasHoldemAI.test.js --runInBand` and both suites passed. 
- Built the web client with `npm --prefix webapp run build` to validate production bundle; build completed successfully.
- Started the dev server and captured a headless browser screenshot of the arena route to verify visual changes (Playwright run completed and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0ecadbac832984dfdf27d25ee69a)