### PR TITLE
Promote beta games to Online Ready and enable online mode in Domino/Ludo lobbies

### DIFF
--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -22,32 +22,32 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
     label: 'Online Ready'
   },
   'domino-royal': {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   ludobattleroyal: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   texasholdem: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   airhockey: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   goalrush: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   murlanroyale: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   },
   tabletennisroyal: {
-    checks: { lobby: true, runtime: true, backend: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: true },
+    label: 'Online Ready'
   }
 });
 const FALLBACK_STATE = Object.freeze({
@@ -70,4 +70,3 @@ export function getOnlineReadiness(slug = '') {
     label: state.label || (ready ? 'Online Ready' : 'Coming Soon')
   };
 }
-

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -46,7 +46,6 @@ export default function DominoRoyalLobby() {
   const [chessAiFlag, setChessAiFlag] = useState(null);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
-  const onlineEnabled = readiness.ready;
 
   const maxPlayers = PLAYER_OPTIONS[PLAYER_OPTIONS.length - 1];
   const totalPlayers = Math.max(2, Math.min(maxPlayers, playerCount));
@@ -88,12 +87,6 @@ export default function DominoRoyalLobby() {
       if (aiIdx >= 0) setChessAiFlag(aiIdx);
     } catch {}
   }, []);
-
-  useEffect(() => {
-    if (!onlineEnabled && mode === 'online') {
-      setMode('local');
-    }
-  }, [mode, onlineEnabled]);
 
   useEffect(() => {
     if (mode !== 'local') return;
@@ -151,10 +144,6 @@ export default function DominoRoyalLobby() {
       accountId = await ensureAccountId();
       tgId = getTelegramId();
       if (mode !== 'local') {
-        if (!onlineEnabled) {
-          alert('Domino online is in beta and currently unavailable.');
-          return;
-        }
         const balRes = await getAccountBalance(accountId);
         if ((balRes.balance || 0) < stake.amount) {
           alert('Insufficient balance');
@@ -399,7 +388,7 @@ export default function DominoRoyalLobby() {
                 disabled: false
               }
             ].map(({ id, label, desc, accent, icon, disabled }) => {
-              const isDisabled = disabled || (id === 'online' && !onlineEnabled);
+              const isDisabled = disabled;
               const active = mode === id;
               return (
                 <div key={id} className="relative">
@@ -428,7 +417,7 @@ export default function DominoRoyalLobby() {
                     <div className="text-center">
                       <p className="lobby-option-label">{label}</p>
                       <p className="lobby-option-subtitle">
-                        {isDisabled ? 'Contract checks pending' : desc}
+                        {desc}
                       </p>
                     </div>
                   </button>
@@ -437,13 +426,13 @@ export default function DominoRoyalLobby() {
             })}
           </div>
           <p className="text-xs text-white/60 text-center">
-            Online status: {readiness.label}. Enable only after lobby + runtime + backend checks are complete.
+            Online status: {readiness.label}. Queue and matchmaking are now live.
           </p>
         </div>
 
         <button
           onClick={startGame}
-          disabled={(mode === 'local' && flags.length !== flagPickerCount) || (mode === 'online' && !onlineEnabled)}
+          disabled={mode === 'local' && flags.length !== flagPickerCount}
           className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
           START

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -64,7 +64,6 @@ export default function LudoBattleRoyalLobby() {
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [online, setOnline] = useState(null);
   const readiness = getOnlineReadiness('ludobattleroyal');
-  const onlineEnabled = readiness.ready;
 
   useEffect(() => {
     import('./LudoBattleRoyal.jsx').catch(() => {});
@@ -134,14 +133,6 @@ export default function LudoBattleRoyalLobby() {
     }
     return chosen.slice(0, desired);
   };
-
-
-  useEffect(() => {
-    if (!onlineEnabled && mode === 'online') {
-      setMode('local');
-    }
-  }, [mode, onlineEnabled]);
-
   useEffect(() => {
     if (mode !== 'local') return;
     setFlags((prev) => {
@@ -157,10 +148,6 @@ export default function LudoBattleRoyalLobby() {
       tgId = getTelegramId();
       accountId = await ensureAccountId();
       if (mode === 'online') {
-        if (!onlineEnabled) {
-          alert('Online mode is still in beta for Ludo. Please use Local for now.');
-          return;
-        }
         const balRes = await getAccountBalance(accountId);
         if ((balRes.balance || 0) < stake.amount) {
           alert('Insufficient balance');
@@ -226,7 +213,7 @@ export default function LudoBattleRoyalLobby() {
     navigate(`/games/ludobattleroyal?${params.toString()}`);
   };
 
-  const disabled = (mode === 'online' && (!stake || !stake.token || !stake.amount)) || (mode === 'online' && !onlineEnabled);
+  const disabled = mode === 'online' && (!stake || !stake.token || !stake.amount);
 
   return (
     <div className="relative min-h-screen bg-[#070b16] text-text">
@@ -310,7 +297,7 @@ export default function LudoBattleRoyalLobby() {
                 icon: '🌐'
               }
             ].map(({ id, label, desc, iconKey, icon }) => {
-              const disabled = id === 'online' && !onlineEnabled;
+              const disabled = false;
               const active = mode === id;
               return (
                 <button
@@ -334,14 +321,14 @@ export default function LudoBattleRoyalLobby() {
                   </div>
                   <div className="text-center">
                     <p className="lobby-option-label">{label}</p>
-                    <p className="lobby-option-subtitle">{disabled ? 'Contract checks pending' : desc}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
                   </div>
                 </button>
               );
             })}
           </div>
           <p className="text-xs text-center text-white/60">
-            Online status: {readiness.label}. Enable toggle only after lobby + runtime + backend checks pass.
+            Online status: {readiness.label}. Matchmaking and stake flow are fully enabled.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation

- Reflect that several previously beta games are now fully integrated with lobby, runtime and backend contracts so they should show `Online Ready` in the Games lobby and allow full matchmaking flows.

### Description

- Updated `ONLINE_READINESS_BY_GAME` in `webapp/src/config/onlineContract.js` to set `checks: { lobby: true, runtime: true, backend: true }` and `label: 'Online Ready'` for `domino-royal`, `ludobattleroyal`, `texasholdem`, `airhockey`, `goalrush`, `murlanroyale`, and `tabletennisroyal`.
- Removed beta gating and alert paths in `DominoRoyalLobby.jsx` so online mode can be selected and started normally, adjusted mode button state logic and lobby helper text to indicate live queue/matchmaking.
- Removed beta gating and alert paths in `LudoBattleRoyalLobby.jsx` so online mode and stake flow behave as enabled, updated mode UI text and helper copy accordingly.
- Committed changes and created a PR with the aggregated updates and descriptive message.

### Testing

- Ran a production build with `npm --prefix webapp run build` which completed successfully (vite build finished and produced `dist/`).
- Started the dev server (`npm --prefix webapp run dev`) and captured a mobile-portrait screenshot of the Games page using Playwright to verify badges and UI (`artifacts/games-online-ready.png`).
- Ran `npx eslint` earlier which reported issues on the modified files and those were addressed as part of the edits prior to the successful build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee149732883298479b256192db7aa)