### PR TITLE
Improve mobile fullscreen handling and Telegram WebView detection

### DIFF
--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -3,11 +3,19 @@ import { useEffect } from 'react';
 import { isTelegramWebView } from '../utils/telegram.js';
 
 const MOBILE_BREAKPOINT_PX = 1024;
+const RETRY_INTERVAL_MS = 2000;
+
+const MOBILE_UA_REGEX = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
 
 const isMobileScreen = () => {
   if (typeof window === 'undefined') return false;
+
   const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches;
-  return coarsePointer || window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const narrowViewport = window.innerWidth <= MOBILE_BREAKPOINT_PX;
+  const uaMobile = MOBILE_UA_REGEX.test(window.navigator.userAgent || '');
+  const touchDevice = (window.navigator.maxTouchPoints || 0) > 0;
+
+  return coarsePointer || narrowViewport || uaMobile || touchDevice;
 };
 
 const setViewportHeightVar = () => {
@@ -28,6 +36,14 @@ const setDisplayModeClass = () => {
 
 const isDocumentFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
 
+const collapseBrowserChrome = () => {
+  // Best-effort fallback for mobile browsers that do not support Fullscreen API
+  // (notably iOS browsers where fullscreen is limited).
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 1);
+  });
+};
+
 const syncMobileFullscreenClass = () => {
   const standalone = setDisplayModeClass();
   const fullscreenActive = standalone || isDocumentFullscreen();
@@ -38,12 +54,32 @@ const syncMobileFullscreenClass = () => {
 const requestBrowserFullscreen = () => {
   const el = document.documentElement;
   const canRequest = el.requestFullscreen || el.webkitRequestFullscreen;
-  if (!canRequest || document.fullscreenElement) return;
+  if (!canRequest || document.fullscreenElement) {
+    collapseBrowserChrome();
+    return;
+  }
 
   const run = () => {
     const request = el.requestFullscreen || el.webkitRequestFullscreen;
     if (!request) return;
-    Promise.resolve(request.call(el)).catch(() => {});
+
+    try {
+      Promise.resolve(request.call(el, { navigationUI: 'hide' }))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    } catch {
+      Promise.resolve(request.call(el))
+        .then(() => {
+          collapseBrowserChrome();
+        })
+        .catch(() => {
+          collapseBrowserChrome();
+        });
+    }
   };
 
   const onFirstInteraction = () => {
@@ -54,6 +90,10 @@ const requestBrowserFullscreen = () => {
 
   window.addEventListener('pointerdown', onFirstInteraction, { passive: true, once: true });
   window.addEventListener('touchstart', onFirstInteraction, { passive: true, once: true });
+
+  collapseBrowserChrome();
+
+  return run;
 };
 
 export default function useMobileFullscreen() {
@@ -64,20 +104,46 @@ export default function useMobileFullscreen() {
 
     syncMobileFullscreenClass();
     setViewportHeightVar();
-    requestBrowserFullscreen();
+    const requestFullscreen = requestBrowserFullscreen();
+
+    const onInteractionRetry = () => {
+      if (isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
+    const periodicRetry = window.setInterval(() => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    }, RETRY_INTERVAL_MS);
 
     const onResize = () => setViewportHeightVar();
     const onModeChange = () => syncMobileFullscreenClass();
+    const onVisibility = () => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+
     window.addEventListener('resize', onResize);
     window.addEventListener('fullscreenchange', onModeChange);
     window.addEventListener('webkitfullscreenchange', onModeChange);
+    window.addEventListener('pointerdown', onInteractionRetry, { passive: true });
+    window.addEventListener('touchstart', onInteractionRetry, { passive: true });
+    window.addEventListener('keydown', onInteractionRetry);
+    window.addEventListener('pageshow', onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
     window.visualViewport?.addEventListener('resize', onResize);
     window.matchMedia?.('(display-mode: standalone)').addEventListener?.('change', onModeChange);
 
     return () => {
+      window.clearInterval(periodicRetry);
       window.removeEventListener('resize', onResize);
       window.removeEventListener('fullscreenchange', onModeChange);
       window.removeEventListener('webkitfullscreenchange', onModeChange);
+      window.removeEventListener('pointerdown', onInteractionRetry);
+      window.removeEventListener('touchstart', onInteractionRetry);
+      window.removeEventListener('keydown', onInteractionRetry);
+      window.removeEventListener('pageshow', onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
       window.visualViewport?.removeEventListener('resize', onResize);
       window.matchMedia?.('(display-mode: standalone)').removeEventListener?.('change', onModeChange);
       document.body.classList.remove('mobile-fullscreen');

--- a/webapp/src/hooks/useTelegramFullscreen.js
+++ b/webapp/src/hooks/useTelegramFullscreen.js
@@ -2,12 +2,68 @@ import { useEffect } from 'react';
 
 import { isTelegramWebView } from '../utils/telegram.js';
 
+const RETRY_INTERVAL_MS = 2000;
+
 const setViewportVars = () => {
   const tg = window?.Telegram?.WebApp;
   const height = tg?.viewportHeight || window.innerHeight;
   const stableHeight = tg?.viewportStableHeight || height;
   document.documentElement.style.setProperty('--tg-viewport-height', `${height}px`);
   document.documentElement.style.setProperty('--tg-viewport-stable-height', `${stableHeight}px`);
+};
+
+const isDocumentFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
+
+const collapseBrowserChrome = () => {
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 1);
+  });
+};
+
+const syncTelegramFullscreenClass = () => {
+  const tg = window?.Telegram?.WebApp;
+  const expanded = Boolean(tg?.isExpanded);
+  const fullscreenActive = expanded || isDocumentFullscreen();
+  document.body.classList.toggle('mobile-fullscreen', fullscreenActive);
+  document.body.classList.toggle('mobile-browser-framed', !fullscreenActive);
+};
+
+const requestBrowserFullscreen = () => {
+  const el = document.documentElement;
+  const canRequest = el.requestFullscreen || el.webkitRequestFullscreen;
+
+  if (!canRequest || isDocumentFullscreen()) {
+    collapseBrowserChrome();
+    return;
+  }
+
+  const run = () => {
+    const request = el.requestFullscreen || el.webkitRequestFullscreen;
+    if (!request) return;
+
+    try {
+      Promise.resolve(request.call(el, { navigationUI: 'hide' }))
+        .then(collapseBrowserChrome)
+        .catch(collapseBrowserChrome);
+    } catch {
+      Promise.resolve(request.call(el))
+        .then(collapseBrowserChrome)
+        .catch(collapseBrowserChrome);
+    }
+  };
+
+  const onFirstInteraction = () => {
+    run();
+    window.removeEventListener('pointerdown', onFirstInteraction);
+    window.removeEventListener('touchstart', onFirstInteraction);
+  };
+
+  window.addEventListener('pointerdown', onFirstInteraction, { passive: true, once: true });
+  window.addEventListener('touchstart', onFirstInteraction, { passive: true, once: true });
+
+  collapseBrowserChrome();
+
+  return run;
 };
 
 export default function useTelegramFullscreen() {
@@ -24,17 +80,54 @@ export default function useTelegramFullscreen() {
     tg?.setBackgroundColor?.('#0b0f1a');
 
     setViewportVars();
+    syncTelegramFullscreenClass();
+    const requestFullscreen = requestBrowserFullscreen();
 
     const onResize = () => setViewportVars();
-    window.addEventListener('resize', onResize);
+    const onModeChange = () => syncTelegramFullscreenClass();
+    const onInteractionRetry = () => {
+      if (isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
+    const onVisibility = () => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    };
 
-    const onViewportChanged = () => setViewportVars();
+    const periodicRetry = window.setInterval(() => {
+      if (document.hidden || isDocumentFullscreen()) return;
+      requestFullscreen?.();
+    }, RETRY_INTERVAL_MS);
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('fullscreenchange', onModeChange);
+    window.addEventListener('webkitfullscreenchange', onModeChange);
+    window.addEventListener('pointerdown', onInteractionRetry, { passive: true });
+    window.addEventListener('touchstart', onInteractionRetry, { passive: true });
+    window.addEventListener('keydown', onInteractionRetry);
+    window.addEventListener('pageshow', onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    const onViewportChanged = () => {
+      setViewportVars();
+      syncTelegramFullscreenClass();
+    };
     tg?.onEvent?.('viewportChanged', onViewportChanged);
 
     return () => {
+      window.clearInterval(periodicRetry);
       window.removeEventListener('resize', onResize);
+      window.removeEventListener('fullscreenchange', onModeChange);
+      window.removeEventListener('webkitfullscreenchange', onModeChange);
+      window.removeEventListener('pointerdown', onInteractionRetry);
+      window.removeEventListener('touchstart', onInteractionRetry);
+      window.removeEventListener('keydown', onInteractionRetry);
+      window.removeEventListener('pageshow', onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
       tg?.offEvent?.('viewportChanged', onViewportChanged);
       document.body.classList.remove('telegram-fullscreen');
+      document.body.classList.remove('mobile-fullscreen');
+      document.body.classList.remove('mobile-browser-framed');
     };
   }, []);
 }

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -2,8 +2,18 @@ import { fetchTelegramInfo } from "./api.js";
 
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
+
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-  return Boolean(window.Telegram?.WebApp || ua.includes('Telegram'));
+  if (ua.includes('Telegram')) return true;
+
+  const tg = window.Telegram?.WebApp;
+  if (!tg) return false;
+
+  return Boolean(
+    (typeof tg.initData === 'string' && tg.initData.length > 0) ||
+      tg.initDataUnsafe?.user?.id ||
+      (typeof tg.platform === 'string' && tg.platform !== '' && tg.platform !== 'unknown')
+  );
 }
 
 function parseTelegramId(value) {


### PR DESCRIPTION
### Motivation
- Improve detection of mobile devices and robustly enter fullscreen on mobile and Telegram WebView contexts where Fullscreen API is flaky or limited.
- Provide fallbacks and periodic retries to collapse browser chrome and keep the app in a framed/fullscreen state on interaction or visibility changes.

### Description
- Enhance `isMobileScreen` with `MOBILE_UA_REGEX`, touch-point detection, and a `MOBILE_BREAKPOINT_PX` check. 
- Add `collapseBrowserChrome` helper that scrolls the window to hide browser chrome as a best-effort fallback when Fullscreen API is unavailable. 
- Make `requestBrowserFullscreen` more robust by attempting `requestFullscreen` with `{ navigationUI: 'hide' }`, handling exceptions, and returning a `run` function so fullscreen can be retried on later interactions. 
- Wire up periodic retries (`RETRY_INTERVAL_MS`) and extra event listeners (`pointerdown`, `touchstart`, `keydown`, `pageshow`, `visibilitychange`) to re-attempt fullscreen when appropriate, and ensure interval/listener cleanup on unmount. 
- Add class sync helpers (`syncMobileFullscreenClass`, `syncTelegramFullscreenClass`) to toggle `mobile-fullscreen`, `mobile-browser-framed`, and `mobile-standalone` based on display-mode, Telegram expansion, or document fullscreen state. 
- Mirror the same robust fullscreen and retry behavior in `useTelegramFullscreen` and ensure Telegram-specific viewport vars are kept in sync. 
- Improve Telegram WebView detection in `webapp/src/utils/telegram.js` by checking `navigator.userAgent`, `Telegram.WebApp.initData`, `initDataUnsafe.user.id`, and `Telegram.WebApp.platform` in addition to presence of `window.Telegram?.WebApp`.

### Testing
- Ran unit test suite with `yarn test` and the tests passed. 
- Ran linting with `yarn lint` and no lint errors were reported. 
- Verified no runtime errors in local development by exercising the hooks in mobile emulation and a Telegram WebView stub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f57637550832984d9bd3c00796266)