### PR TITLE
Align Pool Royale cue stroke animation with requested stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21401,26 +21401,21 @@ const powerRef = useRef(hud.power);
             pullPos,
             impactPos,
             followPos,
-            releaseDuration,
-            followDuration,
-            impactProgress,
+            strikeDuration,
+            holdDuration,
             baseRotationX,
             baseRotationY,
-            strikeDip
+            strikeDip,
+            wobbleAmount
           } = stroke;
-          const release = Math.max(0, releaseDuration ?? 0);
-          const hold = Math.max(0, followDuration ?? 0);
+          const release = Math.max(0, strikeDuration ?? 120);
+          const hold = Math.max(0, holdDuration ?? 50);
           const elapsed = Math.max(0, now - startTime);
           const releaseEnd = release;
           const holdEnd = releaseEnd + hold;
           cueStick.visible = true;
           cueAnimating = true;
-          const hitAt =
-            release * THREE.MathUtils.clamp(
-              Number.isFinite(impactProgress) ? impactProgress : 0.9,
-              0,
-              1
-            );
+          const hitAt = release * 0.9;
           if (!stroke.shotApplied && elapsed >= hitAt) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
@@ -21428,7 +21423,7 @@ const powerRef = useRef(hud.power);
           if (elapsed <= releaseEnd && release > 0) {
             const t = THREE.MathUtils.clamp(elapsed / Math.max(release, 1e-6), 0, 1);
             const eased = easeOutCubic(t);
-            const wobble = Math.sin(t * Math.PI) * BALL_R * 0.03;
+            const wobble = Math.sin(t * Math.PI) * (wobbleAmount ?? BALL_R * 0.03);
             cueStick.position.lerpVectors(pullPos, followPos ?? impactPos, eased);
             cueStick.position.y -= (strikeDip ?? BALL_R * 0.06) * eased;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
@@ -25028,13 +25023,13 @@ const powerRef = useRef(hud.power);
               impactPos: impactPos.clone(),
               followPos: followPos.clone(),
               pullbackDuration,
-              releaseDuration: strikeDuration,
-              followDuration: followDurationResolved,
+              strikeDuration,
+              holdDuration: followDurationResolved,
               recoverDuration,
-              impactProgress: 0.9,
               baseRotationX: cueStick.rotation.x,
               baseRotationY: cueStick.rotation.y,
-              strikeDip: BALL_R * 0.06
+              strikeDip: BALL_R * 0.06,
+              wobbleAmount: BALL_R * 0.03
             };
           } else {
             cueStick.visible = false;


### PR DESCRIPTION
### Motivation
- Make the Pool Royale cue stroke match the simpler reference stroke model (explicit strike + hold timing and deterministic impact point) so the in-game cue animation behaves like the provided example.

### Description
- Replaced the previous `release`/`follow` fields with an explicit `strikeDuration` and `holdDuration` stored on `cueStrokeStateRef.current` and used at runtime. 
- Trigger the shot impact at 90% of the strike phase (`hitAt = strikeDuration * 0.9`) and call the stroke `onImpact` there. 
- Added a `wobbleAmount` field and use it to compute the forward wobble during the strike, preserving the eased forward motion and vertical dip visuals. 
- Updated replay/recording payload to store `strikeDuration`/`holdDuration` (instead of `releaseDuration`/`followDuration`) so replays use the same timing model.

### Testing
- Ran `npm run build` in `webapp/` successfully to validate the bundle.
- Launched the dev server (`vite`) and attempted a headless Playwright screenshot of `/games/poolroyale`, but the screenshot attempt timed out in this environment (Playwright timeout); this did not affect the build verification.
- Changes were committed and a PR created with the above summary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3bfb813f883298d504519f0932876)