### PR TITLE
Refactor Pool Royale cue stroke animation and aim suggestion snapping

### DIFF
--- a/test/poolRoyaleAimSuggestion.test.js
+++ b/test/poolRoyaleAimSuggestion.test.js
@@ -1,0 +1,46 @@
+import {
+  buildPoolSuggestionKey,
+  shouldApplyPoolSuggestion
+} from '../webapp/src/pages/Games/poolRoyaleAimSuggestion.js';
+
+describe('Pool Royale aim suggestion control', () => {
+  it('builds a stable key from target + pocket', () => {
+    const key = buildPoolSuggestionKey({
+      type: 'pot',
+      targetBall: { id: 7 },
+      pocketId: 'TR'
+    });
+    expect(key).toBe('pot:7:TR');
+  });
+
+  it('returns null when no target exists', () => {
+    expect(buildPoolSuggestionKey(null)).toBeNull();
+    expect(buildPoolSuggestionKey({ type: 'pot' })).toBeNull();
+  });
+
+  it('does not re-apply the same suggestion unless forced', () => {
+    expect(
+      shouldApplyPoolSuggestion({
+        currentKey: 'pot:7:TR',
+        nextKey: 'pot:7:TR'
+      })
+    ).toBe(false);
+    expect(
+      shouldApplyPoolSuggestion({
+        currentKey: 'pot:7:TR',
+        nextKey: 'pot:7:TR',
+        forceRefresh: true
+      })
+    ).toBe(true);
+  });
+
+  it('always allows snapping when auto-aim is requested', () => {
+    expect(
+      shouldApplyPoolSuggestion({
+        preferAutoAim: true,
+        currentKey: 'pot:7:TR',
+        nextKey: 'pot:7:TR'
+      })
+    ).toBe(true);
+  });
+});

--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -1,0 +1,34 @@
+import { sampleCueStrokeTimeline } from '../webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js';
+
+describe('Pool Royale cue stroke timeline', () => {
+  const options = {
+    pullbackDuration: 200,
+    strikeDuration: 100,
+    holdDuration: 80,
+    recoverDuration: 120
+  };
+
+  it('starts in pullback phase', () => {
+    const sample = sampleCueStrokeTimeline({ elapsed: 40, ...options });
+    expect(sample.phase).toBe('pullback');
+    expect(sample.t).toBeCloseTo(0.2, 2);
+  });
+
+  it('arms impact near end of release', () => {
+    const preHit = sampleCueStrokeTimeline({ elapsed: 280, ...options });
+    const postHit = sampleCueStrokeTimeline({ elapsed: 292, ...options });
+    expect(preHit.phase).toBe('release');
+    expect(preHit.hitArmed).toBe(false);
+    expect(postHit.phase).toBe('release');
+    expect(postHit.hitArmed).toBe(true);
+  });
+
+  it('enters recover then done', () => {
+    const recovering = sampleCueStrokeTimeline({ elapsed: 430, ...options });
+    const done = sampleCueStrokeTimeline({ elapsed: 510, ...options });
+    expect(recovering.phase).toBe('recover');
+    expect(recovering.done).toBe(false);
+    expect(done.phase).toBe('done');
+    expect(done.done).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -107,6 +107,11 @@ import {
   smoothDamp,
   SPIN_STUN_RADIUS
 } from './poolRoyaleSpinUtils.js';
+import {
+  buildPoolSuggestionKey,
+  shouldApplyPoolSuggestion
+} from './poolRoyaleAimSuggestion.js';
+import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -21391,39 +21396,37 @@ const powerRef = useRef(hud.power);
             pullbackDuration,
             strikeDuration,
             holdDuration,
+            recoverDuration,
             baseRotationX,
             baseRotationY,
             strikeDip,
             wobbleAmount
           } = stroke;
-          const pullback = Math.max(0, pullbackDuration ?? 0);
-          const release = Math.max(0, strikeDuration ?? 120);
-          const hold = Math.max(0, holdDuration ?? 50);
           const elapsed = Math.max(0, now - startTime);
-          const pullEnd = pullback;
-          const releaseEnd = pullEnd + release;
-          const holdEnd = releaseEnd + hold;
+          const sample = sampleCueStrokeTimeline({
+            elapsed,
+            pullbackDuration,
+            strikeDuration,
+            holdDuration,
+            recoverDuration
+          });
           cueStick.visible = true;
-          cueAnimating = true;
-          const hitAt = pullEnd + release * 0.9;
-          if (!stroke.shotApplied && elapsed >= hitAt) {
+          cueAnimating = !sample.done;
+          if (!stroke.shotApplied && sample.hitArmed) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
           }
-          if (elapsed <= pullEnd && pullback > 0) {
-            const t = THREE.MathUtils.clamp(elapsed / Math.max(pullback, 1e-6), 0, 1);
-            const eased = easeInOutCubic(t);
+          if (sample.phase === 'pullback') {
+            const eased = easeInOutCubic(sample.t);
             cueStick.position.lerpVectors(idlePos, pullPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
             return true;
           }
-          if (elapsed <= releaseEnd && release > 0) {
-            const releaseElapsed = elapsed - pullEnd;
-            const t = THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1);
-            const eased = easeOutCubic(t);
-            const wobble = Math.sin(t * Math.PI) * (wobbleAmount ?? 0.0018);
+          if (sample.phase === 'release') {
+            const eased = easeOutCubic(sample.t);
+            const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
             cueStick.position.y -= (strikeDip ?? 0.003) * eased;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
@@ -21431,8 +21434,16 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           }
-          if (elapsed <= holdEnd && hold > 0) {
+          if (sample.phase === 'hold') {
             cueStick.position.copy(impactPos);
+            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+            cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
+            syncCueShadow();
+            return true;
+          }
+          if (sample.phase === 'recover') {
+            const eased = easeInOutCubic(sample.t);
+            cueStick.position.lerpVectors(impactPos, idlePos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -26998,6 +27009,7 @@ const powerRef = useRef(hud.power);
           const options = evaluateShotOptions();
           const plan = options.bestPot ?? null;
           userSuggestionPlanRef.current = plan;
+          const suggestionKey = buildPoolSuggestionKey(plan);
           const summary = summarizePlan(plan);
           userSuggestionRef.current = summary;
           const frameSnapshot = frameRef.current ?? frameState;
@@ -27089,6 +27101,14 @@ const powerRef = useRef(hud.power);
             return applyAimDirection(dir, null);
           };
           const preferAutoAim = autoAimRequestRef.current;
+          const shouldSnapToSuggestion = shouldApplyPoolSuggestion({
+            preferAutoAim,
+            currentKey: suggestionAimKeyRef.current,
+            nextKey: suggestionKey
+          });
+          if (!shouldSnapToSuggestion && !preferAutoAim) {
+            return;
+          }
           if (preferAutoAim) {
             let autoDir = resolveAutoAimDirection();
             if (!autoDir && plan?.targetBall && cue?.pos) {
@@ -27100,8 +27120,7 @@ const powerRef = useRef(hud.power);
                 autoDir = manualDir.normalize();
               }
             }
-            suggestionAimKeyRef.current = null;
-            if (applyAimDirection(autoDir, null)) {
+            if (applyAimDirection(autoDir, suggestionKey)) {
               return;
             }
           }
@@ -27110,7 +27129,7 @@ const powerRef = useRef(hud.power);
               plan.targetBall.pos.x - cue.pos.x,
               plan.targetBall.pos.y - cue.pos.y
             );
-            if (applyAimDirection(directDir, null)) {
+            if (applyAimDirection(directDir, suggestionKey)) {
               return;
             }
           }

--- a/webapp/src/pages/Games/poolRoyaleAimSuggestion.js
+++ b/webapp/src/pages/Games/poolRoyaleAimSuggestion.js
@@ -1,0 +1,19 @@
+export const buildPoolSuggestionKey = (plan) => {
+  if (!plan || !plan.targetBall) return null;
+  const targetId = String(plan.targetBall.id ?? 'unknown');
+  const pocketId = String(plan.pocketId ?? 'NA');
+  const type = String(plan.type ?? 'pot');
+  return `${type}:${targetId}:${pocketId}`;
+};
+
+export const shouldApplyPoolSuggestion = ({
+  preferAutoAim = false,
+  currentKey = null,
+  nextKey = null,
+  forceRefresh = false
+} = {}) => {
+  if (preferAutoAim) return true;
+  if (forceRefresh) return true;
+  if (!nextKey) return currentKey !== null;
+  return currentKey !== nextKey;
+};

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -1,0 +1,35 @@
+import * as THREE from 'three';
+
+export const sampleCueStrokeTimeline = ({
+  elapsed = 0,
+  pullbackDuration = 0,
+  strikeDuration = 120,
+  holdDuration = 50,
+  recoverDuration = 130
+} = {}) => {
+  const pullback = Math.max(0, pullbackDuration ?? 0);
+  const release = Math.max(0, strikeDuration ?? 120);
+  const hold = Math.max(0, holdDuration ?? 50);
+  const recover = Math.max(0, recoverDuration ?? 130);
+  const safeElapsed = Math.max(0, elapsed);
+
+  const pullEnd = pullback;
+  const releaseEnd = pullEnd + release;
+  const holdEnd = releaseEnd + hold;
+  const recoverEnd = holdEnd + recover;
+
+  if (safeElapsed <= pullEnd && pullback > 0) {
+    return { phase: 'pullback', t: THREE.MathUtils.clamp(safeElapsed / Math.max(pullback, 1e-6), 0, 1), hitArmed: false, done: false };
+  }
+  if (safeElapsed <= releaseEnd && release > 0) {
+    const releaseElapsed = safeElapsed - pullEnd;
+    return { phase: 'release', t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1), hitArmed: safeElapsed >= pullEnd + release * 0.9, done: false };
+  }
+  if (safeElapsed <= holdEnd && hold > 0) {
+    return { phase: 'hold', t: THREE.MathUtils.clamp((safeElapsed - releaseEnd) / Math.max(hold, 1e-6), 0, 1), hitArmed: true, done: false };
+  }
+  if (safeElapsed <= recoverEnd && recover > 0) {
+    return { phase: 'recover', t: THREE.MathUtils.clamp((safeElapsed - holdEnd) / Math.max(recover, 1e-6), 0, 1), hitArmed: true, done: false };
+  }
+  return { phase: 'done', t: 1, hitArmed: true, done: true };
+};


### PR DESCRIPTION
### Motivation
- Improve and simplify the cue-stick animation timeline and stop the aiming suggestion system from repeatedly re-snapping the player to the same aim line; this fixes persistent UX issues with the cue pull/recoil animation and auto-snap behavior.

### Description
- Add a reusable timeline sampler `sampleCueStrokeTimeline` and refactor `updateCueStroke` to use explicit phases (pullback → release → hold → recover) with consistent easing and a clear impact arming signal (new file `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js`).
- Introduce stable suggestion identity and gating functions `buildPoolSuggestionKey` and `shouldApplyPoolSuggestion` and integrate them so suggestions are only re-applied when the meaning changes or when auto-aim is explicitly requested (new file `webapp/src/pages/Games/poolRoyaleAimSuggestion.js`).
- Wire the new modules into `webapp/src/pages/Games/PoolRoyale.jsx`, updating `updateUserSuggestion` to use suggestion keys and updating cue stroke handling to use the sampled timeline; preserved replay/record behavior and shot recording metadata.
- Add focused unit tests for the new helpers in `test/poolRoyaleAimSuggestion.test.js` and `test/poolRoyaleCueStrokeTimeline.test.js` to validate suggestion gating and cue-stroke phase timing.

### Testing
- Ran the focused unit tests with `npm test -- --runTestsByPath test/poolRoyaleAimSuggestion.test.js test/poolRoyaleCueStrokeTimeline.test.js` and both test suites passed.
- Ran a combined test that included `test/poolRoyaleSpinController.test.js` and that run failed due to an existing assertion in `poolRoyaleSpinController.test.js` unrelated to these changes.
- Brought up the webapp dev server (`npm --prefix webapp run dev`) and attempted an automated Playwright screenshot, but the Chromium process crashed in this environment (SIGSEGV) so no browser screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4009a044883299b66dcbff54f3d41)