### PR TITLE
Tune Murlan Royale camera height/distance and community card presentation

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1931,14 +1931,15 @@ const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INW
 const CHAIR_SEAT_INWARD_FACTOR = 0.92;
 const CHAIR_VISUAL_SCALE = 1.12 * 1.15;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.14, landscape: 0.72 });
-const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.22, landscape: 0.86 });
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.02, landscape: 0.72 });
+const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.12, landscape: 0.86 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.15;
-const COMMUNITY_CARD_TOP_TILT = 0;
+const COMMUNITY_CARD_TOP_TILT = 0.08;
 const COMMUNITY_CARD_SCALE = HUMAN_HAND_CARD_SCALE;
-const COMMUNITY_CARD_SPACING_MULTIPLIER = 0.88;
+const COMMUNITY_CARD_SPACING_MULTIPLIER = 1;
+const COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET = Math.sin(COMMUNITY_CARD_TOP_TILT) * CARD_H * 0.5;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -3197,7 +3198,7 @@ export default function MurlanRoyaleArena({ search }) {
       setCommunityCardLegibility(mesh, true);
       const target = tableAnchor.clone();
       target.x += tableStartX + idx * tableSpacing;
-      target.y += 0.075 * MODEL_SCALE;
+      target.y += 0.075 * MODEL_SCALE + COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET;
       setMeshPosition(
         mesh,
         target,


### PR DESCRIPTION
### Motivation
- Improve portrait framing by lowering and pulling the seated camera slightly closer to the table for a more intimate view.
- Make the on-table community cards visually match the bottom-hand layout and card styling so players see the same card types and arrangement.
- Lift the top edge of community cards a bit while keeping the card bottoms visually anchored to the table.

### Description
- Adjusted seated camera parameters by reducing `CAMERA_SEATED_RETREAT_OFFSETS.portrait` and `CAMERA_SEATED_ELEVATION_OFFSETS.portrait` to pull the camera in and lower it for portrait mode in `MurlanRoyaleArena.jsx`.
- Enabled a small top-edge tilt by setting `COMMUNITY_CARD_TOP_TILT = 0.08` and made community spread match the bottom hand by changing `COMMUNITY_CARD_SPACING_MULTIPLIER = 1`.
- Added `COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET` (computed from tilt and `CARD_H`) and applied it to table card placement (`target.y`) so the card bottoms remain anchored while the top is visually lifted.
- Single-file change: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (constants and table-card placement adjustments).

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production bundles.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which started successfully for visual verification.
- Captured a portrait screenshot of `/games/murlanroyale` via an automated Playwright script to validate camera and card presentation, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13dd363e08329aec97246611b5bf7)