### PR TITLE
Fix Domino Royal exit freeze and PolyHaven GLTF texture loading

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5,6 +5,8 @@ import { RoundedBoxGeometry } from '/vendor/three/examples/jsm/geometries/Rounde
 import { GLTFLoader } from '/vendor/three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
 import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -2303,6 +2305,8 @@ const CHAIR_THEME_OPTIONS = Object.freeze(
 const CHAIR_MODEL_URLS = Object.freeze([]);
 const polyhavenModelCache = new Map();
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const BASIS_TRANSCODER_PATH = 'https://www.gstatic.com/basis-universal/versioned/2021-04-15-ba1c3e4/';
+let sharedKtx2Loader = null;
 
 function applySRGBColorSpace(texture) {
   if (!texture) return;
@@ -2376,6 +2380,13 @@ function createPolyhavenGltfLoader({ assetId, resolution }) {
   draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setCrossOrigin('anonymous');
   loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+    sharedKtx2Loader.detectSupport(renderer);
+  }
+  loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
 }
 
@@ -9317,8 +9328,11 @@ function monitorFrameHealth(elapsedMs, timing) {
 
 /* ---------- Loop & Resize ---------- */
 function tick(now) {
+  if (isGameShuttingDown) {
+    return;
+  }
   const current = Number.isFinite(now) ? now : performance.now();
-  requestAnimationFrame(tick);
+  animationFrameId = requestAnimationFrame(tick);
   if (contextLost || renderer.getContext?.()?.isContextLost?.()) {
     lastFrameTime = current;
     return;
@@ -9353,7 +9367,57 @@ function tick(now) {
   }
 }
 let lastFrameTime = performance.now();
-requestAnimationFrame(tick);
+let animationFrameId = requestAnimationFrame(tick);
+let isGameShuttingDown = false;
+
+function disposeSceneTree(root) {
+  if (!root?.traverse) return;
+  root.traverse((obj) => {
+    if (!obj?.isMesh) return;
+    obj.geometry?.dispose?.();
+    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+    materials.forEach((material) => {
+      if (!material) return;
+      Object.values(material).forEach((value) => {
+        if (value?.isTexture) {
+          value.dispose?.();
+        }
+      });
+      material.dispose?.();
+    });
+  });
+}
+
+function shutdownDominoRoyal(reason = 'unknown') {
+  if (isGameShuttingDown) return;
+  isGameShuttingDown = true;
+  try {
+    if (typeof animationFrameId === 'number') {
+      cancelAnimationFrame(animationFrameId);
+    }
+    controls?.dispose?.();
+    disposeSceneTree(scene);
+    disposeSeatLabel({ persistPreference: false });
+    disposeSeatAvatars();
+    disposeSeatNameTags();
+    disposeSeatBadges();
+    while (chairs.length) {
+      const chair = chairs.pop();
+      chair?.parent?.remove(chair);
+      disposeChairResources(chair);
+    }
+    if (seatOverlay?.parentNode) {
+      seatOverlay.parentNode.removeChild(seatOverlay);
+    }
+    renderer?.dispose?.();
+    renderer?.forceContextLoss?.();
+  } catch (error) {
+    console.warn('Domino Royal shutdown failed', reason, error);
+  }
+}
+
+window.__dominoRoyalCleanup = shutdownDominoRoyal;
+
 function onResize() {
   applyRendererQuality(frameQuality);
   if (entrySequenceActive) {
@@ -9390,8 +9454,27 @@ addEventListener('resize', onResize);
 if (window.visualViewport) {
   visualViewport.addEventListener('resize', onResize);
 }
-document.addEventListener('visibilitychange', () => {
+
+function onVisibilityChange() {
   slowFrameAccumulatorMs = 0;
+}
+
+function onLifecycleShutdown() {
+  shutdownDominoRoyal('page lifecycle');
+}
+
+document.addEventListener('visibilitychange', onVisibilityChange);
+window.addEventListener('pagehide', onLifecycleShutdown);
+window.addEventListener('beforeunload', onLifecycleShutdown);
+window.addEventListener('unload', onLifecycleShutdown);
+window.addEventListener('message', (event) => {
+  const message = event?.data;
+  if (typeof message === 'string' && /domino-royal:(close|exit|disconnect)/i.test(message)) {
+    shutdownDominoRoyal('postMessage');
+  }
+  if (message?.type && /domino-royal:(close|exit|disconnect)/i.test(String(message.type))) {
+    shutdownDominoRoyal('postMessage type');
+  }
 });
 
 if (shouldRunHallwayEntry) {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -49,6 +49,9 @@ export default function DominoRoyalArena() {
     document.body.appendChild(script);
 
     return () => {
+      if (typeof window.__dominoRoyalCleanup === 'function') {
+        window.__dominoRoyalCleanup('react-unmount');
+      }
       script.remove();
       if (appRoot) {
         appRoot.replaceChildren();


### PR DESCRIPTION
### Motivation
- Prevent the game from freezing the page on exit by ensuring the Domino runtime stops its render loop and releases WebGL resources when the frame is closed, the page unloads, or the React arena unmounts. 
- Restore fidelity of PolyHaven GLTF models (tables/chairs) by matching the loader/decoder stack used elsewhere so original textures and compressed KTX2 payloads are applied correctly.

### Description
- Added a safe shutdown path in `webapp/public/domino-royal-game.js` that cancels the animation frame, disposes controls, traverses and disposes meshes/materials/textures, removes UI overlays, clears chairs, and forces renderer context loss via `shutdownDominoRoyal` and `disposeSceneTree`.
- Exposed a global cleanup hook `window.__dominoRoyalCleanup` and wired lifecycle listeners (`pagehide`, `beforeunload`, `unload`, `visibilitychange`, and `message` postMessage handlers) to trigger shutdown on various exit/disconnect signals.
- Enhanced the PolyHaven GLTF loader to enable `MeshoptDecoder` and `KTX2Loader` with a BASIS transcoder path so KTX2/Basis and meshopt-compressed GLTFs load with original materials and textures similar to the Ludo pipeline.
- Invoked the cleanup hook from the React container by updating `webapp/src/pages/Games/DominoRoyalArena.jsx` to call `window.__dominoRoyalCleanup` during unmount before removing the injected game script and DOM root.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite emitted non-blocking chunk/dynamic-import warnings). 
- Verified that the modified files are included in the build and no runtime syntax errors are produced during bundling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27ea0f78c83298977d55d13125c28)