### PR TITLE
Refine cue stroke timing and visuals (impact timing, wobble, dip, replay fixes)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21236,7 +21236,7 @@ const powerRef = useRef(hud.power);
                 );
                 cueStick.position.lerpVectors(followPos, idlePos, easeInOutCubic(t));
               } else {
-                cueStick.position.copy(idlePos);
+                cueStick.position.copy(pullPos);
               }
             }
             syncCueShadow();
@@ -21332,24 +21332,15 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
+            const eased = easeOutCubic(t);
             tmpReplayCueA.copy(tmpReplayCueB);
-            tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
+            tmpReplayCueB.set(followSnap.x, followSnap.y, followSnap.z);
             cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
             syncCueShadow();
             return;
           }
           if (localTime <= followEnd && followTime > 0) {
-            const t = THREE.MathUtils.clamp(
-              (localTime - impactEnd) / Math.max(followTime, 1e-6),
-              0,
-              1
-            );
-            const eased = easeOutCubic(t);
-            tmpReplayCueA.set(impactSnap.x, impactSnap.y, impactSnap.z);
-            tmpReplayCueB.set(followSnap.x, followSnap.y, followSnap.z);
-            cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
+            cueStick.position.set(followSnap.x, followSnap.y, followSnap.z);
             syncCueShadow();
             return;
           }
@@ -21395,20 +21386,6 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return false;
           }
-          if (stroke.holdUntilStop) {
-            cueStick.visible = true;
-            cueAnimating = true;
-            cueStick.position.copy(stroke.idlePos);
-            syncCueShadow();
-            if (allStopped(balls)) {
-              cueAnimating = false;
-              cuePullCurrentRef.current = 0;
-              cuePullTargetRef.current = 0;
-              cueStrokeStateRef.current = null;
-              pendingImpactRef.current = null;
-            }
-            return true;
-          }
           const {
             startTime,
             idlePos,
@@ -21418,7 +21395,11 @@ const powerRef = useRef(hud.power);
             pullbackDuration,
             releaseDuration,
             followDuration,
-            recoverDuration
+            recoverDuration,
+            impactProgress,
+            wobbleAmplitude,
+            verticalDip,
+            rotationYBase
           } = stroke;
           const pullback = Math.max(0, pullbackDuration ?? 0);
           const release = Math.max(0, releaseDuration ?? 0);
@@ -21431,7 +21412,14 @@ const powerRef = useRef(hud.power);
           const recoverEnd = followEnd + recover;
           cueStick.visible = true;
           cueAnimating = true;
-          if (!stroke.shotApplied && elapsed >= releaseEnd) {
+          const hitAt =
+            pullEnd +
+            release * THREE.MathUtils.clamp(
+              Number.isFinite(impactProgress) ? impactProgress : 0.9,
+              0,
+              1
+            );
+          if (!stroke.shotApplied && elapsed >= hitAt) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
           }
@@ -21452,23 +21440,23 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
-            cueStick.position.lerpVectors(pullPos, impactPos, eased);
+            const eased = easeOutCubic(t);
+            cueStick.position.lerpVectors(pullPos, followPos ?? impactPos, eased);
+            const dip = (Number.isFinite(verticalDip) ? verticalDip : 0.003) * eased;
+            cueStick.position.y -= dip;
+            const wobble =
+              Math.sin(t * Math.PI) *
+              (Number.isFinite(wobbleAmplitude) ? wobbleAmplitude : 0.0018);
+            cueStick.rotation.y =
+              (Number.isFinite(rotationYBase) ? rotationYBase : cueStick.rotation.y) + wobble;
             syncCueShadow();
             return true;
           }
           if (elapsed <= followEnd && follow > 0) {
-            const t = THREE.MathUtils.clamp(
-              (elapsed - releaseEnd) / Math.max(follow, 1e-6),
-              0,
-              1
-            );
-            const eased = easeOutCubic(t);
-            cueStick.position.lerpVectors(
-              impactPos,
-              followPos ?? impactPos,
-              eased
-            );
+            cueStick.position.copy(followPos ?? impactPos);
+            cueStick.rotation.y = Number.isFinite(rotationYBase)
+              ? rotationYBase
+              : cueStick.rotation.y;
             syncCueShadow();
             return true;
           }
@@ -21484,12 +21472,10 @@ const powerRef = useRef(hud.power);
             return true;
           }
           cueStick.position.copy(idlePos);
+          cueStick.rotation.y = Number.isFinite(rotationYBase)
+            ? rotationYBase
+            : cueStick.rotation.y;
           syncCueShadow();
-          if (!allStopped(balls)) {
-            stroke.holdUntilStop = true;
-            cueStrokeStateRef.current = stroke;
-            return true;
-          }
           cueStick.visible = true;
           cueAnimating = false;
           cuePullCurrentRef.current = 0;
@@ -24936,7 +24922,7 @@ const powerRef = useRef(hud.power);
           };
           const idlePos = buildCuePosition(0);
           const pullPos = buildCuePosition(visualPull);
-          cueStick.position.copy(idlePos);
+          cueStick.position.copy(pullPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           cueStick.visible = true;
@@ -24944,36 +24930,25 @@ const powerRef = useRef(hud.power);
             recordReplayFrame(performance.now());
           }
           const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
-          const forwardBlend = Math.pow(powerStrength, PLAYER_CUE_FORWARD_EASE);
-          const baseForwardDuration = THREE.MathUtils.lerp(
-            PLAYER_CUE_FORWARD_MAX_MS,
-            PLAYER_CUE_FORWARD_MIN_MS,
-            forwardBlend
+          const topspinFactor = THREE.MathUtils.clamp(
+            Math.max(0, appliedSpin?.y ?? 0) * powerStrength,
+            0,
+            1
           );
-          const forwardDuration = Math.max(220, baseForwardDuration * PLAYER_FORWARD_SLOWDOWN);
-          const pullbackDuration = Math.max(120, forwardDuration * 0.65);
+          const forwardDuration = 120;
+          const holdDuration = 50;
+          const pullbackDuration = 0;
           const startTime = performance.now();
-          const followThrough = THREE.MathUtils.lerp(
-            CUE_FOLLOW_THROUGH_MIN,
-            CUE_FOLLOW_THROUGH_MAX,
-            powerStrength
+          const followThrough = THREE.MathUtils.clamp(
+            topspinFactor * 0.016,
+            0,
+            0.018
           );
           const impactPos = idlePos.clone();
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
-          const followPos = buildCuePosition(-followDistance);
-          const followSpeed = THREE.MathUtils.lerp(
-            CUE_FOLLOW_SPEED_MIN,
-            CUE_FOLLOW_SPEED_MAX,
-            powerStrength
-          );
-          const followDuration = THREE.MathUtils.clamp(
-            (followThrough / Math.max(followSpeed, 1e-6)) * 1000,
-            CUE_FOLLOW_MIN_MS,
-            CUE_FOLLOW_MAX_MS
-          );
-          const followDurationResolved = followDuration;
-          const recoverDuration = Math.max(120, followDurationResolved * 0.6);
-          const impactTime = startTime + pullbackDuration + forwardDuration;
+          const followPos = buildCuePosition(-followThrough);
+          const followDurationResolved = holdDuration;
+          const recoverDuration = 0;
+          const impactTime = startTime + forwardDuration * 0.9;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -25083,7 +25058,11 @@ const powerRef = useRef(hud.power);
               pullbackDuration,
               releaseDuration: forwardDuration,
               followDuration: followDurationResolved,
-              recoverDuration
+              recoverDuration,
+              impactProgress: 0.9,
+              wobbleAmplitude: 0.0018,
+              verticalDip: 0.003,
+              rotationYBase: cueStick.rotation.y
             };
           } else {
             cueStick.visible = false;


### PR DESCRIPTION
### Motivation

- Improve cue animation realism by exposing impact timing and adding subtle wobble and vertical dip on impact. 
- Fix inconsistencies between replay and live cue animations so replayed strokes match runtime behavior. 
- Simplify player stroke timing to reduce latency and ensure consistent preview/hold behavior.

### Description

- Added new stroke parameters `impactProgress`, `wobbleAmplitude`, `verticalDip`, and `rotationYBase` and wire them into stroke state creation to control hit timing and visual effects. 
- Compute the actual hit time (`hitAt`) from `impactProgress` and use it to trigger `onImpact` earlier/more accurately, and apply a vertical dip and yaw wobble during the release phase. 
- Adjusted multiple default cue positions to use `pullPos` as the visible base in preview code paths and simplified follow/recover sequencing and rotations to restore `rotationYBase` at the end of the stroke. 
- Fixed replay interpolation by using `followSnap` in the impact-to-follow transition and switching easing to `easeOutCubic`, and simplified follow-phase handling to directly set the follow pose. 
- Simplified player input timings: set `forwardDuration`, `holdDuration`, `pullbackDuration`, and `recoverDuration` to new defaults and compute `followThrough` from a `topspinFactor`, updating `impactTime` and preview hold logic accordingly. 
- Removed the old `holdUntilStop` special-case behavior and associated branching to streamline stroke lifecycle handling.

### Testing

- Ran unit tests via `yarn test` and the test suite completed successfully. 
- Ran lint checks via `yarn lint` and no lint errors were reported. 
- Verified the frontend build with `yarn build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e8329fe88329a9978f585f7e9809)