### PR TITLE
Ludo: HUD alignment, token-colored tile highlights, procedural SFX, and FPS/profile tuning

### DIFF
--- a/webapp/src/utils/ludoSfx.js
+++ b/webapp/src/utils/ludoSfx.js
@@ -1,0 +1,53 @@
+// Lightweight procedural SFX inspired by open-source Web Audio patterns (MIT-style oscillator envelopes).
+let sharedCtx = null;
+
+function getAudioContext() {
+  if (typeof window === 'undefined') return null;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) return null;
+  if (!sharedCtx || sharedCtx.state === 'closed') {
+    sharedCtx = new Ctx();
+  }
+  if (sharedCtx.state === 'suspended') {
+    sharedCtx.resume().catch(() => {});
+  }
+  return sharedCtx;
+}
+
+function scheduleTone(ctx, { startAt, duration, fromHz, toHz, volume = 0.4, type = 'triangle' }) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(fromHz, startAt);
+  osc.frequency.exponentialRampToValueAtTime(Math.max(20, toHz), startAt + duration);
+
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(Math.max(0.0001, volume), startAt + Math.min(0.04, duration * 0.45));
+  gain.gain.exponentialRampToValueAtTime(0.0001, startAt + duration);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(startAt);
+  osc.stop(startAt + duration + 0.02);
+}
+
+export function playLudoDiceRollSfx({ volume = 1, muted = false } = {}) {
+  if (muted || volume <= 0) return;
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  const now = ctx.currentTime + 0.005;
+  const v = Math.min(0.4, Math.max(0.08, volume * 0.3));
+  scheduleTone(ctx, { startAt: now, duration: 0.08, fromHz: 420, toHz: 260, volume: v, type: 'square' });
+  scheduleTone(ctx, { startAt: now + 0.06, duration: 0.09, fromHz: 390, toHz: 210, volume: v * 0.9, type: 'square' });
+  scheduleTone(ctx, { startAt: now + 0.12, duration: 0.12, fromHz: 300, toHz: 140, volume: v * 0.85, type: 'triangle' });
+}
+
+export function playLudoTokenStepSfx({ volume = 1, muted = false } = {}) {
+  if (muted || volume <= 0) return;
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  const now = ctx.currentTime + 0.004;
+  const v = Math.min(0.35, Math.max(0.06, volume * 0.22));
+  scheduleTone(ctx, { startAt: now, duration: 0.065, fromHz: 180, toHz: 120, volume: v, type: 'triangle' });
+  scheduleTone(ctx, { startAt: now + 0.024, duration: 0.055, fromHz: 240, toHz: 170, volume: v * 0.8, type: 'sine' });
+}


### PR DESCRIPTION
### Motivation
- Improve the Ludo Battle Royal UX by aligning on-screen controls for portrait phones, make tile highlights visually match the moving token, and add lightweight audio feedback without shipping binary assets.  
- Reduce GPU/DPR pressure on mobile so the advertised FPS is more attainable by tuning render scales and DPR caps.

### Description
- Moved the 2D camera control into the top-right HUD stack (below mute) and nudged the chat icon upward while keeping the gift button at the right edge to match the requested portrait layout (edited `webapp/src/pages/Games/LudoBattleRoyal.jsx`).  
- Tile highlight logic now accepts a `tokenColor` and the in-motion highlight path is set to use the moving player’s token color; animation code calls the new signature so each stepped tile glows in the token’s color (`setTileHighlight` / `updateAnimationHighlight` in `LudoBattleRoyal.jsx`).  
- Added a small procedural Web Audio SFX helper `webapp/src/utils/ludoSfx.js` implementing dice-roll and token-step sounds and wired the Ludo page to call `playLudoDiceRollSfx` / `playLudoTokenStepSfx` so no binary audio files were added.  
- Tuned frame-quality profiles (`FRAME_RATE_OPTIONS`) and renderer clamping: lowered `renderScale` and `pixelRatioCap` values across profiles, changed the default profile to `fhd60`, and relaxed clamping bounds to allow lighter scales for better real-world FPS (changes in `LudoBattleRoyal.jsx`).

### Testing
- Built the web app with `npm -C webapp run build` and the build completed successfully (warnings about chunk sizes only).  
- Launched the dev server and captured a portrait screenshot of `/games/ludobattleroyal` via Playwright to validate HUD placement and rendering; the screenshot run completed after a retry.  
- No binary audio assets were added to this PR; procedural SFX are generated at runtime by `webapp/src/utils/ludoSfx.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4441a4708329b04f0b868cd780ed)