### PR TITLE
Adjust Chess Battle Royal top-right control ordering and vertical offset

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9350,7 +9350,7 @@ function Chess3D({
   return (
     <div ref={wrapRef} className="fixed inset-0 bg-[#0c1020] text-white touch-none select-none">
       <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute top-16 left-4 z-20 flex flex-col items-start gap-3 pointer-events-none">
+        <div className="absolute top-20 left-4 z-20 flex flex-col items-start gap-3 pointer-events-none">
           <button
             type="button"
             onClick={() => setConfigOpen((open) => !open)}
@@ -9375,15 +9375,20 @@ function Chess3D({
             </div>
           )}
         </div>
-        <div className="absolute top-16 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
+        <div className="absolute top-20 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
           <div className="pointer-events-auto flex flex-col items-end gap-3">
-            <button
-              type="button"
-              onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
-              className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
-            >
-              {viewMode === '3d' ? '2D' : '3D'}
-            </button>
+            <BottomLeftIcons
+              showInfo={false}
+              showChat={false}
+              showGift={false}
+              className="flex flex-col"
+              buttonClassName="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+              iconClassName="text-[1.5rem] leading-none"
+              labelClassName="sr-only"
+              muteIconOn="🔇"
+              muteIconOff="🔊"
+              order={['mute']}
+            />
             <button
               type="button"
               onClick={() => replayLastMoveRef.current?.()}
@@ -9409,18 +9414,13 @@ function Chess3D({
               </svg>
               <span className="sr-only">Replay last move</span>
             </button>
-            <BottomLeftIcons
-              showInfo={false}
-              showChat={false}
-              showGift={false}
-              className="flex flex-col"
-              buttonClassName="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
-              iconClassName="text-[1.5rem] leading-none"
-              labelClassName="sr-only"
-              muteIconOn="🔇"
-              muteIconOff="🔊"
-              order={['mute']}
-            />
+            <button
+              type="button"
+              onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))}
+              className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+            >
+              {viewMode === '3d' ? '2D' : '3D'}
+            </button>
           </div>
           {configOpen && (
             <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur max-h-[80vh] overflow-y-auto pr-1">


### PR DESCRIPTION
### Motivation
- Improve portrait UI spacing by nudging the top-left menu and top-right control stacks slightly lower so they appear closer to the bottom of the top area on mobile in portrait.
- Match requested control ordering on the top-right so the mute control is highest, replay is middle, and the 3D/2D toggle sits at the bottom for clearer ergonomics.

### Description
- Updated layout in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to move the two top clusters from `top-16` to `top-20` for both the left menu and right control containers.
- Reordered the right-side controls so the stack is: `Mute` (top), `Replay` (middle), `3D/2D toggle` (bottom) by placing the `BottomLeftIcons` (mute) before the replay button and moving the view toggle after the replay button.
- Kept existing button styles and behavior unchanged; this is purely a UI layout / ordering change.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Launched the dev server and captured a portrait screenshot of the updated UI using Playwright; the screenshot artifact was produced and verified visually.
- No runtime or gameplay logic tests were changed because the modification only affects layout and ordering of UI controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da1001f58832997ba95c6487e2bf1)