### PR TITLE
Ludo Battle Royal: remove info icon and lower configuration button

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -13,7 +13,6 @@ import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
-import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import {
   createMurlanStyleTable,
@@ -2557,7 +2556,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     return false;
   });
-  const [showInfo, setShowInfo] = useState(false);
   const [showChat, setShowChat] = useState(false);
   const [showGift, setShowGift] = useState(false);
   const [isCamera2d, setIsCamera2d] = useState(false);
@@ -5651,7 +5649,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         ) : null}
-        <div className="absolute top-4 left-4 z-20 flex flex-col items-start gap-3">
+        <div className="absolute top-10 left-4 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button
               type="button"
@@ -5874,21 +5872,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           )}
         </div>
         <BottomLeftIcons
-          onInfo={() => setShowInfo(true)}
           className="absolute right-4 top-4 z-20 flex flex-col items-center gap-3 pointer-events-auto"
+          showInfo={false}
           showChat={false}
           showGift={false}
-          order={['info', 'mute']}
+          order={['mute']}
           buttonClassName="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/90 shadow-[0_6px_18px_rgba(0,0,0,0.35)] backdrop-blur transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
           iconClassName="h-5 w-5"
           labelClassName="sr-only"
-          infoIcon={(
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-              <circle cx="12" cy="12" r="9" />
-              <path d="M12 10.5v5" />
-              <path d="M12 7.5h.01" />
-            </svg>
-          )}
           muteIconOn={(
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
               <path d="M11 5 7.5 8.5H4v7h3.5L11 19V5z" />
@@ -5980,14 +5971,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
         </div>
       ))}
-      <div className="pointer-events-auto">
-        <InfoPopup
-          open={showInfo}
-          onClose={() => setShowInfo(false)}
-          title="Ludo Battle Royal"
-          info="Roll the dice to move your tokens around the track. Bring all four tokens home to win. Landing on an opponent sends them back to start."
-        />
-      </div>
       <div className="pointer-events-auto">
         <QuickMessagePopup
           open={showChat}


### PR DESCRIPTION
### Motivation
- The top-right info icon is not needed in the Ludo Battle Royal view and should be removed to simplify the overlay controls. 
- The table configuration button cluster should sit slightly lower on the portrait screen so it is visually closer to the table area.

### Description
- Removed the `InfoPopup` import and the `showInfo` state so the info modal and related state are no longer present in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Hid the info action in the action cluster by setting `showInfo={false}` and adjusting `order` to `['mute']` on the `BottomLeftIcons` instance used in the Ludo view, removing the info button from the top-right cluster.
- Moved the configuration button stack lower by changing its container from `top-4` to `top-10` so the config control appears further down toward the table.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`; lint run completed but the file is ignored by repo config so only a file-ignore warning was shown (no code errors reported).
- Ran full repo build with `npm run build`; this failed due to an unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` and is not caused by these UI changes.
- Launched the webapp dev server and executed a Playwright script that opened `/games/ludobattleroyal` at a mobile viewport and captured a screenshot, which completed successfully and confirms the updated overlay layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c946813cc83299b462ab7f80c4061)