### PR TITLE
Adjust Domino Royal control placement and GLTF texture handling

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -52,14 +52,14 @@ export default function DominoRoyalArena() {
       </div>
       <style>{`
         #viewToggle {
-          position: static !important;
+          position: fixed !important;
+          right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
           left: auto !important;
-          right: auto !important;
-          top: auto !important;
+          top: calc(8.15rem + env(safe-area-inset-top, 0px)) !important;
           margin: 0 !important;
         }
         #configButton {
-          top: calc(4.1rem + env(safe-area-inset-top, 0px)) !important;
+          top: calc(4.55rem + env(safe-area-inset-top, 0px)) !important;
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
           width: auto !important;
           padding: 0 0.95rem !important;
@@ -70,7 +70,7 @@ export default function DominoRoyalArena() {
         #configButton span:first-child { font-size: 1.05rem; line-height: 1; }
         #configButton span:last-child { font-size: 0.72rem; letter-spacing: 0.24em; text-transform: uppercase; }
         #muteButton {
-          top: calc(4.1rem + env(safe-area-inset-top, 0px)) !important;
+          top: calc(4.55rem + env(safe-area-inset-top, 0px)) !important;
           right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
           left: auto !important;
           bottom: auto !important;
@@ -83,7 +83,7 @@ export default function DominoRoyalArena() {
         }
         #quickActions .quick-action {
           position: fixed !important;
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) + clamp(2.8rem, 8vh, 3.4rem)) !important;
         }
         #quickActions .quick-action[data-action="gift"] {
           right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;


### PR DESCRIPTION
### Motivation
- Move Domino Royal HUD controls to better match portrait-mobile layout directions so menu, mute, 2D/3D toggle, gift and chat align visually on the phone screen.
- Preserve original GLTF textures/materials for table and chairs so Domino uses the same reliable material handling as the Ludo Battle Royal flow.
- Ensure Domino uses the same sensible default table and chair selection as Ludo (`murlan-default` table theme and `ruby` chair theme) for a consistent default appearance.

### Description
- Adjusted mobile HUD CSS in `webapp/src/pages/Games/DominoRoyalArena.jsx` to reposition `#configButton`, `#muteButton`, `#viewToggle`, and raise `#quickActions` so the menu is slightly lower, mute and view toggle align, and gift/chat move up by roughly one icon size.
- In `webapp/public/domino-royal-game.js` added `DRACO_DECODER_PATH`, `applySRGBColorSpace`, and `prepareLoadedModel` utilities and invoked `prepareLoadedModel(root)` to ensure loaded GLTF materials get sRGB color-space and proper mesh flags.
- Updated PolyHaven GLTF loader logic to compute a resolved URL, call `loader.setResourcePath(...)` and `loader.setPath('')` before `loadAsync(...)` so external textures referenced by GLTF resolve correctly, and switched DRACO decoder usage to the shared `DRACO_DECODER_PATH` constant (also applied to chair model loader).
- Set Domino default unlocks to use `resolveDefaultOptionId(...)` so `tableTheme` and `chairTheme` default to the Ludo baseline (`murlan-default` / `ruby`) instead of relying only on array order.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with Vite (no errors).
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a portrait screenshot using Playwright to verify UI placement (`artifacts/domino-royal-ui-adjusted.png`).
- Changes were committed and the PR scaffolding message was produced; local validations above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebabb7e38832981274347cd5749f1)