### PR TITLE
Pool Royale: fix career layout (rack orientation + 8-ball), ball-in-hand logic, and shot stability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2213,6 +2213,30 @@ function getPoolBallId(variant, index) {
   return `ball_${index + 1}`;
 }
 
+function buildTrainingRackIndices(variant, desiredCount) {
+  const maxCount = Math.max(0, Math.floor(Number(desiredCount) || 0));
+  if (maxCount <= 0) return [];
+
+  const fallback = Array.from({ length: maxCount }, (_, idx) => idx);
+  if (variant?.id !== 'american') return fallback;
+
+  const numbers = Array.isArray(variant?.objectNumbers) ? variant.objectNumbers : [];
+  if (!numbers.length) return fallback;
+
+  const eightIndex = numbers.indexOf(8);
+  if (eightIndex < 0) return fallback;
+
+  const withoutEight = numbers
+    .map((num, idx) => ({ num, idx }))
+    .filter((entry) => entry.idx !== eightIndex)
+    .map((entry) => entry.idx);
+
+  if (maxCount === 1) return [eightIndex];
+  const target = withoutEight.slice(0, Math.max(0, maxCount - 1));
+  target.push(eightIndex);
+  return target;
+}
+
 function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   const positions = [];
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
@@ -13130,12 +13154,11 @@ function PoolRoyaleGame({
     }
 
     const entries = Array.isArray(trainingLayout?.balls) ? trainingLayout.balls : [];
+    const trainingRackIndices = buildTrainingRackIndices(variantConfig, entries.length);
     trainingLayoutExpectedBallsRef.current = entries.length;
     const assignedBallIds = new Set();
     entries.forEach((entry, idx) => {
-      const rid = Number.isFinite(entry?.rackIndex)
-        ? Math.max(0, Math.floor(entry.rackIndex))
-        : idx % Math.max(1, variantConfig?.objectColors?.length || objectBalls.length || 1);
+      const rid = trainingRackIndices[idx] ?? idx;
       const targetBallId = getPoolBallId(variantConfig, rid);
       const preferredBall = balls.find((ball) => ball?.id === targetBallId);
       const fallbackBall = objectBalls.find((ball) => ball && !assignedBallIds.has(ball.id));
@@ -22829,6 +22852,7 @@ const powerRef = useRef(hud.power);
           ? variantConfig.objectColors
           : [];
         const entries = Array.isArray(layout.balls) ? layout.balls : [];
+        const trainingRackIndices = buildTrainingRackIndices(variantConfig, entries.length);
         const trainingBallCount = Math.max(rackColors.length, entries.length);
         const spawnedTrainingBalls = [];
         for (let rid = 0; rid < trainingBallCount; rid++) {
@@ -22847,9 +22871,7 @@ const powerRef = useRef(hud.power);
         }
 
         entries.forEach((ball, idx) => {
-          const rid = Number.isFinite(ball?.rackIndex)
-            ? Math.max(0, Math.floor(ball.rackIndex))
-            : idx % Math.max(1, rackColors.length || 15);
+          const rid = trainingRackIndices[idx] ?? idx;
           const ballId = getPoolBallId(variantConfig, rid);
           const objectBall =
             spawnedTrainingBalls.find((entryBall) => entryBall?.id === ballId) ||
@@ -27354,9 +27376,9 @@ const powerRef = useRef(hud.power);
             ballId: entry.id
           });
         });
-        const currentState = frameRef.current ?? frameState;
-        const cueBallPotted =
-          potted.some((entry) => entry.color === 'CUE') || !cue.active;
+        const currentState =
+          frameRef.current && typeof frameRef.current === 'object' ? frameRef.current : frameState;
+        const cueBallPotted = potted.some((entry) => entry.color === 'CUE');
         const pottedObjectCount = potted.filter((entry) => String(entry.id || '').toLowerCase() !== 'cue').length;
         const noCushionAfterContact =
           shotContextRef.current.contactMade &&

--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -104,9 +104,9 @@ const resolveLayoutSlot = (pattern, index, level) => {
 
 const buildTrainingLayout = (level) => {
   const targetCount = getTrainingTargetCount(level)
-  const triangleSpacingX = 0.085
-  const triangleSpacingZ = 0.09
-  const apexX = 0.18
+  const triangleSpacingX = 0.09
+  const triangleSpacingZ = 0.085
+  const apexZ = 0.16
   const maxX = 0.44
   const maxZ = 0.31
 
@@ -114,10 +114,10 @@ const buildTrainingLayout = (level) => {
   let row = 0
   while (balls.length < targetCount) {
     const rowBallCount = row + 1
-    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
-    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    const z = clampLayoutCoord(apexZ + row * triangleSpacingZ, -maxZ, maxZ)
+    const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
     for (let column = 0; column < rowBallCount && balls.length < targetCount; column += 1) {
-      const z = clampLayoutCoord(rowStartZ + column * triangleSpacingZ, -maxZ, maxZ)
+      const x = clampLayoutCoord(rowStartX + column * triangleSpacingX, -maxX, maxX)
       balls.push({
         rackIndex: balls.length,
         x,
@@ -128,10 +128,11 @@ const buildTrainingLayout = (level) => {
   }
 
   return {
-    cue: { x: -0.68, z: 0 },
+    cue: { x: 0, z: -0.68 },
     balls
   }
 }
+
 
 
 const buildTrainingDefinition = (level) => {
@@ -168,28 +169,29 @@ export function getTrainingLayout (level) {
 
 export function getPracticeLayout () {
   const triangleRows = 5
-  const triangleSpacingX = 0.086
-  const triangleSpacingZ = 0.094
-  const apexX = 0.2
+  const triangleSpacingX = 0.094
+  const triangleSpacingZ = 0.086
+  const apexZ = 0.2
   const maxX = 0.44
   const maxZ = 0.31
   const balls = []
 
   for (let row = 0; row < triangleRows; row += 1) {
     const rowBallCount = row + 1
-    const x = clampLayoutCoord(apexX + row * triangleSpacingX, -maxX, maxX)
-    const rowStartZ = -((rowBallCount - 1) * triangleSpacingZ) / 2
+    const z = clampLayoutCoord(apexZ + row * triangleSpacingZ, -maxZ, maxZ)
+    const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
     for (let col = 0; col < rowBallCount; col += 1) {
-      const z = clampLayoutCoord(rowStartZ + col * triangleSpacingZ, -maxZ, maxZ)
+      const x = clampLayoutCoord(rowStartX + col * triangleSpacingX, -maxX, maxX)
       balls.push({ rackIndex: balls.length, x, z })
     }
   }
 
   return {
-    cue: { x: -0.7, z: 0 },
+    cue: { x: 0, z: -0.7 },
     balls
   }
 }
+
 
 export function loadTrainingProgress () {
   if (typeof window === 'undefined') { return { completed: [], rewarded: [], lastLevel: 1, carryShots: 0, attemptsAwardedLevels: [] } }


### PR DESCRIPTION
### Motivation
- Career/training layouts were spawned with the rack and cue on opposite sides compared to practice, causing inconsistent ball/cue positions in portrait gameplay. 
- Ball-in-hand was being granted incorrectly on most shots because cue-ball active state was used as the trigger instead of an actual cue-ball pot event. 
- The last target in American 8-ball training should be the 8-ball to match gameplay expectations. 
- The shot resolution path could access a transient/invalid frame reference and cause mid-game crashes.

### Description
- Added `buildTrainingRackIndices(variant, desiredCount)` to `webapp/src/pages/Games/PoolRoyale.jsx` and applied the produced rack indices when spawning training layouts so American pools stage the 8-ball as the final object. 
- Reworked training/practice layout generation in `webapp/src/utils/poolRoyaleTrainingProgress.js` to orient rack rows down-table and place the cue on the baulk side so career/training now match practice orientation. 
- Changed cue-ball foul/in-hand detection to trigger only when a POTTED event for the cue ball is observed (removed the `!cue.active` check) in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Hardened shot resolution by using a safe `currentState` fallback (`frameRef.current && typeof frameRef.current === 'object' ? frameRef.current : frameState`) before calling `rules.applyShot`, reducing risk of crashes from transient frame refs.

### Testing
- Ran unit tests with `npm test -- --runInBand PoolRoyaleRules`, and the suite passed (`3 tests, 3 passed`).
- Ran `npx eslint` against the modified files which produced repo ignore warnings (linting configuration ignores these files). 
- Launched the web dev server (`npm --prefix webapp run dev`) and captured a visual check screenshot from a headless browser during dev runtime, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3fcedb1c8329b23912e84fc83cf5)