### PR TITLE
Improve card peek animation by changing pivot and lift calculation

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -426,7 +426,8 @@ const CAMERA_TURN_DURATION_MS = 240;
 const CARD_PEEK_ANIMATION_MS = 2000;
 const CARD_PEEK_LIFT = 0;
 const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
-const CARD_PEEK_HALF_STAND_ANGLE = THREE.MathUtils.degToRad(34);
+const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
+const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
 
 const CHAIR_MODEL_URLS = [
@@ -3436,17 +3437,18 @@ function TexasHoldemArena({ search }) {
       }
       cards.forEach((mesh, cardIdx) => {
         const outwardSign = cardIdx === 0 ? -1 : 1;
-        const standAngle = CARD_PEEK_HALF_STAND_ANGLE * phase;
-        const edgePivotOffset = CARD_W * 0.5;
-        const upLift = Math.sin(standAngle) * edgePivotOffset;
-        const inwardCompensation = (1 - Math.cos(standAngle)) * edgePivotOffset;
-        const offset = seat.right
-          .clone()
-          .multiplyScalar(outwardSign * (inwardCompensation + CARD_PEEK_OUTER_SWAY * phase))
-          .add(new THREE.Vector3(0, CARD_PEEK_LIFT * phase + upLift, 0));
+        const standAngle = CARD_PEEK_TOP_LIFT_ANGLE * phase;
+        const pivotAxis = seat.right.clone().normalize();
+        const pivotFromCenter = seat.forward.clone().multiplyScalar(-CARD_H * CARD_PEEK_EDGE_PIVOT_FACTOR);
+        const liftQuaternion = new THREE.Quaternion().setFromAxisAngle(pivotAxis, -standAngle);
+        const rotatedPivot = pivotFromCenter.clone().applyQuaternion(liftQuaternion);
+        const hingeCompensation = pivotFromCenter.sub(rotatedPivot);
+        const upwardCorrection = Math.max(0, -hingeCompensation.y);
+        const offset = hingeCompensation
+          .add(seat.right.clone().multiplyScalar(outwardSign * CARD_PEEK_OUTER_SWAY * phase))
+          .add(new THREE.Vector3(0, upwardCorrection + CARD_PEEK_LIFT * phase, 0));
+
         mesh.position.copy(starts[cardIdx].position.clone().add(offset));
-        const pivotAxis = seat.forward.clone().normalize();
-        const liftQuaternion = new THREE.Quaternion().setFromAxisAngle(pivotAxis, -outwardSign * standAngle);
         mesh.quaternion.copy(starts[cardIdx].quaternion).premultiply(liftQuaternion);
       });
       if (t < 1) {


### PR DESCRIPTION
### Motivation
- The card peek animation needed a more natural top-edge lift and corrected pivot behavior to avoid visual clipping and inconsistent lifts across cards.

### Description
- Replaced `CARD_PEEK_HALF_STAND_ANGLE` with `CARD_PEEK_TOP_LIFT_ANGLE` and added `CARD_PEEK_EDGE_PIVOT_FACTOR` to control edge pivoting.
- Reworked the peek animation math to compute a pivot from the card center, apply an axis-angle rotation, and derive a hinge compensation offset so the card lifts from its edge rather than pivoting awkwardly around its center.
- Switched the pivot axis and adjusted outer sway handling so each card uses an outward offset while sharing the refined lift quaternion for consistent animation.
- Kept final quaternion application via `premultiply` to preserve the original card orientation while applying the new lift transform.

### Testing
- Ran the project's unit test suite with `yarn test`, which completed successfully.
- Built the webapp with `yarn build` as a smoke check, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13cda92708329a894bbb6c6ee5689)