### PR TITLE
Align Domino Royale asset resolution and increase domino geometry detail

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2313,6 +2313,12 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
 const polyhavenModelCache = new Map();
+const MURLAN_MODEL_RESOLUTION_ORDER = Object.freeze(['2k', '1k']);
+const DOMINO_FACE_GEOMETRY_RESOLUTION = Object.freeze({
+  roundedBoxSegments: 6,
+  pipSegments: 40,
+  ringSegments: 80
+});
 
 function createPolyhavenGltfLoader({ assetId, resolution }) {
   const manager = new THREE.LoadingManager();
@@ -2339,11 +2345,7 @@ async function loadPolyhavenModel(assetId) {
     const cached = polyhavenModelCache.get(assetId);
     return cached.clone(true);
   }
-  const resolutionOrder = isLowProfileDevice
-    ? ['1k', '2k']
-    : prefersUhd
-      ? ['4k', '2k', '1k']
-      : ['2k', '1k', '4k'];
+  const resolutionOrder = MURLAN_MODEL_RESOLUTION_ORDER;
   const candidates = resolutionOrder.map((resolution) => ({
     url: `https://dl.polyhaven.org/file/ph-assets/Models/gltf/${resolution}/${assetId}/${assetId}_${resolution}.gltf`,
     resolution
@@ -6604,7 +6606,11 @@ function addPips(dominoFace, count, yOffset) {
   const positions = pipPositions();
   const idxs = INDEX_SETS[Math.max(0, Math.min(6, count))];
   const pipRadius = dominoStyleProfile.pipRadius ?? 0.085;
-  const pipGeo = new THREE.SphereGeometry(pipRadius, 32, 32);
+  const pipGeo = new THREE.SphereGeometry(
+    pipRadius,
+    DOMINO_FACE_GEOMETRY_RESOLUTION.pipSegments,
+    DOMINO_FACE_GEOMETRY_RESOLUTION.pipSegments
+  );
   idxs.forEach((i) => {
     const [px, py] = positions[i];
     const sphere = new THREE.Mesh(pipGeo, pipMat);
@@ -6614,7 +6620,11 @@ function addPips(dominoFace, count, yOffset) {
     // Luxury accent ring around each pip
     const innerR = dominoStyleProfile.ringInner ?? 0.107;
     const outerR = dominoStyleProfile.ringOuter ?? 0.12;
-    const ringGeo = new THREE.RingGeometry(innerR, outerR, 64);
+    const ringGeo = new THREE.RingGeometry(
+      innerR,
+      outerR,
+      DOMINO_FACE_GEOMETRY_RESOLUTION.ringSegments
+    );
     const ring = new THREE.Mesh(ringGeo, accentMat.clone());
     ring.material.emissiveIntensity =
       dominoStyleProfile.ringEmissiveIntensity ??
@@ -6643,7 +6653,13 @@ function makeDomino(
   const group = new THREE.Group();
 
   // Body EXACTLY as in your code
-  const bodyGeo = new RoundedBoxGeometry(1, 2, 0.22, 4, 0.06);
+  const bodyGeo = new RoundedBoxGeometry(
+    1,
+    2,
+    0.22,
+    DOMINO_FACE_GEOMETRY_RESOLUTION.roundedBoxSegments,
+    0.06
+  );
   const bodyMaterial = porcelainMat.clone();
   bodyMaterial.envMapIntensity = porcelainMat.envMapIntensity;
   const body = new THREE.Mesh(bodyGeo, bodyMaterial);


### PR DESCRIPTION
### Motivation
- Make Domino Royale use the same Polyhaven model resolution policy as Murlan Royale so table/chair assets load at comparable detail and match the game graphics.
- Improve domino mesh fidelity (body, pips, rings) so tiles visually match the higher-detail cards/textures used elsewhere.

### Description
- Added `MURLAN_MODEL_RESOLUTION_ORDER = ['2k','1k']` and switched Polyhaven model loading in Domino Royale to use this order for table/chair assets in `webapp/public/domino-royal-game.js`.
- Introduced `DOMINO_FACE_GEOMETRY_RESOLUTION` and applied it to domino geometry: increased `RoundedBoxGeometry` segments, `SphereGeometry` (pip) segments, and `RingGeometry` segments to sharpen tile visuals.
- Kept behavior and world-scale of dominoes unchanged; changes are limited to geometry detail and model resolution selection.

### Testing
- `node --check webapp/public/domino-royal-game.js` — success.
- Launched local dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully.
- Automated visual check: Playwright navigated to `/games/domino-royal` and captured a screenshot artifact to validate visual result (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa613573c83298958ce1b861a2bd9)