### PR TITLE
Align Snake & Ladder seating with Ludo and park idle tokens on player rails

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3143,7 +3143,10 @@ function updateTokens(
     baseLevelTop = 0,
     tokenTheme = {},
     tokenShape = null,
-    tokenPrototypes = null
+    tokenPrototypes = null,
+    seatAnchors = [],
+    boardLookTarget = null,
+    boardRoot = null
   } = {}
 ) {
   if (!tokensGroup) return;
@@ -3406,9 +3409,31 @@ function updateTokens(
       baseVector.y += TOKEN_HEIGHT * 0.02;
       worldPos = baseVector;
     } else {
-      const fallbackIndex = Number.isFinite(rawPosition) ? rawPosition : 0;
-      worldPos = serpentineIndexToXZ(fallbackIndex).clone();
-      worldPos.y = (Number.isFinite(baseLevelTop) ? baseLevelTop : worldPos.y) + TOKEN_HEIGHT * 0.02;
+      const seatAnchor = Number.isFinite(seatIndex) ? seatAnchors?.[seatIndex] : null;
+      if (seatAnchor && boardLookTarget && boardRoot) {
+        const seatWorld = new THREE.Vector3();
+        seatAnchor.getWorldPosition(seatWorld);
+        const inward = boardLookTarget.clone().sub(seatWorld).setY(0);
+        if (inward.lengthSq() > 0.0001) {
+          inward.normalize();
+          const lateral = new THREE.Vector3(-inward.z, 0, inward.x);
+          const frontOffset = TOKEN_RADIUS * 1.6;
+          const spreadOffset = TOKEN_RADIUS * 0.95;
+          const offsetSign = index % 2 === 0 ? -1 : 1;
+          const railWorld = seatWorld
+            .clone()
+            .addScaledVector(inward, frontOffset)
+            .addScaledVector(lateral, spreadOffset * offsetSign);
+          worldPos = railWorld.clone();
+          boardRoot.worldToLocal(worldPos);
+          worldPos.y = (Number.isFinite(baseLevelTop) ? baseLevelTop : worldPos.y) + TOKEN_HEIGHT * 0.02;
+        }
+      }
+      if (!worldPos) {
+        const fallbackIndex = Number.isFinite(rawPosition) ? rawPosition : 0;
+        worldPos = serpentineIndexToXZ(fallbackIndex).clone();
+        worldPos.y = (Number.isFinite(baseLevelTop) ? baseLevelTop : worldPos.y) + TOKEN_HEIGHT * 0.02;
+      }
     }
 
     if (!token.userData.isSliding && worldPos) {
@@ -4128,7 +4153,10 @@ export default function SnakeBoard3D({
       baseLevelTop: board.baseLevelTop,
       tokenTheme,
       tokenShape,
-      tokenPrototypes: board.tokenPrototypes
+      tokenPrototypes: board.tokenPrototypes,
+      seatAnchors: board.seatAnchors,
+      boardLookTarget: board.boardLookTarget,
+      boardRoot: board.root
     });
 
     const sanitizedPositions = players.map((player) => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -262,7 +262,7 @@ const SNAKE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = SNAKE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SEAT_LAYOUTS = {
   1: [0],
-  2: [0, 2],
+  2: [3, 1],
   3: [0, 1, 3],
   4: [0, 1, 2, 3]
 };


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder arena match the Ludo Battle Royal seating (left/right for 2 players) so on-screen player positioning reads consistently across games.
- Show idle player tokens on the wooden rail area in front of each assigned seat (like Ludo) instead of using board fallback coordinates, improving visual clarity and UX.

### Description
- Change two-player seat layout in `webapp/src/pages/Games/SnakeAndLadder.jsx` by updating `SEAT_LAYOUTS[2]` from `[0, 2]` to `[3, 1]` so players map to left/right seats.
- Extend `updateTokens` in `webapp/src/components/SnakeBoard3D.jsx` to accept `seatAnchors`, `boardLookTarget`, and `boardRoot`, and compute a stable rail-front idle `worldPos` in front of each seat when a player has no board position.
- Preserve previous fallback behavior: if seat anchors or board context are unavailable, tokens still use the existing serpentine/fallback coordinates.
- Wire the board data through the `useEffect` that calls `updateTokens` so `board.seatAnchors`, `board.boardLookTarget`, and `board.root` are passed at runtime.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (build warnings about chunk sizes were reported but build succeeded).
- Launched the dev server and ran an automated Playwright script to open `/games/snake` in a mobile-portrait viewport and capture a screenshot showing the updated left/right seats and rail-staged tokens; the script completed successfully and produced the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ada50aa68832995ae294a33a1401a)