### PR TITLE
Refine Domino Royal HUD layout and enforce GLTF table/chair textures

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -35,15 +35,9 @@ export default function DominoRoyalArena() {
     <div className="relative h-full w-full bg-black">
       <div id="app" />
       <div id="status" role="status">Ready</div>
-      <button id="configButton" type="button" aria-label="Table setup">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
-          />
-        </svg>
+      <button id="configButton" type="button" aria-label="Open game settings menu">
+        <span aria-hidden="true">☰</span>
+        <span>Menu</span>
       </button>
       <div id="configPanel" role="dialog" aria-modal="true" aria-labelledby="configTitle" tabIndex="-1" aria-hidden="true">
         <div className="config-close">
@@ -56,10 +50,37 @@ export default function DominoRoyalArena() {
         <h3 id="configTitle">Table Setup</h3>
         <div id="configSections" />
       </div>
+      <style>{`
+        #viewToggle {
+          position: static !important;
+          left: auto !important;
+          right: auto !important;
+          top: auto !important;
+          margin: 0 !important;
+        }
+        #configButton {
+          top: calc(4.1rem + env(safe-area-inset-top, 0px)) !important;
+          left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
+          width: auto !important;
+          padding: 0 0.95rem !important;
+          display: flex !important;
+          align-items: center;
+          gap: 0.5rem;
+        }
+        #configButton span:first-child { font-size: 1.05rem; line-height: 1; }
+        #configButton span:last-child { font-size: 0.72rem; letter-spacing: 0.24em; text-transform: uppercase; }
+        #railControls {
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
+        }
+        #quickActions {
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
+          left: auto !important;
+          right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
+          gap: 0.5rem;
+        }
+      `}</style>
       <div id="topRightActions" aria-label="Top actions">
-        <button id="btnRules" className="top-action" type="button" aria-label="Rules" title="Rules">
-          <span aria-hidden="true">ℹ️</span>
-        </button>
+        <button id="viewToggle" type="button" aria-label="Switch view" title="Switch view" />
         <button id="muteButton" className="top-action" type="button" aria-label="Mute" title="Mute">
           <span className="icon" id="muteIcon" aria-hidden="true">🔊</span>
           <span id="muteLabel" className="visually-hidden">Mute</span>
@@ -69,7 +90,6 @@ export default function DominoRoyalArena() {
         <button id="draw" type="button">Draw</button>
         <button id="pass" type="button">Pass</button>
       </div>
-      <button id="viewToggle" type="button" aria-label="Switch view" title="Switch view" />
       <div id="quickActions" aria-label="Quick actions">
         <button className="quick-action" type="button" data-action="chat">
           <span className="icon" aria-hidden="true">💬</span>


### PR DESCRIPTION
### Motivation
- Improve portrait (mobile) ergonomics by placing the 2D/3D toggle above the mute button and aligning quick actions so the Gift button sits on the same horizontal level as the Draw/Pass controls. 
- Replace procedural table/chair fallbacks with GLTF-backed Poly Haven themes to restore authentic mapped textures and higher-fidelity assets. 
- Harden rules-panel event bindings to avoid runtime errors when optional UI elements are removed.

### Description
- UI: Moved the view toggle into the top-right stack above the mute control, converted the config icon to a `☰ Menu` button, and adjusted inline portrait style overrides to lift/right-align `#quickActions` and keep the mute icon below the 2D toggle; changes in `webapp/src/pages/Games/DominoRoyalArena.jsx`.
- Table GLTFs: Removed the procedural default table option from the theme list, added `DEFAULT_TABLE_THEME_OPTION`, and rewrote `applyTableTheme` to load GLTF-only table themes and fall back to a GLTF default on failure; edits in `webapp/public/domino-royal-game.js`.
- Texture/loader fixes: Updated the GLTF loader URL modifier to preserve absolute and `data:` URLs and to remap relative texture URIs to `Models/gltf/...` so GLTF materials use their bundled textures, and increased `MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize` from `2048` to `4096` for higher-resolution domino surfaces; edits in `webapp/public/domino-royal-game.js`.
- Chairs GLTF-only: Removed the procedural chair fallback and the timeout-based fallback race so chairs are built from loaded GLTF theme assets only (with error logging), and simplified `placeChairsWithOption` to require GLTF chair data; edits in `webapp/public/domino-royal-game.js`.
- Robustness: Added null-safety checks around rules-panel event wiring to avoid exceptions when the rules button or panel are absent; edits in `webapp/public/domino-royal-game.js`.

### Testing
- Ran a syntax check with `node --check webapp/public/domino-royal-game.js`, which succeeded. 
- Built the web app with `npm --prefix webapp run build`, which completed successfully (Vite produced chunk-size warnings unrelated to these changes). 
- Launched the dev server and captured a 390×844 portrait screenshot of `/games/domino-royal` via Playwright, which completed successfully and was used to validate the HUD placement adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3f8744708329ae2fe178e38badb7)