### PR TITLE
Snake & Ladder: align 2-player seats left/right and add wooden token rails

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -262,7 +262,7 @@ const SNAKE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = SNAKE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SEAT_LAYOUTS = {
   1: [0],
-  2: [0, 2],
+  2: [3, 1],
   3: [0, 1, 3],
   4: [0, 1, 2, 3]
 };
@@ -3792,6 +3792,15 @@ export default function SnakeAndLadder() {
                     if (p.index !== myIdx) setPlayerPopup(p);
                   }}
                 />
+                <div className="mt-2 flex min-w-[5.5rem] items-center justify-center rounded-full border border-amber-200/30 bg-[linear-gradient(180deg,rgba(152,98,56,0.95),rgba(92,58,30,0.95))] px-2 py-1 shadow-[0_8px_20px_rgba(0,0,0,0.45)]">
+                  <div className="mr-1 h-2.5 w-2.5 rounded-full bg-black/20" />
+                  <div
+                    className="h-3.5 w-3.5 rounded-full border border-white/60 shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+                    style={{ backgroundColor: p.color || '#ffffff' }}
+                    title={`${getPlayerName(p.index)} token`}
+                  />
+                  <div className="ml-1 h-2.5 w-2.5 rounded-full bg-black/20" />
+                </div>
               </div>
             );
           })}


### PR DESCRIPTION
### Motivation
- Make the 2-player Snake & Ladder layout match the side-vs-side feel used in Ludo Battle Royal by positioning the two players left and right. 
- Surface each player’s token visibly in front of them by showing a small wooden rail and token chip under their avatar so tokens are easier to read on mobile portrait screens.

### Description
- Updated the 2-player seat mapping in `SEAT_LAYOUTS` so `2` now maps to `[3, 1]` instead of `[0, 2]` to place players on left/right sides (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Added a compact rail UI under each player avatar that renders a token color chip using the player color (`p.color`) and accessible `title` text, implemented as a styled `div` directly beneath `AvatarTimer` (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Kept the change minimal and localized to the player anchor rendering and seat layout resolution logic.

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx` which executed (the file is currently ignored by repo lint rules) and produced no blocking errors.
- Ran `npm run lint -- webapp/src/pages/Games/SnakeAndLadder.jsx` (repo-wide lint), which failed due to many pre-existing unrelated lint issues in the repository; the change itself is syntactically valid.
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and visually validated the UI by loading `/games/snake?table=snake-2`, capturing a portrait screenshot saved at `browser:/tmp/codex_browser_invocations/80d2d2c315a16c19/artifacts/artifacts/snake-left-right-rail.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ada50aa68832995ae294a33a1401a)