### PR TITLE
Adjust Snake & Ladder camera framing and simplify dice CTA

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4042,11 +4042,7 @@ export default function SnakeAndLadder() {
                 muted={muted}
                 renderVisual={false}
                 placeholder={
-                  <span
-                    className={`text-[0.65rem] font-semibold uppercase tracking-widest ${canRoll ? 'text-amber-200' : 'text-slate-300/70'}`}
-                  >
-                    {canRoll ? 'Tap Dice' : ''}
-                  </span>
+                  <span className="sr-only">Roll dice</span>
                 }
                 diceWrapperClassName={`w-full h-full rounded-full border-2 flex items-center justify-center shadow-[0_0_20px_rgba(250,204,21,0.25)] ${
                   canRoll ? 'border-amber-300/80 bg-amber-200/15 animate-pulse' : 'border-white/15 bg-slate-900/45'
@@ -4076,9 +4072,7 @@ export default function SnakeAndLadder() {
                   divRef={diceRollerDivRef}
                   renderVisual={false}
                   placeholder={
-                    <span className="text-[0.65rem] font-semibold uppercase tracking-widest text-amber-200">
-                      Tap Dice
-                    </span>
+                    <span className="sr-only">Roll dice</span>
                   }
                   diceWrapperClassName={`w-full h-full rounded-full border-2 flex items-center justify-center shadow-[0_0_20px_rgba(250,204,21,0.25)] ${
                     canRoll ? 'border-amber-300/80 bg-amber-200/15 animate-pulse' : 'border-white/15 bg-slate-900/45'


### PR DESCRIPTION
### Motivation

- Improve mobile/portrait visual match for the Snake & Ladder scene by changing default camera placement and make user look interactions behave like a head turn (look-only) instead of moving the camera position. 
- Simplify the dice UI to keep a single clear action (`ROLL`) and remove the distracting secondary "Tap Dice" label while keeping accessibility text.

### Description

- Tuned portrait camera offsets (`cameraBackOffset`, `cameraForwardOffset`, `cameraHeightOffset`) so the default framing better matches the reference composition for phone portrait. (`webapp/src/components/SnakeBoard3D.jsx`).
- Switched off OrbitControls zoom/rotate and replaced touch/drag behavior with a custom look-only handler that updates yaw/pitch and adjusts `controls.target` while keeping the camera position fixed to emulate a player turning their head; added pointer handlers `pointerdown`, `pointermove`, `pointerup`, `pointercancel` and corresponding apply/reset helpers (`headLookState`, `applyHeadLook`, `resetHeadLookBase`). (`webapp/src/components/SnakeBoard3D.jsx`).
- Added cleanup of the custom pointer listeners in the arena dispose handler to avoid event leaks. (`webapp/src/components/SnakeBoard3D.jsx`).
- Removed visible "Tap Dice" text from the interactive dice placeholders and replaced it with an accessible-only label (`<span className="sr-only">Roll dice</span>`), leaving the primary `ROLL` button as the single visible CTA. (`webapp/src/pages/Games/SnakeAndLadder.jsx`).

### Testing

- Ran a production build with `npm --prefix webapp run build` which completed successfully (build warnings about large chunks were reported but the build finished). ✅
- Ran the dev server and captured a mobile-size screenshot using Playwright to verify camera framing and dice UI changes; screenshot artifact was produced. ✅
- Executed `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`; ESLint ran but these files are ignored by project lint ignore settings and produced warnings only. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa361baa4832992a7818d792ee721)