### PR TITLE
Adjust Murlan Royale camera framing for lower viewpoint

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4170,7 +4170,7 @@ export default function MurlanRoyaleArena({ search }) {
         camConfig.near,
         camConfig.far
       );
-      const targetHeightOffset = 0.11 * MODEL_SCALE;
+      const targetHeightOffset = 0.16 * MODEL_SCALE;
       let target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset, 0);
       let initialCameraPosition;
       if (humanSeatConfig) {
@@ -4183,7 +4183,7 @@ export default function MurlanRoyaleArena({ search }) {
           );
         const stoolHeight = humanSeatConfig.stoolHeight ?? TABLE_HEIGHT + seatThickness / 2;
         const retreatOffset = isPortrait ? 1.95 : 1.45;
-        const elevation = isPortrait ? 1.62 : 1.29;
+        const elevation = isPortrait ? 1.52 : 1.21;
         initialCameraPosition = stoolAnchor.addScaledVector(humanSeatConfig.forward, -retreatOffset);
         initialCameraPosition.y = stoolHeight + elevation;
         target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset + 0.15 * MODEL_SCALE, 0);


### PR DESCRIPTION
### Motivation
- Lower the Murlan Royale camera slightly and make it look a bit more upward so the player view on portrait phones sits lower on screen while still keeping existing orbit behavior.

### Description
- Tweaked the initial look target and human-seat camera elevation in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by increasing `targetHeightOffset` to `0.16 * MODEL_SCALE` and reducing the human-seat `elevation` to `1.52` (portrait) / `1.21` (landscape).

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which completed but the file is ignored by the lint config (warning); `npm run build` failed due to a pre-existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts`; the web dev server for the webapp was started (`npm --prefix webapp run dev`) and a portrait screenshot was captured at `browser:/tmp/codex_browser_invocations/6b995632f9945c98/artifacts/artifacts/murlan-camera-adjusted.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a950b0c848329bb3b35d34e68d036)