### PR TITLE
Fix scrolling on Pool Royale career page

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -119,9 +119,11 @@ export default function Layout({ children }) {
   }, [location.pathname]);
 
   useEffect(() => {
+    const isCareerPage = location.pathname.includes('/career');
     const isGamePage =
       location.pathname.startsWith('/games/') &&
-      !location.pathname.includes('/lobby');
+      !location.pathname.includes('/lobby') &&
+      !isCareerPage;
     if (isGamePage) {
       document.body.style.overflow = 'hidden';
     } else {


### PR DESCRIPTION
### Motivation
- The Pool Royale Career screen could not be scrolled because the global layout was forcing `document.body.style.overflow = 'hidden'` for all `/games/*` routes. 
- Career pages should allow vertical scrolling while active match pages should keep the body locked.

### Description
- Updated `webapp/src/components/Layout.jsx` to detect career routes by checking `location.pathname.includes('/career')` and exclude them from the game-page scroll-lock condition. 
- The change preserves the existing behavior for active in-match game pages (they still set `document.body.style.overflow = 'hidden'`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite emitted pre-existing chunk-size/import warnings but the build succeeded). 
- Launched a preview and captured a mobile-viewport screenshot of `/games/poolroyale/career` using Playwright to validate scrolling visually (screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c04d73b108329a10645e64989eab0)