### PR TITLE
Enable seated and wheel zoom plus adjustable camera pitch sensitivity in TexasHoldemArena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -388,7 +388,7 @@ const CAMERA_HEAD_TURN_LIMIT = THREE.MathUtils.degToRad(175);
 const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(8);
 const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
-const HEAD_PITCH_SENSITIVITY = 0;
+const HEAD_PITCH_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
@@ -397,6 +397,10 @@ const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
 const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
+const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
+const SEATED_ZOOM_DEFAULT = 1;
+const SEATED_ZOOM_MIN = 0.86;
+const SEATED_ZOOM_MAX = 1.22;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
@@ -2973,6 +2977,10 @@ function TexasHoldemArena({ search }) {
   const [sliderValue, setSliderValue] = useState(0);
   const [overheadView, setOverheadView] = useState(false);
   const [overheadZoom, setOverheadZoom] = useState(OVERHEAD_ZOOM_DEFAULT);
+  const [seatedZoom, setSeatedZoom] = useState(SEATED_ZOOM_DEFAULT);
+  const overheadViewRef = useRef(overheadView);
+  const overheadZoomRef = useRef(overheadZoom);
+  const seatedZoomRef = useRef(seatedZoom);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -3511,6 +3519,18 @@ function TexasHoldemArena({ search }) {
     three.orientHumanCards?.();
   }, []);
 
+  useEffect(() => {
+    overheadViewRef.current = overheadView;
+  }, [overheadView]);
+
+  useEffect(() => {
+    overheadZoomRef.current = overheadZoom;
+  }, [overheadZoom]);
+
+  useEffect(() => {
+    seatedZoomRef.current = seatedZoom;
+  }, [seatedZoom]);
+
   const stopCameraTurnAnimation = useCallback(() => {
     if (cameraTurnAnimRef.current != null) {
       cancelAnimationFrame(cameraTurnAnimRef.current);
@@ -3548,7 +3568,6 @@ function TexasHoldemArena({ search }) {
       if (lockToStartView) {
         stopCameraTurnAnimation();
         headAnglesRef.current.yaw = 0;
-        headAnglesRef.current.pitch = 0;
         applyHeadOrientation();
         return;
       }
@@ -3578,7 +3597,6 @@ function TexasHoldemArena({ search }) {
       if (Math.abs(yawDelta) <= CAMERA_TURN_SNAP_EPSILON || options.animate === false) {
         stopCameraTurnAnimation();
         headAnglesRef.current.yaw = targetYaw;
-        headAnglesRef.current.pitch = 0;
         applyHeadOrientation();
         return;
       }
@@ -3591,7 +3609,6 @@ function TexasHoldemArena({ search }) {
         const t = Math.min(1, (now - startTime) / Math.max(1, duration));
         const eased = t * (2 - t);
         headAnglesRef.current.yaw = startYaw + yawDelta * eased;
-        headAnglesRef.current.pitch = 0;
         applyHeadOrientation();
         if (t < 1) {
           cameraTurnAnimRef.current = requestAnimationFrame(animateStep);
@@ -4326,12 +4343,15 @@ function TexasHoldemArena({ search }) {
       const lateralOffset = portrait ? CAMERA_LATERAL_OFFSETS.portrait : CAMERA_LATERAL_OFFSETS.landscape;
       const retreatOffset = portrait ? CAMERA_RETREAT_OFFSETS.portrait : CAMERA_RETREAT_OFFSETS.landscape;
       const elevation = portrait ? CAMERA_ELEVATION_OFFSETS.portrait : CAMERA_ELEVATION_OFFSETS.landscape;
+      const zoom = THREE.MathUtils.clamp(options.zoom ?? seatedZoomRef.current, SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
       const position = humanSeat.stoolAnchor
         .clone()
-        .addScaledVector(humanSeat.forward, -retreatOffset)
+        .addScaledVector(humanSeat.forward, -retreatOffset * zoom)
         .addScaledVector(humanSeat.right, lateralOffset);
       const maxCameraHeight = ARENA_WALL_TOP_Y - CAMERA_WALL_HEIGHT_MARGIN;
-      position.y = Math.min(humanSeat.stoolHeight + elevation, maxCameraHeight);
+      position.y = Math.min(humanSeat.stoolHeight + elevation * zoom, maxCameraHeight);
+      camera.fov = CAMERA_SETTINGS.fov;
+      camera.updateProjectionMatrix();
       const focusBase = cameraTarget.clone().add(new THREE.Vector3(0, CAMERA_FOCUS_CENTER_LIFT, 0));
       const seatTopPoint = seatTopPointRef.current;
       const focusForwardPull = portrait
@@ -4399,6 +4419,8 @@ function TexasHoldemArena({ search }) {
     const applyOverheadCamera = (options = {}) => {
       const animate = Boolean(options.animate);
       const zoom = THREE.MathUtils.clamp(options.zoom ?? OVERHEAD_ZOOM_DEFAULT, OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
+      camera.fov = CAMERA_SETTINGS.fov;
+      camera.updateProjectionMatrix();
       const height = TABLE_HEIGHT + BOARD_SIZE * 0.88 * zoom;
       const lateralPull = humanSeat?.forward.clone().setY(0).normalize().multiplyScalar(TABLE_RADIUS * 0.12) ??
         new THREE.Vector3();
@@ -5002,7 +5024,8 @@ function TexasHoldemArena({ search }) {
       }
       if (state.mode === 'camera') {
         const dx = event.clientX - state.startX;
-        if (!state.dragged && Math.abs(dx) > 3) {
+        const dy = event.clientY - state.startY;
+        if (!state.dragged && Math.hypot(dx, dy) > 3) {
           state.dragged = true;
         }
         headAnglesRef.current.yaw = THREE.MathUtils.clamp(
@@ -5010,7 +5033,12 @@ function TexasHoldemArena({ search }) {
           -CAMERA_HEAD_TURN_LIMIT,
           CAMERA_HEAD_TURN_LIMIT
         );
-        headAnglesRef.current.pitch = 0;
+        const pitchLimits = cameraBasisRef.current?.pitchLimits ?? DEFAULT_PITCH_LIMITS;
+        headAnglesRef.current.pitch = THREE.MathUtils.clamp(
+          state.startPitch + dy * HEAD_PITCH_SENSITIVITY,
+          pitchLimits.min,
+          pitchLimits.max
+        );
         applyHeadOrientation();
         return;
       }
@@ -5050,6 +5078,30 @@ function TexasHoldemArena({ search }) {
     element.addEventListener('pointercancel', handlePointerUp);
     element.addEventListener('pointerleave', handlePointerUp);
 
+    const handleWheel = (event) => {
+      event.preventDefault();
+      const wheelScale = Math.max(0.78, 1 + event.deltaY * CAMERA_WHEEL_FACTOR * 0.01);
+      if (overheadViewRef.current) {
+        const nextZoom = THREE.MathUtils.clamp(
+          +(overheadZoomRef.current * wheelScale).toFixed(3),
+          OVERHEAD_ZOOM_MIN,
+          OVERHEAD_ZOOM_MAX
+        );
+        setOverheadZoom(nextZoom);
+        return;
+      }
+      const nextZoom = THREE.MathUtils.clamp(
+        +(seatedZoomRef.current * wheelScale).toFixed(3),
+        SEATED_ZOOM_MIN,
+        SEATED_ZOOM_MAX
+      );
+      setSeatedZoom(nextZoom);
+      const mountWidth = mount?.clientWidth ?? window.innerWidth;
+      const mountHeight = mount?.clientHeight ?? window.innerHeight;
+      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: nextZoom });
+    };
+    element.addEventListener('wheel', handleWheel, { passive: false });
+
     const handleResize = () => {
       if (!mount || !threeRef.current) return;
       const { camera: cam } = threeRef.current;
@@ -5060,7 +5112,7 @@ function TexasHoldemArena({ search }) {
       if (overheadViewRef.current) {
         viewControlsRef.current?.applyOverheadCamera?.({ zoom: overheadZoomRef.current });
       } else {
-        viewControlsRef.current?.applySeatedCamera?.(clientWidth, clientHeight);
+        viewControlsRef.current?.applySeatedCamera?.(clientWidth, clientHeight, { zoom: seatedZoomRef.current });
       }
     };
 
@@ -5085,7 +5137,6 @@ function TexasHoldemArena({ search }) {
         lastFrameRef.current = time - Math.max(0, deltaMs - appliedMs);
         const deltaSeconds = Math.max(0, Math.min(0.1, appliedMs / 1000));
         three.chipFactory.update(deltaSeconds);
-        headAnglesRef.current.pitch = 0;
         applyHeadOrientation();
         three.renderer.render(three.scene, three.camera);
       }
@@ -5114,6 +5165,7 @@ function TexasHoldemArena({ search }) {
       element.removeEventListener('pointerup', handlePointerUp);
       element.removeEventListener('pointercancel', handlePointerUp);
       element.removeEventListener('pointerleave', handlePointerUp);
+      element.removeEventListener('wheel', handleWheel);
       activePointersRef.current.clear();
       resetPinchState();
       if (threeRef.current) {
@@ -6118,9 +6170,9 @@ function TexasHoldemArena({ search }) {
     } else {
       const width = mount?.clientWidth ?? window.innerWidth;
       const height = mount?.clientHeight ?? window.innerHeight;
-      controls.applySeatedCamera?.(width, height, { animate });
+      controls.applySeatedCamera?.(width, height, { animate, zoom: seatedZoom });
     }
-  }, [overheadView, overheadZoom]);
+  }, [overheadView, overheadZoom, seatedZoom]);
 
 
   return (


### PR DESCRIPTION
### Motivation
- Improve player camera control and responsiveness in the Texas Hold'em arena by adding seated zoom, mouse-wheel zooming, and an adjustable vertical head-pitch sensitivity.
- Ensure camera projection (FOV) and zoom state are respected across seated/overhead views and window resizes.

### Description
- Introduced `SEATED_ZOOM_*` constants and `CAMERA_WHEEL_FACTOR` sourced from `ARENA_CAMERA_DEFAULTS`, and exposed a `HEAD_PITCH_SENSITIVITY` based on `ARENA_CAMERA_DEFAULTS.verticalSensitivity`.
- Added `seatedZoom` state and corresponding refs (`overheadZoomRef`, `overheadViewRef`, `seatedZoomRef`) and wired them into camera application logic and resize handling.
- Updated `applySeatedCamera` and `applyOverheadCamera` to consider `zoom` when computing camera position/height and to update `camera.fov` via `camera.updateProjectionMatrix()`.
- Added a wheel event handler to support mouse-wheel zoom for both overhead and seated views, updated pointer handling to compute pitch using the sensitivity setting, and removed forced zeroing of pitch in camera turn/animation code; also registered and cleaned up the `wheel` listener.

### Testing
- Ran the project unit test suite with `yarn test`, which completed successfully and reported no failures.
- Ran the linter via `yarn lint`, which passed with no new issues detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a523b261188329a2e8200b8385499e)