### PR TITLE
Improve mobile fullscreen behavior across major mobile browsers

### DIFF
--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -3,11 +3,19 @@ import { useEffect } from 'react';
 import { isTelegramWebView } from '../utils/telegram.js';
 
 const MOBILE_BREAKPOINT_PX = 1024;
+const RETRY_INTERVAL_MS = 2000;
+
+const MOBILE_UA_REGEX = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
 
 const isMobileScreen = () => {
   if (typeof window === 'undefined') return false;
+
   const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches;
-  return coarsePointer || window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const narrowViewport = window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const uaMobile = MOBILE_UA_REGEX.test(window.navigator.userAgent || '');
+  const touchDevice = (window.navigator.maxTouchPoints || 0) > 0;
+
+  return coarsePointer || narrowViewport || uaMobile || touchDevice;
 };
 
 const setViewportHeightVar = () => {
@@ -28,6 +36,14 @@ const setDisplayModeClass = () => {
 
 const isDocumentFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
 
+const collapseBrowserChrome = () => {
+  // Best-effort fallback for mobile browsers that do not support Fullscreen API
+  // (notably iOS browsers where fullscreen is limited).
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 1);
+  });
+};
+
 const syncMobileFullscreenClass = () => {
   const standalone = setDisplayModeClass();
   const fullscreenActive = standalone || isDocumentFullscreen();
@@ -38,12 +54,32 @@ const syncMobileFullscreenClass = () => {
 const requestBrowserFullscreen = () => {
   const el = document.documentElement;
   const canRequest = el.requestFullscreen || el.webkitRequestFullscreen;
-  if (!canRequest || document.fullscreenElement) return;
+  if (!canRequest || document.fullscreenElement) {
+    collapseBrowserChrome();
+    return;
+  }
 
   const run = () => {
     const request = el.requestFullscreen || el.webkitRequestFullscreen;
     if (!request) return;
-    Promise.resolve(request.call(el)).catch(() => {});
+
+    try {
+      Promise.resolve(request.call(el, { navigationUI: 'hide' }))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    } catch {
+      Promise.resolve(request.call(el))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    }
   };
 
   const onFirstInteraction = () => {
@@ -54,6 +90,10 @@ const requestBrowserFullscreen = () => {
 
   window.addEventListener('pointerdown', onFirstInteraction, { passive: true, once: true });
   window.addEventListener('touchstart', onFirstInteraction, { passive: true, once: true });
+
+  collapseBrowserChrome();
+
+  return run;
 };
 
 export default function useMobileFullscreen() {
@@ -64,20 +104,46 @@ export default function useMobileFullscreen() {
 
     syncMobileFullscreenClass();
     setViewportHeightVar();
-    requestBrowserFullscreen();
+    const requestFullscreen = requestBrowserFullscreen();
+
+    const onInteractionRetry = () => {
+      if (isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
+    const periodicRetry = window.setInterval(() => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    }, RETRY_INTERVAL_MS);
 
     const onResize = () => setViewportHeightVar();
     const onModeChange = () => syncMobileFullscreenClass();
+    const onVisibility = () => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
     window.addEventListener('resize', onResize);
     window.addEventListener('fullscreenchange', onModeChange);
     window.addEventListener('webkitfullscreenchange', onModeChange);
+    window.addEventListener('pointerdown', onInteractionRetry, { passive: true });
+    window.addEventListener('touchstart', onInteractionRetry, { passive: true });
+    window.addEventListener('keydown', onInteractionRetry);
+    window.addEventListener('pageshow', onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
     window.visualViewport?.addEventListener('resize', onResize);
     window.matchMedia?.('(display-mode: standalone)').addEventListener?.('change', onModeChange);
 
     return () => {
+      window.clearInterval(periodicRetry);
       window.removeEventListener('resize', onResize);
       window.removeEventListener('fullscreenchange', onModeChange);
       window.removeEventListener('webkitfullscreenchange', onModeChange);
+      window.removeEventListener('pointerdown', onInteractionRetry);
+      window.removeEventListener('touchstart', onInteractionRetry);
+      window.removeEventListener('keydown', onInteractionRetry);
+      window.removeEventListener('pageshow', onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
       window.visualViewport?.removeEventListener('resize', onResize);
       window.matchMedia?.('(display-mode: standalone)').removeEventListener?.('change', onModeChange);
       document.body.classList.remove('mobile-fullscreen');

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -2,8 +2,18 @@ import { fetchTelegramInfo } from "./api.js";
 
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
+
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-  return Boolean(window.Telegram?.WebApp || ua.includes('Telegram'));
+  if (ua.includes('Telegram')) return true;
+
+  const tg = window.Telegram?.WebApp;
+  if (!tg) return false;
+
+  return Boolean(
+    (typeof tg.initData === 'string' && tg.initData.length > 0) ||
+      tg.initDataUnsafe?.user?.id ||
+      (typeof tg.platform === 'string' && tg.platform !== '' && tg.platform !== 'unknown')
+  );
 }
 
 function parseTelegramId(value) {


### PR DESCRIPTION
### Motivation
- Mobile players should get a true full-screen experience regardless of which mobile browser they use and avoid visible browser nav bars; current behavior was inconsistent across engines (Chrome, Safari/WebKit, Firefox).
- Provide a robust, best-effort approach that uses the Fullscreen API when available and a graceful fallback for engines that prevent fullscreen (notably iOS/WebKit). 

### Description
- Broadened mobile detection in `useMobileFullscreen` to consider coarse pointer, viewport width, mobile user-agent, and touch capability so the hook runs reliably on mobile devices. 
- Implemented a resilient fullscreen flow that attempts `requestFullscreen` with `navigationUI: 'hide'` when supported and falls back to `requestFullscreen` without options if needed. 
- Added retries and event-driven re-attempts (pointer/touch/keydown/pageshow/visibility changes and periodic retry) to trigger fullscreen after first interaction and to recover when the page becomes visible. 
- Added a best-effort fallback `collapseBrowserChrome` (scrollTo(0,1)) for browsers that cannot enter fullscreen (iOS/WebKit) and updated CSS variable sync for stable viewport sizing. 
- Tightened Telegram webview detection in `isTelegramWebView` so the fullscreen hook is not skipped for non-Telegram mobile browsers that expose a `window.Telegram` object. 

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. (succeeded)
- Automated mobile emulation checks using Playwright against the running preview (`vite preview --host 0.0.0.0 --port 4173`) for Chromium, WebKit and Firefox; screenshots and page state were captured for verification. (succeeded)
- Observed behaviors: Chromium emulation entered fullscreen (hook set `mobile-fullscreen` and `fullscreen` was true), Firefox emulation entered fullscreen, and WebKit/iOS-style emulation followed the expected fallback path with viewport vars set when the Fullscreen API was restricted. (results validated)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f57637550832984d9bd3c00796266)