### PR TITLE
Lower Air Hockey HUD and controls by ~3 icon heights

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -179,6 +179,7 @@ const AIR_HOCKEY_COMMENTARY_PRESETS = Object.freeze([
   }
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = AIR_HOCKEY_COMMENTARY_PRESETS[0]?.id || 'english';
+const HUD_VERTICAL_SHIFT_REM = 9;
 
 function detectRefreshRateHint() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
@@ -2378,7 +2379,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
       style={{ touchAction: 'none', overscrollBehavior: 'none' }}
     >
-      <div className="absolute left-2 right-2 top-[6.25rem] z-30 grid grid-cols-2 items-center gap-2 text-white">
+      <div
+        className="absolute left-2 right-2 z-30 grid grid-cols-2 items-center gap-2 text-white"
+        style={{ top: `${6.25 + HUD_VERTICAL_SHIFT_REM}rem` }}
+      >
         <div
           className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
           data-player-index="0"
@@ -2416,9 +2420,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       <button
         type="button"
         onClick={() => setShowCustomizer((prev) => !prev)}
-        className={`absolute left-3 top-[4.25rem] z-40 pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+        className={`absolute left-3 z-40 pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
           showCustomizer ? 'bg-black/60' : 'hover:bg-black/60'
         }`}
+        style={{ top: `${4.25 + HUD_VERTICAL_SHIFT_REM}rem` }}
         aria-label={showCustomizer ? 'Close menu' : 'Open menu'}
       >
         <span className="text-lg leading-none" aria-hidden="true">☰</span>
@@ -2464,7 +2469,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         ) : null}
       </div>
       {!isTopDownView && (
-        <div className="absolute right-3 top-[4.25rem] z-40 flex flex-col items-center gap-2">
+        <div
+          className="absolute right-3 z-40 flex flex-col items-center gap-2"
+          style={{ top: `${4.25 + HUD_VERTICAL_SHIFT_REM}rem` }}
+        >
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
### Motivation
- The top HUD (menu, mute, avatars, usernames and score) should sit further down the mobile portrait view so it doesn't overlap the playfield and matches the requested visual spacing of ~3 icon heights.

### Description
- Added a single tuning constant `HUD_VERTICAL_SHIFT_REM = 9` and applied it to the HUD top offsets so the group can be tuned centrally.
- Moved the player HUD row (avatars / usernames / score) down by adding the shared offset to its `top` style in `AirHockey3D.jsx`.
- Moved the floating `Menu` button and the right-side mute/control cluster down by the same shared offset so controls remain aligned.
- Change affects `webapp/src/components/AirHockey3D.jsx` only and preserves existing responsive/layout logic.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully (Vite build finished).
- Launched the dev server and attempted an automated Playwright screenshot of the `/games/airhockey` page, but `Page.screenshot` timed out in this environment after multiple attempts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b4af996483298c377416f9133374)