### PR TITLE
Align Pool Royale cue stroke with reference forward-push mechanics

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21403,9 +21403,57 @@ const powerRef = useRef(hud.power);
             baseRotationX,
             baseRotationY,
             strikeDip,
-            wobbleAmount
+            wobbleAmount,
+            strikeImpactThreshold,
+            forwardOnly
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
+          if (forwardOnly) {
+            const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
+            const safeHoldDuration = Math.max(0, holdDuration ?? 50);
+            const impactThreshold = THREE.MathUtils.clamp(
+              strikeImpactThreshold ?? 0.9,
+              0,
+              1
+            );
+            const pushT = THREE.MathUtils.clamp(elapsed / safeStrikeDuration, 0, 1);
+            const easedPush = easeOutCubic(pushT);
+            cueStick.visible = true;
+            cueStick.position.lerpVectors(pullPos, impactPos, easedPush);
+            cueStick.position.y -= (strikeDip ?? 0.003) * easedPush;
+            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+            cueStick.rotation.y =
+              (baseRotationY ?? cueStick.rotation.y) +
+              Math.sin(pushT * Math.PI) * (wobbleAmount ?? 0.0018);
+            if (!stroke.shotApplied && pushT >= impactThreshold) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
+            if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
+            cueStick.position.copy(idlePos);
+            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+            cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
+            syncCueShadow();
+            cueStick.visible = true;
+            cueAnimating = false;
+            cuePullCurrentRef.current = 0;
+            cuePullTargetRef.current = 0;
+            cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
+            if (cameraRef.current && sphRef.current) {
+              topViewRef.current = false;
+              topViewLockedRef.current = false;
+              setIsTopDownView(false);
+              const sph = sphRef.current;
+              sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+              updateCamera();
+            }
+            return false;
+          }
           const sample = sampleCueStrokeTimeline({
             elapsed,
             pullbackDuration,
@@ -24923,26 +24971,21 @@ const powerRef = useRef(hud.power);
             0,
             1
           );
-          const strikeDuration = PLAYER_CUE_RELEASE_DURATION_MS;
-          const strikeHoldDuration = PLAYER_CUE_IMPACT_HOLD_MS;
-          const pullbackDuration = PLAYER_CUE_PULLBACK_DURATION_MS;
+          const strikeDuration = 120;
+          const strikeHoldDuration = 50;
+          const pullbackDuration = 0;
           const startTime = performance.now();
-          const followThrough = THREE.MathUtils.clamp(
-            CUE_FOLLOW_THROUGH_MIN +
-              (CUE_FOLLOW_THROUGH_MAX - CUE_FOLLOW_THROUGH_MIN) *
-                (powerStrength * 0.75 + topspinFactor * 0.25),
-            CUE_FOLLOW_THROUGH_MIN,
-            CUE_FOLLOW_THROUGH_MAX
+          const contactEps = 0.001;
+          const followExtra = THREE.MathUtils.clamp(topspinFactor * 0.016, 0, 0.018);
+          const endDistanceFromBallCenter = Math.max(
+            BALL_R * 0.55,
+            BALL_R + contactEps - followExtra
           );
-          const followDistance = Math.min(
-            followThrough,
-            CUE_TIP_GAP + maxPull + BALL_R * 0.5
-          );
-          const impactPos = buildCuePosition(-followDistance);
+          const impactPos = buildCuePosition(-(CUE_TIP_GAP - endDistanceFromBallCenter));
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;
-          const impactTime = startTime + pullbackDuration + strikeDuration * 0.9;
+          const impactTime = startTime + strikeDuration * 0.9;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -25056,7 +25099,9 @@ const powerRef = useRef(hud.power);
               baseRotationX: cueStick.rotation.x,
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
-              wobbleAmount: 0.0018
+              wobbleAmount: 0.0018,
+              strikeImpactThreshold: 0.9,
+              forwardOnly: true
             };
           } else {
             cueStick.visible = false;


### PR DESCRIPTION
### Motivation
- Replace the existing cue-stroke animation path with the forward-push technique from the provided reference so the cue tip movement, timing and impact behavior match the requested mechanics (micro follow-through for topspin, cue anchored to a fixed world position during pull/strike).

### Description
- Implemented a forward-only strike profile: fixed forward push timing and short hold (using a 120ms push + 50ms hold and no pullback/recover phases) for player cue strokes in `PoolRoyale.jsx`.
- Replaced the previous follow-through computation with a near-contact `impactPos` that includes a tiny topspin-driven micro follow-through window and used that position as the forward target for the push.
- Added stroke state metadata fields `forwardOnly` and `strikeImpactThreshold` so stroke state explicitly requests the new forward-only flow and triggers the shot when the push progress crosses the impact threshold.
- Added a fast-path in the stroke update (`updateCueStroke`) that handles `forwardOnly` strokes using an `easeOutCubic` push, applies the wobble/strike dip visually, fires the impact callback when the threshold is crossed, and then snaps the cue back to idle.

### Testing
- Ran linters with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (succeeded; warning only about file ignore patterns). ✅
- Ran full repo build with `npm run build` (failed due to a pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts`, which is unrelated to this change). ❌
- Launched the webapp dev server via `npm --prefix webapp run dev` and confirmed the dev server started (Vite ready), and attempted an automated Playwright screenshot of `/games/poolroyale` but the Playwright run timed out and did not produce an artifact. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4807f80d083298a93e00d82991b5b)