### PR TITLE
Adjust Murlan Royale camera/chair positioning and widen default table

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -100,7 +100,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE * 1.15;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -1923,14 +1923,14 @@ const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
-const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
-const CHAIR_INWARD_OFFSET = 0.18 * MODEL_SCALE;
+const HUMAN_CHAIR_PULLBACK = 0.04 * MODEL_SCALE;
+const CHAIR_INWARD_OFFSET = 0.24 * MODEL_SCALE;
 const CHAIR_RADIUS = BASE_HUMAN_CHAIR_RADIUS + HUMAN_CHAIR_PULLBACK - CHAIR_INWARD_OFFSET;
 const AI_CHAIR_GAP = CARD_W * 0.2;
-const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INWARD_OFFSET * 0.45;
+const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INWARD_OFFSET * 0.65;
 const CHAIR_VISUAL_SCALE = 1.12;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 0.8 });
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.12, landscape: 0.72 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.22, landscape: 0.86 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
@@ -1954,7 +1954,7 @@ const CAMERA_PLAYER_SWITCH_HOLD_MS = 1500;
 const CAMERA_TURN_DURATION_MS = 360;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
-const CAMERA_INWARD_RADIUS_FACTOR = 0.91;
+const CAMERA_INWARD_RADIUS_FACTOR = 0.86;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -4200,8 +4200,8 @@ export default function MurlanRoyaleArena({ search }) {
         target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset + CAMERA_FOCUS_CENTER_LIFT, 0);
       } else {
         const humanSeatAngle = Math.PI / 2;
-        const cameraBackOffset = isPortrait ? 1.65 : 1.05;
-        const cameraForwardOffset = isPortrait ? 0.18 : 0.35;
+        const cameraBackOffset = isPortrait ? 1.5 : 0.96;
+        const cameraForwardOffset = isPortrait ? 0.22 : 0.39;
         const cameraHeightOffset = isPortrait ? 1.16 : 0.88;
         initialCameraPosition = new THREE.Vector3(
           Math.cos(humanSeatAngle) * (chairRadius + cameraBackOffset - cameraForwardOffset),


### PR DESCRIPTION
### Motivation
- Improve visual framing for the Murlan Royale table by bringing the camera and chairs slightly closer to the table in portrait view so the table reads larger and more intimate on phone screens.
- Make the default table footprint wider so the base table appears about 15% broader and better matches the desired composition.

### Description
- Increased the default table radius by 15% via `TABLE_RADIUS = 3.4 * MODEL_SCALE * 1.15` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the table appears wider.
- Pulled chairs inward by reducing `HUMAN_CHAIR_PULLBACK` from `0.08 * MODEL_SCALE` to `0.04 * MODEL_SCALE` and increasing `CHAIR_INWARD_OFFSET` from `0.18 * MODEL_SCALE` to `0.24 * MODEL_SCALE`, and adjusted `AI_CHAIR_RADIUS` calculation to account for the change.
- Brought the default camera framing closer by tightening seated retreat offsets (`CAMERA_SEATED_RETREAT_OFFSETS` portrait/landscape), adjusting fallback `cameraBackOffset`/`cameraForwardOffset` values, and reducing `CAMERA_INWARD_RADIUS_FACTOR` from `0.91` to `0.86` to bias the orbit radius inward.
- All edits are contained in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and aim to preserve other camera/controls constraints and UI layout.

### Testing
- Ran `npm --prefix webapp run build` successfully to validate production bundle generation and ensure no compile errors.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the page loads for interactive validation.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/games/murlanroyale` in a portrait viewport to validate the new camera/chair/table composition, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab88f8d508329832aea83cfba1c64)