### PR TITLE
Adjust Texas Hold'em seat card and chip spacing

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -394,10 +394,10 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.28;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.34;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.56;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.52;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.22;
-const AI_CARD_INWARD_SHIFT = CARD_W * -2.16;
+const AI_CARD_INWARD_SHIFT = CARD_W * -2.54;
 const AI_CHIP_INWARD_SHIFT = CARD_W * -0.1;
 const AI_CARD_LATERAL_SHIFT = CARD_W * 0.48;
 const AI_CHIP_LATERAL_SHIFT = CARD_W * -0.22;
@@ -4956,7 +4956,7 @@ function TexasHoldemArena({ search }) {
           ? seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
           : position.clone().add(seat.forward.clone());
         const face = seat.isHuman || state.showdown ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: !seat.isHuman });
+        orientCard(mesh, lookTarget, { face, flat: false });
         if (seat.isHuman) {
           mesh.rotateX(HUMAN_CARD_FACE_TILT);
         }


### PR DESCRIPTION
### Motivation

- Move opponents' hole cards visually more toward the table cloth (away from wooden rails) to improve visual alignment and readability. 
- Keep the bottom (human) player hole cards unchanged in position and appearance while matching standing orientation across seats. 
- Provide a bit more separation between the bottom player's chips and their cards for clearer visual spacing.

### Description

- Increased the bottom player's chip inward offset by changing `HUMAN_CHIP_INWARD_SHIFT` from `CARD_W * 0.34` to `CARD_W * 0.56` in `webapp/src/pages/Games/TexasHoldemArena.jsx`. 
- Moved non-human seat hole cards inward by changing `AI_CARD_INWARD_SHIFT` from `CARD_W * -2.16` to `CARD_W * -2.54` in the same file. 
- Forced hole card orientation to remain standing for non-human seats by setting `orientCard(..., { face, flat: false })` when computing per-seat card poses so non-human cards stand like the bottom player's cards.

### Testing

- Ran `npm run build` in `webapp/` and the Vite build completed successfully (with existing chunk-size warnings). 
- Started the dev server and exercised the Texas Hold'em pages via an automated Playwright script which captured screenshots of the updated lobby and arena, and the script completed successfully. 
- Verified the modified file `webapp/src/pages/Games/TexasHoldemArena.jsx` builds and loads without runtime errors in the dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a089e1749883298dc80ff3f4a869e3)