### PR TITLE
Adjust Snake & Ladder quick-action icon placement on mobile

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3723,6 +3723,7 @@ export default function SnakeAndLadder() {
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
+            showMute
             onCamera2d={() => setCameraViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
             style={{
               right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
@@ -3731,11 +3732,10 @@ export default function SnakeAndLadder() {
             className="fixed z-30 flex flex-col items-center gap-3"
             showChat={false}
             showGift={false}
-            showMute={false}
             showCamera2d
             camera2dActive={cameraViewMode === '2d'}
             cameraLabel="2D"
-            order={['info', 'camera2d']}
+            order={['info', 'mute', 'camera2d']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
@@ -3745,7 +3745,6 @@ export default function SnakeAndLadder() {
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
             onChat={() => setShowChat(true)}
-            onGift={() => setShowGift(true)}
             style={{
               left: 'calc(0.75rem + env(safe-area-inset-left, 0px))',
               bottom: 'calc(env(safe-area-inset-bottom, 0px) + 3rem)'
@@ -3753,8 +3752,9 @@ export default function SnakeAndLadder() {
             className="fixed z-20 flex flex-col items-center gap-3"
             showInfo={false}
             showMute={false}
+            showGift={false}
             showCamera2d={false}
-            order={['chat', 'gift']}
+            order={['chat']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
@@ -3762,17 +3762,18 @@ export default function SnakeAndLadder() {
         </div>
         <div className="pointer-events-auto w-full">
           <BottomLeftIcons
+            onGift={() => setShowGift(true)}
             style={{
               right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
               bottom: 'calc(env(safe-area-inset-bottom, 0px) + 3rem)'
             }}
             className="fixed z-20 flex flex-col items-center gap-2"
             showInfo={false}
-            showMute
             showChat={false}
-            showGift={false}
+            showMute={false}
+            showGift
             showCamera2d={false}
-            order={['mute']}
+            order={['gift']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation
- Improve mobile (portrait) HUD layout so the mute control sits visually between Info and the 2D camera toggle for clearer ordering. 
- Place the 2D camera toggle under the mute button to reflect the requested stacking. 
- Move the Gift action to the bottom-right while keeping Chat on the bottom-left at the same vertical position for balanced quick actions.

### Description
- Updated `webapp/src/pages/Games/SnakeAndLadder.jsx` to include the mute button in the top-right icon stack by adding `showMute` and changing the `order` from `['info','camera2d']` to `['info','mute','camera2d']`.
- Split the bottom quick actions into two `BottomLeftIcons` instances so `Chat` remains on the bottom-left (`order={['chat']}`) and `Gift` is shown on the bottom-right (`order={['gift']}`).
- Adjusted the `showGift` / `showMute` boolean props and click handlers to match the new positions without changing the shared `BottomLeftIcons` component.

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully (no build errors).
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to verify UI behavior and it launched successfully.
- Captured an automated portrait screenshot of `/games/snake` (mobile viewport) after the dev server started to validate the icon layout, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d49d9daf48329856df104b8cdb869)