### PR TITLE
Adjust Texas Hold’em camera distance and landscape HUD placement

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.34 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.88, landscape: 0.14 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.34, landscape: 0.92 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.6, landscape: -0.04 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.24, landscape: 0.82 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
@@ -6287,7 +6287,7 @@ function TexasHoldemArena({ search }) {
           />
         ))}
       </div>
-      <div className="absolute bottom-14 landscape:bottom-2 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto">
+      <div className="absolute bottom-14 landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.1rem)] left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto">
         <div className="flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur">
           {humanPlayer?.avatar &&
             (isHumanTurn ? (
@@ -6304,7 +6304,7 @@ function TexasHoldemArena({ search }) {
         </div>
       </div>
       {sliderVisible && (
-        <div className="pointer-events-auto absolute right-2 bottom-32 z-10 flex flex-col items-center gap-3 text-white landscape:bottom-4 sm:right-6 sm:bottom-36 sm:landscape:bottom-8">
+        <div className="pointer-events-auto absolute right-2 bottom-32 z-10 flex flex-col items-center gap-3 text-white landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.1rem)] sm:right-6 sm:bottom-36 sm:landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.35rem)]">
           <div className="flex flex-col items-center gap-3">
             <input
               type="range"


### PR DESCRIPTION
### Motivation
- Make the seated 3D camera appear closer to the table in portrait and landscape so the table feels more intimate on mobile portrait screens.
- Move the bet/raise slider and its confirm button text lower in landscape so the control sits nearer the device bottom safe-area.
- Move the bottom (human) player avatar HUD down in landscape so the avatar sits at the very bottom of the page as requested.

### Description
- Reduced camera retreat offsets and slightly lowered camera elevation by changing `CAMERA_RETREAT_OFFSETS` and `CAMERA_ELEVATION_OFFSETS` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to pull the camera inward for both orientations.
- Adjusted the bottom avatar container class to push the human avatar HUD further down in landscape in `TexasHoldemArena.jsx`.
- Adjusted the raise/slider container class to move the vertical slider and its confirm (`Raise`/`Bet`) button lower in landscape in `TexasHoldemArena.jsx`.

### Testing
- Ran `npm run build` from `webapp/` and the production build completed successfully.
- Automated browser capture via Playwright was executed and produced an updated landscape screenshot of the Texas Hold’em screen, validating the visual placement changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a448d59f2c83299e6322280d5fca2f)