### PR TITLE
Add Dev Agent (backend /api/dev-agent + frontend modal)

### DIFF
--- a/bot/routes/devAgent.js
+++ b/bot/routes/devAgent.js
@@ -1,0 +1,213 @@
+import { Router } from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
+import authenticate from '../middleware/auth.js';
+import User from '../models/User.js';
+
+const router = Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const MAX_CONTEXT_FILES = 4;
+const MAX_FILE_CHARS = 2800;
+const SEARCH_EXTENSIONS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.json', '.md', '.mjs', '.cjs', '.css'
+]);
+const ALLOWED_ROOTS = ['bot', 'webapp/src', 'packages', 'docs', 'README.md', 'README-platform-help-agent.md'];
+
+function getDevAccounts() {
+  return [
+    process.env.DEV_ACCOUNT_ID,
+    process.env.VITE_DEV_ACCOUNT_ID,
+    process.env.DEV_ACCOUNT_ID_1,
+    process.env.VITE_DEV_ACCOUNT_ID_1,
+    process.env.DEV_ACCOUNT_ID_2,
+    process.env.VITE_DEV_ACCOUNT_ID_2
+  ].filter(Boolean);
+}
+
+async function resolveAccountId(req) {
+  if (req.auth?.accountId) return req.auth.accountId;
+  if (req.auth?.telegramId) {
+    const user = await User.findOne({ telegramId: req.auth.telegramId }).select('accountId');
+    return user?.accountId || null;
+  }
+  if (req.auth?.googleId) {
+    const user = await User.findOne({ googleId: req.auth.googleId }).select('accountId');
+    return user?.accountId || null;
+  }
+  return null;
+}
+
+function isAllowedPath(absolutePath) {
+  const normalized = absolutePath.replace(/\\/g, '/');
+  return ALLOWED_ROOTS.some((root) => {
+    const fullRoot = path.resolve(repoRoot, root).replace(/\\/g, '/');
+    return normalized === fullRoot || normalized.startsWith(`${fullRoot}/`);
+  });
+}
+
+async function collectFiles(dir, found = []) {
+  if (found.length >= 120) return found;
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build') {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (!isAllowedPath(fullPath)) continue;
+    if (entry.isDirectory()) {
+      await collectFiles(fullPath, found);
+    } else if (SEARCH_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      found.push(fullPath);
+    }
+    if (found.length >= 120) break;
+  }
+  return found;
+}
+
+function scoreFile(content, terms) {
+  const lower = content.toLowerCase();
+  return terms.reduce((acc, t) => acc + (lower.includes(t) ? 1 : 0), 0);
+}
+
+async function buildContext(message) {
+  const terms = String(message || '')
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((term) => term.length >= 3)
+    .slice(0, 10);
+
+  if (!terms.length) return [];
+
+  const files = [];
+  for (const root of ALLOWED_ROOTS) {
+    const rootPath = path.resolve(repoRoot, root);
+    try {
+      const stat = await fs.stat(rootPath);
+      if (stat.isFile()) {
+        files.push(rootPath);
+      } else {
+        await collectFiles(rootPath, files);
+      }
+    } catch {
+      // ignore missing root
+    }
+  }
+
+  const scored = [];
+  for (const file of files) {
+    try {
+      const content = await fs.readFile(file, 'utf8');
+      const score = scoreFile(content, terms);
+      if (score > 0) {
+        scored.push({ file, score, content: content.slice(0, MAX_FILE_CHARS) });
+      }
+    } catch {
+      // ignore unreadable files
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, MAX_CONTEXT_FILES).map((entry) => ({
+    file: path.relative(repoRoot, entry.file).replace(/\\/g, '/'),
+    excerpt: entry.content
+  }));
+}
+
+async function completeWithOpenAI({ message, context }) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+
+  const model = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+  const contextBlock = context
+    .map((item, idx) => `[#${idx + 1}] ${item.file}\n${item.excerpt}`)
+    .join('\n\n');
+
+  const prompt = [
+    'You are a dev-only coding assistant for TonPlaygram.',
+    'Use the provided code snippets only. If unsure, say what is missing.',
+    'Keep answers concise and implementation-focused.',
+    '',
+    `Developer question: ${message}`,
+    '',
+    'Relevant code context:',
+    contextBlock || 'No file context found.'
+  ].join('\n');
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      messages: [{ role: 'user', content: prompt }]
+    })
+  });
+
+  if (!response.ok) {
+    const failText = await response.text().catch(() => '');
+    throw new Error(`OpenAI request failed (${response.status}): ${failText.slice(0, 160)}`);
+  }
+
+  const payload = await response.json();
+  return payload?.choices?.[0]?.message?.content?.trim() || null;
+}
+
+function fallbackAnswer(message, context) {
+  const lines = [
+    'Dev Agent quick response (fallback mode).',
+    `Question: ${String(message || '').slice(0, 400)}`
+  ];
+
+  if (!context.length) {
+    lines.push('No relevant files matched. Try mentioning file/module names.');
+    return lines.join('\n');
+  }
+
+  lines.push('Matched files (fast context):');
+  context.forEach((item) => lines.push(`- ${item.file}`));
+  lines.push('Set OPENAI_API_KEY on server to enable full GPT answers.');
+  return lines.join('\n');
+}
+
+router.post('/chat', authenticate, async (req, res) => {
+  try {
+    const accountId = await resolveAccountId(req);
+    const devAccounts = getDevAccounts();
+    if (!accountId || (devAccounts.length && !devAccounts.includes(accountId))) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const message = String(req.body?.message || '').trim();
+    if (!message) {
+      return res.status(400).json({ error: 'message is required' });
+    }
+
+    const context = await buildContext(message);
+    let answer = null;
+    try {
+      answer = await completeWithOpenAI({ message, context });
+    } catch (err) {
+      console.error('[dev-agent] LLM failed, using fallback:', err?.message || err);
+    }
+
+    if (!answer) {
+      answer = fallbackAnswer(message, context);
+    }
+
+    return res.json({
+      answer,
+      citations: context.map((item) => item.file),
+      mode: process.env.OPENAI_API_KEY ? 'gpt' : 'fallback'
+    });
+  } catch (err) {
+    console.error('[dev-agent] request failed:', err);
+    return res.status(500).json({ error: 'dev agent request failed' });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -30,6 +30,7 @@ import snookerRoyaleRoutes from './routes/snookerRoyal.js';
 import exchangeRoutes from './routes/exchange.js';
 import pushRoutes from './routes/push.js';
 import voiceCommentaryRoutes from './routes/voiceCommentary.js';
+import devAgentRoutes from './routes/devAgent.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -258,6 +259,7 @@ app.use('/api/pool-royale', poolRoyaleRoutes);
 app.use('/api/snooker-royale', snookerRoyaleRoutes);
 app.use('/api/exchange', exchangeRoutes);
 app.use('/api/voice-commentary', voiceCommentaryRoutes);
+app.use('/api/dev-agent', devAgentRoutes);
 
 app.post('/api/goal-rush/calibration', authenticate, async (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/webapp/src/components/DevAgentModal.jsx
+++ b/webapp/src/components/DevAgentModal.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { FiCode, FiSend, FiX } from 'react-icons/fi';
+import { devAgentChat } from '../utils/api.js';
+
+export default function DevAgentModal({ open, onClose }) {
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [answer, setAnswer] = useState('');
+  const [citations, setCitations] = useState([]);
+  const [mode, setMode] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSend = async () => {
+    if (!message.trim() || loading) return;
+    setLoading(true);
+    setError('');
+    const response = await devAgentChat(message.trim());
+    if (response?.error) {
+      setError(response.error);
+      setLoading(false);
+      return;
+    }
+    setAnswer(response?.answer || 'No response.');
+    setCitations(Array.isArray(response?.citations) ? response.citations : []);
+    setMode(response?.mode || 'unknown');
+    setLoading(false);
+  };
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/70 z-[90] flex items-end sm:items-center justify-center">
+      <div className="w-full sm:max-w-2xl bg-surface border border-border rounded-t-2xl sm:rounded-2xl p-4 max-h-[88vh] overflow-auto">
+        <div className="flex items-center justify-between mb-3">
+          <div className="inline-flex items-center gap-2">
+            <span className="w-8 h-8 rounded-lg bg-primary/20 border border-primary/40 inline-flex items-center justify-center">
+              <FiCode className="w-4 h-4 text-primary" />
+            </span>
+            <div>
+              <p className="text-white font-semibold">Dev Coding Agent</p>
+              <p className="text-[11px] text-subtext">Fast mode · uses existing backend connections</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="text-subtext hover:text-white">
+            <FiX className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            placeholder="Ask about code, endpoint flow, or where logic lives…"
+            className="w-full rounded-lg border border-border bg-background/70 p-2 text-sm text-white"
+          />
+          <button
+            onClick={handleSend}
+            disabled={loading}
+            className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background font-semibold disabled:opacity-60"
+          >
+            <FiSend className="w-4 h-4" />
+            {loading ? 'Thinking…' : 'Ask Dev Agent'}
+          </button>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-300">{error}</p>}
+
+        {answer && (
+          <div className="mt-4 rounded-lg border border-border bg-background/60 p-3 space-y-2">
+            <p className="text-[11px] uppercase tracking-wide text-subtext">Response ({mode})</p>
+            <pre className="whitespace-pre-wrap text-sm text-white font-sans">{answer}</pre>
+            {citations.length > 0 && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-subtext mb-1">Citations</p>
+                <ul className="text-xs text-subtext space-y-1">
+                  {citations.map((file) => (
+                    <li key={file}>{file}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -29,6 +29,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
+import DevAgentModal from '../components/DevAgentModal.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import TonConnectButton from '../components/TonConnectButton.jsx';
 import { loadGoogleProfile, clearGoogleProfile } from '../utils/google.js';
@@ -52,7 +53,8 @@ import {
   FiBell,
   FiList,
   FiDollarSign,
-  FiCheckSquare
+  FiCheckSquare,
+  FiCode
 } from 'react-icons/fi';
 
 export default function MyAccount() {
@@ -106,6 +108,7 @@ export default function MyAccount() {
   const [notifyStatus, setNotifyStatus] = useState('');
   const [showNotifyModal, setShowNotifyModal] = useState(false);
   const [showTasksModal, setShowTasksModal] = useState(false);
+  const [showDevAgentModal, setShowDevAgentModal] = useState(false);
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
@@ -944,7 +947,7 @@ export default function MyAccount() {
               </button>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
               <button
                 onClick={() => setShowNotifyModal(true)}
                 className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
@@ -958,6 +961,13 @@ export default function MyAccount() {
               >
                 <FiList className="w-4 h-4" />
                 Open Task Manager
+              </button>
+              <button
+                onClick={() => setShowDevAgentModal(true)}
+                className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
+              >
+                <FiCode className="w-4 h-4" />
+                Open Dev Agent
               </button>
             </div>
 
@@ -999,6 +1009,10 @@ export default function MyAccount() {
       <DevTasksModal
         open={showTasksModal}
         onClose={() => setShowTasksModal(false)}
+      />
+      <DevAgentModal
+        open={showDevAgentModal}
+        onClose={() => setShowDevAgentModal(false)}
       />
       <InfoPopup
         open={showSaved}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -760,3 +760,7 @@ export function getExchangeCoinDetails(coinId) {
   const id = encodeURIComponent(String(coinId || '').trim());
   return get(`/api/exchange/coin/${id}`);
 }
+
+export function devAgentChat(message) {
+  return post('/api/dev-agent/chat', { message });
+}


### PR DESCRIPTION
### Motivation
- Provide a dev-only coding assistant that can search repository files for relevant context and answer developer questions using OpenAI, with a safe fallback when the API key is absent or fails.

### Description
- Add a new Express route `bot/routes/devAgent.js` that authenticates dev accounts, collects and scores allowed repository files for relevance, calls OpenAI chat completions when `OPENAI_API_KEY` is set, and falls back to a concise local responder otherwise.
- Register the route in `bot/server.js` under `/api/dev-agent` and wire imports for the route and associated env-based dev-account checks.
- Add a React modal component `webapp/src/components/DevAgentModal.jsx` and integrate it into the account page in `webapp/src/pages/MyAccount.jsx` with a button to open the Dev Agent modal.
- Expose a new client helper `devAgentChat` in `webapp/src/utils/api.js` that posts to `/api/dev-agent/chat`.
- Implement configuration/limits in the backend: allowed roots, searchable extensions, max files/excerpts, OpenAI model override via `OPENAI_MODEL`, and several environment variables for allowed dev account IDs.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eefbeeae48329bdcc506ea97e29eb)