### PR TITLE
Restore Snake & Ladder dice roll and movement SFX (fix playback regression)

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -96,6 +96,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
+import { createDiceRollAudio, syncDiceRollAudioVolume } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1750,6 +1751,7 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
+  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
@@ -1807,6 +1809,8 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(timerBeep);
     timerSoundRef.current.volume = vol;
+    diceRollSoundRef.current = createDiceRollAudio({ muted });
+    syncDiceRollAudioVolume(diceRollSoundRef.current, { fixedVolume: 1 });
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1820,8 +1824,9 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
+      diceRollSoundRef.current?.pause();
     };
-  }, [accountId]);
+  }, [accountId, muted]);
 
   useEffect(() => {
     [
@@ -1837,6 +1842,7 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
+      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -2161,6 +2167,11 @@ export default function SnakeAndLadder() {
     const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
+      if (!muted && diceRollSoundRef.current) {
+        syncDiceRollAudioVolume(diceRollSoundRef.current, { fixedVolume: 1 });
+        diceRollSoundRef.current.currentTime = 0;
+        diceRollSoundRef.current.play().catch(() => {});
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -4004,6 +4015,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4014,6 +4026,7 @@ export default function SnakeAndLadder() {
               clickable
               showButton={false}
               muted={muted}
+              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -8,3 +8,12 @@ export function createDiceRollAudio ({ muted = false } = {}) {
   audio.volume = getGameVolume()
   return audio
 }
+
+export function syncDiceRollAudioVolume (audio, { fixedVolume = null } = {}) {
+  if (!audio) return
+  if (typeof fixedVolume === 'number' && Number.isFinite(fixedVolume)) {
+    audio.volume = Math.max(0, Math.min(1, fixedVolume))
+    return
+  }
+  audio.volume = getGameVolume()
+}

--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -14,7 +14,14 @@ export function moveSeq(seq, type, ctx, done = () => {}, dir = 'forward') {
     ctx.updatePosition(next);
     if (ctx.moveSoundRef?.current) {
       ctx.moveSoundRef.current.currentTime = 0;
-      if (!ctx.muted) ctx.moveSoundRef.current.play().catch(() => {});
+      if (!ctx.muted) {
+        ctx.moveSoundRef.current.play().catch(() => {
+          if (ctx.oldSnakeSoundRef?.current) {
+            ctx.oldSnakeSoundRef.current.currentTime = 0;
+            ctx.oldSnakeSoundRef.current.play().catch(() => {});
+          }
+        });
+      }
     }
     const hType = idx === seq.length - 1 ? type : dir === 'back' ? 'back' : 'forward';
     ctx.setHighlight({ cell: next, type: hType });


### PR DESCRIPTION
### Motivation
- A recent change removed the Snake & Ladder dice-roll audio wiring and the fixed-volume dice helper, causing dice roll SFX and token movement sound fallback to stop working; the goal is to restore the audio behavior to the prior working baseline.

### Description
- Re-enabled dice roll audio creation and multiplayer roll playback by restoring the dice audio ref usage and playback calls in `webapp/src/pages/Games/SnakeAndLadder.jsx` and passing the sound controls where needed.
- Reintroduced `syncDiceRollAudioVolume` helper in `webapp/src/utils/diceAudio.js` so dice SFX can be forced to a fixed volume when required while keeping global volume syncing available via `getGameVolume`.
- Restored movement sound fallback in `webapp/src/utils/moveHelpers.js` so `moveSoundRef` playback falling back to `oldSnakeSoundRef` occurs when the primary move sound fails, preserving audible token movement.
- Updated related wiring for muted/volume handling and cleanup; key files changed: `SnakeAndLadder.jsx`, `diceAudio.js`, and `moveHelpers.js`.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production bundle completed successfully (warnings about chunk sizes only); build succeeded.
- No additional automated unit tests were modified or run in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c21d8e88c8329bd965966bd220a2a)