### PR TITLE
Adjust Pool Royale 2D top-view framing to match replay and broadcast

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5285,33 +5285,33 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.05; // lift the top view slightly higher
+const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.03; // lower the 2D camera just a touch so the table appears slightly bigger
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.05; // lift the 2D top view slightly higher to keep the framing airy
+const TOP_VIEW_RADIUS_SCALE = 1.03; // lower the 2D top view a bit so the table reads larger
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
-  z: PLAY_H * -0.078 // keep the existing vertical alignment
+  z: PLAY_H * -0.048 // nudge the table lower on portrait screens
 });
-const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // match Snooker Royal rail overhead coordinates
-const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = 1.06; // match Snooker Royal rail overhead coordinates
+const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
+const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const REPLAY_TOP_VIEW_PHI = TOP_VIEW_PHI;
 const REPLAY_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE;
 const REPLAY_TOP_VIEW_RESOLVED_PHI = TOP_VIEW_RESOLVED_PHI;
 const REPLAY_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
-const BROADCAST_TOP_VIEW_MARGIN = 1.14;
-const BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const BROADCAST_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
+const BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const BROADCAST_TOP_VIEW_PHI = 0;
-const BROADCAST_TOP_VIEW_RADIUS_SCALE = 1.06;
+const BROADCAST_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE;
 const BROADCAST_TOP_VIEW_RESOLVED_PHI = BROADCAST_TOP_VIEW_PHI;
 const BROADCAST_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
-const BROADCAST_SNOOKER_TOP_VIEW_MARGIN = 1.14;
-const BROADCAST_SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE = 1.06;
+const BROADCAST_SNOOKER_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
+const BROADCAST_SNOOKER_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const BROADCAST_SNOOKER_TOP_VIEW_PHI = 0;
-const BROADCAST_SNOOKER_TOP_VIEW_RADIUS_SCALE = 1.06;
+const BROADCAST_SNOOKER_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE;
 const BROADCAST_SNOOKER_TOP_VIEW_RESOLVED_PHI = BROADCAST_SNOOKER_TOP_VIEW_PHI;
 const BROADCAST_SNOOKER_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
 const BROADCAST_TOP_VIEW_VARIANTS = Object.freeze({
@@ -5349,7 +5349,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
     (halfLength / Math.tan(halfVertical)) * RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
+const RAIL_OVERHEAD_DISTANCE_BIAS = 1; // keep overhead rail/broadcast framing identical to 2D view
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale


### PR DESCRIPTION
### Motivation
- Make the Pool Royale 2D top (portrait) camera show the table slightly lower on the screen and slightly larger for better visual balance on phones. 
- Ensure replay and broadcast/top-overhead cuts use the exact same 2D framing so the table appears in the same place when switching between the 2D button, replay, and broadcast.

### Description
- Tuned 2D top-view constants in `webapp/src/pages/Games/PoolRoyale.jsx` by lowering `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` to `1.03` so the camera reads closer/zoomed-in. 
- Nudged the 2D focus down on portrait by updating `TOP_VIEW_SCREEN_OFFSET.z` from `PLAY_H * -0.078` to `PLAY_H * -0.048` so the table sits a bit lower on the screen. 
- Unified replay, broadcast, rail-overhead and snooker 2D/broadcast scales and margins to reference the same `TOP_VIEW_*` constants so replay/broadcast framing matches the 2D view. 
- Removed the small broadcast bias by setting `RAIL_OVERHEAD_DISTANCE_BIAS` to `1` (was `1.05`) so the overhead broadcast distance aligns with the 2D top-view distance.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed with the repository ignore warning and produced no lint errors. 
- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to validate the app builds and serves the modified page. 
- Attempted to capture a visual verification screenshot via Playwright against the running dev server, but the screenshot run timed out in this environment so no image artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a029fcda608329ad03d091a72c5fe7)