### PR TITLE
Adjust Air Hockey HUD: remove Info, move Mute to bottom-right, add Menu at top-left

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -8,7 +8,7 @@ import GiftPopup from './GiftPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 import QuickMessagePopup from './QuickMessagePopup.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
-import { AiOutlineInfoCircle, AiOutlineMessage } from 'react-icons/ai';
+import { AiOutlineMessage } from 'react-icons/ai';
 import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 import { buildAirHockeyCommentaryLine, AIR_HOCKEY_SPEAKERS } from '../utils/airHockeyCommentary.js';
@@ -2509,25 +2509,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           <>
             <button
               type="button"
-              onClick={() => setShowInfo(true)}
-              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-            >
-              <AiOutlineInfoCircle className="text-xl" />
-              <span>Info</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                toggleGameMuted();
-                setMuted(isGameMuted());
-              }}
-              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-            >
-              <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
-              <span>{muted ? 'Unmute' : 'Mute'}</span>
-            </button>
-            <button
-              type="button"
               onClick={() => setShowGift(true)}
               className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
             >
@@ -2545,31 +2526,32 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
               <span className="text-xl">🎁</span>
               <span>Gift</span>
             </button>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  toggleGameMuted();
-                  setMuted(isGameMuted());
-                }}
-                className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-              >
-                <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
-                <span>{muted ? 'Unmute' : 'Mute'}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowInfo(true)}
-                className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-              >
-                <AiOutlineInfoCircle className="text-xl" />
-                <span>Info</span>
-              </button>
-            </div>
           </>
         )}
       </div>
+      <div className="absolute top-12 left-2 z-20">
+        <button
+          onClick={() => setShowCustomizer((v) => !v)}
+          className="rounded px-3 py-2 text-xs font-semibold text-white bg-white/10 hover:bg-white/20 backdrop-blur"
+        >
+          <span className="inline-flex items-center gap-1">
+            <span aria-hidden>⚙️</span>
+            {showCustomizer ? 'Close menu' : 'Menu'}
+          </span>
+        </button>
+      </div>
       <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
+        <button
+          type="button"
+          onClick={() => {
+            toggleGameMuted();
+            setMuted(isGameMuted());
+          }}
+          className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+        >
+          <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+          <span>{muted ? 'Unmute' : 'Mute'}</span>
+        </button>
         <button
           type="button"
           aria-pressed={isTopDownView}
@@ -2583,15 +2565,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           <span className="inline-flex items-center gap-1">
             <span aria-hidden>🧭</span>
             <span>{isTopDownView ? '3D' : '2D'}</span>
-          </span>
-        </button>
-        <button
-          onClick={() => setShowCustomizer((v) => !v)}
-          className="rounded px-3 py-2 text-xs font-semibold text-white bg-white/10 hover:bg-white/20 backdrop-blur"
-        >
-          <span className="inline-flex items-center gap-1">
-            <span aria-hidden>⚙️</span>
-            {showCustomizer ? 'Close customizer' : 'Customize table'}
           </span>
         </button>
         {showCustomizer && (


### PR DESCRIPTION
### Motivation
- Update the Air Hockey HUD to match the requested mobile portrait layout: remove the `Info` quick-action, place the mute toggle above the 2D/3D button in the bottom-right, and move the configuration control to the top-left and rename it to `Menu`.

### Description
- Removed the `Info` quick-action button and its `AiOutlineInfoCircle` import from `webapp/src/components/AirHockey3D.jsx` so the left HUD now contains only `Chat` and `Gift` in both view modes.
- Moved the mute toggle UI into the bottom-right control stack and placed it directly above the `2D/3D` toggle so it appears as requested in portrait layout.
- Moved the configuration/customizer control to the top-left and renamed its label to `Menu` with a `Close menu` state when expanded; the existing customizer panel remains unchanged and is shown when `showCustomizer` is true.
- Single file changed: `webapp/src/components/AirHockey3D.jsx` (UI reflow and import cleanup).

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully (Vite produced normal chunking warnings about large chunks but build finished without errors). 
- Attempted a headless screenshot of `/games/airhockey` using Playwright to validate the rendered UI; the screenshot step timed out in this environment (page/screenshot timeout), so visual verification via screenshot could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c999a58d48329b3279318d69b3151)