### PR TITLE
Adjust human card/chip offsets and add single-chip factory for raise controls

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -393,15 +393,18 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.08;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.32;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.46;
-const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.82;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.8;
+const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.86;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.7;
 const HUMAN_CARD_CHIP_BLEND = 0;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
+const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.075;
+const CHIP_BUTTON_GRID_RIGHT_SHIFT = CARD_W * -0.06;
+const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 0.08;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const TURN_DURATION = 30;
@@ -1856,7 +1859,7 @@ function getHumanCardAnchor(seatGroup) {
   const blended = cardBase
     .addScaledVector(seatGroup.forward, HUMAN_CARD_FORWARD_OFFSET)
     .lerp(chipBase, HUMAN_CARD_CHIP_BLEND);
-  blended.y = TABLE_HEIGHT + HUMAN_CARD_VERTICAL_OFFSET;
+  blended.y = TABLE_HEIGHT + HUMAN_CARD_VERTICAL_OFFSET - HUMAN_CARD_LOWER_OFFSET;
   return blended;
 }
 
@@ -2119,20 +2122,17 @@ function createRaiseControls({ arena, seat, chipFactory, tableInfo }) {
     ? seat.cardRailAnchor.clone()
     : fallbackAnchor.clone().addScaledVector(forward, CARD_RAIL_FORWARD_SHIFT).addScaledVector(axis, -CARD_RAIL_LATERAL_SHIFT);
   cardRailAnchor.y = anchorY;
-  const chipCenter = seat.chipRailAnchor
-    ? seat.chipRailAnchor.clone()
-    : fallbackAnchor
-        .clone()
-        .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT)
-        .addScaledVector(axis, CHIP_RAIL_LATERAL_SHIFT);
-  chipCenter.addScaledVector(forward, CARD_D * 0.48);
+  const chipCenter = cardRailAnchor
+    .clone()
+    .addScaledVector(forward, CHIP_RAIL_FORWARD_SHIFT - CARD_RAIL_FORWARD_SHIFT + CHIP_BUTTON_GRID_OUTWARD_SHIFT)
+    .addScaledVector(axis, CHIP_BUTTON_GRID_RIGHT_SHIFT);
   chipCenter.y = anchorY;
   const columns = 3;
   const rows = Math.ceil(CHIP_VALUES.length / columns);
   const colOffset = (columns - 1) / 2;
   const rowOffset = (rows - 1) / 2;
   const chipButtons = CHIP_VALUES.map((value, index) => {
-    const chip = chipFactory.createStack(value, { mode: 'stack' });
+    const chip = chipFactory.createSingleChip?.(value) ?? chipFactory.createStack(value, { mode: 'stack' });
     const baseScale = RAIL_CHIP_SCALE;
     chip.position.copy(chipCenter);
     chip.position.y = anchorY + CARD_D * 0.82;

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -196,6 +196,21 @@ export function createChipFactory(renderer, { cardWidth }) {
     return group;
   }
 
+  function createSingleChip(value) {
+    const amount = Math.max(0, Math.floor(value));
+    const denom = DENOMINATIONS.find((entry) => entry.value === amount) || DENOMINATIONS[0];
+    const group = new THREE.Group();
+    group.userData = {
+      mode: 'stack',
+      chipValue: denom.value,
+      layout: null
+    };
+    const mesh = createChipMesh(denom);
+    mesh.position.y = height / 2;
+    group.add(mesh);
+    return group;
+  }
+
   function disposeStack(group) {
     if (!group) return;
     removeChildren(group);
@@ -322,6 +337,7 @@ export function createChipFactory(renderer, { cardWidth }) {
 
   return {
     createStack,
+    createSingleChip,
     setAmount: applyAmount,
     disposeStack,
     dispose,


### PR DESCRIPTION
### Motivation
- Improve visual alignment of human player cards and chip controls at the table by adjusting spacing and vertical offsets. 
- Shift the raise/quick-chip button grid to better align with the card rail and avoid overlaps. 
- Provide a lightweight single-chip creation API to render individual chip buttons without building full stacks.

### Description
- Tweaked layout constants including `HUMAN_CARD_INWARD_SHIFT`, `HUMAN_CARD_LATERAL_SHIFT`, and `HUMAN_CHIP_LATERAL_SHIFT`, and added `HUMAN_CARD_LOWER_OFFSET`, `CHIP_BUTTON_GRID_RIGHT_SHIFT`, and `CHIP_BUTTON_GRID_OUTWARD_SHIFT` to refine positioning. 
- Applied `HUMAN_CARD_LOWER_OFFSET` to the human card anchor in `getHumanCardAnchor` so human cards sit slightly lower on the table. 
- Reworked `createRaiseControls` to compute `chipCenter` relative to the `cardRailAnchor` using the new grid shifts and to use `chipFactory.createSingleChip` when available (falling back to `createStack`). 
- Added `createSingleChip` to `chips3d.js` and exposed it in the returned factory so callers can build single-chip meshes for UI buttons without full stacks.

### Testing
- Ran the repository's automated test suite including unit tests and linting, and all tests passed. 
- Built and ran the dev UI to exercise the Texas Hold'em arena raise control UI and verify chip/button placement in the scene (visual checks completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f418a814883299e5ffa3c9e8b6dbf)