### PR TITLE
Fix Domino Royal black screen by using BASE_URL and adding load/error status

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -7,6 +7,11 @@ const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
 
 export default function DominoRoyalArena() {
   useEffect(() => {
+    const statusNode = document.getElementById('status');
+    if (statusNode) {
+      statusNode.textContent = 'Loading Domino Royal…';
+    }
+
     const existingStyle = document.getElementById(INLINE_STYLE_ID);
     const styleTag = existingStyle ?? document.createElement('style');
     if (!existingStyle) {
@@ -17,13 +22,28 @@ export default function DominoRoyalArena() {
 
     const existingScript = document.querySelector(GAME_SCRIPT_SELECTOR);
     if (existingScript) {
+      if (statusNode) {
+        statusNode.textContent = 'Ready';
+      }
       return undefined;
     }
 
+    const basePath = import.meta.env.BASE_URL || '/';
+    const normalizedBasePath = basePath.endsWith('/') ? basePath : `${basePath}/`;
     const script = document.createElement('script');
     script.type = 'module';
-    script.src = '/domino-royal-game.js';
+    script.src = `${normalizedBasePath}domino-royal-game.js`;
     script.dataset.dominoRoyalScript = 'true';
+    script.onload = () => {
+      if (statusNode) {
+        statusNode.textContent = 'Ready';
+      }
+    };
+    script.onerror = () => {
+      if (statusNode) {
+        statusNode.textContent = 'Game failed to load. Please refresh and try again.';
+      }
+    };
     document.body.appendChild(script);
 
     return () => {


### PR DESCRIPTION
### Motivation
- The Domino Royal page could show a black/blank screen when the game bootstrap script failed to load silently or when the app was served from a non-root base path.

### Description
- Update `webapp/src/pages/Games/DominoRoyalArena.jsx` to set `#status` to `Loading Domino Royal…` during bootstrap and to `Ready` (or an error message) after load, providing visible feedback.
- Resolve the game script URL using `import.meta.env.BASE_URL` (normalized) instead of a hard-coded root path, preventing path mismatch when the app is hosted under a subpath.
- Add explicit `script.onload` and `script.onerror` handlers and update status immediately when a previously injected game script is present.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Automated Playwright check opened `/games/domino-royal` and verified the `#status` text transitions from `Loading Domino Royal…` to `Ready` (no failed requests observed), which passed.
- Captured a Playwright screenshot of the fixed page state to validate the UI rendering (artifact produced during testing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3ac2a5008329afa355e9db0775e0)