### PR TITLE
AI: smooth aim adjustment, view-aware spin limits, and cue/replay timing tweaks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5448,7 +5448,9 @@ const AI_CAMERA_SETTLE_MS = 320; // allow time for the cue view to settle before
 const AI_CAMERA_DROP_LEAD_MS =
   AI_CAMERA_DROP_DURATION_MS + AI_CAMERA_SETTLE_MS; // start lowering into cue view early enough to finish before the stroke begins
 const AI_CUE_VIEW_HOLD_MS = 180;
-const AI_SPIN_ADJUST_DELAY_MS = 2000;
+const AI_AIM_ADJUST_DELAY_MS = 120;
+const AI_AIM_ADJUST_DURATION_MS = 650;
+const AI_SPIN_ADJUST_DELAY_MS = 1350;
 // Ease the AI camera just partway toward cue view (still above the stick) so the shot preview
 // lingers in a mid-angle frame for a few seconds before firing.
 const AI_CAMERA_DROP_BLEND = 0.65;
@@ -5462,7 +5464,7 @@ const PLAYER_FORWARD_SLOWDOWN = 1.75;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
-const PLAYER_CUE_RELEASE_DURATION_MS = 1120;
+const PLAYER_CUE_RELEASE_DURATION_MS = 980;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
@@ -5470,7 +5472,7 @@ const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so 
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee visible pullback phase when captured stroke timings are too short
-const REPLAY_CUE_MIN_RELEASE_MS = 260; // guarantee visible forward push into impact in replay view
+const REPLAY_CUE_MIN_RELEASE_MS = 420; // guarantee visible forward push into impact in replay view
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -6011,7 +6013,7 @@ function applyAxisClearance(
   }
 }
 
-function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null) {
+function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null, viewInput = null) {
   if (!cueBall || !aimDir) return { ...DEFAULT_SPIN_LIMITS };
   const spinAxes = axesInput || prepareSpinAxes(aimDir);
   const forward = spinAxes.axis;
@@ -6052,6 +6054,25 @@ function computeSpinLimits(cueBall, aimDir, balls = [], axesInput = null) {
     }
     if (nearest !== Infinity) {
       applyAxisClearance(limits, axis.key, axis.positive, nearest);
+    }
+  }
+
+  if (viewInput) {
+    const view = new THREE.Vector2(viewInput.x ?? 0, viewInput.y ?? 0);
+    if (view.lengthSq() > 1e-8) {
+      view.normalize();
+      if (view.dot(lateral) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.maxX = Math.min(limits.maxX, 0);
+      }
+      if (view.dot(lateral.clone().multiplyScalar(-1)) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.minX = Math.max(limits.minX, 0);
+      }
+      if (view.dot(forward) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.maxY = Math.min(limits.maxY, 0);
+      }
+      if (view.dot(forward.clone().multiplyScalar(-1)) < SPIN_VIEW_BLOCK_THRESHOLD) {
+        limits.minY = Math.max(limits.minY, 0);
+      }
     }
   }
 
@@ -14746,6 +14767,7 @@ const powerRef = useRef(hud.power);
   const aiCueViewBlendRef = useRef(AI_CAMERA_DROP_BLEND);
   const aiCuePullReadyAtRef = useRef(0);
   const aiRetryTimeoutRef = useRef(null);
+  const aiAimAdjustRef = useRef(null);
   const aiSpinAdjustRef = useRef(null);
   const aiShotWindowRef = useRef({ startedAt: 0, duration: AI_MIN_SHOT_TIME_MS });
   const [aiTakingShot, setAiTakingShot] = useState(false);
@@ -14760,6 +14782,12 @@ const powerRef = useRef(hud.power);
     if (aiSpinAdjustRef.current) {
       cancelAnimationFrame(aiSpinAdjustRef.current);
       aiSpinAdjustRef.current = null;
+    }
+  }, []);
+  const cancelAiAimAdjust = useCallback(() => {
+    if (aiAimAdjustRef.current) {
+      cancelAnimationFrame(aiAimAdjustRef.current);
+      aiAimAdjustRef.current = null;
     }
   }, []);
 
@@ -14807,12 +14835,13 @@ const powerRef = useRef(hud.power);
       clearTimeout(aiShotCueDropTimeoutRef.current);
       aiShotCueDropTimeoutRef.current = null;
     }
+    cancelAiAimAdjust();
     cancelAiSpinAdjust();
     cancelCameraBlendTween();
     aiCueViewBlendRef.current = AI_CAMERA_DROP_BLEND;
     setAiShotPreviewActive(false);
     setAiShotCueViewActive(false);
-  }, [setAiShotPreviewActive, setAiShotCueViewActive, cancelCameraBlendTween, cancelAiSpinAdjust]);
+  }, [setAiShotPreviewActive, setAiShotCueViewActive, cancelCameraBlendTween, cancelAiAimAdjust, cancelAiSpinAdjust]);
   const clearEarlyAiShot = useCallback(() => {
     const intent = aiEarlyShotIntentRef.current;
     if (intent?.timeout) {
@@ -21172,7 +21201,7 @@ const powerRef = useRef(hud.power);
               ? playback.duration
               : REPLAY_CUE_STICK_HOLD_MS;
             const fallbackPullback = CUE_PULL_BASE * 0.35;
-            const fallbackForward = CUE_PULL_BASE * 0.18;
+            const fallbackForward = CUE_PULL_BASE * 0.3;
             const pullbackTime = 160;
             const forwardTime = 210;
             const settleTime = 120;
@@ -21230,7 +21259,7 @@ const powerRef = useRef(hud.power);
                 );
                 cueStick.position.lerpVectors(followPos, idlePos, easeInOutCubic(t));
               } else {
-                cueStick.position.copy(pullPos);
+                cueStick.position.copy(idlePos);
               }
             }
             syncCueShadow();
@@ -21867,7 +21896,7 @@ const powerRef = useRef(hud.power);
             const axes = prepareSpinAxes(aimVec);
             const activeCamera = activeRenderCameraRef.current ?? camera;
             const viewVec = computeCueViewVector(cueBall, activeCamera);
-            spinLimitsRef.current = computeSpinLimits(cueBall, aimVec, balls, axes);
+            spinLimitsRef.current = computeSpinLimits(cueBall, aimVec, balls, axes, viewVec);
             const requested = spinRequestRef.current || spinRef.current || {
               x: 0,
               y: 0
@@ -24926,11 +24955,11 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = PLAYER_CUE_PULLBACK_DURATION_MS;
           const startTime = performance.now();
           const followThrough = THREE.MathUtils.clamp(
-            topspinFactor * BALL_R * 0.29,
-            0,
-            BALL_R * 0.33
+            BALL_R * 0.22 + topspinFactor * BALL_R * 0.29,
+            BALL_R * 0.22,
+            BALL_R * 0.46
           );
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
+          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.9);
           const impactPos = buildCuePosition(-followDistance);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
@@ -27185,6 +27214,54 @@ const powerRef = useRef(hud.power);
           aiSpinAdjustRef.current = requestAnimationFrame(animate);
         };
 
+        const animateAiAimAdjustment = (targetDir, durationMs, { delayMs = 0 } = {}) => {
+          cancelAiAimAdjust();
+          const initial = aimDirRef.current?.clone?.() ?? targetDir?.clone?.();
+          if (
+            !targetDir ||
+            typeof targetDir.lengthSq !== 'function' ||
+            targetDir.lengthSq() <= 1e-6 ||
+            !initial ||
+            typeof initial.lengthSq !== 'function' ||
+            initial.lengthSq() <= 1e-6 ||
+            !cue?.active
+          ) {
+            return;
+          }
+          const start = initial.clone().normalize();
+          const end = targetDir.clone().normalize();
+          const angle = start.angleTo(end);
+          if (!Number.isFinite(angle) || angle <= THREE.MathUtils.degToRad(0.4)) {
+            aimDirRef.current.copy(end);
+            alignStandingCameraToAim(cue, end, { preserveOrbit: false });
+            return;
+          }
+          const startAt = performance.now() + Math.max(0, delayMs);
+          const animate = (now) => {
+            const elapsed = now - startAt;
+            if (elapsed < 0) {
+              aiAimAdjustRef.current = requestAnimationFrame(animate);
+              return;
+            }
+            const t = durationMs > 0
+              ? THREE.MathUtils.clamp(elapsed / durationMs, 0, 1)
+              : 1;
+            const eased = easeInOutCubic(t);
+            TMP_VEC2_A.copy(start).lerp(end, eased);
+            if (TMP_VEC2_A.lengthSq() > 1e-8) TMP_VEC2_A.normalize();
+            aimDirRef.current.copy(TMP_VEC2_A);
+            alignStandingCameraToAim(cue, TMP_VEC2_A, { preserveOrbit: false });
+            if (t < 1 && aiShotCueViewRef.current && !shootingRef.current) {
+              aiAimAdjustRef.current = requestAnimationFrame(animate);
+            } else {
+              aiAimAdjustRef.current = null;
+              aimDirRef.current.copy(end);
+              alignStandingCameraToAim(cue, end, { preserveOrbit: false });
+            }
+          };
+          aiAimAdjustRef.current = requestAnimationFrame(animate);
+        };
+
         aiShoot.current = () => {
           if (!aiOpponentEnabled) return;
           if (aiRetryTimeoutRef.current) {
@@ -27361,6 +27438,9 @@ const powerRef = useRef(hud.power);
               aiCueViewBlendRef.current = AI_CAMERA_DROP_BLEND;
               aiCuePullReadyAtRef.current = performance.now() + AI_SPIN_ADJUST_DELAY_MS;
               tweenCameraBlend(aiCueViewBlendRef.current, AI_CAMERA_DROP_DURATION_MS);
+              animateAiAimAdjustment(dir, AI_AIM_ADJUST_DURATION_MS, {
+                delayMs: AI_AIM_ADJUST_DELAY_MS
+              });
               animateAiSpinAdjustment(spinToApply, AI_SPIN_ADJUST_DELAY_MS, dir);
               if (aiShotTimeoutRef.current) {
                 clearTimeout(aiShotTimeoutRef.current);
@@ -28231,6 +28311,9 @@ const powerRef = useRef(hud.power);
             aimDir.copy(activeAiPlan.aimDir);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
+              if (cue?.active) {
+                alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false });
+              }
             }
           } else if (autoAimDir && autoAimDir.lengthSq() > 1e-6) {
             if (shouldAutoAimPlayer) {
@@ -28241,7 +28324,7 @@ const powerRef = useRef(hud.power);
             }
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
-              if (shouldAutoAimPlayer && cue?.active) {
+              if ((shouldAutoAimPlayer || shouldAutoAimAi) && cue?.active) {
                 alignStandingCameraToAim(cue, aimDir, { preserveOrbit: false });
               }
             }


### PR DESCRIPTION
### Motivation
- Make AI aim feel smoother and more responsive by animating aim adjustments instead of snapping. 
- Prevent invalid/hidden spin inputs by factoring the current camera/view direction into spin limits. 
- Tighten and sync cue/replay timings and follow-through to improve visual consistency and responsiveness.

### Description
- Added `AI_AIM_ADJUST_DELAY_MS` and `AI_AIM_ADJUST_DURATION_MS`, implemented `aiAimAdjustRef`, `cancelAiAimAdjust`, and `animateAiAimAdjustment` to interpolate AI aim and align the standing camera during AI preview/cue view. 
- Reduced `AI_SPIN_ADJUST_DELAY_MS`, and invoked `animateAiAimAdjustment` inside the AI shot flow so aim animates before the shot; updated related timeouts and kickoff logic. 
- Extended `computeSpinLimits` signature to accept `viewInput` and applied view-based blocking logic to clamp `min/maxX`/`min/maxY` when the camera view would make spins invalid; updated call sites to pass the computed view vector. 
- Adjusted player/replay cue and impact timings and geometry: `PLAYER_CUE_RELEASE_DURATION_MS` decreased, `REPLAY_CUE_MIN_RELEASE_MS` increased, fallback forward/pull/follow distance and follow-through clamped to new ranges, and replay cue idle positioning fixed. 

### Testing
- Ran the automated unit/integration test suite with `yarn test` and `yarn build` and observed no regressions in tests (all tests passed). 
- Ran the linter with `yarn lint` and fixed issues reported during the rollout (lint passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a437ce07708329830399450ea5c7c3)