### PR TITLE
Adjust Texas Hold'em HUD icon vertical alignment

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -5495,7 +5495,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute left-2 top-[5.35rem] z-20 flex flex-col items-start gap-2">
+      <div className="absolute left-2 top-[5.7rem] z-20 flex flex-col items-start gap-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -5761,7 +5761,7 @@ function TexasHoldemArena({ search }) {
           showInfo={false}
           showGift={false}
           showMute={false}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+4rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
@@ -5773,7 +5773,7 @@ function TexasHoldemArena({ search }) {
           showChat={false}
           showMute={false}
           order={['gift']}
-          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+4rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Improve visual alignment on portrait/mobile: nudge the table menu icon slightly lower and raise the chat/gift quick-action icons so they line up with the bottom player avatar row.

### Description
- Tweaked positions in `webapp/src/pages/Games/TexasHoldemArena.jsx` by changing the menu container `top` from `5.35rem` to `5.7rem` and increasing the quick-action `bottom` offsets for the left (chat) and right (gift) `BottomLeftIcons` from `+1rem` to `+4rem`.

### Testing
- Ran a production build with `npm -C webapp run build` which completed successfully.
- Launched the dev server with `npm -C webapp run dev` and captured a portrait screenshot using a Playwright script saved at `artifacts/texas-holdem-icon-position.png` to validate the layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de7b3c4748329a275abb046dddbe6)