### PR TITLE
Fix Texas Hold'em card layout update without black screen

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -348,7 +348,8 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
 const COMMUNITY_SPACING = CARD_W * 1.08;
-const COMMUNITY_CARD_FORWARD_OFFSET = 0;
+const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
+const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
@@ -4274,9 +4275,10 @@ function TexasHoldemArena({ search }) {
             const position = baseAnchor.clone().add(right.clone().multiplyScalar((idx - 0.5) * HOLE_SPACING));
             mesh.position.copy(position);
 
-            const lookTarget = camera.position
-              .clone()
-              .add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
+            const lookTargetBase = humanSeatGroup.focus
+              ? humanSeatGroup.focus.clone().addScaledVector(humanSeatGroup.forward, 2.4 * MODEL_SCALE)
+              : camera.position.clone();
+            const lookTarget = lookTargetBase.add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
             lookTarget.y = position.y + HUMAN_CARD_LOOK_LIFT;
             orientCard(mesh, lookTarget, { face: 'front', flat: false });
             setCardFace(mesh, 'front');
@@ -4771,8 +4773,11 @@ function TexasHoldemArena({ search }) {
         mesh.position.copy(position);
         const lookOrigin = seat.isHuman ? baseAnchor : seat.stoolAnchor;
         const lookTarget = seat.isHuman
-          ? three.camera.position
-              .clone()
+          ? (seat.focus
+              ? seat.focus
+                  .clone()
+                  .addScaledVector(forward, 2.4 * MODEL_SCALE)
+              : three.camera.position.clone())
               .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
               .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
           : lookOrigin


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and a black-screen regression caused by assuming a human seat `focus` always exists while keeping the community cards visually aligned with the Murlan Royale table-area forward offset.
- Keep the existing intra-card spacing and visual orientation behavior while making the targeting robust across scene setup and per-frame updates.

### Description
- Added `TABLE_CARD_AREA_FORWARD_SHIFT` and set `COMMUNITY_CARD_FORWARD_OFFSET` to reuse the table-area forward placement pattern (preserving `COMMUNITY_SPACING`) in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Updated the human hole-card initial orientation (`orientHumanCards`) to compute a `lookTargetBase` that uses `humanSeatGroup.focus` when available or falls back to `camera.position` when not, then applies splay and lift before calling `orientCard`.
- Applied the same safe fallback logic in the per-frame card update path to use `seat.focus` if present or `three.camera.position` as a fallback when computing live `lookTarget` for human cards.
- Left spacing, splay, and lift math intact so visual spacing between cards remains unchanged.

### Testing
- Ran `npm -C webapp run build` which completed successfully (Vite build finished without blocking errors).
- Launched the dev server with `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and performed a Playwright portrait-mode navigation and screenshot of `/games/texasholdem`, which produced a visual artifact confirming the layout and no black screen.
- No unit tests were changed and no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad97c21cc8329a46f0c8459aca445)