### PR TITLE
Improve Pool Royale cue forward stroke readability before camera switch

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5462,8 +5462,8 @@ const PLAYER_FORWARD_SLOWDOWN = 1.75;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
-const PLAYER_CUE_RELEASE_DURATION_MS = 980;
-const PLAYER_CUE_IMPACT_HOLD_MS = 420;
+const PLAYER_CUE_RELEASE_DURATION_MS = 1120;
+const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
@@ -5471,8 +5471,9 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee visible pullback phase when captured stroke timings are too short
 const REPLAY_CUE_MIN_RELEASE_MS = 260; // guarantee visible forward push into impact in replay view
-const CAMERA_SWITCH_MIN_HOLD_MS = 220;
-const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = STOP_EPS;
+const CAMERA_SWITCH_MIN_HOLD_MS = 420;
+const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
+const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 34;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const BREAK_DIE_SIZE = BALL_R * 2.25;
@@ -21425,7 +21426,7 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'release') {
-            const eased = easeOutCubic(sample.t);
+            const eased = easeInOutCubic(sample.t);
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
             cueStick.position.y -= (strikeDip ?? 0.003) * eased;
@@ -25007,7 +25008,7 @@ const powerRef = useRef(hud.power);
               actionView.activationTravel = Math.max(
                 baseTravel,
                 requiresCueBallMovementTrigger
-                  ? BALL_R * 0.2
+                  ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
                   : isMaxPowerShot
                     ? BALL_R * 6
                     : 0

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -23,7 +23,7 @@ export const sampleCueStrokeTimeline = ({
   }
   if (safeElapsed <= releaseEnd && release > 0) {
     const releaseElapsed = safeElapsed - pullEnd;
-    return { phase: 'release', t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1), hitArmed: safeElapsed >= pullEnd + release * 0.9, done: false };
+    return { phase: 'release', t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1), hitArmed: safeElapsed >= pullEnd + release * 0.98, done: false };
   }
   if (safeElapsed <= holdEnd && hold > 0) {
     return { phase: 'hold', t: THREE.MathUtils.clamp((safeElapsed - releaseEnd) / Math.max(hold, 1e-6), 0, 1), hitArmed: true, done: false };


### PR DESCRIPTION
### Motivation

- Players reported the cue pullback is visible but the forward push and the moment the cueball starts moving happen too quickly and the camera switches away before the impact is clearly seen.

### Description

- Increased player forward release timing by changing `PLAYER_CUE_RELEASE_DURATION_MS` from `980` to `1120` and `PLAYER_CUE_IMPACT_HOLD_MS` from `420` to `540` in `webapp/src/pages/Games/PoolRoyale.jsx` to slow the forward stroke and extend impact hold.
- Smoothed the live release interpolation by replacing `easeOutCubic(sample.t)` with `easeInOutCubic(sample.t)` so the cue forward motion is less abrupt during the `release` phase in `PoolRoyale.jsx`.
- Delayed the moment the stroke arms the shot by changing the hit-arming threshold in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` from `release * 0.9` to `release * 0.98` so the forward push is visible before physics are applied.
- Increased camera-switch safety by raising `CAMERA_SWITCH_MIN_HOLD_MS` from `220` to `420`, raising `CUEBALL_EARLY_CAMERA_SWITCH_SPEED` from `STOP_EPS` to `BALL_R * 24`, and requiring more cue travel (`BALL_R * 0.2` → `CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15`) before action-camera activation in `PoolRoyale.jsx` so the camera waits to switch until the cue movement is clearly underway.

### Testing

- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build output reported built chunks). 
- Ran a headless browser check via Playwright to validate the mobile-portrait render and captured `artifacts/pool-royale-cue-camera-change.png`, which succeeded on the second attempt after an initial 30s timeout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4258bbc6c83299170f228f851a72c)