### PR TITLE
Fix Domino Royale GLTF/HDRI loading to match Ludo inventory mapping

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1395,6 +1395,7 @@ const textureLoader = new THREE.TextureLoader();
 textureLoader.setCrossOrigin('anonymous');
 const pmrem = new THREE.PMREMGenerator(renderer);
 const hdriLoader = new RGBELoader();
+hdriLoader.setCrossOrigin?.('anonymous');
 const hdriTextureCache = new Map();
 let hdriBackground = null;
 let environmentApplyToken = 0;
@@ -2487,6 +2488,10 @@ async function loadPolyhavenModel(assetId) {
         candidateUrl,
         typeof window !== 'undefined' ? window.location?.href : candidateUrl
       ).href;
+      const resourcePath =
+        resolvedUrl.slice(0, resolvedUrl.lastIndexOf('/') + 1);
+      loader.setResourcePath(resourcePath);
+      loader.setPath('');
       gltf = await loader.loadAsync(resolvedUrl);
       break;
     } catch (error) {
@@ -4125,6 +4130,34 @@ let activeEnvironmentHdri = null;
 async function loadHdriEnvironment(variant) {
   if (!variant?.assetId) return null;
   if (!shouldLoadExternalHdri()) return null;
+  const pickPolyHavenHdriUrl = (json, preferred = ['4k']) => {
+    if (!json || typeof json !== 'object') return null;
+    const resolutions =
+      Array.isArray(preferred) && preferred.length ? preferred : ['4k'];
+    for (const res of resolutions) {
+      const entry = json[res];
+      if (entry?.hdr) return entry.hdr;
+      if (entry?.exr) return entry.exr;
+    }
+    const fallback = Object.values(json).find((value) => value?.hdr || value?.exr);
+    if (!fallback) return null;
+    return fallback.hdr || fallback.exr || null;
+  };
+
+  const resolvePolyHavenHdriUrl = async (assetId, preferredResolutions = ['4k']) => {
+    const fallbackRes = preferredResolutions[0] || '4k';
+    const fallbackUrl = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${assetId}_${fallbackRes}.hdr`;
+    if (typeof fetch !== 'function') return fallbackUrl;
+    try {
+      const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`);
+      if (!response?.ok) return fallbackUrl;
+      const json = await response.json();
+      return pickPolyHavenHdriUrl(json, preferredResolutions) || fallbackUrl;
+    } catch (error) {
+      return fallbackUrl;
+    }
+  };
+
   const allowedResolutions = resolveHdriResolutionOrder();
   const preferred = Array.isArray(variant.preferredResolutions)
     ? variant.preferredResolutions.filter((res) =>
@@ -4138,7 +4171,9 @@ async function loadHdriEnvironment(variant) {
     if (hdriTextureCache.has(cacheKey)) {
       return hdriTextureCache.get(cacheKey);
     }
+    const primaryUrl = await resolvePolyHavenHdriUrl(variant.assetId, [res]);
     const urls = [
+      primaryUrl,
       `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${res}/${variant.assetId}_${res}.hdr`,
       `https://dl.polyhaven.org/file/ph-assets/HDRIs/exr/${res}/${variant.assetId}_${res}.exr`
     ];


### PR DESCRIPTION
### Motivation
- Players reported missing GLTF textures and HDRI environments in Domino Battle Royal, which indicated Domino's asset resolution/mapping was less robust than other games like Ludo.
- The intent is to make Domino use the same model/texture resolution strategy and HDRI URL resolution as the Ludo pipeline so sidecar textures and HDRIs resolve reliably from Poly Haven.

### Description
- Updated Domino GLTF loading to set the model `resourcePath` from the resolved model URL and call `loader.setPath('')` before `loadAsync` so embedded/external sidecar textures resolve correctly (file: `webapp/public/domino-royal-game.js`).
- Enabled anonymous cross-origin on the Domino HDRI loader by calling `hdriLoader.setCrossOrigin?.('anonymous')` to permit remote HDR/EXR fetches.
- Added a Poly Haven HDRI resolution helper that queries `https://api.polyhaven.com/files/{assetId}` and picks HDR/EXR entries when available, with a deterministic fallback to the standard `dl.polyhaven.org` HDR/EXR URLs per resolution; the resolved primary URL is attempted first when loading HDRIs.
- Kept existing cache and fallback behavior so previously-cached HDRI/env maps remain used and resolution order respects device/profile constraints.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which succeeded with no syntax errors.
- Started the web dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched the Vite dev server successfully (page served).
- Attempted automated browser verification via Playwright to capture screenshots, but the headless Chromium process crashed in this environment (SIGSEGV), so the visual smoke test could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5270854ec8329b1e26287b0bb8a6b)