### PR TITLE
Restore Pool Royale training task layouts and mirror side placement

### DIFF
--- a/webapp/src/utils/poolRoyaleTrainingProgress.js
+++ b/webapp/src/utils/poolRoyaleTrainingProgress.js
@@ -103,32 +103,52 @@ const resolveLayoutSlot = (pattern, index, level) => {
 }
 
 const buildTrainingLayout = (level) => {
+  const pattern = PATTERN_LIBRARY[(level - 1) % PATTERN_LIBRARY.length] || PATTERN_LIBRARY[0]
   const targetCount = getTrainingTargetCount(level)
-  const triangleSpacingX = 0.09
-  const triangleSpacingZ = 0.085
-  const apexZ = 0.16
-  const maxX = 0.44
-  const maxZ = 0.31
+  const rotated = rotate(pattern, (level * 2) % pattern.length)
+  const microShift = ((level % 4) - 1.5) * 0.008
+  const balls = Array.from({ length: targetCount }, (_, idx) => {
+    const rawPos = resolveLayoutSlot(rotated, idx, level)
+    const pos = stabilizeTrainingSlot(rawPos)
+    let x = clampLayoutCoord(pos.x + (idx % 2 === 0 ? microShift : -microShift), -0.44, 0.44)
+    let z = clampLayoutCoord(pos.z + (idx % 3 === 0 ? microShift : 0), -0.31, 0.31)
 
-  const balls = []
-  let row = 0
-  while (balls.length < targetCount) {
-    const rowBallCount = row + 1
-    const z = clampLayoutCoord(apexZ + row * triangleSpacingZ, -maxZ, maxZ)
-    const rowStartX = -((rowBallCount - 1) * triangleSpacingX) / 2
-    for (let column = 0; column < rowBallCount && balls.length < targetCount; column += 1) {
-      const x = clampLayoutCoord(rowStartX + column * triangleSpacingX, -maxX, maxX)
-      balls.push({
-        rackIndex: balls.length,
-        x,
-        z
-      })
+    if (Math.abs(x) > 0.4 && Math.abs(z) > 0.24) {
+      x = Math.sign(x || 1) * 0.39
+      z = Math.sign(z || 1) * 0.22
     }
-    row += 1
+
+    // Keep each task's pattern intact, only swap table side (left ↔ right).
+    return {
+      rackIndex: idx,
+      x: -x,
+      z
+    }
+  })
+
+  for (let i = 0; i < balls.length; i++) {
+    const anchor = balls[i]
+    for (let j = 0; j < i; j++) {
+      const other = balls[j]
+      const dx = anchor.x - other.x
+      const dz = anchor.z - other.z
+      const distSq = (dx * dx) + (dz * dz)
+      if (distSq >= MIN_LAYOUT_GAP * MIN_LAYOUT_GAP) continue
+      const dist = Math.max(1e-6, Math.sqrt(distSq))
+      const push = (MIN_LAYOUT_GAP - dist) + 0.004
+      const nx = dx / dist
+      const nz = dz / dist
+      anchor.x = clampLayoutCoord(anchor.x + (nx * push), -0.44, 0.44)
+      anchor.z = clampLayoutCoord(anchor.z + (nz * push), -0.31, 0.31)
+      if (Math.abs(anchor.x) > 0.4 && Math.abs(anchor.z) > 0.24) {
+        anchor.x = Math.sign(anchor.x || 1) * 0.39
+        anchor.z = Math.sign(anchor.z || 1) * 0.22
+      }
+    }
   }
 
   return {
-    cue: { x: 0, z: -0.68 },
+    cue: { x: 0.7 - (level % 5) * 0.045, z: 0.5 - (level % 6) * 0.065 },
     balls
   }
 }


### PR DESCRIPTION
### Motivation
- Career training tasks must preserve their original pattern-based ball arrangements and only change which table side they appear on, per the requested revert to previous task shapes. 
- Prevent confusing failure/black-screen UX by ensuring Career/training attempts are bootstrapped when entering a career training stage or when retrying with zero attempts.

### Description
- Reworked training layout generation in `webapp/src/utils/poolRoyaleTrainingProgress.js` to use the pattern-based task generator (`PATTERN_LIBRARY` + `rotate` + `resolveLayoutSlot`) instead of a simplified triangular rack. 
- Implemented a side-only swap by mirroring ball X coordinates (`x: -x`) and kept stabilisation, minimum-gap and corner-pocket clamping to avoid overlaps or spawn glitches, and adjusted per-level micro-shifts and spacing logic. 
- Adjusted the cue start position to match the mirrored/task-side orientation for consistent shot entry. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` added bootstrapping of career attempts when entering a career training stage if the stage hasn't been awarded or `carryShots` is `0` by adding `BASE_ATTEMPTS_PER_LEVEL` via `persistCareerAttemptsProgress`. 
- Added a safeguard in `handleCareerTaskTryAgain` to restore `BASE_ATTEMPTS_PER_LEVEL` when retrying a career task with `trainingShotsRemaining` at `0`, and included `usesCareerAttempts` in the hook dependencies.

### Testing
- Ran a module-level smoke check with `node -e "import('./webapp/src/utils/poolRoyaleTrainingProgress.js').then(m=>{for(const lvl of [1,2,10,25]){const l=m.getTrainingLayout(lvl); console.log(lvl,l.cue,l.balls.slice(0,3));}})"` which produced valid cue and ball coordinates for sample levels. 
- Started the dev front-end with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the Vite server came up successfully for visual/manual validation. 
- Attempted an automated Playwright screenshot to validate the in-browser Career UI, but Chromium crashed with a SIGSEGV in this environment so the screenshot step failed (server remained running).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b45ac154c8329ac07bdeedf71ce23)