### PR TITLE
Add lifecycle shutdown/dispose for Domino Royal, lifecycle listeners, and adjust Polyhaven resolution selection for Telegram

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -49,6 +49,9 @@ export default function DominoRoyalArena() {
     document.body.appendChild(script);
 
     return () => {
+      if (typeof window.__dominoRoyalCleanup === 'function') {
+        window.__dominoRoyalCleanup('react-unmount');
+      }
       script.remove();
       if (appRoot) {
         appRoot.replaceChildren();


### PR DESCRIPTION
### Motivation

- Reduce memory leaks and ensure the 3D scene and renderer are disposed when the game is closed or the page lifecycle changes.  
- Prevent excessive asset/texture downloads and runtime work on constrained environments such as the Telegram Web App.  

### Description

- Added render loop control by tracking `animationFrameId`, `isGameShuttingDown`, and `isGameDisposed`, and replaced the direct `requestAnimationFrame` call with managed start/stop logic via `stopRenderLoop`.  
- Implemented `disposeSceneTree`, `softShutdownDominoRoyal`, and `hardShutdownDominoRoyal` to clean up geometries, materials, textures, controls, chairs, overlays and the renderer, and exposed these as `window.__dominoRoyalSoftCleanup` and `window.__dominoRoyalCleanup`.  
- Wire up lifecycle listeners: `visibilitychange`, `pagehide`, `beforeunload`, `unload`, `message`, and Telegram `WebApp.onEvent` hooks to trigger a soft shutdown on relevant events.  
- Hardened the render `tick` to exit early when shutting down and capture the returned `animationFrameId` so the loop can be cancelled.  
- Adjusted Polyhaven GLTF resolution selection to prefer lower resolutions for Telegram and lower-profile devices by using `IS_TELEGRAM_RUNTIME` to limit candidates to `['1k']`, and changed default resolution orders for non-UHD scenarios to `['2k','1k']` to reduce bandwidth/CPU on constrained clients.  
- Reset slow-frame accumulator on visibility changes and added a listener to call the cleanup when the React page unmounts by invoking `window.__dominoRoyalCleanup('react-unmount')` if available.  

### Testing

- Ran the project build with `npm run build` and the build completed successfully.  
- Executed the existing automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27ea0f78c83298977d55d13125c28)