### PR TITLE
Fix Telegram back button fallback navigation

### DIFF
--- a/webapp/src/hooks/useTelegramBackButton.js
+++ b/webapp/src/hooks/useTelegramBackButton.js
@@ -1,29 +1,72 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-export default function useTelegramBackButton(onBack) {
+const resolveFallbackPath = (pathname) => {
+  if (!pathname || pathname === '/') return '/';
+
+  if (pathname.startsWith('/games/')) {
+    const segments = pathname.split('/').filter(Boolean);
+    const gameSlug = segments[1];
+
+    if (segments.length >= 3 && segments[2] === 'lobby') return '/games';
+    if (gameSlug) return `/games/${gameSlug}/lobby`;
+    return '/games';
+  }
+
+  return '/';
+};
+
+const hasInAppBackHistory = () => {
+  const idx = window?.history?.state?.idx;
+  return typeof idx === 'number' ? idx > 0 : window.history.length > 1;
+};
+
+export default function useTelegramBackButton(onBackOrFallback) {
   const navigate = useNavigate();
   const location = useLocation();
-  const cbRef = useRef(onBack);
+  const cbRef = useRef(typeof onBackOrFallback === 'function' ? onBackOrFallback : null);
+  const fallbackRef = useRef(
+    typeof onBackOrFallback === 'string' && onBackOrFallback.trim()
+      ? onBackOrFallback.trim()
+      : null
+  );
 
   // Keep the latest callback without re-registering the listener
   useEffect(() => {
-    cbRef.current = onBack;
-  }, [onBack]);
+    cbRef.current = typeof onBackOrFallback === 'function' ? onBackOrFallback : null;
+    fallbackRef.current =
+      typeof onBackOrFallback === 'string' && onBackOrFallback.trim()
+        ? onBackOrFallback.trim()
+        : null;
+  }, [onBackOrFallback]);
 
   useEffect(() => {
     const tg = window?.Telegram?.WebApp;
     if (!tg) return;
 
-    if (window.history.length <= 1 || location.pathname === '/') {
+    const fallbackPath = fallbackRef.current || resolveFallbackPath(location.pathname);
+    const shouldShowBackButton = Boolean(cbRef.current) || location.pathname !== '/';
+
+    if (!shouldShowBackButton) {
       tg.BackButton.hide();
       return;
     }
 
     const handleBack = () => {
       const cb = cbRef.current;
-      if (cb) cb();
-      else navigate(-1);
+      if (cb) {
+        cb();
+        return;
+      }
+
+      if (hasInAppBackHistory()) {
+        navigate(-1);
+        return;
+      }
+
+      if (location.pathname !== fallbackPath) {
+        navigate(fallbackPath, { replace: true });
+      }
     };
 
     tg.BackButton.show();


### PR DESCRIPTION
### Motivation
- The Telegram in-app back button behaved inconsistently across game pages and deep links, sometimes doing nothing or navigating to the wrong page. 
- Game pages opened directly (deep links) had no in-app history and therefore needed a route-aware fallback instead of `history.back()`. 
- The existing hook accepted only a callback which broke usages that pass a fallback path string (e.g. `PoolRoyaleCareer`).

### Description
- Changed `useTelegramBackButton` to accept either a callback function or a fallback path string and keep both in refs (`cbRef`, `fallbackRef`).
- Added `resolveFallbackPath(pathname)` that returns sensible fallbacks for game routes, where `/games/<slug>` falls back to `/games/<slug>/lobby` and `/games/<slug>/lobby` falls back to `/games`.
- Added `hasInAppBackHistory()` that detects in-app history via `window.history.state.idx` (or `window.history.length`) to prefer `navigate(-1)` when possible.
- Updated back-button visibility and `handleBack` logic to call the custom callback if provided, else use in-app history, else navigate to the computed fallback with `replace: true`.

### Testing
- Ran `npx eslint webapp/src/hooks/useTelegramBackButton.js` which produced a project ignore warning only. 
- Ran `npx eslint --no-ignore webapp/src/hooks/useTelegramBackButton.js` as a style check and it reported existing style rule mismatches (pre-existing project lint rules), not functional failures. 
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a287bb89c483299ed99a48b85e1eda)