### PR TITLE
Align Pool Royale cue stroke timing and pullback with reference motion

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5472,8 +5472,10 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 300; // hold pullback longer so the replay wind-up reads clearly on mobile
 const REPLAY_CUE_MIN_RELEASE_MS = 560; // hold replay push-through longer so forward cue motion is easy to read on mobile
-const LIVE_CUE_FORWARD_DURATION_MS = 340;
-const LIVE_CUE_IMPACT_HOLD_MS = 180;
+// Keep the live stroke timing aligned with the reference cue motion:
+// quick push forward and a short hold before snapping back to idle.
+const LIVE_CUE_FORWARD_DURATION_MS = 120;
+const LIVE_CUE_IMPACT_HOLD_MS = 50;
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -24907,17 +24909,11 @@ const powerRef = useRef(hud.power);
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          const pullVisibilityBoost = PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const pullScale = 1;
-          const pullTarget =
-            computePullTargetFromPower(clampedPower, maxPull) *
-            pullVisibilityBoost *
-            pullScale;
-          const pull = computeCuePull(pullTarget, maxPull, {
-            instant: true,
-            preserveLarger: true
-          });
-          const startPull = Math.max(cuePullCurrentRef.current ?? 0, pull);
+          // Mirror the reference stroke pullback curve exactly:
+          // pull = pullRange * easeOutCubic(power), then push forward on strike.
+          const pullRange = 0.34;
+          const pullTarget = pullRange * easeOutCubic(THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1));
+          const startPull = THREE.MathUtils.clamp(pullTarget, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
@@ -24935,7 +24931,7 @@ const powerRef = useRef(hud.power);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
             dir,
-            pull,
+            startPull,
             activeRenderCameraRef.current ?? cameraRef.current ?? camera
           );
           const { obstructionTilt, obstructionLift, obstructionTiltFromLift } =


### PR DESCRIPTION
### Motivation
- Make the live cue stick movement (pullback and forward strike) match the provided reference behavior so the back-and-forth motion and timing feel identical to the example.
- Ensure the visual pull amount is driven by the same easing model used in the reference implementation so UX is consistent across platforms.

### Description
- Updated live stroke timing constants in `webapp/src/pages/Games/PoolRoyale.jsx` to a fast forward strike and short hold by setting `LIVE_CUE_FORWARD_DURATION_MS = 120` and `LIVE_CUE_IMPACT_HOLD_MS = 50`.
- Replaced the previous power-to-pull mapping with the reference-style curve by computing `pullTarget = pullRange * easeOutCubic(clampedPower)` (where `pullRange = 0.34`) and clamping to available `maxPull` before applying visual compensation.
- Kept existing visual compensation and obstruction logic but now drive those calculations from the updated `startPull` value so obstruction/tilt behavior remains consistent with the new pull model.

### Testing
- Ran the unit test suite for the cue stroke timeline with `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (3 tests, all passing).
- No test regressions observed in the targeted cue-stroke timeline tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51d3b5c6c8329906c006b6b7565ee)