### PR TITLE
Raise Snake & Ladder bottom action icons on mobile and refine HUD layout

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -4475,7 +4475,7 @@ export default function SnakeBoard3D({
         </div>
       )}
       {pot != null && (
-        <div className="absolute top-4 right-4 bg-slate-900/70 text-slate-100 text-xs px-3 py-2 rounded-xl">
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 bg-slate-900/70 text-slate-100 text-xs px-3 py-2 rounded-xl">
           Pot: {pot}
         </div>
       )}

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3499,7 +3499,7 @@ export default function SnakeAndLadder() {
       <div
         className="absolute z-30 pointer-events-auto"
         style={{
-          top: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
+          top: 'calc(4.5rem + env(safe-area-inset-top, 0px))',
           left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
         }}
       >
@@ -3741,18 +3741,36 @@ export default function SnakeAndLadder() {
           <BottomLeftIcons
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
-            onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
             style={{
               left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
-              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 2rem)'
             }}
             className="fixed z-20 flex flex-col items-center gap-2"
             showInfo={false}
             showMute={false}
+            showCamera2d={false}
+            order={['chat', 'gift']}
+            buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            iconClassName="text-2xl leading-none"
+            labelClassName="sr-only"
+          />
+        </div>
+        <div className="pointer-events-auto w-full">
+          <BottomLeftIcons
+            onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
+            style={{
+              right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 2rem)'
+            }}
+            className="fixed z-20 flex flex-col items-center gap-2"
+            showInfo={false}
+            showMute={false}
+            showChat={false}
+            showGift={false}
             showCamera2d
             camera2dActive={cameraViewMode === '2d'}
             cameraLabel="2D"
-            order={['chat', 'gift', 'camera2d']}
+            order={['camera2d']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
@@ -4051,7 +4069,7 @@ export default function SnakeAndLadder() {
         </div>
       )}
       {!watchOnly && (
-        <div className="fixed bottom-6 inset-x-0 flex flex-col items-center z-30 pointer-events-none space-y-3">
+        <div className="fixed bottom-10 inset-x-0 flex flex-col items-center z-30 pointer-events-none space-y-3">
           {displayedTurnMessage && (
             <div className="px-4 py-2 rounded-full bg-[rgba(7,10,18,0.7)] border border-[rgba(255,215,0,0.25)] text-white text-sm font-semibold backdrop-blur">
               {displayedTurnMessage}


### PR DESCRIPTION
### Motivation
- Improve portrait-mobile HUD spacing so the chat, gift and 2D icons sit higher and avoid overlapping bottom controls while keeping the controls visually aligned.
- Make the pot indicator more prominent and ensure the top menu lines up with the top-right info controls for better visual hierarchy.

### Description
- Centered the pot badge by updating `webapp/src/components/SnakeBoard3D.jsx` to use `left-1/2 -translate-x-1/2` for the pot wrapper so `Pot: {pot}` appears top-center.
- Lowered the in-game menu in `webapp/src/pages/Games/SnakeAndLadder.jsx` by setting its `top` to `calc(4.5rem + env(safe-area-inset-top, 0px))` to align with top-right controls.
- Split bottom controls into two `BottomLeftIcons` instances in `webapp/src/pages/Games/SnakeAndLadder.jsx`, keeping `chat`/`gift` on the bottom-left and rendering `camera2d` as a separate bottom-right control.
- Raised all three action icons and the turn/commentary container by increasing bottom safe-area offsets (bottom icon offsets from `+1rem` to `+2rem` and turn container from `bottom-6` to `bottom-10`).

### Testing
- Ran `npm --prefix webapp run build` which completed successfully without blocking errors.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched and served the app.
- Attempted an automated Playwright screenshot to validate the mobile layout but the headless Chromium process crashed with a SIGSEGV in this environment, so no screenshot artifact could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c988e147083298e2f6f8c19efc14a)