### PR TITLE
Domino Royal: separate theme catalog, default Murlan table, and higher-res domino textures

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -77,7 +77,7 @@ const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 2048,
   chairClothTextureSize: 2048,
-  dominoTextureSize: 4096
+  dominoTextureSize: 8192
 });
 
 function detectCoarsePointer() {
@@ -2248,6 +2248,15 @@ const MURLAN_STOOL_THEMES = Object.freeze([
 
 const MURLAN_TABLE_THEMES = Object.freeze(
   [
+    {
+      id: 'murlan-default',
+      label: 'Murlan Default Table',
+      source: 'procedural',
+      price: 0,
+      thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+      description:
+        'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
     { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
@@ -2261,17 +2270,20 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     { id: 'side_table_01', label: 'Side Table 01' },
     { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
     { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' }
-  ].map((option, index) => ({
-    ...option,
-    assetId: option.assetId || option.id,
-    source: option.source || 'polyhaven',
-    thumbnail: option.thumbnail || POLYHAVEN_THUMB(option.id),
-    price: option.price ?? 980 + index * 40,
-    preserveMaterials: option.preserveMaterials ?? true,
-    description:
-      option.description ||
-      `${option.label} with preserved Poly Haven materials.`
-  }))
+  ].map((option, index) => {
+    const source = option.source || 'polyhaven';
+    return {
+      ...option,
+      assetId: source === 'polyhaven' ? option.assetId || option.id : null,
+      source,
+      thumbnail: option.thumbnail || POLYHAVEN_THUMB(option.id),
+      price: option.price ?? 980 + index * 40,
+      preserveMaterials: option.preserveMaterials ?? source === 'polyhaven',
+      description:
+        option.description ||
+        `${option.label} with preserved Poly Haven materials.`
+    };
+  })
 );
 
 const CHAIR_THEME_OPTIONS = Object.freeze(

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,4 +1,7 @@
-import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import {
+  DOMINO_ROYAL_CHAIR_THEMES,
+  DOMINO_ROYAL_TABLE_THEMES
+} from './dominoRoyalThemeCatalog.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
@@ -20,7 +23,7 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     description,
     swatches
   })),
-  tableTheme: MURLAN_TABLE_THEMES.map(({ id, label, price = 0, description, source, assetId, preserveMaterials }) => ({
+  tableTheme: DOMINO_ROYAL_TABLE_THEMES.map(({ id, label, price = 0, description, source, assetId, preserveMaterials }) => ({
     id,
     label,
     price,
@@ -44,7 +47,7 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'iceTracer', label: 'Ice Tracer' },
     { id: 'violetPulse', label: 'Violet Pulse' }
   ],
-  chairTheme: MURLAN_STOOL_THEMES.map(({ id, label, price = 0, description }) => ({
+  chairTheme: DOMINO_ROYAL_CHAIR_THEMES.map(({ id, label, price = 0, description }) => ({
     id,
     label,
     price,
@@ -128,7 +131,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     name: option.label,
     price: option.price || 900 + idx * 45,
     description: option.description || 'Apply the Murlan Royale table collection to Domino.',
-    thumbnail: MURLAN_TABLE_THEMES.find((theme) => theme.id === option.id)?.thumbnail
+    thumbnail: DOMINO_ROYAL_TABLE_THEMES.find((theme) => theme.id === option.id)?.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.environmentHdri.slice(1).map((option, idx) => ({
     id: `domino-hdri-${option.id}`,
@@ -164,7 +167,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     name: option.label,
     price: option.price || 300 + idx * 25,
     description: option.description || 'Murlan Royale seating set for Domino Royal.',
-    thumbnail: MURLAN_STOOL_THEMES.find((theme) => theme.id === option.id)?.thumbnail
+    thumbnail: DOMINO_ROYAL_CHAIR_THEMES.find((theme) => theme.id === option.id)?.thumbnail
   }))
 ];
 

--- a/webapp/src/config/dominoRoyalThemeCatalog.js
+++ b/webapp/src/config/dominoRoyalThemeCatalog.js
@@ -1,0 +1,129 @@
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+
+const BASE_CHAIR_THEMES = [
+  {
+    id: 'ruby',
+    label: 'Ruby',
+    seatColor: '#8b0000',
+    legColor: '#1f1f1f',
+    price: 0,
+    description: 'Default ruby cushions with noir legs.',
+    thumbnail: swatchThumbnail(['#8b0000', '#1f1f1f', '#f8fafc'])
+  },
+  {
+    id: 'slate',
+    label: 'Slate',
+    seatColor: '#374151',
+    legColor: '#0f172a',
+    price: 210,
+    description: 'Slate seats with midnight legs.',
+    thumbnail: swatchThumbnail(['#374151', '#0f172a', '#e2e8f0'])
+  },
+  {
+    id: 'teal',
+    label: 'Teal',
+    seatColor: '#0f766e',
+    legColor: '#082f2a',
+    price: 230,
+    description: 'Teal cushions with deep green support.',
+    thumbnail: swatchThumbnail(['#0f766e', '#082f2a', '#5eead4'])
+  },
+  {
+    id: 'amber',
+    label: 'Amber',
+    seatColor: '#b45309',
+    legColor: '#2f2410',
+    price: 250,
+    description: 'Amber seats with rich brown legs.',
+    thumbnail: swatchThumbnail(['#b45309', '#2f2410', '#fde68a'])
+  },
+  {
+    id: 'violet',
+    label: 'Violet',
+    seatColor: '#7c3aed',
+    legColor: '#2b1059',
+    price: 270,
+    description: 'Violet cushions with twilight framing.',
+    thumbnail: swatchThumbnail(['#7c3aed', '#2b1059', '#ddd6fe'])
+  },
+  {
+    id: 'frost',
+    label: 'Ice',
+    seatColor: '#1f2937',
+    legColor: '#0f172a',
+    price: 290,
+    description: 'Frosted charcoal seats with dark legs.',
+    thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#e2e8f0'])
+  },
+  {
+    id: 'leather',
+    label: 'Leather',
+    seatColor: '#6a4a32',
+    legColor: '#1a1410',
+    price: 320,
+    description: 'Leather-wrapped seats with dark studio legs.',
+    thumbnail: swatchThumbnail(['#6a4a32', '#1a1410', '#fcd34d'])
+  }
+];
+
+const POLYHAVEN_CHAIR_THEMES = [
+  { id: 'ArmChair_01', label: 'Arm Chair 01', source: 'polyhaven', assetId: 'ArmChair_01' },
+  { id: 'BarberShopChair_01', label: 'Barber Shop Chair 01', source: 'polyhaven', assetId: 'BarberShopChair_01' },
+  { id: 'GreenChair_01', label: 'Green Chair 01', source: 'polyhaven', assetId: 'GreenChair_01' },
+  { id: 'SchoolChair_01', label: 'School Chair 01', source: 'polyhaven', assetId: 'SchoolChair_01' },
+  { id: 'dining_chair_02', label: 'Dining Chair 02', source: 'polyhaven', assetId: 'dining_chair_02' },
+  { id: 'gallinera_chair', label: 'Gallinera Chair', source: 'polyhaven', assetId: 'gallinera_chair' },
+  { id: 'mid_century_lounge_chair', label: 'Mid-Century Lounge', source: 'polyhaven', assetId: 'mid_century_lounge_chair' },
+  { id: 'modern_arm_chair_01', label: 'Modern Arm Chair', source: 'polyhaven', assetId: 'modern_arm_chair_01' },
+  { id: 'painted_wooden_chair_01', label: 'Painted Wooden Chair 01', source: 'polyhaven', assetId: 'painted_wooden_chair_01' },
+  { id: 'painted_wooden_chair_02', label: 'Painted Wooden Chair 02', source: 'polyhaven', assetId: 'painted_wooden_chair_02' },
+  { id: 'plastic_monobloc_chair_01', label: 'Plastic Monobloc Chair', source: 'polyhaven', assetId: 'plastic_monobloc_chair_01' },
+  { id: 'wheelchair_01', label: 'Wheelchair 01', source: 'polyhaven', assetId: 'wheelchair_01' }
+].map((option, index) => ({
+  ...option,
+  thumbnail: polyHavenThumb(option.assetId),
+  price: 520 + index * 35,
+  description: `${option.label} with preserved original materials.`,
+  preserveMaterials: true
+}));
+
+const POLYHAVEN_TABLE_THEMES = [
+  { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
+  { id: 'WoodenTable_02', label: 'Wooden Table 02' },
+  { id: 'chinese_tea_table', label: 'Chinese Tea Table' },
+  { id: 'coffee_table_round_01', label: 'Coffee Table Round 01' },
+  { id: 'gallinera_table', label: 'Gallinera Table' },
+  { id: 'gothic_coffee_table', label: 'Gothic Coffee Table' },
+  { id: 'industrial_coffee_table', label: 'Industrial Coffee Table' },
+  { id: 'modern_coffee_table_01', label: 'Modern Coffee Table 01' },
+  { id: 'modern_coffee_table_02', label: 'Modern Coffee Table 02' },
+  { id: 'round_wooden_table_02', label: 'Round Wooden Table 02' },
+  { id: 'side_table_01', label: 'Side Table 01' },
+  { id: 'side_table_tall_01', label: 'Side Table Tall 01' },
+  { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' }
+].map((option, index) => ({
+  ...option,
+  assetId: option.id,
+  source: 'polyhaven',
+  thumbnail: polyHavenThumb(option.id),
+  price: 980 + index * 40,
+  preserveMaterials: true,
+  description: option.description || `${option.label} with preserved Poly Haven materials.`
+}));
+
+export const DOMINO_ROYAL_TABLE_THEMES = [
+  {
+    id: 'murlan-default',
+    label: 'Murlan Default Table',
+    source: 'procedural',
+    price: 0,
+    thumbnail: polyHavenThumb('CoffeeTable_01'),
+    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+  },
+  ...POLYHAVEN_TABLE_THEMES
+];
+
+export const DOMINO_ROYAL_CHAIR_THEMES = [
+  ...BASE_CHAIR_THEMES,
+  ...POLYHAVEN_CHAIR_THEMES
+];


### PR DESCRIPTION
### Motivation
- Make Domino Royal use the same table/chair lineup as Ludo Battle Royal while keeping Domino-specific configuration and preventing shared runtime coupling.  
- Ensure the default Domino table matches the Ludo default (`murlan-default`) and improve domino tile fidelity by increasing generated texture resolution.  

### Description
- Added a Domino-only theme catalog `webapp/src/config/dominoRoyalThemeCatalog.js` that mirrors the Murlan/Ludo table and chair entries (including a `murlan-default` procedural table) so Domino has its own inventory source.  
- Switched `webapp/src/config/dominoRoyalInventoryConfig.js` to import `DOMINO_ROYAL_TABLE_THEMES` and `DOMINO_ROYAL_CHAIR_THEMES` and updated store thumbnail lookups to use the Domino-specific arrays.  
- Updated `webapp/public/domino-royal-game.js` to add `murlan-default` as the first/default table theme, to avoid forcing PolyHaven GLTF asset IDs for procedural entries, and to preserve `preserveMaterials` behavior depending on the theme source.  
- Increased `MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize` from `4096` to `8192` to produce higher-resolution domino tile textures.  

### Testing
- Performed syntax/type checks with `node --check webapp/src/config/dominoRoyalInventoryConfig.js`, `node --check webapp/src/config/dominoRoyalThemeCatalog.js`, and `node --check webapp/public/domino-royal-game.js`, all of which succeeded.  
- Launched the dev webapp with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a Domino Royal page screenshot via Playwright for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb5ed6d388329936237ddbc769720)