### PR TITLE
Murlan Royale: tighten camera, bring card pile forward, and increase chair height

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1939,7 +1939,7 @@ const HUMAN_HAND_CARD_SCALE = 1.15;
 const COMMUNITY_CARD_TOP_TILT = 0;
 const COMMUNITY_CARD_SCALE = HUMAN_HAND_CARD_SCALE;
 const COMMUNITY_CARD_SPACING_MULTIPLIER = 0.88;
-const TABLE_CARD_AREA_FORWARD_SHIFT = 0.34 * MODEL_SCALE;
+const TABLE_CARD_AREA_FORWARD_SHIFT = 0.42 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
@@ -1958,7 +1958,7 @@ const CAMERA_TURN_DURATION_MS = 360;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
 const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
-const CAMERA_INWARD_RADIUS_FACTOR = 0.88;
+const CAMERA_INWARD_RADIUS_FACTOR = 0.86;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -4110,7 +4110,11 @@ export default function MurlanRoyaleArena({ search }) {
       for (let i = 0; i < CHAIR_COUNT; i++) {
         const player = players[i] ?? null;
         const chair = new THREE.Group();
-        chair.scale.setScalar(CHAIR_VISUAL_SCALE);
+        chair.scale.set(
+          CHAIR_VISUAL_SCALE,
+          CHAIR_VISUAL_SCALE * 1.08,
+          CHAIR_VISUAL_SCALE
+        );
         const chairModel = chairTemplate.clone(true);
         chair.add(chairModel);
         chair.userData.chairModel = chairModel;


### PR DESCRIPTION
### Motivation
- Improve visual composition on portrait phones by bringing the camera and table elements slightly closer to the bottom player.  
- Make chairs read a bit taller to improve player presence and legibility in the 3D arena.  

### Description
- Reduced `CAMERA_INWARD_RADIUS_FACTOR` from `0.88` to `0.86` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to pull the arena camera slightly inward for portrait screens.  
- Increased `TABLE_CARD_AREA_FORWARD_SHIFT` from `0.34 * MODEL_SCALE` to `0.42 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so community/table/discard cards sit a bit closer toward the bottom (player) view.  
- Made chairs slightly taller by replacing `chair.scale.setScalar(CHAIR_VISUAL_SCALE)` with `chair.scale.set(CHAIR_VISUAL_SCALE, CHAIR_VISUAL_SCALE * 1.08, CHAIR_VISUAL_SCALE)` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to boost Y-axis scale while keeping X/Z stable.  

### Testing
- Ran unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed.  
- Ran linter with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which executed but reported the file is ignored by the current ESLint ignore settings (warning, no errors).  
- Performed an automated visual check by launching the dev server and capturing a portrait screenshot via Playwright; the script completed and produced the updated arena screenshot for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac1af8aa48329aec36a51c08470e4)