### PR TITLE
Tune human card/chip offsets and enforce chip layout min/max counts

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -393,10 +393,10 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
-const HUMAN_CARD_INWARD_SHIFT = CARD_W * -1.72;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.06;
+const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.28;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.18;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.55;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.8;
+const HUMAN_CHIP_LATERAL_SHIFT = 0;
 const HUMAN_CARD_CHIP_BLEND = 0;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
@@ -404,7 +404,7 @@ const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
 const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.11;
 const CHIP_BUTTON_GRID_RIGHT_SHIFT = 0;
-const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 0.56;
+const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 0.7;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const TURN_DURATION = 30;
@@ -527,6 +527,8 @@ const CHIP_SCATTER_LAYOUT = Object.freeze({
 
 const CHIP_RAIL_LAYOUT = Object.freeze({
   perRow: 3,
+  minCount: 9,
+  maxCount: 9,
   spacing: CARD_W * 0.46,
   rowSpacing: CARD_W * 0.42,
   jitter: CARD_W * 0.06,
@@ -4192,7 +4194,11 @@ function TexasHoldemArena({ search }) {
             forward: seat.forward.clone().multiplyScalar(player.isHuman ? 1 : -1),
             right: seat.right.clone().multiplyScalar(player.isHuman ? 1 : -1)
           };
-          seatGroup.railLayout = seatGroup.tableLayout;
+          seatGroup.railLayout = {
+            ...railLayout,
+            forward: seat.forward.clone().multiplyScalar(player.isHuman ? 1 : -1),
+            right: seat.right.clone().multiplyScalar(player.isHuman ? 1 : -1)
+          };
           if (player.isHuman) {
             cameraTarget.copy(seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0)));
           }
@@ -4210,7 +4216,11 @@ function TexasHoldemArena({ search }) {
           forward: seat.forward.clone().negate(),
           right: seat.right.clone().negate()
         };
-        seat.railLayout = seat.tableLayout;
+        seat.railLayout = {
+          ...seat.railLayout,
+          forward: seat.forward.clone().negate(),
+          right: seat.right.clone().negate()
+        };
       });
 
       const nameplates = seatGroups.map((seat) => seat.nameplate);

--- a/webapp/src/utils/chips3d.js
+++ b/webapp/src/utils/chips3d.js
@@ -109,6 +109,8 @@ export function createChipFactory(renderer, { cardWidth }) {
     }
     return {
       perRow: Math.max(1, Math.floor(overrides.perRow ?? baseLayout.perRow ?? 5)),
+      minCount: Math.max(0, Math.floor(overrides.minCount ?? baseLayout.minCount ?? 0)),
+      maxCount: Math.max(0, Math.floor(overrides.maxCount ?? baseLayout.maxCount ?? 0)),
       spacing: overrides.spacing ?? baseLayout.spacing ?? radius * 1.65,
       rowSpacing: overrides.rowSpacing ?? baseLayout.rowSpacing ?? radius * 1.25,
       jitter: overrides.jitter ?? baseLayout.jitter ?? radius * 0.28,
@@ -139,8 +141,17 @@ export function createChipFactory(renderer, { cardWidth }) {
   }
 
   function scatterChips(group, amount, options = {}) {
-    const chips = expandChips(amount);
     const layout = buildLayout(group, options.layout);
+    let chips = expandChips(amount);
+    if (layout.maxCount > 0 && chips.length > layout.maxCount) {
+      chips = chips.slice(0, layout.maxCount);
+    }
+    if (layout.minCount > 0 && chips.length < layout.minCount) {
+      const fillerDenom = chips[chips.length - 1]?.denom ?? DENOMINATIONS[0];
+      while (chips.length < layout.minCount) {
+        chips.push({ denom: fillerDenom });
+      }
+    }
     const offsets = layoutOffsets(chips.length, layout);
     chips.forEach((chip, index) => {
       const mesh = createChipMesh(chip.denom);


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the human player's cards and chips and ensure consistent chip rail population by constraining scatter layout counts.
- Fix incorrect propagation of rail layout orientation so seat-specific forward/right vectors are used for chip placement.

### Description
- Adjusted human-player layout constants: `HUMAN_CARD_INWARD_SHIFT`, `HUMAN_CHIP_INWARD_SHIFT`, `HUMAN_CHIP_LATERAL_SHIFT`, and `CHIP_BUTTON_GRID_OUTWARD_SHIFT` to change card/chip positioning and button grid offset.
- Replaced assignments of `seatGroup.railLayout = seatGroup.tableLayout` with explicit copies of `railLayout` that apply seat-specific `forward` and `right` multipliers for both human and AI seats so rail orientation is correct per seat.
- Extended the chip layout system in `createChipFactory` by adding `minCount` and `maxCount` to `buildLayout`, and updated `scatterChips` to clamp to `maxCount` and pad to `minCount` using filler denominations for consistent visual counts.
- Preserved existing layout behavior and defaults while allowing callers to specify `minCount`/`maxCount` through layout overrides.

### Testing
- Ran unit tests via `yarn test` and verified they passed without regressions.
- Performed a production build using `yarn build` to ensure there are no compile/runtime errors and the bundle built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe2c565148329bcbddec3f6e01c3c)