### PR TITLE
Restore Snake & Ladder dice SFX volume and re-enable slide movement SFX

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getGameVolume } from '../utils/sound.js';
-import { createDiceRollAudio } from '../utils/diceAudio.js';
+import { createDiceRollAudio, syncDiceRollAudioVolume } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
 
@@ -18,6 +17,7 @@ export default function DiceRoller({
   diceTransparent = false,
   renderVisual = true,
   placeholder = null,
+  fixedSoundVolume = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
@@ -34,18 +34,19 @@ export default function DiceRoller({
 
   useEffect(() => {
     soundRef.current = createDiceRollAudio({ muted });
+    syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
     return () => {
       soundRef.current?.pause();
     };
-  }, [muted]);
+  }, [muted, fixedSoundVolume]);
 
   useEffect(() => {
     const handler = () => {
-      if (soundRef.current) soundRef.current.volume = getGameVolume();
+      syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);
-  }, []);
+  }, [fixedSoundVolume]);
 
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
@@ -57,6 +58,8 @@ export default function DiceRoller({
   const rollDice = () => {
     if (rolling) return;
     if (soundRef.current && !muted) {
+      soundRef.current.muted = muted;
+      syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1419,6 +1419,7 @@ export default function SnakeAndLadder() {
 
   const diceRollerDivRef = useRef(null);
   const slideStateRef = useRef(null);
+  const slideSoundIntervalRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
   const diceRollIdRef = useRef(0);
@@ -1447,11 +1448,23 @@ export default function SnakeAndLadder() {
         type,
         onComplete
       };
+      if (!muted && moveSoundRef.current) {
+        moveSoundRef.current.currentTime = 0;
+        moveSoundRef.current.play().catch(() => {});
+      }
+      if (!muted) {
+        if (slideSoundIntervalRef.current) clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = setInterval(() => {
+          if (!slideStateRef.current?.id || !moveSoundRef.current) return;
+          moveSoundRef.current.currentTime = 0;
+          moveSoundRef.current.play().catch(() => {});
+        }, 350);
+      }
       slideStateRef.current = payload;
       setSlideAnimation(payload);
       return true;
     },
-    []
+    [muted]
   );
 
   const handleSlideComplete = useCallback((id) => {
@@ -1459,6 +1472,10 @@ export default function SnakeAndLadder() {
       if (!current || current.id !== id) return current;
       const finalize = current.onComplete;
       slideStateRef.current = null;
+      if (slideSoundIntervalRef.current) {
+        clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = null;
+      }
       if (typeof finalize === 'function') finalize();
       return null;
     });
@@ -1820,6 +1837,10 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
+      if (slideSoundIntervalRef.current) {
+        clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = null;
+      }
     };
   }, [accountId]);
 
@@ -4004,6 +4025,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4014,6 +4036,7 @@ export default function SnakeAndLadder() {
               clickable
               showButton={false}
               muted={muted}
+              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -8,3 +8,12 @@ export function createDiceRollAudio ({ muted = false } = {}) {
   audio.volume = getGameVolume()
   return audio
 }
+
+export function syncDiceRollAudioVolume (audio, { fixedVolume = null } = {}) {
+  if (!audio) return
+  if (typeof fixedVolume === 'number' && Number.isFinite(fixedVolume)) {
+    audio.volume = Math.max(0, Math.min(1, fixedVolume))
+    return
+  }
+  audio.volume = getGameVolume()
+}


### PR DESCRIPTION
### Motivation
- Dice roll SFX for Snake & Ladder became effectively inaudible after a refactor removed the fixed-volume path for the dice audio helper.  
- Token slide animations in the 3D board were not producing repeating movement sound while sliding, so token moves lacked audible feedback.  

### Description
- Reintroduced a centralized volume sync helper `syncDiceRollAudioVolume` in `webapp/src/utils/diceAudio.js` to support either global volume or a fixed per-instance volume.  
- Restored `DiceRoller` support for an optional `fixedSoundVolume` prop and used the sync helper to keep dice roll SFX at a pinned level when requested (changes in `webapp/src/components/DiceRoller.jsx`).  
- Re-enabled fixed dice-roll volume for Snake & Ladder by passing `fixedSoundVolume={1}` where the game uses `DiceRoller` so rolls remain audible in that flow (changes in `webapp/src/pages/Games/SnakeAndLadder.jsx`).  
- Added repeated move SFX during 3D slide animations by starting the existing `moveSoundRef` immediately when a slide is requested, looping playback on an interval while the slide is active, and clearing the interval on slide completion and component cleanup (changes in `webapp/src/pages/Games/SnakeAndLadder.jsx`).  

### Testing
- Built the webapp with `npm run build` from `webapp/` and the build completed successfully (Vite build completed; only non-blocking warnings about large chunks were emitted).  
- Verified the build error caused by an invalid optional-chaining pattern was fixed and the codebase now bundles without transform errors.  
- No unit tests were present/modified; manual smoke validation was performed by running the production build step and ensuring no runtime transform failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c12cb06788329b0b87127b606e042)