### PR TITLE
Snake & Ladder: add turn-focused camera orbit + dice-look and slow AI roll pacing

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -180,6 +180,8 @@ const PLAYERS = 4;
 // while keeping the total cell count at 100
 const FINAL_TILE = BOARD_FINAL_TILE;
 const TURN_TIME = 15;
+const AI_ROLL_DECISION_DELAY_MS = 3400;
+const AI_EXTRA_TURN_DELAY_MS = 2600;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -2994,7 +2996,7 @@ export default function SnakeAndLadder() {
       setDiceVisible(true);
       setMoving(false);
       if (extraTurn && next === index) {
-        setTimeout(() => triggerAIRoll(index), 1800);
+        setTimeout(() => triggerAIRoll(index), AI_EXTRA_TURN_DELAY_MS);
       }
     };
 
@@ -3068,7 +3070,7 @@ export default function SnakeAndLadder() {
       if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
       aiRollTimeoutRef.current = setTimeout(() => {
         setAiRollTrigger((t) => t + 1);
-      }, 1800);
+      }, AI_EXTRA_TURN_DELAY_MS);
       return () => clearTimeout(aiRollTimeoutRef.current);
     }
   }, [aiRollingIndex]);
@@ -3094,7 +3096,7 @@ export default function SnakeAndLadder() {
         setTimeLeft(parseFloat(remaining.toFixed(1)));
       }, 100);
       if (!isMultiplayer) {
-        aiRollTimeRef.current = Date.now() + 2500;
+        aiRollTimeRef.current = Date.now() + AI_ROLL_DECISION_DELAY_MS;
         if (aiRollTimeoutRef.current) clearInterval(aiRollTimeoutRef.current);
         aiRollTimeoutRef.current = setInterval(() => {
           if (Date.now() >= aiRollTimeRef.current) {


### PR DESCRIPTION
### Motivation
- Improve camera flow so the view rotates to face the active player on turn changes (no zoom) and briefly looks at the dice when they are rolled to match the Domino/royal camera behavior request.
- Tone down AI pacing so AI rolls feel slower and less abrupt during gameplay.

### Description
- Added camera helpers in `webapp/src/components/SnakeBoard3D.jsx`: `createTurnCameraOrbitAnimation` to orbit the camera to face the active seat, and `createCameraTargetLookAnimation` to temporarily pan the camera target to the dice before returning to the board look target.
- Hooked the orbit animation to turn changes using a `prevTurnRef` and pushed the animation into the existing `animationsRef` flow so token follow and other camera sequences coexist.
- When dice rolls start, compute a dice focus target and enqueue a short look animation that holds briefly then returns focus to the board to satisfy the requested "look at dice then token" flow.
- Slowed AI timing in `webapp/src/pages/Games/SnakeAndLadder.jsx` by adding `AI_ROLL_DECISION_DELAY_MS` and `AI_EXTRA_TURN_DELAY_MS` and using them for auto-roll decision timing and extra-turn rerolls.
- Kept existing token-follow and dice roll animations intact and reused existing animation removal helpers to avoid conflicting camera moves.

### Testing
- Ran lint focused on the two changed files with `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx` and saw those files are allowed by current config (no blocking errors for the changes). (succeeded)
- Ran project lint command `npm run lint -- webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx` which surfaced many pre-existing repository-wide lint errors unrelated to this change (reported but not caused by this PR). (reported failures unrelated)
- Ran the test suite with `npm run test -- --runInBand --watchAll=false` which executed many tests; several unrelated tests in other areas failed (pre-existing failures) while many snake-related tests passed; no new unit-test failures were introduced that are traceable to these camera/AI timing edits. (mixed results: unrelated failures present)
- Started the webapp dev server and validated the camera behavior visually by opening `/games/snake?ai=2` in a small portrait viewport and capturing a screenshot showing the updated turn/dice camera behavior. (manual visual validation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a118f3af483299825aa26069bf99c)