### PR TITLE
Align Texas Hold'em card placement with Murlan Royale layout

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -348,7 +348,8 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
 const COMMUNITY_SPACING = CARD_W * 1.08;
-const COMMUNITY_CARD_FORWARD_OFFSET = 0;
+const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
+const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
@@ -4274,8 +4275,9 @@ function TexasHoldemArena({ search }) {
             const position = baseAnchor.clone().add(right.clone().multiplyScalar((idx - 0.5) * HOLE_SPACING));
             mesh.position.copy(position);
 
-            const lookTarget = camera.position
+            const lookTarget = humanSeatGroup.focus
               .clone()
+              .addScaledVector(humanSeatGroup.forward, 2.4 * MODEL_SCALE)
               .add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
             lookTarget.y = position.y + HUMAN_CARD_LOOK_LIFT;
             orientCard(mesh, lookTarget, { face: 'front', flat: false });
@@ -4771,8 +4773,9 @@ function TexasHoldemArena({ search }) {
         mesh.position.copy(position);
         const lookOrigin = seat.isHuman ? baseAnchor : seat.stoolAnchor;
         const lookTarget = seat.isHuman
-          ? three.camera.position
+          ? seat.focus
               .clone()
+              .addScaledVector(forward, 2.4 * MODEL_SCALE)
               .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
               .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
           : lookOrigin


### PR DESCRIPTION
### Motivation
- Make Texas Hold'em community and player hole cards visually consistent with the Murlan Royale arena by aligning forward placement and orientation behaviors while keeping existing intra-card spacing.

### Description
- Added `TABLE_CARD_AREA_FORWARD_SHIFT` and set `COMMUNITY_CARD_FORWARD_OFFSET` to it so the community row uses the same table-area forward offset pattern as Murlan Royale while preserving `COMMUNITY_SPACING`.
- Updated initial human hole-card orientation to target the seat `focus` plus a forward offset (`focus + forward * 2.4 * MODEL_SCALE`) instead of aiming at the camera.
- Applied the same focus-forward targeting in the per-frame update path so human hole cards stay consistently oriented across gameplay transitions and animations.
- Changed file: `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran `npm -C webapp run build`, which completed successfully (Vite build finished; only non-blocking chunk-size/dynamic-import warnings were reported).
- Launched the dev server (`npm -C webapp run dev`) and captured a portrait screenshot of `/games/texasholdem` via Playwright to visually validate the updated card layout (screenshot artifact produced).
- No unit tests were modified; no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad97c21cc8329a46f0c8459aca445)