### PR TITLE
Snake & Ladder: turn-aware camera choreography and slower AI pacing

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -180,6 +180,8 @@ const PLAYERS = 4;
 // while keeping the total cell count at 100
 const FINAL_TILE = BOARD_FINAL_TILE;
 const TURN_TIME = 15;
+const AI_ROLL_DELAY_MS = 3400;
+const AI_EXTRA_ROLL_DELAY_MS = 2600;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -2994,7 +2996,7 @@ export default function SnakeAndLadder() {
       setDiceVisible(true);
       setMoving(false);
       if (extraTurn && next === index) {
-        setTimeout(() => triggerAIRoll(index), 1800);
+        setTimeout(() => triggerAIRoll(index), AI_EXTRA_ROLL_DELAY_MS);
       }
     };
 
@@ -3068,7 +3070,7 @@ export default function SnakeAndLadder() {
       if (aiRollTimeoutRef.current) clearTimeout(aiRollTimeoutRef.current);
       aiRollTimeoutRef.current = setTimeout(() => {
         setAiRollTrigger((t) => t + 1);
-      }, 1800);
+      }, AI_EXTRA_ROLL_DELAY_MS);
       return () => clearTimeout(aiRollTimeoutRef.current);
     }
   }, [aiRollingIndex]);
@@ -3094,7 +3096,7 @@ export default function SnakeAndLadder() {
         setTimeLeft(parseFloat(remaining.toFixed(1)));
       }, 100);
       if (!isMultiplayer) {
-        aiRollTimeRef.current = Date.now() + 2500;
+        aiRollTimeRef.current = Date.now() + AI_ROLL_DELAY_MS;
         if (aiRollTimeoutRef.current) clearInterval(aiRollTimeoutRef.current);
         aiRollTimeoutRef.current = setInterval(() => {
           if (Date.now() >= aiRollTimeRef.current) {


### PR DESCRIPTION
### Motivation
- Improve spectator feel by making the 3D camera rotate to face the active player when turns change (no zoom), show the dice when rolled, then follow the token movement before moving to the next player's turn. 
- Make AI-driven turns feel less abrupt by slowing down AI roll timings so the cinematic camera beats can be appreciated.

### Description
- Added turn-focused camera logic in `webapp/src/components/SnakeBoard3D.jsx` with `computeTurnCameraFocusState` and `computeDiceCameraFocusState`, new timing constants, and a `useEffect` that triggers a smooth camera rotation toward the active seat on `currentTurn` changes.
- When dice rolling starts the camera now performs a brief dice-look beat (`cameraDiceZoom`) that holds and then returns to the turn framing, keeping the sequence `turn -> dice -> token -> next turn` intact.
- Token-follow animations were adjusted to restore to the maintained turn framing (via `turnCameraStateRef` / `cinematicRestoreRef`) so transitions feel consistent across token slides and slides/rolls.
- Slowed AI pacing by introducing `AI_ROLL_DELAY_MS` and `AI_EXTRA_ROLL_DELAY_MS` in `webapp/src/pages/Games/SnakeAndLadder.jsx` and applying them to the normal AI roll timer and extra-turn/failsafe delays.

### Testing
- Ran the webapp production build with `npm --prefix webapp run build`, which completed successfully.
- Ran unit tests with `npm test -- --runInBand`, which exercised the monorepo test suites but reported failures in unrelated, pre-existing tests (examples: `poolUk8Ball`, `storePurchaseRoute`, `poolRoyaleSpinController`, and several platform-help tests), so no test failures attributable to these changes were isolated.
- Ran `npx eslint` against the edited files but the files are skipped by repository ignore rules so lint emitted warnings about ignored files rather than actionable errors.
- Started the dev server and captured a viewport screenshot to validate the camera flow visually (`vite dev` + headless browser screenshot), confirming the UI loads and the updated camera code runs in the app environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a118f3af483299825aa26069bf99c)