### PR TITLE
Tune Pool Royale cushion bounce and cue stroke readability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1464,7 +1464,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 0.99,
+  restitution: 1.03,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
@@ -5466,12 +5466,12 @@ const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
 const PLAYER_CUE_RELEASE_DURATION_MS = 1120;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1.75;
+const REPLAY_CUE_STROKE_SLOWDOWN = 2.25;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee visible pullback phase when captured stroke timings are too short
-const REPLAY_CUE_MIN_RELEASE_MS = 260; // guarantee visible forward push into impact in replay view
+const REPLAY_CUE_MIN_RELEASE_MS = 340; // guarantee visible forward push into impact in replay view
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -21175,8 +21175,8 @@ const powerRef = useRef(hud.power);
             const fallbackPullback = CUE_PULL_BASE * 0.35;
             const fallbackForward = CUE_PULL_BASE * 0.18;
             const pullbackTime = 160;
-            const forwardTime = 210;
-            const settleTime = 120;
+            const forwardTime = 320;
+            const settleTime = 160;
             const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
             const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
             const holdWindow = Math.max(replayHoldWindow, totalStroke);
@@ -24971,8 +24971,8 @@ const powerRef = useRef(hud.power);
             0,
             1
           );
-          const strikeDuration = 120;
-          const strikeHoldDuration = 50;
+          const strikeDuration = 190;
+          const strikeHoldDuration = 90;
           const pullbackDuration = 0;
           const startTime = performance.now();
           const contactEps = 0.001;
@@ -24985,7 +24985,7 @@ const powerRef = useRef(hud.power);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;
-          const impactTime = startTime + strikeDuration * 0.9;
+          const impactTime = startTime + strikeDuration * 0.76;
           const forwardPreviewHold =
             impactTime +
             Math.min(
@@ -25098,9 +25098,9 @@ const powerRef = useRef(hud.power);
               recoverDuration,
               baseRotationX: cueStick.rotation.x,
               baseRotationY: cueStick.rotation.y,
-              strikeDip: 0.003,
-              wobbleAmount: 0.0018,
-              strikeImpactThreshold: 0.9,
+              strikeDip: 0.0045,
+              wobbleAmount: 0.0024,
+              strikeImpactThreshold: 0.76,
               forwardOnly: true
             };
           } else {


### PR DESCRIPTION
### Motivation
- Improve perceived cushion/rail responsiveness so rebounds feel slightly livelier during play. 
- Make the cue push-forward animation and replay cue stroke easier to read for both live AI/user shots and replay playback. 
- Ensure fallback replay timing (when recorded stroke snapshots are missing) is slower so replay doesn’t look too fast.

### Description
- Increased physics restitution by changing `PHYSICS_PROFILE.restitution` from `0.99` to `1.03` in `webapp/src/pages/Games/PoolRoyale.jsx` to make cushions bounce a bit more. 
- Slowed replay stroke playback by updating `REPLAY_CUE_STROKE_SLOWDOWN` from `1.75` to `2.25` and raised `REPLAY_CUE_MIN_RELEASE_MS` from `260` to `340` to guarantee a more visible forward-release window. 
- Extended fallback replay stroke timings by increasing `forwardTime` from `210` to `320` and `settleTime` from `120` to `160` so recordings without explicit cue snapshots play back more legibly. 
- Tuned live cue stroke parameters by increasing `strikeDuration` from `120` to `190`, `strikeHoldDuration` from `50` to `90`, adjusting `impactTime` calculation, and enlarging `strikeDip`/`wobbleAmount` while lowering the `strikeImpactThreshold` so the forward push is more noticeable during shots. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`, which completed with an ignore-pattern warning but no syntax errors reported for the edited file. 
- Attempted `npm run -s build`, which failed due to an unrelated pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` and not because of these changes. 
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a mobile-portrait screenshot using Playwright for visual verification of the cue/table visuals which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a488bd3758832995844a71b4d87dd7)