### PR TITLE
Improve Ludo dice SFX, match tile highlight to player colors, and nudge menu position

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3420,13 +3420,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (active) {
       if (tile.material.emissive) {
         if (tokenColor) {
-          tile.material.emissive.copy(tokenColor).lerp(new THREE.Color(0xffffff), 0.12);
+          tile.material.emissive.copy(tokenColor);
         } else if (data.highlightEmissive) {
           tile.material.emissive.copy(data.highlightEmissive);
         }
       }
       if (tile.material.color && tokenColor) {
-        tile.material.color.copy(data.baseColor).lerp(tokenColor, 0.55);
+        tile.material.color.copy(tokenColor);
       } else if (tile.material.color && data.highlightColor) {
         tile.material.color.copy(data.highlightColor);
       }
@@ -5665,7 +5665,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         ) : null}
-        <div className="absolute top-[5rem] left-3 z-20 flex flex-col items-start gap-3">
+        <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Make the dice-roll sound more audible and phone-friendly while keeping the SFX procedural and original (no binary assets). 
- Ensure the tile highlight when a token steps matches the center quadrant colors so visual feedback is consistent. 
- Slightly reposition the on-screen menu control for better portrait alignment on phones.

### Description
- Increased presence of the procedural dice roll in `webapp/src/utils/ludoSfx.js` by boosting the base gain, adding a secondary high-band noise burst, widening/tightening filter Q parameters, and tuning impact timing and frequency envelopes. 
- Changed tile highlight logic in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to apply the exact `tokenColor` to `material.emissive` and `material.color` (removed the previous lerp/blend), so highlighted tiles match center colors. 
- Nudged the menu button placement in `LudoBattleRoyal.jsx` by updating the wrapper classes from `top-[5rem] left-3` to `top-[5.35rem] left-2` for a slightly lower and left-shifted position.

### Testing
- Ran `npx eslint webapp/src/utils/ludoSfx.js webapp/src/pages/Games/LudoBattleRoyal.jsx`, which returned repository ignore warnings but no lint errors. 
- Built the webapp with `npm --prefix webapp run build`, which succeeded (Vite produced non-blocking chunking/import warnings but the production build completed). 
- Started the dev server (`npm --prefix webapp run dev`) and executed a Playwright script that loaded `/games/ludobattleroyal` in a 390x844 viewport and captured a screenshot, confirming the UI placement and rendering changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6ceb6e608329b41f90a8407c2cae)