### PR TITLE
Add cue impact-hold and forward overshoot to replay and live stroke animations

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1841,6 +1841,7 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slig
 const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 2.7; // strengthen minimum forward push so cue-stroke follow-through is always visible
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 6.8; // extend forward travel so high-power shots show a clear cue push animation
+const CUE_FORWARD_OVERSHOOT_MAX = BALL_R * 2.6; // allow a clear forward follow-through so the cue visibly pushes through contact on phone view
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -5463,6 +5464,7 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 160; // guarantee visible pullback phase when captured stroke timings are too short
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // guarantee visible forward push into impact in replay view
+const REPLAY_CUE_MIN_IMPACT_HOLD_MS = 90; // keep cue near impact briefly so viewers can clearly see the forward strike in replay
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = STOP_EPS;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 34;
@@ -21181,9 +21183,11 @@ const powerRef = useRef(hud.power);
             const fallbackForward = CUE_PULL_BASE * 0.18;
             const pullbackTime = 160;
             const forwardTime = 210;
+            const impactHoldTime = 110;
             const settleTime = 120;
             const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
-            const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
+            const totalStroke =
+              pullbackTime + forwardTime + impactHoldTime + settleTime + returnTime;
             const holdWindow = Math.max(replayHoldWindow, totalStroke);
             const showCue = targetTime <= holdWindow;
             cueStick.visible = showCue;
@@ -21204,7 +21208,15 @@ const powerRef = useRef(hud.power);
                 cuePos.y,
                 cuePos.z - TMP_VEC3_CUE_DIR.z * CUE_TIP_GAP
               );
-              const followDistance = Math.max(BALL_R * 0.16, CUE_TIP_GAP - fallbackForward);
+              const fallbackFollowThrough = THREE.MathUtils.clamp(
+                fallbackForward + BALL_R * 0.45,
+                BALL_R * 0.85,
+                BALL_R * 3.8
+              );
+              const followDistance = Math.min(
+                CUE_TIP_GAP + CUE_FORWARD_OVERSHOOT_MAX,
+                CUE_TIP_GAP + fallbackFollowThrough
+              );
               const followPos = tmpReplayCueA.set(
                 cuePos.x - TMP_VEC3_CUE_DIR.x * followDistance,
                 cuePos.y,
@@ -21220,16 +21232,19 @@ const powerRef = useRef(hud.power);
                   1
                 );
                 cueStick.position.lerpVectors(pullPos, impactPos, easeOutCubic(t));
-              } else if (targetTime <= pullbackTime + forwardTime + settleTime) {
+              } else if (targetTime <= pullbackTime + forwardTime + impactHoldTime) {
+                cueStick.position.copy(impactPos);
+              } else if (targetTime <= pullbackTime + forwardTime + impactHoldTime + settleTime) {
                 const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime) / Math.max(settleTime, 1e-6),
+                  (targetTime - pullbackTime - forwardTime - impactHoldTime) /
+                    Math.max(settleTime, 1e-6),
                   0,
                   1
                 );
                 cueStick.position.lerpVectors(impactPos, followPos, easeOutCubic(t));
               } else if (targetTime <= totalStroke) {
                 const t = THREE.MathUtils.clamp(
-                  (targetTime - pullbackTime - forwardTime - settleTime) /
+                  (targetTime - pullbackTime - forwardTime - impactHoldTime - settleTime) /
                     Math.max(returnTime, 1e-6),
                   0,
                   1
@@ -21289,6 +21304,11 @@ const powerRef = useRef(hud.power);
                 stroke.settleDuration ??
                 0
             ) * replayScale;
+          const impactHoldTime =
+            Math.max(
+              REPLAY_CUE_MIN_IMPACT_HOLD_MS,
+              Math.max(0, stroke.impactHoldTime ?? stroke.impactHoldDuration ?? 0) * replayScale
+            );
           const recoverTime =
             Math.max(
               0,
@@ -21302,7 +21322,8 @@ const powerRef = useRef(hud.power);
           const localTime = targetTime - Math.max(0, startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
           const pullEnd = pullback;
           const impactEnd = pullEnd + release;
-          const followEnd = impactEnd + followTime;
+          const impactHoldEnd = impactEnd + impactHoldTime;
+          const followEnd = impactHoldEnd + followTime;
           const recoverEnd = followEnd + recoverTime;
           tmpReplayCueA.set(idleSnap.x, idleSnap.y, idleSnap.z);
           tmpReplayCueB.set(pullSnap.x, pullSnap.y, pullSnap.z);
@@ -21332,16 +21353,22 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
+            const eased = easeInCubic(t);
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
             cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
+          if (localTime <= impactHoldEnd && impactHoldTime > 0) {
+            cueStick.visible = true;
+            cueStick.position.set(impactSnap.x, impactSnap.y, impactSnap.z);
+            syncCueShadow();
+            return;
+          }
           if (localTime <= followEnd && followTime > 0) {
             const t = THREE.MathUtils.clamp(
-              (localTime - impactEnd) / Math.max(followTime, 1e-6),
+              (localTime - impactHoldEnd) / Math.max(followTime, 1e-6),
               0,
               1
             );
@@ -21417,17 +21444,20 @@ const powerRef = useRef(hud.power);
             followPos,
             pullbackDuration,
             releaseDuration,
+            impactHoldDuration,
             followDuration,
             recoverDuration
           } = stroke;
           const pullback = Math.max(0, pullbackDuration ?? 0);
           const release = Math.max(0, releaseDuration ?? 0);
+          const impactHold = Math.max(0, impactHoldDuration ?? 0);
           const follow = Math.max(0, followDuration ?? 0);
           const recover = Math.max(0, recoverDuration ?? 0);
           const elapsed = Math.max(0, now - startTime);
           const pullEnd = pullback;
           const releaseEnd = pullEnd + release;
-          const followEnd = releaseEnd + follow;
+          const impactHoldEnd = releaseEnd + impactHold;
+          const followEnd = impactHoldEnd + follow;
           const recoverEnd = followEnd + recover;
           cueStick.visible = true;
           cueAnimating = true;
@@ -21452,14 +21482,19 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
+            const eased = easeInCubic(t);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
+            syncCueShadow();
+            return true;
+          }
+          if (elapsed <= impactHoldEnd && impactHold > 0) {
+            cueStick.position.copy(impactPos);
             syncCueShadow();
             return true;
           }
           if (elapsed <= followEnd && follow > 0) {
             const t = THREE.MathUtils.clamp(
-              (elapsed - releaseEnd) / Math.max(follow, 1e-6),
+              (elapsed - impactHoldEnd) / Math.max(follow, 1e-6),
               0,
               1
             );
@@ -24429,6 +24464,7 @@ const powerRef = useRef(hud.power);
       const easeInOutCubic = (t) =>
         t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const easeInCubic = (t) => t * t * t;
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
         const horiz = Math.hypot(vec.x ?? 0, vec.z ?? 0);
@@ -24959,7 +24995,10 @@ const powerRef = useRef(hud.power);
             powerStrength
           );
           const impactPos = idlePos.clone();
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
+          const followDistance = Math.min(
+            followThrough,
+            CUE_TIP_GAP + CUE_FORWARD_OVERSHOOT_MAX
+          );
           const followPos = buildCuePosition(-followDistance);
           const followSpeed = THREE.MathUtils.lerp(
             CUE_FOLLOW_SPEED_MIN,
@@ -24972,13 +25011,15 @@ const powerRef = useRef(hud.power);
             CUE_FOLLOW_MAX_MS
           );
           const followDurationResolved = followDuration;
+          const impactHoldDuration = THREE.MathUtils.lerp(80, 140, powerStrength);
           const recoverDuration = Math.max(120, followDurationResolved * 0.6);
           const impactTime = startTime + pullbackDuration + forwardDuration;
           const forwardPreviewHold =
             impactTime +
+            impactHoldDuration +
             Math.min(
               followDurationResolved,
-              Math.max(420, forwardDuration * 1.25)
+              Math.max(560, forwardDuration * 1.45)
             );
           powerImpactHoldRef.current = Math.max(
             powerImpactHoldRef.current || 0,
@@ -25066,6 +25107,7 @@ const powerRef = useRef(hud.power);
               rotationY: cueStick.rotation.y,
               pullbackDuration,
               releaseDuration: forwardDuration,
+              impactHoldDuration,
               followDuration: followDurationResolved,
               recoverDuration,
               startOffset: strokeStartOffset
@@ -25082,6 +25124,7 @@ const powerRef = useRef(hud.power);
               followPos: followPos.clone(),
               pullbackDuration,
               releaseDuration: forwardDuration,
+              impactHoldDuration,
               followDuration: followDurationResolved,
               recoverDuration
             };


### PR DESCRIPTION
### Motivation

- Make cue strike and replays more readable by holding the cue at impact briefly and allowing a visible forward overshoot on follow-through.

### Description

- Add `CUE_FORWARD_OVERSHOOT_MAX` and `REPLAY_CUE_MIN_IMPACT_HOLD_MS` constants and wire an impact-hold phase into replay, recorded, and live cue stroke timelines.  
- Introduce `impactHoldTime`/`impactHoldDuration` handling in replay preview, serialized strokes, stroke playback, and the live `cueStrokeStateRef` so the cue stays at `impactPos` for the configured hold window.  
- Change release easing from `easeInOutCubic` to a snappier `easeInCubic` for the forward release phase and add a new `easeInCubic` helper.  
- Adjust follow-through distance calculations to include the forward overshoot cap and clamp fallback follow distances, and slightly extend forward-preview hold timing to account for the impact hold.

### Testing

- Built the web app with `yarn build` and verified compilation succeeded.  
- Ran the frontend unit test suite with `yarn test` and all tests passed.  
- Executed `yarn lint` to ensure formatting and style checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15b8a3fa48329b3a14842c54a9931)