### PR TITLE
Align Texas Hold'em card backs with Lucky Card, enable 3x3 chip buttons from start, and reduce chip pile overlap

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -535,7 +535,7 @@ const CARD_RAIL_FORWARD_SHIFT_RATIO = CARD_RAIL_FORWARD_SHIFT / RAIL_FORWARD_MAR
 const CHIP_RAIL_FORWARD_SHIFT_RATIO = CHIP_RAIL_FORWARD_SHIFT / RAIL_FORWARD_MARGIN;
 const HUMAN_SEAT_RADIUS_OFFSET = CHAIR_RADIUS - TABLE_RADIUS;
 const AI_SEAT_RADIUS_OFFSET = AI_CHAIR_RADIUS - TABLE_RADIUS;
-const BET_DISTANCE_RATIO = 0.6;
+const BET_DISTANCE_RATIO = 0.68;
 
 const RAIL_CHIP_SCALE = 1.08;
 const RAIL_CHIP_SPACING = CARD_W * 0.44;
@@ -545,9 +545,9 @@ const RAIL_CHIP_ROW_SPACING = CARD_H * 0.42;
 
 const CHIP_SCATTER_LAYOUT = Object.freeze({
   perRow: 5,
-  spacing: CARD_W * 0.56,
-  rowSpacing: CARD_W * 0.44,
-  jitter: CARD_W * 0.1,
+  spacing: CARD_W * 0.46,
+  rowSpacing: CARD_W * 0.36,
+  jitter: CARD_W * 0.06,
   lift: 0
 });
 
@@ -5962,19 +5962,29 @@ function TexasHoldemArena({ search }) {
   }, [gameState.stage, gameState.actionIndex, gameState.players, handleAction, toCall]);
 
   useEffect(() => {
-    if (!sliderVisible) {
+    if (!sliderVisible || sliderMax <= 0) {
       setChipSelection([]);
       setSliderValue(0);
       return;
     }
-    if (sliderMax <= 0) {
-      setChipSelection([]);
-      setSliderValue(0);
-      return;
-    }
-    setChipSelection([]);
-    setSliderValue(defaultRaise);
-  }, [humanPlayer?.id, sliderMax, minRaiseAmount, gameState.stage, defaultRaise, sliderVisible]);
+    setChipSelection((prev) => {
+      if (!prev.length) {
+        setSliderValue(defaultRaise);
+        return prev;
+      }
+      const clamped = [];
+      let running = 0;
+      prev.forEach((chip) => {
+        const next = running + chip;
+        if (next <= sliderMax) {
+          clamped.push(chip);
+          running = next;
+        }
+      });
+      setSliderValue(clamped.length ? running : defaultRaise);
+      return clamped;
+    });
+  }, [humanPlayer?.id, sliderMax, defaultRaise, sliderVisible]);
 
   useEffect(() => {
     if (sliderMax <= 0 || !sliderVisible) return;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -149,11 +149,9 @@ function makeCardBackTexture(theme, w = 2048, h = 2880) {
   canvas.height = h;
   const ctx = canvas.getContext('2d');
   const drawBack = () => {
-    const cardBackPattern = ctx.createPattern(makeLuckyCardBackPatternCanvas(), 'repeat');
-    ctx.fillStyle = cardBackPattern || '#112233';
-    ctx.fillRect(0, 0, w, h);
-
-    drawLogoFrame(ctx, w, h, theme);
+    drawLuckyCardBackBase(ctx, w, h);
+    drawLuckyCardBackLogo(ctx, w, h, theme);
+    drawLuckyCardBackBorder(ctx, w, h);
   };
 
   drawBack();
@@ -177,22 +175,42 @@ function makeCardBackTexture(theme, w = 2048, h = 2880) {
   return texture;
 }
 
-function makeLuckyCardBackPatternCanvas(size = 96) {
-  const patternCanvas = document.createElement('canvas');
-  patternCanvas.width = size;
-  patternCanvas.height = size;
-  const patternCtx = patternCanvas.getContext('2d');
-  patternCtx.fillStyle = '#223333';
-  patternCtx.fillRect(0, 0, size, size);
-  patternCtx.fillStyle = '#112222';
-  patternCtx.beginPath();
-  patternCtx.moveTo(0, size * 0.5);
-  patternCtx.lineTo(size * 0.5, 0);
-  patternCtx.lineTo(size, size * 0.5);
-  patternCtx.lineTo(size * 0.5, size);
-  patternCtx.closePath();
-  patternCtx.fill();
-  return patternCanvas;
+function drawLuckyCardBackBase(ctx, w, h) {
+  const stripeWidth = Math.max(12, Math.round((w / 2048) * 180));
+  const diagLength = Math.hypot(w, h);
+  ctx.save();
+  ctx.translate(w / 2, h / 2);
+  ctx.rotate(Math.PI / 4);
+  ctx.translate(-diagLength / 2, -diagLength / 2);
+  for (let x = -stripeWidth * 2; x <= diagLength + stripeWidth * 2; x += stripeWidth * 2) {
+    ctx.fillStyle = '#223333';
+    ctx.fillRect(x, 0, stripeWidth, diagLength * 2);
+    ctx.fillStyle = '#112222';
+    ctx.fillRect(x + stripeWidth, 0, stripeWidth, diagLength * 2);
+  }
+  ctx.restore();
+}
+
+function drawLuckyCardBackLogo(ctx, w, h, theme) {
+  const logoImage = getTonplaygramLogoImage();
+  ctx.save();
+  if (logoImage?.complete && logoImage.naturalWidth > 0) {
+    const logoBoxWidth = w * 0.9;
+    const logoBoxHeight = h * 0.9;
+    const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
+    const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
+    const drawHeight = drawWidth / ratio;
+    const logoX = (w - drawWidth) / 2;
+    const logoY = (h - drawHeight) / 2;
+    ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+  } else {
+    ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.font = '700 120px "Inter", system-ui, sans-serif';
+    ctx.fillText('TonPlaygram', w / 2, h / 2);
+  }
+  ctx.restore();
 }
 
 function drawBackPattern(ctx, w, h, theme) {
@@ -336,42 +354,14 @@ function drawBackPattern(ctx, w, h, theme) {
   ctx.restore();
 }
 
-function drawLogoFrame(ctx, w, h, theme) {
-  const frameInset = Math.min(w, h) * 0.045;
-  const frameRadius = Math.min(w, h) * 0.04;
-  const frameWidth = w - frameInset * 2;
-  const frameHeight = h - frameInset * 2;
-  const logoImage = getTonplaygramLogoImage();
-
+function drawLuckyCardBackBorder(ctx, w, h) {
+  const borderWidth = Math.max(14, Math.round((w / 2048) * 26));
+  const inset = borderWidth / 2;
   ctx.save();
-  ctx.strokeStyle = 'rgba(255,255,255,0.56)';
-  ctx.lineWidth = Math.max(12, Math.round(w * 0.007));
-  roundRect(ctx, frameInset, frameInset, frameWidth, frameHeight, frameRadius);
+  ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+  ctx.lineWidth = borderWidth;
+  roundRect(ctx, inset, inset, w - borderWidth, h - borderWidth, Math.min(w, h) * 0.04);
   ctx.stroke();
-  ctx.strokeStyle = 'rgba(255,255,255,0.3)';
-  ctx.lineWidth = Math.max(5, Math.round(w * 0.003));
-  roundRect(ctx, frameInset + 24, frameInset + 24, frameWidth - 48, frameHeight - 48, frameRadius * 0.85);
-  ctx.stroke();
-  ctx.restore();
-
-  ctx.save();
-  if (logoImage?.complete && logoImage.naturalWidth > 0) {
-    const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.9;
-    const logoBoxHeight = h * 0.42;
-    const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
-    const drawHeight = drawWidth / ratio;
-    const logoX = w / 2 - drawWidth / 2;
-    const logoY = h / 2 - drawHeight / 2;
-    ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
-  } else {
-    ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.font = '700 48px "Inter", system-ui, sans-serif';
-    ctx.fillText('TonPlaygram', w / 2, h / 2);
-  }
-
   ctx.restore();
 }
 


### PR DESCRIPTION
### Motivation
- Make the 3D Texas Hold'em card backs visually match the Lucky Card back on the mining page while keeping the card fronts unchanged. 
- Allow players to use the 3x3 chip buttons immediately (not only after a later state change) to match expected UX. 
- Prevent chip piles placed by players from overlapping/touching by tightening chip scatter and nudging bet anchors.

### Description
- Reworked card-back rendering in `webapp/src/utils/cards3d.js` by replacing the previous pattern/logo frame code with `drawLuckyCardBackBase`, `drawLuckyCardBackLogo`, and `drawLuckyCardBackBorder` to reproduce the Lucky Card striped background, centered logo treatment, and border styling while preserving existing card-face generation. 
- Modified chip selection handling in `webapp/src/pages/Games/TexasHoldemArena.jsx` to preserve and clamp previously selected chips on visibility/state changes instead of resetting them, enabling preselecting 3x3 chip combinations from the start of a hand. 
- Tuned table/pile layout parameters in `webapp/src/pages/Games/TexasHoldemArena.jsx` by increasing `BET_DISTANCE_RATIO` and tightening `CHIP_SCATTER_LAYOUT` (`spacing`, `rowSpacing`, `jitter`) to reduce pile overlap between players. 
- Kept all card-front rendering and card-face cache logic unchanged so front visuals remain identical.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished without errors). 
- Ran `npx eslint webapp/src/utils/cards3d.js webapp/src/pages/Games/TexasHoldemArena.jsx`; linter executed but the files are ignored by repo lint rules so only ignore warnings were produced. 
- Launched the dev server and captured a Playwright screenshot of `/games/texasholdem` at mobile viewport to validate visual changes; the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f41b329c8329a3da4f9ee4618dc1)