### PR TITLE
Align Chess Battle Royale default chair ordering with Ludo

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -65,8 +65,8 @@ const mapStoolThemeToChair = (theme) => ({
 });
 
 export const CHESS_CHAIR_OPTIONS = Object.freeze([
-  ...BASE_CHAIR_OPTIONS,
-  ...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)
+  ...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair),
+  ...BASE_CHAIR_OPTIONS
 ]);
 
 export const CHESS_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES]);


### PR DESCRIPTION
### Motivation
- Ensure Chess Battle Royale uses the same baseline furniture textures/mapping as Ludo by making Chess defaults resolve to the same Murlan stool theme family so table/chair visuals match across games.

### Description
- Reordered `CHESS_CHAIR_OPTIONS` in `webapp/src/config/chessBattleInventoryConfig.js` so `MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)` comes before the Chess-specific `BASE_CHAIR_OPTIONS`, preserving all options but changing which entry is index `0`.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Launched the dev server with `npm --prefix webapp run dev` and captured a Playwright screenshot of `/games/chessbattleroyal` to validate the default appearance; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6da27cbc8329a41aa143da5d6313)