### PR TITLE
Fix Texas Hold'em community card alignment and spacing

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -347,7 +347,7 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
-const COMMUNITY_SPACING = CARD_W * 0.62;
+const COMMUNITY_SPACING = CARD_W * 1.08;
 const COMMUNITY_CARD_FORWARD_OFFSET = 0;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
@@ -3863,10 +3863,7 @@ function TexasHoldemArena({ search }) {
     const humanSeat = seatLayout.find((seat) => seat.isHuman) ?? seatLayout[0];
     humanSeatRef.current = humanSeat;
     seatTopPointRef.current = seatTopPoint;
-    const communityRowRotation = Math.atan2(humanSeat.right.z, humanSeat.right.x);
-    const resolvedCommunityRowRotation = Number.isFinite(communityRowRotation)
-      ? communityRowRotation
-      : COMMUNITY_ROW_ROTATION;
+    const resolvedCommunityRowRotation = COMMUNITY_ROW_ROTATION;
     const raiseControls = createRaiseControls({ arena: arenaGroup, seat: humanSeat, chipFactory, tableInfo });
     const cameraTarget = new THREE.Vector3(0, TABLE_HEIGHT + CAMERA_TARGET_LIFT, 0);
 
@@ -4912,7 +4909,7 @@ function TexasHoldemArena({ search }) {
       const surfaceY = three.tableInfo?.surfaceY ?? TABLE_HEIGHT;
       const slotPosition = computeCommunitySlotPosition(idx, { rotationY: rowRotation, surfaceY });
       mesh.position.copy(slotPosition);
-      const forward = new THREE.Vector3(0, 0, 1).applyAxisAngle(WORLD_UP, COMMUNITY_ROW_ROTATION);
+      const forward = new THREE.Vector3(0, 0, 1).applyAxisAngle(WORLD_UP, rowRotation);
       const lookTarget = slotPosition
         .clone()
         .add(new THREE.Vector3(0, COMMUNITY_CARD_LOOK_LIFT, 0))


### PR DESCRIPTION
### Motivation
- Community (board) cards were visually too close and could overlap; the board must appear as a straight horizontal row with gaps between cards so they do not touch.

### Description
- Increased community card slot spacing by updating `COMMUNITY_SPACING` from `CARD_W * 0.62` to `CARD_W * 1.08` to prevent overlapping. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Stabilized the community row rotation by removing derivation from the human seat and using the fixed `COMMUNITY_ROW_ROTATION` when resolving the community row rotation. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Use the active row rotation (`rowRotation`) when computing the community card look/forward vector so card faces orient consistently with the row. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. (success)
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which produced a file-ignore warning but no errors. (warning)
- Launched the dev server and captured a Playwright screenshot of `/games/texasholdem` to validate the horizontal community card layout; screenshot artifact: `artifacts/texas-community-cards-horizontal.png`. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac9a05fd4832986e8334b287849b6)