### PR TITLE
Restore Snake & Ladder dice SFX volume to prior baseline

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4004,7 +4004,6 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
-            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4015,7 +4014,6 @@ export default function SnakeAndLadder() {
               clickable
               showButton={false}
               muted={muted}
-              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -8,12 +8,3 @@ export function createDiceRollAudio ({ muted = false } = {}) {
   audio.volume = getGameVolume()
   return audio
 }
-
-export function syncDiceRollAudioVolume (audio, { fixedVolume = null } = {}) {
-  if (!audio) return
-  if (typeof fixedVolume === 'number' && Number.isFinite(fixedVolume)) {
-    audio.volume = Math.max(0, Math.min(1, fixedVolume))
-    return
-  }
-  audio.volume = getGameVolume()
-}


### PR DESCRIPTION
### Motivation
- A recent change introduced a fixed-volume override for dice SFX which caused inconsistent loudness for Snake & Ladder rolls, degrading the dice feedback UX. 
- The intent is to restore the previous behavior that sources dice volume from the global game volume while preserving mute handling.

### Description
- Removed the `syncDiceRollAudioVolume` helper from `webapp/src/utils/diceAudio.js` and kept `createDiceRollAudio` as the single audio creator. 
- Reverted `DiceRoller` (`webapp/src/components/DiceRoller.jsx`) to use `getGameVolume()` and the existing `gameVolumeChanged` event to control `audio.volume`, and removed the `fixedSoundVolume` prop and related logic. 
- Removed the forced `fixedSoundVolume={1}` wiring from `webapp/src/pages/Games/SnakeAndLadder.jsx` so Snake & Ladder dice rolls again obey the global volume. 

### Testing
- Ran a production build with `cd webapp && npm run build`, and the Vite build completed successfully. 
- The build emitted the pre-existing chunking/import warnings but produced no build errors and no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0e3e9e3883298318415afa9f9b42)