### PR TITLE
Tweak Goal Rush UI spacing and rink vertical positioning

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -21,7 +21,7 @@
     html,body{height:100vh;height:100dvh;overscroll-behavior:none;}
     body{margin:0;background:var(--bg);color:#e5e7eb;font-family:'Luckiest Guy','Comic Sans MS',cursive;overflow:hidden}
     .ui{position:fixed;inset:0;}
-    .scoreboard{position:absolute;top:16px;left:0;right:0;height:46px;display:flex;align-items:center;justify-content:center;pointer-events:none;}
+    .scoreboard{position:absolute;top:22px;left:0;right:0;height:46px;display:flex;align-items:center;justify-content:center;pointer-events:none;}
     .score{font-variant-numeric:tabular-nums;background:#0b1220;border:1px solid #233050;border-radius:12px;padding:5px 8px;display:flex;align-items:center;gap:6px;-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;color:#fff;font-size:14px;}
     .score span{-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;color:#fff}
     .score-player{display:flex;align-items:center;gap:6px;min-width:0;}
@@ -33,12 +33,12 @@
 
     .canvasWrap{
       position:absolute;
-      top:82px;
-      bottom:-14px;
+      top:78px;
+      bottom:-24px;
       left:0;
       right:0;
       display:flex;
-      align-items:center;
+      align-items:flex-start;
       justify-content:center;
     }
     canvas{
@@ -260,7 +260,7 @@
   const commentarySupportNote = document.getElementById('commentarySupportNote');
   const muteIcon = document.getElementById('muteIcon');
   const muteLabel = document.getElementById('muteLabel');
-  const TOP_BAR = 56; // reserve room for top UI while keeping field lower on portrait screens
+  const TOP_BAR = 48; // reserve room for top UI while allowing slightly taller field toward the top
   const BOTTOM_GAP = -30; // add a bit more vertical room so goal nets remain visible
   const GOAL_PAUSE = 1500; // pause after a goal
   let fieldScaleActual = 1;
@@ -516,8 +516,8 @@
     rink.w = Math.round(baseW * fsx);
     rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
-    // Keep the overall game area visually a little lower on screen.
-    const verticalShift = Math.round(H * 0.004);
+    // Keep the game area visually balanced while nudging it slightly upward.
+    const verticalShift = Math.round(H * -0.01);
     rink.y = Math.round((H - rink.h) / 2 + verticalShift);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;


### PR DESCRIPTION
### Motivation

- Improve visual layout on portrait and small screens so the scoreboard and goal nets remain more visible. 
- Nudge the rink upward and adjust canvas alignment to better balance the game area relative to top UI elements.

### Description

- Adjusted CSS positioning: moved `.scoreboard` down (`top:16px` → `top:22px`) and tweaked `.canvasWrap` margins (`top:82px` → `top:78px`, `bottom:-14px` → `bottom:-24px`) and alignment (`align-items:center` → `align-items:flex-start`).
- Reduced reserved top UI space by changing `TOP_BAR` from `56` to `48` to allow a taller field near the top of the viewport.
- Changed rink vertical offset logic by replacing the small positive vertical shift with a slight negative shift (`Math.round(H * 0.004)` → `Math.round(H * -0.01)`) and updated the accompanying comment to reflect the intent.

### Testing

- Ran the frontend lint and build (`npm run lint` and `npm run build`) and both succeeded.
- No automated unit tests were added or modified for this visual/layout tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29a1d12c883298b2f1b5a8e3dbe65)