### PR TITLE
Fix game HUD alignment outside Telegram WebApp runtime

### DIFF
--- a/webapp/src/hooks/useMobileFullscreen.js
+++ b/webapp/src/hooks/useMobileFullscreen.js
@@ -99,7 +99,7 @@ const requestBrowserFullscreen = () => {
 export default function useMobileFullscreen() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (isTelegramWebView()) return;
+    if (isTelegramWebView() && window.Telegram?.WebApp) return;
     if (!isMobileScreen()) return;
 
     syncMobileFullscreenClass();

--- a/webapp/src/hooks/useTelegramFullscreen.js
+++ b/webapp/src/hooks/useTelegramFullscreen.js
@@ -41,9 +41,9 @@ const requestBrowserFullscreen = () => {
 
 export default function useTelegramFullscreen() {
   useEffect(() => {
-    if (!isTelegramWebView()) return;
-
     const tg = window.Telegram?.WebApp;
+    if (!isTelegramWebView() || !tg) return;
+
     document.body.classList.add('telegram-fullscreen');
 
     const requestTelegramFullscreen = () => {


### PR DESCRIPTION
### Motivation
- Prevent the app from treating ordinary mobile Telegram/Chrome sessions as the Telegram WebApp fullscreen runtime to avoid HUD/buttons being inset away from screen edges.

### Description
- Require the real runtime when enabling the Telegram fullscreen hook by checking `window.Telegram?.WebApp` in `useTelegramFullscreen.js` so the hook only runs in true WebApp contexts.
- Allow the mobile fullscreen fallback to run when Telegram is only detected via user-agent by changing the guard in `useMobileFullscreen.js` to skip only when the actual `window.Telegram.WebApp` runtime exists.
- Modified files: `webapp/src/hooks/useTelegramFullscreen.js` and `webapp/src/hooks/useMobileFullscreen.js`.

### Testing
- Ran `npx eslint` on the two changed files (eslint reports these files are ignored by the current config; no code errors reported). 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Started the dev server and captured a mobile viewport screenshot of `/games/poolroyale` to validate HUD alignment (visual check artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fddbdfe248329b0a87ff8872508d9)