### PR TITLE
Fix Texas Hold'em raise chips to sit on the player rail again

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2112,18 +2112,20 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
   arena.add(group);
   const forward = seat.forward.clone().normalize();
   const axis = seat.right.clone().normalize();
-  const anchorY = seat.cardRailAnchor?.y ?? seat.chipRailAnchor?.y ?? tableInfo.surfaceY + RAIL_HEIGHT_OFFSET + RAIL_SURFACE_LIFT;
+  const anchorY = seat.chipRailAnchor?.y ?? seat.cardRailAnchor?.y ?? tableInfo.surfaceY + RAIL_HEIGHT_OFFSET + RAIL_SURFACE_LIFT;
   const fallbackAnchor = forward.clone().multiplyScalar(tableInfo.radius * RAIL_ANCHOR_RATIO);
   fallbackAnchor.y = anchorY;
   const cardRailAnchor = seat.cardRailAnchor
     ? seat.cardRailAnchor.clone()
     : fallbackAnchor.clone().addScaledVector(forward, CARD_RAIL_FORWARD_SHIFT).addScaledVector(axis, -CARD_RAIL_LATERAL_SHIFT);
   cardRailAnchor.y = anchorY;
-  const chipCenter = (seat.cardRailAnchor ?? seat.chipRailAnchor)
-    ? (seat.cardRailAnchor ?? seat.chipRailAnchor).clone()
-    : fallbackAnchor.clone().addScaledVector(axis, CARD_RAIL_LATERAL_SHIFT + CHIP_RAIL_LATERAL_SHIFT);
-  chipCenter.addScaledVector(axis, CARD_W * 0.82);
-  chipCenter.addScaledVector(forward, -CARD_D * 0.7);
+  const chipCenter = seat.chipRailAnchor
+    ? seat.chipRailAnchor.clone()
+    : seat.cardRailAnchor
+      ? seat.cardRailAnchor.clone().addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT)
+      : fallbackAnchor.clone().addScaledVector(axis, CARD_RAIL_LATERAL_SHIFT + CHIP_RAIL_LATERAL_SHIFT);
+  chipCenter.addScaledVector(axis, CARD_W * 0.2);
+  chipCenter.addScaledVector(forward, CARD_D * 0.2);
   chipCenter.y = anchorY;
   const columns = CHIP_VALUES.length;
   const rows = 1;


### PR DESCRIPTION
### Motivation
- Raise-chip buttons were anchored using the card anchor fallback which caused the clickable stacks to drift away from the player rail and become hard to tap for manual raises.
- Restore the chips to the wooden rail beside the player cards so manual raises can be performed by tapping the visible chip stacks.

### Description
- Prefer the seat's `chipRailAnchor` when computing `anchorY` and `chipCenter` in `createRaiseControls` inside `webapp/src/pages/Games/TexasHoldemArena.jsx` so chip buttons anchor to the rail first.
- Adjust chip center lateral/forward offsets to sit the chip row cleanly on the rail instead of overlapping the card area.
- Kept existing chip button creation, interaction and disposal logic unchanged so only spatial placement was corrected.

### Testing
- Ran `npm run build` (from `webapp/`) and the production build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the scene loaded for the Texas Hold'em route.
- Captured a visual regression check with a Playwright script pointed at `/games/texasholdem?mode=local&players=6&token=TPC&amount=1000` and produced a screenshot showing the chip stacks positioned on the rail (screenshot artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e914887f08329abe1a8a6bba34ee6)