### PR TITLE
Adjust Murlan Royale HUD icon positions and sizes

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4643,7 +4643,7 @@ export default function MurlanRoyaleArena({ search }) {
         <div
           className="absolute z-30 pointer-events-auto"
           style={{
-            top: 'calc(4.5rem + env(safe-area-inset-top, 0px))',
+            top: 'calc(4.8rem + env(safe-area-inset-top, 0px))',
             left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
           }}
         >
@@ -4831,8 +4831,9 @@ export default function MurlanRoyaleArena({ search }) {
             showInfo={false}
           />
           <BottomLeftIcons
-            className="fixed left-4 bottom-[10.2rem] z-20"
+            className="fixed left-4 bottom-[10.8rem] z-20"
             buttonClassName="flex flex-col items-center bg-transparent p-1 text-white hover:bg-transparent focus-visible:ring-2 focus-visible:ring-sky-300"
+            iconClassName="text-2xl"
             order={['chat']}
             showGift={false}
             showInfo={false}
@@ -4840,8 +4841,9 @@ export default function MurlanRoyaleArena({ search }) {
             onChat={() => setShowChat(true)}
           />
           <BottomLeftIcons
-            className="fixed right-4 bottom-[10.2rem] z-20"
+            className="fixed right-4 bottom-[10.8rem] z-20"
             buttonClassName="flex flex-col items-center bg-transparent p-1 text-white hover:bg-transparent focus-visible:ring-2 focus-visible:ring-sky-300"
+            iconClassName="text-2xl"
             order={['gift']}
             showChat={false}
             showInfo={false}


### PR DESCRIPTION
### Motivation
- Improve the mobile portrait HUD layout so the menu, chat and gift controls are slightly better positioned and more visible on-screen.

### Description
- Shifted the top-left menu down by changing the top offset from `4.5rem` to `4.8rem`, raised the chat and gift groups by changing `bottom-[10.2rem]` to `bottom-[10.8rem]`, and increased chat/gift icon size by adding `iconClassName="text-2xl"` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully; the dev server `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` started successfully; and an automated Playwright script loaded `/games/murlanroyale` at a mobile viewport and produced an updated screenshot confirming the visual changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5f92444c8329a4f354409bc256f3)