### PR TITLE
Add Dev Agent feature: backend /api/dev-agent and frontend DevAgent modal

### DIFF
--- a/bot/routes/devAgent.js
+++ b/bot/routes/devAgent.js
@@ -1,0 +1,379 @@
+import { Router } from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { fileURLToPath } from 'url';
+import OpenAI from 'openai';
+import authenticate from '../middleware/auth.js';
+import User from '../models/User.js';
+
+const router = Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const MAX_CONTEXT_FILES = 5;
+const MAX_SCAN_FILES = 180;
+const MAX_FILE_CHARS = 3800;
+const SEARCH_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.json',
+  '.md',
+  '.mjs',
+  '.cjs',
+  '.css',
+  '.yml',
+  '.yaml'
+]);
+
+const ALLOWED_ROOTS = [
+  'bot',
+  'webapp/src',
+  'packages',
+  'docs',
+  'README.md',
+  'README-platform-help-agent.md'
+];
+
+const IGNORED_FILE_PATTERNS = [
+  /package-lock\.json$/i,
+  /pnpm-lock\.yaml$/i,
+  /yarn\.lock$/i,
+  /dist\//i,
+  /build\//i,
+  /\.min\./i,
+  /coverage\//i,
+  /webapp\/src\/assets\//i
+];
+
+const QUICK_ACTIONS = {
+  explain: 'Explain this module and key flows',
+  find_bug: 'Find likely bug or risky logic path and propose a patch plan',
+  api_map: 'Map endpoint flow request -> route -> model/service and list touched files',
+  ui_plan: 'Give a concrete mobile-first UI implementation plan'
+};
+
+let openAIClient = null;
+function getOpenAIClient() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+  if (!openAIClient) openAIClient = new OpenAI({ apiKey });
+  return openAIClient;
+}
+
+function getDevAccounts() {
+  return [
+    process.env.DEV_ACCOUNT_ID,
+    process.env.VITE_DEV_ACCOUNT_ID,
+    process.env.DEV_ACCOUNT_ID_1,
+    process.env.VITE_DEV_ACCOUNT_ID_1,
+    process.env.DEV_ACCOUNT_ID_2,
+    process.env.VITE_DEV_ACCOUNT_ID_2
+  ].filter(Boolean);
+}
+
+async function resolveAccountId(req) {
+  if (req.auth?.accountId) return req.auth.accountId;
+  if (req.auth?.telegramId) {
+    const user = await User.findOne({ telegramId: req.auth.telegramId }).select('accountId');
+    return user?.accountId || null;
+  }
+  if (req.auth?.googleId) {
+    const user = await User.findOne({ googleId: req.auth.googleId }).select('accountId');
+    return user?.accountId || null;
+  }
+  return null;
+}
+
+function normalizePath(absolutePath) {
+  return absolutePath.replace(/\\/g, '/');
+}
+
+function isIgnoredFile(absolutePath) {
+  const normalized = normalizePath(absolutePath);
+  return IGNORED_FILE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function isAllowedPath(absolutePath) {
+  const normalized = normalizePath(absolutePath);
+  return ALLOWED_ROOTS.some((root) => {
+    const fullRoot = normalizePath(path.resolve(repoRoot, root));
+    return normalized === fullRoot || normalized.startsWith(`${fullRoot}/`);
+  });
+}
+
+async function collectFiles(dir, found = []) {
+  if (found.length >= MAX_SCAN_FILES) return found;
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build') {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (!isAllowedPath(fullPath)) continue;
+
+    if (entry.isDirectory()) {
+      await collectFiles(fullPath, found);
+    } else if (SEARCH_EXTENSIONS.has(path.extname(entry.name).toLowerCase()) && !isIgnoredFile(fullPath)) {
+      found.push(fullPath);
+    }
+    if (found.length >= MAX_SCAN_FILES) break;
+  }
+  return found;
+}
+
+
+function extractExplicitPaths(message) {
+  const raw = String(message || '');
+  const matches = raw.match(/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_./-]+\.(?:jsx|tsx|ts|js|json|md|css)/g) || [];
+  return [...new Set(matches.map((m) => normalizePath(m)))];
+}
+
+function extractQueryTerms(message) {
+  return String(message || '')
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((term) => term.length >= 3)
+    .slice(0, 14);
+}
+
+function scoreFile(content, terms, message, filePath) {
+  const lower = content.toLowerCase();
+  const lowerPath = String(filePath || '').toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    const hits = lower.split(term).length - 1;
+    score += hits;
+    if (lowerPath.includes(term)) score += 4;
+  }
+  if (message && lower.includes(String(message).toLowerCase())) score += 6;
+  if (/export\s+default|router\.|app\.use|function\s+|const\s+/.test(content)) score += 2;
+  if (/dev.?agent/.test(lowerPath) && /dev|agent/.test(String(message || '').toLowerCase())) score += 12;
+  return score;
+}
+
+function makeExcerpt(content, terms) {
+  const lower = content.toLowerCase();
+  const firstHit = terms
+    .map((term) => lower.indexOf(term))
+    .filter((idx) => idx >= 0)
+    .sort((a, b) => a - b)[0];
+
+  if (firstHit == null) {
+    return content.slice(0, MAX_FILE_CHARS);
+  }
+
+  const start = Math.max(0, firstHit - 700);
+  return content.slice(start, start + MAX_FILE_CHARS);
+}
+
+async function buildContext(message) {
+  const terms = extractQueryTerms(message);
+  const explicitPaths = extractExplicitPaths(message);
+  if (!terms.length && !explicitPaths.length) return [];
+
+  const files = new Set();
+  for (const explicitPath of explicitPaths) {
+    const abs = path.resolve(repoRoot, explicitPath);
+    if (isAllowedPath(abs) && !isIgnoredFile(abs)) files.add(abs);
+  }
+
+  if (files.size) {
+    const directMatches = [];
+    for (const file of Array.from(files)) {
+      try {
+        const content = await fs.readFile(file, 'utf8');
+        directMatches.push({
+          file: normalizePath(path.relative(repoRoot, file)),
+          excerpt: content.slice(0, MAX_FILE_CHARS),
+          score: 999
+        });
+      } catch {
+        // ignore invalid explicit path
+      }
+    }
+    if (directMatches.length) return directMatches.slice(0, MAX_CONTEXT_FILES);
+  }
+  for (const root of ALLOWED_ROOTS) {
+    const rootPath = path.resolve(repoRoot, root);
+    try {
+      const stat = await fs.stat(rootPath);
+      if (stat.isFile()) {
+        if (!isIgnoredFile(rootPath)) files.add(rootPath);
+      } else {
+        const collected = [];
+        await collectFiles(rootPath, collected);
+        collected.forEach((f) => files.add(f));
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const scored = [];
+  for (const file of Array.from(files)) {
+    try {
+      const content = await fs.readFile(file, 'utf8');
+      const relativePath = normalizePath(path.relative(repoRoot, file));
+      let score = scoreFile(content, terms, message, file);
+      if (explicitPaths.some((p) => relativePath.endsWith(p) || relativePath === p)) score += 120;
+      if (score > 0) {
+        scored.push({
+          file,
+          score,
+          excerpt: makeExcerpt(content, terms)
+        });
+      }
+    } catch {
+      // ignore unreadable
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, MAX_CONTEXT_FILES).map((entry) => ({
+    file: normalizePath(path.relative(repoRoot, entry.file)),
+    excerpt: entry.excerpt,
+    score: entry.score
+  }));
+}
+
+function buildPrompt({ message, context, quickAction }) {
+  const contextBlock = context
+    .map(
+      (item, idx) =>
+        `[#${idx + 1}] ${item.file}\nscore=${item.score}\n${item.excerpt}`
+    )
+    .join('\n\n');
+
+  return [
+    'You are TonPlaygram Dev Agent, a senior full-stack coding assistant.',
+    'Goals: practical implementation, mobile-first UX, secure defaults, concise but actionable answers.',
+    'Rules: never fabricate files; use only provided context; if missing context, state exactly what file is needed.',
+    'Format: 1) Diagnosis 2) Action steps 3) Minimal code sketch (if useful) 4) Risks/checks.',
+    quickAction ? `Requested quick action: ${quickAction}` : '',
+    '',
+    `Developer message: ${message}`,
+    '',
+    'Repository context:',
+    contextBlock || 'No matching files found.'
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function completeWithOpenAI({ message, context, quickAction }) {
+  const client = getOpenAIClient();
+  if (!client) return null;
+  const model = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+  const completion = await client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    messages: [
+      {
+        role: 'user',
+        content: buildPrompt({ message, context, quickAction })
+      }
+    ]
+  });
+
+  return completion.choices?.[0]?.message?.content?.trim() || null;
+}
+
+function buildSmartFallback({ message, context, quickAction }) {
+  const first = context[0];
+  const topFiles = context.map((item) => `- ${item.file}`).join('\n');
+
+  const intro = quickAction
+    ? `Quick action executed locally: ${quickAction}.`
+    : 'GPT is unavailable, so this is a local smart analysis.';
+
+  const guidance = !first
+    ? 'I could not find strong file matches. Mention a route/component/file name for better targeting.'
+    : [
+      `Best match: ${first.file}.`,
+      'Recommended next steps:',
+      '1) Open the top matched file and verify entry points (exports, route handlers, effects).',
+      '2) Trace its direct imports and update exactly one layer at a time (UI -> API helper -> route).',
+      '3) Re-run build and smoke-test the affected screen on mobile portrait.',
+      '4) If needed, ask me with a file path (example: "explain webapp/src/pages/MyAccount.jsx").'
+    ].join('\n');
+
+  return [
+    intro,
+    `Question: ${String(message || '').slice(0, 500)}`,
+    guidance,
+    context.length ? 'Top matched files:\n' + topFiles : 'Top matched files: none',
+    'To unlock full GPT answers in this route, set OPENAI_API_KEY (same backend env used by /ask command).'
+  ].join('\n\n');
+}
+
+async function requireDev(req, res) {
+  const accountId = await resolveAccountId(req);
+  const devAccounts = getDevAccounts();
+  if (!accountId || (devAccounts.length && !devAccounts.includes(accountId))) {
+    res.status(403).json({ error: 'forbidden' });
+    return null;
+  }
+  return { accountId, hasGpt: Boolean(getOpenAIClient()) };
+}
+
+router.get('/status', authenticate, async (req, res) => {
+  try {
+    const dev = await requireDev(req, res);
+    if (!dev) return;
+    return res.json({
+      ok: true,
+      gptConnected: dev.hasGpt,
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      quickActions: QUICK_ACTIONS
+    });
+  } catch (err) {
+    console.error('[dev-agent] status failed:', err);
+    return res.status(500).json({ error: 'status failed' });
+  }
+});
+
+router.post('/chat', authenticate, async (req, res) => {
+  try {
+    const dev = await requireDev(req, res);
+    if (!dev) return;
+
+    const message = String(req.body?.message || '').trim();
+    const quickActionKey = String(req.body?.quickAction || '').trim();
+    const quickAction = QUICK_ACTIONS[quickActionKey] || '';
+
+    if (!message) {
+      return res.status(400).json({ error: 'message is required' });
+    }
+
+    const context = await buildContext(message);
+
+    let answer = null;
+    let mode = 'fallback';
+    try {
+      answer = await completeWithOpenAI({ message, context, quickAction });
+      if (answer) mode = 'gpt';
+    } catch (err) {
+      console.error('[dev-agent] gpt failed, fallback:', err?.message || err);
+    }
+
+    if (!answer) {
+      answer = buildSmartFallback({ message, context, quickAction });
+    }
+
+    return res.json({
+      answer,
+      citations: context.map((item) => item.file),
+      mode,
+      gptConnected: dev.hasGpt,
+      quickActions: QUICK_ACTIONS
+    });
+  } catch (err) {
+    console.error('[dev-agent] request failed:', err);
+    return res.status(500).json({ error: 'dev agent request failed' });
+  }
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -30,6 +30,7 @@ import snookerRoyaleRoutes from './routes/snookerRoyal.js';
 import exchangeRoutes from './routes/exchange.js';
 import pushRoutes from './routes/push.js';
 import voiceCommentaryRoutes from './routes/voiceCommentary.js';
+import devAgentRoutes from './routes/devAgent.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -258,6 +259,7 @@ app.use('/api/pool-royale', poolRoyaleRoutes);
 app.use('/api/snooker-royale', snookerRoyaleRoutes);
 app.use('/api/exchange', exchangeRoutes);
 app.use('/api/voice-commentary', voiceCommentaryRoutes);
+app.use('/api/dev-agent', devAgentRoutes);
 
 app.post('/api/goal-rush/calibration', authenticate, async (req, res) => {
   const { accountId, calibration } = req.body || {};

--- a/webapp/src/components/DevAgentModal.jsx
+++ b/webapp/src/components/DevAgentModal.jsx
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  FiActivity,
+  FiCode,
+  FiSend,
+  FiWifi,
+  FiWifiOff,
+  FiX,
+  FiZap
+} from 'react-icons/fi';
+import { devAgentChat, getDevAgentStatus } from '../utils/api.js';
+
+const QUICK_ACTION_PRESETS = [
+  {
+    key: 'explain',
+    label: 'Explain module',
+    prompt: 'Explain MyAccount dev panel flow and where Dev Agent is wired.'
+  },
+  {
+    key: 'find_bug',
+    label: 'Find risky bug',
+    prompt: 'Find likely failure points for Dev Agent responses and suggest a patch.'
+  },
+  {
+    key: 'api_map',
+    label: 'Map API flow',
+    prompt: 'Map /api/dev-agent/chat request flow from frontend to backend.'
+  },
+  {
+    key: 'ui_plan',
+    label: 'UI improvement plan',
+    prompt: 'Give a mobile portrait UX improvement plan for this Dev Agent modal.'
+  }
+];
+
+export default function DevAgentModal({ open, onClose }) {
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [mode, setMode] = useState('unknown');
+  const [gptConnected, setGptConnected] = useState(false);
+  const [history, setHistory] = useState([]);
+  const [citations, setCitations] = useState([]);
+  const [selectedAction, setSelectedAction] = useState('');
+
+  const canSend = useMemo(() => message.trim().length > 0 && !loading, [message, loading]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    async function loadStatus() {
+      setStatusLoading(true);
+      const data = await getDevAgentStatus();
+      if (cancelled) return;
+      if (data?.error) {
+        setError(data.error);
+      } else {
+        setGptConnected(Boolean(data?.gptConnected));
+      }
+      setStatusLoading(false);
+    }
+    loadStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const pushHistory = (role, content, extra = {}) => {
+    setHistory((prev) => [
+      ...prev,
+      {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        role,
+        content,
+        mode: extra.mode || '',
+        citations: extra.citations || []
+      }
+    ]);
+  };
+
+  const usePreset = (preset) => {
+    setSelectedAction(preset.key);
+    setMessage(preset.prompt);
+  };
+
+  const handleSend = async () => {
+    const trimmed = message.trim();
+    if (!trimmed || loading) return;
+
+    setLoading(true);
+    setError('');
+    pushHistory('user', trimmed);
+
+    const response = await devAgentChat(trimmed, selectedAction || undefined);
+    if (response?.error) {
+      setError(response.error);
+      setLoading(false);
+      return;
+    }
+
+    const answer = response?.answer || 'No response returned.';
+    const nextCitations = Array.isArray(response?.citations) ? response.citations : [];
+    setMode(response?.mode || 'unknown');
+    setGptConnected(Boolean(response?.gptConnected));
+    setCitations(nextCitations);
+    pushHistory('assistant', answer, {
+      mode: response?.mode || 'unknown',
+      citations: nextCitations
+    });
+
+    setLoading(false);
+    setMessage('');
+  };
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/70 z-[90] flex items-end sm:items-center justify-center">
+      <div className="w-full sm:max-w-3xl bg-surface border border-border rounded-t-2xl sm:rounded-2xl p-4 max-h-[90vh] overflow-auto">
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="inline-flex items-start gap-2">
+            <span className="w-8 h-8 rounded-lg bg-primary/20 border border-primary/40 inline-flex items-center justify-center mt-0.5">
+              <FiCode className="w-4 h-4 text-primary" />
+            </span>
+            <div>
+              <p className="text-white font-semibold">Dev Coding Agent · Admin Panel</p>
+              <p className="text-[11px] text-subtext">Mobile-first live assistant using existing backend API flow</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="text-subtext hover:text-white">
+            <FiX className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-3">
+          <div className="rounded-lg border border-border bg-background/60 px-3 py-2">
+            <p className="text-[10px] uppercase text-subtext tracking-wide">Connection</p>
+            <div className="mt-1 inline-flex items-center gap-2 text-sm font-semibold text-white">
+              {gptConnected ? <FiWifi className="text-green-400" /> : <FiWifiOff className="text-yellow-300" />}
+              {statusLoading ? 'Checking…' : gptConnected ? 'GPT Connected' : 'Fallback Active'}
+            </div>
+          </div>
+          <div className="rounded-lg border border-border bg-background/60 px-3 py-2">
+            <p className="text-[10px] uppercase text-subtext tracking-wide">Last mode</p>
+            <p className="mt-1 text-sm font-semibold text-white">{mode}</p>
+          </div>
+          <div className="rounded-lg border border-border bg-background/60 px-3 py-2">
+            <p className="text-[10px] uppercase text-subtext tracking-wide">Messages</p>
+            <p className="mt-1 text-sm font-semibold text-white">{history.length}</p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-background/50 p-2 mb-3">
+          <p className="text-[11px] uppercase tracking-wide text-subtext mb-2 inline-flex items-center gap-1">
+            <FiZap className="w-3 h-3" /> Quick actions
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {QUICK_ACTION_PRESETS.map((preset) => (
+              <button
+                key={preset.key}
+                onClick={() => usePreset(preset)}
+                className={`px-2 py-1.5 rounded text-xs border transition ${
+                  selectedAction === preset.key
+                    ? 'bg-primary text-background border-primary'
+                    : 'bg-background/70 text-white border-border hover:border-primary/50'
+                }`}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            placeholder="Ask about bugfix, architecture, endpoint flow, or request a patch plan…"
+            className="w-full rounded-lg border border-border bg-background/70 p-2 text-sm text-white"
+          />
+          <button
+            onClick={handleSend}
+            disabled={!canSend}
+            className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background font-semibold disabled:opacity-60"
+          >
+            <FiSend className="w-4 h-4" />
+            {loading ? 'Thinking…' : 'Send to Dev Agent'}
+          </button>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-300">{error}</p>}
+
+        <div className="mt-4 rounded-lg border border-border bg-background/60 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-subtext mb-2 inline-flex items-center gap-1">
+            <FiActivity className="w-3 h-3" /> Conversation
+          </p>
+          {history.length === 0 ? (
+            <p className="text-sm text-subtext">No messages yet. Use a quick action or type your request.</p>
+          ) : (
+            <div className="space-y-2">
+              {history.map((item) => (
+                <div
+                  key={item.id}
+                  className={`rounded-lg border px-3 py-2 ${
+                    item.role === 'user'
+                      ? 'border-primary/50 bg-primary/10'
+                      : 'border-border bg-background/70'
+                  }`}
+                >
+                  <p className="text-[10px] uppercase tracking-wide text-subtext mb-1">
+                    {item.role === 'user' ? 'You' : `Agent (${item.mode || mode})`}
+                  </p>
+                  <pre className="whitespace-pre-wrap text-sm text-white font-sans">{item.content}</pre>
+                  {item.role === 'assistant' && item.citations?.length > 0 && (
+                    <div className="mt-2 pt-2 border-t border-border">
+                      <p className="text-[10px] uppercase tracking-wide text-subtext mb-1">Citations</p>
+                      <ul className="text-xs text-subtext space-y-0.5">
+                        {item.citations.map((file) => (
+                          <li key={`${item.id}-${file}`}>{file}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {citations.length > 0 && (
+          <div className="mt-3 text-xs text-subtext">
+            Latest matched files: {citations.join(' • ')}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -29,6 +29,7 @@ import InfoPopup from '../components/InfoPopup.jsx';
 import DevNotifyModal from '../components/DevNotifyModal.jsx';
 import InfluencerClaimsCard from '../components/InfluencerClaimsCard.jsx';
 import DevTasksModal from '../components/DevTasksModal.jsx';
+import DevAgentModal from '../components/DevAgentModal.jsx';
 import LinkGoogleButton from '../components/LinkGoogleButton.jsx';
 import TonConnectButton from '../components/TonConnectButton.jsx';
 import { loadGoogleProfile, clearGoogleProfile } from '../utils/google.js';
@@ -52,7 +53,8 @@ import {
   FiBell,
   FiList,
   FiDollarSign,
-  FiCheckSquare
+  FiCheckSquare,
+  FiCode
 } from 'react-icons/fi';
 
 export default function MyAccount() {
@@ -106,6 +108,7 @@ export default function MyAccount() {
   const [notifyStatus, setNotifyStatus] = useState('');
   const [showNotifyModal, setShowNotifyModal] = useState(false);
   const [showTasksModal, setShowTasksModal] = useState(false);
+  const [showDevAgentModal, setShowDevAgentModal] = useState(false);
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
@@ -944,7 +947,7 @@ export default function MyAccount() {
               </button>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
               <button
                 onClick={() => setShowNotifyModal(true)}
                 className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
@@ -958,6 +961,13 @@ export default function MyAccount() {
               >
                 <FiList className="w-4 h-4" />
                 Open Task Manager
+              </button>
+              <button
+                onClick={() => setShowDevAgentModal(true)}
+                className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
+              >
+                <FiCode className="w-4 h-4" />
+                Open Dev Agent
               </button>
             </div>
 
@@ -999,6 +1009,10 @@ export default function MyAccount() {
       <DevTasksModal
         open={showTasksModal}
         onClose={() => setShowTasksModal(false)}
+      />
+      <DevAgentModal
+        open={showDevAgentModal}
+        onClose={() => setShowDevAgentModal(false)}
       />
       <InfoPopup
         open={showSaved}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -760,3 +760,11 @@ export function getExchangeCoinDetails(coinId) {
   const id = encodeURIComponent(String(coinId || '').trim());
   return get(`/api/exchange/coin/${id}`);
 }
+
+export function devAgentChat(message, quickAction) {
+  return post('/api/dev-agent/chat', { message, quickAction });
+}
+
+export function getDevAgentStatus() {
+  return get('/api/dev-agent/status');
+}


### PR DESCRIPTION
### Motivation
- Provide a developer-only assistant that can scan repository files, summarize code, and call OpenAI to help with debugging, mapping, and patch planning.
- Expose the helper via a secure backend route gated to configured dev account IDs and a mobile-first frontend modal for quick developer access.

### Description
- Add a new backend route `bot/routes/devAgent.js` that collects repository files under approved roots, scores and excerpts matches, builds prompts, calls the OpenAI chat completion, and falls back to a local smart analysis when GPT is unavailable.
- Gate access to the route by resolving `accountId` from `req.auth` and comparing against dev account IDs provided via environment variables, and expose `/api/dev-agent/status` and `/api/dev-agent/chat` endpoints in `bot/server.js`.
- Add a new React component `webapp/src/components/DevAgentModal.jsx` and integrate it into `webapp/src/pages/MyAccount.jsx` with a button to open the modal and conversation UI including quick actions and citations.
- Add client helpers `devAgentChat` and `getDevAgentStatus` in `webapp/src/utils/api.js` to call the new backend endpoints.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eefbeeae48329bdcc506ea97e29eb)