### PR TITLE
Fix Texas Hold'em raise chip placement on player rail

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2119,19 +2119,21 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
     ? seat.cardRailAnchor.clone()
     : fallbackAnchor.clone().addScaledVector(forward, CARD_RAIL_FORWARD_SHIFT).addScaledVector(axis, -CARD_RAIL_LATERAL_SHIFT);
   cardRailAnchor.y = anchorY;
-  const chipCenter = seat.chipRailAnchor
-    ? seat.chipRailAnchor.clone()
+  const chipCenter = (seat.cardRailAnchor ?? seat.chipRailAnchor)
+    ? (seat.cardRailAnchor ?? seat.chipRailAnchor).clone()
     : fallbackAnchor.clone().addScaledVector(axis, CARD_RAIL_LATERAL_SHIFT + CHIP_RAIL_LATERAL_SHIFT);
+  chipCenter.addScaledVector(axis, CARD_W * 0.82);
+  chipCenter.addScaledVector(forward, -CARD_D * 0.7);
   chipCenter.y = anchorY;
-  const columns = 3;
-  const rows = Math.max(1, Math.ceil(CHIP_VALUES.length / columns));
+  const columns = CHIP_VALUES.length;
+  const rows = 1;
   const colOffset = (columns - 1) / 2;
   const rowOffset = (rows - 1) / 2;
   const chipButtons = CHIP_VALUES.map((value, index) => {
     const chip = chipFactory.createStack(value, { mode: 'stack' });
     const baseScale = RAIL_CHIP_SCALE;
     chip.position.copy(chipCenter);
-    chip.position.y = anchorY + CARD_D * 2.2;
+    chip.position.y = anchorY + CARD_D * 0.82;
     const row = Math.floor(index / columns);
     const col = index % columns;
     chip.position.addScaledVector(axis, (col - colOffset) * RAIL_CHIP_SPACING);


### PR DESCRIPTION
### Motivation
- Restore the missing manual-raise chip controls to the wooden rail beside the human player's cards so users can tap chips to build raises as before.

### Description
- Updated `createRaiseControls` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to anchor chip buttons from `seat.cardRailAnchor` or `seat.chipRailAnchor` when available instead of the previous fallback placement.
- Applied lateral and forward offsets to the `chipCenter` and lowered the chip vertical placement from `CARD_D * 2.2` to `CARD_D * 0.82` so chips sit on the rail surface.
- Switched the raise chip layout to a single horizontal row by setting `columns = CHIP_VALUES.length` and `rows = 1` so all denominations are presented in an easy-to-tap strip.
- Preserved `userData.type = 'chip-button'`, base scale, interactables array and the `dispose` logic so existing interaction and cleanup behavior remain unchanged.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which reported an ignore-warning but no errors in this file.
- Ran `npm run build` which failed due to an unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` and not caused by this change.
- Launched the webapp dev server with `npm --prefix webapp run dev` and captured a portrait screenshot of `/games/texasholdem` via Playwright to visually validate that chips are positioned on the player rail, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e84088aa48329892eb917e09c5c05)