### PR TITLE
Adjust player card/chip layout and add single-chip factory for chip buttons

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -393,7 +393,7 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.08;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.32;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.46;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.8;
@@ -402,6 +402,9 @@ const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
+const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.085;
+const CHIP_BUTTON_GRID_RIGHT_SHIFT = CARD_W * 0.28;
+const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 0.22;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const TURN_DURATION = 30;
@@ -1856,7 +1859,7 @@ function getHumanCardAnchor(seatGroup) {
   const blended = cardBase
     .addScaledVector(seatGroup.forward, HUMAN_CARD_FORWARD_OFFSET)
     .lerp(chipBase, HUMAN_CARD_CHIP_BLEND);
-  blended.y = TABLE_HEIGHT + HUMAN_CARD_VERTICAL_OFFSET;
+  blended.y = TABLE_HEIGHT + HUMAN_CARD_VERTICAL_OFFSET - HUMAN_CARD_LOWER_OFFSET;
   return blended;
 }
 
@@ -2119,20 +2122,17 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
     ? seat.cardRailAnchor.clone()
     : fallbackAnchor.clone().addScaledVector(forward, CARD_RAIL_FORWARD_SHIFT).addScaledVector(axis, -CARD_RAIL_LATERAL_SHIFT);
   cardRailAnchor.y = anchorY;
-  const chipCenter = seat.chipRailAnchor
-    ? seat.chipRailAnchor.clone()
-    : fallbackAnchor
-        .clone()
-        .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT)
-        .addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT);
-  chipCenter.addScaledVector(forward, CARD_D * 0.48);
+  const chipCenter = cardRailAnchor
+    .clone()
+    .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT - CARD_RAIL_FORWARD_SHIFT + CHIP_BUTTON_GRID_OUTWARD_SHIFT)
+    .addScaledVector(axis, CHIP_BUTTON_GRID_RIGHT_SHIFT);
   chipCenter.y = anchorY;
   const columns = 3;
   const rows = Math.ceil(CHIP_VALUES.length / columns);
   const colOffset = (columns - 1) / 2;
   const rowOffset = (rows - 1) / 2;
   const chipButtons = CHIP_VALUES.map((value, index) => {
-    const chip = chipFactory.createStack(value, { mode: 'stack' });
+    const chip = chipFactory.createSingleChip?.(value) ?? chipFactory.createStack(value, { mode: 'stack' });
     const baseScale = RAIL_CHIP_SCALE;
     chip.position.copy(chipCenter);
     chip.position.y = anchorY + CARD_D * 0.82;

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -196,6 +196,21 @@ export function createChipFactory(renderer, { cardWidth }) {
     return group;
   }
 
+  function createSingleChip(value) {
+    const amount = Math.max(0, Math.floor(value));
+    const denom = DENOMINATIONS.find((entry) => entry.value === amount) || DENOMINATIONS[0];
+    const group = new THREE.Group();
+    group.userData = {
+      mode: 'stack',
+      chipValue: denom.value,
+      layout: null
+    };
+    const mesh = createChipMesh(denom);
+    mesh.position.y = height / 2;
+    group.add(mesh);
+    return group;
+  }
+
   function disposeStack(group) {
     if (!group) return;
     removeChildren(group);
@@ -322,6 +337,7 @@ export function createChipFactory(renderer, { cardWidth }) {
 
   return {
     createStack,
+    createSingleChip,
     setAmount: applyAmount,
     disposeStack,
     dispose,


### PR DESCRIPTION
### Motivation
- Improve visual alignment of human player cards and chip button grid so buttons and cards sit at the intended height and lateral positions.
- Use a more appropriate chip creation API for rendering individual chip buttons instead of full stacks to reduce overhead and simplify layout calculations.

### Description
- Tuned human card horizontal offset by changing `HUMAN_CARD_INWARD_SHIFT` from `CARD_W * -1.08` to `CARD_W * -1.32` and added `HUMAN_CARD_LOWER_OFFSET` to lower human card anchor height.
- Updated `getHumanCardAnchor` to subtract `HUMAN_CARD_LOWER_OFFSET` from the card surface Y so human cards render slightly lower.
- Added new constants `CHIP_BUTTON_GRID_RIGHT_SHIFT` and `CHIP_BUTTON_GRID_OUTWARD_SHIFT` and changed chip button center computation in `createRaiseControls` to derive from `cardRailAnchor` and apply the new shifts.
- Switched chip button creation to use `chipFactory.createSingleChip?.(value)` with fallback to `createStack` when `createSingleChip` is unavailable.
- Implemented `createSingleChip` in `chips3d.js` and exposed it from the chip factory so single-chip instances can be produced for button UIs.

### Testing
- Ran the existing test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.
- Performed a local smoke check of the arena UI to verify chip buttons and human card positions render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f418a814883299e5ffa3c9e8b6dbf)