### PR TITLE
Fix Domino Royal black screen by forcing clean re-bootstrap

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -8,8 +8,13 @@ const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
 export default function DominoRoyalArena() {
   useEffect(() => {
     const statusNode = document.getElementById('status');
+    const appRoot = document.getElementById('app');
     if (statusNode) {
       statusNode.textContent = 'Loading Domino Royal…';
+    }
+
+    if (appRoot) {
+      appRoot.replaceChildren();
     }
 
     const existingStyle = document.getElementById(INLINE_STYLE_ID);
@@ -22,10 +27,7 @@ export default function DominoRoyalArena() {
 
     const existingScript = document.querySelector(GAME_SCRIPT_SELECTOR);
     if (existingScript) {
-      if (statusNode) {
-        statusNode.textContent = 'Ready';
-      }
-      return undefined;
+      existingScript.remove();
     }
 
     const basePath = import.meta.env.BASE_URL || '/';
@@ -48,6 +50,9 @@ export default function DominoRoyalArena() {
 
     return () => {
       script.remove();
+      if (appRoot) {
+        appRoot.replaceChildren();
+      }
     };
   }, []);
 


### PR DESCRIPTION
### Motivation
- Prevent the Domino Battle Royal page from showing a black/blank screen caused by stale renderer state when remounting the arena. 
- Ensure the game module bootstrap always runs against a clean DOM root so the Three.js renderer and assets initialize reliably.

### Description
- Clear the rendering root element `#app` before bootstrapping the game to remove stale canvas/children. (`webapp/src/pages/Games/DominoRoyalArena.jsx`)
- Remove any pre-existing Domino module script (`script[data-domino-royal-script=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04d389e7c8329b20fe52e75942835)