### PR TITLE
Sync Domino Royale table finishes with Ludo/Murlan finishes and update thumbnails/quality

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -76,7 +76,7 @@ function isTelegramRuntime() {
 const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 2048,
-  chairClothTextureSize: 1024,
+  chairClothTextureSize: 2048,
   dominoTextureSize: 2048
 });
 
@@ -2099,7 +2099,7 @@ const DEFAULT_CHAIR_THEME = Object.freeze({
 });
 
 const POLYHAVEN_THUMB = (id) =>
-  `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256&height=256`;
+  `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=512&height=512`;
 
 const MURLAN_BASE_STOOL_THEMES = [
   {
@@ -2981,7 +2981,7 @@ function applyWoodTextures(
   return { map: material.map, roughnessMap: material.roughnessMap };
 }
 
-function makeTableWoodOption({ id, label, presetId, grainId }) {
+function makeTableWoodOption({ id, label, presetId, grainId, price, description }) {
   const fallbackPreset = WOOD_PRESETS_BY_ID.walnut ?? WOOD_FINISH_PRESETS[0];
   const preset = (presetId && WOOD_PRESETS_BY_ID[presetId]) || fallbackPreset;
   return Object.freeze({
@@ -2999,6 +2999,21 @@ function makeTableWoodOption({ id, label, presetId, grainId }) {
       preset.hue,
       shiftSaturation(preset.sat, 0.12),
       shiftLightness(preset.light, -0.18)
+    ),
+    price,
+    description,
+    thumbnail: POLYHAVEN_THUMB(
+      id === 'peelingPaintWeathered'
+        ? 'wood_peeling_paint_weathered'
+        : id === 'oakVeneer01'
+          ? 'oak_veneer_01'
+          : id === 'woodTable001'
+            ? 'wood_table_001'
+            : id === 'darkWood'
+              ? 'dark_wood'
+              : id === 'rosewoodVeneer01'
+                ? 'rosewood_veneer_01'
+                : 'wood_table_001'
     )
   });
 }
@@ -3017,16 +3032,44 @@ function resolveWoodComponents(option) {
 
 const TABLE_WOOD_OPTIONS = Object.freeze([
   makeTableWoodOption({
-    id: 'oakEstate',
-    label: 'Lis Estate',
+    id: 'peelingPaintWeathered',
+    label: 'Peeling Paint Weathered',
     presetId: 'oak',
-    grainId: 'estateBands'
+    grainId: 'estateBands',
+    price: 980,
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
   }),
   makeTableWoodOption({
-    id: 'teakStudio',
-    label: 'Tik Studio',
-    presetId: 'teak',
-    grainId: 'studioVeins'
+    id: 'oakVeneer01',
+    label: 'Oak Veneer 01',
+    presetId: 'oak',
+    grainId: 'studioVeins',
+    price: 990,
+    description: 'Warm oak veneer rails with smooth satin polish.'
+  }),
+  makeTableWoodOption({
+    id: 'woodTable001',
+    label: 'Wood Table 001',
+    presetId: 'walnut',
+    grainId: 'estateBands',
+    price: 1000,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+  }),
+  makeTableWoodOption({
+    id: 'darkWood',
+    label: 'Dark Wood',
+    presetId: 'smokedOak',
+    grainId: 'studioVeins',
+    price: 1010,
+    description: 'Deep espresso rails with strong grain contrast.'
+  }),
+  makeTableWoodOption({
+    id: 'rosewoodVeneer01',
+    label: 'Rosewood Veneer 01',
+    presetId: 'cherry',
+    grainId: 'estateBands',
+    price: 1020,
+    description: 'Rosewood veneer rails with rich, reddish undertones.'
   })
 ]);
 
@@ -6072,6 +6115,19 @@ function createOptionPreview(key, option) {
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';
       swatch.style.background = `linear-gradient(135deg, ${option.baseHex ?? option.top}, ${option.accentHex ?? option.rim})`;
+      if (option?.thumbnail) {
+        const thumbImage = document.createElement('img');
+        thumbImage.src = option.thumbnail;
+        thumbImage.alt = `${option?.label || option?.id || 'Table finish'} thumbnail`;
+        thumbImage.loading = 'lazy';
+        thumbImage.decoding = 'async';
+        thumbImage.style.position = 'absolute';
+        thumbImage.style.inset = '0';
+        thumbImage.style.width = '100%';
+        thumbImage.style.height = '100%';
+        thumbImage.style.objectFit = 'cover';
+        swatch.appendChild(thumbImage);
+      }
       {
         const sheen = document.createElement('div');
         sheen.style.position = 'absolute';

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,13 +1,18 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
-  tableWood: [
-    { id: 'oakEstate', label: 'Lis Estate' },
-    { id: 'teakStudio', label: 'Tik Studio' }
-  ],
+  tableWood: MURLAN_TABLE_FINISHES.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
+    id,
+    label,
+    price,
+    description,
+    thumbnail,
+    woodOption
+  })),
   tableCloth: POOL_ROYALE_CLOTH_VARIANTS.map(({ id, name, price = 0, description, swatches }) => ({
     id,
     label: name,
@@ -47,10 +52,6 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   }))
 });
 
-const DOMINO_TABLE_WOOD_THUMBNAILS = Object.freeze({
-  oakEstate: polyHavenThumb('oak_veneer_01'),
-  teakStudio: polyHavenThumb('kitchen_wood')
-});
 
 const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
   crimson: swatchThumbnail(['#960019', '#4a0012', '#fecaca']),
@@ -102,14 +103,14 @@ export const DOMINO_ROYAL_OPTION_LABELS = Object.freeze(
 );
 
 export const DOMINO_ROYAL_STORE_ITEMS = [
-  ...DOMINO_ROYAL_OPTION_SETS.tableWood.slice(1).map((option) => ({
+  ...DOMINO_ROYAL_OPTION_SETS.tableWood.slice(1).map((option, idx) => ({
     id: `domino-wood-${option.id}`,
     type: 'tableWood',
     optionId: option.id,
     name: option.label,
-    price: 780,
-    description: 'Alternate premium table finish for your Domino Royal arena.',
-    thumbnail: DOMINO_TABLE_WOOD_THUMBNAILS[option.id]
+    price: option.price || 980 + idx * 40,
+    description: option.description || 'Table finish from the Ludo/Murlan Royale collection.',
+    thumbnail: option.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableCloth.slice(1).map((option, idx) => ({
     id: `domino-cloth-${option.id}`,


### PR DESCRIPTION
### Motivation
- Unify Domino Royale table finishes with the Ludo/Murlan finish set so Domino uses the same visual assets and removes legacy Domino-only finishes.
- Improve visual fidelity of chairs/thumbnails in Domino by increasing texture/thumbnail resolution and surface preview clarity.

### Description
- Replaced the Domino-only `tableWood` list with `MURLAN_TABLE_FINISHES` in `webapp/src/config/dominoRoyalInventoryConfig.js` and removed the legacy `DOMINO_TABLE_WOOD_THUMBNAILS` mapping. 
- Updated Domino store items to surface finish-native metadata (`price`, `description`, `thumbnail`) and adjusted default pricing behavior for table finishes. 
- Increased runtime asset sizes in `webapp/public/domino-royal-game.js` by raising `chairClothTextureSize` to `2048` and changing `POLYHAVEN_THUMB` requests to `512x512` for sharper thumbnails. 
- Extended `makeTableWoodOption` to include `price`, `description` and a `thumbnail` resolver and replaced the old two-option `TABLE_WOOD_OPTIONS` with the Ludo-like lineup (`peelingPaintWeathered`, `oakVeneer01`, `woodTable001`, `darkWood`, `rosewoodVeneer01`). 
- Enhanced the config preview renderer for `tableWood` to render the finish thumbnail with a sheen overlay and a grain badge for clearer UI presentation.

### Testing
- Ran `node --check webapp/src/config/dominoRoyalInventoryConfig.js` and the check succeeded. 
- Ran `node --check webapp/public/domino-royal-game.js` and the check succeeded. 
- Changes were committed locally with a descriptive message and included only the intended config/game UI edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfeec64308329a5c03ac7c5b6a844)