### PR TITLE
Lock portrait game UI positions across mobile fullscreen transitions

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -54,6 +54,7 @@ import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
+import useStablePortraitViewport from './hooks/useStablePortraitViewport.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
@@ -82,6 +83,7 @@ export default function App() {
 
   useTelegramAuth();
   useTelegramFullscreen();
+  useStablePortraitViewport();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2457,7 +2457,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   return (
     <div
       ref={hostRef}
-      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+      className="w-full h-app-stable bg-black relative overflow-hidden select-none"
     >
       <div className="absolute top-2 left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur">
         <span className="uppercase tracking-wide">{playType}</span>

--- a/webapp/src/hooks/useStablePortraitViewport.js
+++ b/webapp/src/hooks/useStablePortraitViewport.js
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+
+const STABLE_HEIGHT_ATTR = 'data-app-stable-height';
+
+const setViewportHeightVars = ({ resetStable = false } = {}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  const viewportHeight = Math.round(window.visualViewport?.height || window.innerHeight || 0);
+  if (!viewportHeight) return;
+
+  const root = document.documentElement;
+  root.style.setProperty('--app-viewport-height', `${viewportHeight}px`);
+
+  const shouldReset = resetStable || !root.hasAttribute(STABLE_HEIGHT_ATTR);
+  if (shouldReset) {
+    root.style.setProperty('--app-viewport-stable-height', `${viewportHeight}px`);
+    root.setAttribute(STABLE_HEIGHT_ATTR, '1');
+  }
+};
+
+export default function useStablePortraitViewport() {
+  useEffect(() => {
+    setViewportHeightVars({ resetStable: true });
+
+    const onResize = () => setViewportHeightVars();
+    const onOrientationChange = () => {
+      // Let mobile browsers finish recalculating viewport after rotation.
+      window.setTimeout(() => setViewportHeightVars({ resetStable: true }), 120);
+    };
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onOrientationChange);
+    window.visualViewport?.addEventListener?.('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onOrientationChange);
+      window.visualViewport?.removeEventListener?.('resize', onResize);
+    };
+  }, []);
+}
+

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -6,7 +6,18 @@
   --cell-width: 135px;
   /* Slightly taller default height for snake board cells */
   --cell-height: 80px;
+  --app-viewport-height: 100dvh;
+  --app-viewport-stable-height: 100dvh;
 }
+
+.h-app-stable {
+  height: var(--app-viewport-stable-height, 100dvh);
+}
+
+.min-h-app-stable {
+  min-height: var(--app-viewport-stable-height, 100dvh);
+}
+
 
 html,
 body {

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -5,7 +5,7 @@ export default function DominoRoyal() {
   useTelegramBackButton();
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <DominoRoyalArena />
     </div>
   );

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -4,7 +4,7 @@ export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-[100dvh]">
+    <div className="relative w-full h-app-stable">
       <iframe
         src={`/goal-rush.html${search}`}
         title="Goal Rush"

--- a/webapp/src/pages/Games/MurlanRoyale.jsx
+++ b/webapp/src/pages/Games/MurlanRoyale.jsx
@@ -8,7 +8,7 @@ export default function MurlanRoyale() {
   const { search } = useLocation();
 
   return (
-    <div className="relative w-full h-screen bg-[#050812]">
+    <div className="relative w-full h-app-stable bg-[#050812]">
       <MurlanRoyaleArena search={search} />
     </div>
   );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31117,7 +31117,7 @@ const powerRef = useRef(hud.power);
   );
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3468,7 +3468,7 @@ export default function SnakeAndLadder() {
       rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
     });
   return (
-    <div className="relative w-screen h-dvh overflow-hidden bg-[#05070f] text-text select-none">
+    <div className="relative w-screen h-app-stable overflow-hidden bg-[#05070f] text-text select-none">
       <div className="absolute inset-0">
         <SnakeBoard3D
           players={players}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26735,7 +26735,7 @@ const powerRef = useRef(hud.power);
   }, []);
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -1455,8 +1455,8 @@ export default function TableTennisRoyal() {
     <ErrorBoundary>
       <div
         ref={rootRef}
-        className="w-full h-[92vh] relative select-none"
-        style={{ background: "#070b1a", touchAction: "none" }}
+        className="w-full relative select-none"
+        style={{ height: "calc(var(--app-viewport-stable-height, 100dvh) * 0.92)", background: "#070b1a", touchAction: "none" }}
         onPointerDown={(e) => {
           onDown(e);
           if (sim.current.phase === "ready" && sim.current.score.server === "player") serve();

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -6,7 +6,7 @@ export default function TexasHoldem() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <TexasHoldemArena search={search} />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Mobile browsers (and Telegram WebView) change viewport height as browser chrome shows/hides, which makes fixed UI controls/buttons shift position in portrait fullscreen; this change aims to keep game UI elements visually stable.
- Provide a single, app-wide stable viewport baseline so every game can anchor buttons/icons to the same visual positions on portrait mobile screens.

### Description
- Added a new hook `useStablePortraitViewport` that measures `visualViewport`/`innerHeight` and exposes two CSS variables `--app-viewport-height` and `--app-viewport-stable-height`, refreshing the stable baseline only on orientation changes. (`webapp/src/hooks/useStablePortraitViewport.js`)
- Wired the hook into application bootstrap by calling `useStablePortraitViewport()` from `App` so the stable viewport variables are available globally. (`webapp/src/App.jsx`)
- Introduced CSS utilities `.h-app-stable` and `.min-h-app-stable` and root variables to let game pages size themselves from the stable viewport value. (`webapp/src/index.css`)
- Updated game root containers to reference the stable height instead of `h-screen`/`100vh`/`100dvh`, and preserved existing special sizing (Table Tennis uses `calc(var(--app-viewport-stable-height) * 0.92)`), so controls/icons across all games remain at the same positions during mobile fullscreen transitions (`webapp/src/pages/Games/*`, `webapp/src/components/AirHockey3D.jsx`, etc.).

### Testing
- Built the web app with `npm --prefix webapp run build` and the build finished successfully (warnings about large chunks only). 
- Ran a local preview with `npm --prefix webapp run preview` and captured a portrait screenshot via a Playwright script to visually validate layout rendering, which completed successfully.
- No unit test changes were required for this UI-only change and automated build/preview validations passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c27d5d5f48329af2f5a1fec3659ad)