### PR TITLE
Move Murlan Royale config button down and remove Info icon

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4640,7 +4640,7 @@ export default function MurlanRoyaleArena({ search }) {
             );
           })}
         </div>
-        <div className="pointer-events-none flex items-start justify-start px-4 pt-4">
+        <div className="pointer-events-none flex items-start justify-start px-4 pt-7">
           <div className="pointer-events-none flex flex-col items-start gap-2">
             <button
               type="button"
@@ -4833,8 +4833,7 @@ export default function MurlanRoyaleArena({ search }) {
           <BottomLeftIcons
             className="fixed right-4 top-4 flex flex-col items-center space-y-2 z-20"
             buttonClassName="flex flex-col items-center bg-transparent p-1 text-white hover:bg-transparent focus-visible:ring-2 focus-visible:ring-sky-300"
-            order={['info', 'mute', 'chat', 'gift']}
-            onInfo={() => setShowInfo(true)}
+            order={['mute', 'chat', 'gift']}
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
           />


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale arena UI clearer on portrait mobile by lowering the configuration (gear) control and removing the Info action from the top-right quick-actions stack.

### Description
- Increased top padding for the config button container in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (changed `pt-4` → `pt-7`) to move the gear button slightly downward.
- Removed the `info` action from the `BottomLeftIcons` ordering and dropped the `onInfo` handler in the same file so only `mute`, `chat`, and `gift` remain.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Verified the UI via `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and captured a portrait-mode screenshot of `/games/murlanroyale` to confirm the layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c95f1851c83299329c9bc580d7397)