### PR TITLE
Tune Goal Rush layout placement and shot physics

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,7 +33,7 @@
 
     .canvasWrap{
       position:absolute;
-      top:32px;
+      top:40px;
       bottom:-24px;
       left:0;
       right:0;
@@ -507,7 +507,7 @@
     canvas.style.height = height + 'px';
     // expand field by reducing canvas margins ~5% on each side
     const baseW = W * 0.98;
-    const baseH = H * 0.98;
+    const baseH = H * 0.992;
     const maxFieldScaleX = W/baseW;
     const maxFieldScaleY = H/baseH;
     const fsx = Math.min(fieldScaleX, maxFieldScaleX);
@@ -516,7 +516,8 @@
     rink.w = Math.round(baseW * fsx);
     rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
-    rink.y = Math.round((H - rink.h) / 2);
+    const verticalShift = Math.round(H * 0.004);
+    rink.y = Math.round((H - rink.h) / 2 + verticalShift);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;
     goalTopY = rink.y + rink.h * goalOffsetYPct;
@@ -1741,8 +1742,8 @@
   function getCSS(v){ return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
 
   const friction = 0.996;
-  const wallBounce = 1.12;
-  const minWallSpeed = 5;
+  const wallBounce = 1.16;
+  const minWallSpeed = 5.6;
   function constrainPaddle(p, bottom){
     const margin=12;
     const minX = rink.x + margin + p.r;
@@ -1851,13 +1852,23 @@
         const relVY = puck.vy - p.vy;
         const relAlongNormal = relVX*nx + relVY*ny;
         const tangential = relVX*(-ny) + relVY*nx;
-        puck.spin += tangential * 0.012;
+        puck.spin += tangential * 0.008;
         if (relAlongNormal <= 0){
-          const restitution = 1.15;
+          const restitution = 1.18;
           const impulse = -(1+restitution) * relAlongNormal;
           puck.vx += impulse * nx;
           puck.vy += impulse * ny;
-          puck.vx += p.vx*0.2; puck.vy += p.vy*0.2;
+          puck.vx += p.vx*0.24; puck.vy += p.vy*0.24;
+
+          if (p === p1) {
+            const shotPower = Math.hypot(p.vx, p.vy);
+            const upwardDrive = -p.vy;
+            const contactLift = -ny;
+            if (shotPower > 7 && upwardDrive > 3.2 && contactLift > 0.2) {
+              const liftBoost = Math.min(1.9, (upwardDrive - 3.2) * 0.18 + shotPower * 0.035);
+              puck.vy -= liftBoost;
+            }
+          }
         } else {
           const speed = Math.hypot(puck.vx, puck.vy);
           const minSpeed = 2;
@@ -1867,7 +1878,7 @@
             puck.vy += ny * boost;
           }
         }
-        const v = Math.hypot(puck.vx,puck.vy); const maxV = puck.max*speedMul*1.25;
+        const v = Math.hypot(puck.vx,puck.vy); const maxV = puck.max*speedMul*1.3;
         if (v>maxV){ const s=maxV/v; puck.vx*=s; puck.vy*=s; }
         lastTouch = (p === p1) ? 'p1' : 'p2';
         if (p === p2) {
@@ -1994,8 +2005,8 @@
     puck.vx *= Math.pow(friction, dt*60);
     puck.vy *= Math.pow(friction, dt*60);
     puck.angle += Math.hypot(puck.vx, puck.vy) * dt * 0.1;
-    puck.angle += puck.spin * dt * 13;
-    puck.spin *= Math.pow(0.991, dt*60);
+    puck.angle += puck.spin * dt * 10;
+    puck.spin *= Math.pow(0.985, dt*60);
 
     handleCollisions();
 


### PR DESCRIPTION
### Motivation

- Improve the visual framing on portrait phones by lowering the play area slightly and extending the green field vertically so the top and bottom have a bit more room.  
- Make puck behaviour feel more controllable by reducing excessive spin while increasing bounce and shot power transfer.  
- Allow high-power upward strikes to produce a small, realistic lift when contact angle and input power support it.

### Description

- Adjusted layout: increased `.canvasWrap` top offset and expanded rink vertical sizing in `fit()` by changing `baseH` and adding a `verticalShift` so the field is visually lowered (`webapp/public/goal-rush.html`).  
- Tuned collision/physics constants by raising `wallBounce` and `minWallSpeed`, increasing collision `restitution`, raising paddle-to-puck transfer, and increasing the post-collision `maxV` cap to give slightly more power to shots (`webapp/public/goal-rush.html`).  
- Reduced spin accumulation and persistence by lowering the spin gain multiplier and accelerating spin decay, and reduced spin contribution to puck rotation to make the puck spin less noticeable (`webapp/public/goal-rush.html`).  
- Added a conditional lift impulse applied to `puck.vy` for strong upward player strikes when contact angle and shot power criteria are met, so powerful upward shots produce a small lift (`webapp/public/goal-rush.html`).

### Testing

- Ran `node --check /tmp/goal-rush-inline.js` to validate the inline script syntax and it succeeded.  
- Served the modified `goal-rush.html` locally and verified the page responds via `curl -I http://127.0.0.1:4173/goal-rush.html`.  
- Captured a portrait viewport screenshot of the updated page using an automated Playwright script for visual verification and the capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e85611c0083299d5cbe0edbb2579a)