### PR TITLE
Domino Royal: add graceful shutdown, runtime message handling, and Polyhaven loader tweaks

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -49,6 +49,9 @@ export default function DominoRoyalArena() {
     document.body.appendChild(script);
 
     return () => {
+      if (typeof window.__dominoRoyalCleanup === 'function') {
+        window.__dominoRoyalCleanup('react-unmount');
+      }
       script.remove();
       if (appRoot) {
         appRoot.replaceChildren();


### PR DESCRIPTION
### Motivation
- Ensure the Domino Royal game can be cleanly stopped when the host page lifecycle or external runtime requests a close, and avoid leaking event listeners, RAFs, or renderer/controls resources.
- Prevent rendering and performance issues on constrained runtimes (e.g. Telegram runtime / low-profile devices) by restricting Polyhaven GLTF resolution choices.
- Make lifecycle handlers explicit and expose a programmatic cleanup entry so React unmounts and runtime messages can trigger safe shutdown.

### Description
- Added a `shutdownDominoRoyal` function that cancels the animation frame, detaches listeners, hides the scene, and optionally disposes `controls` and `renderer` when unmounted by React.
- Track `animationFrameId`, `isGameShuttingDown`, and `runtimeListenersDetached` to guard the main loop and resize logic, and prevent double-teardown.
- Introduced `runtimeMessageHandler` to listen for external messages (`domino-royal:close|exit|disconnect`) and call the shutdown path, and added `window.__dominoRoyalCleanup` to expose programmatic cleanup for the host page.
- Reworked event wiring to named handlers (`onResize`, `onVisibilityChange`, `onLifecycleShutdown`) and ensure they are removed during shutdown; moved initial `requestAnimationFrame` assignment into the controlled flow and store the RAF id.
- Adjusted `loadPolyhavenModel` resolution selection to prefer lower-resolution assets on Telegram or low-profile devices by using `IS_TELEGRAM_RUNTIME` and simplified resolution fallbacks.
- Updated the React host `DominoRoyalArena` to call the exposed `window.__dominoRoyalCleanup('react-unmount')` when the component unmounts.

### Testing
- Ran the project build with `npm run build` and the build completed successfully.
- Executed the automated test suite with `npm test` and all tests passed.
- Verified that the game loop stops and event listeners are removed when `window.__dominoRoyalCleanup` is invoked by the host (smoke test scripted during CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27ea0f78c83298977d55d13125c28)