### PR TITLE
Keep games fullscreen and retain portrait UI stability baseline

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -54,6 +54,7 @@ import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
+import useStablePortraitViewport from './hooks/useStablePortraitViewport.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
@@ -82,6 +83,7 @@ export default function App() {
 
   useTelegramAuth();
   useTelegramFullscreen();
+  useStablePortraitViewport();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2457,7 +2457,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   return (
     <div
       ref={hostRef}
-      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+      className="w-full h-app-live bg-black relative overflow-hidden select-none"
     >
       <div className="absolute top-2 left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur">
         <span className="uppercase tracking-wide">{playType}</span>

--- a/webapp/src/hooks/useStablePortraitViewport.js
+++ b/webapp/src/hooks/useStablePortraitViewport.js
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+const STABLE_HEIGHT_ATTR = 'data-app-stable-height';
+
+const setViewportHeightVars = ({ resetStable = false } = {}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  const viewportHeight = Math.round(window.visualViewport?.height || window.innerHeight || 0);
+  if (!viewportHeight) return;
+
+  const root = document.documentElement;
+  root.style.setProperty('--app-viewport-height', `${viewportHeight}px`);
+
+  const stableHeightValue = Number.parseInt(root.style.getPropertyValue('--app-viewport-stable-height'), 10);
+  const resolvedStableHeight = Number.isFinite(stableHeightValue) && stableHeightValue > 0 ? stableHeightValue : viewportHeight;
+  const extraHeight = Math.max(0, viewportHeight - resolvedStableHeight);
+  root.style.setProperty('--app-viewport-extra-height', `${extraHeight}px`);
+
+  const shouldReset = resetStable || !root.hasAttribute(STABLE_HEIGHT_ATTR);
+  if (shouldReset) {
+    root.style.setProperty('--app-viewport-stable-height', `${viewportHeight}px`);
+    root.style.setProperty('--app-viewport-extra-height', '0px');
+    root.setAttribute(STABLE_HEIGHT_ATTR, '1');
+  }
+};
+
+export default function useStablePortraitViewport() {
+  useEffect(() => {
+    setViewportHeightVars({ resetStable: true });
+
+    const onResize = () => setViewportHeightVars();
+    const onOrientationChange = () => {
+      // Let mobile browsers finish recalculating viewport after rotation.
+      window.setTimeout(() => setViewportHeightVars({ resetStable: true }), 120);
+    };
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onOrientationChange);
+    window.visualViewport?.addEventListener?.('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onOrientationChange);
+      window.visualViewport?.removeEventListener?.('resize', onResize);
+    };
+  }, []);
+}
+

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -6,7 +6,23 @@
   --cell-width: 135px;
   /* Slightly taller default height for snake board cells */
   --cell-height: 80px;
+  --app-viewport-height: 100dvh;
+  --app-viewport-stable-height: 100dvh;
+  --app-viewport-extra-height: 0px;
 }
+
+.h-app-stable {
+  height: var(--app-viewport-stable-height, 100dvh);
+}
+
+.h-app-live {
+  height: var(--app-viewport-height, 100dvh);
+}
+
+.min-h-app-stable {
+  min-height: var(--app-viewport-stable-height, 100dvh);
+}
+
 
 html,
 body {

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -5,7 +5,7 @@ export default function DominoRoyal() {
   useTelegramBackButton();
 
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-live">
       <DominoRoyalArena />
     </div>
   );

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -4,7 +4,7 @@ export default function GoalRush() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-[100dvh]">
+    <div className="relative w-full h-app-live">
       <iframe
         src={`/goal-rush.html${search}`}
         title="Goal Rush"

--- a/webapp/src/pages/Games/MurlanRoyale.jsx
+++ b/webapp/src/pages/Games/MurlanRoyale.jsx
@@ -8,7 +8,7 @@ export default function MurlanRoyale() {
   const { search } = useLocation();
 
   return (
-    <div className="relative w-full h-screen bg-[#050812]">
+    <div className="relative w-full h-app-live bg-[#050812]">
       <MurlanRoyaleArena search={search} />
     </div>
   );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31117,7 +31117,7 @@ const powerRef = useRef(hud.power);
   );
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-live bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3468,7 +3468,7 @@ export default function SnakeAndLadder() {
       rankMap[p.idx] = p.pos === 0 ? 0 : i + 1;
     });
   return (
-    <div className="relative w-screen h-dvh overflow-hidden bg-[#05070f] text-text select-none">
+    <div className="relative w-screen h-app-live overflow-hidden bg-[#05070f] text-text select-none">
       <div className="absolute inset-0">
         <SnakeBoard3D
           players={players}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26735,7 +26735,7 @@ const powerRef = useRef(hud.power);
   }, []);
 
   return (
-    <div className="w-full h-[100vh] bg-black text-white overflow-hidden select-none">
+    <div className="w-full h-app-live bg-black text-white overflow-hidden select-none">
       {/* Canvas host now stretches full width so table reaches the slider */}
       <div ref={mountRef} className="absolute inset-0" />
 

--- a/webapp/src/pages/Games/TableTennisRoyal.tsx
+++ b/webapp/src/pages/Games/TableTennisRoyal.tsx
@@ -1455,8 +1455,8 @@ export default function TableTennisRoyal() {
     <ErrorBoundary>
       <div
         ref={rootRef}
-        className="w-full h-[92vh] relative select-none"
-        style={{ background: "#070b1a", touchAction: "none" }}
+        className="w-full relative select-none"
+        style={{ height: "calc(var(--app-viewport-stable-height, 100dvh) * 0.92)", background: "#070b1a", touchAction: "none" }}
         onPointerDown={(e) => {
           onDown(e);
           if (sim.current.phase === "ready" && sim.current.score.server === "player") serve();

--- a/webapp/src/pages/Games/TexasHoldem.jsx
+++ b/webapp/src/pages/Games/TexasHoldem.jsx
@@ -6,7 +6,7 @@ export default function TexasHoldem() {
   useTelegramBackButton();
   const { search } = useLocation();
   return (
-    <div className="relative w-full h-screen">
+    <div className="relative w-full h-app-live">
       <TexasHoldemArena search={search} />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Restore true fullscreen rendering for games while keeping a stable portrait baseline so controls/icons remain visually anchored during mobile browser chrome show/hide transitions. 
- Previous change used the stable viewport for entire game roots which prevented games from expanding to full mobile height and caused a regression. 
- Provide both a live fullscreen metric and a stable baseline so gameplay surfaces can be full height while UI anchoring logic remains consistent.

### Description
- Added `useStablePortraitViewport` hook that exposes three CSS variables: `--app-viewport-height` (live fullscreen), `--app-viewport-stable-height` (portrait baseline), and `--app-viewport-extra-height` (live minus stable delta). (`webapp/src/hooks/useStablePortraitViewport.js`)
- Wired the hook into app bootstrap by calling `useStablePortraitViewport()` from `App`. (`webapp/src/App.jsx`)
- Introduced `.h-app-live` utility and kept `.h-app-stable`/`.min-h-app-stable` in `index.css` so layout can choose between live fullscreen and stable-height sizing. (`webapp/src/index.css`)
- Switched affected game root containers back to live fullscreen (`h-app-live`) so canvases and iframes can use full mobile height, and preserved Table Tennis special sizing using the stable baseline via `style={{ height: 'calc(var(--app-viewport-stable-height, 100dvh) * 0.92)' }}`. (pages/components under `webapp/src/pages/Games/*` and `webapp/src/components/AirHockey3D.jsx`)

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with only chunk size warnings. (success)
- Launched a local preview with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and verified the app served correctly. (success)
- Captured a portrait screenshot of a game route using a Playwright script to visually validate fullscreen rendering and UI anchoring, and the script completed successfully. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c27d5d5f48329af2f5a1fec3659ad)