### PR TITLE
Preserve player camera orbit when applying Pool Royale aim suggestions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24264,7 +24264,11 @@ const powerRef = useRef(hud.power);
       const pottedIds = new Set();
       let firstHit = null;
 
-      const alignStandingCameraToAim = (cueBall, aimDir) => {
+      const alignStandingCameraToAim = (
+        cueBall,
+        aimDir,
+        { preserveOrbit = true } = {}
+      ) => {
         if (!cueBall || !aimDir) return;
         const dir = aimDir.clone();
         if (dir.lengthSq() < 1e-6) return;
@@ -24272,10 +24276,17 @@ const powerRef = useRef(hud.power);
         const sph = sphRef.current;
         if (!sph) return;
         const standingBounds = cameraBoundsRef.current?.standing;
-        if (standingBounds) {
+        if (!preserveOrbit && standingBounds) {
           sph.radius = clampOrbitRadius(standingBounds.radius);
           sph.phi = THREE.MathUtils.clamp(
             standingBounds.phi,
+            CAMERA.minPhi,
+            CAMERA.maxPhi
+          );
+        } else {
+          sph.radius = clampOrbitRadius(sph.radius ?? BREAK_VIEW.radius);
+          sph.phi = THREE.MathUtils.clamp(
+            sph.phi ?? standingBounds?.phi ?? STANDING_VIEW.phi,
             CAMERA.minPhi,
             CAMERA.maxPhi
           );
@@ -26651,13 +26662,13 @@ const powerRef = useRef(hud.power);
             if (plan) {
               aiPlanRef.current = plan;
               aimDirRef.current.copy(plan.aimDir);
-              alignStandingCameraToAim(cue, plan.aimDir);
+              alignStandingCameraToAim(cue, plan.aimDir, { preserveOrbit: false });
             } else {
               aiPlanRef.current = null;
               const fallbackDir = resolveAutoAimDirection();
               if (fallbackDir) {
                 aimDirRef.current.copy(fallbackDir);
-                alignStandingCameraToAim(cue, fallbackDir);
+                alignStandingCameraToAim(cue, fallbackDir, { preserveOrbit: false });
               }
             }
             updateAiPlanningState(plan, options, remaining / 1000);
@@ -27310,7 +27321,7 @@ const powerRef = useRef(hud.power);
             topViewRef.current = false;
             topViewLockedRef.current = false;
             setIsTopDownView(false);
-            alignStandingCameraToAim(cue, dir);
+            alignStandingCameraToAim(cue, dir, { preserveOrbit: false });
             setAiShotCueViewActive(false);
             setAiShotPreviewActive(true);
             cancelCameraBlendTween();


### PR DESCRIPTION
### Motivation
- Players expect the camera to simply turn toward the suggested target while staying in the same camera mode (cue or standing) instead of snapping back to the standing framing.
- Keep AI planning/preview behavior unchanged while making the default behavior preserve the player’s chosen orbit when suggestions are applied.

### Description
- Added an optional parameter `preserveOrbit` (default `true`) to the `alignStandingCameraToAim` helper in `webapp/src/pages/Games/PoolRoyale.jsx` so calling code can choose whether to override the current orbit radius/phi or only rotate `theta` toward the aim direction.
- When `preserveOrbit` is `true` the function preserves the existing `sph.radius` and `sph.phi` (clamped) and only updates `sph.theta`; when `false` it applies the standing bounds as before.
- Updated AI flows to explicitly call `alignStandingCameraToAim(..., { preserveOrbit: false })` so AI planning and previews retain their previous standing framing behavior.

### Testing
- Ran the aim-suggestion unit tests with `npm test -- --runInBand test/poolRoyaleAimSuggestion.test.js` and all tests passed (4 tests, 1 suite).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which produced a repo-level ignore warning (file is skipped by ESLint config) but no lint errors for the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40fa1033483298acf7fd24fa02939)