### PR TITLE
Fix Texas Hold'em card layout alignment and runtime error

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -348,7 +348,8 @@ const TEXAS_HOLDEM_COMMENTARY_PRESETS = Object.freeze([
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = TEXAS_HOLDEM_COMMENTARY_PRESETS[0]?.id || 'english';
 const COMMUNITY_SPACING = CARD_W * 1.08;
-const COMMUNITY_CARD_FORWARD_OFFSET = 0;
+const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
+const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
@@ -4274,8 +4275,9 @@ function TexasHoldemArena({ search }) {
             const position = baseAnchor.clone().add(right.clone().multiplyScalar((idx - 0.5) * HOLE_SPACING));
             mesh.position.copy(position);
 
-            const lookTarget = camera.position
+            const lookTarget = baseAnchor
               .clone()
+              .addScaledVector(humanSeatGroup.forward, 2.4 * MODEL_SCALE)
               .add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
             lookTarget.y = position.y + HUMAN_CARD_LOOK_LIFT;
             orientCard(mesh, lookTarget, { face: 'front', flat: false });
@@ -4771,8 +4773,9 @@ function TexasHoldemArena({ search }) {
         mesh.position.copy(position);
         const lookOrigin = seat.isHuman ? baseAnchor : seat.stoolAnchor;
         const lookTarget = seat.isHuman
-          ? three.camera.position
+          ? baseAnchor
               .clone()
+              .addScaledVector(forward, 2.4 * MODEL_SCALE)
               .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
               .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
           : lookOrigin


### PR DESCRIPTION
### Motivation
- Restore the intended Murlan Royale–style forward offset for community cards while preserving existing spacing. 
- Fix a black-page runtime regression caused by referencing a missing `seat.focus`/`camera.position` when orienting human hole cards. 

### Description
- Introduced `TABLE_CARD_AREA_FORWARD_SHIFT` and set `COMMUNITY_CARD_FORWARD_OFFSET` to it so community cards use the same forward table-area offset pattern as other arenas. 
- Replaced invalid references to `seat.focus`/`camera.position` when computing human hole-card look targets with a stable `baseAnchor`-based target and a forward offset (`baseAnchor.clone().addScaledVector(forward, 2.4 * MODEL_SCALE)`), applied in both the initial `orientHumanCards` setup and the per-frame update path. 
- Kept existing card spacing and lift values unchanged while updating orientation logic to avoid null/undefined access on seats. 

### Testing
- Ran `npm -C webapp run build`, which completed successfully (Vite build finished with non-blocking warnings). 
- Launched the dev server via `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and served the app successfully. 
- Captured a portrait screenshot of `/games/texasholdem` with Playwright to visually validate the card layout; screenshot produced and used for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad97c21cc8329a46f0c8459aca445)