### PR TITLE
Improve cue stick push visibility and replay stroke playback in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1839,6 +1839,8 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
+const CUE_IMPACT_PUSH_MIN = BALL_R * 0.95; // make the forward strike phase visibly pass the idle/contact point even on low power
+const CUE_IMPACT_PUSH_MAX = BALL_R * 2.1; // keep high-power strike extension readable before follow-through begins
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 2.7; // strengthen minimum forward push so cue-stroke follow-through is always visible
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 6.8; // extend forward travel so high-power shots show a clear cue push animation
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
@@ -21132,7 +21134,7 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           };
-          if (hasCueSnapshots) {
+          if (!stroke && hasCueSnapshots) {
             applyCueSnapshot();
             return;
           }
@@ -24958,8 +24960,13 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_THROUGH_MAX,
             powerStrength
           );
-          const impactPos = idlePos.clone();
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
+          const impactAdvance = THREE.MathUtils.lerp(
+            CUE_IMPACT_PUSH_MIN,
+            CUE_IMPACT_PUSH_MAX,
+            powerStrength
+          );
+          const impactPos = buildCuePosition(-impactAdvance);
+          const followDistance = impactAdvance + followThrough;
           const followPos = buildCuePosition(-followDistance);
           const followSpeed = THREE.MathUtils.lerp(
             CUE_FOLLOW_SPEED_MIN,


### PR DESCRIPTION
### Motivation
- Make cue-stroke animation clearly show both the backward pull and a visible forward push so shots (player and AI) read correctly on-screen and in replays. 
- Ensure replay playback starts with the same cue animation that produced the shot (recorded stroke takes precedence over sparse snapshots). 

### Description
- Added two new constants `CUE_IMPACT_PUSH_MIN` and `CUE_IMPACT_PUSH_MAX` to control visible forward strike travel range. 
- Compute an `impactAdvance` from `powerStrength` and use `impactPos = buildCuePosition(-impactAdvance)` so the cue moves forward past the idle/contact point before follow-through. 
- Extend follow-through distance to start from the new impact position (`followDistance = impactAdvance + followThrough`) so forward motion is visually readable at all power levels. 
- Adjusted replay application logic so procedural `cueStroke` playback is used when available and cue snapshots are used as a fallback (changed snapshot vs stroke precedence). 
- All changes are in `webapp/src/pages/Games/PoolRoyale.jsx` and keep the single source-of-truth mapping of power → pull → impulse. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which executed successfully but the file is ignored by the repo eslint config (warning reported). 
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`, which launched Vite and served the app (server ready). 
- Attempted an automated screenshot with Playwright to validate visual changes, but the headless browser crashed in this environment (Playwright run failed with a browser SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1276833688329a331c9b3c5a0353e)