### PR TITLE
Pool Royale: fix cue helper clearance, auto-aim target lock, and cue visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28208,7 +28208,7 @@ const powerRef = useRef(hud.power);
           !shooting &&
           !shouldLockAiAim;
         const autoAimDir = shouldAutoAimPlayer
-          ? resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: true })
+          ? resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: false })
           : shouldAutoAimAi
             ? resolveAutoAimDirection({ turnOwner: 'ai', cycleToNext: false })
             : null;
@@ -28404,7 +28404,7 @@ const powerRef = useRef(hud.power);
           TMP_VEC3_CUE_SAMPLE_START.copy(tipTarget);
           TMP_VEC3_CUE_SAMPLE_END
             .copy(tipTarget)
-            .addScaledVector(dirVec3, -cueLen);
+            .addScaledVector(dirVec3, -(cueLen + Math.max(pullDistance, 0)));
           const cushionBoxes = table?.userData?.cueObstructionBoxes ?? [];
           let minDistance = Infinity;
           for (let i = 0; i < sampleCount; i += 1) {
@@ -28427,7 +28427,7 @@ const powerRef = useRef(hud.power);
             }
             for (const box of cushionBoxes) {
               if (!box || typeof box.distanceToPoint !== 'function') continue;
-              const gap = box.distanceToPoint(point);
+              const gap = box.distanceToPoint(point) - CUE_OBSTRUCTION_POINT_RADIUS;
               if (gap < minDistance) minDistance = gap;
             }
           }
@@ -29095,7 +29095,13 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          if (!cueAnimating) cueStick.visible = false;
+          if (
+            !cueAnimating &&
+            !replayActive &&
+            !(ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current)
+          ) {
+            cueStick.visible = false;
+          }
           updateChalkVisibility(null);
         }
 


### PR DESCRIPTION
### Motivation
- Make the aiming helper reliably target the next legal ball during normal auto-aim so the player aiming line feels predictable.
- Prevent the cue helper geometry from intersecting cushions and other balls by including the pull-back distance and the cue-point radius in obstruction checks.
- Keep the cue stick visible during replay and while cue-stroke animations are active so replays and shot animations remain clear.

### Description
- Updated player auto-aim behavior in `webapp/src/pages/Games/PoolRoyale.jsx` to call `resolveAutoAimDirection({ turnOwner: 'player', cycleToNext: false })` so auto-aim selects the best next legal target rather than cycling to alternates.
- Improved cue obstruction sampling by extending the sample end to include the current pull distance using `-(cueLen + Math.max(pullDistance, 0))` and subtracting `CUE_OBSTRUCTION_POINT_RADIUS` from cushion distance checks so the cue-tip radius is respected.
- Changed cue visibility gating so the cue is not force-hidden when `replayActive` is true or when `ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current` is active, preserving visibility during replay/shot animations.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and validated runtime behavior by capturing a screenshot (Playwright), which completed successfully.
- No repository unit tests were found/run as part of this change; build/dev checks were used for validation and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a282f57b0083298e9a8a7b1dffcd46)