### PR TITLE
Pool Royale: prioritize highest-pot suggestions and improve cue forward stroke visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21395,6 +21395,7 @@ const powerRef = useRef(hud.power);
             idlePos,
             pullPos,
             impactPos,
+            followPos,
             pullbackDuration,
             strikeDuration,
             holdDuration,
@@ -21437,7 +21438,8 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'hold') {
-            cueStick.position.copy(impactPos);
+            const eased = easeOutCubic(sample.t);
+            cueStick.position.lerpVectors(impactPos, followPos ?? impactPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -21445,7 +21447,7 @@ const powerRef = useRef(hud.power);
           }
           if (sample.phase === 'recover') {
             const eased = easeInOutCubic(sample.t);
-            cueStick.position.lerpVectors(impactPos, idlePos, eased);
+            cueStick.position.lerpVectors(followPos ?? impactPos, idlePos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -24932,8 +24934,13 @@ const powerRef = useRef(hud.power);
             BALL_R * 0.33
           );
           const followDistance = Math.min(followThrough, CUE_TIP_GAP * 0.85);
-          const impactPos = buildCuePosition(-followDistance);
-          const followPos = impactPos.clone();
+          const impactTravel = Math.max(BALL_R * 0.1, followDistance * 0.55);
+          const followTravel = Math.max(
+            BALL_R * 0.24 + powerStrength * BALL_R * 0.12,
+            followDistance + BALL_R * 0.18
+          );
+          const impactPos = buildCuePosition(-impactTravel);
+          const followPos = buildCuePosition(-followTravel);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;
           const impactTime = startTime + pullbackDuration + strikeDuration * 0.9;
@@ -26700,12 +26707,33 @@ const powerRef = useRef(hud.power);
           if (!cuePos) return null;
 
           const turnOwner = options?.turnOwner === 'ai' ? 'ai' : 'player';
-          const cycleToNext = options?.cycleToNext ?? (turnOwner === 'player');
+          const cycleToNext = options?.cycleToNext ?? false;
 
           const activeBalls = ballsList.filter(
             (ball) => ball.active && String(ball.id) !== 'cue'
           );
           if (activeBalls.length === 0) return null;
+
+          const highestProbabilityPlan = normalizeAiPlanAim(
+            evaluateAiShotOptions({ allowSafety: false })?.bestPot ?? null
+          );
+          if (highestProbabilityPlan?.aimDir?.lengthSq?.() > 1e-6) {
+            const preferredDir = highestProbabilityPlan.aimDir.clone().normalize();
+            const preferredContact = calcTarget(cue, preferredDir, activeBalls);
+            if (
+              preferredContact?.targetBall &&
+              highestProbabilityPlan.targetBall &&
+              String(preferredContact.targetBall.id) ===
+                String(highestProbabilityPlan.targetBall.id)
+            ) {
+              autoAimCycleRef.current[turnOwner] = {
+                index: 0,
+                lastTargetId: highestProbabilityPlan.targetBall.id
+              };
+              return preferredDir;
+            }
+          }
+
           const clearance = BALL_R * 1.5;
           const isDirectLaneOpen = (target) => {
             if (!target) return false;


### PR DESCRIPTION
### Motivation
- Suggestions should prefer the single highest-probability pot (bestPot) so users and AI lock on the most promising shot rather than cycling heuristics. 
- The cue stick forward motion is often not visible enough; the animation should show a clearer follow-through so players perceive the push into the ball.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` prioritize the computed `bestPot` plan by attempting to apply its normalized `aimDir` first, and set the auto-aim cycle default to stable behavior (`cycleToNext` defaults to `false`).
- Add logic to record and honor a `followPos` for cue stroke playback and use it for the `hold` and `recover` phases so the stick visibly follows through before returning to idle.
- Increase forward travel calculations used to build the `impactPos`/`followPos` so the push-forward movement is more pronounced and scales with shot power.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleAimSuggestion.test.js test/poolRoyaleCueStrokeTimeline.test.js` and they passed: 2 suites, 7 tests (`PASS`).
- Started the webapp dev server with `npm --prefix webapp run dev` which reported Vite ready and reachable locally, but a Playwright screenshot attempt failed due to a Chromium crash in this environment (SIGSEGV) so no visual screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4684fee2883298d305b24b3bc6483)