### PR TITLE
Ludo: add capture laugh and token step sound effects

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2489,6 +2489,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const stateRef = useRef(null);
   const uiRef = useRef(null);
   const moveSoundRef = useRef(null);
+  const moveStepSoundAtRef = useRef(0);
   const captureSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const diceSoundRef = useRef(null);
@@ -4603,6 +4604,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const seg = anim.segments?.[anim.segment];
         if (anim.highlightIndex !== anim.segment) {
           updateAnimationHighlight(anim, anim.segment);
+          if (anim.segment > 0) {
+            playTokenStepSound();
+          }
         }
         if (!seg) {
           const done = anim.onComplete;
@@ -4791,20 +4795,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     };
   }, []);
 
-  const playMove = () => {
-    if (!settingsRef.current.soundEnabled) return;
-    if (moveSoundRef.current) {
-      moveSoundRef.current.currentTime = 0;
-      moveSoundRef.current.play().catch(() => {});
-    }
-  };
-
   const playCapture = () => {
     if (!settingsRef.current.soundEnabled) return;
     if (captureSoundRef.current) {
       captureSoundRef.current.currentTime = 0;
       captureSoundRef.current.play().catch(() => {});
     }
+    if (hahaSoundRef.current) {
+      hahaSoundRef.current.currentTime = 0;
+      hahaSoundRef.current.play().catch(() => {});
+    }
+  };
+
+  const playTokenStepSound = () => {
+    if (!settingsRef.current.soundEnabled) return;
+    if (!moveSoundRef.current) return;
+    const now = performance.now();
+    if (now - moveStepSoundAtRef.current < 110) return;
+    moveStepSoundAtRef.current = now;
+    moveSoundRef.current.currentTime = 0;
+    moveSoundRef.current.play().catch(() => {});
   };
 
   const playCheer = () => {
@@ -5116,6 +5126,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       highlightTiles,
       highlightIndex: -1
     };
+    playTokenStepSound();
   };
 
   const getTrackIndexForProgress = (player, progress) => {
@@ -5425,7 +5436,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const finalPos = getWorldForProgress(player, target, tokenIndex);
       state.tokens[player][tokenIndex].position.copy(finalPos);
       state.tokens[player][tokenIndex].rotation.set(0, 0, 0);
-      playMove();
       const captures = handleCaptures(player, tokenIndex);
       updateTokenStacks();
       const playerName = resolvePlayerLabel(player);


### PR DESCRIPTION
### Motivation
- Improve audio feedback for Ludo Battle Royal so captures use the same laugh cue as Snake & Ladder and tokens make audible steps while moving to increase tactile feedback.
- Keep changes lightweight and asset-free by reusing existing sound assets and avoiding binary files in the PR.

### Description
- Added `moveStepSoundAtRef` and `playTokenStepSound()` to throttle and play the token movement SFX during token animations (not only at move completion) in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Trigger `playTokenStepSound()` when a token animation starts and each time the animation advances a segment so movement audio aligns with visible steps.
- Updated `playCapture()` to also play the `Haha.mp3` laugh SFX alongside the existing capture impact sound so captures mirror Snake & Ladder behavior.
- Removed the old single end-of-move `playMove()` firing so movement audio is tied to animation progression rather than only landing.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite warnings about large chunks/dynamic imports are present but unchanged and non-blocking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bef34388c8329875e17b718ad925b)