### PR TITLE
Adjust rink vertical positioning and allow small bottom extension to keep goal visible on portrait screens

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -262,7 +262,8 @@
   const muteLabel = document.getElementById('muteLabel');
   const TOP_BAR = 0; // no top offset: HUD moved to bottom so the field can rise up a bit
   const BOTTOM_GAP = -24; // keep bottom goal visible while still giving field extra vertical room
-  const FIELD_DOWN_SHIFT_PCT = -0.018; // move the field a bit higher on portrait screens
+  const FIELD_DOWN_SHIFT_PCT = -0.03; // move the field higher toward the top on portrait screens
+  const FIELD_BOTTOM_EXTENSION_PUCK_SIZE = 2; // extend field only downward by ~1 puck diameter
   const GOAL_PAUSE = 1500; // pause after a goal
   let fieldScaleActual = 1;
 
@@ -525,6 +526,11 @@
     const minY = safeGap;
     const maxY = H - rink.h - safeGap;
     rink.y = Math.max(minY, Math.min(maxY, rink.y));
+    const previewPuckRadius = Math.max(24, Math.round(estimatedBase * 1.3 * puckScale));
+    const bottomFieldExtension = Math.round(previewPuckRadius * FIELD_BOTTOM_EXTENSION_PUCK_SIZE);
+    const maxBottomBound = H - safeGap;
+    const extendedHeight = Math.min(maxBottomBound - rink.y, rink.h + bottomFieldExtension);
+    rink.h = Math.max(rink.h, extendedHeight);
     centerX = W/2; centerY = H/2;
     goalCenterX = centerX + rink.w * goalOffsetXPct;
     const goalInset = Math.round(Math.min(W, H) * 0.012);


### PR DESCRIPTION
### Motivation

- Ensure the bottom goal stays visible on narrow/portrait viewports by nudging the play field upward and permitting a small downward extension based on puck size.
- Improve visual layout and avoid clipping between the HUD and the rink across varied device aspect ratios.

### Description

- Increase `FIELD_DOWN_SHIFT_PCT` from `-0.018` to `-0.03` to move the field higher on portrait screens.
- Add a new `FIELD_BOTTOM_EXTENSION_PUCK_SIZE` constant to control the downward extension amount relative to the puck radius.
- In `fit()` compute `previewPuckRadius`, derive a `bottomFieldExtension` from that radius, constrain the extension to screen bounds, and increase `rink.h` when needed so the bottom goal remains visible.
- Maintain existing safe-gap, scaling, and centering logic while applying the new vertical shift and extension calculations.

### Testing

- No automated tests were added or run for this UI/layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3dc9cb2108329a985abb0d137c9c9)