### PR TITLE
Adjust Snake & Ladder mobile control icon positioning

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3499,7 +3499,7 @@ export default function SnakeAndLadder() {
       <div
         className="absolute z-30 pointer-events-auto"
         style={{
-          top: 'calc(5.25rem + env(safe-area-inset-top, 0px))',
+          top: 'calc(5.8rem + env(safe-area-inset-top, 0px))',
           left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
         }}
       >
@@ -3723,14 +3723,19 @@ export default function SnakeAndLadder() {
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
+            onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
             style={{
               right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
               top: 'calc(4.5rem + env(safe-area-inset-top, 0px))'
             }}
-            className="fixed z-30 flex flex-col items-center gap-2"
+            className="fixed z-30 flex flex-col items-center gap-3"
             showChat={false}
             showGift={false}
-            order={['info', 'mute']}
+            showMute={false}
+            showCamera2d
+            camera2dActive={cameraViewMode === '2d'}
+            cameraLabel="2D"
+            order={['info', 'camera2d']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
@@ -3743,9 +3748,9 @@ export default function SnakeAndLadder() {
             onGift={() => setShowGift(true)}
             style={{
               left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
-              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 2rem)'
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 3rem)'
             }}
-            className="fixed z-20 flex flex-col items-center gap-2"
+            className="fixed z-20 flex flex-col items-center gap-3"
             showInfo={false}
             showMute={false}
             showCamera2d={false}
@@ -3757,20 +3762,17 @@ export default function SnakeAndLadder() {
         </div>
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
-            onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
             style={{
               right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
-              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 2rem)'
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 3rem)'
             }}
             className="fixed z-20 flex flex-col items-center gap-2"
             showInfo={false}
-            showMute={false}
+            showMute
             showChat={false}
             showGift={false}
-            showCamera2d
-            camera2dActive={cameraViewMode === '2d'}
-            cameraLabel="2D"
-            order={['camera2d']}
+            showCamera2d={false}
+            order={['mute']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation
- Align on-screen controls to requested portrait layout by nudging the Menu icon slightly downward. 
- Swap the mute and 2D camera buttons so the camera sits in the top-right stack and mute moves to the bottom-right. 
- Increase vertical spacing and lift bottom controls so Chat, Gift and Mute sit a bit higher with a small gap between Chat and Gift and between Info and 2D.

### Description
- Updated `webapp/src/pages/Games/SnakeAndLadder.jsx` to move the menu top offset from `calc(5.25rem ...)` to `calc(5.8rem ...)` to shift the Menu button lower. 
- Reworked the three `BottomLeftIcons` usages in the page to swap the `mute` and `camera2d` placements by toggling `showMute`/`showCamera2d` and changing the `order` props so top-right shows `['info','camera2d']` and bottom-right shows `['mute']`. 
- Raised the bottom stacks by changing `bottom` values from `calc(... + 2rem)` to `calc(... + 3rem)` and increased vertical spacing classes from `gap-2` to `gap-3` where appropriate. 
- Added a top-right `onCamera2d` handler and updated `camera2dActive`/`cameraLabel` props so the 2D toggle works in its new position.

### Testing
- Ran `npm -C webapp run build` which completed successfully with no build errors. 
- Served a local preview with `npm -C webapp run preview` and captured a portrait-mode screenshot via Playwright to validate layout at `browser:/tmp/codex_browser_invocations/0b766459050ee4f5/artifacts/artifacts/snake-controls-layout.png`. 
- Committed the change and verified the modified file `webapp/src/pages/Games/SnakeAndLadder.jsx` was updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d42cb01f48329a3851ad217202696)