### PR TITLE
Restore Snake & Ladder dice roll SFX and slide movement sound

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getGameVolume } from '../utils/sound.js';
-import { createDiceRollAudio } from '../utils/diceAudio.js';
+import { createDiceRollAudio, syncDiceRollAudioVolume } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
 
@@ -18,6 +17,7 @@ export default function DiceRoller({
   diceTransparent = false,
   renderVisual = true,
   placeholder = null,
+  fixedSoundVolume = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
@@ -34,18 +34,19 @@ export default function DiceRoller({
 
   useEffect(() => {
     soundRef.current = createDiceRollAudio({ muted });
+    syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
     return () => {
       soundRef.current?.pause();
     };
-  }, [muted]);
+  }, [muted, fixedSoundVolume]);
 
   useEffect(() => {
     const handler = () => {
-      if (soundRef.current) soundRef.current.volume = getGameVolume();
+      syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);
-  }, []);
+  }, [fixedSoundVolume]);
 
   useEffect(() => {
     if (trigger !== undefined && trigger !== triggerRef.current) {
@@ -57,6 +58,8 @@ export default function DiceRoller({
   const rollDice = () => {
     if (rolling) return;
     if (soundRef.current && !muted) {
+      soundRef.current.muted = muted;
+      syncDiceRollAudioVolume(soundRef.current, { fixedVolume: fixedSoundVolume });
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1419,6 +1419,7 @@ export default function SnakeAndLadder() {
 
   const diceRollerDivRef = useRef(null);
   const slideStateRef = useRef(null);
+  const slideSoundIntervalRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
   const diceRollIdRef = useRef(0);
@@ -1447,11 +1448,23 @@ export default function SnakeAndLadder() {
         type,
         onComplete
       };
+      if (!muted && moveSoundRef.current) {
+        moveSoundRef.current.currentTime = 0;
+        moveSoundRef.current.play().catch(() => {});
+      }
+      if (!muted) {
+        if (slideSoundIntervalRef.current) clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = setInterval(() => {
+          if (!slideStateRef.current?.id || !moveSoundRef.current) return;
+          moveSoundRef.current.currentTime = 0;
+          moveSoundRef.current.play().catch(() => {});
+        }, 350);
+      }
       slideStateRef.current = payload;
       setSlideAnimation(payload);
       return true;
     },
-    []
+    [muted]
   );
 
   const handleSlideComplete = useCallback((id) => {
@@ -1459,6 +1472,10 @@ export default function SnakeAndLadder() {
       if (!current || current.id !== id) return current;
       const finalize = current.onComplete;
       slideStateRef.current = null;
+      if (slideSoundIntervalRef.current) {
+        clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = null;
+      }
       if (typeof finalize === 'function') finalize();
       return null;
     });
@@ -1820,6 +1837,10 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
+      if (slideSoundIntervalRef.current) {
+        clearInterval(slideSoundIntervalRef.current);
+        slideSoundIntervalRef.current = null;
+      }
     };
   }, [accountId]);
 
@@ -4004,6 +4025,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4014,6 +4036,7 @@ export default function SnakeAndLadder() {
               clickable
               showButton={false}
               muted={muted}
+              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -8,3 +8,12 @@ export function createDiceRollAudio ({ muted = false } = {}) {
   audio.volume = getGameVolume()
   return audio
 }
+
+export function syncDiceRollAudioVolume (audio, { fixedVolume = null } = {}) {
+  if (!audio) return
+  if (typeof fixedVolume === 'number' && Number.isFinite(fixedVolume)) {
+    audio.volume = Math.max(0, Math.min(1, fixedVolume))
+    return
+  }
+  audio.volume = getGameVolume()
+}


### PR DESCRIPTION
### Motivation
- Restore the Snake & Ladder audio behavior that was lost by a recent revert so dice roll SFX and token slide movement SFX behave exactly as before (fixed dice SFX volume and periodic move-sound during slides). 

### Description
- Added `syncDiceRollAudioVolume` to `webapp/src/utils/diceAudio.js` and kept `createDiceRollAudio` to centralize dice SFX volume handling.  
- Updated `webapp/src/components/DiceRoller.jsx` to accept `fixedSoundVolume`, call `syncDiceRollAudioVolume` when the audio is created and before playback, and re-sync on `gameVolumeChanged`.  
- Re-enabled periodic movement SFX for slide animations in `webapp/src/pages/Games/SnakeAndLadder.jsx` by adding `slideSoundIntervalRef`, starting an interval that replays `moveSoundRef` during a slide, and cleaning the interval on slide completion and unmount; the interval respects the `muted` state.  
- Wired both single-player and multiplayer dice rollers in Snake & Ladder to `fixedSoundVolume={1}` so dice SFX use the fixed full-volume playback path as prior baseline.  

### Testing
- Ran `npx eslint webapp/src/components/DiceRoller.jsx webapp/src/pages/Games/SnakeAndLadder.jsx webapp/src/utils/diceAudio.js`; it completed with warnings only (files are ignored by the repo ESLint ignore patterns).  
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c21d8e88c8329bd965966bd220a2a)