### PR TITLE
Align Snake 3D effect SFX with 2D snake and ladder sounds

### DIFF
--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -35,10 +35,9 @@ export function applyEffect(startPos, ctx, finalizeMove) {
     ctx.setTrail([{ cell: startPos, type: 'snake' }]);
     ctx.setOffsetPopup({ cell: startPos, type: 'snake', amount: offset });
     setTimeout(() => ctx.setOffsetPopup(null), 1000);
-    if (!ctx.muted) {
-      ctx.snakeSoundRef?.current?.play().catch(() => {});
-      ctx.oldSnakeSoundRef?.current?.play().catch(() => {});
-      ctx.badLuckSoundRef?.current?.play().catch(() => {});
+    if (!ctx.muted && ctx.snakeSoundRef?.current) {
+      ctx.snakeSoundRef.current.currentTime = 0;
+      ctx.snakeSoundRef.current.play().catch(() => {});
     }
     const seq = [];
     for (let i = 1; i <= offset && startPos - i >= 0; i++) seq.push(startPos - i);
@@ -64,7 +63,10 @@ export function applyEffect(startPos, ctx, finalizeMove) {
     ctx.setTrail((t) => t.map((h) => (h.cell === startPos ? { ...h, type: 'ladder' } : h)));
     ctx.setOffsetPopup({ cell: startPos, type: 'ladder', amount: offset });
     setTimeout(() => ctx.setOffsetPopup(null), 1000);
-    if (!ctx.muted) ctx.ladderSoundRef?.current?.play().catch(() => {});
+    if (!ctx.muted && ctx.ladderSoundRef?.current) {
+      ctx.ladderSoundRef.current.currentTime = 0;
+      ctx.ladderSoundRef.current.play().catch(() => {});
+    }
     const seq = [];
     for (let i = 1; i <= offset && startPos + i <= ctx.FINAL_TILE; i++) seq.push(startPos + i);
     const target = Math.min(ctx.FINAL_TILE, ladderEnd);


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder 3D effect playback match the 2D game: play the same primary snake/ladder SFX and ensure deterministic restart behavior rather than layering fallback/effect clips.

### Description
- Changed effect handling in `webapp/src/utils/moveHelpers.js` so the snake effect now plays only `snakeSoundRef` (resetting `currentTime` before play) and no longer triggers the older fallback/effect clips.
- Updated ladder effect playback to reset `currentTime = 0` then play `ladderSoundRef` for deterministic, 2D-consistent behavior.

### Testing
- Ran `npx eslint webapp/src/utils/moveHelpers.js`, which completed with a project ignore warning but no errors.
- Committed the change as "Align Snake 3D effect SFX with 2D snake and ladder sounds" and prepared the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2b26d3fc8329994c84f537a43d87)