### PR TITLE
Adjust Texas Hold'em HUD icon positions (gift bottom-right, remove info, lower menu & mute)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -5495,7 +5495,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute top-4 left-4 z-20 flex flex-col items-start gap-2">
+      <div className="absolute left-2 top-[5.35rem] z-20 flex flex-col items-start gap-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -5758,13 +5758,9 @@ function TexasHoldemArena({ search }) {
       <div className="pointer-events-auto">
         <BottomLeftIcons
           onChat={() => setShowChat(true)}
-          onGift={() => setShowGift(true)}
-          onCamera2d={() => {}}
           showInfo={false}
+          showGift={false}
           showMute={false}
-          showCamera2d={false}
-          camera2dActive={overheadView}
-          order={['chat', 'gift']}
           className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
@@ -5772,10 +5768,23 @@ function TexasHoldemArena({ search }) {
         />
 
         <BottomLeftIcons
-          onInfo={() => setShowInfo(true)}
+          onGift={() => setShowGift(true)}
+          showInfo={false}
+          showChat={false}
+          showMute={false}
+          order={['gift']}
+          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
+          buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
+          iconClassName="text-lg leading-none"
+          labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
+        />
+
+        <BottomLeftIcons
+          showInfo={false}
           showChat={false}
           showGift={false}
-          className="fixed right-[0.75rem] top-[calc(env(safe-area-inset-top,0px)+0.75rem)] flex flex-row gap-2.5 z-20"
+          order={['mute']}
+          className="fixed right-[0.75rem] top-[calc(env(safe-area-inset-top,0px)+5.2rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Align Texas Hold'em HUD with the Murlan Battle Royal 3D layout so controls feel consistent in portrait mobile view. 
- Place the gift icon on the bottom-right on the same horizontal line as the chat icon for symmetrical quick-actions. 
- Remove the info icon and move the menu and mute controls down so they don't crowd the top of the screen.

### Description
- Updated `webapp/src/pages/Games/TexasHoldemArena.jsx` to change the config/menu button container location from `top-4 left-4` to `left-2 top-[5.35rem]`. 
- Split HUD controls into three `BottomLeftIcons` instances so `chat` remains bottom-left, `gift` is bottom-right (same horizontal line), and `mute` is a standalone control moved lower on the right (`top + 5.2rem`). 
- Removed the right-side `info` icon by setting `showInfo={false}` for the right cluster and hiding the info action from the right controls. 
- Adjusted several `className` and `order` props to preserve styling and button sizing while changing fixed positions for portrait safe-area handling.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which completed with a repository ignore-pattern warning (no lint errors in the changed code). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the app served successfully for visual verification. 
- Captured portrait UI screenshots using a Playwright script to verify icon placement; screenshots were produced successfully for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de40bb4748329ad3940ef58f99d7c)