### PR TITLE
Raise bottom navigation slightly for better mobile positioning

### DIFF
--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -10,7 +10,7 @@ import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
   return (
-    <nav className="app-bottom-nav fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
+    <nav className="app-bottom-nav fixed inset-x-0 bottom-2 z-50 bg-surface text-text shadow border-t border-accent">
       <div className="container mx-auto px-4 pt-3 pb-1 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
         <NavItem to="/mining" icon={GiMining} label="Mining" />


### PR DESCRIPTION
### Motivation
- The persistent bottom navigation on portrait mobile screens needed a small upward shift so the buttons (Home, Mining, Games, Tasks, Store, Profile) appear visually higher and not flush with the bottom edge.

### Description
- Updated the navbar positioning in `webapp/src/components/Navbar.jsx` by changing the Tailwind class from `bottom-0` to `bottom-2` to add a small gap from the bottom edge.

### Testing
- Ran `npm run build` in `webapp/` and the build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and performed a visual verification using a Playwright screenshot on a 390x844 portrait viewport which confirmed the nav moved upward.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3f287b1483298b73064a4ae7ba06)