### PR TITLE
Prefer highest pot probability in Pool AI and improve cue stroke visibility

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -661,11 +661,30 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     targetBallId: target.id,
     targetPocket: entry,
     aimPoint: ghost,
+    potChance,
     quality,
     rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
     nextScore,
     hasNext
   }
+}
+
+function isBetterPlanCandidate (candidate, incumbent) {
+  if (!candidate) return false
+  if (!incumbent) return true
+  const candidatePotChance = Number.isFinite(candidate.potChance) ? candidate.potChance : -Infinity
+  const incumbentPotChance = Number.isFinite(incumbent.potChance) ? incumbent.potChance : -Infinity
+  if (candidatePotChance !== incumbentPotChance) {
+    return candidatePotChance > incumbentPotChance
+  }
+  const candidateQuality = Number.isFinite(candidate.quality) ? candidate.quality : -Infinity
+  const incumbentQuality = Number.isFinite(incumbent.quality) ? incumbent.quality : -Infinity
+  if (candidateQuality !== incumbentQuality) {
+    return candidateQuality > incumbentQuality
+  }
+  const candidateDifficulty = Number.isFinite(candidate.difficulty) ? candidate.difficulty : Infinity
+  const incumbentDifficulty = Number.isFinite(incumbent.difficulty) ? incumbent.difficulty : Infinity
+  return candidateDifficulty < incumbentDifficulty
 }
 
 function safetyShot (req) {
@@ -840,7 +859,7 @@ export function planShot (req) {
         if (baseCand) {
           hasViableShot = true
           const { nextScore, hasNext, ...rest } = baseCand
-          if (!best || rest.quality > best.quality) {
+          if (isBetterPlanCandidate(rest, best)) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
           }
           // Only explore additional power/spin if next position is poor and there is a next target
@@ -869,7 +888,7 @@ export function planShot (req) {
             if (cand) {
               hasViableShot = true
               const { nextScore, hasNext, ...rest } = cand
-              if (!best || rest.quality > best.quality) {
+              if (isBetterPlanCandidate(rest, best)) {
                 best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
               }
             }

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -245,7 +245,7 @@ test('UNASSIGNED group defers to ballOn value', () => {
   assert.equal(decision.targetBallId, 1);
 });
 
-test('prefers target with smallest cut angle', () => {
+test('prefers target with highest pot probability over pure cut-angle heuristics', () => {
   const req = {
     game: 'AMERICAN_BILLIARDS',
     state: {
@@ -263,7 +263,7 @@ test('prefers target with smallest cut angle', () => {
     timeBudgetMs: 50
   };
   const decision = planShot(req);
-  assert.equal(decision.targetBallId, 1);
+  assert.equal(decision.targetBallId, 2);
 });
 
 test('cue ball remains within table bounds for varied power and spin', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5465,6 +5465,8 @@ const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
 const PLAYER_CUE_RELEASE_DURATION_MS = 1120;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
+const PLAYER_CUE_FORWARD_PUSH_MIN = BALL_R * 0.32;
+const PLAYER_CUE_FORWARD_PUSH_MAX = BALL_R * 0.52;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
@@ -21173,7 +21175,7 @@ const powerRef = useRef(hud.power);
               ? playback.duration
               : REPLAY_CUE_STICK_HOLD_MS;
             const fallbackPullback = CUE_PULL_BASE * 0.35;
-            const fallbackForward = CUE_PULL_BASE * 0.18;
+            const fallbackForward = Math.max(CUE_PULL_BASE * 0.24, PLAYER_CUE_FORWARD_PUSH_MIN);
             const pullbackTime = 160;
             const forwardTime = 210;
             const settleTime = 120;
@@ -24927,12 +24929,16 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = PLAYER_CUE_PULLBACK_DURATION_MS;
           const startTime = performance.now();
           const followThrough = THREE.MathUtils.clamp(
-            topspinFactor * BALL_R * 0.29,
+            topspinFactor * BALL_R * 0.34,
             0,
-            BALL_R * 0.33
+            PLAYER_CUE_FORWARD_PUSH_MAX
           );
-          const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
-          const impactPos = buildCuePosition(-followDistance);
+          const forwardPushDistance = THREE.MathUtils.clamp(
+            Math.max(PLAYER_CUE_FORWARD_PUSH_MIN, followThrough),
+            PLAYER_CUE_FORWARD_PUSH_MIN,
+            PLAYER_CUE_FORWARD_PUSH_MAX
+          );
+          const impactPos = buildCuePosition(-forwardPushDistance);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;
@@ -26385,6 +26391,7 @@ const powerRef = useRef(hud.power);
                 : 0,
             spin,
             quality,
+            potChance: Number.isFinite(decision.potChance) ? decision.potChance : quality,
             suggestedAimDir:
               suggestedAimDir && suggestedAimDir.lengthSq() > 1e-6
                 ? suggestedAimDir
@@ -26424,9 +26431,19 @@ const powerRef = useRef(hud.power);
             if (!openSourcePlan) return baseline;
             const result = { ...baseline };
             if (openSourcePlan.type === 'pot') {
+              const currentPotChance = Number.isFinite(result.bestPot?.potChance)
+                ? result.bestPot.potChance
+                : result.bestPot?.quality ?? -Infinity;
+              const nextPotChance = Number.isFinite(openSourcePlan.potChance)
+                ? openSourcePlan.potChance
+                : openSourcePlan.quality ?? 0;
               const currentQuality = result.bestPot?.quality ?? -Infinity;
-              const nextQuality = openSourcePlan.quality ?? 0;
-              if (!result.bestPot || nextQuality >= currentQuality) {
+              const nextQuality = openSourcePlan.quality ?? -Infinity;
+              if (
+                !result.bestPot ||
+                nextPotChance > currentPotChance ||
+                (nextPotChance === currentPotChance && nextQuality >= currentQuality)
+              ) {
                 result.bestPot = openSourcePlan;
               }
             } else {


### PR DESCRIPTION
### Motivation
- Make AI/suggestion picks favor the most makeable pot (highest probability) rather than just quality/cut heuristics so suggestions match player/AI intent more reliably.
- Make the cue forward push in Pool Royale more visually readable by increasing forward travel and providing explicit forward push limits for live and replay strokes.

### Description
- Added `potChance` to shot evaluation results in `lib/poolAi.js` and return it from `evaluate()` so candidates carry an explicit probability metric.
- Introduced `isBetterPlanCandidate()` in `lib/poolAi.js` and switched plan selection to prefer higher `potChance` first, then `quality`, then lower `difficulty` as tie-breakers.
- Updated Pool Royale UI integration in `webapp/src/pages/Games/PoolRoyale.jsx` to preserve `potChance` from open-source AI plans and prefer pot plans by `potChance` before falling back to quality.
- Increased cue forward push visibility by adding `PLAYER_CUE_FORWARD_PUSH_MIN` / `PLAYER_CUE_FORWARD_PUSH_MAX`, applying them to both player stroke calculation and replay fallback positions, and adjusting related fallbacks.
- Small test update: adjusted `test/poolAi.test.js` expectation to validate the probability-first targeting behavior.

### Testing
- Ran the targeted Jest suites with `npm test -- --runInBand test/poolAi.test.js test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleAimSuggestion.test.js` and all tests passed (21/21).
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured UI screenshots for the Pool Royale route; the dev server started successfully and screenshots were produced.
- No other automated failures observed in the local verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4684fee2883298d305b24b3bc6483)