### PR TITLE
Adjust Air Hockey mobile controls spacing and camera framing

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -106,6 +106,8 @@ const GRAPHICS_OPTIONS = Object.freeze([
 ]);
 const DEFAULT_GRAPHICS_ID = 'fhd60';
 const DEFAULT_CAMERA_LIFT = 1;
+const MOBILE_FIELD_BOTTOM_BIAS = 0.02;
+const MOBILE_FIELD_CLOSEUP_FACTOR = 0.96;
 const AIR_HOCKEY_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'english',
@@ -1607,12 +1609,12 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     const cameraFocus = new THREE.Vector3(
       0,
       elevatedTableSurfaceY + TABLE.thickness * 0.06,
-      tableCenterZ
+      tableCenterZ + PLAYFIELD.h * MOBILE_FIELD_BOTTOM_BIAS
     );
     const standingCameraAnchor = new THREE.Vector3(
       0,
-      elevatedTableSurfaceY + TABLE.h * 0.31,
-      tableCenterZ + playerRailZ + TABLE.w * 0.12
+      elevatedTableSurfaceY + TABLE.h * 0.3,
+      tableCenterZ + (playerRailZ + TABLE.w * 0.12) * MOBILE_FIELD_CLOSEUP_FACTOR
     );
     const resolveCameraAnchor = () => standingCameraAnchor.clone();
     const getCameraDirection = (anchor) =>
@@ -2428,8 +2430,15 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         className={`absolute z-20 flex flex-col gap-3 pointer-events-auto ${
           isTopDownView
             ? 'left-3 top-[45%] -translate-y-1/2 items-center'
-            : 'bottom-2 left-2 items-start'
+            : 'left-2 items-start'
         }`}
+        style={
+          isTopDownView
+            ? undefined
+            : {
+                bottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.125rem)'
+              }
+        }
       >
         <button
           type="button"
@@ -2493,7 +2502,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           </button>
         </div>
       )}
-      <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
+      <div
+        className="absolute right-2 flex flex-col items-end space-y-2 z-20"
+        style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.125rem)' }}
+      >
         {!isTopDownView && (
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Make the bottom control icons sit visually lower on portrait phones (including devices with safe-area insets) and make the playfield appear slightly larger toward the bottom/player side while preserving the existing field layout.

### Description
- Introduced `MOBILE_FIELD_BOTTOM_BIAS` and `MOBILE_FIELD_CLOSEUP_FACTOR` to provide small, tunable camera offsets for a subtle player-side framing bias in `AirHockey3D.jsx`.
- Shifted `cameraFocus` and nudged the `standingCameraAnchor` to bias the camera slightly toward the player side and to bring the table a bit closer without changing playfield proportions.
- Moved non-top-down control stacks closer to the device bottom by removing fixed `bottom-2` and adding safe-area-aware inline style `bottom: calc(env(safe-area-inset-bottom, 0px) + 0.125rem)` on the left and right control containers.
- Kept top-down view behavior unchanged and preserved the original UI layout and sizing logic.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced a production build without errors.
- Started the dev server with `npm --prefix webapp run dev` and the app served successfully (Vite ready). 
- Attempted an automated Playwright screenshot to validate the mobile visual result but the browser screenshot step timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b525bf44832990cfcf4de9ba1132)