### PR TITLE
Adjust Pool Royale cue forward stroke visibility and camera switch timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5464,6 +5464,8 @@ const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
 const PLAYER_CUE_RELEASE_DURATION_MS = 980;
 const PLAYER_CUE_IMPACT_HOLD_MS = 420;
+const PLAYER_CUE_IMPACT_ARMING_RATIO = 0.97;
+const PLAYER_POST_IMPACT_CAMERA_HOLD_MS = 220;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
@@ -21408,7 +21410,8 @@ const powerRef = useRef(hud.power);
             pullbackDuration,
             strikeDuration,
             holdDuration,
-            recoverDuration
+            recoverDuration,
+            impactArmingRatio: stroke.impactArmingRatio
           });
           cueStick.visible = true;
           cueAnimating = !sample.done;
@@ -21425,7 +21428,7 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'release') {
-            const eased = easeOutCubic(sample.t);
+            const eased = sample.t;
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
             cueStick.position.y -= (strikeDip ?? 0.003) * eased;
@@ -25000,7 +25003,10 @@ const powerRef = useRef(hud.power);
               actionView.pendingActivation = true;
               const baseDelay = actionView.activationDelay ?? null;
               const delayed = requiresCueBallMovementTrigger
-                ? baseDelay ?? 0
+                ? Math.max(
+                    baseDelay ?? 0,
+                    impactTime + PLAYER_POST_IMPACT_CAMERA_HOLD_MS
+                  )
                 : Math.max(baseDelay ?? 0, holdUntil ?? 0);
               actionView.activationDelay = delayed > 0 ? delayed : null;
               const baseTravel = actionView.activationTravel ?? 0;
@@ -25048,7 +25054,8 @@ const powerRef = useRef(hud.power);
               baseRotationX: cueStick.rotation.x,
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
-              wobbleAmount: 0.0018
+              wobbleAmount: 0.0018,
+              impactArmingRatio: PLAYER_CUE_IMPACT_ARMING_RATIO
             };
           } else {
             cueStick.visible = false;

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -5,7 +5,8 @@ export const sampleCueStrokeTimeline = ({
   pullbackDuration = 0,
   strikeDuration = 120,
   holdDuration = 50,
-  recoverDuration = 130
+  recoverDuration = 130,
+  impactArmingRatio = 0.9
 } = {}) => {
   const pullback = Math.max(0, pullbackDuration ?? 0);
   const release = Math.max(0, strikeDuration ?? 120);
@@ -17,13 +18,19 @@ export const sampleCueStrokeTimeline = ({
   const releaseEnd = pullEnd + release;
   const holdEnd = releaseEnd + hold;
   const recoverEnd = holdEnd + recover;
+  const safeImpactArmingRatio = THREE.MathUtils.clamp(impactArmingRatio, 0, 1);
 
   if (safeElapsed <= pullEnd && pullback > 0) {
     return { phase: 'pullback', t: THREE.MathUtils.clamp(safeElapsed / Math.max(pullback, 1e-6), 0, 1), hitArmed: false, done: false };
   }
   if (safeElapsed <= releaseEnd && release > 0) {
     const releaseElapsed = safeElapsed - pullEnd;
-    return { phase: 'release', t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1), hitArmed: safeElapsed >= pullEnd + release * 0.9, done: false };
+    return {
+      phase: 'release',
+      t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1),
+      hitArmed: safeElapsed >= pullEnd + release * safeImpactArmingRatio,
+      done: false
+    };
   }
   if (safeElapsed <= holdEnd && hold > 0) {
     return { phase: 'hold', t: THREE.MathUtils.clamp((safeElapsed - releaseEnd) / Math.max(hold, 1e-6), 0, 1), hitArmed: true, done: false };


### PR DESCRIPTION
### Motivation
- The forward push of the cue was hard to see and the camera switched away too quickly at impact, reducing visual clarity of the stroke. 
- Impact was being armed too early during release, causing the hit to register before the forward motion completed visually. 
- The goal is to make the forward stroke more visible and hold the camera a bit longer so players can see the cue-ball start moving before switching views.

### Description
- Added a configurable `impactArmingRatio` parameter to `sampleCueStrokeTimeline` in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` to control when the impact becomes armed relative to the release phase. 
- Switched the release-phase interpolation to linear progress (`sample.t`) during the forward push in `webapp/src/pages/Games/PoolRoyale.jsx` so the cue forward motion reads at a steadier, more visible speed. 
- Introduced `PLAYER_CUE_IMPACT_ARMING_RATIO` and `PLAYER_POST_IMPACT_CAMERA_HOLD_MS` constants and wired `impactArmingRatio` into the stroke state so player strokes arm later (set to `0.97`) and camera activation for movement-triggered action views waits a short post-impact hold. 
- Adjusted the action-camera activation delay logic to account for `impactTime + PLAYER_POST_IMPACT_CAMERA_HOLD_MS` so the camera switch is deferred briefly after impact for better visibility.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js`, and the suite passed (`3 passed, 3 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4258bbc6c83299170f228f851a72c)