### PR TITLE
Improve showdown visuals and pot transfer stacks; update card back texture and pot label sizing

### DIFF
--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -77,12 +77,11 @@ export function orientCard(mesh, lookTarget, { face = 'front', flat = true } = {
 
 export function setCardFace(mesh, face) {
   if (!mesh?.material) return;
-  const { frontMaterial, backMaterial, hiddenMaterial } = mesh.userData ?? {};
+  const { frontMaterial, backMaterial } = mesh.userData ?? {};
   if (!frontMaterial || !backMaterial) return;
   if (face === 'back') {
-    const mat = hiddenMaterial ?? backMaterial;
-    mesh.material[4] = mat;
-    mesh.material[5] = mat;
+    mesh.material[4] = backMaterial;
+    mesh.material[5] = backMaterial;
     mesh.userData.cardFace = 'back';
   } else {
     mesh.material[4] = frontMaterial;
@@ -144,7 +143,7 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   return texture;
 }
 
-function makeCardBackTexture(theme, w = 512, h = 720) {
+function makeCardBackTexture(theme, w = 2048, h = 2880) {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
@@ -339,34 +338,23 @@ function drawBackPattern(ctx, w, h, theme) {
 }
 
 function drawLogoFrame(ctx, w, h, theme) {
-  const frameWidth = w * 0.68;
-  const frameHeight = h * 0.22;
-  const frameX = (w - frameWidth) / 2;
-  const frameY = (h - frameHeight) / 2;
+  const frameWidth = w * 0.86;
+  const frameHeight = h * 0.3;
+  const logoImage = getTonplaygramLogoImage();
 
   ctx.save();
-  ctx.fillStyle = 'rgba(2, 6, 23, 0.32)';
-  roundRect(ctx, frameX - 4, frameY - 4, frameWidth + 8, frameHeight + 8, 24);
-  ctx.fill();
-
-  ctx.strokeStyle = theme.backAccent || 'rgba(255,255,255,0.45)';
-  ctx.lineWidth = 3;
-  roundRect(ctx, frameX, frameY, frameWidth, frameHeight, 20);
-  ctx.stroke();
-
-  const logoImage = getTonplaygramLogoImage();
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const drawWidth = Math.min(frameWidth * 0.82, frameHeight * ratio);
+    const drawWidth = Math.min(frameWidth, frameHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;
     const logoY = h / 2 - drawHeight / 2;
     ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
   } else {
-    ctx.fillStyle = 'rgba(255,255,255,0.9)';
+    ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.font = '700 34px "Inter", system-ui, sans-serif';
+    ctx.font = '700 48px "Inter", system-ui, sans-serif';
     ctx.fillText('TonPlaygram', w / 2, h / 2);
   }
 


### PR DESCRIPTION
### Motivation
- Improve visual feedback for pot transfers by showing transient "drop" chip piles per seat and cleaning them up automatically.
- Make showdown reveals more dramatic by tilting revealed cards and lengthening the reset delay to give players more time to view winners.
- Improve card art fidelity and pot label legibility by increasing back texture resolution and enlarging the pot label canvas.

### Description
- Added `computeSeatPotDropAnchor` to calculate anchor positions for transient per-seat pot drop stacks and integrated it when applying pot gains so small temporary stacks are created and capped (oldest disposed after 8 entries). 
- Added `potDropPiles` and `potDropCount` to seat group state, ensured disposal in cleanup and when pot resets, and limited retained drop stacks to avoid leaks.
- Changed showdown animation logic to orient revealed cards differently (`SHOWDOWN_CARD_STAND_TILT`) and adjusted `orientCard` usage so revealed cards are not forced flat, and increased `SHOWDOWN_RESET_DELAY` from `6500` to `9200`.
- Adjusted pot label sizing and positioning (`POT_LABEL_FORWARD_OFFSET` set to `0`, increased pot label `width`/`height`, and minor vertical offset tweak) for improved readability.
- Updated slider enablement logic to rely on available call/raise amounts instead of `uiState.canRaise` so the slider is enabled when appropriate (`toCall > 0 || sliderMax > 0`).
- In `cards3d.js`, increased default card back texture resolution (`makeCardBackTexture` from `512x720` to `2048x2880`), simplified `setCardFace` to always use the back material for the back face, and adjusted logo frame drawing and fallback text sizing/color.

### Testing
- Ran unit tests with `yarn test`, and all tests passed.
- Ran linter with `yarn lint`, and no new lint errors were reported.
- Performed a production build with `yarn build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d784b26c8329b79ddc7bc823be87)