### PR TITLE
Improve cue-stick forward stroke visibility and replay impact-hold

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1841,6 +1841,7 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slig
 const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 2.7; // strengthen minimum forward push so cue-stroke follow-through is always visible
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 6.8; // extend forward travel so high-power shots show a clear cue push animation
+const CUE_FORWARD_OVERSHOOT_MAX = BALL_R * 0.42; // allow the tip to travel slightly past contact so the push phase reads clearly on mobile
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -5463,6 +5464,7 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 160; // guarantee visible pullback phase when captured stroke timings are too short
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // guarantee visible forward push into impact in replay view
+const REPLAY_CUE_MIN_IMPACT_HOLD_MS = 90; // keep cue near impact briefly so viewers can clearly see the forward strike in replay
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = STOP_EPS;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 34;
@@ -21181,9 +21183,11 @@ const powerRef = useRef(hud.power);
             const fallbackForward = CUE_PULL_BASE * 0.18;
             const pullbackTime = 160;
             const forwardTime = 210;
+            const impactHoldTime = 110;
             const settleTime = 120;
             const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
-            const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
+            const totalStroke =
+              pullbackTime + forwardTime + impactHoldTime + settleTime + returnTime;
             const holdWindow = Math.max(replayHoldWindow, totalStroke);
             const showCue = targetTime <= holdWindow;
             cueStick.visible = showCue;
@@ -21204,7 +21208,10 @@ const powerRef = useRef(hud.power);
                 cuePos.y,
                 cuePos.z - TMP_VEC3_CUE_DIR.z * CUE_TIP_GAP
               );
-              const followDistance = Math.max(BALL_R * 0.16, CUE_TIP_GAP - fallbackForward);
+              const followDistance = Math.min(
+                CUE_TIP_GAP + CUE_FORWARD_OVERSHOOT_MAX,
+                Math.max(BALL_R * 0.2, CUE_TIP_GAP - fallbackForward)
+              );
               const followPos = tmpReplayCueA.set(
                 cuePos.x - TMP_VEC3_CUE_DIR.x * followDistance,
                 cuePos.y,
@@ -21220,16 +21227,19 @@ const powerRef = useRef(hud.power);
                   1
                 );
                 cueStick.position.lerpVectors(pullPos, impactPos, easeOutCubic(t));
-              } else if (targetTime <= pullbackTime + forwardTime + settleTime) {
+              } else if (targetTime <= pullbackTime + forwardTime + impactHoldTime) {
+                cueStick.position.copy(impactPos);
+              } else if (targetTime <= pullbackTime + forwardTime + impactHoldTime + settleTime) {
                 const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime) / Math.max(settleTime, 1e-6),
+                  (targetTime - pullbackTime - forwardTime - impactHoldTime) /
+                    Math.max(settleTime, 1e-6),
                   0,
                   1
                 );
                 cueStick.position.lerpVectors(impactPos, followPos, easeOutCubic(t));
               } else if (targetTime <= totalStroke) {
                 const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime - settleTime) /
+                  (targetTime - pullbackTime - forwardTime - impactHoldTime - settleTime) /
                     Math.max(returnTime, 1e-6),
                   0,
                   1
@@ -21289,6 +21299,11 @@ const powerRef = useRef(hud.power);
                 stroke.settleDuration ??
                 0
             ) * replayScale;
+          const impactHoldTime =
+            Math.max(
+              REPLAY_CUE_MIN_IMPACT_HOLD_MS,
+              Math.max(0, stroke.impactHoldTime ?? stroke.impactHoldDuration ?? 0) * replayScale
+            );
           const recoverTime =
             Math.max(
               0,
@@ -21302,7 +21317,8 @@ const powerRef = useRef(hud.power);
           const localTime = targetTime - Math.max(0, startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
           const pullEnd = pullback;
           const impactEnd = pullEnd + release;
-          const followEnd = impactEnd + followTime;
+          const impactHoldEnd = impactEnd + impactHoldTime;
+          const followEnd = impactHoldEnd + followTime;
           const recoverEnd = followEnd + recoverTime;
           tmpReplayCueA.set(idleSnap.x, idleSnap.y, idleSnap.z);
           tmpReplayCueB.set(pullSnap.x, pullSnap.y, pullSnap.z);
@@ -21339,9 +21355,15 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return;
           }
+          if (localTime <= impactHoldEnd && impactHoldTime > 0) {
+            cueStick.visible = true;
+            cueStick.position.set(impactSnap.x, impactSnap.y, impactSnap.z);
+            syncCueShadow();
+            return;
+          }
           if (localTime <= followEnd && followTime > 0) {
             const t = THREE.MathUtils.clamp(
-              (localTime - impactEnd) / Math.max(followTime, 1e-6),
+              (localTime - impactHoldEnd) / Math.max(followTime, 1e-6),
               0,
               1
             );
@@ -21417,17 +21439,20 @@ const powerRef = useRef(hud.power);
             followPos,
             pullbackDuration,
             releaseDuration,
+            impactHoldDuration,
             followDuration,
             recoverDuration
           } = stroke;
           const pullback = Math.max(0, pullbackDuration ?? 0);
           const release = Math.max(0, releaseDuration ?? 0);
+          const impactHold = Math.max(0, impactHoldDuration ?? 0);
           const follow = Math.max(0, followDuration ?? 0);
           const recover = Math.max(0, recoverDuration ?? 0);
           const elapsed = Math.max(0, now - startTime);
           const pullEnd = pullback;
           const releaseEnd = pullEnd + release;
-          const followEnd = releaseEnd + follow;
+          const impactHoldEnd = releaseEnd + impactHold;
+          const followEnd = impactHoldEnd + follow;
           const recoverEnd = followEnd + recover;
           cueStick.visible = true;
           cueAnimating = true;
@@ -21452,14 +21477,19 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
+            const eased = easeInCubic(t);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
+            syncCueShadow();
+            return true;
+          }
+          if (elapsed <= impactHoldEnd && impactHold > 0) {
+            cueStick.position.copy(impactPos);
             syncCueShadow();
             return true;
           }
           if (elapsed <= followEnd && follow > 0) {
             const t = THREE.MathUtils.clamp(
-              (elapsed - releaseEnd) / Math.max(follow, 1e-6),
+              (elapsed - impactHoldEnd) / Math.max(follow, 1e-6),
               0,
               1
             );
@@ -24429,6 +24459,7 @@ const powerRef = useRef(hud.power);
       const easeInOutCubic = (t) =>
         t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const easeInCubic = (t) => t * t * t;
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
         const horiz = Math.hypot(vec.x ?? 0, vec.z ?? 0);
@@ -24959,7 +24990,10 @@ const powerRef = useRef(hud.power);
             powerStrength
           );
           const impactPos = idlePos.clone();
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
+          const followDistance = Math.min(
+            followThrough,
+            CUE_TIP_GAP + CUE_FORWARD_OVERSHOOT_MAX
+          );
           const followPos = buildCuePosition(-followDistance);
           const followSpeed = THREE.MathUtils.lerp(
             CUE_FOLLOW_SPEED_MIN,
@@ -24972,6 +25006,7 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_MAX_MS
           );
           const followDurationResolved = followDuration;
+          const impactHoldDuration = THREE.MathUtils.lerp(80, 140, powerStrength);
           const recoverDuration = Math.max(120, followDurationResolved * 0.6);
           const impactTime = startTime + pullbackDuration + forwardDuration;
           const forwardPreviewHold =
@@ -25066,6 +25101,7 @@ const powerRef = useRef(hud.power);
               rotationY: cueStick.rotation.y,
               pullbackDuration,
               releaseDuration: forwardDuration,
+              impactHoldDuration,
               followDuration: followDurationResolved,
               recoverDuration,
               startOffset: strokeStartOffset
@@ -25082,6 +25118,7 @@ const powerRef = useRef(hud.power);
               followPos: followPos.clone(),
               pullbackDuration,
               releaseDuration: forwardDuration,
+              impactHoldDuration,
               followDuration: followDurationResolved,
               recoverDuration
             };


### PR DESCRIPTION
### Motivation
- Make the cue animation clearly show both the pull-back and the forward push so players can see the strike in live play and in Replay. 
- Ensure Replay playback reproduces the same visual timing as the live shot by recording and replaying the strike timing (impact hold) so visual and physics cues remain aligned. 

### Description
- Added `CUE_FORWARD_OVERSHOOT_MAX` to allow a slight forward overshoot so the cue tip visibly travels past contact for a clearer push on mobile framing. 
- Introduced `REPLAY_CUE_MIN_IMPACT_HOLD_MS` and an `impactHoldDuration`/`impactHold` phase in both live stroke synthesis and replay playback so the cue lingers at impact before follow-through. 
- Adjusted replay fallback stroke timings and fallback follow distance to include the impact-hold window and to accept the forward overshoot. 
- Changed the release easing for live strokes to `easeInCubic` to accelerate into impact, added `easeInCubic` helper, and stored `impactHoldDuration` into `shotRecording.cueStroke` so recorded shots and replay use the same cadence. 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which reported only the repository ignore warning for this large file (no lint errors introduced). 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to validate the visual change but Chromium crashed in the container (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15b8a3fa48329b3a14842c54a9931)