### PR TITLE
Separate Telegram and mobile fullscreen padding to align in-game icons

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -37,13 +37,17 @@ body {
   min-height: 100%;
 }
 
-body.telegram-fullscreen,
-body.mobile-fullscreen {
+body.telegram-fullscreen {
   min-height: var(--tg-viewport-stable-height, var(--app-viewport-stable-height, var(--app-viewport-height, 100dvh)));
   padding-top: max(env(safe-area-inset-top), var(--app-viewport-offset-top, 0px));
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+}
+
+body.mobile-fullscreen {
+  min-height: var(--tg-viewport-stable-height, var(--app-viewport-stable-height, var(--app-viewport-height, 100dvh)));
+  padding: 0;
 }
 
 body.telegram-fullscreen #root,


### PR DESCRIPTION
### Motivation
- Mobile browsers were applying a shared fullscreen body padding that shifted fixed in-game icons inward compared to the Telegram WebApp fullscreen, causing inconsistent icon placement across mobile browsers.

### Description
- Updated `webapp/src/index.css` to stop using a combined `body.telegram-fullscreen, body.mobile-fullscreen` rule and introduced a distinct `body.mobile-fullscreen` rule.
- Kept Telegram-specific fullscreen behavior (safe-area and viewport offset paddings) while making non-Telegram mobile fullscreen use `padding: 0` so fixed UI elements match Telegram layout.
- Ensured `#root` fullscreen min-height behavior remains unchanged so only padding/offset behavior was adjusted.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully (Vite built the app; only chunk-size warnings were reported). 
- Started the dev server with `npm --prefix webapp run dev` and used an automated Playwright script to load a mobile viewport and capture a screenshot to verify quick-action / fixed icon positions, which produced the verification artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a006cff94c8329982154d606e9b14e)