### PR TITLE
Adjust Domino Royal HUD icon positions for portrait layout

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -69,14 +69,27 @@ export default function DominoRoyalArena() {
         }
         #configButton span:first-child { font-size: 1.05rem; line-height: 1; }
         #configButton span:last-child { font-size: 0.72rem; letter-spacing: 0.24em; text-transform: uppercase; }
+        #muteButton {
+          top: calc(4.1rem + env(safe-area-inset-top, 0px)) !important;
+          right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
+          left: auto !important;
+          bottom: auto !important;
+        }
         #railControls {
           bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
         }
         #quickActions {
+          position: static !important;
+        }
+        #quickActions .quick-action {
+          position: fixed !important;
           bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
-          left: auto !important;
+        }
+        #quickActions .quick-action[data-action="gift"] {
           right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
-          gap: 0.5rem;
+        }
+        #quickActions .quick-action[data-action="chat"] {
+          left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
         }
       `}</style>
       <div id="topRightActions" aria-label="Top actions">
@@ -91,13 +104,13 @@ export default function DominoRoyalArena() {
         <button id="pass" type="button">Pass</button>
       </div>
       <div id="quickActions" aria-label="Quick actions">
-        <button className="quick-action" type="button" data-action="chat">
-          <span className="icon" aria-hidden="true">💬</span>
-          <span>Chat</span>
-        </button>
         <button className="quick-action" type="button" data-action="gift">
           <span className="icon" aria-hidden="true">🎁</span>
           <span>Gift</span>
+        </button>
+        <button className="quick-action" type="button" data-action="chat">
+          <span className="icon" aria-hidden="true">💬</span>
+          <span>Chat</span>
         </button>
       </div>
       <div id="rules">


### PR DESCRIPTION
### Motivation
- Improve HUD layout on portrait mobile so primary controls align with expected screen edges and in the same horizontal lines.
- Move mute control to the top-right to align with the existing menu control and safe-area insets.
- Place Gift on the bottom-right and Chat on the bottom-left so quick actions sit on the same horizontal line but opposite sides.

### Description
- Updated inline CSS in `webapp/src/pages/Games/DominoRoyalArena.jsx` to pin `#muteButton` to the top-right and respect safe-area insets.
- Reworked `#quickActions` rules so each `.quick-action` is positioned fixed, with the Gift button anchored to the bottom-right and the Chat button anchored to the bottom-left.
- Reordered quick-action markup so Gift renders before Chat to match the new visual layout.
- Only the DOM and inline style in `webapp/src/pages/Games/DominoRoyalArena.jsx` were modified to implement the layout changes.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully.
- Started the dev server (`vite`) and captured a portrait viewport screenshot of the Domino Royal page to validate placement: `artifacts/domino-royal-ui-update.png` (captured during the run).
- Changes were committed to `webapp/src/pages/Games/DominoRoyalArena.jsx` and the build artifacts updated without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9f9934c88329afdaaf8cd02a8b94)