### PR TITLE
Fix Pool Royale career launch query flag

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleCareer.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleCareer.jsx
@@ -91,7 +91,7 @@ export default function PoolRoyaleCareer() {
     const params = new URLSearchParams();
     params.set('type', stage.type);
     params.set('mode', 'ai');
-    params.set('careerMode', '1');
+    params.set('career', '1');
     params.set('careerStageId', stage.id);
     if (stage.title) params.set('careerStageTitle', stage.title);
     if (stage.type === 'training' && stage.trainingLevel) {


### PR DESCRIPTION
### Motivation
- Career stage launches from the Career UI were falling back to regular practice because the launcher used `careerMode=1` instead of the `career=1` query flag expected by the `PoolRoyale` route.

### Description
- Replace `params.set('careerMode', '1')` with `params.set('career', '1')` in `webapp/src/pages/Games/PoolRoyaleCareer.jsx` so stages launched from the Career page open in Career mode.

### Testing
- Executed `npx eslint webapp/src/pages/Games/PoolRoyaleCareer.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyaleCareer.jsx`; both commands completed and produced an ignore-pattern warning but no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c3bb649548329b444859af4b55191)