### PR TITLE
Refine portrait viewport stabilization to keep fullscreen game height

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -54,6 +54,7 @@ import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
+import useStablePortraitViewport from './hooks/useStablePortraitViewport.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
@@ -82,6 +83,7 @@ export default function App() {
 
   useTelegramAuth();
   useTelegramFullscreen();
+  useStablePortraitViewport();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2457,7 +2457,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   return (
     <div
       ref={hostRef}
-      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+      className="w-full h-app-stable bg-black relative overflow-hidden select-none"
     >
       <div className="absolute top-2 left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur">
         <span className="uppercase tracking-wide">{playType}</span>

--- a/webapp/src/hooks/useStablePortraitViewport.js
+++ b/webapp/src/hooks/useStablePortraitViewport.js
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+
+const STABLE_HEIGHT_ATTR = 'data-app-stable-height';
+const SETTLE_WINDOW_MS = 2200;
+
+const readViewportHeight = () => {
+  const tg = window?.Telegram?.WebApp;
+  const tgHeight = Number(tg?.viewportHeight || 0);
+  const visualHeight = Number(window.visualViewport?.height || 0);
+  const innerHeight = Number(window.innerHeight || 0);
+  return Math.round(Math.max(tgHeight, visualHeight, innerHeight, 0));
+};
+
+const readStableHeight = (root) => {
+  const current = Number.parseFloat(root.style.getPropertyValue('--app-viewport-stable-height') || '0');
+  return Number.isFinite(current) ? current : 0;
+};
+
+const setViewportHeightVars = ({ resetStable = false, allowGrowStable = false } = {}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  const viewportHeight = readViewportHeight();
+  if (!viewportHeight) return;
+
+  const root = document.documentElement;
+  root.style.setProperty('--app-viewport-height', `${viewportHeight}px`);
+
+  const hasStable = root.hasAttribute(STABLE_HEIGHT_ATTR);
+  const stableHeight = readStableHeight(root);
+
+  const shouldReset = resetStable || !hasStable;
+  const shouldGrow = allowGrowStable && viewportHeight > stableHeight;
+  if (shouldReset || shouldGrow) {
+    root.style.setProperty('--app-viewport-stable-height', `${viewportHeight}px`);
+    root.setAttribute(STABLE_HEIGHT_ATTR, '1');
+  }
+};
+
+export default function useStablePortraitViewport() {
+  useEffect(() => {
+    let settleTimeout = 0;
+    let shouldGrowStable = true;
+
+    setViewportHeightVars({ resetStable: true, allowGrowStable: true });
+
+    const onResize = () => setViewportHeightVars({ allowGrowStable: shouldGrowStable });
+    const onOrientationChange = () => {
+      // Let mobile browsers finish recalculating viewport after rotation.
+      window.setTimeout(() => {
+        shouldGrowStable = true;
+        setViewportHeightVars({ resetStable: true, allowGrowStable: true });
+      }, 120);
+    };
+
+    const tg = window?.Telegram?.WebApp;
+    const onViewportChanged = () => setViewportHeightVars({ allowGrowStable: shouldGrowStable });
+
+    settleTimeout = window.setTimeout(() => {
+      shouldGrowStable = false;
+      setViewportHeightVars({ allowGrowStable: false });
+    }, SETTLE_WINDOW_MS);
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onOrientationChange);
+    window.visualViewport?.addEventListener?.('resize', onResize);
+    tg?.onEvent?.('viewportChanged', onViewportChanged);
+
+    return () => {
+      window.clearTimeout(settleTimeout);
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onOrientationChange);
+      window.visualViewport?.removeEventListener?.('resize', onResize);
+      tg?.offEvent?.('viewportChanged', onViewportChanged);
+    };
+  }, []);
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -6,7 +6,18 @@
   --cell-width: 135px;
   /* Slightly taller default height for snake board cells */
   --cell-height: 80px;
+  --app-viewport-height: 100dvh;
+  --app-viewport-stable-height: 100dvh;
 }
+
+.h-app-stable {
+  height: var(--app-viewport-stable-height, 100dvh);
+}
+
+.min-h-app-stable {
+  min-height: var(--app-viewport-stable-height, 100dvh);
+}
+
 
 html,
 body {

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -5,7 +5,7 @@ export default function DominoRoyal() {
   useTelegramBackButton();
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <DominoRoyalArena />
     </div>
   );

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -4,7 +4,7 @@ export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-[100dvh]">
+    <div className="relative w-full h-app-stable">
       <iframe
         src={`/goal-rush.html${search}`}
         title="Goal Rush"

--- a/webapp/src/pages/Games/MurlanRoyale.jsx
+++ b/webapp/src/pages/Games/MurlanRoyale.jsx
@@ -8,7 +8,7 @@ export default function MurlanRoyale() {
   const { search } = useLocation();
 
   return (
-    <div className="relative w-full h-screen bg-[#050812]">
+    <div className="relative w-full h-app-stable bg-[#050812]">
       <MurlanRoyaleArena search={search} />
     </div>
   );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31117,7 +31117,7 @@ const powerRef = useRef(hud.power);
   );
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3468,7 +3468,7 @@ export default function SnakeAndLadder() {
       rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
     });
   return (
-    <div className="relative w-screen h-dvh overflow-hidden bg-[#05070f] text-text select-none">
+    <div className="relative w-screen h-app-stable overflow-hidden bg-[#05070f] text-text select-none">
       <div className="absolute inset-0">
         <SnakeBoard3D
           players={players}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26735,7 +26735,7 @@ const powerRef = useRef(hud.power);
   }, []);
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-stable bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -1455,8 +1455,8 @@ export default function TableTennisRoyal() {
     <ErrorBoundary>
       <div
         ref={rootRef}
-        className="w-full h-[92vh] relative select-none"
-        style={{ background: "#070b1a", touchAction: "none" }}
+        className="w-full relative select-none"
+        style={{ height: "calc(var(--app-viewport-stable-height, 100dvh) * 0.92)", background: "#070b1a", touchAction: "none" }}
         onPointerDown={(e) => {
           onDown(e);
           if (sim.current.phase === "ready" && sim.current.score.server === "player") serve();

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -6,7 +6,7 @@ export default function TexasHoldem() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-stable">
       <TexasHoldemArena search={search} />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Mobile browsers and Telegram WebView can change viewport height during startup/fullscreen transitions which previously caused the stable viewport baseline to lock too early and prevent games from reaching full-screen height while keeping UI controls visually stable.
- The goal is to preserve the no-jump behavior for buttons/icons while allowing the game surface to expand to the true fullscreen height on portrait mobile.

### Description
- Added a new hook `useStablePortraitViewport` that measures the best available height (`Telegram.WebApp.viewportHeight`, `visualViewport.height`, `innerHeight`) and sets `--app-viewport-height` and `--app-viewport-stable-height` on `:root` (`webapp/src/hooks/useStablePortraitViewport.js`).
- The hook introduces a short settle window (`SETTLE_WINDOW_MS = 2200`) during which the stable baseline is allowed to grow so the app can capture a later, larger fullscreen height; after the window it stops growing to avoid UI jumps.
- The hook listens for `window.resize`, `visualViewport.resize`, `orientationchange`, and `Telegram.WebApp` `viewportChanged` events and includes orientation-reset behavior to re-establish the stable baseline on rotation.
- Wired the hook into app bootstrap by calling `useStablePortraitViewport()` from `App` and added CSS variables/utilities (`--app-viewport-stable-height`, `.h-app-stable`, `.min-h-app-stable`) and updated game containers to use `h-app-stable` or `calc(var(--app-viewport-stable-height) * 0.92)` where appropriate so games fill the screen while HUD remains stable. (`webapp/src/App.jsx`, `webapp/src/index.css`, and multiple `webapp/src/pages/Games/*` files)

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with only chunk-size warnings. (passed)
- Launched a local preview with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and inspected `/games/goalrush` in a 390×844 portrait viewport. (preview served)
- Captured a Playwright portrait screenshot to validate layout rendering and confirmed the game surface reaches fullscreen while UI controls remain anchored (screenshot artifact generated). (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c27d5d5f48329af2f5a1fec3659ad)