### PR TITLE
Adjust Pool Royale menu/restart alignment and lift HUD controls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13399,7 +13399,8 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const sharedHudLiftPx = 14;
+  const sharedHudLiftPx = 22;
+  const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 56 * 0.18;
   const sideControlsBottomPx =
@@ -31489,7 +31490,7 @@ const powerRef = useRef(hud.power);
       <div
         className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
-          top: 'calc(5.8rem + env(safe-area-inset-top, 0px))',
+          top: topControlsOffset,
           left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
         }}
       >
@@ -32095,7 +32096,13 @@ const powerRef = useRef(hud.power);
       </div>
 
       {isTraining && !replayActive && (
-        <div className="absolute right-3 top-3 z-50 flex flex-col items-end gap-2">
+        <div
+          className="absolute z-50 flex flex-col items-end gap-2"
+          style={{
+            top: topControlsOffset,
+            right: 'calc(0.75rem + env(safe-area-inset-right, 0px))'
+          }}
+        >
           {usesCareerAttempts && showTrainingIntroCard && (
             <div className="pointer-events-none w-60 rounded-2xl border border-emerald-400/50 bg-black/80 p-3 text-sm text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur">
               <p className="text-[11px] uppercase tracking-[0.28em] text-emerald-200">Practice start</p>


### PR DESCRIPTION
### Motivation

- Align the Pool Royale top-left configuration control with the same visual/menu treatment used in Snake & Ladder and pull it slightly lower on portrait screens for consistency and better tap reach. 
- Place the practice-mode restart control on the same horizontal line as the menu so both top controls share the same anchor in practice mode. 
- Nudge HUD elements (spin controller, player frame with avatars/usernames/points/balls, and chat/gift quick actions) slightly upward so the top/bottom controls feel visually balanced on portrait phones.

### Description

- Introduced `topControlsOffset` and applied it to the Pool Royale top-left menu container so the `☰ Menu` button uses the shared top anchor. 
- Moved the practice-mode top-right container (including the free-practice restart button) to use the same `topControlsOffset` and right anchor so the restart and menu sit on one horizontal line. 
- Increased `sharedHudLiftPx` from `14` to `22` which raises bottom HUD placement and therefore moves the spin controller, player frame, and side chat/gift icons slightly upward. 
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx` and keep existing classes/visuals (menu label/icon unchanged besides the anchor update).

### Testing

- Built the webapp with `npm --prefix webapp run build` which completed successfully (build warnings about large chunks only). 
- Started a local preview with `npm --prefix webapp run preview -- --host 0.0.0.0 --port 4173` to serve the app (preview started). 
- Attempted an automated Playwright screenshot to validate on a 390×844 viewport but the headless Chromium process crashed in this environment, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e86549d008329ba3a53c402bb20ed)