### PR TITLE
Use Snake & Ladder dice roll SFX in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3963,7 +3963,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     moveSoundRef.current = new Audio(dropSound);
     captureSoundRef.current = new Audio(bombSound);
     cheerSoundRef.current = new Audio(cheerSound);
-    diceSoundRef.current = createDiceRollAudio();
+    // Match Snake & Ladder dice roll SFX by using the shared dice audio helper.
+    diceSoundRef.current = createDiceRollAudio({ muted: !settingsRef.current.soundEnabled });
     diceRewardSoundRef.current = new Audio('/assets/sounds/successful.mp3');
     sixRollSoundRef.current = new Audio('/assets/sounds/yabba-dabba-doo.mp3');
     hahaSoundRef.current = new Audio('/assets/sounds/Haha.mp3');
@@ -4147,6 +4148,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const level = soundEnabled ? baseVolume : 0;
     [moveSoundRef, captureSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef, sixRollSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
       if (ref.current) {
+        ref.current.muted = !soundEnabled;
         ref.current.volume = level;
         if (!soundEnabled) {
           try {


### PR DESCRIPTION
### Motivation
- Align Ludo Battle Royal dice audio behavior with the Snake & Ladder game by reusing the same shared dice SFX and ensure audio respects the global sound toggle so the dice SFX behaves consistently when sound is toggled.

### Description
- Initialize the Ludo dice audio via the shared helper by calling `createDiceRollAudio({ muted: !settingsRef.current.soundEnabled })` and sync each audio element's `muted` flag when `soundEnabled` changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; both runs completed but reported the file is ignored by repo ESLint settings (warning only), no runtime errors observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c06a9edac83298974a0663d3f44ba)