### PR TITLE
Adjust quick-action spacing and expand play field vertically in goal-rush

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -59,10 +59,10 @@
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
     .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
-    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
-    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.6rem);}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.2rem);}
+    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.2rem);}
+    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.2rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 4.2rem);}
     .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
     .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
     .quick-action .icon{font-size:1.1rem;line-height:1;}
@@ -506,9 +506,9 @@
     H = canvas.height = Math.floor(height * devicePixelRatio);
     canvas.style.width = width + 'px';
     canvas.style.height = height + 'px';
-    // expand field by reducing canvas margins ~5% on each side
+    // expand play field vertically by 5% toward the top and 5% toward the bottom
     const baseW = W * 0.98;
-    const baseH = H * 0.94;
+    const baseH = H * 1.10;
     const maxFieldScaleX = W/baseW;
     const maxFieldScaleY = H/baseH;
     const fsx = Math.min(fieldScaleX, maxFieldScaleX);


### PR DESCRIPTION
### Motivation
- Nudge the on-screen quick-action buttons slightly upward to improve spacing with bottom UI elements on small screens.
- Expand the playable rink area vertically so the field uses more of the available canvas height instead of shrinking margins horizontally.

### Description
- Reduced the bottom offset for `#quickActionChat`, `#quickActionGift`, `#quickActionAudio`, and `#quickActionMute` from `4.6rem` to `4.2rem` in the page CSS.
- Updated the fit calculation comment to reflect vertical expansion and changed the rink base height calculation from `H * 0.94` to `H * 1.10` to increase vertical play area.
- Kept horizontal base width at `W * 0.98` and preserved existing clamping logic for field scales and derived rink/puck/paddle sizing.
- Continued persisting `goalTopY` and `goalBottomY` to `localStorage` after recalculation.

### Testing
- Ran the app build with `npm run build` and the build completed successfully.
- Ran the project's automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2eb9f13f88329893964762fe44c3c)