### PR TITLE
Align Domino Royal table setup with Murlan/Pool inventory and thumbnail menu

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2255,8 +2255,9 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Murlan Default Table',
-      source: 'procedural',
+      source: 'polyhaven',
       price: 0,
+      assetId: 'WoodenTable_01',
       thumbnail: POLYHAVEN_THUMB('WoodenTable_01'),
       description:
         'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
@@ -3039,62 +3040,30 @@ const TABLE_WOOD_OPTIONS = Object.freeze([
   })
 ]);
 
-const TABLE_CLOTH_OPTIONS = Object.freeze([
-  {
-    id: 'crimson',
-    label: 'Crimson Cloth',
-    feltTop: '#960019',
-    feltBottom: '#4a0012',
-    border: '#210308',
-    emissive: '#210308',
-    emissiveIntensity: dimIntensity(0.42)
-  },
-  {
-    id: 'emerald',
-    label: 'Emerald Cloth',
-    feltTop: '#0f6a2f',
-    feltBottom: '#054d24',
-    border: '#021a0b',
-    emissive: '#021a0b',
-    emissiveIntensity: dimIntensity(0.42)
-  },
-  {
-    id: 'arctic',
-    label: 'Arctic Cloth',
-    feltTop: '#2563eb',
-    feltBottom: '#1d4ed8',
-    border: '#071a42',
-    emissive: '#071a42',
-    emissiveIntensity: dimIntensity(0.42)
-  },
-  {
-    id: 'sunset',
-    label: 'Sunset Cloth',
-    feltTop: '#ea580c',
-    feltBottom: '#c2410c',
-    border: '#320e03',
-    emissive: '#320e03',
-    emissiveIntensity: dimIntensity(0.42)
-  },
-  {
-    id: 'violet',
-    label: 'Violet Cloth',
-    feltTop: '#7c3aed',
-    feltBottom: '#5b21b6',
-    border: '#1f0a47',
-    emissive: '#1f0a47',
-    emissiveIntensity: dimIntensity(0.42)
-  },
-  {
-    id: 'amber',
-    label: 'Amber Cloth',
-    feltTop: '#b7791f',
-    feltBottom: '#92571a',
-    border: '#2b1402',
-    emissive: '#2b1402',
-    emissiveIntensity: dimIntensity(0.42)
-  }
+const POOL_ROYALE_DOMINO_CLOTH_PALETTE = Object.freeze([
+  { id: 'cabanGreenMeadow', label: 'Caban Wool — Green Meadow', feltTop: '#33b46a', feltBottom: '#2ca85f', border: '#1f6a3f' },
+  { id: 'cabanGreenSpruce', label: 'Caban Wool — Green Spruce', feltTop: '#2ca85f', feltBottom: '#238f4a', border: '#1a5d35' },
+  { id: 'cabanBlueHarbor', label: 'Caban Wool — Blue Harbor', feltTop: '#0b74c6', feltBottom: '#0a6eb8', border: '#0a355a' },
+  { id: 'cabanBlueFjord', label: 'Caban Wool — Blue Fjord', feltTop: '#1589e6', feltBottom: '#0b74c6', border: '#0a355a' },
+  { id: 'polarFleeceGreenMeadow', label: 'Polar Fleece — Green Meadow', feltTop: '#33b46a', feltBottom: '#2ca85f', border: '#205f40' },
+  { id: 'polarFleeceBlueHarbor', label: 'Polar Fleece — Blue Harbor', feltTop: '#0b74c6', feltBottom: '#0a6eb8', border: '#0b365e' },
+  { id: 'polarFleecePlushGreenMeadow', label: 'Polar Fleece Plush — Green Meadow', feltTop: '#42c47a', feltBottom: '#2ca85f', border: '#1f6b40' },
+  { id: 'polarFleecePlushBlueHarbor', label: 'Polar Fleece Plush — Blue Harbor', feltTop: '#1fa3ff', feltBottom: '#0b74c6', border: '#0b3c66' },
+  { id: 'polarFleeceNatureOceanGreenFern', label: 'Polar Fleece Nature & Ocean — Green Fern', feltTop: '#33b46a', feltBottom: '#238f4a', border: '#1c5a37' },
+  { id: 'polarFleeceNatureOceanBlueCrest', label: 'Polar Fleece Nature & Ocean — Blue Crest', feltTop: '#1589e6', feltBottom: '#095fa4', border: '#0a3458' },
+  { id: 'terryClothGreenMeadow', label: 'Polyhaven Terry Cloth — Green Meadow', feltTop: '#42c47a', feltBottom: '#2ca85f', border: '#1d603b' },
+  { id: 'terryClothBlueHarbor', label: 'Polyhaven Terry Cloth — Blue Harbor', feltTop: '#1fa3ff', feltBottom: '#0b74c6', border: '#0b365f' }
 ]);
+
+const TABLE_CLOTH_OPTIONS = Object.freeze(
+  POOL_ROYALE_DOMINO_CLOTH_PALETTE.map((option) => ({
+    ...option,
+    emissive: option.border,
+    emissiveIntensity: dimIntensity(0.42),
+    swatches: [option.feltTop, option.feltBottom, option.border]
+  }))
+);
+
 
 const TABLE_BASE_OPTIONS = Object.freeze([
   {
@@ -3103,41 +3072,6 @@ const TABLE_BASE_OPTIONS = Object.freeze([
     base: '#141414',
     column: '#0b0d10',
     trim: '#1f232a'
-  },
-  {
-    id: 'forestBronze',
-    label: 'Forest Base',
-    base: '#101714',
-    column: '#0a0f0c',
-    trim: '#1f2d24'
-  },
-  {
-    id: 'midnightChrome',
-    label: 'Midnight Base',
-    base: '#0f172a',
-    column: '#0a1020',
-    trim: '#1e2f4a'
-  },
-  {
-    id: 'emberCopper',
-    label: 'Copper Base',
-    base: '#231312',
-    column: '#140707',
-    trim: '#5c2d1b'
-  },
-  {
-    id: 'violetShadow',
-    label: 'Violet Shadow Base',
-    base: '#1f1130',
-    column: '#130622',
-    trim: '#3f1b5b'
-  },
-  {
-    id: 'desertGold',
-    label: 'Desert Base',
-    base: '#1c1a12',
-    column: '#0f0d06',
-    trim: '#5a4524'
   }
 ]);
 
@@ -3585,9 +3519,8 @@ const TABLE_SETUP_SECTIONS = [
     options: ENVIRONMENT_HDRI_OPTIONS
   },
   { key: 'tableTheme', label: 'Table Theme', options: TABLE_THEME_OPTIONS },
-  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
+  { key: 'tableWood', label: 'Table Finish', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
-  { key: 'tableBase', label: 'Bazamenti', options: TABLE_BASE_OPTIONS },
   { key: 'dominoStyle', label: 'Domino', options: DOMINO_STYLE_OPTIONS },
   {
     key: 'highlightStyle',
@@ -3602,7 +3535,6 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   tableTheme: TABLE_THEME_OPTIONS,
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
-  tableBase: TABLE_BASE_OPTIONS,
   dominoStyle: DOMINO_STYLE_OPTIONS,
   highlightStyle: HIGHLIGHT_STYLE_OPTIONS,
   chairTheme: CHAIR_THEME_OPTIONS
@@ -3717,7 +3649,6 @@ function normalizeAppearance(raw) {
     ['tableTheme', TABLE_THEME_OPTIONS.length],
     ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
-    ['tableBase', TABLE_BASE_OPTIONS.length],
     ['dominoStyle', DOMINO_STYLE_OPTIONS.length],
     ['highlightStyle', HIGHLIGHT_STYLE_OPTIONS.length],
     ['chairTheme', CHAIR_THEME_OPTIONS.length]
@@ -6021,6 +5952,20 @@ function createOptionPreview(key, option) {
   swatch.style.height = '1.5rem';
   swatch.style.borderRadius = '0.75rem';
   swatch.style.border = '1px solid rgba(255,255,255,0.12)';
+  if (option?.thumbnail) {
+    swatch.style.position = 'relative';
+    swatch.style.overflow = 'hidden';
+    swatch.style.height = '3rem';
+    const thumbImage = document.createElement('img');
+    thumbImage.src = option.thumbnail;
+    thumbImage.alt = `${option?.label || option?.id || 'Option'} thumbnail`;
+    thumbImage.loading = 'lazy';
+    thumbImage.decoding = 'async';
+    thumbImage.style.width = '100%';
+    thumbImage.style.height = '100%';
+    thumbImage.style.objectFit = 'cover';
+    swatch.appendChild(thumbImage);
+  }
   switch (key) {
     case 'environmentHdri': {
       swatch.style.background =
@@ -6095,9 +6040,6 @@ function createOptionPreview(key, option) {
       break;
     case 'tableCloth':
       swatch.style.background = `linear-gradient(135deg, ${option.feltTop}, ${option.feltBottom})`;
-      break;
-    case 'tableBase':
-      swatch.style.background = `linear-gradient(135deg, ${option.base}, ${option.trim})`;
       break;
     case 'dominoStyle':
       swatch.style.position = 'relative';
@@ -6251,12 +6193,14 @@ function refreshConfigUI() {
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
     optionsGrid.className = 'config-options';
+    optionsGrid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(110px, 1fr))';
     const availableOptions = getUnlockedOptions(section.key, dominoInventory);
     availableOptions.forEach((option) => {
       const idx = findDominoOptionIndex(section.key, option.id);
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'config-option';
+      button.style.alignItems = 'stretch';
       if (appearance[section.key] === idx) {
         button.classList.add('active');
       }

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,4 +1,5 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
@@ -7,26 +8,20 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'oakEstate', label: 'Lis Estate' },
     { id: 'teakStudio', label: 'Tik Studio' }
   ],
-  tableCloth: [
-    { id: 'crimson', label: 'Crimson Cloth' },
-    { id: 'emerald', label: 'Emerald Cloth' },
-    { id: 'arctic', label: 'Arctic Cloth' },
-    { id: 'sunset', label: 'Sunset Cloth' },
-    { id: 'violet', label: 'Violet Cloth' },
-    { id: 'amber', label: 'Amber Cloth' }
-  ],
-  tableBase: [
-    { id: 'obsidian', label: 'Obsidian Base' },
-    { id: 'forestBronze', label: 'Forest Base' },
-    { id: 'midnightChrome', label: 'Midnight Base' },
-    { id: 'emberCopper', label: 'Copper Base' },
-    { id: 'violetShadow', label: 'Violet Shadow Base' },
-    { id: 'desertGold', label: 'Desert Base' }
-  ],
-  tableTheme: MURLAN_TABLE_THEMES.map(({ id, label, price = 0, description }) => ({
+  tableCloth: POOL_ROYALE_CLOTH_VARIANTS.map(({ id, name, price = 0, description, swatches }) => ({
+    id,
+    label: name,
+    price,
+    description,
+    swatches
+  })),
+  tableTheme: MURLAN_TABLE_THEMES.map(({ id, label, price = 0, description, source, assetId, preserveMaterials }) => ({
     id,
     label,
     price,
+    source: id === 'murlan-default' ? 'polyhaven' : source,
+    assetId: id === 'murlan-default' ? 'WoodenTable_01' : assetId,
+    preserveMaterials: id === 'murlan-default' ? true : preserveMaterials,
     description: description || `${label} table from Murlan Royale`
   })),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map(({ id, name }) => ({ id, label: `${name} HDRI` })),
@@ -66,15 +61,6 @@ const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
   amber: swatchThumbnail(['#b7791f', '#92571a', '#fde68a'])
 });
 
-const DOMINO_TABLE_BASE_THUMBNAILS = Object.freeze({
-  obsidian: swatchThumbnail(['#141414', '#1f232a', '#94a3b8']),
-  forestBronze: swatchThumbnail(['#101714', '#1f2d24', '#4ade80']),
-  midnightChrome: swatchThumbnail(['#0f172a', '#1e2f4a', '#93c5fd']),
-  emberCopper: swatchThumbnail(['#231312', '#5c2d1b', '#fdba74']),
-  violetShadow: swatchThumbnail(['#1f1130', '#3f1b5b', '#c4b5fd']),
-  desertGold: swatchThumbnail(['#1c1a12', '#5a4524', '#fcd34d'])
-});
-
 const DOMINO_STYLE_THUMBNAILS = Object.freeze({
   imperialIvory: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0']),
   obsidianPlatinum: swatchThumbnail(['#1f2937', '#6b7280', '#e5e7eb']),
@@ -96,7 +82,6 @@ const getDefaultOptionId = (options) => options?.[0]?.id;
 export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze({
   tableWood: [getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableWood)].filter(Boolean),
   tableCloth: [getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableCloth)].filter(Boolean),
-  tableBase: [getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableBase)].filter(Boolean),
   tableTheme: [getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableTheme)].filter(Boolean),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   dominoStyle: [getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.dominoStyle)].filter(Boolean),
@@ -123,7 +108,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 780,
-    description: 'Alternate premium wood finish for your Domino Royal arena.',
+    description: 'Alternate premium table finish for your Domino Royal arena.',
     thumbnail: DOMINO_TABLE_WOOD_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableCloth.slice(1).map((option, idx) => ({
@@ -131,18 +116,9 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     type: 'tableCloth',
     optionId: option.id,
     name: option.label,
-    price: 340 + idx * 30,
-    description: 'Unlock a new felt tone for the Domino Royal table surface.',
-    thumbnail: DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
-  })),
-  ...DOMINO_ROYAL_OPTION_SETS.tableBase.slice(1).map((option, idx) => ({
-    id: `domino-base-${option.id}`,
-    type: 'tableBase',
-    optionId: option.id,
-    name: option.label,
-    price: 520 + idx * 40,
-    description: 'Swap in a different pedestal finish beneath the table.',
-    thumbnail: DOMINO_TABLE_BASE_THUMBNAILS[option.id]
+    price: option.price || 340 + idx * 30,
+    description: option.description || 'Unlock a new felt tone for the Domino Royal table surface.',
+    thumbnail: option.swatches?.length ? swatchThumbnail(option.swatches) : DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
     id: `domino-table-theme-${option.id}`,
@@ -206,11 +182,6 @@ export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
     type: 'tableCloth',
     optionId: getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableCloth),
     label: getLabelForOption('tableCloth', getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableCloth))
-  },
-  {
-    type: 'tableBase',
-    optionId: getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableBase),
-    label: getLabelForOption('tableBase', getDefaultOptionId(DOMINO_ROYAL_OPTION_SETS.tableBase))
   },
   {
     type: 'tableTheme',


### PR DESCRIPTION
### Motivation
- Make Domino Royal table setup match the thumbnail-first layout used in Snake & Ladder and Pool/Murlan games for consistent UX.  
- Use the same Murlan default table GLTF/material behavior and Pool Royale cloth materials so Domino visuals match the Murlan Royale quality.  
- Surface the table finish and cloth options from the shared catalogs and remove the separate table base category to simplify store/setup parity.  

### Description
- Reworked Domino inventory so `tableCloth` is sourced from `POOL_ROYALE_CLOTH_VARIANTS` and cloth store items use the Pool cloth palette and swatches (updated `webapp/src/config/dominoRoyalInventoryConfig.js`).  
- Removed `tableBase` from Domino option sets, default loadout and store items, and simplified `TABLE_BASE_OPTIONS` to a single internal fallback (changes in `webapp/src/config/dominoRoyalInventoryConfig.js` and `webapp/public/domino-royal-game.js`).  
- Treat `murlan-default` table as Polyhaven/preserved-material style (added `assetId`/`source`/`preserveMaterials` metadata) to keep GLTF/material parity with Murlan Royale (changes to `MURLAN_TABLE_THEMES` metadata).  
- Updated Domino public game script `webapp/public/domino-royal-game.js` to present setup options in a thumbnail-first card grid by: showing `option.thumbnail` in `createOptionPreview`, changing the setup grid columns, and relabeling `tableWood` to `Table Finish`.  
- Adjusted store item descriptions and thumbnail handling for cloth and wood finishes to prefer provided swatches/thumbnails, keeping prices/descriptions pluggable from the pool catalog.  

### Testing
- Ran syntax checks: `node --check webapp/public/domino-royal-game.js` and `node --check webapp/src/config/dominoRoyalInventoryConfig.js`, both succeeded.  
- Ran unit/integration test: `npm test -- test/storePurchaseRoute.test.js --runInBand`, which failed due to an existing assertion mismatch in the test expecting transaction type `storefront` but receiving `store` (failure appears unrelated to the Domino UI/inventory changes).  
- Launched the webapp dev server and captured a mobile portrait screenshot of the updated Domino setup panel using Playwright; screenshot artifact was produced (`artifacts/domino-setup-menu.png`) and verifies thumbnail-first option cards render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8756e7a08329bfa52e2b54c14a1e)