### PR TITLE
Adjust Pool Royale HUD spacing and control alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13477,11 +13477,18 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const sharedHudLiftPx = 30;
+  const spinControllerLiftPx = 18;
+  const bottomHudExtraLiftPx = 28;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
-    SPIN_CONTROL_DIAMETER_PX + 2 + chromeUiLiftPx + sharedHudLiftPx - viewButtonsOffsetPx;
+    SPIN_CONTROL_DIAMETER_PX +
+    2 +
+    chromeUiLiftPx +
+    sharedHudLiftPx +
+    spinControllerLiftPx -
+    viewButtonsOffsetPx;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
   );
@@ -31127,11 +31134,11 @@ const powerRef = useRef(hud.power);
       ? String(lastOpponentPot.id ?? lastOpponentPot.color)
       : null;
   const bottomHudVisible = hud.turn != null && !hud.over && !shotActive && !replayActive;
-  const bottomHudScale = isPortrait ? uiScale * 1.08 : uiScale * 1.12;
-  const avatarSizeClass = isPortrait ? 'h-[2.6rem] w-[2.6rem]' : 'h-[3.5rem] w-[3.5rem]';
-  const nameWidthClass = isPortrait ? 'max-w-[9rem]' : 'max-w-[12rem]';
-  const nameTextClass = isPortrait ? 'text-sm' : 'text-base';
-  const hudGapClass = isPortrait ? 'gap-4' : 'gap-6';
+  const bottomHudScale = isPortrait ? uiScale * 1.16 : uiScale * 1.15;
+  const avatarSizeClass = isPortrait ? 'h-[2.85rem] w-[2.85rem]' : 'h-[3.65rem] w-[3.65rem]';
+  const nameWidthClass = isPortrait ? 'max-w-[10rem]' : 'max-w-[13rem]';
+  const nameTextClass = isPortrait ? 'text-[0.96rem]' : 'text-[1.02rem]';
+  const hudGapClass = isPortrait ? 'gap-5' : 'gap-6';
   const bottomHudLayoutClass = isPortrait ? 'justify-center px-4 w-full' : 'justify-center';
   const chatGiftOverlayClass =
     'fixed inset-0 z-50 flex items-center justify-center bg-black/70';
@@ -31162,9 +31169,7 @@ const powerRef = useRef(hud.power);
       }`;
   const playerPanelStyle = isPortrait
     ? {
-        boxShadow: isPlayerTurn
-          ? '0 0 18px rgba(16,185,129,0.32), -10px 0 18px rgba(16,185,129,0.18)'
-          : '0 6px 14px rgba(0,0,0,0.35)'
+        boxShadow: 'none'
       }
     : {
         boxShadow: isPlayerTurn
@@ -31173,9 +31178,7 @@ const powerRef = useRef(hud.power);
       };
   const opponentPanelStyle = isPortrait
     ? {
-        boxShadow: isOpponentTurn
-          ? '0 0 18px rgba(16,185,129,0.32), 10px 0 18px rgba(16,185,129,0.18)'
-          : '0 6px 14px rgba(0,0,0,0.35)'
+        boxShadow: 'none'
       }
     : {
         boxShadow: isOpponentTurn
@@ -32552,7 +32555,7 @@ const powerRef = useRef(hud.power);
 
       <div
         ref={leftControlsRef}
-        className={`pointer-events-none absolute right-0 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+        className={`pointer-events-none absolute right-0 z-50 flex flex-row items-center gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
           bottom: `${sideControlsBottomPx}px`,
           transform: `scale(${uiScale * 1.08})`,
@@ -32615,14 +32618,14 @@ const powerRef = useRef(hud.power);
           className={`absolute flex ${bottomHudLayoutClass} pointer-events-none z-50 transition-opacity duration-200 ${pocketCameraActive || replayActive ? 'opacity-0' : 'opacity-100'}`}
           aria-hidden={pocketCameraActive || replayActive}
           style={{
-            bottom: `${18 + chromeUiLiftPx + sharedHudLiftPx}px`,
+            bottom: `${18 + chromeUiLiftPx + sharedHudLiftPx + bottomHudExtraLiftPx}px`,
             left: hudInsets.left,
             right: hudInsets.right,
             transform: isPortrait ? `translateX(${bottomHudOffset}px)` : undefined
           }}
         >
             <div
-              className={`pointer-events-auto flex min-h-[3rem] max-w-full items-center justify-center ${isFreePractice ? '' : hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'pl-6 pr-8 py-2' : 'pl-7 pr-9 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
+              className={`pointer-events-auto flex min-h-[3.35rem] max-w-full items-center justify-center ${isFreePractice ? '' : hudGapClass} rounded-full border border-emerald-400/40 bg-black/70 ${isPortrait ? 'pl-7 pr-9 py-2.5' : 'pl-7 pr-9 py-2.5'} text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur`}
               style={{
                 transform: `scale(${bottomHudScale})`,
                 transformOrigin: 'bottom center',
@@ -32640,7 +32643,7 @@ const powerRef = useRef(hud.power);
                     <img
                       src={player.avatar || '/assets/icons/profile.svg'}
                       alt="player avatar"
-                      className={`${avatarSizeClass} rounded-full border-2 object-cover transition-all duration-150 ${
+                      className={`${avatarSizeClass} rounded-full object-cover transition-all duration-150 ${
                         isPlayerTurn
                           ? 'border-emerald-200 shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                           : 'border-white/50 shadow-[0_4px_10px_rgba(0,0,0,0.45)]'
@@ -32650,7 +32653,7 @@ const powerRef = useRef(hud.power);
                     <img
                       src={resolvedPlayerAvatar || '/assets/icons/profile.svg'}
                       alt="player avatar"
-                      className={`${avatarSizeClass} rounded-full border-2 object-cover transition-all duration-150 ${
+                      className={`${avatarSizeClass} rounded-full object-cover transition-all duration-150 ${
                         isPlayerTurn
                           ? 'border-emerald-200 shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                           : 'border-white/50 shadow-[0_4px_10px_rgba(0,0,0,0.45)]'
@@ -32688,7 +32691,7 @@ const powerRef = useRef(hud.power);
                         <img
                           src={opponentDisplayAvatar}
                           alt="opponent avatar"
-                          className={`${avatarSizeClass} rounded-full border-2 object-cover transition-all duration-150 ${
+                          className={`${avatarSizeClass} rounded-full object-cover transition-all duration-150 ${
                             isOpponentTurn
                               ? 'border-emerald-200 shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                               : 'border-white/50 shadow-[0_4px_10px_rgba(0,0,0,0.45)]'
@@ -32708,7 +32711,7 @@ const powerRef = useRef(hud.power);
                         <img
                           src={opponentDisplayAvatar || '/assets/icons/profile.svg'}
                           alt="opponent avatar"
-                          className={`${avatarSizeClass} rounded-full border-2 object-cover transition-all duration-150 ${
+                          className={`${avatarSizeClass} rounded-full object-cover transition-all duration-150 ${
                             isOpponentTurn
                               ? 'border-emerald-200 shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                               : 'border-white/50 shadow-[0_4px_10px_rgba(0,0,0,0.45)]'
@@ -32985,7 +32988,7 @@ const powerRef = useRef(hud.power);
           ref={spinBoxRef}
           className={`absolute right-1 ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
-            bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx}px`,
+            bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,
             transformOrigin: 'bottom right'
           }}


### PR DESCRIPTION
### Motivation
- Improve portrait mobile HUD legibility by increasing the player info frame size (avatars, usernames, points, potted balls) and removing competing small portrait frames behind avatars. 
- Create clearer spatial separation between the player HUD and the spin controller by lifting the spin control upward and moving the HUD slightly down. 
- Align the watch / view toggle controls horizontally with the chat control cluster so bottom icons sit on the same visual baseline.

### Description
- Added new layout offsets `spinControllerLiftPx` and `bottomHudExtraLiftPx` and applied them to the spin controller and bottom HUD anchors to increase vertical separation. 
- Adjusted `sideControlsBottomPx` to account for the spin controller lift so left controls and bottom icons align correctly. 
- Increased bottom HUD scale, avatar size, name width/text size and inter-item gap by updating `bottomHudScale`, `avatarSizeClass`, `nameWidthClass`, `nameTextClass` and `hudGapClass` to make the HUD wider/taller and more readable. 
- Removed the portrait mini-frame appearance by disabling per-player portrait shadowing in portrait (`playerPanelStyle`/`opponentPanelStyle`) and removing the static `border-2` on avatar image class names so only the primary HUD frame remains dominant. 
- Changed the left control container to a horizontal layout (`flex-row items-center`) so the watch and 2D/3D toggle appear on the same horizontal row as the chat cluster.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite chunk-size warnings are unrelated). 
- Linted the updated file with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which produced a repo ignore warning (file is ignored by current lint config). 
- Started the dev server (Vite) and attempted an end-to-end screenshot with Playwright targeting `/games/poolroyale`, but the screenshot attempt timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe6dcd43c8329bee3fd9ff2cde501)