### PR TITLE
Adjust Murlan Royale chair sizing and seated camera framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1923,13 +1923,14 @@ const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
-const HUMAN_CHAIR_PULLBACK = 0.32 * MODEL_SCALE;
+const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
 const CHAIR_RADIUS = BASE_HUMAN_CHAIR_RADIUS + HUMAN_CHAIR_PULLBACK;
-const AI_CHAIR_GAP = CARD_W * 0.4;
+const AI_CHAIR_GAP = CARD_W * 0.2;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
+const CHAIR_VISUAL_SCALE = 1.12;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.56, landscape: 0.98 });
-const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.34, landscape: 0.98 });
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 0.8 });
+const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.14, landscape: 0.82 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(7);
@@ -4091,6 +4092,7 @@ export default function MurlanRoyaleArena({ search }) {
       for (let i = 0; i < CHAIR_COUNT; i++) {
         const player = players[i] ?? null;
         const chair = new THREE.Group();
+        chair.scale.setScalar(CHAIR_VISUAL_SCALE);
         const chairModel = chairTemplate.clone(true);
         chair.add(chairModel);
         chair.userData.chairModel = chairModel;


### PR DESCRIPTION
### Motivation
- Make Murlan Royale seating visually larger and bring chairs closer to the table for a tighter composition. 
- Lower and move the seated camera closer so the table appears larger and more centered on mobile portrait screens. 
- Keep changes localized to arena layout and camera framing to preserve other gameplay systems.

### Description
- Updated chair/table staging constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by reducing `HUMAN_CHAIR_PULLBACK` and halving `AI_CHAIR_GAP` so chairs sit closer to the table. 
- Added `CHAIR_VISUAL_SCALE = 1.12` and apply `chair.scale.setScalar(CHAIR_VISUAL_SCALE)` when spawning each chair so chairs appear slightly larger. 
- Tuned seated camera parameters by reducing `CAMERA_SEATED_RETREAT_OFFSETS` and `CAMERA_SEATED_ELEVATION_OFFSETS` (portrait and landscape) to lower and move the camera closer to the table. 
- Changes are confined to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (chair build, chair placement loop, and camera setup constants).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Launched the dev server with `npm --prefix webapp run dev` and captured a mobile-portrait screenshot of `/games/murlanroyale` using Playwright (artifact: `browser:/tmp/codex_browser_invocations/0dde70339ee4a763/artifacts/artifacts/murlan-royale-chair-camera.png`). 
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced a repository ignore warning but no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa4511fcc8329803a309c55da70c6)