### PR TITLE
Center Texas Hold'em pot and nudge total-pot label inward

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -375,9 +375,9 @@ const NAMEPLATE_BACK_TILT = -Math.PI / 14;
 const BET_FORWARD_OFFSET = CARD_W * -0.2;
 const HUMAN_BET_FORWARD_OFFSET = CARD_W * -0.02;
 const HUMAN_BET_CLUSTER_SCALE = 0.88;
-const POT_BELOW_COMMUNITY_OFFSET = CARD_H * -1.02;
+const POT_BELOW_COMMUNITY_OFFSET = 0;
 const POT_RIGHT_ALIGNMENT_SHIFT = 0;
-const POT_LABEL_FORWARD_OFFSET = CARD_H * 0.16;
+const POT_LABEL_FORWARD_OFFSET = CARD_H * 0.06;
 const DECK_POSITION = new THREE.Vector3(-TABLE_RADIUS * 0.55, TABLE_HEIGHT + CARD_SURFACE_OFFSET, TABLE_RADIUS * 0.55);
 const CAMERA_SETTINGS = buildArenaCameraConfig(BOARD_SIZE);
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
@@ -1921,10 +1921,7 @@ function computePotAnchor(options = {}) {
     forward.applyAxisAngle(WORLD_UP, rotationY);
     right.applyAxisAngle(WORLD_UP, rotationY);
   }
-  const center = computeCommunitySlotPosition(2, { rotationY, surfaceY, right, forward });
-  return center
-    .clone()
-    .setY(surfaceY + CARD_SURFACE_OFFSET)
+  return new THREE.Vector3(0, surfaceY + CARD_SURFACE_OFFSET, 0)
     .addScaledVector(forward, POT_BELOW_COMMUNITY_OFFSET)
     .addScaledVector(right, POT_RIGHT_ALIGNMENT_SHIFT);
 }


### PR DESCRIPTION
### Motivation
- Align the visual pot location with the geometric center of the table so chips moving from players converge on a true mid-table pot. 
- Move the total pot amount + TPC icon slightly closer to the table center so it reads as farther from the top player and more centred on screen.

### Description
- Changed `POT_BELOW_COMMUNITY_OFFSET` to `0` and reduced `POT_LABEL_FORWARD_OFFSET` to `CARD_H * 0.06` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to reduce forward shift. 
- Reimplemented `computePotAnchor` to return `new THREE.Vector3(0, surfaceY + CARD_SURFACE_OFFSET, 0)` and then apply the (now-zero) offset so the pot anchor is at table center while preserving rotation/orientation logic. 
- Kept existing orientation/row rotation and label orientation logic intact so camera/rotation behavior remains unchanged.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully. 
- Loaded the game in a headless browser with Playwright (visited `/games/texasholdem`, waited for full load) and captured a screenshot to validate the pot and total-pot label position, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2993928108329809f55415899cf14)