### PR TITLE
Improve Ludo dice SFX, tile highlight coloration, and HUD positioning

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3420,16 +3420,24 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (active) {
       if (tile.material.emissive) {
         if (tokenColor) {
-          tile.material.emissive.copy(tokenColor);
+          tile.material.emissive.copy(tokenColor).lerp(new THREE.Color(0xffffff), 0.12);
         } else if (data.highlightEmissive) {
           tile.material.emissive.copy(data.highlightEmissive);
         }
       }
-      tile.material.emissiveIntensity = tokenColor ? Math.max(data.baseIntensity + 0.88, 0.9) : data.highlightIntensity;
+      if (tile.material.color && tokenColor) {
+        tile.material.color.copy(data.baseColor).lerp(tokenColor, 0.55);
+      } else if (tile.material.color && data.highlightColor) {
+        tile.material.color.copy(data.highlightColor);
+      }
+      tile.material.emissiveIntensity = tokenColor ? Math.max(data.baseIntensity + 1.08, 1.05) : data.highlightIntensity;
       data.isHighlighted = true;
     } else {
       if (tile.material.emissive && data.baseEmissive) {
         tile.material.emissive.copy(data.baseEmissive);
+      }
+      if (tile.material.color && data.baseColor) {
+        tile.material.color.copy(data.baseColor);
       }
       tile.material.emissiveIntensity = data.baseIntensity;
       data.isHighlighted = false;
@@ -5657,7 +5665,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         ) : null}
-        <div className="absolute top-[4.5rem] left-4 z-20 flex flex-col items-start gap-3">
+        <div className="absolute top-[5rem] left-3 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button
               type="button"
@@ -5866,7 +5874,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           )}
         </div>
         <BottomLeftIcons
-          className="absolute right-4 top-[4.5rem] z-20 flex flex-col items-center gap-3 pointer-events-auto"
+          className="absolute right-4 top-[5.2rem] z-20 flex flex-col items-center gap-3 pointer-events-auto"
           showInfo={false}
           showChat={false}
           showGift={false}
@@ -5890,7 +5898,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           )}
         />
         <BottomLeftIcons
-          className="absolute right-4 top-[8rem] z-20 flex flex-col items-center gap-3 pointer-events-auto"
+          className="absolute right-4 top-[8.7rem] z-20 flex flex-col items-center gap-3 pointer-events-auto"
           showInfo={false}
           showChat={false}
           showGift={false}
@@ -6140,14 +6148,17 @@ async function buildLudoBoard(
     const baseEmissive = mat?.emissive?.clone?.() ?? new THREE.Color(0x000000);
     const baseIntensity = mat?.emissiveIntensity ?? 0;
     const baseColor = mat?.color?.clone?.() ?? new THREE.Color(0xffffff);
+    const highlightColor = baseColor.clone().lerp(new THREE.Color(0xffffff), 0.16).offsetHSL(0.01, 0.22, 0.06);
     const highlightEmissive = baseColor.clone().lerp(new THREE.Color(0xffffff), 0.6);
     mesh.userData = {
       ...mesh.userData,
       boardTile: {
+        baseColor,
+        highlightColor,
         baseEmissive,
         baseIntensity,
         highlightEmissive,
-        highlightIntensity: Math.max(baseIntensity + 0.7, 0.75)
+        highlightIntensity: Math.max(baseIntensity + 0.85, 0.9)
       }
     };
   };


### PR DESCRIPTION
### Motivation
- Make the dice roll sound feel more authentic and physical by replacing the short oscillator-only burst with a layered rolling/noise + impacts profile. 
- Increase visual feedback when a token steps on a tile by making highlights more colorized and perceptible. 
- Slightly adjust HUD controls in portrait so the menu, mute and 2D camera icons align better on mobile screens.

### Description
- Reworked dice SFX in `webapp/src/utils/ludoSfx.js` by adding `scheduleNoiseBurst` and updating `playLudoDiceRollSfx` to layer a filtered noise burst (rolling texture), staggered impact tones, and a low-end tail for a more physical dice feel while preserving mute/volume handling. 
- Enhanced tile highlighting in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by blending tile albedo toward the token color during active highlights, increasing emissive intensity, and restoring the original `baseColor`/emissive when highlight ends; also added `highlightColor` and `baseColor` into tile `userData` at registration. 
- Nudged HUD placement in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by moving the menu button slightly lower and left, and lowering the mute and 2D camera quick-action buttons a bit on the right side for improved portrait alignment. 
- Changes are limited to presentation and audio feedback; gameplay logic was not modified.

### Testing
- Ran a production build with `npm run build` (from `webapp/`) which completed successfully (build produced some chunk-size warnings but finished). 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and validated the UI visually. 
- Captured a portrait screenshot of `/games/ludobattleroyal` via Playwright to verify HUD placement and highlight appearance; screenshot was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d65cf84548329b39e5b13f1fc28d8)