### PR TITLE
Improve Texas Hold'em card logo clarity and manual chip persistence

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -5972,9 +5972,25 @@ function TexasHoldemArena({ search }) {
       setSliderValue(0);
       return;
     }
-    setChipSelection([]);
-    setSliderValue(defaultRaise);
-  }, [humanPlayer?.id, sliderMax, minRaiseAmount, gameState.stage, defaultRaise, sliderVisible]);
+    // Keep manual chip picks available from hand start until the player changes them,
+    // matching the slider behavior across turn changes.
+    setChipSelection((prev) => {
+      const next = [];
+      let total = 0;
+      for (const chip of prev) {
+        if (total + chip > sliderMax) break;
+        next.push(chip);
+        total += chip;
+      }
+      return next;
+    });
+    setSliderValue((prev) => {
+      if (gameState.stage === 'preflop' && gameState.handId >= 0 && prev <= 0) {
+        return defaultRaise;
+      }
+      return Math.max(0, Math.min(prev, sliderMax));
+    });
+  }, [humanPlayer?.id, gameState.handId, gameState.stage, sliderMax, defaultRaise, sliderVisible]);
 
   useEffect(() => {
     if (sliderMax <= 0 || !sliderVisible) return;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -41,9 +41,12 @@ export function createCardMesh(card, geometry, cache, theme = DEFAULT_CARD_THEME
   });
   const backMaterial = new THREE.MeshStandardMaterial({
     map: backTexture,
-    color: new THREE.Color(theme.backColor || '#0f172a'),
+    // Keep the texture colors true-to-source (logo + pattern) instead of tinting.
+    color: new THREE.Color('#ffffff'),
     roughness: 0.6,
-    metalness: 0.15
+    metalness: 0.15,
+    emissive: new THREE.Color('#0f172a'),
+    emissiveIntensity: 0.08
   });
   const hiddenMaterial = new THREE.MeshStandardMaterial({
     color: new THREE.Color(theme.hiddenColor || theme.backColor || '#0f172a'),
@@ -143,7 +146,7 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   return texture;
 }
 
-function makeCardBackTexture(theme, w = 2048, h = 2880) {
+function makeCardBackTexture(theme, w = 3072, h = 4320) {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
@@ -160,7 +163,10 @@ function makeCardBackTexture(theme, w = 2048, h = 2880) {
 
   const texture = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(texture);
-  texture.anisotropy = 8;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = true;
+  texture.anisotropy = 16;
 
   const logoImage = getTonplaygramLogoImage();
   if (logoImage && !(logoImage.complete && logoImage.naturalWidth > 0)) {
@@ -357,8 +363,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.save();
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.9;
-    const logoBoxHeight = h * 0.42;
+    const logoBoxWidth = w * 0.94;
+    const logoBoxHeight = h * 0.56;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Make the card-back logo more visible and faithful to the original artwork by increasing texture fidelity and avoiding color tinting. 
- Let players use the 3x3 manual chip controls from the start of a hand and preserve manual chip picks across turn transitions, matching slider UX expectations.

### Description
- Kept card-back artwork colors unmodified by removing the back material tint and added a subtle `emissive` lift for on-table readability in `webapp/src/utils/cards3d.js`.
- Increased card-back canvas size (default from `2048x2880` to `3072x4320`), enabled mipmaps, stronger filtering and higher anisotropy to improve perceived resolution and sharpness of the logo in `makeCardBackTexture` in `webapp/src/utils/cards3d.js`.
- Enlarged the logo draw area on the card back so the centered logo occupies a bigger footprint when rendered (`drawLogoFrame` changes) in `webapp/src/utils/cards3d.js`.
- Updated manual-bet initialization logic so the 3x3 chip selection persists from hand start and is clamped to `sliderMax` instead of being fully reset; slider initialization now considers `gameState.handId` and `gameState.stage` to match slider behavior in `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Built production assets with `npm --prefix webapp run build` which completed successfully. (vite build completed without errors.)
- Ran the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a mobile-portrait screenshot of `/games/texasholdem` using Playwright to validate on-screen layout and manual-bet controls; screenshot was produced successfully.
- No automated unit tests were present/modified; validations were limited to the build and manual UI verification described above and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fadb534c832991303356f991d2c0)