### PR TITLE
Align Domino Royale table/chair inventory with Ludo defaults and handle procedural default table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2251,18 +2251,14 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Murlan Default Table',
-      source: 'polyhaven',
+      source: 'procedural',
       price: 0,
-      assetId: 'WoodenTable_01',
-      thumbnail: POLYHAVEN_THUMB('WoodenTable_01'),
+      thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
         'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
-    { id: 'WoodenTable_01', label: 'Wooden Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
-    { id: 'WoodenTable_03', label: 'Wooden Table 03' },
-    { id: 'chinese_console_table', label: 'Chinese Console Table' },
     { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
     { id: 'coffee_table_round_01', label: 'Coffee Table Round 01' },
     { id: 'gallinera_table', label: 'Gallinera Table' },
@@ -2270,12 +2266,10 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     { id: 'industrial_coffee_table', label: 'Industrial Coffee Table' },
     { id: 'modern_coffee_table_01', label: 'Modern Coffee Table 01' },
     { id: 'modern_coffee_table_02', label: 'Modern Coffee Table 02' },
-    { id: 'painted_wooden_table', label: 'Painted Wooden Table' },
     { id: 'round_wooden_table_02', label: 'Round Wooden Table 02' },
     { id: 'side_table_01', label: 'Side Table 01' },
     { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
-    { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' },
-    { id: 'wooden_table_02', label: 'Wooden Table 02 (Alt)' }
+    { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' }
   ].map((option, index) => ({
     ...option,
     assetId: option.assetId || option.id,
@@ -5080,6 +5074,11 @@ async function applyTableTheme(
   if (!theme) {
     setProceduralTableVisible(true);
     activeTableThemeId = null;
+    return;
+  }
+  if (theme.source !== 'polyhaven' || !theme.assetId) {
+    setProceduralTableVisible(true);
+    activeTableThemeId = theme.id;
     return;
   }
   setProceduralTableVisible(false);

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -19,9 +19,9 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     id,
     label,
     price,
-    source: id === 'murlan-default' ? 'polyhaven' : source,
-    assetId: id === 'murlan-default' ? 'WoodenTable_01' : assetId,
-    preserveMaterials: id === 'murlan-default' ? true : preserveMaterials,
+    source,
+    assetId,
+    preserveMaterials,
     description: description || `${label} table from Murlan Royale`
   })),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map(({ id, name }) => ({ id, label: `${name} HDRI` })),


### PR DESCRIPTION
### Motivation
- Make Domino Royal use the same table and chair options as Ludo Battle Royal so store/inventory and in-game defaults are consistent. 
- Ensure the shared default Murlan table (procedural) is applied correctly in the Domino game instead of attempting to load it as a PolyHaven GLTF model.

### Description
- Updated `webapp/src/config/dominoRoyalInventoryConfig.js` to use the shared `MURLAN_TABLE_THEMES` entries directly (no special-case override for `murlan-default`) so Domino inventory/store metadata aligns with the Ludo/Murlan definitions. 
- Modified `webapp/public/domino-royal-game.js` to mark the `murlan-default` table as `source: 'procedural'` and adjusted its thumbnail, and trimmed some non-shared table entries to match the Murlan set used elsewhere. 
- Added a guard in `applyTableTheme` in `webapp/public/domino-royal-game.js` so themes that are not PolyHaven/GLTF (`theme.source !== 'polyhaven' || !theme.assetId`) show the procedural table parts instead of trying to `loadPolyhavenModel`. 
- Kept procedural footprint/fit helpers and procedural parts logic intact so procedural tables render as before when selected.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and `node --check webapp/src/config/dominoRoyalInventoryConfig.js`, both succeeded. 
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (page load attempted). 
- Attempted an automated Playwright screenshot of `/games/domino-royal` but the browser script timed out before capture; server startup and code checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b467e09f48329af6bdbcf9e7488d3)