### PR TITLE
Adjust Pool Royale HUD positions for portrait layout

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13480,6 +13480,12 @@ function PoolRoyaleGame({
   const spinControllerLiftPx = 14;
   const hudExtraClearancePx = 8;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
+  const menuButtonTopNudgePx = 8;
+  const menuButtonLeftNudgePx = -4;
+  const sideActionButtonsLiftPx = 10;
+  const rightHudShiftPx = 8;
+  const bottomHudDownPx = 7;
+  const bottomHudLeftPx = -8;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -31570,8 +31576,8 @@ const powerRef = useRef(hud.power);
       <div
         className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
-          top: topControlsOffset,
-          left: 'calc(0.75rem + env(safe-area-inset-left, 0px))'
+          top: `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
+          left: `calc(0.75rem + env(safe-area-inset-left, 0px) + ${menuButtonLeftNudgePx}px)`
         }}
       >
         <button
@@ -32555,9 +32561,10 @@ const powerRef = useRef(hud.power);
 
         <div
           ref={leftControlsRef}
-          className={`pointer-events-none absolute right-0 z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+          className={`pointer-events-none absolute z-50 flex flex-col gap-2.5 ${replayActive ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          bottom: `${sideControlsBottomPx + rightControlsLiftPx}px`,
+          right: `${rightHudShiftPx}px`,
+          bottom: `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx}px`,
           transform: `scale(${uiScale * 1.08})`,
           transformOrigin: 'bottom right'
         }}
@@ -32598,8 +32605,8 @@ const powerRef = useRef(hud.power);
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
             className="fixed left-0 z-50 flex flex-col gap-2.5 -translate-x-1"
-            style={{ bottom: `${sideControlsBottomPx + rightControlsLiftPx}px` }}
-            buttonClassName="pointer-events-auto flex h-14 w-14 flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-black/60 shadow-[0_8px_18px_rgba(0,0,0,0.35)] backdrop-blur"
+            style={{ bottom: `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx}px` }}
+            buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border-none bg-transparent p-0 text-white shadow-none"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
             chatIcon="💬"
@@ -32618,10 +32625,10 @@ const powerRef = useRef(hud.power);
           className={`absolute flex ${bottomHudLayoutClass} pointer-events-none z-50 transition-opacity duration-200 ${pocketCameraActive || replayActive ? 'opacity-0' : 'opacity-100'}`}
           aria-hidden={pocketCameraActive || replayActive}
           style={{
-            bottom: `${18 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx + hudExtraClearancePx}px`,
+            bottom: `${18 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx + hudExtraClearancePx - bottomHudDownPx}px`,
             left: hudInsets.left,
             right: hudInsets.right,
-            transform: isPortrait ? `translateX(${bottomHudOffset}px)` : undefined
+            transform: isPortrait ? `translateX(${bottomHudOffset + bottomHudLeftPx}px)` : undefined
           }}
         >
             <div
@@ -32986,8 +32993,9 @@ const powerRef = useRef(hud.power);
       {showSpinController && !replayActive && (
         <div
           ref={spinBoxRef}
-          className={`absolute right-1 ${showPlayerControls ? '' : 'pointer-events-none'}`}
+          className={`absolute ${showPlayerControls ? '' : 'pointer-events-none'}`}
           style={{
+            right: `${rightHudShiftPx}px`,
             bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx}px`,
             transform: `scale(${uiScale * 0.88})`,
             transformOrigin: 'bottom right'


### PR DESCRIPTION
### Motivation
- Fine-tune Pool Royale HUD alignment for portrait phones so menu, chat/gift, spin controller and bottom player frame better match the visual layout used by Goal Rush. 
- Make quick-action frames (chat/gift) use the same compact/transparent style and positioning as Goal Rush for consistent UX across games.

### Description
- Introduced small UI tuning constants (`menuButtonTopNudgePx`, `menuButtonLeftNudgePx`, `sideActionButtonsLiftPx`, `rightHudShiftPx`, `bottomHudDownPx`, `bottomHudLeftPx`) to allow independent nudges for menu, side actions, right HUD and bottom HUD in `PoolRoyale.jsx`.
- Moved the settings/menu container slightly down and left by applying the new nudge offsets to its `style` block.
- Shifted the right-side control cluster (spin controller / view buttons) left and up by adjusting `right`/`bottom` positioning and scale origin.
- Updated chat/gift quick-action buttons to a transparent, compact frame (`buttonClassName` adjusted) so the chat/gift frames match the Goal Rush quick-action style.
- Nudged the bottom player HUD (avatars, names, points/balls row) down and slightly left with the new bottom offsets to improve spacing relative to other HUD elements.
- All changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and parameterized so values are easy to iterate.

### Testing
- Built the web client with `npm run build` from `webapp/` and the production build completed successfully (no runtime compile errors).
- Attempted automated visual verification with Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot run timed out in this environment; the build step completed, so the changes compile into the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00100a35083299a9d12ee0705054e)