### PR TITLE
Pool Royale: cue clearance solver, auto-aim next-target, and cue visibility fixes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1875,6 +1875,8 @@ const CUE_OBSTRUCTION_SAMPLE_STEP = BALL_R * 0.6;
 const CUE_OBSTRUCTION_SAMPLE_MIN = 6;
 const CUE_OBSTRUCTION_SAMPLE_MAX = 18;
 const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.2, CUE_TIP_RADIUS * 1.75);
+const CUE_CLEARANCE_SOLVER_STEPS = 6;
+const CUE_CLEARANCE_MAX_LIFT = BALL_R * 1.3;
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * PHYSICS_PROFILE.maxTipOffsetRatio;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -23265,6 +23267,55 @@ const powerRef = useRef(hud.power);
         cueStick.position.copy(tipTarget).sub(TMP_VEC3_CUE_TIP_OFFSET);
         TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
       };
+      const resolveCueMinClearanceGap = (tipTarget, sampleCount) => {
+        if (!tipTarget) return Infinity;
+        TMP_VEC3_CUE_SAMPLE_START.copy(tipTarget);
+        TMP_VEC3_CUE_SAMPLE_END
+          .copy(tipTarget)
+          .addScaledVector(TMP_VEC3_CUE_DIR.setFromMatrixColumn(cueStick.matrixWorld, 2).normalize(), -cueLen);
+        const cushionBoxes = table?.userData?.cueObstructionBoxes ?? [];
+        const count = clamp(
+          sampleCount ?? Math.ceil(cueLen / CUE_OBSTRUCTION_SAMPLE_STEP),
+          CUE_OBSTRUCTION_SAMPLE_MIN,
+          CUE_OBSTRUCTION_SAMPLE_MAX
+        );
+        let minGap = Infinity;
+        for (let i = 0; i < count; i += 1) {
+          const t = count === 1 ? 0 : i / (count - 1);
+          const point = CUE_OBSTRUCTION_SAMPLE_POINTS[i];
+          point.lerpVectors(TMP_VEC3_CUE_SAMPLE_START, TMP_VEC3_CUE_SAMPLE_END, t);
+          for (const b of balls) {
+            if (!b?.active || b === cue || !b?.pos) continue;
+            TMP_VEC3_OBSTRUCTION_TARGET.set(b.pos.x, BALL_CENTER_Y, b.pos.y);
+            const gap =
+              point.distanceTo(TMP_VEC3_OBSTRUCTION_TARGET) -
+              (BALL_R + CUE_OBSTRUCTION_POINT_RADIUS);
+            if (gap < minGap) minGap = gap;
+          }
+          for (const box of cushionBoxes) {
+            if (!box || typeof box.distanceToPoint !== 'function') continue;
+            const gap = box.distanceToPoint(point);
+            if (gap < minGap) minGap = gap;
+          }
+        }
+        return minGap;
+      };
+      const solveCueClearance = (tipTarget, sampleCount) => {
+        if (!tipTarget) return;
+        const originalY = tipTarget.y;
+        const requiredGap = Math.max(CUE_TIP_CLEARANCE, BALL_R * 0.08);
+        let bestGap = resolveCueMinClearanceGap(tipTarget, sampleCount);
+        if (bestGap >= requiredGap) return;
+        const stepLift = CUE_CLEARANCE_MAX_LIFT / CUE_CLEARANCE_SOLVER_STEPS;
+        for (let i = 1; i <= CUE_CLEARANCE_SOLVER_STEPS; i += 1) {
+          tipTarget.y = originalY + stepLift * i;
+          applyCueStickTransform(tipTarget);
+          clampCueButtAboveCushion(tipTarget);
+          const gap = resolveCueMinClearanceGap(tipTarget, sampleCount);
+          if (gap > bestGap) bestGap = gap;
+          if (gap >= requiredGap) return;
+        }
+      };
       const clampCueButtAboveCushion = (tipTarget) => {
         if (!tipTarget) return;
         const cushionTop = table?.userData?.cushionTopLocal;
@@ -28199,9 +28250,9 @@ const powerRef = useRef(hud.power);
           isAiTurn && activeAiPlan?.aimDir && (previewingAiShot || aiCueViewActive);
         const shouldAutoAimPlayer =
           isPlayerTurn &&
-          autoAimRequestRef.current &&
           !inHandPlacementModeRef.current &&
-          !shooting;
+          !shooting &&
+          (!lookModeRef.current || autoAimRequestRef.current);
         const shouldAutoAimAi =
           isAiTurn &&
           !inHandPlacementModeRef.current &&
@@ -28680,6 +28731,7 @@ const powerRef = useRef(hud.power);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
+          solveCueClearance(tipTarget);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -28970,6 +29022,7 @@ const powerRef = useRef(hud.power);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
+          solveCueClearance(tipTarget);
           cueStick.visible = true;
           updateChalkVisibility(null);
           if (targetDir && targetBall) {
@@ -29080,6 +29133,7 @@ const powerRef = useRef(hud.power);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
+          solveCueClearance(tipTarget);
           cueStick.visible = true;
         } else {
           aimFocusRef.current = null;
@@ -29095,7 +29149,18 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          if (!cueAnimating) cueStick.visible = false;
+          const forceCueVisible =
+            replayActive ||
+            shooting ||
+            Boolean(cueStrokeStateRef.current) ||
+            aiTakingShot ||
+            previewingAiShot ||
+            aiCueViewActive;
+          if (forceCueVisible) {
+            cueStick.visible = true;
+          } else if (!cueAnimating) {
+            cueStick.visible = false;
+          }
           updateChalkVisibility(null);
         }
 


### PR DESCRIPTION
### Motivation
- Prevent the cue-stick helper from intersecting cushions and other balls during aiming and AI previews. 
- Make the aiming line automatically select the next valid target when appropriate so players/AI don’t need to manually re-target. 
- Ensure cue-stick animation/visibility is correct during replays and while shots are executing (player or AI). 

### Description
- Added a cue clearance solver (`resolveCueMinClearanceGap` and `solveCueClearance`) and related constants to compute shaft-sample gaps against cushion boxes and active balls and progressively lift the tip until a safe gap is achieved. Changes live in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Applied the clearance solver in all key cue-display paths (live player aim, remote/preview aim, and active AI plan rendering) so the cuestick helper is adjusted before rendering the cue mesh/visuals.
- Modified auto-aim logic so the player auto-aim condition uses `resolveAutoAimDirection` more reliably when not in-hand and not shooting, and prevents look-mode from blocking helpful auto-targeting unless explicitly requested (adjusted `shouldAutoAimPlayer`).
- Improved cue visibility fallback so the cue remains visible during replay playback, during the shot forward-stroke path, and for AI shot states when appropriate (guarded by a `forceCueVisible` check).

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (vite build finished and output bundles generated). 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured an automated portrait screenshot to verify the scene boots and the Pool Royale page renders. 
- Noted repository has no `lint` script; `npm --prefix webapp run lint` is not available (no lint run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a282f57b0083298e9a8a7b1dffcd46)