### PR TITLE
Align live cue timing and pullback to reference stroke; refine impact positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5472,8 +5472,10 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 300; // hold pullback longer so the replay wind-up reads clearly on mobile
 const REPLAY_CUE_MIN_RELEASE_MS = 560; // hold replay push-through longer so forward cue motion is easy to read on mobile
-const LIVE_CUE_FORWARD_DURATION_MS = 340;
-const LIVE_CUE_IMPACT_HOLD_MS = 180;
+// Keep the live stroke timing aligned with the reference cue motion:
+// quick push forward and a short hold before snapping back to idle.
+const LIVE_CUE_FORWARD_DURATION_MS = 120;
+const LIVE_CUE_IMPACT_HOLD_MS = 50;
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -24907,17 +24909,12 @@ const powerRef = useRef(hud.power);
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          const pullVisibilityBoost = PLAYER_CUE_PULL_VISIBILITY_BOOST;
-          const pullScale = 1;
-          const pullTarget =
-            computePullTargetFromPower(clampedPower, maxPull) *
-            pullVisibilityBoost *
-            pullScale;
-          const pull = computeCuePull(pullTarget, maxPull, {
-            instant: true,
-            preserveLarger: true
-          });
-          const startPull = Math.max(cuePullCurrentRef.current ?? 0, pull);
+          // Mirror the reference stroke pullback curve exactly:
+          // pull = pullRange * easeOutCubic(power), then push forward on strike.
+          const pullRange = 0.34;
+          const pullTarget = pullRange * easeOutCubic(THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1));
+          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
+          const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
@@ -24935,7 +24932,7 @@ const powerRef = useRef(hud.power);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
             dir,
-            pull,
+            startPull,
             activeRenderCameraRef.current ?? cameraRef.current ?? camera
           );
           const { obstructionTilt, obstructionLift, obstructionTiltFromLift } =
@@ -24977,13 +24974,16 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
+          const idleGap = 0.01;
           const contactEps = 0.001;
           const followExtra = THREE.MathUtils.clamp(topspinFactor * 0.016, 0, 0.018);
           const endDistanceFromBallCenter = Math.max(
             BALL_R * 0.55,
             BALL_R + contactEps - followExtra
           );
-          const impactPos = buildCuePosition(-(CUE_TIP_GAP - endDistanceFromBallCenter));
+          const idleDistanceFromBallCenter = BALL_R + idleGap;
+          const forwardPush = Math.max(0, idleDistanceFromBallCenter - endDistanceFromBallCenter);
+          const impactPos = idlePos.clone().addScaledVector(dir, forwardPush);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;


### PR DESCRIPTION
### Motivation
- Align the live player stroke with the reference cue motion for a quicker forward push and a shorter impact hold to improve visual clarity.
- Ensure the live pullback curve mirrors the reference stroke so shot visuals remain consistent and predictable.

### Description
- Shorten `LIVE_CUE_FORWARD_DURATION_MS` from `340` to `120` and `LIVE_CUE_IMPACT_HOLD_MS` from `180` to `50` to tighten live stroke timing.
- Replace the previous pull computation with a deterministic pull computed as `pullRange * easeOutCubic(clampedPower)` and clamp against the current `cuePullCurrentRef`.
- Use the computed `startPull` when resolving cue obstruction and remove the earlier visibility-boost logic for pull; update impact position computation to use an `idleGap` plus a `forwardPush` from `idlePos` toward the ball instead of the prior negative-gap build.
- Introduce `idleGap`, `idleDistanceFromBallCenter`, and `forwardPush` to explicitly control how far the cue advances into the strike pose with the new timing.

### Testing
- Ran the project unit tests with `yarn test` and all tests passed.
- Built the production bundle with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51d3b5c6c8329906c006b6b7565ee)