### PR TITLE
Adjust goal-rush canvas height and quick-action bottom offsets

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -47,7 +47,7 @@
       width:100%;
       height:auto;
       max-height:100%;
-      aspect-ratio:720/1280;
+      aspect-ratio:720/1350;
       transform-origin:center;
       transform:scale(0);
       transition:transform .5s ease,width .3s ease,height .3s ease;
@@ -59,10 +59,10 @@
     .hint{position:fixed;inset:0;display:none;align-items:center;justify-content:center;margin:auto;max-width:680px;background:rgba(10,16,34,.6);backdrop-filter:blur(6px);border:1px solid #1f2944;border-radius:12px;padding:8px 12px;text-align:center;font-size:.9rem}
 
     .quick-action-slot{position:fixed;z-index:6;pointer-events:auto;}
-    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.2rem);}
-    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.2rem);}
-    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.2rem);}
-    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 3.2rem);}
+    #quickActionChat{left:calc(env(safe-area-inset-left,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 2.75rem);}
+    #quickActionGift{left:calc(env(safe-area-inset-left,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 2.75rem);}
+    #quickActionAudio{right:calc(env(safe-area-inset-right,0px) + 4.15rem);bottom:calc(env(safe-area-inset-bottom,0px) + 2.75rem);}
+    #quickActionMute{right:calc(env(safe-area-inset-right,0px) + 0.5rem);bottom:calc(env(safe-area-inset-bottom,0px) + 2.75rem);}
     .quick-action{width:3.15rem;height:3.15rem;border-radius:14px;background:transparent;border:none;color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.25rem;box-shadow:none;padding:0;}
     .quick-action span{font-size:.6rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;}
     .quick-action .icon{font-size:1.1rem;line-height:1;}
@@ -493,7 +493,7 @@
 
   let W = 720, H = 1280, goalCenterX = 0, goalTopY = 0, goalBottomY = 0;
   function fit(){
-    const ratio = 1280 / 720;
+    const ratio = 1350 / 720;
     const maxWidth = window.innerWidth;
     const maxHeight = window.innerHeight - TOP_BAR - BOTTOM_GAP;
     let width = maxWidth;


### PR DESCRIPTION
### Motivation
- Increase the vertical canvas/playfield space to accommodate a taller layout and nudge quick-action buttons to align with the new bottom spacing.

### Description
- In `goal-rush.html` the canvas `aspect-ratio` was changed from `720/1280` to `720/1350`, the JS `fit()` ratio was updated from `1280/720` to `1350/720`, and quick-action bottom offsets were reduced from `3.2rem` to `2.75rem` for `#quickActionChat`, `#quickActionGift`, `#quickActionAudio`, and `#quickActionMute`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f51e7c2c8329892dc0a4923c680e)