### PR TITLE
Improve Pool Royale cue stroke forward visibility (replay & live)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21178,7 +21178,7 @@ const powerRef = useRef(hud.power);
               ? playback.duration
               : REPLAY_CUE_STICK_HOLD_MS;
             const fallbackPullback = CUE_PULL_BASE * 0.35;
-            const fallbackForward = CUE_PULL_BASE * 0.18;
+            const fallbackForward = Math.max(BALL_R * 0.58, CUE_PULL_BASE * 0.42);
             const pullbackTime = 160;
             const forwardTime = 210;
             const settleTime = 120;
@@ -21199,16 +21199,17 @@ const powerRef = useRef(hud.power);
                 cuePos.y,
                 cuePos.z - TMP_VEC3_CUE_DIR.z * (CUE_TIP_GAP + fallbackPullback)
               );
+              const impactDistance = Math.max(BALL_R * 0.08, CUE_TIP_GAP - fallbackForward);
               const impactPos = TMP_VEC3_C.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * CUE_TIP_GAP,
+                cuePos.x - TMP_VEC3_CUE_DIR.x * impactDistance,
                 cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * CUE_TIP_GAP
+                cuePos.z - TMP_VEC3_CUE_DIR.z * impactDistance
               );
-              const followDistance = Math.max(BALL_R * 0.16, CUE_TIP_GAP - fallbackForward);
+              const settleDistance = THREE.MathUtils.lerp(impactDistance, CUE_TIP_GAP, 0.52);
               const followPos = tmpReplayCueA.set(
-                cuePos.x - TMP_VEC3_CUE_DIR.x * followDistance,
+                cuePos.x - TMP_VEC3_CUE_DIR.x * settleDistance,
                 cuePos.y,
-                cuePos.z - TMP_VEC3_CUE_DIR.z * followDistance
+                cuePos.z - TMP_VEC3_CUE_DIR.z * settleDistance
               );
               if (targetTime <= pullbackTime && pullbackTime > 0) {
                 const t = THREE.MathUtils.clamp(targetTime / pullbackTime, 0, 1);
@@ -24958,9 +24959,15 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_THROUGH_MAX,
             powerStrength
           );
-          const impactPos = idlePos.clone();
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
-          const followPos = buildCuePosition(-followDistance);
+          const maxForwardTravel = CUE_TIP_GAP + BALL_R * 0.92;
+          const impactForwardTravel = THREE.MathUtils.clamp(
+            followThrough,
+            BALL_R * 0.36,
+            maxForwardTravel
+          );
+          const impactPos = buildCuePosition(-impactForwardTravel);
+          const settleForwardTravel = impactForwardTravel * 0.48;
+          const followPos = buildCuePosition(-settleForwardTravel);
           const followSpeed = THREE.MathUtils.lerp(
             CUE_FOLLOW_SPEED_MIN,
             CUE_FOLLOW_SPEED_MAX,


### PR DESCRIPTION
### Motivation
- The cue stick animation in Pool Royale replay and live shots was visually dominated by pullback and often lacked a clear forward push, making strikes hard to read in playback and during AI/player shots.
- The goal is to make the cue motion show an obvious pullback → forward push → settle sequence so the impact and follow-through are visible on screen and in replays.
- Changes must apply consistently to both recorded replay fallback behavior and live stroke generation (player + AI share the same pipeline).

### Description
- Updated fallback replay stroke logic in `webapp/src/pages/Games/PoolRoyale.jsx` to increase forward travel and compute an explicit `impactPos` and `followPos` (settle) instead of reusing the tip gap, producing a visible forward push in replay fallback paths. 
- Adjusted replay timing/fallback constants usage to bias forward travel (`fallbackForward`) and derive `impactDistance` / `settleDistance` for clearer pull → push → settle interpolation. 
- Updated live shot stroke generation in the same file to compute `impactForwardTravel` and `settleForwardTravel` (clamped by `BALL_R` and `CUE_TIP_GAP`) and use `buildCuePosition` to place impact then a shorter settle before recovery, so live strikes show a visible push and follow-through.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. 
- Attempted to capture an in-environment screenshot using Playwright (`mcp__browser_tools__run_playwright_script`), but the headless browser crashed (SIGSEGV) so no screenshot could be produced. 
- The change was committed with message `Improve Pool Royale cue stroke forward visibility` and only `webapp/src/pages/Games/PoolRoyale.jsx` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15b8a3fa48329b3a14842c54a9931)