### PR TITLE
Mirror Pool Royale training layouts left/right and restore original career attempt flow

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13115,6 +13115,7 @@ function PoolRoyaleGame({
 
     const cueBall = balls.find((ball) => ball?.id === 'cue');
     const objectBalls = balls.filter((ball) => ball?.id !== 'cue');
+    const layoutSideMultiplier = usesCareerAttempts ? -1 : 1;
     const limitX = PLAY_W / 2 - BALL_R * 2.5;
     const limitZ = PLAY_H / 2 - BALL_R * 2.5;
     const normalize = (value, limit) => Math.min(limit, Math.max(-limit, (value ?? 0) * limit));
@@ -13143,7 +13144,7 @@ function PoolRoyaleGame({
     const stateById = new Map(snapshot.map((entry) => [entry.id, entry]));
     if (cueBall) {
       const cueState = stateById.get(cueBall.id);
-      const cueX = normalize(trainingLayout?.cue?.x, limitX);
+      const cueX = normalize((trainingLayout?.cue?.x ?? 0) * layoutSideMultiplier, limitX);
       const cueZ = normalize(trainingLayout?.cue?.z, limitZ);
       if (cueState) {
         cueState.active = true;
@@ -13166,7 +13167,7 @@ function PoolRoyaleGame({
       if (!objectBall || assignedBallIds.has(objectBall.id)) return;
       assignedBallIds.add(objectBall.id);
       const ballState = stateById.get(objectBall.id);
-      const x = normalize(entry?.x, limitX);
+      const x = normalize((entry?.x ?? 0) * layoutSideMultiplier, limitX);
       const z = normalize(entry?.z, limitZ);
       if (!ballState) return;
       ballState.active = true;
@@ -22840,12 +22841,16 @@ const powerRef = useRef(hud.power);
 
       const placeTrainingLayout = (layout) => {
         if (!layout) return false;
+        const layoutSideMultiplier = usesCareerAttempts ? -1 : 1;
         const limitX = PLAY_W / 2 - BALL_R * 2.5;
         const limitZ = PLAY_H / 2 - BALL_R * 2.5;
         const normalize = (val, limit) => Math.min(limit, Math.max(-limit, (val ?? 0) * limit));
         const hideY = -PLAY_H * 0.75;
         if (layout.cue) {
-          cue.pos.set(normalize(layout.cue.x, limitX), normalize(layout.cue.z, limitZ));
+          cue.pos.set(
+            normalize((layout.cue.x ?? 0) * layoutSideMultiplier, limitX),
+            normalize(layout.cue.z, limitZ)
+          );
         }
 
         const rackColors = Array.isArray(variantConfig?.objectColors)
@@ -22877,7 +22882,7 @@ const powerRef = useRef(hud.power);
             spawnedTrainingBalls.find((entryBall) => entryBall?.id === ballId) ||
             spawnedTrainingBalls[idx];
           if (!objectBall) return;
-          const px = normalize(ball?.x, limitX);
+          const px = normalize((ball?.x ?? 0) * layoutSideMultiplier, limitX);
           const pz = normalize(ball?.z, limitZ);
           objectBall.active = true;
           objectBall.pos.set(px, pz);


### PR DESCRIPTION
### Motivation
- Career training tasks must preserve their exact ball arrangements while only swapping which side (left/right) the layout appears on to match design feedback.
- Previous changes that bootstrapped career attempts and altered retry behavior changed task flow and were reverted to keep progression logic unchanged.

### Description
- Reverted the attempt-bootstrap and retry fallback logic so career attempt state and `handleCareerTaskTryAgain` behavior remain as before. 
- Added a side multiplier so training layouts are mirrored on the X axis when `usesCareerAttempts` is active, and applied it to cue placement and ball coordinates in both `applyTrainingLayoutForLevel` and `placeTrainingLayout`.
- All changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect training layout placement (left/right mirroring) and the removed attempt fallback.

### Testing
- Ran `npm run build`, which failed due to a pre-existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (not caused by these changes). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the front-end served successfully. 
- Captured a Playwright screenshot of the training route to validate the side-swap layout visually (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b45ac154c8329ac07bdeedf71ce23)