### PR TITLE
Adjust SnakeBoard3D token visibility and camera follow behaviour

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -161,9 +161,9 @@ const CAMERA_FOLLOW_MIN_TILE = Infinity;
 const TOKEN_CAMERA_FOLLOW_IN_DURATION = 480;
 const TOKEN_CAMERA_FOLLOW_HOLD_DURATION = 820;
 const TOKEN_CAMERA_FOLLOW_OUT_DURATION = 480;
-const TOKEN_CAMERA_FOLLOW_DISTANCE = TILE_SIZE * 2.6;
-const TOKEN_CAMERA_HEIGHT_OFFSET = TILE_SIZE * 1.9;
-const TOKEN_CAMERA_LATERAL_OFFSET = TILE_SIZE * 0.55;
+const TOKEN_CAMERA_FOLLOW_DISTANCE = TILE_SIZE * 5.2;
+const TOKEN_CAMERA_HEIGHT_OFFSET = TILE_SIZE * 2.8;
+const TOKEN_CAMERA_LATERAL_OFFSET = TILE_SIZE * 0.18;
 const TURN_CAMERA_TURN_IN_DURATION = 620;
 const DICE_CAMERA_LOOK_IN_DURATION = 360;
 const DICE_CAMERA_LOOK_HOLD_DURATION = 900;
@@ -191,11 +191,6 @@ const EDGE_TILE_OUTWARD_OFFSET = TILE_SIZE * 0.3;
 const TILE_EDGE_INSET = TILE_SIZE * 0.22;
 const BASE_PLATFORM_EXTRA_MULTIPLIER = 1.72;
 const FIRST_LEVEL_PLATFORM_EXTRA = TILE_SIZE * 0.9;
-const HOME_TOKEN_FORWARD_LIFT = TILE_SIZE * 1.05;
-const HOME_TOKEN_OUTWARD_EXTRA = TILE_SIZE * 1.6;
-// Extra distance so side-seat tokens rest closer to their players than the board edge.
-const SIDE_HOME_EXTRA_DISTANCE = TILE_SIZE * 3.2;
-const BACK_HOME_EXTRA_DISTANCE = TILE_SIZE * 3.6;
 const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKEN_SCALE_MULTIPLIER;
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
@@ -1501,8 +1496,8 @@ function createCameraTransitionAnimation(
   };
 }
 
-function computeTokenFollowCameraState(board, fromIndex, toIndex) {
-  if (!board) return null;
+function computeTokenFollowCameraState(board, camera, fromIndex, toIndex) {
+  if (!board || !camera) return null;
   const { indexToPosition, serpentineIndexToXZ } = board;
   const sanitizeIndex = (value) => {
     const num = Number(value);
@@ -1537,7 +1532,11 @@ function computeTokenFollowCameraState(board, fromIndex, toIndex) {
   const focusTarget = baseVector.clone();
   focusTarget.y += TOKEN_HEIGHT * 0.65;
 
-  const backward = direction.clone().multiplyScalar(-TOKEN_CAMERA_FOLLOW_DISTANCE);
+  const boardLookTarget = board.boardLookTarget;
+  const cameraBoardDistance = boardLookTarget ? camera.position.distanceTo(boardLookTarget) : TOKEN_CAMERA_FOLLOW_DISTANCE;
+  const followDistance = Math.max(TOKEN_CAMERA_FOLLOW_DISTANCE, cameraBoardDistance * 0.82);
+
+  const backward = direction.clone().multiplyScalar(-followDistance);
   const lateral = new THREE.Vector3().crossVectors(direction, WORLD_UP).normalize();
   const cameraPosition = focusTarget
     .clone()
@@ -1577,6 +1576,7 @@ function computeTurnCameraFocusState(board, camera, turnIndex) {
   const anchors = Array.isArray(board.seatAnchors) ? board.seatAnchors : [];
   const seatIndex = Number.isInteger(turnIndex) ? turnIndex : Number(turnIndex);
   if (!Number.isFinite(seatIndex) || seatIndex < 0 || seatIndex >= anchors.length) return null;
+  if (seatIndex === 0) return null;
   const anchor = anchors[seatIndex];
   const boardLookTarget = board.boardLookTarget;
   if (!anchor || !boardLookTarget) return null;
@@ -3119,8 +3119,6 @@ function updateTokens(
     rollingIndex = null,
     currentTurn = null,
     boardRoot = null,
-    seatAnchors = [],
-    baseLevelTop = 0,
     tokenTheme = {},
     tokenShape = null,
     tokenPrototypes = null
@@ -3143,40 +3141,6 @@ function updateTokens(
   });
 
   const keep = new Set();
-
-  const seatHomes = [];
-  if (boardRoot && Array.isArray(seatAnchors) && seatAnchors.length) {
-    boardRoot.updateMatrixWorld(true);
-    const boardHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
-    const baseY = Number.isFinite(baseLevelTop) ? baseLevelTop : 0;
-    const center = new THREE.Vector3(0, baseY, 0);
-    const forwardLift = HOME_TOKEN_FORWARD_LIFT + HOME_TOKEN_OUTWARD_EXTRA;
-    seatAnchors.forEach((anchor, index) => {
-      if (!anchor) {
-        seatHomes[index] = null;
-        return;
-      }
-      anchor.updateMatrixWorld?.(true);
-      const seatWorld = new THREE.Vector3();
-      anchor.getWorldPosition(seatWorld);
-      const seatLocal = seatWorld.clone();
-      boardRoot.worldToLocal(seatLocal);
-      const direction = seatLocal.clone().sub(center);
-      direction.y = 0;
-      if (direction.lengthSq() < 1e-6) {
-        direction.set(0, 0, 1);
-      } else {
-        direction.normalize();
-      }
-      let seatBonus = 0;
-      if (index === 1 || index === 3) seatBonus = SIDE_HOME_EXTRA_DISTANCE;
-      else if (index === 2) seatBonus = BACK_HOME_EXTRA_DISTANCE;
-      const distanceFromBoard = boardHalf + BOARD_EDGE_BUFFER + forwardLift + seatBonus;
-      const target = center.clone().addScaledVector(direction, distanceFromBoard);
-      target.y = baseY + TOKEN_HEIGHT * 0.02;
-      seatHomes[index] = { position: target, direction };
-    });
-  }
 
   const accentTarget = toThreeColor(tokenTheme.accentTarget, TOKEN_ACCENT_TARGET);
   const sheenBlend = Number.isFinite(tokenTheme.sheenBlend) ? tokenTheme.sheenBlend : 0.55;
@@ -3419,19 +3383,9 @@ function updateTokens(
       baseVector.z += offsetZ;
       baseVector.y += TOKEN_HEIGHT * 0.02;
       worldPos = baseVector;
-    } else {
-      const fallbackHomeIndex = seatHomes.length > 0 ? seatIndex % seatHomes.length : -1;
-      const home =
-        seatHomes[seatIndex] || (fallbackHomeIndex >= 0 ? seatHomes[fallbackHomeIndex] : null) || null;
-      if (home?.position) {
-        worldPos = home.position.clone();
-      } else {
-        const fallbackIndex = Number.isFinite(rawPosition) ? rawPosition : 0;
-        worldPos = serpentineIndexToXZ(fallbackIndex).clone();
-        worldPos.y = (Number.isFinite(baseLevelTop) ? baseLevelTop : worldPos.y) + TOKEN_HEIGHT * 0.02;
-      }
     }
 
+    token.visible = hasBoardPosition;
     if (!token.userData.isSliding && worldPos) {
       token.position.copy(worldPos);
     }
@@ -4147,8 +4101,6 @@ export default function SnakeBoard3D({
       rollingIndex,
       currentTurn,
       boardRoot: board.root,
-      seatAnchors: board.seatAnchors,
-      baseLevelTop: board.baseLevelTop,
       tokenTheme,
       tokenShape,
       tokenPrototypes: board.tokenPrototypes
@@ -4179,7 +4131,7 @@ export default function SnakeBoard3D({
     if (movement && shouldFollowTileChange(movement.from, movement.to)) {
       const camera = cameraRef.current;
       const controls = board.controls;
-      const followState = computeTokenFollowCameraState(board, movement.from, movement.to);
+      const followState = computeTokenFollowCameraState(board, camera, movement.from, movement.to);
       if (camera && controls && followState) {
         removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
         removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
@@ -4266,7 +4218,7 @@ export default function SnakeBoard3D({
     const lift = TOKEN_HEIGHT * 0.6;
     const camera = cameraRef.current;
     const controls = board.controls;
-    const followState = computeTokenFollowCameraState(board, slide.from, slide.to);
+    const followState = computeTokenFollowCameraState(board, camera, slide.from, slide.to);
     if (camera && controls && followState && shouldFollowTileChange(slide.from, slide.to)) {
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');


### PR DESCRIPTION
### Motivation
- Remove tokens rendered under player avatars when they are not on the board so only board tokens are visible. 
- Preserve the initial camera orientation for the bottom-seat player instead of auto-rotating the view when their turn begins. 
- Make the camera follow behaviour less intrusive when tokens move by staying behind the token at a larger distance and avoiding aggressive zoom-ins so the board context remains visible. 

### Description
- Increased follow framing constants (`TOKEN_CAMERA_FOLLOW_DISTANCE`, `TOKEN_CAMERA_HEIGHT_OFFSET`, `TOKEN_CAMERA_LATERAL_OFFSET`) to provide a farther, higher, and less lateral camera during token movement. 
- Changed `computeTokenFollowCameraState` signature to accept the active `camera` and compute a `followDistance` using the camera-to-board distance so follow framing scales with the current camera state. 
- Updated calls to token-follow functions to pass the `camera` reference and wired the follow animation creation to use the revised follow state. 
- Prevented the turn-refocus for the bottom seat by returning `null` from `computeTurnCameraFocusState` when `seatIndex === 0` to keep the startup camera orientation. 
- Removed the off-board/home-seat token placement fallback and set tokens to `visible = hasBoardPosition` so tokens are hidden until `position >= 1`, eliminating the visuals beneath avatars. 

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` which reported the repository ESLint ignore-warning for that path (warning only). 
- Ran full lint across the repo which failed due to many pre-existing/unrelated lint errors in other files (pre-existing issues, not introduced by this change). 
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the server started successfully. 
- Captured visual verification screenshots using Playwright for the home page and the Snake game page (`/games/snake?ai=1`) which were produced successfully for manual inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a894c5f9083299553281791f38109)