### PR TITLE
Restore GLTF-backed chess piece set options for Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1360,16 +1360,18 @@ const POLYGONAL_GRAPHITE_STYLE = Object.freeze({
   blackAccent: '#50b8d8'
 });
 
-const PIECE_STYLE_OPTIONS = Object.freeze(
-  [
-    { id: 'beautifulGameClassic', label: 'Classic (Ivory)', color: '#ffffff' },
-    { id: 'beautifulGameMono', label: 'Mono (Onyx)', color: '#111827' },
-    { id: 'beautifulGameAmber', label: 'Amber', color: '#f59e0b' },
-    { id: 'beautifulGameMint', label: 'Mint', color: '#10b981' },
-    { id: 'beautifulGameBlue', label: 'Blue', color: '#3b82f6' },
-    { id: 'beautifulGamePink', label: 'Pink', color: '#ef4444' },
-    { id: 'beautifulGameTeal', label: 'Teal', color: '#8b5cf6' }
-  ].map((preset) => ({
+const BEAUTIFUL_GAME_PIECE_PRESETS = [
+  { id: 'beautifulGameClassic', label: 'Classic (Ivory)', color: '#ffffff' },
+  { id: 'beautifulGameMono', label: 'Mono (Onyx)', color: '#111827' },
+  { id: 'beautifulGameAmber', label: 'Amber', color: '#f59e0b' },
+  { id: 'beautifulGameMint', label: 'Mint', color: '#10b981' },
+  { id: 'beautifulGameBlue', label: 'Blue', color: '#3b82f6' },
+  { id: 'beautifulGamePink', label: 'Pink', color: '#ef4444' },
+  { id: 'beautifulGameTeal', label: 'Teal', color: '#8b5cf6' }
+];
+
+const PIECE_STYLE_OPTIONS = Object.freeze([
+  ...BEAUTIFUL_GAME_PIECE_PRESETS.map((preset) => ({
     ...preset,
     style: {
       ...BASE_PIECE_STYLE,
@@ -1383,8 +1385,44 @@ const PIECE_STYLE_OPTIONS = Object.freeze(
       blackAccent: BASE_PIECE_STYLE.blackAccent
     },
     loader: (targetBoardSize) => resolveBeautifulGameAssets(targetBoardSize)
-  }))
-);
+  })),
+  {
+    id: STAUNTON_CLASSIC_STYLE.id,
+    label: STAUNTON_CLASSIC_STYLE.label,
+    style: STAUNTON_CLASSIC_STYLE,
+    loader: (targetBoardSize) => loadPieceSetFromUrls(STAUNTON_SET_URLS, {
+      targetBoardSize,
+      styleId: STAUNTON_CLASSIC_STYLE.id,
+      pieceStyle: STAUNTON_CLASSIC_STYLE,
+      assetScale: STAUNTON_ASSET_SCALE,
+      fallbackBuilder: buildStauntonFallbackAssets
+    })
+  },
+  {
+    id: HERITAGE_WALNUT_STYLE.id,
+    label: HERITAGE_WALNUT_STYLE.label,
+    style: HERITAGE_WALNUT_STYLE,
+    loader: (targetBoardSize) => loadWalnutStauntonAssets(targetBoardSize)
+  },
+  {
+    id: MARBLE_ONYX_STYLE.id,
+    label: MARBLE_ONYX_STYLE.label,
+    style: MARBLE_ONYX_STYLE,
+    loader: (targetBoardSize) => loadMarbleOnyxStauntonAssets(targetBoardSize)
+  },
+  {
+    id: KENNEY_WOOD_STYLE.id,
+    label: KENNEY_WOOD_STYLE.label,
+    style: KENNEY_WOOD_STYLE,
+    loader: (targetBoardSize) => loadKenneyAssets(targetBoardSize)
+  },
+  {
+    id: POLYGONAL_GRAPHITE_STYLE.id,
+    label: POLYGONAL_GRAPHITE_STYLE.label,
+    style: POLYGONAL_GRAPHITE_STYLE,
+    loader: (targetBoardSize) => loadPolygonalAssets(targetBoardSize)
+  }
+]);
 
 const BEAUTIFUL_GAME_PIECE_INDEX = Math.max(
   0,


### PR DESCRIPTION
### Motivation
- The Chess Battle Royal UI had been limited to ABeautifulGame color variants and needed the original GLTF piece sets restored so players can choose the full catalog of 3D piece models. 

### Description
- Added a `BEAUTIFUL_GAME_PIECE_PRESETS` list and refactored the ABeautifulGame presets into it to keep presets reusable. 
- Replaced the old `PIECE_STYLE_OPTIONS` with a new `PIECE_STYLE_OPTIONS` array that includes the ABeautifulGame presets plus the restored GLTF-backed sets: Staunton Classics, Heritage Walnut Staunton, Marble & Onyx Tournament, Kenney Woodcut, and Polygonal Graphite. 
- Wired each restored option to its loader pipeline (e.g. `loadPieceSetFromUrls(STAUNTON_SET_URLS, ...)`, `loadKenneyAssets`, `loadPolygonalAssets`, `loadWalnutStauntonAssets`, `loadMarbleOnyxStauntonAssets`) and preserved existing fallback builders and style objects. 
- Changes made in `webapp/src/pages/Games/ChessBattleRoyal.jsx` (reintroduce full piece-set selector and loader wiring). 

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully (Vite reported chunk-size/dynamic-import warnings but no build failures). 
- Started the dev server with `npm --prefix webapp run dev` and verified the Chess Battle Royal page loads in a headless browser via a Playwright script which saved a screenshot (`artifacts/chessbattleroyal-gltf-restored.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8d6e368883298d3ce59c0c695b3c)