### PR TITLE
Domino Royal: Fix HDRI and Polyhaven model texture loading

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2414,6 +2414,54 @@ function buildPolyhavenModelUrls(assetId, resolutionOrder = ['2k', '1k']) {
   return urls;
 }
 
+function extractAllHttpUrls(value) {
+  const urls = [];
+  const visit = (node) => {
+    if (!node) return;
+    if (typeof node === 'string') {
+      if (/^https?:\/\//i.test(node)) urls.push(node);
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (typeof node === 'object') {
+      Object.values(node).forEach(visit);
+    }
+  };
+  visit(value);
+  return urls;
+}
+
+async function loadPolyhavenModelCandidatesFromApi(assetId) {
+  if (!assetId || typeof fetch !== 'function') return [];
+  try {
+    const response = await fetch(
+      `https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`
+    );
+    if (!response.ok) {
+      return [];
+    }
+    const payload = await response.json();
+    const urls = extractAllHttpUrls(payload).filter(
+      (url) => /\.(gltf|glb)(\?|$)/i.test(url)
+    );
+    // Prefer embedded GLB first so we don't depend on potentially stale sidecar texture paths.
+    return urls.sort((a, b) => {
+      const score = (url) => {
+        if (/\.glb(\?|$)/i.test(url)) return 3;
+        if (/\/2k\//i.test(url)) return 2;
+        if (/\/1k\//i.test(url)) return 1;
+        return 0;
+      };
+      return score(b) - score(a);
+    });
+  } catch (error) {
+    return [];
+  }
+}
+
 async function loadPolyhavenModel(assetId) {
   if (!assetId) return null;
   const cacheKey = assetId.toLowerCase();
@@ -2426,7 +2474,10 @@ async function loadPolyhavenModel(assetId) {
     : isLowProfileDevice
       ? ['1k']
       : ['2k', '1k'];
-  const candidates = buildPolyhavenModelUrls(assetId, preferredResolutions);
+  const candidates = [
+    ...(await loadPolyhavenModelCandidatesFromApi(assetId)),
+    ...buildPolyhavenModelUrls(assetId, preferredResolutions)
+  ];
   const loader = createPolyhavenGltfLoader();
   let gltf = null;
   let lastError = null;
@@ -4046,7 +4097,8 @@ function resolveHdriResolutionOrder() {
   return ['2k', '1k'];
 }
 function shouldLoadExternalHdri() {
-  return !isLowProfileDevice;
+  // Keep HDRI enabled on mobile/Telegram too (at 1k) so players still see purchased environments.
+  return true;
 }
 
 function isCachedHdriTexture(texture) {


### PR DESCRIPTION
### Motivation
- Players reported missing GLTF textures and HDRI backgrounds in the Domino Royal runtime because some Poly Haven model entries rely on canonical `.glb`/`.gltf` URLs (with embedded textures) while the runtime only tried a legacy sidecar URL pattern, causing texture 404s. 
- HDRI loading was disabled for low-profile/Telegram/mobile paths which caused purchased/environment HDRIs to silently fall back to a generated PMREM instead of showing the chosen HDRI. 
- The change aims to make model and HDRI loading more resilient so environments and model textures render correctly across devices. 

### Description
- Added `extractAllHttpUrls` and `loadPolyhavenModelCandidatesFromApi` helpers to query `https://api.polyhaven.com/files/{assetId}`, extract canonical `.glb`/`.gltf` URLs and prefer embedded `.glb` assets. 
- Updated `loadPolyhavenModel` to try API-discovered candidate URLs first and then fall back to the existing `buildPolyhavenModelUrls` hardcoded pattern to preserve compatibility. 
- Enabled external HDRI loading on low-profile/mobile/Telegram devices by returning `true` from `shouldLoadExternalHdri` (resolution selection still respects the existing resolution-order logic). 
- Change is scoped to the standalone runtime script `webapp/public/domino-royal-game.js` and keeps prior fallback behavior intact. 

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the file passed static syntax checking (success). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the Domino Royal page loaded for manual verification (server started successfully). 
- Captured a headless browser screenshot of `http://127.0.0.1:4173/games/domino-royal` using Playwright to confirm the updated runtime produced visible environment/HDRI and model textures (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51cc57780832992384eff0d5dc009)