### PR TITLE
Align Ludo Battle Royale SFX with Snake & Ladder cues

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2492,6 +2492,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const captureSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const diceSoundRef = useRef(null);
+  const diceRewardSoundRef = useRef(null);
   const hahaSoundRef = useRef(null);
   const giftBombSoundRef = useRef(null);
   const aiTimeoutRef = useRef(null);
@@ -3941,7 +3942,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   useEffect(() => {
     const applyVolume = (baseVolume) => {
       const level = settingsRef.current.soundEnabled ? baseVolume : 0;
-      [moveSoundRef, captureSoundRef, cheerSoundRef, diceSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
+      [
+        moveSoundRef,
+        captureSoundRef,
+        cheerSoundRef,
+        diceSoundRef,
+        diceRewardSoundRef,
+        hahaSoundRef,
+        giftBombSoundRef
+      ].forEach((ref) => {
         if (ref.current) {
           ref.current.volume = level;
           if (!settingsRef.current.soundEnabled) {
@@ -3958,6 +3967,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     captureSoundRef.current = new Audio(bombSound);
     cheerSoundRef.current = new Audio(cheerSound);
     diceSoundRef.current = new Audio(diceSound);
+    diceRewardSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     hahaSoundRef.current = new Audio('/assets/sounds/Haha.mp3');
     giftBombSoundRef.current = new Audio(bombSound);
     applyVolume(vol);
@@ -4133,7 +4143,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     settingsRef.current.soundEnabled = soundEnabled;
     const baseVolume = getGameVolume();
     const level = soundEnabled ? baseVolume : 0;
-    [moveSoundRef, captureSoundRef, cheerSoundRef, diceSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
+    [
+      moveSoundRef,
+      captureSoundRef,
+      cheerSoundRef,
+      diceSoundRef,
+      diceRewardSoundRef,
+      hahaSoundRef,
+      giftBombSoundRef
+    ].forEach((ref) => {
       if (ref.current) {
         ref.current.volume = level;
         if (!soundEnabled) {
@@ -4166,7 +4184,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const setupScene = async () => {
 
       const baseVolume = settingsRef.current.soundEnabled ? getGameVolume() : 0;
-      [moveSoundRef, captureSoundRef, cheerSoundRef, diceSoundRef].forEach((ref) => {
+      [moveSoundRef, captureSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef].forEach((ref) => {
         if (ref.current) {
           ref.current.volume = baseVolume;
         }
@@ -4801,6 +4819,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       captureSoundRef.current.currentTime = 0;
       captureSoundRef.current.play().catch(() => {});
     }
+    if (hahaSoundRef.current) {
+      hahaSoundRef.current.currentTime = 0;
+      hahaSoundRef.current.play().catch(() => {});
+    }
   };
 
   const playCheer = () => {
@@ -4816,6 +4838,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (diceSoundRef.current) {
       diceSoundRef.current.currentTime = 0;
       diceSoundRef.current.play().catch(() => {});
+    }
+  };
+
+  const playDiceReward = () => {
+    if (!settingsRef.current.soundEnabled) return;
+    if (diceRewardSoundRef.current) {
+      diceRewardSoundRef.current.currentTime = 0;
+      diceRewardSoundRef.current.play().catch(() => {});
     }
   };
 
@@ -5523,6 +5553,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const playerName = resolvePlayerLabel(player);
     enqueueLudoCommentaryEvent('diceRoll', { player: playerName, roll: value });
     if (value === 6) {
+      playDiceReward();
       enqueueLudoCommentaryEvent('extraTurn', { player: playerName });
     }
     scheduleDiceClear();


### PR DESCRIPTION
### Motivation
- Ensure Ludo Battle Royale uses the same audio cues and behavior as Snake & Ladder so core feedback (dice roll, token moves, bomb/capture, rolling a six reward) is consistent across games.

### Description
- Added a dedicated `diceRewardSoundRef` and initialized it with `/assets/sounds/successful.mp3` to provide the same six-roll reward cue used by Snake & Ladder in `LudoBattleRoyal`.
- Wired the new reward ref into existing volume/mute synchronization paths (initial setup, sound-toggle effect, and scene setup) so it follows global sound settings with other SFX.
- Implemented `playDiceReward()` and invoked it when a `6` is rolled during dice resolution so six-rolls produce the reward sound.
- Matched bomb/capture behavior by also playing the laugh (`haha`) SFX alongside the capture/bomb cue for closer parity with Snake & Ladder; all changes are in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`; ESLint reported the file is ignored by repository ignore patterns and produced a warning but no lint errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; the same ignore-pattern warning appeared and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bdd3adf088329a4511b2629f41be6)