### PR TITLE
Texas Hold'em: pull camera closer and lower landscape HUD/slider

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,7 +390,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.34 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 1.03, landscape: 0.24 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.88, landscape: 0.14 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.34, landscape: 0.92 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
@@ -6287,7 +6287,7 @@ function TexasHoldemArena({ search }) {
           />
         ))}
       </div>
-      <div className="absolute bottom-14 landscape:bottom-6 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto">
+      <div className="absolute bottom-14 landscape:bottom-2 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto">
         <div className="flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur">
           {humanPlayer?.avatar &&
             (isHumanTurn ? (
@@ -6304,7 +6304,7 @@ function TexasHoldemArena({ search }) {
         </div>
       </div>
       {sliderVisible && (
-        <div className="pointer-events-auto absolute right-2 bottom-32 z-10 flex flex-col items-center gap-3 text-white landscape:bottom-10 sm:right-6 sm:bottom-36 sm:landscape:bottom-14">
+        <div className="pointer-events-auto absolute right-2 bottom-32 z-10 flex flex-col items-center gap-3 text-white landscape:bottom-4 sm:right-6 sm:bottom-36 sm:landscape:bottom-8">
           <div className="flex flex-col items-center gap-3">
             <input
               type="range"


### PR DESCRIPTION
### Motivation
- Improve visual framing on mobile by pulling the seated camera closer to the table in both portrait and landscape, and by moving the bottom player avatar and bet controls further down in landscape so they sit nearer the bottom edge.

### Description
- Touched `webapp/src/pages/Games/TexasHoldemArena.jsx` to reduce the camera retreat distances (`CAMERA_RETREAT_OFFSETS` changed from `{ portrait: 1.03, landscape: 0.24 }` to `{ portrait: 0.88, landscape: 0.14 }`) and to adjust the layout classes for the bottom player pill (`landscape:bottom-2`) and the bet slider/bet button container (`landscape:bottom-4 sm:landscape:bottom-8`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which reported only a project ignore warning (no new lint errors in the changed file).
- Captured automated viewport screenshots via Playwright for portrait and landscape to visually validate the changes (artifacts: `artifacts/texas-holdem-portrait.png` and `artifacts/texas-holdem-landscape.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4452bf9d8832982451632d745a424)