### PR TITLE
Fix Texas Hold'em chip selector placement on player rail

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -2119,11 +2119,13 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
     ? seat.cardRailAnchor.clone()
     : fallbackAnchor.clone().addScaledVector(forward, CARD_RAIL_FORWARD_SHIFT).addScaledVector(axis, -CARD_RAIL_LATERAL_SHIFT);
   cardRailAnchor.y = anchorY;
-  const chipCenter = (seat.cardRailAnchor ?? seat.chipRailAnchor)
-    ? (seat.cardRailAnchor ?? seat.chipRailAnchor).clone()
-    : fallbackAnchor.clone().addScaledVector(axis, CARD_RAIL_LATERAL_SHIFT + CHIP_RAIL_LATERAL_SHIFT);
-  chipCenter.addScaledVector(axis, CARD_W * 0.82);
-  chipCenter.addScaledVector(forward, -CARD_D * 0.7);
+  const chipCenter = seat.chipRailAnchor
+    ? seat.chipRailAnchor.clone()
+    : fallbackAnchor
+        .clone()
+        .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT)
+        .addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT);
+  chipCenter.addScaledVector(forward, CARD_D * 0.48);
   chipCenter.y = anchorY;
   const columns = CHIP_VALUES.length;
   const rows = 1;


### PR DESCRIPTION
### Motivation
- Players reported the manual-raise chip buttons no longer appearing on the wooden rail near the bottom player, making manual raises awkward to select; this change restores chip placement to the rail so taps/clicks are intuitive in portrait view.

### Description
- Updated the chip anchor logic in `webapp/src/pages/Games/TexasHoldemArena.jsx` to prefer the player's `seat.chipRailAnchor` instead of the previous card-anchor fallback. 
- Adjusted the fallback to compute chip positions using rail-specific forward/lateral offsets (`CHIP_RAIL_FORWARD_SHIFT`, `CHIP_RAIL_LATERAL_SHIFT`) so chips remain on the wooden rail when `chipRailAnchor` is absent. 
- Applied a small forward nudge to the chip center so the chip button row sits visibly on the rail and is easier to tap/click; left the chip button layout/interaction code unchanged.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`, which reported the file is ignored by the repo eslint config (warning). 
- Ran `npm run -s lint`, which failed due to large pre-existing repository-wide lint issues in unrelated generated/build files (no new lint errors attributable to this change were observed before the run returned repo-wide issues). 
- Launched the frontend with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the dev server started successfully. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/games/texasholdem` in a portrait viewport to visually verify the chips are positioned on the wooden rail; the screenshot confirms the chip selector is visible and reachable on the rail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e914887f08329abe1a8a6bba34ee6)