### PR TITLE
Adjust Texas Hold'em chip rail and player card spacing/orientation

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -361,7 +361,7 @@ const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
     COMMUNITY_CARD_FORWARD_OFFSET
   )
 );
-const HOLE_SPACING = CARD_W * 0.65;
+const HOLE_SPACING = CARD_W * 1.08;
 const HUMAN_CARD_SPREAD = HOLE_SPACING * 1.32;
 const HUMAN_CARD_FORWARD_OFFSET = CARD_W * 0.04;
 const HUMAN_CARD_VERTICAL_OFFSET = CARD_H * 0.52;
@@ -394,9 +394,9 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.68;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.78;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.7;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 1.12;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.92;
 const HUMAN_CARD_CHIP_BLEND = 0.08;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
@@ -4804,6 +4804,7 @@ function TexasHoldemArena({ search }) {
           position.y = (seat.isHuman ? baseAnchor.y : seat.cardRailAnchor.y) + CARD_D * 0.6;
         }
         mesh.position.copy(position);
+        const isSideSeat = !seat.isHuman && Math.abs(seat.forward.x) > Math.abs(seat.forward.z);
         const lookOrigin = seat.isHuman ? baseAnchor : seat.stoolAnchor;
         const lookTarget = seat.isHuman
           ? baseAnchor
@@ -4811,13 +4812,19 @@ function TexasHoldemArena({ search }) {
               .addScaledVector(forward, 2.4 * MODEL_SCALE)
               .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
               .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
-          : lookOrigin
-              .clone()
-              .add(new THREE.Vector3(0, seat.stoolHeight * 0.5 + CARD_LOOK_LIFT, 0))
-              .add(right.clone().multiplyScalar((cardIdx - 0.5) * CARD_LOOK_SPLAY))
-              .addScaledVector(forward, 0);
+          : (isSideSeat
+              ? baseAnchor
+                  .clone()
+                  .addScaledVector(forward, 2.2 * MODEL_SCALE)
+                  .add(right.clone().multiplyScalar((cardIdx - 0.5) * CARD_LOOK_SPLAY))
+                  .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
+              : lookOrigin
+                  .clone()
+                  .add(new THREE.Vector3(0, seat.stoolHeight * 0.5 + CARD_LOOK_LIFT, 0))
+                  .add(right.clone().multiplyScalar((cardIdx - 0.5) * CARD_LOOK_SPLAY))
+                  .addScaledVector(forward, 0));
         const face = overheadView || seat.isHuman || state.showdown ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: seat.isHuman });
+        orientCard(mesh, lookTarget, { face, flat: seat.isHuman || isSideSeat });
         setCardFace(mesh, face);
         if (seat.isHuman) {
           mesh.rotation.x = 0;


### PR DESCRIPTION
### Motivation
- Restore the human player's chip stacks to the wooden rail beside the hole cards so chips no longer overlap with the cards. 
- Prevent the bottom player's two hole cards from touching each other by increasing hole-card spacing. 
- Make side players (left/right) present their hole cards straighter, matching the top/bottom visual presentation.

### Description
- Increased hole spacing by updating `HOLE_SPACING` to `CARD_W * 1.08` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to separate player hole cards. 
- Tuned rail offsets by changing `HUMAN_CHIP_INWARD_SHIFT` to `CARD_W * -0.7` and `HUMAN_CHIP_LATERAL_SHIFT` to `CARD_W * 0.92` so human chip stacks sit on the wooden rail next to the cards. 
- Added side-seat detection (`isSideSeat`) and adjusted card look-target/orientation for non-human side seats so left/right players hold cards more upright; also pass `flat` when orienting side-seat cards to keep them visually straight. 
- All edits are contained in `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran unit tests with `npm test -- --runTestsByPath test/texasHoldemGame.test.js` and the suite passed (2 tests, 0 failures). 
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured portrait screenshots of `/games/texasholdem` via Playwright for visual verification (artifacts generated), confirming chips sit by the rail and cards do not touch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb1ae96f0832998295e8156a7f41a)