### PR TITLE
CueController: add cue-stroke state machine, visible push-through and replay trigger

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -1,18 +1,142 @@
+using System;
 using UnityEngine;
 
 namespace Aiming
 {
     public class CueController : MonoBehaviour
     {
+        public enum CueStrokeState
+        {
+            Idle,
+            Charging,
+            Release,
+            FollowThrough,
+            Recover
+        }
+
+        [Serializable]
+        public struct ShotPlaybackRecord
+        {
+            public float timeStamp;
+            public Vector3 aimDirection;
+            [Range(0f, 1f)] public float powerNormalized;
+            public float pullDistance;
+            public float releaseSpeed;
+            public float followThroughRatio;
+            public float recoverSpeed;
+        }
+
+        [Header("References")]
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
-        public Transform cueBall, objectBall, pocket;
+        public Transform cueBall;
+        public Transform objectBall;
+        public Transform pocket;
+
+        [Header("Table")]
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
 
-        void Update()
+        [Header("Cue stroke tuning")]
+        [Range(0f, 1f)] public float livePowerNormalized;
+        public float minPullDistance = 0.045f;
+        public float maxPullDistance = 0.18f;
+        [Range(1.2f, 2.4f)] public float powerGamma = 1.8f;
+        public float releaseSpeed = 2.2f;
+        [Range(0.1f, 0.35f)] public float followThroughRatio = 0.2f;
+        public float recoverSpeed = 0.9f;
+        public float cueTipRestDistance = 0.065f;
+
+        public CueStrokeState StrokeState => strokeState;
+        public ShotPlaybackRecord LastShotRecord => lastShotRecord;
+
+        public event Action<ShotPlaybackRecord> OnCueStrike;
+
+        private CueStrokeState strokeState = CueStrokeState.Idle;
+        private ShotPlaybackRecord lastShotRecord;
+
+        private float currentPullOffset;
+        private float frozenPullDistance;
+        private float followThroughDistance;
+        private bool strikeSent;
+
+        private Vector3 currentAimDirection = Vector3.forward;
+        private Vector3 cueTipLocalOffset = Vector3.zero;
+
+        private void Awake()
         {
-            if (aiming == null || cueBall == null || objectBall == null || pocket == null) return;
+            if (cueTip != null)
+            {
+                cueTipLocalOffset = transform.InverseTransformPoint(cueTip.position);
+            }
+        }
+
+        private void Update()
+        {
+            if (aiming == null || cueBall == null || objectBall == null || pocket == null)
+            {
+                return;
+            }
+
+            ResolveAimDirection();
+            UpdateStrokeState(Time.deltaTime);
+            UpdateCueTransform();
+        }
+
+        public void BeginCharging(float powerNormalized)
+        {
+            livePowerNormalized = Mathf.Clamp01(powerNormalized);
+            strokeState = CueStrokeState.Charging;
+            strikeSent = false;
+        }
+
+        public void UpdateChargePower(float powerNormalized)
+        {
+            livePowerNormalized = Mathf.Clamp01(powerNormalized);
+            if (strokeState == CueStrokeState.Idle)
+            {
+                strokeState = CueStrokeState.Charging;
+            }
+        }
+
+        public void CommitShot()
+        {
+            if (strokeState != CueStrokeState.Charging)
+            {
+                return;
+            }
+
+            frozenPullDistance = EvaluatePullDistance(livePowerNormalized);
+            followThroughDistance = Mathf.Max(0.001f, frozenPullDistance * followThroughRatio);
+            strokeState = CueStrokeState.Release;
+            strikeSent = false;
+        }
+
+        public void TriggerAiShot(float powerNormalized)
+        {
+            BeginCharging(powerNormalized);
+            currentPullOffset = EvaluatePullDistance(livePowerNormalized);
+            CommitShot();
+        }
+
+        public void PlayReplayShot(ShotPlaybackRecord record)
+        {
+            currentAimDirection = record.aimDirection.sqrMagnitude > 1e-6f ? record.aimDirection.normalized : currentAimDirection;
+            livePowerNormalized = Mathf.Clamp01(record.powerNormalized);
+
+            releaseSpeed = Mathf.Max(0.05f, record.releaseSpeed);
+            followThroughRatio = Mathf.Clamp(record.followThroughRatio, 0.1f, 0.35f);
+            recoverSpeed = Mathf.Max(0.05f, record.recoverSpeed);
+
+            frozenPullDistance = Mathf.Max(minPullDistance, record.pullDistance);
+            followThroughDistance = Mathf.Max(0.001f, frozenPullDistance * followThroughRatio);
+            currentPullOffset = frozenPullDistance;
+            strokeState = CueStrokeState.Release;
+            strikeSent = false;
+        }
+
+        private void ResolveAimDirection()
+        {
             ShotContext ctx = new ShotContext
             {
                 cueBallPos = cueBall.position,
@@ -24,18 +148,98 @@ namespace Aiming
                 highSpin = false,
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
+
             var sol = aiming.GetAimSolution(ctx);
-            if (sol.isValid && cueTip != null)
+            if (!sol.isValid)
             {
-                Vector3 dir = (sol.aimEnd - sol.aimStart);
-                if (dir.sqrMagnitude > 1e-6f)
-                {
-                    dir.Normalize();
-                    transform.position = sol.aimStart;
-                    transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
-                    cueTip.position = sol.aimStart + dir * 0.1f;
-                }
+                return;
             }
+
+            Vector3 dir = sol.aimEnd - sol.aimStart;
+            if (dir.sqrMagnitude <= 1e-6f)
+            {
+                return;
+            }
+
+            currentAimDirection = dir.normalized;
+        }
+
+        private void UpdateStrokeState(float deltaTime)
+        {
+            switch (strokeState)
+            {
+                case CueStrokeState.Idle:
+                    currentPullOffset = Mathf.MoveTowards(currentPullOffset, 0f, deltaTime * recoverSpeed);
+                    break;
+
+                case CueStrokeState.Charging:
+                    {
+                        float targetPull = EvaluatePullDistance(livePowerNormalized);
+                        currentPullOffset = Mathf.MoveTowards(currentPullOffset, targetPull, deltaTime * (recoverSpeed + 0.35f));
+                        break;
+                    }
+
+                case CueStrokeState.Release:
+                    {
+                        currentPullOffset = Mathf.MoveTowards(currentPullOffset, -followThroughDistance, deltaTime * releaseSpeed);
+
+                        if (!strikeSent && currentPullOffset <= 0f)
+                        {
+                            strikeSent = true;
+                            lastShotRecord = new ShotPlaybackRecord
+                            {
+                                timeStamp = Time.time,
+                                aimDirection = currentAimDirection,
+                                powerNormalized = livePowerNormalized,
+                                pullDistance = frozenPullDistance,
+                                releaseSpeed = releaseSpeed,
+                                followThroughRatio = followThroughRatio,
+                                recoverSpeed = recoverSpeed
+                            };
+                            OnCueStrike?.Invoke(lastShotRecord);
+                        }
+
+                        if (Mathf.Approximately(currentPullOffset, -followThroughDistance))
+                        {
+                            strokeState = CueStrokeState.FollowThrough;
+                        }
+                        break;
+                    }
+
+                case CueStrokeState.FollowThrough:
+                    strokeState = CueStrokeState.Recover;
+                    break;
+
+                case CueStrokeState.Recover:
+                    currentPullOffset = Mathf.MoveTowards(currentPullOffset, 0f, deltaTime * recoverSpeed);
+                    if (Mathf.Approximately(currentPullOffset, 0f))
+                    {
+                        strokeState = CueStrokeState.Idle;
+                    }
+                    break;
+            }
+        }
+
+        private void UpdateCueTransform()
+        {
+            Vector3 aimDirection = currentAimDirection.sqrMagnitude > 1e-6f ? currentAimDirection.normalized : transform.forward;
+            transform.rotation = Quaternion.LookRotation(aimDirection, Vector3.up);
+
+            Vector3 tipPosition = cueBall.position - aimDirection * (cueTipRestDistance + currentPullOffset);
+            Vector3 rootPosition = tipPosition - transform.TransformVector(cueTipLocalOffset);
+            transform.position = rootPosition;
+
+            if (cueTip != null && cueTip.parent != transform)
+            {
+                cueTip.position = tipPosition;
+                cueTip.rotation = transform.rotation;
+            }
+        }
+
+        private float EvaluatePullDistance(float normalizedPower)
+        {
+            float curvedPower = Mathf.Pow(Mathf.Clamp01(normalizedPower), powerGamma);
+            return Mathf.Lerp(minPullDistance, maxPullDistance, curvedPower);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Fix visual issue where the cue only appeared to pull back and did not visibly push forward through contact.  
- Ensure player and AI shots share the same animation→physics source-of-truth so replays can reproduce the exact stroke.  
- Provide an API surface so gameplay, AI and replay systems can drive the same cue animation and receive the strike event.

### Description
- Reworked `Assets/Scripts/Gameplay/CueController.cs` into an explicit cue-stroke state machine with states `Idle`, `Charging`, `Release`, `FollowThrough`, and `Recover` to show both backward pull and forward drive.  
- Added `ShotPlaybackRecord` struct and `OnCueStrike` event to capture and emit deterministic shot metadata (aim, normalized power, pull distance, and timing) at strike time.  
- Exposed public shot flow methods `BeginCharging`, `UpdateChargePower`, `CommitShot`, `TriggerAiShot`, and `PlayReplayShot` so player, AI and replay flows use the same animation/impulse mapping.  
- Implemented single source mapping `EvaluatePullDistance` (gamma-shaped curve, `minPullDistance`..`maxPullDistance`), freeze-on-release semantics and follow-through math, and updated cue transform so the cue tip travels along the aim direction with signed offsets (positive pull, negative follow-through).

### Testing
- Attempted to run the unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj` but the command failed in this environment because `dotnet` is not installed.  
- No other automated tests were executed in this environment; change was smoke-validated by static inspection and by running lightweight repository searches to confirm references and new APIs were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15b8a3fa48329b3a14842c54a9931)