### PR TITLE
Add KTX2/Meshopt support for Domino PolyHaven assets and align HDRI inventory with Ludo

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5,6 +5,8 @@ import { RoundedBoxGeometry } from '/vendor/three/examples/jsm/geometries/Rounde
 import { GLTFLoader } from '/vendor/three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
 import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -2311,6 +2313,9 @@ const CHAIR_THEME_OPTIONS = Object.freeze(
 const CHAIR_MODEL_URLS = Object.freeze([]);
 const polyhavenModelCache = new Map();
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const BASIS_TRANSCODER_PATH =
+  'https://unpkg.com/three@0.160.0/examples/jsm/libs/basis/';
+let sharedKtx2Loader = null;
 
 function applySRGBColorSpace(texture) {
   if (!texture) return;
@@ -2397,6 +2402,21 @@ function createPolyhavenGltfLoader() {
   draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setCrossOrigin('anonymous');
   loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+    if (renderer) {
+      try {
+        sharedKtx2Loader.detectSupport(renderer);
+      } catch (error) {
+        console.warn('KTX2 detection failed', error);
+      }
+    }
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
 }
 
@@ -3484,16 +3504,6 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
     exposure: 1.08,
     environmentIntensity: 1.05,
     backgroundIntensity: 0.98
-  },
-  {
-    id: 'entranceHall',
-    name: 'Entrance Hall',
-    assetId: 'entrance_hall',
-    preferredResolutions: ['4k', '2k'],
-    fallbackResolution: '4k',
-    exposure: 1.09,
-    environmentIntensity: 1.06,
-    backgroundIntensity: 1
   },
   {
     id: 'mirroredHall',


### PR DESCRIPTION
### Motivation
- Domino Battle Royal was missing GLTF textures/HDRIs and needed the same PolyHaven/GLTF decoding pipeline and inventory mapping used by the Ludo Battle Royal to ensure tables, chairs and HDRIs share identical configuration and mapping.
- Improve compatibility for compressed/optimized GLTF assets (KTX2 textures and meshopt-compressed geometry) so remote PolyHaven models load with correct textures and mappings.

### Description
- Added `KTX2Loader` and `MeshoptDecoder` imports and introduced `BASIS_TRANSCODER_PATH` plus a `sharedKtx2Loader` to the Domino loader pipeline.
- Wired `loader.setMeshoptDecoder(MeshoptDecoder)` and `loader.setKTX2Loader(sharedKtx2Loader)` inside `createPolyhavenGltfLoader()` and perform KTX2 support detection when a `renderer` is available.
- Kept existing DRACO and texture normalization flow intact and removed the extra `entranceHall` HDRI variant from the Domino HDRI list to align HDRI/table/chair inventories with the Ludo setup.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed successfully.
- Verified code changes via `rg -n "entrance_hall|KTX2Loader|MeshoptDecoder|setKTX2Loader" webapp/public/domino-royal-game.js` which returned the expected matches.
- Attempted a Playwright-based smoke screenshot of the running app but the Chromium instance crashed in this environment (SIGSEGV), so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5270854ec8329b1e26287b0bb8a6b)