### PR TITLE
Lower and expand Goal Rush playfield for portrait view

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -262,6 +262,8 @@
   const muteLabel = document.getElementById('muteLabel');
   const TOP_BAR = 48; // reserve room for top UI while allowing slightly taller field toward the top
   const BOTTOM_GAP = -30; // add a bit more vertical room so goal nets remain visible
+  const FIELD_DOWN_SHIFT_PCT = 0.02; // lower field on screen to better match portrait framing
+  const FIELD_EXTRA_BOTTOM_BALLS = 2; // extend playfield downward by roughly two puck diameters
   const GOAL_PAUSE = 1500; // pause after a goal
   let fieldScaleActual = 1;
 
@@ -516,9 +518,12 @@
     rink.w = Math.round(baseW * fsx);
     rink.h = Math.round(baseH * fsy);
     rink.x = Math.round((W - rink.w) / 2);
-    // Keep the game area visually balanced while nudging it slightly upward.
-    const verticalShift = Math.round(H * -0.01);
+    const estimatedBase = Math.max(24, Math.round(Math.min(W,H)*0.035*fieldScaleActual));
+    const estimatedPuckDiameter = Math.max(24, Math.round(estimatedBase * 1.3)) * 2;
+    const extraBottomPixels = Math.round(estimatedPuckDiameter * FIELD_EXTRA_BOTTOM_BALLS);
+    const verticalShift = Math.round(H * FIELD_DOWN_SHIFT_PCT);
     rink.y = Math.round((H - rink.h) / 2 + verticalShift);
+    rink.h = Math.min(H - rink.y, rink.h + extraBottomPixels);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;
     const goalInset = Math.round(Math.min(W, H) * 0.012);


### PR DESCRIPTION
### Motivation
- Make the Goal Rush green field sit slightly lower on portrait screens and expand its bottom edge by roughly two puck diameters so the play area reads better on phones while keeping layout stable.

### Description
- Add `FIELD_DOWN_SHIFT_PCT` and `FIELD_EXTRA_BOTTOM_BALLS` constants and adjust `rink.y` and `rink.h` calculation in `webapp/public/goal-rush.html` so the canvas field is nudged downward and extended toward the bottom within canvas bounds.

### Testing
- Served the updated `webapp/public` directory with `python3 -m http.server 4173` and visually validated the page at `/goal-rush.html` with a Playwright script that captured a portrait screenshot (screenshot saved as `artifacts/goal-rush-field-adjusted.png`).
- Committed the change and inspected the commit with `git show --stat --oneline` to confirm only `webapp/public/goal-rush.html` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a01413cc8329be50c34ed96b468c)