### PR TITLE
Add online-readiness contract, UI badges and gate online toggles for Domino & Ludo

### DIFF
--- a/docs/online-contract-checklist.md
+++ b/docs/online-contract-checklist.md
@@ -1,0 +1,25 @@
+# Online Contract Checklist
+
+Use this checklist before enabling any game's **Online** toggle in lobby.
+
+## Contract gates (must all be ✅)
+
+- [ ] **Lobby contract**
+  - Seats through shared `seatTable` flow.
+  - Sends `confirmReady` and handles timeout/cancel cleanup.
+  - Enforces stake reserve/refund rules.
+- [ ] **Runtime contract**
+  - Reads `tableId` + `accountId` from URL/session.
+  - Registers socket session and joins game room.
+  - Applies socket state updates/reconnect flow (not local-only simulation).
+- [ ] **Backend event contract**
+  - Emits/handles `seatTable`, `lobbyUpdate`, `gameStart`, `leaveLobby`, refund/cancel.
+  - Match completion, stake settlement, and win/loss are authoritative.
+  - Telemetry emits queued → matched → started → completed/refunded.
+
+## Release policy
+
+Only set a game to **Online Ready** when all three contracts pass.
+
+- If one or more contracts are missing: label as **Beta** or **Coming Soon**.
+- Never expose an enabled online toggle when any contract gate is failing.

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -1,0 +1,50 @@
+export const ONLINE_CONTRACT_CHECKS = Object.freeze({
+  lobby: 'Lobby uses shared online flow and validated seat/join handling',
+  runtime: 'Game runtime consumes tableId/accountId and stays socket-synced',
+  backend: 'Backend event contract for seat/ready/start/cleanup is validated'
+});
+
+export const ONLINE_READINESS_BY_GAME = Object.freeze({
+  poolroyale: {
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
+  },
+  snookerroyale: {
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
+  },
+  snake: {
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
+  },
+  'domino-royal': {
+    checks: { lobby: true, runtime: true, backend: false },
+    label: 'Beta'
+  },
+  ludobattleroyal: {
+    checks: { lobby: true, runtime: true, backend: false },
+    label: 'Beta'
+  }
+});
+
+const FALLBACK_STATE = Object.freeze({
+  checks: { lobby: false, runtime: false, backend: false },
+  label: 'Coming Soon'
+});
+
+export function getOnlineReadiness(slug = '') {
+  const state = ONLINE_READINESS_BY_GAME[slug] || FALLBACK_STATE;
+  const checks = {
+    lobby: Boolean(state.checks?.lobby),
+    runtime: Boolean(state.checks?.runtime),
+    backend: Boolean(state.checks?.backend)
+  };
+  const ready = checks.lobby && checks.runtime && checks.backend;
+  return {
+    slug,
+    checks,
+    ready,
+    label: state.label || (ready ? 'Online Ready' : 'Coming Soon')
+  };
+}
+

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -4,6 +4,13 @@ import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
+import { getOnlineReadiness } from '../config/onlineContract.js';
+
+const BADGE_STYLES = {
+  'Online Ready': 'bg-emerald-500/20 text-emerald-300 border-emerald-400/40',
+  Beta: 'bg-amber-500/20 text-amber-200 border-amber-300/40',
+  'Coming Soon': 'bg-slate-500/20 text-slate-200 border-slate-300/30'
+};
 
 export default function Games() {
   useTelegramBackButton();
@@ -17,6 +24,8 @@ export default function Games() {
       <div className="grid grid-cols-3 gap-3">
         {gamesCatalog.map((game) => {
           const thumbnail = getGameThumbnail(game.slug);
+          const readiness = getOnlineReadiness(game.slug);
+          const badgeTone = BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
           return (
             <Link
               key={game.name}
@@ -40,6 +49,11 @@ export default function Games() {
             </div>
             <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
               <p className="text-[10px] text-subtext line-clamp-2">{game.description}</p>
+              <span
+                className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
+              >
+                {readiness.label}
+              </span>
               <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
                 Enter Lobby
               </span>

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -1,8 +1,46 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import DominoRoyalArena from './DominoRoyalArena.jsx';
+import { socket } from '../../utils/socket.js';
+import { ensureAccountId, getTelegramUsername } from '../../utils/telegram.js';
 
 export default function DominoRoyal() {
   useTelegramBackButton();
+  const { search } = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const mode = params.get('mode');
+    const tableId = params.get('tableId') || params.get('table');
+    if (mode !== 'online' || !tableId) return undefined;
+
+    let cancelled = false;
+    let resolvedAccountId = (params.get('accountId') || '').trim();
+
+    const syncRuntime = async () => {
+      if (!resolvedAccountId) {
+        resolvedAccountId = (await ensureAccountId().catch(() => '')) || '';
+      }
+      if (cancelled || !resolvedAccountId) return;
+      socket.emit('register', { playerId: resolvedAccountId });
+      socket.emit('joinRoom', {
+        roomId: tableId,
+        accountId: resolvedAccountId,
+        name: getTelegramUsername() || 'Player'
+      });
+      socket.emit('confirmReady', { accountId: resolvedAccountId, tableId });
+    };
+
+    syncRuntime().catch(() => {});
+
+    return () => {
+      cancelled = true;
+      if (resolvedAccountId) {
+        socket.emit('leaveLobby', { accountId: resolvedAccountId, tableId });
+      }
+    };
+  }, [search]);
 
   return (
     <div className="relative w-full h-screen">


### PR DESCRIPTION
### Motivation
- Reduce "false-online" behaviour by making online readiness explicit and gating lobby toggles until all online contracts pass.
- Ensure runtimes are wired to authoritative table/session state so game instances join the same socket room as the backend lobby.
- Provide a single source-of-truth for per-game readiness (Online Ready / Beta / Coming Soon) to avoid ad-hoc flags across code.

### Description
- Added a shared online contract module at `webapp/src/config/onlineContract.js` that declares the `lobby`, `runtime`, and `backend` gates per game and exposes `getOnlineReadiness(slug)`. 
- Rendered per-game readiness badges on the Games page and added visual badge styles for `Online Ready`, `Beta`, and `Coming Soon` (`webapp/src/pages/Games.jsx`).
- Integrated contract gating into Domino and Ludo lobbies so the online toggle and Start flow are disabled when contract checks are not all passing, and the UI shows contract status messaging (`DominoRoyalLobby.jsx`, `LudoBattleRoyalLobby.jsx`).
- Wired Domino and Ludo runtime entrypoints to consume `tableId`/`accountId` and perform socket lifecycle sync (`register`, `joinRoom`, `confirmReady`, `leaveLobby`), and added Ludo seating flow that requests a table id from `seatTable` before navigating into runtime (`DominoRoyal.jsx`, `LudoBattleRoyal.jsx`, `LudoBattleRoyalLobby.jsx`).
- Added a human-readable checklist documenting the online contract gates and release policy at `docs/online-contract-checklist.md`.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully (build warnings about large chunks are informational). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully. 
- Captured an automated Playwright screenshot of the Games page to validate the new readiness badges were rendered (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed133c7f88329864e94c506a0bc30)