### PR TITLE
Restore Snake & Ladder sounds to 11am baseline

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,10 +1,10 @@
-import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getGameVolume } from '../utils/sound.js';
 import { createDiceRollAudio } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
 
-const DiceRoller = forwardRef(function DiceRoller({
+export default function DiceRoller({
   onRollEnd,
   onRollStart,
   clickable = false,
@@ -19,7 +19,7 @@ const DiceRoller = forwardRef(function DiceRoller({
   renderVisual = true,
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
-}, ref) {
+}) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
@@ -96,15 +96,6 @@ const DiceRoller = forwardRef(function DiceRoller({
     }, tick);
   };
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      roll: () => rollDice(),
-      isRolling: () => rolling
-    }),
-    [rolling]
-  );
-
   return (
     <div className={`flex flex-col items-center space-y-4 ${className}`}>
       <div
@@ -146,6 +137,4 @@ const DiceRoller = forwardRef(function DiceRoller({
       )}
     </div>
   );
-});
-
-export default DiceRoller;
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -96,6 +96,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
+import { createDiceRollAudio } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1418,7 +1419,6 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
 
   const diceRollerDivRef = useRef(null);
-  const diceRollerRef = useRef(null);
   const slideStateRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
@@ -1751,6 +1751,7 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
+  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
@@ -1808,6 +1809,8 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(timerBeep);
     timerSoundRef.current.volume = vol;
+    diceRollSoundRef.current = createDiceRollAudio({ muted });
+    if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1821,8 +1824,9 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
+      diceRollSoundRef.current?.pause();
     };
-  }, [accountId]);
+  }, [accountId, muted]);
 
   useEffect(() => {
     [
@@ -1838,6 +1842,7 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
+      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -2162,6 +2167,11 @@ export default function SnakeAndLadder() {
     const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
+      if (!muted && diceRollSoundRef.current) {
+        if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
+        diceRollSoundRef.current.currentTime = 0;
+        diceRollSoundRef.current.play().catch(() => {});
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -3207,8 +3217,7 @@ export default function SnakeAndLadder() {
 
 
   const handleRollButtonClick = () => {
-    if (diceRollerRef.current?.isRolling?.()) return;
-    diceRollerRef.current?.roll?.();
+    diceRollerDivRef.current?.click();
   };
 
   const renderPreview = (key, option) => {
@@ -3962,7 +3971,6 @@ export default function SnakeAndLadder() {
       {!isMultiplayer && (
         <div className="sr-only" aria-hidden="true">
           <DiceRoller
-            ref={diceRollerRef}
             divRef={diceRollerDivRef}
             onRollEnd={(vals) => {
               startDiceBoardAnimation({
@@ -4007,6 +4015,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4014,10 +4023,10 @@ export default function SnakeAndLadder() {
         <div className="sr-only" aria-hidden="true">
           {currentTurn === myPlayerIndex && !moving ? (
             <DiceRoller
-              ref={diceRollerRef}
               clickable
               showButton={false}
               muted={muted}
+              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {


### PR DESCRIPTION
### Motivation
- Users reported dice/token movement sounds regressed after an earlier change that switched roll triggering to an imperative API, so the goal was to restore the exact 11am audio behavior for Snake & Ladder.
- Ensure dice-roll SFX play under browser user-gesture audio gating and keep mute/volume handling consistent with other game SFX.

### Description
- Reverted `DiceRoller` to the non-imperative API by removing `forwardRef`/`useImperativeHandle` and restoring click-driven roll triggering in `webapp/src/components/DiceRoller.jsx`.
- Restored a dedicated dice-roll audio instance in `webapp/src/pages/Games/SnakeAndLadder.jsx` by reintroducing `diceRollSoundRef` initialized via `createDiceRollAudio`, wiring mute propagation and cleanup, and playing it on roll events.
- Switched the roll-button handler back to triggering the hidden dice roller via the `diceRollerDivRef` `click()` path (replacing the earlier imperative `roll()` calls), and added `fixedSoundVolume={1}` where the dice roller is used to preserve previous volume behavior.
- Removed the now-missing `syncDiceRollAudioVolume` import usage and replaced it with direct audio `volume` assignment to avoid build-time export errors.

### Testing
- Ran `npx eslint webapp/src/components/DiceRoller.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`, which completed with existing ignore-pattern warnings only (no code errors).
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3b57664083298549699855565eed)