### PR TITLE
Align player camera with Pool Royale auto-aim suggestions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28240,6 +28240,9 @@ const powerRef = useRef(hud.power);
             }
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
+              if (shouldAutoAimPlayer && cue?.active) {
+                alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false });
+              }
             }
           } else {
             const shouldAssistLegalAim =
@@ -28255,6 +28258,14 @@ const powerRef = useRef(hud.power);
             aimDir.lerp(desiredAim, aimLerpFactor);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
+              if (
+                shouldAssistLegalAim &&
+                isPlayerTurn &&
+                cue?.active &&
+                !shooting
+              ) {
+                alignStandingCameraToAim(cue, aimDir);
+              }
             }
           }
         }


### PR DESCRIPTION
### Motivation
- Keep camera, aiming line and cue stick visually synchronized with the suggested shot so the player view turns toward the suggested ball/lane when an auto-aim or assisted-aim is applied.

### Description
- When player auto-aim snaps to a suggested direction, call `alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false })` so the standing camera immediately orients to the suggestion, and call `alignStandingCameraToAim(cue, aimDir)` during assisted legal-aim smoothing so the camera follows aim interpolation; changes are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran unit tests with `npm test -- test/poolRoyaleAimSuggestion.test.js --runInBand` and the test suite passed (1 suite, 4 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a41b81bbec8329873dc742fe375249)