### PR TITLE
Fix pot chip transfer landing and reposition TOTAL POT label in Texas Hold'em arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -377,7 +377,7 @@ const HUMAN_BET_FORWARD_OFFSET = CARD_W * -0.02;
 const HUMAN_BET_CLUSTER_SCALE = 0.88;
 const POT_BELOW_COMMUNITY_OFFSET = 0;
 const POT_RIGHT_ALIGNMENT_SHIFT = 0;
-const POT_LABEL_FORWARD_OFFSET = CARD_H * 0.06;
+const POT_LABEL_FORWARD_OFFSET = CARD_H * -1.06;
 const DECK_POSITION = new THREE.Vector3(-TABLE_RADIUS * 0.55, TABLE_HEIGHT + CARD_SURFACE_OFFSET, TABLE_RADIUS * 0.55);
 const CAMERA_SETTINGS = buildArenaCameraConfig(BOARD_SIZE);
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
@@ -615,6 +615,13 @@ const DEFAULT_FRAME_RATE_ID = 'fhd60';
 const POT_SCATTER_LAYOUT = Object.freeze({
   perRow: 24,
   spacing: CARD_W * 0.52,
+  rowSpacing: 0,
+  jitter: 0,
+  lift: 0
+});
+const POT_TRANSFER_LOCK_LAYOUT = Object.freeze({
+  perRow: 1,
+  spacing: 0,
   rowSpacing: 0,
   jitter: 0,
   lift: 0
@@ -5278,7 +5285,7 @@ function TexasHoldemArena({ search }) {
             end: endBase,
             startLayout: seat.railLayout,
             midLayout: seat.tableLayout,
-            endLayout: potLayout,
+            endLayout: { ...potLayout, ...POT_TRANSFER_LOCK_LAYOUT },
             pauseDuration: 0.45,
             toMidDuration: 0.35,
             toEndDuration: 0.6,


### PR DESCRIPTION
### Motivation
- Bet chips were animating to the center pot and then drifting left after landing instead of staying visually centered in the pot during a hand. 
- The `TOTAL POT` label was anchored toward the top player and needed to be moved much closer to the bottom player and the folded-cards horizontal band for correct portrait layout alignment.

### Description
- Add a new locked layout `POT_TRANSFER_LOCK_LAYOUT` to force a single, centered transfer endpoint for bet-to-pot animations by defining a compact layout: `perRow: 1, spacing: 0, rowSpacing: 0, jitter: 0, lift: 0`.
- Force bet-to-pot transfer end layout to merge with the lock layout by changing the transfer call to use `endLayout: { ...potLayout, ...POT_TRANSFER_LOCK_LAYOUT }` so chips stop at the center pot and do not drift afterward.
- Move the pot label anchor by changing `POT_LABEL_FORWARD_OFFSET` to `CARD_H * -1.06` so the `TOTAL POT` rail sprite sits much closer toward the bottom player / folded-cards area.

### Testing
- Built the frontend with `npm --prefix webapp run build` and the build completed successfully. 
- Launched the dev server and used a Playwright script to open `/games/texasholdem` in a portrait viewport and captured a screenshot to validate the visual change, which succeeded. 
- No unit tests were modified; the change is limited to rendering/animation layout and visual verification was performed via the build + screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29efd985883298460e3c16ff3c15d)