### PR TITLE
Adjust canvas and quick-action positions in goal-rush UI

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -33,8 +33,8 @@
 
     .canvasWrap{
       position:absolute;
-      top:48px;
-      bottom:-128px;
+      top:-2px;
+      bottom:-479px;
       left:0;
       right:0;
       display:flex;
@@ -59,10 +59,10 @@
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
     .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
-    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.5rem);}
     .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
     .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
     .quick-action .icon{font-size:1.1rem;line-height:1;}


### PR DESCRIPTION
### Motivation

- Fix visual layout issues where the canvas and quick-action buttons were misaligned on certain viewports and with device safe-area insets.

### Description

- Update `.canvasWrap` positioning by changing `top` from `48px` to `-2px` and `bottom` from `-128px` to `-479px` to better center the canvas area.
- Move quick-action button vertical offsets by reducing bottom spacing from `4.6rem` to `3.5rem` for `#quickActionChat`, `#quickActionGift`, `#quickActionAudio`, and `#quickActionMute` to improve accessibility and alignment.

### Testing

- Ran the frontend build with `npm run build` to ensure assets compile successfully and the updated CSS is included, and the build succeeded.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c89bea488329aa3988a5cd518870)