### PR TITLE
Restore dice roll & movement SFX with playback fallbacks for Snake & Ladder

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -20,6 +20,18 @@ export default function DiceRoller({
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
 }) {
+  const playWithFallback = (audio) => {
+    if (!audio || muted) return;
+    const fallbackSrc = audio.__fallbackSrc;
+    audio.play().catch(() => {
+      if (!fallbackSrc || audio.__fallbackApplied) return;
+      audio.__fallbackApplied = true;
+      audio.src = fallbackSrc;
+      audio.load();
+      audio.play().catch(() => {});
+    });
+  };
+
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
@@ -58,7 +70,7 @@ export default function DiceRoller({
     if (rolling) return;
     if (soundRef.current && !muted) {
       soundRef.current.currentTime = 0;
-      soundRef.current.play().catch(() => {});
+      playWithFallback(soundRef.current);
     }
     startValuesRef.current = values;
     setRolling(true);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1464,6 +1464,20 @@ export default function SnakeAndLadder() {
     });
   }, []);
 
+
+  useEffect(() => {
+    if (!slideAnimation || muted || !moveSoundRef.current) return undefined;
+    const tickMs = 650;
+    const playTick = () => {
+      if (!moveSoundRef.current || muted) return;
+      moveSoundRef.current.currentTime = 0;
+      moveSoundRef.current.play().catch(() => {});
+    };
+    playTick();
+    const id = setInterval(playTick, tickMs);
+    return () => clearInterval(id);
+  }, [slideAnimation, muted]);
+
   const startDiceBoardAnimation = useCallback((phase) => {
     setDiceBoardEvent(phase);
   }, []);

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -1,10 +1,14 @@
 import { diceSound } from '../assets/soundData.js'
 import { getGameVolume } from './sound.js'
 
+export const DICE_ROLL_FALLBACK_SRC = '/assets/sounds/2FilesMerged_20250717_131957.mp3'
+
 export function createDiceRollAudio ({ muted = false } = {}) {
   const audio = new Audio(diceSound)
   audio.preload = 'auto'
   audio.muted = muted
   audio.volume = getGameVolume()
+  audio.__fallbackSrc = DICE_ROLL_FALLBACK_SRC
+  audio.__fallbackApplied = false
   return audio
 }

--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -7,6 +7,19 @@ export function flashHighlight(cell, type, ctx, times = 1, done = () => {}) {
   }, 150);
 }
 
+const MOVE_SOUND_FALLBACK_SRC = '/assets/sounds/2FilesMerged_20250717_131957.mp3';
+
+function playMoveSound(audio, muted) {
+  if (!audio || muted) return;
+  audio.play().catch(() => {
+    if (audio.__fallbackApplied) return;
+    audio.__fallbackApplied = true;
+    audio.src = MOVE_SOUND_FALLBACK_SRC;
+    audio.load();
+    audio.play().catch(() => {});
+  });
+}
+
 export function moveSeq(seq, type, ctx, done = () => {}, dir = 'forward') {
   const stepMove = (idx) => {
     if (idx >= seq.length) return done();
@@ -14,7 +27,7 @@ export function moveSeq(seq, type, ctx, done = () => {}, dir = 'forward') {
     ctx.updatePosition(next);
     if (ctx.moveSoundRef?.current) {
       ctx.moveSoundRef.current.currentTime = 0;
-      if (!ctx.muted) ctx.moveSoundRef.current.play().catch(() => {});
+      playMoveSound(ctx.moveSoundRef.current, ctx.muted);
     }
     const hType = idx === seq.length - 1 ? type : dir === 'back' ? 'back' : 'forward';
     ctx.setHighlight({ cell: next, type: hType });


### PR DESCRIPTION
### Motivation
- Restore the missing dice roll and token movement sounds in the Snake & Ladder flow by making audio playback resilient when embedded/encoded sources fail on some devices or browsers.

### Description
- Add a fallback dice-roll source constant and attach fallback metadata to the dice audio object in `webapp/src/utils/diceAudio.js` so the dice SFX can retry a stable file when the primary source fails.
- Update `webapp/src/components/DiceRoller.jsx` to attempt playback and, on rejection, swap to the fallback source and retry so dice rolling produces audible feedback reliably.
- Add a small resilient playback helper and fallback constant in `webapp/src/utils/moveHelpers.js` and use it from `moveSeq` so token step movement SFX will also recover if the original audio fails to play.
- Restore continuous movement feedback during snake/ladder slide animations by adding a slide-animation sound ticker (`useEffect`) in `webapp/src/pages/Games/SnakeAndLadder.jsx` that plays the move SFX periodically while a slide is active.

Files changed: `webapp/src/utils/diceAudio.js`, `webapp/src/components/DiceRoller.jsx`, `webapp/src/utils/moveHelpers.js`, `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing
- Ran unit tests: `npm test -- test/snakeGame.test.js --runInBand`; test suite passed (all tests in that file passed), but the test run in this environment reported an open-handle warning and a console message about a database buffering timeout (non-test failure related to environment).
- Ran ESLint (`npx eslint`) and observed linting issues during development which were addressed in the modified files; lint was used to find and correct formatting/usage problems introduced during changes.
- Manual smoke: updates exercise dice roll and slide code paths so playback fallback path is triggered when a browser rejects the embedded source (behavior added to code; please validate on target devices/browsers if the original embedded audio is known to fail).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c12cb06788329b0b87127b606e042)