### PR TITLE
Preserve Poly Haven GLTF texture mapping for Domino Royal tables & chairs

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2354,7 +2354,7 @@ function getRendererTextureSizeCap() {
   return renderer?.capabilities?.maxTextureSize ?? 8192;
 }
 
-function prepareLoadedModel(model) {
+function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) {
   if (!model) return;
   const maxAnisotropy = getRendererAnisotropyCap();
   model.traverse((obj) => {
@@ -2364,6 +2364,28 @@ function prepareLoadedModel(model) {
     const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
     mats.forEach((mat) => {
       if (!mat) return;
+      if (preserveGltfTextureMapping) {
+        if (mat.map) mat.map.anisotropy = Math.max(mat.map.anisotropy ?? 1, maxAnisotropy);
+        if (mat.normalMap)
+          mat.normalMap.anisotropy = Math.max(
+            mat.normalMap.anisotropy ?? 1,
+            maxAnisotropy
+          );
+        if (mat.roughnessMap)
+          mat.roughnessMap.anisotropy = Math.max(
+            mat.roughnessMap.anisotropy ?? 1,
+            maxAnisotropy
+          );
+        if (mat.metalnessMap)
+          mat.metalnessMap.anisotropy = Math.max(
+            mat.metalnessMap.anisotropy ?? 1,
+            maxAnisotropy
+          );
+        if (mat.aoMap)
+          mat.aoMap.anisotropy = Math.max(mat.aoMap.anisotropy ?? 1, maxAnisotropy);
+        mat.needsUpdate = true;
+        return;
+      }
       normalizeMaterialTextures(mat, maxAnisotropy);
     });
   });
@@ -2414,12 +2436,6 @@ async function loadPolyhavenModel(assetId) {
         candidateUrl,
         typeof window !== 'undefined' ? window.location?.href : candidateUrl
       ).href;
-      const resourcePath = resolvedUrl.substring(
-        0,
-        resolvedUrl.lastIndexOf('/') + 1
-      );
-      loader.setResourcePath(resourcePath);
-      loader.setPath('');
       gltf = await loader.loadAsync(resolvedUrl);
       break;
     } catch (error) {
@@ -2433,7 +2449,7 @@ async function loadPolyhavenModel(assetId) {
   }
   const root = gltf.scene || gltf.scenes?.[0];
   if (!root) throw new Error(`Poly Haven model missing scene for ${assetId}`);
-  prepareLoadedModel(root);
+  prepareLoadedModel(root, { preserveGltfTextureMapping: true });
   polyhavenModelCache.set(cacheKey, root);
   return root.clone(true);
 }


### PR DESCRIPTION
### Motivation
- Domino tables and chairs imported from Poly Haven were having their authored GLTF texture/UV mapping altered by aggressive post-processing. 
- The change ensures original GLTF mapping and material intent from Poly Haven is preserved for table and chair models. 
- Keep renderer improvements (anisotropy) without rewriting color-space/texture path handling that can distort UV-driven materials.

### Description
- Add optional parameter to `prepareLoadedModel` (`preserveGltfTextureMapping`) so GLTF imports can opt out of full texture normalization. 
- When `preserveGltfTextureMapping` is true, the loader only boosts `anisotropy` and sets `needsUpdate` without changing maps, colorSpace, wrapping, or filters. 
- Stop overriding the loader `resourcePath`/`setPath` for Poly Haven URLs and instead load the resolved GLTF URL directly so relative GLB/GTLF resources resolve with the default `GLTFLoader` behavior. 
- Use `prepareLoadedModel(root, { preserveGltfTextureMapping: true })` when loading Poly Haven models used for table/chair themes so original texture mapping is preserved.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed successfully. 
- Attempted an automated browser screenshot run for `/games/domino-royal` via Playwright, but the local dev servers on ports `5173`, `3000`, and `4173` were not listening in this environment so the capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5132cb1a08329a64ef4f2d2242067)