### PR TITLE
Adjust Goal Rush vertical layout and expand playfield

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,8 +33,8 @@
 
     .canvasWrap{
       position:absolute;
-      top:58px;
-      bottom:-6px;
+      top:66px;
+      bottom:-14px;
       left:0;
       right:0;
       display:flex;
@@ -507,7 +507,7 @@
     canvas.style.height = height + 'px';
     // expand field by reducing canvas margins ~5% on each side
     const baseW = W * 0.98;
-    const baseH = H * 0.996;
+    const baseH = H;
     const maxFieldScaleX = W/baseW;
     const maxFieldScaleY = H/baseH;
     const fsx = Math.min(fieldScaleX, maxFieldScaleX);
@@ -516,9 +516,8 @@
     rink.w = Math.round(baseW * fsx);
     rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
-    // Keep the overall game area visually a little lower on screen,
-    // while lifting the field itself slightly upward within the canvas.
-    const verticalShift = Math.round(H * -0.006);
+    // Keep the overall game area visually a little lower on screen.
+    const verticalShift = Math.round(H * -0.002);
     rink.y = Math.round((H - rink.h) / 2 + verticalShift);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;


### PR DESCRIPTION
### Motivation
- Make the Goal Rush play area sit slightly lower on portrait screens so the game appears closer to the bottom of the device, matching the mobile-oriented layout guidance.
- Let the green field (goals and play area) extend a bit more toward the top and bottom of the canvas so goals and field feel less cramped.

### Description
- Updated `webapp/public/goal-rush.html` to shift the canvas wrapper down by changing `.canvasWrap` CSS `top` from `58px` to `66px` and `bottom` from `-6px` to `-14px`.
- Increased the in-canvas field height by using `const baseH = H` instead of `H * 0.996` so the rink/goal area expands vertically inside the canvas.
- Reduced the upward offset used to balance the expanded field by changing the vertical shift factor from `-0.006` to `-0.002` so the field remains visually balanced while still appearing slightly lower overall.

### Testing
- Launched a local static server (`python3 -m http.server`) serving `webapp/public` and confirmed the page loads without errors.
- Ran a Playwright script with a portrait viewport (`390x844`) to load `/goal-rush.html` and captured a screenshot artifact showing the updated layout, which visually verifies the requested adjustments.
- Verified that game assets requested by the page were served during the test and no layout errors occurred (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0911441f08329b70dcb89a280aace)