### PR TITLE
Improve Ludo Battle Royal dice SFX and tile/menu visuals

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3420,17 +3420,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (active) {
       if (tile.material.emissive) {
         if (tokenColor) {
-          tile.material.emissive.copy(tokenColor).lerp(new THREE.Color(0xffffff), 0.12);
+          tile.material.emissive.copy(tokenColor).lerp(new THREE.Color(0xffffff), 0.06);
         } else if (data.highlightEmissive) {
           tile.material.emissive.copy(data.highlightEmissive);
         }
       }
       if (tile.material.color && tokenColor) {
-        tile.material.color.copy(data.baseColor).lerp(tokenColor, 0.55);
+        tile.material.color.copy(tokenColor);
       } else if (tile.material.color && data.highlightColor) {
         tile.material.color.copy(data.highlightColor);
       }
-      tile.material.emissiveIntensity = tokenColor ? Math.max(data.baseIntensity + 1.08, 1.05) : data.highlightIntensity;
+      tile.material.emissiveIntensity = tokenColor ? Math.max(data.baseIntensity + 0.95, 0.92) : data.highlightIntensity;
       data.isHighlighted = true;
     } else {
       if (tile.material.emissive && data.baseEmissive) {
@@ -5665,7 +5665,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         ) : null}
-        <div className="absolute top-[5rem] left-3 z-20 flex flex-col items-start gap-3">
+        <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button
               type="button"

--- a/webapp/src/utils/ludoSfx.js
+++ b/webapp/src/utils/ludoSfx.js
@@ -61,41 +61,68 @@ function scheduleNoiseBurst(ctx, { startAt, duration, volume = 0.2, bandHz = 180
   source.stop(startAt + duration + 0.01);
 }
 
+function scheduleRumble(ctx, { startAt, duration, volume = 0.12, fromHz = 120, toHz = 70 }) {
+  scheduleTone(ctx, {
+    startAt,
+    duration,
+    fromHz,
+    toHz,
+    volume,
+    type: 'sawtooth'
+  });
+}
+
 export function playLudoDiceRollSfx({ volume = 1, muted = false } = {}) {
   if (muted || volume <= 0) return;
   const ctx = getAudioContext();
   if (!ctx) return;
   const now = ctx.currentTime + 0.004;
-  const baseVolume = Math.min(0.42, Math.max(0.12, volume * 0.32));
+  const baseVolume = Math.min(0.58, Math.max(0.2, volume * 0.46));
+
+  // Procedural, source-code-only dice roll SFX (no binary assets), shaped from free Web Audio synthesis patterns.
+  scheduleRumble(ctx, {
+    startAt: now,
+    duration: 0.28,
+    volume: baseVolume * 0.3,
+    fromHz: 132,
+    toHz: 74
+  });
 
   scheduleNoiseBurst(ctx, {
     startAt: now,
-    duration: 0.22,
-    volume: baseVolume * 0.72,
-    bandHz: 1450
+    duration: 0.24,
+    volume: baseVolume * 0.85,
+    bandHz: 1580
   });
 
-  const impacts = [0.026, 0.072, 0.116, 0.162, 0.204];
+  scheduleNoiseBurst(ctx, {
+    startAt: now + 0.085,
+    duration: 0.18,
+    volume: baseVolume * 0.52,
+    bandHz: 1120
+  });
+
+  const impacts = [0.02, 0.055, 0.09, 0.125, 0.165, 0.205, 0.235];
   impacts.forEach((offset, index) => {
-    const decay = 1 - index * 0.12;
-    const impactVolume = baseVolume * (0.7 + Math.random() * 0.25) * decay;
+    const decay = Math.max(0.18, 1 - index * 0.11);
+    const impactVolume = baseVolume * (0.78 + Math.random() * 0.28) * decay;
     const impactStart = now + offset + (Math.random() - 0.5) * 0.01;
     scheduleTone(ctx, {
       startAt: impactStart,
-      duration: 0.045 + Math.random() * 0.02,
-      fromHz: 430 - index * 34 + Math.random() * 18,
-      toHz: 170 + Math.random() * 45,
+      duration: 0.038 + Math.random() * 0.026,
+      fromHz: 490 - index * 41 + Math.random() * 24,
+      toHz: 130 + Math.random() * 46,
       volume: impactVolume,
       type: index % 2 === 0 ? 'triangle' : 'sine'
     });
   });
 
   scheduleTone(ctx, {
-    startAt: now + 0.19,
-    duration: 0.12,
-    fromHz: 220,
-    toHz: 96,
-    volume: baseVolume * 0.42,
+    startAt: now + 0.22,
+    duration: 0.14,
+    fromHz: 180,
+    toHz: 86,
+    volume: baseVolume * 0.52,
     type: 'triangle'
   });
 }


### PR DESCRIPTION
### Motivation
- Replace the quiet/missing dice audio with an original, open-source-friendly runtime SFX (no binary assets) and make it more perceptible on mobile; align tile highlight color with center player colors for clearer feedback; slightly reposition the menu control for better portrait UI alignment.

### Description
- Reworked the dice SFX in `webapp/src/utils/ludoSfx.js` by adding a `scheduleRumble` layer and tuning layered noise bursts, impact transients, timings and base volume so the effect is louder and clearer while remaining purely procedural (no binary audio files added). 
- Updated tile highlight logic in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so highlighted tiles adopt the player color directly (`tile.material.color.copy(tokenColor)`), reduced the emissive lerp amount and tuned emissive intensity for better visual match with the center colored tiles. 
- Nudged the in-game menu button placement in `LudoBattleRoyal.jsx` by adjusting the wrapper classes to `top-[5.35rem] left-2` to move it slightly lower and a bit left on portrait screens. 
- Changes are limited to `webapp/src/utils/ludoSfx.js` and `webapp/src/pages/Games/LudoBattleRoyal.jsx` and avoid adding any binary assets.

### Testing
- Ran `npm run build` from `webapp/` and the production build completed successfully. 
- Started the dev server and captured a Playwright screenshot of `http://127.0.0.1:4173/games/ludobattleroyal` in a portrait viewport to validate UI placement; screenshot artifact was produced. 
- No failing automated build steps were observed and no binary sound files were added to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6ceb6e608329b41f90a8407c2cae)