### PR TITLE
Restore Snake & Ladder dice audio and token roll behavior

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,10 +1,10 @@
-import React, { forwardRef, useState, useEffect, useRef, useImperativeHandle } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getGameVolume } from '../utils/sound.js';
 import { createDiceRollAudio } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
 
-const DiceRoller = forwardRef(function DiceRoller({
+export default function DiceRoller({
   onRollEnd,
   onRollStart,
   clickable = false,
@@ -19,7 +19,7 @@ const DiceRoller = forwardRef(function DiceRoller({
   renderVisual = true,
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
-}, ref) {
+}) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
   const soundRef = useRef(null);
@@ -96,15 +96,6 @@ const DiceRoller = forwardRef(function DiceRoller({
     }, tick);
   };
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      roll: () => rollDice(),
-      isRolling: () => rolling
-    }),
-    [rolling]
-  );
-
   return (
     <div className={`flex flex-col items-center space-y-4 ${className}`}>
       <div
@@ -146,6 +137,4 @@ const DiceRoller = forwardRef(function DiceRoller({
       )}
     </div>
   );
-});
-
-export default DiceRoller;
+}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -96,6 +96,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
+import { createDiceRollAudio } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1418,7 +1419,6 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
 
   const diceRollerDivRef = useRef(null);
-  const diceRollerRef = useRef(null);
   const slideStateRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
@@ -1751,6 +1751,7 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
+  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
@@ -1808,6 +1809,8 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(timerBeep);
     timerSoundRef.current.volume = vol;
+    diceRollSoundRef.current = createDiceRollAudio({ muted });
+    if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1821,8 +1824,9 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
+      diceRollSoundRef.current?.pause();
     };
-  }, [accountId]);
+  }, [accountId, muted]);
 
   useEffect(() => {
     [
@@ -1838,6 +1842,7 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
+      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -2162,6 +2167,11 @@ export default function SnakeAndLadder() {
     const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
+      if (!muted && diceRollSoundRef.current) {
+        if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
+        diceRollSoundRef.current.currentTime = 0;
+        diceRollSoundRef.current.play().catch(() => {});
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -3207,8 +3217,7 @@ export default function SnakeAndLadder() {
 
 
   const handleRollButtonClick = () => {
-    if (diceRollerRef.current?.isRolling?.()) return;
-    diceRollerRef.current?.roll?.();
+    diceRollerDivRef.current?.click();
   };
 
   const renderPreview = (key, option) => {
@@ -3962,7 +3971,6 @@ export default function SnakeAndLadder() {
       {!isMultiplayer && (
         <div className="sr-only" aria-hidden="true">
           <DiceRoller
-            ref={diceRollerRef}
             divRef={diceRollerDivRef}
             onRollEnd={(vals) => {
               startDiceBoardAnimation({
@@ -4007,6 +4015,7 @@ export default function SnakeAndLadder() {
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
             muted={muted}
+            fixedSoundVolume={1}
           />
         </div>
       )}
@@ -4014,10 +4023,10 @@ export default function SnakeAndLadder() {
         <div className="sr-only" aria-hidden="true">
           {currentTurn === myPlayerIndex && !moving ? (
             <DiceRoller
-              ref={diceRollerRef}
               clickable
               showButton={false}
               muted={muted}
+              fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {


### PR DESCRIPTION
### Motivation
- Players reported missing/incorrect dice roll SFX and broken token movement sequencing compared to the earlier 11am baseline, so the UI should use the same audio assets and trigger path as before. 
- Recent refactors removed the DiceRoller imperative trigger and moved roll audio playback, which disrupted the external roll button -> dice -> token movement sequence.

### Description
- Restore `DiceRoller` to own dice-roll audio playback timing and visual roll flow by keeping its `createDiceRollAudio` usage and internal `rollDice()` playback path (file: `webapp/src/components/DiceRoller.jsx`).
- Re-introduce Snake & Ladder local dice SFX wiring (`diceRollSoundRef = createDiceRollAudio({...})`) and play the roll sound from the game event handler so the roll audio matches the previous baseline (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Reinstate the original roll trigger path that uses the hidden clickable dice container (`diceRollerDivRef.current?.click()`), restoring the external button -> hidden dice -> roll -> token movement sequence.
- Minor cleanups to ensure mute/volume sync remain intact and the roll playback volume is set consistently for the restored path.

### Testing
- Ran a production build with `npm run build` (from `webapp/`) which completed successfully and produced the app bundles. ✅
- Started the dev server (`vite`) to smoke-check the page boot process and the server became available. ✅
- Attempted an automated browser screenshot with Playwright to visually validate the scene, but the headless browser crashed in this environment (SIGSEGV) so no screenshot artifact could be captured. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c478014748329b42262fb7aa901a9)