### PR TITLE
Enable Telegram-style fullscreen layout on mobile browsers

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -54,6 +54,7 @@ import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
+import useMobileFullscreen from './hooks/useMobileFullscreen.js';
 import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
@@ -82,6 +83,7 @@ export default function App() {
 
   useTelegramAuth();
   useTelegramFullscreen();
+  useMobileFullscreen();
   useReferralClaim();
   useNativePushNotifications();
 

--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+
+import { isTelegramWebView } from '../utils/telegram.js';
+
+const MOBILE_BREAKPOINT_PX = 1024;
+
+const isMobileScreen = () => {
+  if (typeof window === 'undefined') return false;
+  const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches;
+  return coarsePointer || window.innerWidth <= MOBILE_BREAKPOINT_PX;
+};
+
+const setViewportHeightVar = () => {
+  const visualHeight = window.visualViewport?.height;
+  const height = Math.round(visualHeight || window.innerHeight);
+  document.documentElement.style.setProperty('--app-viewport-height', `${height}px`);
+};
+
+export default function useMobileFullscreen() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (isTelegramWebView()) return;
+    if (!isMobileScreen()) return;
+
+    document.body.classList.add('mobile-fullscreen');
+    setViewportHeightVar();
+
+    const onResize = () => setViewportHeightVar();
+    window.addEventListener('resize', onResize);
+    window.visualViewport?.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.visualViewport?.removeEventListener('resize', onResize);
+      document.body.classList.remove('mobile-fullscreen');
+    };
+  }, []);
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -32,16 +32,18 @@ body {
   min-height: 100%;
 }
 
-body.telegram-fullscreen {
-  min-height: var(--tg-viewport-stable-height, 100dvh);
+body.telegram-fullscreen,
+body.mobile-fullscreen {
+  min-height: var(--tg-viewport-stable-height, var(--app-viewport-height, 100dvh));
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
 }
 
-body.telegram-fullscreen #root {
-  min-height: var(--tg-viewport-stable-height, 100dvh);
+body.telegram-fullscreen #root,
+body.mobile-fullscreen #root {
+  min-height: var(--tg-viewport-stable-height, var(--app-viewport-height, 100dvh));
 }
 
 /* Outline text with contrasting edges */


### PR DESCRIPTION
### Motivation
- Ensure the site on mobile browsers (non-Telegram) uses the same safe-area-aware, fullscreen layout currently provided by the Telegram in-app browser. 
- Prevent layout/viewport inconsistencies on mobile (portrait) by keeping a stable viewport-height variable synced with the actual visual viewport.

### Description
- Added a new hook `webapp/src/hooks/useMobileFullscreen.js` that enables a `mobile-fullscreen` body class on mobile devices (detects coarse pointer or `window.innerWidth <= 1024`) and synchronizes `--app-viewport-height` with `visualViewport.height` or `window.innerHeight`.
- The hook skips activation when running inside the Telegram WebApp (keeps existing Telegram behavior intact).
- Wired the hook into the global bootstrap by importing and calling `useMobileFullscreen()` in `webapp/src/App.jsx` alongside `useTelegramFullscreen()` so the behavior applies app-wide.
- Updated `webapp/src/index.css` to share the same safe-area-aware layout for both Telegram and non-Telegram mobile modes by adding `body.mobile-fullscreen` and using `--app-viewport-height` as a fallback for `min-height` on `body` and `#root`.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced a production build without breaking the app.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the layout in a mobile viewport using an automated Playwright check that captured a screenshot; the mobile fullscreen behavior was observed.
- No automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8e05c38083299e60d86a48982942)