### PR TITLE
Pool Royale: fix PolyHaven cloth mapping, neutralize albedo, and tighten procedural weave

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3381,7 +3381,7 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.656; // 20% larger pattern footprint for a looser weave
+const CLOTH_PATTERN_SCALE = 0.72; // slightly tighter weave so the procedural pattern appears a bit smaller on-screen
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 7;
@@ -3462,7 +3462,7 @@ const buildPolyHavenTextureUrls = (sourceId, resolution) => {
   const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${res}/${normalized}/${normalized}`;
   return {
     diffuse: `${base}_diff_${res}.jpg`,
-    normal: `${base}_nor_dx_${res}.jpg`,
+    normal: `${base}_nor_gl_${res}.jpg`,
     roughness: `${base}_rough_${res}.jpg`
   };
 };
@@ -3919,6 +3919,10 @@ const createClothTextures = (() => {
           loadTextureWithFallbacks(loader, normalCandidates, false),
           loadTextureWithFallbacks(loader, roughnessCandidates, false)
         ]);
+
+        if (map) {
+          map = neutralizePolyHavenColorMap(map);
+        }
 
         [map, normal, roughness].forEach((tex) =>
           applyTextureDefaults(tex, { isPolyHaven: true })


### PR DESCRIPTION
### Motivation

- Ensure Poly Haven scanned cloths load with the correct normal map variant and better match the procedural cloth tinting. 
- Make procedural weave details render slightly smaller so patterns visually align with the scanned textures on-screen.

### Description

- Changed the procedural cloth scale constant from `CLOTH_PATTERN_SCALE = 0.656` to `0.72` so generated weave/patterns appear a bit smaller on-screen in Pool Royale.
- Updated the PolyHaven URL template to use the OpenGL normal suffix (`_nor_gl_`) in `buildPolyHavenTextureUrls` for correct normal-map lookup.
- Call `neutralizePolyHavenColorMap(map)` on downloaded PolyHaven albedo maps before applying texture defaults so scanned albedos are desaturated/normalized and match procedural tinting.
- All edits are contained in `webapp/src/pages/Games/PoolRoyale.jsx` (texture URL build, pattern scale and load/postprocess logic changes).

### Testing

- Ran a production build with `npm --prefix webapp run build`, which completed successfully (Vite reported only non-blocking chunk-size warnings). 
- Started the dev server and loaded the Pool Royale page, then captured a screenshot from a mobile-sized viewport using Playwright to validate visual behavior (artifact: `artifacts/poolroyale-cloth-update.png`).
- No automated test failures were observed during the build and local verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9255e008832980a494aa478d498c)