### PR TITLE
Improve mobile/Telegram fullscreen handling with retries, UA detection, and fallback chrome collapse

### DIFF
--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -3,11 +3,19 @@ import { useEffect } from 'react';
 import { isTelegramWebView } from '../utils/telegram.js';
 
 const MOBILE_BREAKPOINT_PX = 1024;
+const RETRY_INTERVAL_MS = 2000;
+
+const MOBILE_UA_REGEX = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
 
 const isMobileScreen = () => {
   if (typeof window === 'undefined') return false;
+
   const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches;
-  return coarsePointer || window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const narrowViewport = window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const uaMobile = MOBILE_UA_REGEX.test(window.navigator.userAgent || '');
+  const touchDevice = (window.navigator.maxTouchPoints || 0) > 0;
+
+  return coarsePointer || narrowViewport || uaMobile || touchDevice;
 };
 
 const setViewportHeightVar = () => {
@@ -28,6 +36,14 @@ const setDisplayModeClass = () => {
 
 const isDocumentFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
 
+const collapseBrowserChrome = () => {
+  // Best-effort fallback for mobile browsers that do not support Fullscreen API
+  // (notably iOS browsers where fullscreen is limited).
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 1);
+  });
+};
+
 const syncMobileFullscreenClass = () => {
   const standalone = setDisplayModeClass();
   const fullscreenActive = standalone || isDocumentFullscreen();
@@ -38,12 +54,32 @@ const syncMobileFullscreenClass = () => {
 const requestBrowserFullscreen = () => {
   const el = document.documentElement;
   const canRequest = el.requestFullscreen || el.webkitRequestFullscreen;
-  if (!canRequest || document.fullscreenElement) return;
+  if (!canRequest || document.fullscreenElement) {
+    collapseBrowserChrome();
+    return;
+  }
 
   const run = () => {
     const request = el.requestFullscreen || el.webkitRequestFullscreen;
     if (!request) return;
-    Promise.resolve(request.call(el)).catch(() => {});
+
+    try {
+      Promise.resolve(request.call(el, { navigationUI: 'hide' }))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    } catch {
+      Promise.resolve(request.call(el))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    }
   };
 
   const onFirstInteraction = () => {
@@ -54,6 +90,10 @@ const requestBrowserFullscreen = () => {
 
   window.addEventListener('pointerdown', onFirstInteraction, { passive: true, once: true });
   window.addEventListener('touchstart', onFirstInteraction, { passive: true, once: true });
+
+  collapseBrowserChrome();
+
+  return run;
 };
 
 export default function useMobileFullscreen() {
@@ -64,20 +104,46 @@ export default function useMobileFullscreen() {
 
     syncMobileFullscreenClass();
     setViewportHeightVar();
-    requestBrowserFullscreen();
+    const requestFullscreen = requestBrowserFullscreen();
+
+    const onInteractionRetry = () => {
+      if (isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
+    const periodicRetry = window.setInterval(() => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    }, RETRY_INTERVAL_MS);
 
     const onResize = () => setViewportHeightVar();
     const onModeChange = () => syncMobileFullscreenClass();
+    const onVisibility = () => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
     window.addEventListener('resize', onResize);
     window.addEventListener('fullscreenchange', onModeChange);
     window.addEventListener('webkitfullscreenchange', onModeChange);
+    window.addEventListener('pointerdown', onInteractionRetry, { passive: true });
+    window.addEventListener('touchstart', onInteractionRetry, { passive: true });
+    window.addEventListener('keydown', onInteractionRetry);
+    window.addEventListener('pageshow', onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
     window.visualViewport?.addEventListener('resize', onResize);
     window.matchMedia?.('(display-mode: standalone)').addEventListener?.('change', onModeChange);
 
     return () => {
+      window.clearInterval(periodicRetry);
       window.removeEventListener('resize', onResize);
       window.removeEventListener('fullscreenchange', onModeChange);
       window.removeEventListener('webkitfullscreenchange', onModeChange);
+      window.removeEventListener('pointerdown', onInteractionRetry);
+      window.removeEventListener('touchstart', onInteractionRetry);
+      window.removeEventListener('keydown', onInteractionRetry);
+      window.removeEventListener('pageshow', onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
       window.visualViewport?.removeEventListener('resize', onResize);
       window.matchMedia?.('(display-mode: standalone)').removeEventListener?.('change', onModeChange);
       document.body.classList.remove('mobile-fullscreen');

--- a/webapp/src/hooks/useTelegramFullscreen.js
+++ b/webapp/src/hooks/useTelegramFullscreen.js
@@ -2,12 +2,41 @@ import { useEffect } from 'react';
 
 import { isTelegramWebView } from '../utils/telegram.js';
 
+const RETRY_INTERVAL_MS = 2000;
+
 const setViewportVars = () => {
   const tg = window?.Telegram?.WebApp;
   const height = tg?.viewportHeight || window.innerHeight;
   const stableHeight = tg?.viewportStableHeight || height;
   document.documentElement.style.setProperty('--tg-viewport-height', `${height}px`);
   document.documentElement.style.setProperty('--tg-viewport-stable-height', `${stableHeight}px`);
+};
+
+const collapseBrowserChrome = () => {
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 1);
+  });
+};
+
+const isDocumentFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
+
+const requestBrowserFullscreen = () => {
+  const el = document.documentElement;
+  const request = el.requestFullscreen || el.webkitRequestFullscreen;
+  if (!request || isDocumentFullscreen()) {
+    collapseBrowserChrome();
+    return;
+  }
+
+  try {
+    Promise.resolve(request.call(el, { navigationUI: 'hide' }))
+      .then(collapseBrowserChrome)
+      .catch(collapseBrowserChrome);
+  } catch {
+    Promise.resolve(request.call(el))
+      .then(collapseBrowserChrome)
+      .catch(collapseBrowserChrome);
+  }
 };
 
 export default function useTelegramFullscreen() {
@@ -17,23 +46,64 @@ export default function useTelegramFullscreen() {
     const tg = window.Telegram?.WebApp;
     document.body.classList.add('telegram-fullscreen');
 
+    const requestTelegramFullscreen = () => {
+      tg?.expand?.();
+      tg?.requestFullscreen?.();
+      requestBrowserFullscreen();
+      collapseBrowserChrome();
+    };
+
     tg?.ready?.();
-    tg?.expand?.();
     tg?.disableVerticalSwipes?.();
     tg?.setHeaderColor?.('#0b0f1a');
     tg?.setBackgroundColor?.('#0b0f1a');
 
     setViewportVars();
+    requestTelegramFullscreen();
 
-    const onResize = () => setViewportVars();
+    const onResize = () => {
+      setViewportVars();
+      requestTelegramFullscreen();
+    };
+
+    const onViewportChanged = () => {
+      setViewportVars();
+      requestTelegramFullscreen();
+    };
+
+    const onFullscreenRetry = () => {
+      if (document.hidden) return;
+      requestTelegramFullscreen();
+    };
+
+    const retryInterval = window.setInterval(() => {
+      if (document.hidden) return;
+      requestTelegramFullscreen();
+    }, RETRY_INTERVAL_MS);
+
     window.addEventListener('resize', onResize);
-
-    const onViewportChanged = () => setViewportVars();
+    window.addEventListener('pointerdown', onFullscreenRetry, { passive: true });
+    window.addEventListener('touchstart', onFullscreenRetry, { passive: true });
+    window.addEventListener('keydown', onFullscreenRetry);
+    window.addEventListener('pageshow', onFullscreenRetry);
+    window.addEventListener('fullscreenchange', onFullscreenRetry);
+    window.addEventListener('webkitfullscreenchange', onFullscreenRetry);
+    document.addEventListener('visibilitychange', onFullscreenRetry);
     tg?.onEvent?.('viewportChanged', onViewportChanged);
+    tg?.onEvent?.('fullscreenChanged', onFullscreenRetry);
 
     return () => {
+      window.clearInterval(retryInterval);
       window.removeEventListener('resize', onResize);
+      window.removeEventListener('pointerdown', onFullscreenRetry);
+      window.removeEventListener('touchstart', onFullscreenRetry);
+      window.removeEventListener('keydown', onFullscreenRetry);
+      window.removeEventListener('pageshow', onFullscreenRetry);
+      window.removeEventListener('fullscreenchange', onFullscreenRetry);
+      window.removeEventListener('webkitfullscreenchange', onFullscreenRetry);
+      document.removeEventListener('visibilitychange', onFullscreenRetry);
       tg?.offEvent?.('viewportChanged', onViewportChanged);
+      tg?.offEvent?.('fullscreenChanged', onFullscreenRetry);
       document.body.classList.remove('telegram-fullscreen');
     };
   }, []);

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -2,8 +2,18 @@ import { fetchTelegramInfo } from "./api.js";
 
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
+
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-  return Boolean(window.Telegram?.WebApp || ua.includes('Telegram'));
+  if (ua.includes('Telegram')) return true;
+
+  const tg = window.Telegram?.WebApp;
+  if (!tg) return false;
+
+  return Boolean(
+    (typeof tg.initData === 'string' && tg.initData.length > 0) ||
+      tg.initDataUnsafe?.user?.id ||
+      (typeof tg.platform === 'string' && tg.platform !== '' && tg.platform !== 'unknown')
+  );
 }
 
 function parseTelegramId(value) {


### PR DESCRIPTION
### Motivation
- Fix unreliable fullscreen behavior on mobile browsers and Telegram WebApp where the Fullscreen API is limited or requires user interaction.
- Keep viewport-related CSS variables correct during dynamic viewport changes and when browser chrome collapses.
- Improve detection of Telegram WebView beyond simple user-agent string checks.

### Description
- Enhanced `useMobileFullscreen` to detect mobile via `(pointer: coarse)`, viewport width, a `MOBILE_UA_REGEX`, and touch capability, and added a `collapseBrowserChrome` fallback for browsers without Fullscreen API support.
- Modified `requestBrowserFullscreen` to attempt `navigationUI: 'hide'` with try/catch fallbacks and to schedule best-effort chrome collapsing, and added interaction-based and periodic retry logic using `RETRY_INTERVAL_MS` plus additional event listeners to re-run fullscreen attempts.
- Updated `useTelegramFullscreen` to centralize fullscreen/expand attempts (`requestTelegramFullscreen`), call browser fullscreen with fallbacks, add periodic and interaction retries, and refresh viewport vars when viewport changes.
- Strengthened `isTelegramWebView` in `utils/telegram.js` to check `Telegram.WebApp.initData`, `initDataUnsafe.user.id`, and `platform` properties in addition to the UA check.

### Testing
- Ran `npm run lint` to validate code style and static checks, which completed successfully.
- Ran `npm test` to execute the existing unit test suite, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f57637550832984d9bd3c00796266)