### PR TITLE
Adjust bottom navbar positioning and raise nav item content

### DIFF
--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -10,8 +10,8 @@ import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
   return (
-    <nav className="app-bottom-nav fixed inset-x-0 bottom-2 z-50 bg-surface text-text shadow border-t border-accent">
-      <div className="container mx-auto px-4 pt-3 pb-1 flex items-center justify-between text-base">
+    <nav className="app-bottom-nav fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
+      <div className="container mx-auto px-4 pt-2 pb-1 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
         <NavItem to="/mining" icon={GiMining} label="Mining" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />


### PR DESCRIPTION
### Motivation
- Move the bottom navigation bar slightly lower and raise its icons/text so the bar and its contents align better on mobile portrait, matching the requested visual tweak.

### Description
- Updated `webapp/src/components/Navbar.jsx` to change the nav container from `bottom-2` to `bottom-0` and reduced top padding from `pt-3` to `pt-2` so the bar sits lower and the icons/text sit slightly higher inside it.

### Testing
- Built the webapp with `npm --prefix webapp run build` (succeeded) and started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` then captured a mobile-portrait screenshot via an automated Playwright script to verify the visual change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4b479040832993b5d37dae08f3f0)