### PR TITLE
Adjust Texas Hold'em pot anchor and rail chip grid positioning

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -373,8 +373,8 @@ const CARD_LOOK_LIFT = HUMAN_CARD_LOOK_LIFT;
 const CARD_LOOK_SPLAY = HUMAN_CARD_LOOK_SPLAY;
 const NAMEPLATE_BACK_TILT = -Math.PI / 14;
 const BET_FORWARD_OFFSET = CARD_W * -0.2;
-const POT_BELOW_COMMUNITY_OFFSET = 0;
-const POT_RIGHT_ALIGNMENT_SHIFT = CARD_W * 0.42;
+const POT_BELOW_COMMUNITY_OFFSET = CARD_H * 0.78;
+const POT_RIGHT_ALIGNMENT_SHIFT = 0;
 const DECK_POSITION = new THREE.Vector3(-TABLE_RADIUS * 0.55, TABLE_HEIGHT + CARD_SURFACE_OFFSET, TABLE_RADIUS * 0.55);
 const CAMERA_SETTINGS = buildArenaCameraConfig(BOARD_SIZE);
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
@@ -414,7 +414,7 @@ const FOLD_PILE_CARD_GAP = CARD_D * 0.9;
 const FOLD_PILE_LATERAL_STEP = CARD_W * 0.1;
 const FOLD_PILE_FORWARD_OFFSET = CARD_H * -0.82;
 const CHIP_BUTTON_GRID_RIGHT_SHIFT = 0;
-const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 1.72;
+const CHIP_BUTTON_GRID_OUTWARD_SHIFT = CARD_W * 1.52;
 const CHIP_VALUES = [1000, 500, 100, 50, 20, 10, 5, 2, 1];
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const TURN_DURATION = 30;
@@ -2192,6 +2192,7 @@ function createRailTextSprite(initialLines = [], options = {}) {
     lastPayload = parsePayload(payload);
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     const amountLabel = `${lastPayload.amount.toLocaleString()} ${lastPayload.token}`;
+    const totalPotLabel = 'TOTAL POT';
     const iconSize = 140 * resolutionScale;
     const iconX = 120 * resolutionScale;
     const iconY = canvas.height / 2 - iconSize / 2;
@@ -2205,6 +2206,9 @@ function createRailTextSprite(initialLines = [], options = {}) {
 
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
+    ctx.font = `800 ${42 * resolutionScale}px "Inter", system-ui, sans-serif`;
+    ctx.fillStyle = 'rgba(186,230,253,0.95)';
+    ctx.fillText(totalPotLabel, iconX + iconSize + 28 * resolutionScale, canvas.height / 2 - 86 * resolutionScale);
     ctx.font = `900 ${110 * resolutionScale}px "Inter", system-ui, sans-serif`;
     ctx.lineJoin = 'round';
     ctx.strokeStyle = 'rgba(2,6,23,0.85)';


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the pot and raise-chip grid so the pot stack appears centered between the top avatar lane and the middle (3rd) community card in portrait view.
- Make the pot label clearer by adding a visible heading while keeping the token icon and amount.

### Description
- Moved the pot anchor vertically/forward by changing `POT_BELOW_COMMUNITY_OFFSET` and removed the right alignment offset by setting `POT_RIGHT_ALIGNMENT_SHIFT = 0` to place the pot on the center vertical line.
- Nudged the 3×3 raise chip grid slightly toward the rail controls by reducing `CHIP_BUTTON_GRID_OUTWARD_SHIFT`.
- Updated the rail pot label sprite in `createRailTextSprite` to render a `TOTAL POT` heading above the token icon + amount and applied a compact font/color for the heading.
- Changes were applied to `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran `npm run build` in `webapp/` and the build completed successfully.
- Launched the dev server and ran a Playwright visual check on a portrait viewport for the Texas Hold'em page, which produced a screenshot capturing the updated pot/chip layout (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d69d8f0883298948b58ef62143a4)