### PR TITLE
Refine Texas Hold'em camera, nameplates, pot label, and folded-card behavior

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -385,7 +385,7 @@ const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.68, landscape: 1.04 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.16, landscape: 0.9 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.08, landscape: 0.86 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
@@ -408,8 +408,6 @@ const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
 const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.18;
 const COMMUNITY_REVEAL_CAMERA_HOLD_MS = 2000;
-const FOLD_PILE_CARD_GAP = CARD_D * 0.9;
-const FOLD_PILE_LATERAL_STEP = CARD_W * 0.1;
 const FOLD_PILE_FORWARD_OFFSET = CARD_H * -0.82;
 const CHIP_BUTTON_GRID_RIGHT_SHIFT = 0;
 const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 1.72;
@@ -428,7 +426,6 @@ const CARD_PEEK_LIFT = 0;
 const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
-const FOLD_TO_PILE_ANIMATION_MS = 420;
 
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
@@ -506,7 +503,7 @@ function pickBestModelUrl(urls) {
 }
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
-const LABEL_SIZE = Object.freeze({ width: 1.24 * MODEL_SCALE, height: 0.58 * MODEL_SCALE });
+const LABEL_SIZE = Object.freeze({ width: 1.42 * MODEL_SCALE, height: 0.72 * MODEL_SCALE });
 const LABEL_BASE_HEIGHT = SEAT_THICKNESS + 0.32 * MODEL_SCALE;
 const HUMAN_LABEL_FORWARD = SEAT_DEPTH * 0.12;
 const AI_LABEL_FORWARD = SEAT_DEPTH * 0.16;
@@ -1918,8 +1915,8 @@ function computePotAnchor(options = {}) {
 
 function makeNameplate(name, chips, renderer, avatar) {
   const canvas = document.createElement('canvas');
-  canvas.width = 512;
-  canvas.height = 256;
+  canvas.width = 640;
+  canvas.height = 320;
   const ctx = canvas.getContext('2d');
   const fallbackAvatar = '/assets/icons/profile.svg';
   let avatarSrc = getAvatarUrl(avatar) || fallbackAvatar;
@@ -1946,23 +1943,23 @@ function makeNameplate(name, chips, renderer, avatar) {
     lastTimer = timerSeconds;
     lastTimerProgress = timerProgress;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const panelRadius = 44;
-    const panelX = 12;
-    const panelY = 18;
+    const panelRadius = 48;
+    const panelX = 14;
+    const panelY = 16;
     const panelW = canvas.width - panelX * 2;
     const panelH = canvas.height - panelY * 2;
     const panelGradient = ctx.createLinearGradient(panelX, panelY, panelX, panelY + panelH);
-    panelGradient.addColorStop(0, 'rgba(10,14,24,0.9)');
-    panelGradient.addColorStop(1, 'rgba(7,10,18,0.75)');
+    panelGradient.addColorStop(0, 'rgba(6,14,30,0.93)');
+    panelGradient.addColorStop(1, 'rgba(6,10,20,0.88)');
     ctx.fillStyle = panelGradient;
-    ctx.strokeStyle = highlight ? 'rgba(96,165,250,0.75)' : 'rgba(255,215,0,0.38)';
-    ctx.lineWidth = 10;
+    ctx.strokeStyle = highlight ? 'rgba(125,211,252,0.88)' : 'rgba(250,204,21,0.48)';
+    ctx.lineWidth = 9;
     roundRect(ctx, panelX, panelY, panelW, panelH, panelRadius);
     ctx.fill();
     ctx.stroke();
 
-    const avatarSize = 148;
-    const avatarX = panelX + 20;
+    const avatarSize = 170;
+    const avatarX = panelX + 24;
     const avatarY = panelY + (panelH - avatarSize) / 2;
     const ringGradient = ctx.createLinearGradient(avatarX, avatarY, avatarX + avatarSize, avatarY + avatarSize);
     ringGradient.addColorStop(0, 'rgba(255,215,0,0.65)');
@@ -1986,16 +1983,19 @@ function makeNameplate(name, chips, renderer, avatar) {
     ctx.fillStyle = '#f8fafc';
     ctx.font = '700 68px "Inter", system-ui, sans-serif';
     ctx.textBaseline = 'top';
-    const textX = avatarX + avatarSize + 32;
-    const textY = panelY + 32;
+    const textX = avatarX + avatarSize + 36;
+    const textY = panelY + 42;
+    ctx.font = '700 30px "Inter", system-ui, sans-serif';
+    ctx.fillStyle = 'rgba(186,230,253,0.95)';
+    ctx.fillText('PLAYER', textX, textY - 30);
     ctx.fillText(playerName, textX, textY);
-    ctx.font = '600 54px "Inter", system-ui, sans-serif';
+    ctx.font = '600 58px "Inter", system-ui, sans-serif';
     ctx.fillStyle = '#f7e7a4';
-    ctx.fillText(`${stack} chips`, textX, textY + 86);
+    ctx.fillText(`${stack} TPC`, textX, textY + 94);
     if (status) {
-      ctx.font = '600 44px "Inter", system-ui, sans-serif';
+      ctx.font = '600 42px "Inter", system-ui, sans-serif';
       ctx.fillStyle = '#c7d2fe';
-      ctx.fillText(status, textX, textY + 150);
+      ctx.fillText(status, textX, textY + 170);
     }
 
     const timerValue = Number.isFinite(timerSeconds) ? Math.max(0, timerSeconds) : null;
@@ -2159,15 +2159,14 @@ function createRailTextSprite(initialLines = [], options = {}) {
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
   texture.anisotropy = 16;
-  const material = new THREE.MeshBasicMaterial({
+  const material = new THREE.SpriteMaterial({
     map: texture,
     transparent: true,
     depthWrite: false,
-    toneMapped: false,
-    side: THREE.DoubleSide
+    toneMapped: false
   });
-  const geometry = new THREE.PlaneGeometry(width, height);
-  const sprite = new THREE.Mesh(geometry, material);
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(width, height, 1);
   sprite.userData.update = (payload) => {
     draw(payload);
     texture.needsUpdate = true;
@@ -2175,7 +2174,6 @@ function createRailTextSprite(initialLines = [], options = {}) {
   sprite.userData.dispose = () => {
     texture.dispose();
     material.dispose();
-    geometry.dispose();
   };
   sprite.userData.canvas = canvas;
   sprite.userData.texture = texture;
@@ -3520,28 +3518,6 @@ function TexasHoldemArena({ search }) {
     peekCardAnimationRef.current.set(key, { frame });
   }, []);
 
-  const animateFoldCardToPile = useCallback((mesh, targetPosition, lookTarget) => {
-    if (!mesh?.position || !targetPosition?.isVector3) return;
-    const existingFrame = mesh.userData?.foldAnimFrame;
-    if (existingFrame) {
-      cancelAnimationFrame(existingFrame);
-    }
-    const startPosition = mesh.position.clone();
-    const startTime = performance.now();
-    const tick = (now) => {
-      const t = Math.min(1, (now - startTime) / FOLD_TO_PILE_ANIMATION_MS);
-      const eased = t * (2 - t);
-      mesh.position.lerpVectors(startPosition, targetPosition, eased);
-      orientCard(mesh, lookTarget, { face: 'back', flat: true });
-      if (t < 1) {
-        mesh.userData.foldAnimFrame = requestAnimationFrame(tick);
-      } else {
-        mesh.userData.foldAnimFrame = null;
-      }
-    };
-    mesh.userData.foldAnimFrame = requestAnimationFrame(tick);
-  }, []);
-
   const findSeatWithAvatar = useCallback((startIndex = 0, options = {}) => {
     const state = gameStateRef.current;
     const players = state?.players ?? [];
@@ -4493,19 +4469,16 @@ function TexasHoldemArena({ search }) {
       const potLayout = { ...POT_SCATTER_LAYOUT, right: potRight, forward: potForward };
       chipFactory.setAmount(potStack, 0, { mode: 'scatter', layout: potLayout });
       const foldPileAnchor = potAnchor.clone().add(new THREE.Vector3(0, CARD_SURFACE_OFFSET * 0.2, FOLD_PILE_FORWARD_OFFSET));
-        const potLabel = createRailTextSprite({ amount: 0, token: 'TPC' }, {
-          width: (2.4 * MODEL_SCALE) / 3,
-          height: (0.9 * MODEL_SCALE) / 3
-        });
-        potLabel.position.copy(potAnchor.clone().add(new THREE.Vector3(0, CARD_H * 0.8, 0)));
-        const potLabelLook = potLabel.position.clone().add(potForward);
-        orientCard(potLabel, potLabelLook, { face: 'front', flat: true });
-        potLabel.rotateX(HUMAN_CARD_FACE_TILT * 0.7);
-        potLabel.renderOrder = 12;
-        if (potLabel.material) {
-          potLabel.material.depthWrite = false;
-        }
-        arenaGroup.add(potLabel);
+      const potLabel = createRailTextSprite({ amount: 0, token: 'TPC' }, {
+        width: (2.6 * MODEL_SCALE) / 3,
+        height: (1.08 * MODEL_SCALE) / 3
+      });
+      potLabel.position.copy(potAnchor.clone().add(new THREE.Vector3(0, CARD_H * 0.86, 0)));
+      potLabel.renderOrder = 12;
+      if (potLabel.material) {
+        potLabel.material.depthWrite = false;
+      }
+      arenaGroup.add(potLabel);
 
         const turnIndicatorMaterial = new THREE.MeshStandardMaterial({
           color: new THREE.Color(TURN_INDICATOR_COLOR),
@@ -4960,7 +4933,7 @@ function TexasHoldemArena({ search }) {
   useEffect(() => {
     const three = threeRef.current;
     if (!three) return;
-    const { seatGroups, communityMeshes, chipFactory, potStack, potLabel, potLayout, foldPileAnchor, deckAnchor, arenaGroup } = three;
+    const { seatGroups, communityMeshes, chipFactory, potStack, potLabel, potLayout, deckAnchor, arenaGroup } = three;
     const rowRotation = three.communityRowRotation ?? COMMUNITY_ROW_ROTATION;
     const cardTheme = CARD_THEMES.find((theme) => theme.id === three.cardThemeId) ?? CARD_THEMES[0];
     const state = gameState;
@@ -4971,9 +4944,6 @@ function TexasHoldemArena({ search }) {
     if (potLabel?.userData?.update) {
       potLabel.userData.update({ amount: Math.round(state.pot ?? 0), token: state.token });
       potLabel.userData.texture.needsUpdate = true;
-      const lookForward = (potLayout?.forward ?? three.communityAxes?.forward ?? new THREE.Vector3(0, 0, 1)).clone().normalize();
-      orientCard(potLabel, potLabel.position.clone().add(lookForward), { face: 'front', flat: true });
-      potLabel.rotateX(HUMAN_CARD_FACE_TILT * 0.7);
     }
 
     const showdownState = showdownAnimationRef.current;
@@ -5002,11 +4972,6 @@ function TexasHoldemArena({ search }) {
       ...three.communityAxes
     }).addScaledVector(winnerOffsetDirection, POT_BELOW_COMMUNITY_OFFSET * 0.92);
     const winnerSpreadOffset = (winnerSeatOrder.length - 1) * 0.5;
-    const foldedSeatOrder = new Map();
-    state.players.forEach((entry, seatIdx) => {
-      if (entry?.folded) foldedSeatOrder.set(seatIdx, foldedSeatOrder.size);
-    });
-
     state.players.forEach((player, idx) => {
       const seat = seatGroups[idx];
       if (!seat) return;
@@ -5039,27 +5004,26 @@ function TexasHoldemArena({ search }) {
         }
         mesh.visible = true;
         applyCardToMesh(mesh, card, three.cardGeometry, three.faceCache, cardTheme);
+        const position = baseAnchor
+          .clone()
+          .addScaledVector(forward, HUMAN_CARD_FORWARD_OFFSET)
+          .add(right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING));
         if (player.folded && !state.showdown) {
-          const foldedOrder = foldedSeatOrder.get(idx) ?? 0;
-          const pilePosition = (foldPileAnchor ?? potStack?.position ?? new THREE.Vector3())
-            .clone()
-            .add(new THREE.Vector3((cardIdx - 0.5) * FOLD_PILE_LATERAL_STEP, foldedOrder * FOLD_PILE_CARD_GAP, 0));
-          const pileLookTarget = pilePosition.clone().add(new THREE.Vector3(0, 0, 1));
-          if (player.folded && !(prevPlayer?.folded)) {
-            animateFoldCardToPile(mesh, pilePosition, pileLookTarget);
-          } else if (!mesh.userData?.foldAnimFrame) {
-            mesh.position.copy(pilePosition);
-            orientCard(mesh, pileLookTarget, { face: 'back', flat: true });
+          const clothY = (three.tableInfo?.surfaceY ?? TABLE_HEIGHT) + CARD_D * 0.4;
+          position.y = seat.isHuman ? clothY : clothY + CARD_H * 0.48;
+          mesh.position.copy(position);
+          const foldLookTarget = seat.isHuman
+            ? seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
+            : position.clone().add(seat.forward.clone());
+          orientCard(mesh, foldLookTarget, { face: 'back', flat: !seat.isHuman });
+          if (seat.isHuman) {
+            mesh.rotateX(HUMAN_CARD_FACE_TILT);
           }
           setCardFace(mesh, 'back');
           setCardHighlight(mesh, false);
           return;
         }
         const winnerOrderIndex = winnerDisplayIndex.get(idx);
-        const position = baseAnchor
-          .clone()
-          .addScaledVector(forward, HUMAN_CARD_FORWARD_OFFSET)
-          .add(right.clone().multiplyScalar((cardIdx - 0.5) * HOLE_SPACING));
         if (state.showdown && Number.isInteger(winnerOrderIndex)) {
           position.copy(
             winnerDisplayCenter
@@ -5088,8 +5052,13 @@ function TexasHoldemArena({ search }) {
 
       if (seat.foldBadge) {
         if (player.folded && !state.showdown) {
-          const foldBadgePos = seat.cardRailAnchor.clone();
-          foldBadgePos.y += CARD_D * 0.6;
+          const foldBadgePos = seat.cardMeshes
+            .filter((mesh) => mesh.visible)
+            .reduce((acc, mesh, _, allCards) => {
+              if (!acc) return mesh.position.clone().multiplyScalar(1 / allCards.length);
+              return acc.addScaledVector(mesh.position, 1 / allCards.length);
+            }, null) ?? seat.cardRailAnchor.clone();
+          foldBadgePos.y += CARD_D * 0.62;
           seat.foldBadge.position.copy(foldBadgePos);
           seat.foldBadge.visible = true;
         } else {
@@ -5292,7 +5261,7 @@ function TexasHoldemArena({ search }) {
       stage: state.stage,
       actionIndex: state.actionIndex
     };
-  }, [animateFoldCardToPile, findSeatWithAvatar, gameState, overheadView, playSound, resetCameraToStartView, turnCameraTowardsSeat]);
+  }, [findSeatWithAvatar, gameState, overheadView, playSound, resetCameraToStartView, turnCameraTowardsSeat]);
 
   const currentActionIndex = gameState?.actionIndex;
   const currentStage = gameState?.stage;


### PR DESCRIPTION
### Motivation
- Make the Texas Hold'em scene read better on phone portrait: lower the camera slightly so the table appears a bit lower on screen. 
- Ensure the pot/TPC display and fold indicators behave and read like the folded cards (upright and anchored). 
- Improve player frames (avatar / username / total TPC) with a more professional, slightly larger layout. 

### Description
- Lowered the arena camera elevation offsets for both `portrait` and `landscape` by updating `CAMERA_ELEVATION_OFFSETS` to bring the camera visually down on mobile. (`webapp/src/pages/Games/TexasHoldemArena.jsx`) 
- Reworked player nameplate rendering in `makeNameplate`: increased canvas resolution, enlarged avatar, updated typography, and added a clearer hierarchy (`PLAYER` label, username, total TPC). Also increased `LABEL_SIZE` so the in-world mesh is larger and more legible. (`makeNameplate`, `LABEL_SIZE`) 
- Converted the pot/TPC rail text to a billboard sprite using `THREE.Sprite` (was a tilted plane mesh), adjusted its size and position so it stands upright and reads like fold markers. Removed the oriented-card rotation for that label so it remains billboarded. (`createRailTextSprite`, pot label setup) 
- Changed folded-card handling so folded cards remain at each seat’s card positions (no longer animated/collected to a center pile), and anchored the red `FOLD` badge to the folded-card area by averaging visible card mesh positions for better positional alignment. Removed the fold-to-pile animation code paths. (fold logic in seat update loop, fold badge placement) 
- Minor styling tweaks in the canvas draw (gradients, stroke colors, font sizes) and some hook dependency cleanups related to the updated fold behavior. 

### Testing
- Ran lint check with `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`; file is ignored by repo pattern so only a workspace warning appeared (no new errors). (warning) 
- Attempted full TypeScript build with `npm run build`; build failed due to an existing unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (pre-existing, not caused by these changes). (failed) 
- Launched the dev server (`npm --prefix webapp run dev`) and captured a mobile-viewport screenshot using Playwright of `/games/texasholdem` to validate visual result; the screenshot was produced successfully (artifact captured). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19201f0c88329bd30d60e4c63c64a)