### PR TITLE
Align 3D Snake SFX with 2D behavior

### DIFF
--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -35,11 +35,7 @@ export function applyEffect(startPos, ctx, finalizeMove) {
     ctx.setTrail([{ cell: startPos, type: 'snake' }]);
     ctx.setOffsetPopup({ cell: startPos, type: 'snake', amount: offset });
     setTimeout(() => ctx.setOffsetPopup(null), 1000);
-    if (!ctx.muted) {
-      ctx.snakeSoundRef?.current?.play().catch(() => {});
-      ctx.oldSnakeSoundRef?.current?.play().catch(() => {});
-      ctx.badLuckSoundRef?.current?.play().catch(() => {});
-    }
+    if (!ctx.muted) ctx.snakeSoundRef?.current?.play().catch(() => {});
     const seq = [];
     for (let i = 1; i <= offset && startPos - i >= 0; i++) seq.push(startPos - i);
     const target = Math.max(0, snakeEnd);


### PR DESCRIPTION
### Motivation
- Ensure the 3D Snake & Ladder encounter uses the same single-sound behavior as the 2D version (restore prior SFX semantics so snake hits only play the main snake sound). 

### Description
- Update to `webapp/src/utils/moveHelpers.js`: in `applyEffect` for snake encounters only call `ctx.snakeSoundRef?.current?.play()` when not muted and remove the extra/stacked calls to `ctx.oldSnakeSoundRef` and `ctx.badLuckSoundRef` so the 3D flow matches the 2D sound behavior (one-line change). 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully; Vite emitted chunk-size/dynamic-import warnings but the build did not fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2b26d3fc8329994c84f537a43d87)