### PR TITLE
Keep cue camera locked until forward stroke is visible in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5464,6 +5464,7 @@ const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 160; // guarantee visible pullback phase when captured stroke timings are too short
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // guarantee visible forward push into impact in replay view
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
+const CUE_STROKE_POST_IMPACT_CAMERA_HOLD_MS = 260; // keep cue view briefly after impact so the forward stroke remains visible
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = STOP_EPS;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 34;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -14222,7 +14223,8 @@ function PoolRoyaleGame({
     placedFromHand: false,
     contactMade: false,
     cushionAfterContact: false,
-    attemptsPenaltyApplied: false
+    attemptsPenaltyApplied: false,
+    cameraSwitchUnlockAt: 0
   });
   const shotReplayRef = useRef(null);
   const replayPlaybackRef = useRef(null);
@@ -24562,6 +24564,7 @@ const powerRef = useRef(hud.power);
           contactMade: false,
           cushionAfterContact: false,
           attemptsPenaltyApplied: false,
+          cameraSwitchUnlockAt: shotStartTime + CAMERA_SWITCH_MIN_HOLD_MS,
           spin: {
             x: appliedSpinSnapshot.x ?? 0,
             y: appliedSpinSnapshot.y ?? 0
@@ -24974,6 +24977,10 @@ const powerRef = useRef(hud.power);
           const followDurationResolved = followDuration;
           const recoverDuration = Math.max(120, followDurationResolved * 0.6);
           const impactTime = startTime + pullbackDuration + forwardDuration;
+          shotContextRef.current = {
+            ...shotContextRef.current,
+            cameraSwitchUnlockAt: impactTime + CUE_STROKE_POST_IMPACT_CAMERA_HOLD_MS
+          };
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -27758,6 +27765,7 @@ const powerRef = useRef(hud.power);
           contactMade: false,
           cushionAfterContact: false,
           attemptsPenaltyApplied: false,
+          cameraSwitchUnlockAt: 0,
           spin: { x: 0, y: 0 }
         };
         let nextInHand = cueBallPotted;
@@ -29420,7 +29428,12 @@ const powerRef = useRef(hud.power);
               !suspendedActionView.activationDelay ||
               now >= suspendedActionView.activationDelay;
             const cueSpeed = cueBall.vel.length() * frameScale;
-            if (cueSpeed > CUEBALL_EARLY_CAMERA_SWITCH_SPEED) {
+            const cameraSwitchUnlockAt =
+              shotContextRef.current?.cameraSwitchUnlockAt ?? 0;
+            if (
+              cueSpeed > CUEBALL_EARLY_CAMERA_SWITCH_SPEED &&
+              now >= cameraSwitchUnlockAt
+            ) {
               powerImpactHoldRef.current = 0;
             }
             const holdReady =


### PR DESCRIPTION
### Motivation
- Players reported the camera switching away from the cue view before the cue stick’s forward push and impact were visible, making the stroke feel like it only pulled back; this change prevents premature camera handoff so the forward stroke and impact are clearly seen.

### Description
- Added a new constant `CUE_STROKE_POST_IMPACT_CAMERA_HOLD_MS` to provide a short post-impact camera hold window. 
- Extended `shotContextRef` with `cameraSwitchUnlockAt` and initialize it at shot start, then update it to `impactTime + CUE_STROKE_POST_IMPACT_CAMERA_HOLD_MS` when the stroke timings are computed. 
- Modified the action-camera activation logic to only clear the camera hold when the cue ball speed threshold is exceeded **and** the `cameraSwitchUnlockAt` timestamp has passed. 
- Applied the changes in `webapp/src/pages/Games/PoolRoyale.jsx` to ensure each stroke has its own camera-unlock window and that it is reset after shot resolution.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production `dist/` assets. 
- Started a preview server with `npm --prefix webapp run preview` and attempted an automated Playwright screenshot of `/games/poolroyale`, but the Playwright capture timed out in this environment; the build itself succeeded. 
- Recommend manual playtesting on a device (portrait viewport) to verify the cue pull, visible forward push and impact are now shown before camera transitions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c72985d883299067add4b3d165ef)