### PR TITLE
Adjust Texas Hold'em bottom player card/chip positioning and chip grid (3x3)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -393,11 +393,11 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.68;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.7;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -0.86;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.56;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.92;
-const HUMAN_CARD_CHIP_BLEND = 0.08;
+const HUMAN_CARD_CHIP_BLEND = 0.02;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
@@ -2127,8 +2127,8 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
         .addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT);
   chipCenter.addScaledVector(forward, CARD_D * 0.48);
   chipCenter.y = anchorY;
-  const columns = CHIP_VALUES.length;
-  const rows = 1;
+  const columns = 3;
+  const rows = Math.ceil(CHIP_VALUES.length / columns);
   const colOffset = (columns - 1) / 2;
   const rowOffset = (rows - 1) / 2;
   const chipButtons = CHIP_VALUES.map((value, index) => {


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving the bottom player's hole cards slightly closer to the table center and ensuring the cards visually appear ahead of their chips.
- Replace the single-row raise-chip layout with a compact 3x3 grid so chip buttons are easier to tap on small portrait screens.

### Description
- Tuned human anchor constants in `webapp/src/pages/Games/TexasHoldemArena.jsx` by changing `HUMAN_CARD_INWARD_SHIFT` from `CARD_W * -0.68` to `CARD_W * -0.86` and `HUMAN_CHIP_INWARD_SHIFT` from `CARD_W * -0.7` to `CARD_W * -0.56` so player cards are pulled inward and chips sit slightly behind them.
- Reduced the card/chip blending by changing `HUMAN_CARD_CHIP_BLEND` from `0.08` to `0.02` so cards remain visually ahead when anchors are adjusted.
- Changed raise-chip controls to render in a 3-column grid by setting `columns = 3` and `rows = Math.ceil(CHIP_VALUES.length / columns)` and computing per-chip row/column placement instead of a single row.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- Launched a dev server and captured a portrait screenshot of `/games/texasholdem` via Playwright to validate visual layout changes (screenshot saved during validation).
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which produced a file-ignore warning only and no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb73901888329b845587a76755b40)