### PR TITLE
Normalize mobile browser rendering to match Telegram WebView

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -12,11 +12,16 @@ html,
 body {
   overscroll-behavior: none;
   height: 100%;
+  width: 100%;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   @apply text-text overflow-x-hidden font-thin;
   background: radial-gradient(
       1200px 800px at 70% -10%,
@@ -134,7 +139,19 @@ h6 {
 }
 
 button {
+  appearance: none;
+  -webkit-appearance: none;
+  font: inherit;
+  line-height: 1;
+  border: none;
   @apply px-2 py-1 bg-primary hover:bg-primary-hover text-white text-outline-black text-sm rounded;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .icon-only-button {


### PR DESCRIPTION
### Motivation
- Mobile browsers render fonts, buttons and images slightly differently than Telegram's WebView which causes icon/button layout and sizing inconsistencies on portrait phones, so normalize global rendering to match Telegram behavior.

### Description
- Updated `webapp/src/index.css` to enforce stable mobile scaling and sizing by setting `width: 100%` and `-webkit-text-size-adjust: 100%` / `text-size-adjust: 100%` on `html, body`.
- Added font smoothing (`-webkit-font-smoothing`, `-moz-osx-font-smoothing`) to `body` to reduce glyph/icon rendering differences across engines.
- Normalized button defaults by removing native appearance and forcing inherited typography with `appearance: none`, `-webkit-appearance: none`, `font: inherit`, `line-height: 1`, and `border: none` so icon-only and labeled buttons render consistently.
- Normalized media layout by making `img` and `svg` `display: block` with responsive sizing (`max-width: 100%`, `height: auto`) to avoid inline sizing quirks.

### Testing
- Ran `npm --prefix webapp run build` and the Vite build completed successfully (warnings only, no errors).
- Ran the dev server and captured a mobile viewport screenshot via Playwright for visual verification which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a002c836b4832996af74a5aa5e7bf5)