### PR TITLE
Fix Texas Hold'em rail chip placement and raise chip layouts

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1786,9 +1786,9 @@ function createSeatLayout(count, tableInfo = null, options = {}) {
       railAnchorDistance - railSpan * 0.05
     );
     const chipRailDistance = clampValue(
-      chipRailBase,
-      innerDistance + railSpan * 0.4,
-      outerDistance - railSpan * 0.05
+      Math.max(chipRailBase, cardRailDistance + railSpan * 0.08),
+      innerDistance + railSpan * 0.22,
+      outerDistance - railSpan * 0.02
     );
     const seatRadius = outerDistance + (isHuman ? HUMAN_SEAT_RADIUS_OFFSET : AI_SEAT_RADIUS_OFFSET);
     const seatPos = forward.clone().multiplyScalar(seatRadius);
@@ -4188,7 +4188,11 @@ function TexasHoldemArena({ search }) {
             forward: seat.forward.clone().multiplyScalar(player.isHuman ? 1 : -1),
             right: seat.right.clone().multiplyScalar(player.isHuman ? 1 : -1)
           };
-          seatGroup.railLayout = seatGroup.tableLayout;
+          seatGroup.railLayout = {
+            ...seatGroup.railLayout,
+            forward: seat.forward.clone().multiplyScalar(player.isHuman ? 1 : -1),
+            right: seat.right.clone().multiplyScalar(player.isHuman ? 1 : -1)
+          };
           if (player.isHuman) {
             cameraTarget.copy(seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0)));
           }
@@ -4206,7 +4210,11 @@ function TexasHoldemArena({ search }) {
           forward: seat.forward.clone().negate(),
           right: seat.right.clone().negate()
         };
-        seat.railLayout = seat.tableLayout;
+        seat.railLayout = {
+          ...seat.railLayout,
+          forward: seat.forward.clone().negate(),
+          right: seat.right.clone().negate()
+        };
       });
 
       const nameplates = seatGroups.map((seat) => seat.nameplate);


### PR DESCRIPTION
### Motivation
- Player chip stacks had drifted off the wooden rail and were no longer sitting next to the human player's cards, breaking the manual-raise UX where players click chips on the rail to build raises.  
- A regression overwrote dedicated rail layout parameters with the table scatter layout, causing rail stacks to lose their intended spacing and orientation.

### Description
- Move chip anchor outward by changing `chipRailDistance` to `clampValue(Math.max(chipRailBase, cardRailDistance + railSpan * 0.08), ...)` so rail stacks sit closer to the card rail area and remain visible on the wooden rail.  
- Tighten the min/max clamp used for chip placement (use `railSpan * 0.22` and `outerDistance - railSpan * 0.02`) to keep stacks within the rail area across table shapes.  
- Preserve and update `railLayout` independently from the table scatter `tableLayout` for both human and AI seats by merging orientation updates into the existing `railLayout` instead of assigning `seat.tableLayout` to `seat.railLayout`.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production build without errors.  
- Launched the dev server with `npm --prefix webapp run dev` and exercised the Texas Hold'em route to confirm chips render on the wooden rail.  
- Captured UI verification screenshots using Playwright (first attempt timed out, second attempt succeeded and produced a screenshot of the `/games/texas-holdem` route).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e84088aa48329892eb917e09c5c05)