### PR TITLE
Improve Pool Royale cushion bounce and cue/replay stroke readability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1464,7 +1464,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 1.02,
+  restitution: 1.08,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
@@ -1522,8 +1522,8 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 0.84; // keep jaw cuts lively so cushion-first routes rebound with a touch more energy
-const CUSHION_CUT_FRICTION_SCALE = 1.2; // add a touch more grab on angled cuts to prevent over-bouncy jaw rebounds
+const CUSHION_CUT_RESTITUTION_SCALE = 0.9; // increase jaw rebound energy so cushion cuts feel a bit bouncier
+const CUSHION_CUT_FRICTION_SCALE = 1.12; // trim grab slightly so added bounce is visible without making cuts skid
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
 let SIDE_POCKET_SPAN =
@@ -1845,8 +1845,8 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 2.7; // strengthen minimum forward push so cue-stroke follow-through is always visible
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 6.8; // extend forward travel so high-power shots show a clear cue push animation
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.4; // raise minimum forward push so every shot clearly shows the cue driving through
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 7.8; // extend top-end follow-through so powerful shots visibly punch forward
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -5412,7 +5412,7 @@ const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
 const CUE_STROKE_VISUAL_SLOWDOWN = 1.5;
 const AI_CUE_PULLBACK_DURATION_MS = 260;
-const AI_CUE_FORWARD_DURATION_MS = 980;
+const AI_CUE_FORWARD_DURATION_MS = 1160;
 const AI_STROKE_VISIBLE_DURATION_MS =
   (AI_CUE_PULLBACK_DURATION_MS + AI_CUE_FORWARD_DURATION_MS) * CUE_STROKE_VISUAL_SLOWDOWN;
 const AI_CAMERA_POST_STROKE_HOLD_MS = 2000;
@@ -5463,16 +5463,16 @@ const PLAYER_FORWARD_SLOWDOWN = 1.75;
 const PLAYER_STROKE_PULLBACK_FACTOR = 0.82;
 const PLAYER_PULLBACK_MIN_SCALE = 1.35;
 const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
-const PLAYER_CUE_RELEASE_DURATION_MS = 1120;
+const PLAYER_CUE_RELEASE_DURATION_MS = 1320;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 2.35;
+const REPLAY_CUE_STROKE_SLOWDOWN = 2.85;
 const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 300; // hold pullback longer so the replay wind-up reads clearly on mobile
-const REPLAY_CUE_MIN_RELEASE_MS = 420; // give replay strokes a slower, more readable push-through into impact
-const LIVE_CUE_FORWARD_DURATION_MS = 260;
+const REPLAY_CUE_MIN_RELEASE_MS = 560; // hold replay push-through longer so forward cue motion is easy to read on mobile
+const LIVE_CUE_FORWARD_DURATION_MS = 340;
 const LIVE_CUE_IMPACT_HOLD_MS = 180;
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;


### PR DESCRIPTION
### Motivation
- Make Pool Royale feel livelier at rails by increasing cushion rebound while keeping cuts controllable. 
- Ensure the cue push-forward animation is clearly visible for both player and AI shots. 
- Slow replay and live cue timings so the replay cue motion and follow-through are readable on mobile portrait displays.

### Description
- Updated physics and cushion tuning in `webapp/src/pages/Games/PoolRoyale.jsx` by raising `PHYSICS_PROFILE.restitution` from `1.02` to `1.08` and increasing `CUSHION_CUT_RESTITUTION_SCALE` from `0.84` to `0.9` while lowering `CUSHION_CUT_FRICTION_SCALE` from `1.2` to `1.12`.
- Increased visible cue follow-through by changing `CUE_FOLLOW_THROUGH_MIN` from `BALL_R * 2.7` to `BALL_R * 3.4` and `CUE_FOLLOW_THROUGH_MAX` from `BALL_R * 6.8` to `BALL_R * 7.8`.
- Slowed cue timing to improve readability by adjusting `AI_CUE_FORWARD_DURATION_MS` `980 -> 1160`, `PLAYER_CUE_RELEASE_DURATION_MS` `1120 -> 1320`, `REPLAY_CUE_STROKE_SLOWDOWN` `2.35 -> 2.85`, `REPLAY_CUE_MIN_RELEASE_MS` `420 -> 560`, and `LIVE_CUE_FORWARD_DURATION_MS` `260 -> 340` in the same file.

### Testing
- Ran `npm run build` from `webapp/` and the production build completed successfully.
- Started the dev server with `npm run dev` and the Vite server reported ready and reachable locally.
- Attempted an automated Playwright screenshot of `/games/poolroyale` but the browser tooling timed out in this environment, so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a512bbae988329a5777b7d630ea121)