### PR TITLE
Restore Snake & Ladder SFX logic to prior behavior

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -96,7 +96,6 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
-import { createDiceRollAudio, syncDiceRollAudioVolume } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1751,7 +1750,6 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
-  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
@@ -1809,8 +1807,6 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(timerBeep);
     timerSoundRef.current.volume = vol;
-    diceRollSoundRef.current = createDiceRollAudio({ muted });
-    syncDiceRollAudioVolume(diceRollSoundRef.current, { fixedVolume: 1 });
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1824,9 +1820,8 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
-      diceRollSoundRef.current?.pause();
     };
-  }, [accountId, muted]);
+  }, [accountId]);
 
   useEffect(() => {
     [
@@ -1842,7 +1837,6 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
-      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -2167,11 +2161,6 @@ export default function SnakeAndLadder() {
     const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
-      if (!muted && diceRollSoundRef.current) {
-        syncDiceRollAudioVolume(diceRollSoundRef.current, { fixedVolume: 1 });
-        diceRollSoundRef.current.currentTime = 0;
-        diceRollSoundRef.current.play().catch(() => {});
-      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -4015,7 +4004,6 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
-            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4026,7 +4014,6 @@ export default function SnakeAndLadder() {
               clickable
               showButton={false}
               muted={muted}
-              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -8,12 +8,3 @@ export function createDiceRollAudio ({ muted = false } = {}) {
   audio.volume = getGameVolume()
   return audio
 }
-
-export function syncDiceRollAudioVolume (audio, { fixedVolume = null } = {}) {
-  if (!audio) return
-  if (typeof fixedVolume === 'number' && Number.isFinite(fixedVolume)) {
-    audio.volume = Math.max(0, Math.min(1, fixedVolume))
-    return
-  }
-  audio.volume = getGameVolume()
-}

--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -14,14 +14,7 @@ export function moveSeq(seq, type, ctx, done = () => {}, dir = 'forward') {
     ctx.updatePosition(next);
     if (ctx.moveSoundRef?.current) {
       ctx.moveSoundRef.current.currentTime = 0;
-      if (!ctx.muted) {
-        ctx.moveSoundRef.current.play().catch(() => {
-          if (ctx.oldSnakeSoundRef?.current) {
-            ctx.oldSnakeSoundRef.current.currentTime = 0;
-            ctx.oldSnakeSoundRef.current.play().catch(() => {});
-          }
-        });
-      }
+      if (!ctx.muted) ctx.moveSoundRef.current.play().catch(() => {});
     }
     const hType = idx === seq.length - 1 ? type : dir === 'back' ? 'back' : 'forward';
     ctx.setHighlight({ cell: next, type: hType });


### PR DESCRIPTION
### Motivation
- Revert recent audio changes that altered dice-roll and movement SFX playback so the Snake & Ladder experience matches the previous, expected sound behavior. 

### Description
- Removed the dedicated dice-roll audio ref and fixed-volume overrides by deleting `diceRollSoundRef` usage and `fixedSoundVolume` props on `DiceRoller` so dice SFX follow the original flow in `SnakeAndLadder.jsx`.
- Reverted the movement-step fallback that attempted to play an alternate sound on playback failure and restored the direct `moveSoundRef` playback in `webapp/src/utils/moveHelpers.js`.
- Deleted the `syncDiceRollAudioVolume` helper from `webapp/src/utils/diceAudio.js` and returned `createDiceRollAudio` to its prior, simpler implementation.
- Changes touch `webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/utils/moveHelpers.js`, and `webapp/src/utils/diceAudio.js` to restore the earlier SFX logic.

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully without errors.
- No additional automated tests were modified or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c27065be083298e07745b3aee1d6d)