### PR TITLE
Preserve hidden Texas Hold'em cards when changing themes and ensure TonPlaygram logo on card backs

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -3885,28 +3885,39 @@ function TexasHoldemArena({ search }) {
       }
     }
     three.cardThemeId = cardTheme.id;
-    const applyThemeToMesh = (mesh, cardData) => {
+    const currentStage = gameStateRef.current?.stage;
+    const communityRevealCount =
+      currentStage === 'flop'
+        ? 3
+        : currentStage === 'turn'
+          ? 4
+          : currentStage === 'river' || currentStage === 'showdown'
+            ? 5
+            : 0;
+    const applyThemeToMesh = (mesh, cardData, fallbackFace = null) => {
       if (!mesh) return;
-      const priorFace = mesh.userData?.cardFace || 'front';
+      const priorFace = mesh.userData?.cardFace || fallbackFace || 'front';
       applyCardToMesh(mesh, cardData, three.cardGeometry, three.faceCache, cardTheme);
       setCardFace(mesh, priorFace);
     };
     three.seatGroups?.forEach((seat) => {
       seat.cardMeshes.forEach((mesh) => {
         const data = mesh.userData?.card;
+        const fallbackFace = seat.isHuman || currentStage === 'showdown' ? 'front' : 'back';
         if (data) {
-          applyThemeToMesh(mesh, data);
+          applyThemeToMesh(mesh, data, fallbackFace);
         } else {
-          applyThemeToMesh(mesh, { rank: 'A', suit: 'S' });
+          applyThemeToMesh(mesh, { rank: 'A', suit: 'S' }, fallbackFace);
         }
       });
     });
-    three.communityMeshes?.forEach((mesh) => {
+    three.communityMeshes?.forEach((mesh, index) => {
       const data = mesh.userData?.card;
+      const fallbackFace = index < communityRevealCount ? 'front' : 'back';
       if (data) {
-        applyThemeToMesh(mesh, data);
+        applyThemeToMesh(mesh, data, fallbackFace);
       } else {
-        applyThemeToMesh(mesh, { rank: 'A', suit: 'S' });
+        applyThemeToMesh(mesh, { rank: 'A', suit: 'S' }, fallbackFace);
       }
     });
     if (environmentOption) {

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -149,34 +149,49 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
   canvas.width = w;
   canvas.height = h;
   const ctx = canvas.getContext('2d');
-  const [c1, c2] = theme.backGradient || [theme.backColor, theme.backColor];
-  const gradient = ctx.createLinearGradient(0, 0, w, h);
-  gradient.addColorStop(0, c1 || '#0f172a');
-  gradient.addColorStop(1, c2 || '#0b1220');
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, w, h);
+  const paint = () => {
+    ctx.clearRect(0, 0, w, h);
+    const [c1, c2] = theme.backGradient || [theme.backColor, theme.backColor];
+    const gradient = ctx.createLinearGradient(0, 0, w, h);
+    gradient.addColorStop(0, c1 || '#0f172a');
+    gradient.addColorStop(1, c2 || '#0b1220');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, w, h);
 
-  drawBackPattern(ctx, w, h, theme);
+    drawBackPattern(ctx, w, h, theme);
 
-  ctx.strokeStyle = theme.backBorder || 'rgba(255,255,255,0.18)';
-  ctx.lineWidth = 14;
-  roundRect(ctx, 18, 18, w - 36, h - 36, 48);
-  ctx.stroke();
-  if (theme.backAccent) {
-    ctx.strokeStyle = theme.backAccent;
-    ctx.lineWidth = 8;
-    for (let i = 0; i < 6; i += 1) {
-      const inset = 36 + i * 18;
-      roundRect(ctx, inset, inset, w - inset * 2, h - inset * 2, 42);
-      ctx.stroke();
+    ctx.strokeStyle = theme.backBorder || 'rgba(255,255,255,0.18)';
+    ctx.lineWidth = 14;
+    roundRect(ctx, 18, 18, w - 36, h - 36, 48);
+    ctx.stroke();
+    if (theme.backAccent) {
+      ctx.strokeStyle = theme.backAccent;
+      ctx.lineWidth = 8;
+      for (let i = 0; i < 6; i += 1) {
+        const inset = 36 + i * 18;
+        roundRect(ctx, inset, inset, w - inset * 2, h - inset * 2, 42);
+        ctx.stroke();
+      }
     }
-  }
 
-  drawLogoFrame(ctx, w, h, theme);
+    drawLogoFrame(ctx, w, h, theme);
+  };
+  paint();
 
   const texture = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(texture);
   texture.anisotropy = 8;
+  const logoImage = getTonplaygramLogoImage();
+  if (logoImage && !(logoImage.complete && logoImage.naturalWidth > 0)) {
+    logoImage.addEventListener(
+      'load',
+      () => {
+        paint();
+        texture.needsUpdate = true;
+      },
+      { once: true }
+    );
+  }
   return texture;
 }
 


### PR DESCRIPTION
### Motivation
- Changing card colors/themes during a hand was unintentionally flipping open opponents' hole cards and unrevealed community cards, which breaks game integrity and UX.  
- Card backs should display the TonPlaygram logo used in the app header so back art matches the rest of the UI.

### Description
- Ensure theme re-application preserves each mesh's current face by keeping `cardFace` and introducing a `fallbackFace` chosen from seat type and game stage, implemented in `TexasHoldemArena.jsx` (compute `communityRevealCount`, pass `fallbackFace` to `applyThemeToMesh`, and use `priorFace` when re-applying materials).  
- Make card-back generation in `webapp/src/utils/cards3d.js` repaint via a `paint()` function and attach a listener to the TonPlaygram logo image so textures created before the logo loads are updated and `texture.needsUpdate` is set after load.  
- Minor robustness: avoid forcing a front-facing card when theme is switched by respecting existing `mesh.userData.cardFace` and using stage-aware fallback logic for community cards and opponent seats.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully.  
- Launched the dev server with `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and loaded `/games/texasholdem` for visual verification.  
- Captured an automated Playwright screenshot of the running page to validate that changing card themes no longer reveals hidden hands and that card backs show the TonPlaygram logo, and the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ced192f08329ae39892ea49755eb)