### PR TITLE
Adjust Texas Hold'em bottom-seat card/chips layout and make raise chip buttons render single-denomination chips

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -364,7 +364,7 @@ const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
 const HOLE_SPACING = CARD_W * 1.08;
 const HUMAN_CARD_SPREAD = HOLE_SPACING * 1.32;
 const HUMAN_CARD_FORWARD_OFFSET = CARD_W * 0.04;
-const HUMAN_CARD_VERTICAL_OFFSET = CARD_H * 0.52;
+const HUMAN_CARD_VERTICAL_OFFSET = CARD_H * 0.46;
 const HUMAN_CARD_LOOK_LIFT = CARD_H * 0.24;
 const HUMAN_CARD_LOOK_SPLAY = HOLE_SPACING * 0.45;
 const CARD_FORWARD_OFFSET = HUMAN_CARD_FORWARD_OFFSET;
@@ -393,10 +393,14 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.08;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.22;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.46;
-const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.8;
+const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.94;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.94;
+const AI_CARD_INWARD_SHIFT = CARD_W * -1.08;
+const AI_CHIP_INWARD_SHIFT = CARD_W * -0.46;
+const AI_CARD_LATERAL_SHIFT = CARD_W * 0.82;
+const AI_CHIP_LATERAL_SHIFT = CARD_W * 0.8;
 const HUMAN_CARD_CHIP_BLEND = 0;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
@@ -513,6 +517,7 @@ const RAIL_CHIP_SPACING = CARD_W * 0.44;
 const RAIL_HEIGHT_OFFSET = CARD_D * 6.2;
 const RAIL_SURFACE_LIFT = CARD_D * 0.8;
 const RAIL_CHIP_ROW_SPACING = CARD_H * 0.45;
+const RAISE_CHIP_GRID_LATERAL_SHIFT = CARD_W * 0.36;
 
 const CHIP_SCATTER_LAYOUT = Object.freeze({
   perRow: 5,
@@ -1797,25 +1802,29 @@ function createSeatLayout(count, tableInfo = null, options = {}) {
     cardRailCenter.y = railSurfaceY;
     const chipRailCenter = forward.clone().multiplyScalar(chipRailDistance);
     chipRailCenter.y = railSurfaceY;
+    const seatCardInwardShift = isHuman ? HUMAN_CARD_INWARD_SHIFT : AI_CARD_INWARD_SHIFT;
+    const seatChipInwardShift = isHuman ? HUMAN_CHIP_INWARD_SHIFT : AI_CHIP_INWARD_SHIFT;
+    const seatCardLateralShift = isHuman ? HUMAN_CARD_LATERAL_SHIFT : AI_CARD_LATERAL_SHIFT;
+    const seatChipLateralShift = isHuman ? HUMAN_CHIP_LATERAL_SHIFT : AI_CHIP_LATERAL_SHIFT;
     const cardAnchor = cardRailCenter
       .clone()
-      .addScaledVector(forward, HUMAN_CARD_INWARD_SHIFT)
-      .addScaledVector(right, -HUMAN_CARD_LATERAL_SHIFT);
+      .addScaledVector(forward, seatCardInwardShift)
+      .addScaledVector(right, -seatCardLateralShift);
     cardAnchor.y = tableSurfaceY + CARD_SURFACE_OFFSET;
     const chipAnchor = chipRailCenter
       .clone()
-      .addScaledVector(forward, HUMAN_CHIP_INWARD_SHIFT)
-      .addScaledVector(right, HUMAN_CHIP_LATERAL_SHIFT);
+      .addScaledVector(forward, seatChipInwardShift)
+      .addScaledVector(right, seatChipLateralShift);
     chipAnchor.y = railSurfaceY;
     const cardRailAnchor = cardRailCenter
       .clone()
-      .addScaledVector(forward, HUMAN_CARD_INWARD_SHIFT)
-      .addScaledVector(right, -HUMAN_CARD_LATERAL_SHIFT);
+      .addScaledVector(forward, seatCardInwardShift)
+      .addScaledVector(right, -seatCardLateralShift);
     cardRailAnchor.y = railSurfaceY;
     const chipRailAnchor = chipRailCenter
       .clone()
-      .addScaledVector(forward, HUMAN_CHIP_INWARD_SHIFT)
-      .addScaledVector(right, HUMAN_CHIP_LATERAL_SHIFT);
+      .addScaledVector(forward, seatChipInwardShift)
+      .addScaledVector(right, seatChipLateralShift);
     chipRailAnchor.y = railSurfaceY;
     const betAnchor = forward
       .clone()
@@ -2126,13 +2135,14 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
         .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT)
         .addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT);
   chipCenter.addScaledVector(forward, CARD_D * 0.48);
+  chipCenter.addScaledVector(axis, RAISE_CHIP_GRID_LATERAL_SHIFT);
   chipCenter.y = anchorY;
   const columns = 3;
   const rows = Math.ceil(CHIP_VALUES.length / columns);
   const colOffset = (columns - 1) / 2;
   const rowOffset = (rows - 1) / 2;
   const chipButtons = CHIP_VALUES.map((value, index) => {
-    const chip = chipFactory.createStack(value, { mode: 'stack' });
+    const chip = chipFactory.createStack(value, { mode: 'single', denominationValue: value });
     const baseScale = RAIL_CHIP_SCALE;
     chip.position.copy(chipCenter);
     chip.position.y = anchorY + CARD_D * 0.82;

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -81,6 +81,13 @@ export function createChipFactory(renderer, { cardWidth }) {
     }
   }
 
+
+  function getDenominationByValue(value) {
+    const target = Math.floor(Number(value));
+    if (!Number.isFinite(target) || target <= 0) return null;
+    return DENOMINATIONS.find((entry) => entry.value === target) ?? null;
+  }
+
   function expandChips(amount) {
     const chips = [];
     splitAmount(amount).forEach(({ denom, count }) => {
@@ -161,7 +168,9 @@ export function createChipFactory(renderer, { cardWidth }) {
     const currentMode = group?.userData?.mode ?? 'stack';
     const sameMode = currentMode === mode;
     const sameAmount = group?.userData?.chipValue === amount;
-    if (sameAmount && sameMode && mode !== 'scatter') {
+    const denominationValue = options.denominationValue ?? group?.userData?.denominationValue ?? null;
+    const sameDenomination = (group?.userData?.denominationValue ?? null) === denominationValue;
+    if (sameAmount && sameMode && mode !== 'scatter' && (mode !== 'single' || sameDenomination)) {
       return;
     }
     if (sameAmount && sameMode && mode === 'scatter' && !options.force) {
@@ -170,6 +179,13 @@ export function createChipFactory(renderer, { cardWidth }) {
     removeChildren(group);
     if (mode === 'scatter') {
       scatterChips(group, amount, options);
+    } else if (mode === 'single') {
+      const denom = getDenominationByValue(denominationValue ?? amount) ?? splitAmount(amount)[0]?.denom;
+      if (denom) {
+        const mesh = createChipMesh(denom);
+        mesh.position.y = height / 2;
+        group.add(mesh);
+      }
     } else {
       let offset = 0;
       splitAmount(amount).forEach(({ denom, count }) => {
@@ -183,6 +199,7 @@ export function createChipFactory(renderer, { cardWidth }) {
     }
     group.userData.mode = mode;
     group.userData.chipValue = amount;
+    group.userData.denominationValue = mode === 'single' ? (denominationValue ?? amount) : null;
   }
 
   function createStack(amount = 0, options = {}) {
@@ -190,7 +207,8 @@ export function createChipFactory(renderer, { cardWidth }) {
     group.userData = {
       mode: options.mode ?? 'stack',
       chipValue: 0,
-      layout: options.mode === 'scatter' ? buildLayout(null, options.layout) : group.userData?.layout
+      layout: options.mode === 'scatter' ? buildLayout(null, options.layout) : group.userData?.layout,
+      denominationValue: options.mode === 'single' ? options.denominationValue ?? amount : null
     };
     applyAmount(group, amount, options);
     return group;


### PR DESCRIPTION
### Motivation
- Improve the portrait UX for the human (bottom) player by nudging their hole cards visually toward table center, slightly left on the screen, and a bit lower to match the requested on-screen adjustments. 
- Move the 3x3 raise-chip control grid a bit more to the right so it aligns better with the bottom player's UI in portrait. 
- Ensure each raise-chip button renders exactly one chip of the requested denomination (so the `20` button shows a single 20-value chip) to avoid stacked/mixed visuals.

### Description
- Tweaked card placement constants: changed `HUMAN_CARD_INWARD_SHIFT`, `HUMAN_CARD_LATERAL_SHIFT`, and `HUMAN_CARD_VERTICAL_OFFSET` to shift the human seat cards inward, left and lower on screen. 
- Preserved previous AI offsets by introducing `AI_*` constants and switched seat anchor math to use seat-specific shifts (`seatCardInwardShift`, `seatCardLateralShift`, `seatChipInwardShift`, `seatChipLateralShift`) when computing `cardAnchor`, `chipAnchor`, `cardRailAnchor`, and `chipRailAnchor`. 
- Shifted raise-grid anchor by adding `RAISE_CHIP_GRID_LATERAL_SHIFT` and applying it to `chipCenter` used by `createRaiseControls` so the 3x3 chip buttons move slightly to the right for the bottom player. 
- Added a `single` render mode to the chip factory (`webapp/src/utils/chips3d.js`) with a helper `getDenominationByValue`, updated `applyAmount`/`createStack` to support `mode: 'single'` and `denominationValue`, and switched raise control buttons to create stacks with `{ mode: 'single', denominationValue: value }` so each button shows a single chip of that denomination. 

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully (Vite build finished and artifacts created). 
- Ran the repository linter in its default mode (`npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx webapp/src/utils/chips3d.js`), which completed but reported the files are ignored by the repo's lint patterns (no blocking errors in CI). 
- Ran a stricter lint (`npx eslint --no-ignore ...`) which surfaced many style errors in `webapp/src/utils/chips3d.js` (mostly formatting/semicolons/space rules); these are stylistic and come from the file-level linting configuration differences. 
- Launched the dev server and captured a portrait screenshot of `/games/texasholdem` using Playwright to visually validate layout changes (artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f418a814883299e5ffa3c9e8b6dbf)