### PR TITLE
Lower Snake & Ladder in-game menu button position

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3499,7 +3499,7 @@ export default function SnakeAndLadder() {
       <div
         className="absolute z-30 pointer-events-auto"
         style={{
-          top: 'calc(4.5rem + env(safe-area-inset-top, 0px))',
+          top: 'calc(5.25rem + env(safe-area-inset-top, 0px))',
           left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
         }}
       >


### PR DESCRIPTION
### Motivation
- Move the in-game Menu button slightly lower on portrait screens so it appears visually further down and improves alignment with the requested UI placement.

### Description
- Increase the `top` safe-area offset in `webapp/src/pages/Games/SnakeAndLadder.jsx` from `calc(4.5rem + env(safe-area-inset-top, 0px))` to `calc(5.25rem + env(safe-area-inset-top, 0px))` so the menu sits lower on the page.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully.
- Launched the dev server with `npm --prefix webapp run dev` and captured a portrait screenshot of `/games/snake` verifying the new menu placement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca0f789d48329be25ea38dac17a8a)