### PR TITLE
Push Snake table-side tokens slightly farther outward

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3424,7 +3424,9 @@ function updateTokens(
         if (seatDirection.lengthSq() > 0.0001) {
           seatDirection.normalize();
           const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-          const restRadius = BOARD_RADIUS + TILE_SIZE * 1.7;
+          const baseRestRadius = BOARD_RADIUS + TILE_SIZE * 3.4;
+          const seatRestNudge = seatIndex === 0 ? TILE_SIZE * 0.18 : TILE_SIZE * 0.4;
+          const restRadius = baseRestRadius + seatRestNudge;
           const railSpread = TOKEN_RADIUS * 0.78;
           const pairIndex = index % 2;
           const pairSign = pairIndex === 0 ? -1 : 1;


### PR DESCRIPTION
### Motivation
- Off-board player tokens in portrait view were still visually too close to the board and needed a small outward adjustment to avoid tile crowding. 
- The adjustment must be seat-specific so the bottom seat moves outward slightly less than the other three seats to preserve visual balance.

### Description
- Updated off-board token placement in `webapp/src/components/SnakeBoard3D.jsx` by replacing the single `restRadius` with a `baseRestRadius` plus a `seatRestNudge` to apply seat-specific offsets. 
- Set `baseRestRadius = BOARD_RADIUS + TILE_SIZE * 3.4` and `seatRestNudge = seatIndex === 0 ? TILE_SIZE * 0.18 : TILE_SIZE * 0.4`, then compute `restRadius = baseRestRadius + seatRestNudge` so all table-side tokens move slightly farther outward. 
- Kept all other placement math (rail spread, pair offsets, fallback) unchanged and committed the change.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which produced a repository-ignore warning only. 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which started successfully. 
- Performed a Playwright visual check by loading `/games/snake` in a portrait viewport and captured an updated screenshot for verification (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af0011dec8329ae1c5cef7b1be2e5)