### PR TITLE
Preserve Pool Royale camera view when snapping aim suggestions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24271,15 +24271,14 @@ const powerRef = useRef(hud.power);
         dir.normalize();
         const sph = sphRef.current;
         if (!sph) return;
-        const standingBounds = cameraBoundsRef.current?.standing;
-        if (standingBounds) {
-          sph.radius = clampOrbitRadius(standingBounds.radius);
-          sph.phi = THREE.MathUtils.clamp(
-            standingBounds.phi,
-            CAMERA.minPhi,
-            CAMERA.maxPhi
-          );
-        }
+        // Keep the active camera mode (cue / standing) exactly where the user left it
+        // and only yaw the orbit so the aiming line points at the suggested ball.
+        sph.radius = clampOrbitRadius(sph.radius);
+        sph.phi = THREE.MathUtils.clamp(
+          sph.phi,
+          CAMERA.minPhi,
+          CAMERA.maxPhi
+        );
         const aimTheta = Math.atan2(dir.x, dir.y) + Math.PI;
         sph.theta = aimTheta;
         syncBlendToSpherical();


### PR DESCRIPTION
### Motivation
- Improve aim-suggestion UX by keeping the player's current camera mode (cue or standing) intact and only yawing the orbit to point the aiming line at the suggested ball, avoiding abrupt camera jumps to the standing framing.

### Description
- Modified `alignStandingCameraToAim` in `webapp/src/pages/Games/PoolRoyale.jsx` to stop forcing the standing-camera bounds and instead clamp the existing spherical `phi`/`radius`, then set `theta` to yaw toward the suggestion so the view remains as the user left it while aligning the aim line.
- Retained the existing orbit focus update so the forward framing along the aim direction still tracks the cue-ball-forward target.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleAimSuggestion.test.js`, which passed (1 suite, 4 tests all OK). 
- Launched the web dev server (`npm --prefix webapp run dev`) and attempted an automated Playwright screenshot of `/games/poolroyale?mode=local`, but the browser capture timed out in this environment (server started successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40fa1033483298acf7fd24fa02939)