### PR TITLE
Restore dice/token audio by invoking DiceRoller imperatively

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle } from 'react';
 import { getGameVolume } from '../utils/sound.js';
 import { createDiceRollAudio } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
 
-export default function DiceRoller({
+const DiceRoller = forwardRef(function DiceRoller({
   onRollEnd,
   onRollStart,
   clickable = false,
@@ -19,7 +19,7 @@ export default function DiceRoller({
   renderVisual = true,
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
-}) {
+}, ref) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
@@ -96,6 +96,15 @@ export default function DiceRoller({
     }, tick);
   };
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      roll: () => rollDice(),
+      isRolling: () => rolling
+    }),
+    [rolling]
+  );
+
   return (
     <div className={`flex flex-col items-center space-y-4 ${className}`}>
       <div
@@ -137,4 +146,6 @@ export default function DiceRoller({
       )}
     </div>
   );
-}
+});
+
+export default DiceRoller;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1418,6 +1418,7 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
 
   const diceRollerDivRef = useRef(null);
+  const diceRollerRef = useRef(null);
   const slideStateRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
@@ -3206,7 +3207,8 @@ export default function SnakeAndLadder() {
 
 
   const handleRollButtonClick = () => {
-    diceRollerDivRef.current?.click();
+    if (diceRollerRef.current?.isRolling?.()) return;
+    diceRollerRef.current?.roll?.();
   };
 
   const renderPreview = (key, option) => {
@@ -3960,6 +3962,7 @@ export default function SnakeAndLadder() {
       {!isMultiplayer && (
         <div className="sr-only" aria-hidden="true">
           <DiceRoller
+            ref={diceRollerRef}
             divRef={diceRollerDivRef}
             onRollEnd={(vals) => {
               startDiceBoardAnimation({
@@ -4011,6 +4014,7 @@ export default function SnakeAndLadder() {
         <div className="sr-only" aria-hidden="true">
           {currentTurn === myPlayerIndex && !moving ? (
             <DiceRoller
+              ref={diceRollerRef}
               clickable
               showButton={false}
               muted={muted}


### PR DESCRIPTION
### Motivation
- Rolling was triggered by programmatically clicking a hidden element after the dice icon was removed, which can fail browser user-gesture audio gating and prevent dice/token movement sounds from playing. 
- The change restores a direct user-gesture-safe path so the audio and token movement feedback work as before removing the icon.

### Description
- Updated `DiceRoller` to use `forwardRef` and `useImperativeHandle`, exposing an imperative `roll()` API and `isRolling()` check so external callers can trigger a roll safely. 
- Rewired `SnakeAndLadder` to add a `diceRollerRef` and call `diceRollerRef.current.roll()` from `handleRollButtonClick` instead of doing a synthetic `click()` on a hidden element. 
- Wired the new `diceRollerRef` into both single-player and multiplayer render paths so behavior and event hooks (`onRollStart` / `onRollEnd`) remain unchanged. 
- Preserved existing click/keyboard behavior and dice animation logic inside `DiceRoller` to avoid other behavior regressions.

### Testing
- Ran `npx eslint webapp/src/components/DiceRoller.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`, which completed with warnings due to current ignore patterns (no code errors reported). 
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c386ef1648329ac616d2b260171d2)