### PR TITLE
Adjust Texas Hold'em mobile table layout alignment

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -366,7 +366,7 @@ const HUMAN_CARD_SPREAD = HOLE_SPACING * 1.32;
 const HUMAN_CARD_FORWARD_OFFSET = CARD_W * 0.04;
 const HUMAN_CARD_VERTICAL_OFFSET = CARD_H * 0.52;
 const HUMAN_CARD_LOOK_LIFT = CARD_H * 0.24;
-const HUMAN_CARD_LOOK_SPLAY = HOLE_SPACING * 0.45;
+const HUMAN_CARD_LOOK_SPLAY = 0;
 const CARD_FORWARD_OFFSET = HUMAN_CARD_FORWARD_OFFSET;
 const CARD_VERTICAL_OFFSET = HUMAN_CARD_VERTICAL_OFFSET;
 const CARD_LOOK_LIFT = HUMAN_CARD_LOOK_LIFT;
@@ -395,14 +395,14 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.28;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * -0.18;
-const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.55;
-const HUMAN_CHIP_LATERAL_SHIFT = 0;
+const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.68;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * -0.12;
 const HUMAN_CARD_CHIP_BLEND = 0;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
-const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.14;
+const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.18;
 const CHIP_BUTTON_GRID_RIGHT_SHIFT = 0;
 const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 1.15;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
@@ -4213,16 +4213,6 @@ function TexasHoldemArena({ search }) {
         const seat = aiSeats[index];
         if (!seat) return;
         seat.player = opponent;
-        seat.tableLayout = {
-          ...seat.tableLayout,
-          forward: seat.forward.clone().negate(),
-          right: seat.right.clone().negate()
-        };
-        seat.railLayout = {
-          ...seat.railLayout,
-          forward: seat.forward.clone().negate(),
-          right: seat.right.clone().negate()
-        };
       });
 
       const nameplates = seatGroups.map((seat) => seat.nameplate);
@@ -4822,8 +4812,8 @@ function TexasHoldemArena({ search }) {
           .addScaledVector(forward, 2.4 * MODEL_SCALE)
           .add(right.clone().multiplyScalar((cardIdx - 0.5) * HUMAN_CARD_LOOK_SPLAY))
           .add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0));
-        const face = overheadView || seat.isHuman || state.showdown ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: true });
+        const face = 'front';
+        orientCard(mesh, lookTarget, { face, flat: false });
         setCardFace(mesh, face);
         mesh.rotation.x = 0;
         const key = cardKey(card);
@@ -5761,7 +5751,7 @@ function TexasHoldemArena({ search }) {
           showInfo={false}
           showGift={false}
           showMute={false}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.45rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
@@ -5773,7 +5763,7 @@ function TexasHoldemArena({ search }) {
           showChat={false}
           showMute={false}
           order={['gift']}
-          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.45rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation

- Make the portrait/mobile table UI feel tighter and more consistent by nudging the chat and gift action icons upward to avoid overlapping the safe-area and nearby controls.
- Improve the bottom (human) player's visual layout by shifting its cards slightly left, lowering them a bit, and moving the chip pile outward so the hand is clearer on small portrait screens.
- Ensure all opponents use the same card/chip orientation and layout as the bottom player so cards stand straight and chips share the same 3x layout baseline.

### Description

- Tuned layout constants in `webapp/src/pages/Games/TexasHoldemArena.jsx`: set `HUMAN_CARD_LOOK_SPLAY = 0`, increased `HUMAN_CARD_LATERAL_SHIFT` from `CARD_W * 0.55` to `CARD_W * 0.68`, set `HUMAN_CHIP_LATERAL_SHIFT` to `CARD_W * -0.12`, and increased `HUMAN_CARD_LOWER_OFFSET` from `CARD_H * 0.14` to `CARD_H * 0.18` to shift/lower the bottom player cards and pull chips away a bit.
- Unified per-seat card/chip presentation by removing the AI-seat mirroring that previously negated `forward`/`right` for non-human seats so opponents share the same baseline layout as the human seat.
- Forced cards to render facing the player consistently by setting the card face to `'front'` and calling `orientCard(..., { face: 'front', flat: false })` for all seats so hole cards stand straight toward each player.
- Moved the floating quick-action icon positions upward by updating the `BottomLeftIcons` container classes (`bottom` safe-area offset from `+5.1rem` to `+5.45rem`) for both chat and gift slots.

### Testing

- Ran `npx eslint --no-ignore --no-warn-ignored webapp/src/pages/Games/TexasHoldemArena.jsx` which completed without error for the modified file.
- Launched the dev server using `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to verify changes in-browser and the server started successfully.
- Captured a mobile-viewport screenshot of `/games/texasholdem?mode=local` with a Playwright script for visual verification; screenshot artifact was produced at `browser:/tmp/codex_browser_invocations/e333e429f375682a/artifacts/artifacts/texas-holdem-layout-mobile.png` and was used to confirm the adjusted layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00a708d688329bb89ed7587406c25)