### PR TITLE
Adjust Snake & Ladder token spacing and camera stability

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -171,6 +171,7 @@ const TURN_CAMERA_SIDE_PLAYER_ROTATION_BLEND = 0.8;
 const DICE_CAMERA_LOOK_IN_DURATION = 360;
 const DICE_CAMERA_LOOK_HOLD_DURATION = 900;
 const DICE_CAMERA_LOOK_OUT_DURATION = 420;
+const USER_BOTTOM_SEAT_INDEX = 0;
 
 const BOARD_TILE_HEIGHT = TILE_SIZE * 0.14 * PYRAMID_HEIGHT_MULTIPLIER;
 const TILE_SIDE_COLOR = new THREE.Color(0x8b5e34);
@@ -2548,8 +2549,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   const camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
   const isPortrait = host.clientHeight > host.clientWidth;
   const cameraSeatAngle = Math.PI / 2;
-  const cameraBackOffset = isPortrait ? 1.48 : 0.95;
-  const cameraForwardOffset = isPortrait ? 0.18 : 0.35;
+  const cameraBackOffset = isPortrait ? 1.36 : 0.88;
+  const cameraForwardOffset = isPortrait ? 0.24 : 0.4;
   const cameraHeightOffset = isPortrait ? 1.64 : 1.23;
   const cameraRadius = chairRadius + cameraBackOffset - cameraForwardOffset;
   camera.position.set(
@@ -3424,8 +3425,8 @@ function updateTokens(
         if (seatDirection.lengthSq() > 0.0001) {
           seatDirection.normalize();
           const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-          const baseRestRadius = BOARD_RADIUS + TILE_SIZE * 3.4;
-          const seatRestNudge = seatIndex === 0 ? TILE_SIZE * 0.18 : TILE_SIZE * 0.4;
+          const baseRestRadius = BOARD_RADIUS + TILE_SIZE * 3.65;
+          const seatRestNudge = seatIndex === USER_BOTTOM_SEAT_INDEX ? TILE_SIZE * 0.24 : TILE_SIZE * 0.48;
           const restRadius = baseRestRadius + seatRestNudge;
           const railSpread = TOKEN_RADIUS * 0.78;
           const pairIndex = index % 2;
@@ -4395,7 +4396,8 @@ export default function SnakeBoard3D({
         const camera = cameraRef.current;
         const controls = board.controls;
         const diceCameraState = computeDiceCameraFocusState(board, camera);
-        if (camera && controls && diceCameraState && cameraViewMode !== '2d') {
+        const shouldLockDiceCameraForBottomSeat = seatIndex === USER_BOTTOM_SEAT_INDEX;
+        if (camera && controls && diceCameraState && cameraViewMode !== '2d' && !shouldLockDiceCameraForBottomSeat) {
           removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
           const restoreState = turnCameraStateRef.current || captureCameraState(camera, controls);
           const diceCameraAnimation = createCameraTransitionAnimation(camera, controls, {


### PR DESCRIPTION
### Motivation
- Improve visual layout so off-board player tokens sit further outward from the table center for clearer separation from the board.
- Bring the default camera slightly closer to the table for better framing on mobile portrait and landscape.
- Prevent unwanted camera pull-in/push-out when the bottom (user) player rolls so the view stays stable.

### Description
- Added a named constant `USER_BOTTOM_SEAT_INDEX` for explicit bottom-seat behavior.
- Increased the off-board token resting radius by adjusting `baseRestRadius` and increased per-seat `seatRestNudge` so tokens are positioned farther from the table center (in `webapp/src/components/SnakeBoard3D.jsx`).
- Tighter startup framing by changing `cameraBackOffset` and `cameraForwardOffset` to pull the default camera slightly closer (in `webapp/src/components/SnakeBoard3D.jsx`).
- Prevented dice zoom camera transitions when the bottom player rolls by gating the dice camera animation when `seatIndex === USER_BOTTOM_SEAT_INDEX` (in `webapp/src/components/SnakeBoard3D.jsx`).

### Testing
- Ran `npm run lint` which reported repository-wide lint failures unrelated to this change so lint did not pass for the whole repo (known pre-existing issues). (failed)
- Launched the web dev server for the webapp with Vite (`npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`) to verify runtime behavior. (succeeded)
- Performed an automated visual check using Playwright to open `/games/snake` on a 390×844 viewport and captured a screenshot to confirm camera and token placement changes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b14eae6608329b8259c266d35ccdd)