### PR TITLE
Pool Royale: align AI auto-aim camera, replay cue return, and spin visibility limits

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6011,7 +6011,7 @@ function applyAxisClearance(
   }
 }
 
-function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null) {
+function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null, viewInput = null) {
   if (!cueBall || !aimDir) return { ...DEFAULT_SPIN_LIMITS };
   const spinAxes = axesInput || prepareSpinAxes(aimDir);
   const forward = spinAxes.axis;
@@ -6052,6 +6052,25 @@ function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null) {
     }
     if (nearest !== Infinity) {
       applyAxisClearance(limits, axis.key, axis.positive, nearest);
+    }
+  }
+
+  if (viewInput) {
+    const view = new THREE.Vector2(viewInput.x ?? 0, viewInput.y ?? 0);
+    if (view.lengthSq() > 1e-8) {
+      view.normalize();
+      if (view.dot(lateral) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.maxX = Math.min(limits.maxX, 0);
+      }
+      if (view.dot(lateral.clone().multiplyScalar(-1)) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.minX = Math.max(limits.minX, 0);
+      }
+      if (view.dot(forward) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.maxY = Math.min(limits.maxY, 0);
+      }
+      if (view.dot(forward.clone().multiplyScalar(-1)) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.minY = Math.max(limits.minY, 0);
+      }
     }
   }
 
@@ -21230,7 +21249,7 @@ const powerRef = useRef(hud.power);
                 );
                 cueStick.position.lerpVectors(followPos, idlePos, easeInOutCubic(t));
               } else {
-                cueStick.position.copy(pullPos);
+                cueStick.position.copy(idlePos);
               }
             }
             syncCueShadow();
@@ -21867,7 +21886,7 @@ const powerRef = useRef(hud.power);
             const axes = prepareSpinAxes(aimVec);
             const activeCamera = activeRenderCameraRef.current ?? camera;
             const viewVec = computeCueViewVector(cueBall, activeCamera);
-            spinLimitsRef.current = computeSpinLimits(cueBall, aimVec, balls, axes);
+            spinLimitsRef.current = computeSpinLimits(cueBall, aimVec, balls, axes, viewVec);
             const requested = spinRequestRef.current || spinRef.current || {
               x: 0,
               y: 0
@@ -28231,6 +28250,9 @@ const powerRef = useRef(hud.power);
             aimDir.copy(activeAiPlan.aimDir);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
+              if (cue?.active) {
+                alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false });
+              }
             }
           } else if (autoAimDir && autoAimDir.lengthSq() > 1e-6) {
             if (shouldAutoAimPlayer) {
@@ -28241,7 +28263,7 @@ const powerRef = useRef(hud.power);
             }
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
-              if (shouldAutoAimPlayer && cue?.active) {
+              if ((shouldAutoAimPlayer || shouldAutoAimAi) && cue?.active) {
                 alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false });
               }
             }


### PR DESCRIPTION
### Motivation
- Improve AI shot presentation so AI aiming uses the same visual camera alignment as player auto-aim for a consistent feel. 
- Ensure replay playback shows a full cue stroke (pullback → forward → return) so the forward push is visible and replays match in-game motion. 
- Reduce confusing spin options by preventing players from applying spin to strike points that are visually blocked from the current camera view.

### Description
- Updated `computeSpinLimits` to accept an optional `viewInput` and clamp spin axes when the camera cannot see the strike hemisphere, preventing application of hidden strike points. 
- Pass the computed cue-view vector into `computeSpinLimits` where spin limits are calculated using `spinLimitsRef.current = computeSpinLimits(cueBall, aimVec, balls, axes, viewVec)`. 
- Fixed replay fallback cue animation so finished replay strokes return the cue to the idle/start position instead of snapping back to pullback by changing the final fallback from copying `pullPos` to `idlePos`. 
- When AI aim is locked or auto-aim is applied, auto-align the standing camera by calling `alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false })` so AI aiming presentation matches player aiming behavior.

### Testing
- Ran focused regression tests with `npx jest test/poolRoyaleRules.test.ts test/poolAi.test.js --runInBand` and both suites passed. 
- Attempted full project test with `npm test -- --runInBand`, but unrelated pre-existing failures/timeouts and a missing `undici` dependency in bot tests prevented a full green run. 
- Launched the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`; server started successfully but automated Playwright screenshot attempts timed out in the container so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a437ce07708329830399450ea5c7c3)