### PR TITLE
Adjust Air Hockey HUD placement for portrait view

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -182,6 +182,7 @@ const DEFAULT_COMMENTARY_PRESET_ID = AIR_HOCKEY_COMMENTARY_PRESETS[0]?.id || 'en
 const HUD_VERTICAL_SHIFT_REM = 9;
 const HUD_TOP_ROW_LIFT_REM = 2.5;
 const HUD_ICON_ROW_TOP_REM = 0.9;
+const HUD_MENU_LEFT_REM = 0.5;
 
 function detectRefreshRateHint() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
@@ -2382,8 +2383,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       style={{ touchAction: 'none', overscrollBehavior: 'none' }}
     >
       <div
-        className="absolute left-2 right-2 z-30 grid grid-cols-2 items-center gap-2 text-white"
-        style={{ top: `${2.35 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+        className={`absolute left-2 right-2 z-30 grid grid-cols-2 items-center gap-2 text-white ${
+          isTopDownView ? 'bottom-12' : ''
+        }`}
+        style={isTopDownView ? undefined : { top: `${2.35 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
       >
         <div
           className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
@@ -2413,8 +2416,14 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         </div>
       </div>
       <div
-        className="absolute left-1/2 -translate-x-1/2 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur"
-        style={{ top: `${3.75 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+        className={`absolute z-40 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur ${
+          isTopDownView ? 'left-1/2 -translate-x-1/2 bottom-4' : 'right-3'
+        }`}
+        style={
+          isTopDownView
+            ? undefined
+            : { top: `${3.7 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }
+        }
       >
         <span className="uppercase tracking-wide">{playType}</span>
         <span className="mx-2">•</span>
@@ -2423,10 +2432,13 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       <button
         type="button"
         onClick={() => setShowCustomizer((prev) => !prev)}
-        className={`absolute left-3 z-40 pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+        className={`absolute z-40 pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
           showCustomizer ? 'bg-black/60' : 'hover:bg-black/60'
         }`}
-        style={{ top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+        style={{
+          left: `${HUD_MENU_LEFT_REM}rem`,
+          top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM - 0.35}rem`
+        }}
         aria-label={showCustomizer ? 'Close menu' : 'Open menu'}
       >
         <span className="text-lg leading-none" aria-hidden="true">☰</span>
@@ -2473,18 +2485,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       </div>
       {!isTopDownView && (
         <>
-          <button
-            type="button"
-            onClick={() => {
-              toggleGameMuted();
-              setMuted(isGameMuted());
-            }}
-            className="absolute right-3 z-40 flex items-center justify-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-            style={{ top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
-            aria-label={muted ? 'Unmute' : 'Mute'}
-          >
-            <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
-          </button>
           <div
             className="absolute right-3 z-40 flex flex-col items-center gap-1"
             style={{ top: `${3.7 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
@@ -2503,6 +2503,17 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
                 <span aria-hidden>🧭</span>
                 <span>{isTopDownView ? '3D' : '2D'}</span>
               </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                toggleGameMuted();
+                setMuted(isGameMuted());
+              }}
+              className="flex items-center justify-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              aria-label={muted ? 'Unmute' : 'Mute'}
+            >
+              <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
             </button>
           </div>
         </>


### PR DESCRIPTION
### Motivation
- Improve HUD layout for portrait mobile: nudge the menu slightly left and up, align the target frame with the 2D toggle, stack the mute icon vertically under the 2D toggle, and move avatars/usernames/points/target to the bottom in 2D view for clearer, more consistent UX.

### Description
- Adjusted HUD constants and introduced `HUD_MENU_LEFT_REM` to control menu horizontal offset and fine-tune vertical placement for portrait alignment in `AirHockey3D`.
- Changed the top HUD container to reposition player/AI score cards to a bottom area when in 2D view and to use a bottom-aligned layout for top-down (3D) view.
- Reworked target card placement so it aligns horizontally with the 2D toggle in 3D mode and shifts toward the bottom in 2D mode.
- Moved the mute control into the right-side control stack so it sits directly below the 2D toggle in 3D mode and adjusted menu button `left`/`top` styles for the requested nudge.
- Modified file: `webapp/src/components/AirHockey3D.jsx`.

### Testing
- Ran the webapp production build with `npm --prefix webapp run build`, which completed successfully and produced the `dist/` output.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to exercise the UI, which launched successfully in the environment.
- Attempted an automated Playwright screenshot of `/games/airhockey` to validate visual placement, but the screenshot run timed out in this environment and did not produce an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f77ca9d88329b5c40106af515b95)