### PR TITLE
Fix GLTF chair texture disposal check in Domino Royal

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6868,7 +6868,10 @@ function disposeChairResources(root) {
       if (!material) return;
       CHAIR_TEXTURE_PROPS.forEach((prop) => {
         const texture = material[prop];
-        if (texture?.isTexture) {
+        // GLTF material clones share underlying texture instances.
+        // Disposing them here can blank textures on active chairs and cached templates.
+        // Only dispose textures explicitly marked as disposable by this game.
+        if (texture?.isTexture && texture.userData?.dominoCanDispose === true) {
           texture.dispose();
         }
       });


### PR DESCRIPTION
### Motivation
- Prevent shared GLTF textures used by cloned chair materials from being disposed when chairs are removed, which caused blank/missing textures in the Domino Royal scene.

### Description
- Update `disposeChairResources` in `webapp/public/domino-royal-game.js` to only call `texture.dispose()` when `texture.userData.dominoCanDispose === true` and add comments explaining why GLTF textures must be preserved.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which passed, and launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` then used a Playwright script to load `/games/domino-royal` and capture a screenshot, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c403d1488329bbc0b906def1645b)