### PR TITLE
Adjust Texas Hold'em card visuals and bottom chip spacing

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -394,7 +394,7 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.28;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.04;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.2;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.52;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.22;
 const AI_CARD_INWARD_SHIFT = CARD_W * -2.02;
@@ -4188,6 +4188,7 @@ function TexasHoldemArena({ search }) {
                 face: seat.isHuman ? 'front' : 'back',
                 flat: false
               });
+              mesh.rotateX(HUMAN_CARD_FACE_TILT);
               setCardFace(mesh, seat.isHuman ? 'front' : 'back');
               mesh.visible = true;
             } else {
@@ -4316,6 +4317,7 @@ function TexasHoldemArena({ search }) {
               .add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
             lookTarget.y = position.y;
             orientCard(mesh, lookTarget, { face: 'front', flat: false });
+            mesh.rotateX(HUMAN_CARD_FACE_TILT);
             setCardFace(mesh, 'front');
           });
         };
@@ -4822,8 +4824,8 @@ function TexasHoldemArena({ search }) {
           .add(new THREE.Vector3(0, 0, 0));
         const face = 'front';
         orientCard(mesh, lookTarget, { face, flat: false });
+        mesh.rotateX(HUMAN_CARD_FACE_TILT);
         setCardFace(mesh, face);
-        mesh.rotation.x = 0;
         const key = cardKey(card);
         setCardHighlight(mesh, state.showdown && winningCardSet.has(key));
       });


### PR DESCRIPTION
### Motivation

- Improve visual separation between the human player's chips and their hole cards so chips don't sit too close to the cards. 
- Make player card visuals consistent by ensuring the human card face tilt is applied wherever human cards are oriented so they match the bottom player's appearance.

### Description

- Increased the human chip rail inward offset by changing `HUMAN_CHIP_INWARD_SHIFT` from `CARD_W * 0.04` to `CARD_W * 0.2` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to pull the bottom player's chips slightly farther from the cards. 
- Applied `HUMAN_CARD_FACE_TILT` rotation to human card meshes in three places (`initial render`, `orientHumanCards` helper, and `live state updates`) so human player cards use the same face tilt while keeping their positions unchanged. 
- The only modified file is `webapp/src/pages/Games/TexasHoldemArena.jsx` and the changes are limited to card orientation and chip layout constants.

### Testing

- Ran unit tests with `npm test -- --runInBand test/texasHoldemGame.test.js`, and the suite passed (2 tests, 2 passed). 
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the Texas Hold'em page loaded successfully for visual inspection. 
- Captured a portrait screenshot of the updated Texas Hold'em page via a Playwright script to validate the layout change (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02a77cdd08329a04c164c613498e8)