### PR TITLE
Adjust Air Hockey HUD spacing and top-right control alignment

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2382,7 +2382,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     >
       <div
         className="absolute left-2 right-2 z-30 grid grid-cols-2 items-center gap-2 text-white"
-        style={{ top: `${6.25 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+        style={{ top: `${5.5 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
       >
         <div
           className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
@@ -2412,7 +2412,8 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         </div>
       </div>
       <div
-        className="absolute top-2 left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur"
+        className="absolute left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur"
+        style={{ top: `${2.75 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
       >
         <span className="uppercase tracking-wide">{playType}</span>
         <span className="mx-2">•</span>
@@ -2471,8 +2472,8 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       </div>
       {!isTopDownView && (
         <div
-          className="absolute right-3 z-40 flex flex-col items-center gap-2"
-          style={{ top: `${4.25 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+          className="absolute right-3 z-40 flex flex-col items-center gap-1"
+          style={{ top: `${3.9 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
         >
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Improve the Air Hockey portrait HUD so avatars/usernames/scores sit closer to the target badge and reduce visual gaps between the 2D toggle and mute icon for a tighter, more balanced top area.

### Description
- Updated layout values in `webapp/src/components/AirHockey3D.jsx` to move the avatar/score row upward (`top: 6.25rem` -> `5.5rem`).
- Moved the target badge downwards by adding an explicit `style.top` (`2.75rem`) and removed the previous `top-2` utility so it visually aligns nearer the scoreboard.
- Tightened the top-right control stack by changing `gap-2` to `gap-1` and nudged its `top` from `4.25rem` to `3.9rem` so the mute and 2D/3D icons sit closer together and slightly higher.
- One source file modified: `webapp/src/components/AirHockey3D.jsx` (plus build metadata changes produced by the build run).

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully (Vite build completed and assets emitted).
- Attempted a Playwright screenshot of `/games/airhockey` to visually validate the UI, but the screenshot run timed out and failed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d384cbd883299bf690012e71599d)