### PR TITLE
Reposition canvas and quick-action buttons in goal-rush UI

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,8 +33,8 @@
 
     .canvasWrap{
       position:absolute;
-      top:48px;
-      bottom:-128px;
+      top:-2px;
+      bottom:-620px;
       left:0;
       right:0;
       display:flex;
@@ -59,10 +59,10 @@
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
     .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
-    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
     .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
     .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
     .quick-action .icon{font-size:1.1rem;line-height:1;}


### PR DESCRIPTION
### Motivation
- Fix layout issues so the game canvas and quick-action buttons are positioned correctly across viewports and safe-area insets, preventing overlap with other UI chrome.

### Description
- Update CSS in `webapp/public/goal-rush.html` to change `.canvasWrap` `top` from `48px` to `-2px` and `bottom` from `-128px` to `-620px`, and to lower the `bottom` offsets for `#quickActionChat`, `#quickActionGift`, `#quickActionAudio`, and `#quickActionMute` from `4.6rem` to `3.5rem`.

### Testing
- Ran `npm run build` and `npm run lint` as automated checks and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c89bea488329aa3988a5cd518870)