### PR TITLE
Guard shot state in PoolRoyale to prevent career first-shot black screen

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27378,6 +27378,8 @@ const powerRef = useRef(hud.power);
         });
         const currentState =
           frameRef.current && typeof frameRef.current === 'object' ? frameRef.current : frameState;
+        const fallbackState =
+          frameState && typeof frameState === 'object' ? frameState : initialFrame;
         const cueBallPotted = potted.some((entry) => entry.color === 'CUE');
         const pottedObjectCount = potted.filter((entry) => String(entry.id || '').toLowerCase() !== 'cue').length;
         const noCushionAfterContact =
@@ -27392,7 +27394,8 @@ const powerRef = useRef(hud.power);
           noCushionAfterContact,
           variant: variantId
         };
-        let safeState = currentState;
+        let safeState =
+          currentState && typeof currentState === 'object' ? currentState : fallbackState;
         let shotResolved = false;
         try {
           const resolved = rules.applyShot(currentState, shotEvents, shotContext);
@@ -27801,8 +27804,16 @@ const powerRef = useRef(hud.power);
         } catch (err) {
           console.error('Pool Royale post-resolution update failed:', err);
         } finally {
-          frameRef.current = safeState;
-          setFrameState(safeState);
+          const resolvedState =
+            safeState && typeof safeState === 'object' ? safeState : fallbackState;
+          if (resolvedState !== safeState) {
+            console.warn('Pool Royale recovered from invalid shot state payload.', {
+              safeState,
+              fallbackState
+            });
+          }
+          frameRef.current = resolvedState;
+          setFrameState(resolvedState);
           setTurnCycle((value) => value + 1);
           setHud((prev) => ({
             ...prev,
@@ -27813,7 +27824,7 @@ const powerRef = useRef(hud.power);
             const layout = captureBallSnapshot();
             socket.emit('poolShot', {
               tableId,
-              state: safeState,
+              state: resolvedState,
               hud: hudRef.current,
               layout
             });


### PR DESCRIPTION
### Motivation
- The Career/training first-shot could produce a black/blank screen when an invalid/non-object frame state was applied after shot resolution, so the shot state flow needs defensive validation.

### Description
- Added a `fallbackState` (using `initialFrame`) and ensured `safeState` is always an object by falling back to `fallbackState` when needed in `PoolRoyale.jsx`.
- In the `finally` block a `resolvedState` is computed and used for `frameRef.current`, `setFrameState`, and the online `socket.emit('poolShot', ...)` payload to avoid sending/setting invalid states.
- Emitted a `console.warn` when recovery occurs to help diagnose future occurrences.
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx` and only affect post-shot state handling and sync.

### Testing
- Ran `npm run build` in `webapp/` successfully, producing a production build (build completed with minor chunk-size warnings but no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b45ac154c8329ac07bdeedf71ce23)