### PR TITLE
Adjust Texas Hold'em card lift behavior and bottom-seat offsets

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -394,9 +394,9 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.28;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.56;
-const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.52;
-const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.22;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.74;
+const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.6;
+const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.3;
 const AI_CARD_INWARD_SHIFT = CARD_W * -2.54;
 const AI_CHIP_INWARD_SHIFT = CARD_W * -0.1;
 const AI_CARD_LATERAL_SHIFT = CARD_W * 0.48;
@@ -407,6 +407,8 @@ const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
 const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.18;
+const AI_CARD_IDLE_LIFT = CARD_D * 0.8;
+const AI_CARD_TURN_LIFT = CARD_H * 0.48;
 const COMMUNITY_REVEAL_CAMERA_HOLD_MS = 900;
 const FOLD_PILE_CARD_GAP = CARD_D * 0.9;
 const FOLD_PILE_LATERAL_STEP = CARD_W * 0.1;
@@ -4949,14 +4951,18 @@ function TexasHoldemArena({ search }) {
           position.y = winnerDisplayCenter.y + SHOWDOWN_WINNER_CARD_Y_OFFSET;
         } else {
           const clothY = (three.tableInfo?.surfaceY ?? TABLE_HEIGHT) + CARD_D * 0.4;
-          position.y = seat.isHuman ? clothY : clothY + CARD_H * 0.48;
+          const isActiveSeat = idx === state.actionIndex && !player.folded && !player.allIn;
+          position.y = seat.isHuman ? clothY : clothY + (isActiveSeat ? AI_CARD_TURN_LIFT : AI_CARD_IDLE_LIFT);
         }
         mesh.position.copy(position);
+        const aiActiveTurn = !seat.isHuman && idx === state.actionIndex && !player.folded && !player.allIn;
         const lookTarget = seat.isHuman
           ? seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
-          : position.clone().add(seat.forward.clone());
+          : aiActiveTurn
+            ? position.clone().add(seat.forward.clone())
+            : position.clone().add(new THREE.Vector3(0, COMMUNITY_CARD_LOOK_LIFT, 0));
         const face = seat.isHuman || state.showdown ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: false });
+        orientCard(mesh, lookTarget, { face, flat: !seat.isHuman && !aiActiveTurn });
         if (seat.isHuman) {
           mesh.rotateX(HUMAN_CARD_FACE_TILT);
         }


### PR DESCRIPTION
### Motivation
- Improve visual clarity: keep opponents' hole cards laid down except when it is their active turn so viewers see which player is acting and cards otherwise remain laid.
- Make the bottom (human) seat layout clearer by nudging their cards and chips slightly left and increasing the chips' separation from the cards.

### Description
- Modified bottom-player offsets by increasing `HUMAN_CHIP_INWARD_SHIFT`, `HUMAN_CARD_LATERAL_SHIFT`, and `HUMAN_CHIP_LATERAL_SHIFT` to nudge the human seat cards/chips left and increase separation. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Added `AI_CARD_IDLE_LIFT` and `AI_CARD_TURN_LIFT` constants to control non-human card height when idle vs during their turn. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Changed card placement and orientation logic so that non-human cards are laid flat/low by default (`flat: true` behavior and lower `y`), and only lift/face forward while that non-human seat is the active action index; human bottom-seat card behavior is preserved. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Updated AI look target selection so inactive AI cards look like laid community/back-facing cards and active AI cards orient towards seat forward vector for the “player is acting” effect. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx`, which reported the file is ignored by repo lint patterns (no errors introduced by the change in this environment).
- Attempted full repo build with `npm run build` at repo root and it failed due to a pre-existing, unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts`, so a full type-checked build of the entire monorepo could not be completed.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully (site served locally), indicating the modified frontend file loads in dev mode.
- Tried an automated screenshot via Playwright to validate visuals, but the headless Chromium process crashed (SIGSEGV) in the environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08f29f9b08329bceb3017be27412f)