### PR TITLE
Adjust Goal Rush vertical layout for portrait screens

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,8 +33,8 @@
 
     .canvasWrap{
       position:absolute;
-      top:40px;
-      bottom:-24px;
+      top:58px;
+      bottom:-6px;
       left:0;
       right:0;
       display:flex;
@@ -516,7 +516,9 @@
     rink.w = Math.round(baseW * fsx);
     rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
-    const verticalShift = Math.round(H * 0.008);
+    // Keep the overall game area visually a little lower on screen,
+    // while lifting the field itself slightly upward within the canvas.
+    const verticalShift = Math.round(H * -0.006);
     rink.y = Math.round((H - rink.h) / 2 + verticalShift);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;


### PR DESCRIPTION
### Motivation
- Improve visual balance on phones in portrait: the overall play area should sit lower on the screen while the green field (rink + goals) appears slightly higher inside the canvas to keep goals visible and give more top breathing room.

### Description
- Increased the `.canvasWrap` top offset from `40px` to `58px` and reduced the bottom inset from `-24px` to `-6px` to move the full game block downward on portrait viewports.
- Changed the rink vertical offset computation in `fit()` by setting `verticalShift` to `Math.round(H * -0.006)` and added an inline comment to clarify intent, which nudges the green field upward inside the canvas.
- All edits are in `webapp/public/goal-rush.html` and are limited to layout/CSS and the `fit()` positioning logic.

### Testing
- Launched a local static server with `python3 -m http.server 4173 --bind 0.0.0.0` and verified the page loads successfully, which succeeded.
- Ran a Playwright script that opened `http://127.0.0.1:4173/goal-rush.html` in a portrait viewport (`width: 430, height: 932`) and captured `artifacts/goal-rush-layout-adjusted.png` to visually confirm the layout change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04e5af92483298c99b64ceb9643c8)