### PR TITLE
Fix aiming guide visibility and add cue stick pullback animation

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -9,6 +9,11 @@ namespace Aiming
         public Transform cueBall, objectBall, pocket;
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
+        public float cueDistanceFromBall = 0.12f;
+        public float animationPullbackDistance = 0.045f;
+        public float animationSpeed = 4f;
+
+        Vector3 _lastAimDirection = Vector3.forward;
 
         void Update()
         {
@@ -25,16 +30,27 @@ namespace Aiming
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
             var sol = aiming.GetAimSolution(ctx);
-            if (sol.isValid && cueTip != null)
+            if (sol.isValid)
             {
                 Vector3 dir = (sol.aimEnd - sol.aimStart);
                 if (dir.sqrMagnitude > 1e-6f)
                 {
                     dir.Normalize();
-                    transform.position = sol.aimStart;
+                    _lastAimDirection = dir;
+
+                    float animationPhase = (Mathf.Sin(Time.time * animationSpeed) + 1f) * 0.5f;
+                    float pullback = animationPhase * animationPullbackDistance;
+                    transform.position = sol.aimStart - dir * (cueDistanceFromBall + pullback);
                     transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
-                    cueTip.position = sol.aimStart + dir * 0.1f;
+                    if (cueTip != null)
+                    {
+                        cueTip.position = sol.aimStart;
+                    }
                 }
+            }
+            else
+            {
+                transform.rotation = Quaternion.LookRotation(_lastAimDirection, Vector3.up);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Players reported the automatic aiming suggestion line was not consistently visible and the cue stick had no motion, reducing clarity of aim feedback and polish.
- The change aims to make aiming guidance always available (including a fallback when a shot is blocked) and to add a subtle cue stick animation so players perceive aiming intent.

### Description
- Centralized `LineRenderer` setup in `ConfigureLineRenderer` and added `DrawGuideLine` in `AdaptiveAimingEngine` so the guide line is reliably created and updated regardless of debug overlay state.
- Render a fallback guide (cue ball → object ball) when line-of-sight is blocked so players still receive a visual suggestion for blocked shots.
- Preserve `showDebug` behavior by only updating the debug overlay when enabled while keeping the visual guide active via `DrawGuideLine`.
- Updated `CueController` to add configurable distances and an animated pullback using a time-based sine phase, keep the cue tip aligned to the aim start, and preserve the last valid aim direction when the current solution is invalid.

### Testing
- Inspected modified files with file listing/inspection commands and verified the new methods `ConfigureLineRenderer` and `DrawGuideLine` are present and referenced, which completed successfully.
- Ran `git status --short` and local file inspection to confirm the changes were staged and present in the working tree; these checks succeeded.
- No automated Unity PlayMode or unit tests were executed in this PR; recommend running a Unity editor compile and a PlayMode smoke test to validate visual behavior on device.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f48ef7b88329acb5b59f8e329c03)