### PR TITLE
Pool Royale: AI pocket-line aim compensation and cue strike timing

### DIFF
--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -1,0 +1,42 @@
+import { resolveAiPotGhostAim } from '../webapp/src/pages/Games/poolRoyaleAiAimCompensation.js';
+
+describe('Pool Royale AI aim compensation', () => {
+  const cuePos = { x: -0.35, y: -0.4 };
+  const targetPos = { x: 0.1, y: 0.05 };
+  const pocketPos = { x: 0.45, y: 0.45 };
+
+  it('returns a normalized center-pocket ghost aim without spin', () => {
+    const result = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0, y: 0 },
+      power: 0.7
+    });
+    expect(result).toBeTruthy();
+    expect(result.aimDir.length()).toBeCloseTo(1, 5);
+    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeGreaterThan(0.04);
+  });
+
+  it('applies side-spin compensation as a measurable aim shift', () => {
+    const neutral = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0, y: 0 },
+      power: 0.8
+    });
+    const withSide = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0.45, y: 0 },
+      power: 0.8
+    });
+    expect(withSide).toBeTruthy();
+    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeGreaterThan(0.001);
+  });
+});

--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -14,20 +14,13 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(sample.t).toBeCloseTo(0.2, 2);
   });
 
-  it('arms impact near end of release', () => {
-    const preHit = sampleCueStrokeTimeline({ elapsed: 280, ...options });
-    const postHit = sampleCueStrokeTimeline({ elapsed: 292, ...options });
+  it('arms impact exactly when release reaches the start contact position', () => {
+    const preHit = sampleCueStrokeTimeline({ elapsed: 299, ...options });
+    const atHit = sampleCueStrokeTimeline({ elapsed: 300, ...options });
     expect(preHit.phase).toBe('release');
     expect(preHit.hitArmed).toBe(false);
-    expect(postHit.phase).toBe('release');
-    expect(postHit.hitArmed).toBe(true);
-  });
-
-
-  it('arms impact before the very end of release so forward push is visible', () => {
-    const armed = sampleCueStrokeTimeline({ elapsed: 283, ...options });
-    expect(armed.phase).toBe('release');
-    expect(armed.hitArmed).toBe(true);
+    expect(atHit.phase).toBe('release');
+    expect(atHit.hitArmed).toBe(true);
   });
 
   it('enters recover then done', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,7 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -26550,16 +26551,18 @@ const powerRef = useRef(hud.power);
             plan.targetBall = pickLegalTargetBall();
           }
           if (plan.pocketCenter && plan.targetBall?.pos) {
-            const toPocket = plan.pocketCenter.clone().sub(plan.targetBall.pos);
-            if (toPocket.lengthSq() > 1e-6) {
-              const toPocketDir = toPocket.normalize();
-              const ghost = plan.targetBall.pos
-                .clone()
-                .sub(toPocketDir.multiplyScalar(BALL_R * 2));
-              const cueVec = ghost.sub(cueBall.pos);
-              if (cueVec.lengthSq() > 1e-6) {
-                corrected = cueVec.normalize();
-                plan.cueToTarget = cueBall.pos.distanceTo(ghost);
+            const compensatedAim = resolveAiPotGhostAim({
+              cuePos: cueBall.pos,
+              targetPos: plan.targetBall.pos,
+              pocketPos: plan.pocketCenter,
+              ballRadius: BALL_R,
+              spin: plan.spin,
+              power: plan.power
+            });
+            if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
+              corrected = compensatedAim.aimDir.clone();
+              if (compensatedAim.ghost) {
+                plan.cueToTarget = cueBall.pos.distanceTo(compensatedAim.ghost);
               }
             }
           }

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+
+const MIN_VECTOR_EPS = 1e-6;
+
+export const resolveAiPotGhostAim = ({
+  cuePos,
+  targetPos,
+  pocketPos,
+  ballRadius,
+  spin,
+  power
+} = {}) => {
+  if (!cuePos || !targetPos || !pocketPos) return null;
+  const radius = Math.max(0, ballRadius ?? 0);
+  const toPocket = new THREE.Vector2().subVectors(pocketPos, targetPos);
+  if (toPocket.lengthSq() <= MIN_VECTOR_EPS) return null;
+
+  const toPocketDir = toPocket.normalize();
+  const sideSpin = THREE.MathUtils.clamp(spin?.x ?? 0, -1, 1);
+  const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
+  const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
+
+  // Small compensation for squirt/throw so AI can still target the center pocket entry.
+  const compensationAngle = sideSpin * power01 * 0.085;
+  // Slightly adjust contact depth with top/back spin to account for throw speed changes.
+  const contactDepth = radius * 2 * (1 + topBackSpin * power01 * 0.07);
+  const ghost = new THREE.Vector2()
+    .copy(targetPos)
+    .sub(toPocketDir.clone().multiplyScalar(Math.max(radius * 1.5, contactDepth)));
+
+  const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
+  if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;
+  finalCueVector.rotateAround(new THREE.Vector2(0, 0), -compensationAngle);
+
+  return {
+    aimDir: finalCueVector.normalize(),
+    ghost
+  };
+};

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -26,9 +26,8 @@ export const sampleCueStrokeTimeline = ({
     return {
       phase: 'release',
       t: THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1),
-      // Arm impact a little earlier so the forward cue-stick travel is visible
-      // before the simulated hit is applied in both live-play and replay.
-      hitArmed: safeElapsed >= pullEnd + release * 0.82,
+      // Cue-ball movement starts only after the cue returns to the start contact point.
+      hitArmed: safeElapsed >= pullEnd + release,
       done: false
     };
   }


### PR DESCRIPTION
### Motivation
- Improve AI pot aiming so the suggested aim accounts for side/top/back spin and targets the central pocket entry (ghost-ball) rather than mis-aiming when spin/force causes squirt/throw.
- Make the cue-stick animation match expected visuals by ensuring the cue pushes forward visibly before the cue-ball begins moving.

### Description
- Added `resolveAiPotGhostAim` in `webapp/src/pages/Games/poolRoyaleAiAimCompensation.js` to compute a pocket-center ghost-ball position and apply lightweight spin/power compensation for final AI aim direction. 
- Integrated the helper into AI plan normalization in `PoolRoyale.jsx` so `normalizeAiPlanAim` refines `aimDir` and `cueToTarget` using the new compensation logic. 
- Changed the cue stroke timeline in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` so `hitArmed` is set at the end of the forward release (`safeElapsed >= pullEnd + release`), delaying cue-ball movement until the visual forward push completes. 
- Updated tests by modifying `test/poolRoyaleCueStrokeTimeline.test.js` to match the new impact timing and adding `test/poolRoyaleAiAimCompensation.test.js` to validate ghost aim and side-spin influence. 

### Testing
- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleAiAimCompensation.test.js test/poolRoyaleAimSuggestion.test.js` and all targeted suites passed. 
- Individual Jest runs for `test/poolRoyaleCueStrokeTimeline.test.js`, `test/poolRoyaleAiAimCompensation.test.js`, and `test/poolRoyaleAimSuggestion.test.js` completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45041cbb8832999007f620114c4c8)