### PR TITLE
Add Career sections and stage-wide 3-heart progression logic

### DIFF
--- a/test/poolRoyaleCareerProgress.test.js
+++ b/test/poolRoyaleCareerProgress.test.js
@@ -56,4 +56,19 @@ describe('pool royale career progression isolation', () => {
     expect(giftStage.giftThumbnail).toContain('/store-thumbs/poolRoyale/tableFinish/')
   })
 
+
+  test('career roadmap exposes section metadata for tasks, cups, tournaments, leagues, and matches', () => {
+    const eventTypes = new Set(CAREER_STAGES.map((stage) => stage.eventType))
+    expect(eventTypes.has('task')).toBe(true)
+    expect(eventTypes.has('cup')).toBe(true)
+    expect(eventTypes.has('tournament')).toBe(true)
+    expect(eventTypes.has('league')).toBe(true)
+    expect(eventTypes.has('match')).toBe(true)
+
+    const cupStage = CAREER_STAGES.find((stage) => stage.eventType === 'cup')
+    const tournamentStage = CAREER_STAGES.find((stage) => stage.eventType === 'tournament')
+    expect(cupStage?.roundTarget).toBeGreaterThan(1)
+    expect(tournamentStage?.roundTarget).toBeGreaterThan(1)
+  })
+
 })

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -42,6 +42,7 @@ const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal
 const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
+import PoolRoyaleCareer from './pages/Games/PoolRoyaleCareer.jsx';
 import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 import TableTennisRoyal from './pages/Games/TableTennisRoyal.tsx';
@@ -184,6 +185,10 @@ export default function App() {
             <Route
               path="/games/poolroyale/lobby"
               element={<PoolRoyaleLobby />}
+            />
+            <Route
+              path="/games/poolroyale/career"
+              element={<PoolRoyaleCareer />}
             />
             <Route path="/games/poolroyale" element={<PoolRoyale />} />
             <Route

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12674,7 +12674,7 @@ function PoolRoyaleGame({
     tableFinishId
   ]);
   const isTraining = playType === 'training';
-  const usesCareerAttempts = isTraining && careerMode;
+  const usesCareerAttempts = careerMode;
   const isFreePractice = isTraining && !usesCareerAttempts;
   const [trainingAttemptsStoreOpen, setTrainingAttemptsStoreOpen] = useState(false);
   const [selectedTrainingBundleId, setSelectedTrainingBundleId] = useState(TRAINING_ATTEMPT_BUNDLES[0]?.id || '');

--- a/webapp/src/pages/Games/PoolRoyaleCareer.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleCareer.jsx
@@ -1,0 +1,286 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  CAREER_LEVEL_COUNT,
+  getCareerRoadmap,
+  getNextCareerStage,
+  loadCareerProgress
+} from '../../utils/poolRoyaleCareerProgress.js';
+import { loadTrainingProgress } from '../../utils/poolRoyaleTrainingProgress.js';
+
+const TPC_ICON_SRC = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+
+const stageTypeLabel = (type) => {
+  if (type === 'training') return '🎯 Task drill';
+  if (type === 'friendly') return '🤝 Match';
+  if (type === 'league') return '🗓️ League';
+  if (type === 'showdown') return '⚡ Showdown';
+  return '🏆 Tournament';
+};
+
+const fallbackThumb = (type) => {
+  if (type === 'training') return 'https://placehold.co/160x96/0f172a/f8fafc?text=TASK';
+  if (type === 'tournament') return 'https://placehold.co/160x96/1f2937/fbbf24?text=CUP';
+  if (type === 'showdown') return 'https://placehold.co/160x96/111827/f87171?text=DUEL';
+  if (type === 'league') return 'https://placehold.co/160x96/1e293b/67e8f9?text=LEAGUE';
+  return 'https://placehold.co/160x96/0f172a/86efac?text=MATCH';
+};
+
+export default function PoolRoyaleCareer() {
+  useTelegramBackButton('/games/poolroyale/lobby?type=career');
+  const navigate = useNavigate();
+
+  const trainingProgress = useMemo(() => loadTrainingProgress(), []);
+  const careerProgress = useMemo(() => loadCareerProgress(), []);
+  const roadmap = useMemo(
+    () => getCareerRoadmap(trainingProgress, careerProgress),
+    [trainingProgress, careerProgress]
+  );
+  const nextStage = useMemo(
+    () => getNextCareerStage(trainingProgress, careerProgress),
+    [trainingProgress, careerProgress]
+  );
+
+  const completedCount = roadmap.filter((stage) => stage.completed).length;
+  const giftStages = roadmap.filter((stage) => stage.hasGift && stage.giftThumbnail);
+
+  const sections = useMemo(
+    () => [
+      {
+        key: 'task',
+        title: 'Tasks',
+        subtitle: 'Skill drills and guided objectives',
+        icon: '🎯',
+        items: roadmap.filter((stage) => stage.eventType === 'task')
+      },
+      {
+        key: 'cup',
+        title: 'Cups',
+        subtitle: 'Knockout cup brackets',
+        icon: '🏅',
+        items: roadmap.filter((stage) => stage.eventType === 'cup')
+      },
+      {
+        key: 'tournament',
+        title: 'Tournaments',
+        subtitle: 'Full-field competitive brackets',
+        icon: '🏆',
+        items: roadmap.filter((stage) => stage.eventType === 'tournament')
+      },
+      {
+        key: 'league',
+        title: 'Leagues',
+        subtitle: 'Season rounds and ranking control',
+        icon: '🗓️',
+        items: roadmap.filter((stage) => stage.eventType === 'league')
+      },
+      {
+        key: 'match',
+        title: 'Matches',
+        subtitle: 'Friendlies and showdown battles',
+        icon: '🤝',
+        items: roadmap.filter((stage) => stage.eventType === 'match')
+      }
+    ],
+    [roadmap]
+  );
+
+  const launchStage = (stage = nextStage) => {
+    if (!stage) return;
+    const params = new URLSearchParams();
+    params.set('type', stage.type);
+    params.set('mode', 'ai');
+    params.set('careerMode', '1');
+    params.set('careerStageId', stage.id);
+    if (stage.title) params.set('careerStageTitle', stage.title);
+    if (stage.type === 'training' && stage.trainingLevel) {
+      params.set('trainingLevel', String(stage.trainingLevel));
+    }
+    if (stage.type === 'tournament' && stage.players) {
+      params.set('players', String(stage.players));
+    }
+    navigate(`/games/poolroyale?${params.toString()}`);
+  };
+
+  return (
+    <section className="mx-auto w-full max-w-4xl space-y-4 px-3 pb-24 pt-3 text-white sm:px-4">
+      <div className="overflow-hidden rounded-3xl border border-amber-200/40 bg-gradient-to-br from-[#32204a] via-[#121632] to-[#0d2f35] p-4 shadow-[0_24px_65px_rgba(0,0,0,0.52)]">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.28em] text-amber-200">Pool Royale Career</p>
+            <h1 className="bg-gradient-to-r from-amber-100 via-white to-cyan-100 bg-clip-text text-xl font-bold text-transparent">
+              Roadmap Command Center
+            </h1>
+            <p className="mt-1 text-xs text-white/70">
+              Stylish full-career view with mixed tasks, matches, tournaments, and gift milestones.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/games/poolroyale/lobby?type=career')}
+            className="rounded-xl border border-white/20 bg-black/35 px-3 py-1.5 text-xs font-semibold text-white/90"
+          >
+            Lobby
+          </button>
+        </div>
+
+        <div className="mt-3 grid grid-cols-3 gap-2 text-center text-[11px] sm:text-xs">
+          <div className="rounded-xl border border-white/10 bg-black/30 p-2.5">
+            <p className="text-white/60">Progress</p>
+            <p className="mt-0.5 text-sm font-semibold">{completedCount}/{CAREER_LEVEL_COUNT}</p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-black/30 p-2.5">
+            <p className="text-white/60">Next phase</p>
+            <p className="mt-0.5 text-sm font-semibold">{nextStage?.phaseTitle || 'Legend complete'}</p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-black/30 p-2.5">
+            <p className="text-white/60">Gift milestones</p>
+            <p className="mt-0.5 text-sm font-semibold">{giftStages.length}</p>
+          </div>
+        </div>
+
+        {nextStage ? (
+          <div className="mt-3 rounded-2xl border border-amber-200/50 bg-black/35 p-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-amber-100">Next up</p>
+            <div className="mt-1 flex items-start gap-3">
+              <img
+                src={nextStage.giftThumbnail || fallbackThumb(nextStage.type)}
+                alt={nextStage.title}
+                className="h-14 w-20 rounded-lg border border-white/20 object-cover"
+                loading="lazy"
+              />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold text-white">{nextStage.icon} {nextStage.title}</p>
+                <p className="mt-0.5 line-clamp-2 text-[11px] text-white/70">{nextStage.objective}</p>
+                <div className="mt-1.5 inline-flex items-center gap-1 rounded-full border border-emerald-200/40 bg-emerald-300/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-100">
+                  <img src={TPC_ICON_SRC} alt="TPC" className="h-3.5 w-3.5" />
+                  {Number(nextStage.rewardTpc || 0).toLocaleString('en-US')} TPC
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => launchStage(nextStage)}
+              className="mt-2.5 w-full rounded-xl bg-amber-300 px-4 py-2.5 text-sm font-semibold text-black"
+            >
+              Launch {nextStage.title}
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-black/35 via-[#131b2f]/85 to-black/20 p-4">
+        <h2 className="text-sm font-semibold text-white">Gift thumbnails on roadmap</h2>
+        <div className="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {giftStages.slice(0, 12).map((stage) => (
+            <div key={stage.id} className="rounded-xl border border-amber-200/40 bg-amber-100/5 p-1.5">
+              <img src={stage.giftThumbnail} alt={stage.title} className="h-16 w-full rounded object-cover" loading="lazy" />
+              <p className="mt-1 truncate text-[10px] text-amber-100">Stage {stage.level}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+        <h2 className="text-sm font-semibold text-white">Career sections</h2>
+        <p className="mt-1 text-[11px] text-white/65">
+          Each round gives 3 ❤️ attempts one time only. When attempts reach 0, buy heart bundles to continue.
+        </p>
+        <div className="mt-2 space-y-2">
+          {sections.map((section) => {
+            const playable = section.items.find((item) => item.playable) || null;
+            return (
+              <div key={section.key} className="rounded-xl border border-white/10 bg-white/[0.03] p-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <p className="text-xs font-semibold text-white">{section.icon} {section.title}</p>
+                    <p className="text-[10px] text-white/60">{section.subtitle}</p>
+                  </div>
+                  <span className="rounded-full border border-white/15 bg-black/30 px-2 py-0.5 text-[10px] text-white/80">
+                    {section.items.filter((s) => s.completed).length}/{section.items.length}
+                  </span>
+                </div>
+                {playable ? (
+                  <div className="mt-2 flex items-center justify-between gap-2 rounded-lg border border-amber-200/35 bg-amber-200/10 p-2">
+                    <p className="min-w-0 truncate text-[11px] text-amber-50">Next: {playable.title} · Rounds {playable.roundTarget || 1}</p>
+                    <button
+                      type="button"
+                      onClick={() => launchStage(playable)}
+                      className="shrink-0 rounded-md bg-amber-300 px-2 py-1 text-[10px] font-semibold text-black"
+                    >
+                      Play
+                    </button>
+                  </div>
+                ) : (
+                  <p className="mt-2 text-[10px] text-white/45">No unlocked stage in this section yet.</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-2.5">
+        {roadmap.map((stage) => (
+          <article
+            key={stage.id}
+            className={`rounded-2xl border p-3 shadow-[0_12px_30px_rgba(0,0,0,0.28)] ${stage.playable ? 'border-amber-300/55 bg-gradient-to-br from-amber-300/18 to-orange-300/8' : stage.completed ? 'border-emerald-300/50 bg-gradient-to-br from-emerald-300/16 to-emerald-500/8' : 'border-white/10 bg-white/[0.03]'}`}
+          >
+            <div className="flex items-start gap-3">
+              <img
+                src={stage.hasGift && stage.giftThumbnail ? stage.giftThumbnail : fallbackThumb(stage.type)}
+                alt={stage.title}
+                className="h-16 w-24 shrink-0 rounded-xl border border-white/20 object-cover"
+                loading="lazy"
+              />
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-semibold text-white">
+                      Stage {String(stage.level).padStart(3, '0')} · {stage.icon} {stage.title}
+                    </p>
+                    <p className="text-[10px] text-white/60">
+                      {stage.phaseTitle} · {stage.competitionLabel || stage.type} · Rounds {stage.roundTarget || 1} · {stage.difficulty}
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full border border-white/20 bg-black/30 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-white/75">
+                    {stage.statusLabel}
+                  </span>
+                </div>
+
+                <p className="mt-1 line-clamp-2 text-[11px] text-white/80">{stage.objective}</p>
+                <p className="mt-1 line-clamp-2 text-[10px] text-white/65">{stage.detailBrief}</p>
+
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[10px]">
+                  <span className="rounded-full border border-white/20 bg-white/10 px-2 py-0.5">{stageTypeLabel(stage.type)}</span>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200/40 bg-emerald-300/10 px-2 py-0.5 font-semibold text-emerald-100">
+                    <img src={TPC_ICON_SRC} alt="TPC" className="h-3.5 w-3.5" />
+                    {Number(stage.rewardTpc || 0).toLocaleString('en-US')} TPC
+                  </span>
+                  {stage.hasGift && stage.giftThumbnail ? (
+                    <span className="rounded-full border border-amber-200/45 bg-amber-300/15 px-2 py-0.5 text-amber-100">
+                      🎁 Gift unlocked
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+
+            <p className="mt-2 text-[10px] text-cyan-100/80">Win condition: {stage.winCondition}</p>
+            {stage.playable ? (
+              <button
+                type="button"
+                onClick={() => launchStage(stage)}
+                className="mt-2.5 w-full rounded-lg bg-amber-300 px-3 py-2 text-xs font-semibold text-black"
+              >
+                Play this stage
+              </button>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -824,23 +824,44 @@ export default function PoolRoyaleLobby() {
               <div>
                 <h3 className="font-semibold text-white">Career Roadmap</h3>
                 <p className="text-xs text-white/60">
-                  Elite path with drills, friendlies, and championship brackets.
+                  Mixed drills, match tasks, and tournaments with detailed phase progression.
                 </p>
               </div>
-              <span className="text-xs font-semibold text-amber-200">
-                {careerRoadmapNodes.filter((node) => node.completed).length}/
-                {CAREER_LEVEL_COUNT}
-              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => navigate('/games/poolroyale/career')}
+                  className="rounded-lg border border-amber-200/55 bg-black/35 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-100"
+                >
+                  Open
+                </button>
+                <span className="text-xs font-semibold text-amber-200">
+                  {careerRoadmapNodes.filter((node) => node.completed).length}/
+                  {CAREER_LEVEL_COUNT}
+                </span>
+              </div>
             </div>
             {nextCareerTask ? (
               <div className="rounded-xl border border-amber-300/45 bg-amber-300/10 p-3 text-xs text-amber-50">
                 <p className="font-semibold uppercase tracking-[0.16em]">
                   Next milestone
                 </p>
-                <p className="mt-1 text-sm font-semibold text-white">
-                  {nextCareerTask.icon} {nextCareerTask.title}
-                </p>
-                <p className="mt-1 text-white/75">{nextCareerTask.objective}</p>
+                <div className="mt-1 flex items-start gap-2.5">
+                  {nextCareerTask?.giftThumbnail ? (
+                    <img
+                      src={nextCareerTask.giftThumbnail}
+                      alt="Next career gift"
+                      className="h-12 w-16 rounded-lg border border-amber-100/30 object-cover"
+                      loading="lazy"
+                    />
+                  ) : null}
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white">
+                      {nextCareerTask.icon} {nextCareerTask.title}
+                    </p>
+                    <p className="mt-1 text-white/75">{nextCareerTask.objective}</p>
+                  </div>
+                </div>
                 <div className="mt-2 flex flex-wrap items-center gap-1.5">
                   <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200/40 bg-emerald-300/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-100">
                     <img


### PR DESCRIPTION
### Motivation
- Surface distinct Career sections (tasks, cups, tournaments, leagues, matches) and expose per-stage competition metadata so the UI can present rounds/brackets and let players launch the right event type. 
- Apply the one-time-per-stage 3-heart award across all Career rounds (not just training) and retain a bundle purchase flow so players can continue after hearts are exhausted. 

### Description
- Added a dedicated Career page `webapp/src/pages/Games/PoolRoyaleCareer.jsx` with sectioned views for Tasks, Cups, Tournaments, Leagues and Matches, per-section counters and quick "Play" actions. 
- Extended stage metadata in `webapp/src/utils/poolRoyaleCareerProgress.js` to include `eventType`, `competitionLabel`, `roundTarget`, difficulty/phase fields, `getTournamentPlayers` and a `getBracketRounds` helper so cups/tournaments and league/showdown semantics are represented and bracket rounds can be derived. 
- Switched in-game attempt gating so career hearts are applied for Career mode rounds (changed `usesCareerAttempts` to use `careerMode` in `webapp/src/pages/Games/PoolRoyale.jsx`) while preserving the one-time award behavior driven by `attemptsAwardedStageIds` and `carryShots`, and kept the existing bundle purchase/continuation flow intact. 
- Updated lobby UI (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) to surface an `Open` button into the new Career page and show the upcoming milestone thumbnail and TPC badge; registered the new route in `webapp/src/App.jsx`. 
- Added / updated unit coverage to assert the new section metadata and round-targets in `test/poolRoyaleCareerProgress.test.js`.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCareerProgress.test.js` which passed (all tests green). 
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the new route renders. 
- Captured a Playwright screenshot of `/games/poolroyale/career` for visual validation (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf65634f88329bf05e354bdcd695f)