### PR TITLE
Refactor cue stroke/impact handling; add wobble and hold timing adjustments

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21401,26 +21401,21 @@ const powerRef = useRef(hud.power);
             pullPos,
             impactPos,
             followPos,
-            releaseDuration,
-            followDuration,
-            impactProgress,
+            strikeDuration,
+            holdDuration,
             baseRotationX,
             baseRotationY,
-            strikeDip
+            strikeDip,
+            wobbleAmount
           } = stroke;
-          const release = Math.max(0, releaseDuration ?? 0);
-          const hold = Math.max(0, followDuration ?? 0);
+          const release = Math.max(0, strikeDuration ?? 120);
+          const hold = Math.max(0, holdDuration ?? 50);
           const elapsed = Math.max(0, now - startTime);
           const releaseEnd = release;
           const holdEnd = releaseEnd + hold;
           cueStick.visible = true;
           cueAnimating = true;
-          const hitAt =
-            release * THREE.MathUtils.clamp(
-              Number.isFinite(impactProgress) ? impactProgress : 0.9,
-              0,
-              1
-            );
+          const hitAt = release * 0.9;
           if (!stroke.shotApplied && elapsed >= hitAt) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
@@ -21428,7 +21423,7 @@ const powerRef = useRef(hud.power);
           if (elapsed <= releaseEnd && release > 0) {
             const t = THREE.MathUtils.clamp(elapsed / Math.max(release, 1e-6), 0, 1);
             const eased = easeOutCubic(t);
-            const wobble = Math.sin(t * Math.PI) * BALL_R * 0.03;
+            const wobble = Math.sin(t * Math.PI) * (wobbleAmount ?? BALL_R * 0.03);
             cueStick.position.lerpVectors(pullPos, followPos ?? impactPos, eased);
             cueStick.position.y -= (strikeDip ?? BALL_R * 0.06) * eased;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
@@ -24771,36 +24766,38 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          const applyCueImpact = () => {
+            cue.vel.copy(base);
+            if (cue.spin) {
+              cue.spin.set(spinSide, spinTop);
+            }
+            if (cue.omega) {
+              cue.omega.set(0, 0, 0);
+              TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
+              if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
+              TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
+              if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
+              TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
+              TMP_VEC3_C.y += scaledSpin.y * BALL_R;
+              const impulseMag = BALL_MASS * base.length();
+              TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+              TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+              cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+            }
+            if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+            cue.spinMode = 'standard';
+            cue.swerveStrength = 0;
+            cue.swervePowerStrength = 0;
+            resetSpinRef.current?.();
+            cueLiftRef.current.lift = 0;
+            cueLiftRef.current.startLift = 0;
+            cue.impacted = false;
+            cue.launchDir = shotAimDir.clone().normalize();
+            maxPowerLiftTriggered = false;
+            cue.lift = 0;
+            cue.liftVel = 0;
+            playCueHit(clampedPower * 0.6);
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25028,15 +25025,17 @@ const powerRef = useRef(hud.power);
               impactPos: impactPos.clone(),
               followPos: followPos.clone(),
               pullbackDuration,
-              releaseDuration: strikeDuration,
-              followDuration: followDurationResolved,
+              strikeDuration,
+              holdDuration: followDurationResolved,
               recoverDuration,
-              impactProgress: 0.9,
               baseRotationX: cueStick.rotation.x,
               baseRotationY: cueStick.rotation.y,
-              strikeDip: BALL_R * 0.06
+              strikeDip: BALL_R * 0.06,
+              wobbleAmount: BALL_R * 0.03,
+              onImpact: applyCueImpact
             };
           } else {
+            applyCueImpact();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Improve separation of concerns between cue stroke animation and the actual ball impact application to ensure the impact always executes whether or not animation is enabled.
- Add explicit timing defaults and expose wobble magnitude to make stroke animation behavior more deterministic and configurable.

### Description
- Extracted the cue impact logic into a dedicated `applyCueImpact` function and wire it into the stroke state via an `onImpact` callback so impact gets applied at the correct time during animations or immediately when animations are disabled.
- Renamed and adjusted timing fields in the stroke state from `releaseDuration`/`followDuration` to `strikeDuration`/`holdDuration` with sane defaults (`strikeDuration` defaulting to 120 and `holdDuration` to 50) and use a fixed hit moment at `release * 0.9`.
- Introduced a `wobbleAmount` field and used it for the cue wobble calculation while preserving the existing `strikeDip` fallback.
- Updated the stroke state serialization to include new fields and ensure `applyCueImpact` runs when animations are disabled.

### Testing
- Ran the frontend unit test suite with `yarn test`, which completed successfully. 
- Ran the application build with `yarn build`, which produced a successful build. 
- Ran the linter with `yarn lint`, which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3bfb813f883298d504519f0932876)