### PR TITLE
Adjust Pool Royale HUD alignment and menu icon sizing on mobile

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13477,15 +13477,16 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const sharedHudLiftPx = 30;
-  const spinControllerLiftPx = 14;
+  const spinControllerLiftPx = 20;
   const hudExtraClearancePx = 8;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = 8;
   const menuButtonLeftNudgePx = -4;
   const sideActionButtonsLiftPx = 10;
-  const rightHudShiftPx = 8;
+  const sideActionButtonsDropPx = 6;
+  const rightHudShiftPx = 12;
   const bottomHudDownPx = 7;
-  const bottomHudLeftPx = -8;
+  const bottomHudLeftPx = -14;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -31595,7 +31596,7 @@ const powerRef = useRef(hud.power);
           }`}
           aria-label={configOpen ? 'Close game settings menu' : 'Open game settings menu'}
         >
-          <span className="text-base leading-none" aria-hidden="true">☰</span>
+          <span className="text-lg leading-none" aria-hidden="true">☰</span>
           <span className="leading-none">Menu</span>
         </button>
         {configOpen && (
@@ -32605,7 +32606,7 @@ const powerRef = useRef(hud.power);
             onChat={() => setShowChat(true)}
             onGift={() => setShowGift(true)}
             className="fixed left-0 z-50 flex flex-col gap-2.5 -translate-x-1"
-            style={{ bottom: `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx}px` }}
+            style={{ bottom: `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx - sideActionButtonsDropPx}px` }}
             buttonClassName="pointer-events-auto flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border-none bg-transparent p-0 text-white shadow-none"
             iconClassName="text-[1.1rem] leading-none"
             labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the Pool Royale HUD on portrait mobile: move the spin controller slightly up and inward, separate the bottom player frame a bit from the spin control, align left chat/gift stack better with the right-side watch/2D controls, and make the menu icon slightly larger for visibility.

### Description
- Tweaked HUD layout constants in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing `spinControllerLiftPx` and adjusting `rightHudShiftPx` and `bottomHudLeftPx` to shift the spin controller and bottom HUD framing.
- Added `sideActionButtonsDropPx` and subtracted it from the `BottomLeftIcons` `style.bottom` calculation so the left chat/gift icon stack sits slightly lower relative to the right-side controls.
- Increased the menu icon size by changing the menu button span class from `text-base` to `text-lg` for better visibility on small screens.
- All edits are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect HUD positioning and icon sizing.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which produced no lint errors for the change path (the file is ignored by the current lint config, so only a warning was raised). — succeeded (warning only).
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to validate the app builds and serves, and the dev server came up successfully. — succeeded.
- Attempted a headless UI validation via Playwright to capture a screenshot of `/games/poolroyale`, but the screenshot tooling timed out in the execution environment. — timed out (no screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0079e1c7c8329b6f8ac3595a562a1)