### PR TITLE
Snake & Ladder: hide tap-dice UI, tune 3D camera, and skip AI startup warning

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -2541,9 +2541,9 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   const camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
   const isPortrait = host.clientHeight > host.clientWidth;
   const cameraSeatAngle = Math.PI / 2;
-  const cameraBackOffset = isPortrait ? 1.65 : 1.05;
+  const cameraBackOffset = isPortrait ? 1.56 : 1.0;
   const cameraForwardOffset = isPortrait ? 0.18 : 0.35;
-  const cameraHeightOffset = isPortrait ? 1.46 : 1.12;
+  const cameraHeightOffset = isPortrait ? 1.56 : 1.18;
   const cameraRadius = chairRadius + cameraBackOffset - cameraForwardOffset;
   camera.position.set(
     Math.cos(cameraSeatAngle) * cameraRadius,


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by removing the floating circular "Tap Dice" control and leaving the bottom ROLL button as the primary input. 
- Pull the 3D camera slightly closer and a bit higher so the board appears more prominent and centered on phone screens. 
- Remove the startup quit-warning when a player is facing AI to streamline single-player onboarding.

### Description
- Hidden the on-screen circular dice tap UI and moved active `DiceRoller` instances into visually hidden (`sr-only`) containers so rolling logic and events remain functional while the visible ring/button is removed (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Removed/disabled dice anchor/visibility layout variables and references so the UI no longer renders the floating dice anchor or ring (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Tuned portrait camera offsets to be slightly closer and higher by adjusting `cameraBackOffset` and `cameraHeightOffset` in the 3D board component (`webapp/src/components/SnakeBoard3D.jsx`).
- Disabled the initial quit-warning popup for AI matches by defaulting `showQuitInfo` to hidden and setting it only for non-AI sessions (`webapp/src/pages/Games/SnakeAndLadder.jsx`).

### Testing
- Ran lint on the modified files with `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx webapp/src/components/SnakeBoard3D.jsx`, which completed but produced repo ignore warnings for those paths. 
- Ran unit tests with `npm test -- --runInBand test/snakeGame.test.js`, which reported all assertions passing (10 tests passed) but the Jest process exited non-zero due to an unrelated async/mongoose teardown warning (open handle), not caused by these UI changes. 
- Launched the webapp dev server and captured a portrait screenshot of the updated scene using a Playwright script (`vite` dev server + automated screenshot), which produced a visual verification artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac02029948329b352e1f9e145f182)