### PR TITLE
Snake & Ladder: turn-focus 3D camera and slower AI pacing

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3068,7 +3068,7 @@ export default function SnakeAndLadder() {
       if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
       aiRollTimeoutRef.current = setTimeout(() => {
         setAiRollTrigger((t) => t + 1);
-      }, 1800);
+      }, 2600);
       return () => clearTimeout(aiRollTimeoutRef.current);
     }
   }, [aiRollingIndex]);
@@ -3094,7 +3094,7 @@ export default function SnakeAndLadder() {
         setTimeLeft(parseFloat(remaining.toFixed(1)));
       }, 100);
       if (!isMultiplayer) {
-        aiRollTimeRef.current = Date.now() + 2500;
+        aiRollTimeRef.current = Date.now() + 3600;
         if (aiRollTimeoutRef.current) clearInterval(aiRollTimeoutRef.current);
         aiRollTimeoutRef.current = setInterval(() => {
           if (Date.now() >= aiRollTimeRef.current) {


### PR DESCRIPTION
### Motivation
- Improve player clarity by making the 3D camera rotate to face the active player when turns change (no zoom), briefly pivot to the dice on roll, and slow AI actions for better pacing.

### Description
- Added camera timing constants and two helpers `computeTurnFocusCameraState` and `computeDiceLookCameraState` in `webapp/src/components/SnakeBoard3D.jsx` to derive camera positions/targets for turn focus and dice look.
- Hooked a turn-focused camera transition on `currentTurn` that rotates the camera toward the active seat while preserving distance using `createCameraTransitionAnimation` (type `cameraTurnFocus`).
- Added a dice-look camera phase on roll start that briefly focuses on the dice before token-follow animations (type `cameraDiceZoom`).
- Tuned AI pacing in `webapp/src/pages/Games/SnakeAndLadder.jsx` by increasing the AI scheduling delays (`aiRollTimeRef` from `2500ms` to `3600ms`, and the AI roll failsafe trigger from `1800ms` to `2600ms`).

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`; lint run reported the files are ignored by repo ignore patterns so no actionable lint errors surfaced for the changed files.
- Ran `npm test -- --runInBand test/snakeGame.test.js`; the test suite passed (10 tests passed) though the test run produced Jest open-handle/DB buffering warnings in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a118f3af483299825aa26069bf99c)