### PR TITLE
Lower Murlan Royale arena camera and tilt view slightly upward

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4170,7 +4170,7 @@ export default function MurlanRoyaleArena({ search }) {
         camConfig.near,
         camConfig.far
       );
-      const targetHeightOffset = 0.08 * MODEL_SCALE;
+      const targetHeightOffset = 0.11 * MODEL_SCALE;
       let target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset, 0);
       let initialCameraPosition;
       if (humanSeatConfig) {
@@ -4183,15 +4183,15 @@ export default function MurlanRoyaleArena({ search }) {
           );
         const stoolHeight = humanSeatConfig.stoolHeight ?? TABLE_HEIGHT + seatThickness / 2;
         const retreatOffset = isPortrait ? 1.95 : 1.45;
-        const elevation = isPortrait ? 1.7 : 1.37;
+        const elevation = isPortrait ? 1.62 : 1.29;
         initialCameraPosition = stoolAnchor.addScaledVector(humanSeatConfig.forward, -retreatOffset);
         initialCameraPosition.y = stoolHeight + elevation;
-        target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset + 0.12 * MODEL_SCALE, 0);
+        target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset + 0.15 * MODEL_SCALE, 0);
       } else {
         const humanSeatAngle = Math.PI / 2;
         const cameraBackOffset = isPortrait ? 1.65 : 1.05;
         const cameraForwardOffset = isPortrait ? 0.18 : 0.35;
-        const cameraHeightOffset = isPortrait ? 1.24 : 0.96;
+        const cameraHeightOffset = isPortrait ? 1.16 : 0.88;
         initialCameraPosition = new THREE.Vector3(
           Math.cos(humanSeatAngle) * (chairRadius + cameraBackOffset - cameraForwardOffset),
           TABLE_HEIGHT + cameraHeightOffset,


### PR DESCRIPTION
### Motivation
- Improve portrait framing on mobile by moving the initial arena camera a bit lower and angling the view slightly upward so the table and characters read better on-screen.

### Description
- Tweak initial camera setup in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by increasing `targetHeightOffset` from `0.08 * MODEL_SCALE` to `0.11 * MODEL_SCALE`, reducing the seated `elevation` (from `1.7/1.37` to `1.62/1.29`), lifting the human-seat target from `0.12 * MODEL_SCALE` to `0.15 * MODEL_SCALE`, and decreasing the fallback `cameraHeightOffset` (from `1.24/0.96` to `1.16/0.88`) to achieve a slightly lower camera position and a more upward look.

### Testing
- Built the web app with `npm --prefix webapp run build` which completed successfully; and
- Launched a preview and captured an automated Playwright screenshot of `/games/murlanroyale` to validate the adjusted framing (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8c1fe150832988867bd9f65ee4e2)