### PR TITLE
Align mobile browser fullscreen layout with Telegram fullscreen UI

### DIFF
--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -152,7 +152,10 @@ export default function Layout({ children }) {
   const showPwaBanner = showNavbar && (canInstall || canShowTelegramInstall);
 
   return (
-    <div className="flex flex-col min-h-screen text-text relative overflow-hidden">
+    <div
+      className="flex flex-col text-text relative overflow-hidden"
+      style={{ minHeight: "var(--tg-viewport-stable-height, var(--app-viewport-stable-height, var(--app-viewport-height, 100dvh)))" }}
+    >
       {showHeader && (
         <header className="w-full bg-surface border-b-2 border-accent flex justify-center py-0.5">
           <img
@@ -166,8 +169,8 @@ export default function Layout({ children }) {
         className={`flex-grow ${
           showNavbar
             ? isLobby
-              ? 'w-full p-4 pb-24'
-              : 'container mx-auto p-4 pb-24'
+              ? 'w-full p-4 pb-28'
+              : 'container mx-auto p-4 pb-28'
             : 'w-full p-0'
         }`}
       >

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -10,8 +10,8 @@ import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
-      <div className="container mx-auto px-4 py-4 flex items-center justify-between text-base">
+    <nav className="app-bottom-nav fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
+      <div className="container mx-auto px-4 pt-3 pb-1 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
         <NavItem to="/mining" icon={GiMining} label="Mining" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />

--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -11,9 +11,39 @@ const isMobileScreen = () => {
 };
 
 const setViewportHeightVar = () => {
-  const visualHeight = window.visualViewport?.height;
-  const height = Math.round(visualHeight || window.innerHeight);
+  const viewport = window.visualViewport;
+  const height = Math.round(viewport?.height || window.innerHeight);
+  const stableHeight = Math.round(window.innerHeight);
+  const topOffset = Math.max(0, Math.round(viewport?.offsetTop || 0));
   document.documentElement.style.setProperty('--app-viewport-height', `${height}px`);
+  document.documentElement.style.setProperty('--app-viewport-stable-height', `${stableHeight}px`);
+  document.documentElement.style.setProperty('--app-viewport-offset-top', `${topOffset}px`);
+};
+
+const setDisplayModeClass = () => {
+  const standalone = window.matchMedia?.('(display-mode: standalone)').matches || window.navigator.standalone;
+  document.body.classList.toggle('mobile-standalone', Boolean(standalone));
+};
+
+const requestBrowserFullscreen = () => {
+  const el = document.documentElement;
+  const canRequest = el.requestFullscreen || el.webkitRequestFullscreen;
+  if (!canRequest || document.fullscreenElement) return;
+
+  const run = () => {
+    const request = el.requestFullscreen || el.webkitRequestFullscreen;
+    if (!request) return;
+    Promise.resolve(request.call(el)).catch(() => {});
+  };
+
+  const onFirstInteraction = () => {
+    run();
+    window.removeEventListener('pointerdown', onFirstInteraction);
+    window.removeEventListener('touchstart', onFirstInteraction);
+  };
+
+  window.addEventListener('pointerdown', onFirstInteraction, { passive: true, once: true });
+  window.addEventListener('touchstart', onFirstInteraction, { passive: true, once: true });
 };
 
 export default function useMobileFullscreen() {
@@ -23,16 +53,22 @@ export default function useMobileFullscreen() {
     if (!isMobileScreen()) return;
 
     document.body.classList.add('mobile-fullscreen');
+    setDisplayModeClass();
     setViewportHeightVar();
+    requestBrowserFullscreen();
 
     const onResize = () => setViewportHeightVar();
+    const onModeChange = () => setDisplayModeClass();
     window.addEventListener('resize', onResize);
     window.visualViewport?.addEventListener('resize', onResize);
+    window.matchMedia?.('(display-mode: standalone)').addEventListener?.('change', onModeChange);
 
     return () => {
       window.removeEventListener('resize', onResize);
       window.visualViewport?.removeEventListener('resize', onResize);
+      window.matchMedia?.('(display-mode: standalone)').removeEventListener?.('change', onModeChange);
       document.body.classList.remove('mobile-fullscreen');
+      document.body.classList.remove('mobile-standalone');
     };
   }, []);
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -34,8 +34,8 @@ body {
 
 body.telegram-fullscreen,
 body.mobile-fullscreen {
-  min-height: var(--tg-viewport-stable-height, var(--app-viewport-height, 100dvh));
-  padding-top: env(safe-area-inset-top);
+  min-height: var(--tg-viewport-stable-height, var(--app-viewport-stable-height, var(--app-viewport-height, 100dvh)));
+  padding-top: max(env(safe-area-inset-top), var(--app-viewport-offset-top, 0px));
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
@@ -43,7 +43,15 @@ body.mobile-fullscreen {
 
 body.telegram-fullscreen #root,
 body.mobile-fullscreen #root {
-  min-height: var(--tg-viewport-stable-height, var(--app-viewport-height, 100dvh));
+  min-height: var(--tg-viewport-stable-height, var(--app-viewport-stable-height, var(--app-viewport-height, 100dvh)));
+}
+
+.app-bottom-nav {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 8px);
+}
+
+body.mobile-standalone .app-bottom-nav {
+  padding-bottom: max(env(safe-area-inset-bottom), 10px);
 }
 
 /* Outline text with contrasting edges */


### PR DESCRIPTION
### Motivation
- Mobile Chrome and installed PWA modes placed navbar icons and menus differently than Telegram WebApp fullscreen, causing inconsistent UX on portrait phones.
- The app needs a consistent fullscreen layout across Telegram in-app view and regular mobile browsers so controls, icons and menus stay in the same positions.

### Description
- Enhanced the non-Telegram fullscreen hook by syncing `visualViewport` metrics into CSS variables (`--app-viewport-height`, `--app-viewport-stable-height`, `--app-viewport-offset-top`) to reflect the actual on-screen area. (`webapp/src/hooks/useMobileFullscreen.js`)
- Added detection of `display-mode: standalone` and a `mobile-standalone` class, and a best-effort `requestFullscreen()` on first user interaction to approximate Telegram fullscreen in supporting browsers. (`webapp/src/hooks/useMobileFullscreen.js`)
- Updated CSS to use the new viewport/stable-height vars and apply safe-area/top offsets so body/root sizes match Telegram fullscreen behavior, and added `.app-bottom-nav` to normalize bottom navbar safe-area padding. (`webapp/src/index.css`)
- Adjusted layout sizing and bottom padding so main content and the bottom navigation reserve identical space to Telegram fullscreen (increased `pb` and set root `minHeight` to use stable viewport var), and slightly tweaked navbar markup to apply the `.app-bottom-nav` class. (`webapp/src/components/Layout.jsx`, `webapp/src/components/Navbar.jsx`)

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully. 
- Ran the preview server with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` and validated changes in a simulated mobile Chromium session. 
- Captured a Playwright mobile screenshot at `390x844` to confirm visual alignment; the run and screenshot completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9eac2c7c83298d47b41e29762efc)