### PR TITLE
Keep mobile games fullscreen while stabilizing portrait UI positions

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -54,6 +54,7 @@ import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
+import useStablePortraitViewport from './hooks/useStablePortraitViewport.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
@@ -82,6 +83,7 @@ export default function App() {
 
   useTelegramAuth();
   useTelegramFullscreen();
+  useStablePortraitViewport();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2457,7 +2457,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   return (
     <div
       ref={hostRef}
-      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+      className="w-full h-app-stable bg-black relative overflow-hidden select-none"
     >
       <div className="absolute top-2 left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur">
         <span className="uppercase tracking-wide">{playType}</span>

--- a/webapp/src/hooks/useStablePortraitViewport.js
+++ b/webapp/src/hooks/useStablePortraitViewport.js
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+
+const STABLE_HEIGHT_ATTR = 'data-app-stable-height';
+const STABLE_HEIGHT_VALUE_ATTR = 'data-app-stable-height-value';
+
+const readStableHeight = (root) => {
+  const stableFromAttr = Number(root.getAttribute(STABLE_HEIGHT_VALUE_ATTR) || 0);
+  if (Number.isFinite(stableFromAttr) && stableFromAttr > 0) return stableFromAttr;
+  const stableFromStyle = Number.parseFloat(
+    root.style.getPropertyValue('--app-viewport-stable-height') || '0'
+  );
+  return Number.isFinite(stableFromStyle) && stableFromStyle > 0 ? stableFromStyle : 0;
+};
+
+const setViewportHeightVars = ({ resetStable = false } = {}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  const tg = window.Telegram?.WebApp;
+  const viewportHeight = Math.round(
+    tg?.viewportHeight || window.visualViewport?.height || window.innerHeight || 0
+  );
+  const tgStableHeight = Math.round(tg?.viewportStableHeight || 0);
+  if (!viewportHeight && !tgStableHeight) return;
+
+  const currentHeight = Math.max(viewportHeight, tgStableHeight);
+  const root = document.documentElement;
+  root.style.setProperty('--app-viewport-height', `${currentHeight}px`);
+
+  const previousStable = readStableHeight(root);
+  const nextStable = resetStable
+    ? currentHeight
+    : Math.max(previousStable || 0, currentHeight);
+
+  root.style.setProperty('--app-viewport-stable-height', `${nextStable}px`);
+  root.setAttribute(STABLE_HEIGHT_ATTR, '1');
+  root.setAttribute(STABLE_HEIGHT_VALUE_ATTR, String(nextStable));
+};
+
+export default function useStablePortraitViewport() {
+  useEffect(() => {
+    setViewportHeightVars({ resetStable: true });
+
+    const onResize = () => setViewportHeightVars();
+    const onOrientationChange = () => {
+      // Let mobile browsers finish recalculating viewport after rotation.
+      window.setTimeout(() => setViewportHeightVars({ resetStable: true }), 120);
+    };
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onOrientationChange);
+    window.visualViewport?.addEventListener?.('resize', onResize);
+
+    const tg = window.Telegram?.WebApp;
+    tg?.onEvent?.('viewportChanged', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onOrientationChange);
+      window.visualViewport?.removeEventListener?.('resize', onResize);
+      tg?.offEvent?.('viewportChanged', onResize);
+    };
+  }, []);
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -6,7 +6,18 @@
   --cell-width: 135px;
   /* Slightly taller default height for snake board cells */
   --cell-height: 80px;
+  --app-viewport-height: 100dvh;
+  --app-viewport-stable-height: 100dvh;
 }
+
+.h-app-stable {
+  height: var(--app-viewport-stable-height, 100dvh);
+}
+
+.min-h-app-stable {
+  min-height: var(--app-viewport-stable-height, 100dvh);
+}
+
 
 html,
 body {

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -5,7 +5,7 @@ export default function DominoRoyal() {
   useTelegramBackButton();
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <DominoRoyalArena />
     </div>
   );

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -4,7 +4,7 @@ export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-[100dvh]">
+    <div className="relative w-full h-app-stable">
       <iframe
         src={`/goal-rush.html${search}`}
         title="Goal Rush"

--- a/webapp/src/pages/Games/MurlanRoyale.jsx
+++ b/webapp/src/pages/Games/MurlanRoyale.jsx
@@ -8,7 +8,7 @@ export default function MurlanRoyale() {
   const { search } = useLocation();
 
   return (
-    <div className="relative w-full h-screen bg-[#050812]">
+    <div className="relative w-full h-app-stable bg-[#050812]">
       <MurlanRoyaleArena search={search} />
     </div>
   );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31117,7 +31117,7 @@ const powerRef = useRef(hud.power);
   );
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3468,7 +3468,7 @@ export default function SnakeAndLadder() {
       rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
     });
   return (
-    <div className="relative w-screen h-dvh overflow-hidden bg-[#05070f] text-text select-none">
+    <div className="relative w-screen h-app-stable overflow-hidden bg-[#05070f] text-text select-none">
       <div className="absolute inset-0">
         <SnakeBoard3D
           players={players}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26735,7 +26735,7 @@ const powerRef = useRef(hud.power);
   }, []);
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -1455,8 +1455,8 @@ export default function TableTennisRoyal() {
     <ErrorBoundary>
       <div
         ref={rootRef}
-        className="w-full h-[92vh] relative select-none"
-        style={{ background: "#070b1a", touchAction: "none" }}
+        className="w-full relative select-none"
+        style={{ height: "calc(var(--app-viewport-stable-height, 100dvh) * 0.92)", background: "#070b1a", touchAction: "none" }}
         onPointerDown={(e) => {
           onDown(e);
           if (sim.current.phase === "ready" && sim.current.score.server === "player") serve();

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -6,7 +6,7 @@ export default function TexasHoldem() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <TexasHoldemArena search={search} />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Mobile browsers and Telegram WebView can change viewport height (browser chrome show/hide) which previously caused fixed UI buttons/icons to jump or made games appear not fully fullscreen.
- The change aims to let games continue to use the full available fullscreen height while anchoring UI controls to a stable portrait baseline so they don't shift during fullscreen transitions.

### Description
- Reworked the viewport hook (`webapp/src/hooks/useStablePortraitViewport.js`) to prefer `window.Telegram.WebApp` values when available and compute `--app-viewport-height` from the current viewport while tracking a `--app-viewport-stable-height` that uses the maximum observed portrait height (and can be reset on orientation changes).
- Added stable-height attributes (`data-app-stable-height` and `data-app-stable-height-value`) and Telegram `viewportChanged` listener handling to keep CSS vars synchronized in WebView environments.
- Wired the hook into app bootstrap by calling `useStablePortraitViewport()` from `webapp/src/App.jsx` so the CSS vars are available globally.
- Introduced CSS utilities and root variables in `webapp/src/index.css` (`.h-app-stable`, `.min-h-app-stable`, `--app-viewport-height`, `--app-viewport-stable-height`) and updated game containers to use `h-app-stable` / `var(--app-viewport-stable-height)` (including `TableTennisRoyal` using `calc(var(--app-viewport-stable-height,100dvh) * 0.92)`) so canvases remain fullscreen while UI anchors stay stable.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (warnings about chunk sizes only). ✅
- Ran a local preview with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and captured a portrait screenshot via a Playwright script for `/games/texasholdem` to visually validate layout; the preview and screenshot capture succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c27d5d5f48329af2f5a1fec3659ad)