### PR TITLE
Ludo Battle Royal — enlarge/move chat & gift quick-actions and switch to 'Menu' trigger

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5663,26 +5663,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               type="button"
               onClick={() => setConfigOpen((prev) => !prev)}
               aria-expanded={configOpen}
-              aria-label="Open menu"
-              className="flex h-10 w-10 items-center justify-center bg-transparent text-white/90 shadow-none transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+              aria-label={configOpen ? 'Close game settings menu' : 'Open game settings menu'}
+              className="flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                className="h-6 w-6"
-                aria-hidden="true"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="m19.4 13.5-.44 1.74a1 1 0 0 1-1.07.75l-1.33-.14a7.03 7.03 0 0 1-1.01.59l-.2 1.32a1 1 0 0 1-.98.84h-1.9a1 1 0 0 1-.98-.84l-.2-1.32a7.03 7.03 0 0 1-1.01-.59l-1.33.14a1 1 0 0 1-1.07-.75L4.6 13.5a1 1 0 0 1 .24-.96l1-.98a6.97 6.97 0 0 1 0-1.12l-1-.98a1 1 0 0 1-.24-.96l.44-1.74a1 1 0 0 1 1.07-.75l1.33.14c.32-.23.66-.43 1.01-.6l.2-1.31a1 1 0 0 1 .98-.84h1.9a1 1 0 0 1 .98.84l.2 1.31c.35.17.69.37 1.01.6l1.33-.14a1 1 0 0 1 1.07.75l.44 1.74a1 1 0 0 1-.24.96l-1 .98c.03.37.03.75 0 1.12l1 .98a1 1 0 0 1 .24.96z"
-                />
-              </svg>
-              <span className="sr-only">Open menu</span>
+              <span className="text-base leading-none">☰</span>
+              <span className="leading-none">Menu</span>
             </button>
           </div>
           {configOpen && (
@@ -5920,24 +5905,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         />
         <BottomLeftIcons
           onChat={() => setShowChat(true)}
-          className="absolute bottom-8 left-4 z-20 flex flex-col items-center gap-3 pointer-events-auto"
+          className="absolute bottom-14 left-3 z-20 flex flex-col items-center gap-3 pointer-events-auto"
           showInfo={false}
           showGift={false}
           showMute={false}
-          buttonClassName="flex items-center justify-center bg-transparent p-2 text-white/90 shadow-none transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
-          iconClassName="text-2xl"
-          labelClassName="sr-only"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border-none bg-transparent p-0 text-white shadow-none transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          iconClassName="text-[1.35rem] leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em] leading-none"
+          chatIcon="💬"
         />
         <BottomLeftIcons
           onGift={() => setShowGift(true)}
-          className="absolute bottom-6 right-4 z-20 flex flex-col items-center gap-3 pointer-events-auto"
+          className="absolute bottom-14 right-3 z-20 flex flex-col items-center gap-3 pointer-events-auto"
           showInfo={false}
           showChat={false}
           showMute={false}
           order={['gift']}
-          buttonClassName="flex items-center justify-center bg-transparent p-2 text-white/90 shadow-none transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
-          iconClassName="text-2xl"
-          labelClassName="sr-only"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border-none bg-transparent p-0 text-white shadow-none transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+          iconClassName="text-[1.35rem] leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em] leading-none"
+          giftIcon="🎁"
         />
         <div className="absolute inset-0 z-10 pointer-events-none">
           {players.map((player) => {


### PR DESCRIPTION
### Motivation
- Align Ludo Battle Royal UI with Goal Rush / Snake & Ladder by lifting and slightly enlarging the chat and gift quick-action controls so they match the existing framed layout and visual weight. 
- Replace the gear/config icon with the same `☰ Menu` layout and accessible label used in Snake & Ladder for consistent cross-game UX.

### Description
- Replaced the gear SVG with a `☰ Menu` button and updated aria-label logic to `aria-label={configOpen ? 'Close game settings menu' : 'Open game settings menu'}` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to match Snake & Ladder. 
- Moved the Chat quick-action up and adjusted positioning from `bottom-8 left-4` to `bottom-14 left-3` and changed sizing/appearance to use a `3.15rem` square framed style and richer label/icon treatment. 
- Moved the Gift quick-action up and adjusted positioning from `bottom-6 right-4` to `bottom-14 right-3` and applied the same framed sizing, icon and label adjustments so chat and gift share the same layout. 
- Small class and prop updates on the two `BottomLeftIcons` usages: updated `buttonClassName`, `iconClassName`, `labelClassName`, and added `chatIcon`/`giftIcon` props to render matching emoji icons.

### Testing
- Ran `npx eslint` on the modified file path; ESLint ran but the file is currently ignored by the project ignore rules (warning reported). 
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app successfully. 
- Executed a headless Playwright script to load `/games/ludobattleroyal` in a 390x844 viewport and produced a portrait screenshot to validate visual placement; the artifact was generated at `artifacts/ludo-ui-update.png` and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d60752a50832982b110889c209e88)