### PR TITLE
Align Pool Royale HUD: align quick-actions with watch/2D and adjust player frame spacing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13478,7 +13478,7 @@ function PoolRoyaleGame({
   }, []);
   const sharedHudLiftPx = 30;
   const spinControllerLiftPx = 14;
-  const hudExtraClearancePx = 20;
+  const hudExtraClearancePx = 8;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
@@ -30506,7 +30506,7 @@ const powerRef = useRef(hud.power);
       : uiScale * 24;
       const rightInset =
       (spinBox?.width ?? fallbackSpinWidth) +
-      uiScale * 32 +
+      uiScale * 44 +
       12;
       setHudInsets({
       left: `${leftInset}px`,
@@ -32598,8 +32598,8 @@ const powerRef = useRef(hud.power);
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
             className="fixed left-0 z-50 flex flex-col gap-2.5 -translate-x-1"
-            style={{ bottom: `${sideControlsBottomPx}px` }}
-            buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
+            style={{ bottom: `${sideControlsBottomPx + rightControlsLiftPx}px` }}
+            buttonClassName="pointer-events-auto flex h-14 w-14 flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
             chatIcon="💬"


### PR DESCRIPTION
### Motivation
- Improve visual alignment in portrait so chat/gift quick-actions line up horizontally with the watch and 2D controls. 
- Reduce crowding between the bottom player frame (avatars/usernames/points/balls) and the spin controller for clearer on-screen composition.

### Description
- Reduced `hudExtraClearancePx` from `20` to `8` so the bottom player HUD sits slightly lower and closer to the spin controller. 
- Increased portrait right inset by changing `uiScale * 32` to `uiScale * 44` so the player frame is further from the spin controller. 
- Aligned the left quick-action stack with the right-side controls by updating the `BottomLeftIcons` wrapper to use `style={{ bottom: \\`${sideControlsBottomPx + rightControlsLiftPx}px\\` }}` and normalized the quick-action button size from `h-[3.15rem] w-[3.15rem]` to `h-14 w-14`. 
- All edits made in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; the linter executed successfully (the file is ignored by the repo ESLint ignore rules). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0`; the server launched and served the app. 
- Attempted a Playwright screenshot of `/games/poolroyale` for visual validation, but the screenshot operation timed out in the container (render/screenshot failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff13b87c88329b7dd5abdc160e4ab)