### PR TITLE
Adjust Goal Rush bottom controls and field vertical coverage

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -34,7 +34,7 @@
     .canvasWrap{
       position:absolute;
       top:48px;
-      bottom:-24px;
+      bottom:-128px;
       left:0;
       right:0;
       display:flex;
@@ -59,10 +59,10 @@
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
     .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
-    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 5.4rem);}
-    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 5.4rem);}
-    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 5.4rem);}
-    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 5.4rem);}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
     .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
     .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
     .quick-action .icon{font-size:1.1rem;line-height:1;}


### PR DESCRIPTION
### Motivation
- Improve mobile portrait layout so the quick-action icons sit slightly lower and the green play field visually extends further toward the bottom without changing visual styling.

### Description
- Updated `webapp/public/goal-rush.html` CSS to move the quick-action icons' bottom offset from `5.4rem` to `4.6rem` and to extend `.canvasWrap` bottom from `-24px` to `-128px` so the field appears larger while preserving existing proportions and styles.

### Testing
- Launched a local static server with `python3 -m http.server 4173` and verified `http://localhost:4173/goal-rush.html` returned HTTP 200 successfully.
- Captured a mobile-portrait screenshot using Playwright (viewport 390x844) of the updated page to validate visual spacing and layout, and the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c09e8c248329b673ed52dae4918a)