### PR TITLE
Add 5 cue-stick animation techniques and hold cue camera through strike

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -4,6 +4,15 @@ namespace Aiming
 {
     public class CueController : MonoBehaviour
     {
+        public enum CueAnimationTechnique
+        {
+            DirectLerp = 0,
+            SmoothDamp = 1,
+            SpringDamper = 2,
+            CurveDriven = 3,
+            ImpulseOvershoot = 4
+        }
+
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
@@ -12,8 +21,35 @@ namespace Aiming
         public float cueDistanceFromBall = 0.12f;
         public float animationPullbackDistance = 0.045f;
         public float animationSpeed = 4f;
+        [Header("Cue animation menu")]
+        public CueAnimationTechnique animationTechnique = CueAnimationTechnique.DirectLerp;
+        [Range(0f, 1f)] public float sliderPull01;
+        public bool autoPreviewInEditor = true;
+        public float strokeDuration = 0.14f;
+        public AnimationCurve strokeCurve = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+        float _smoothedPull;
+        float _smoothVelocity;
+        float _springVelocity;
+        float _strokeTimer;
+        float _strokeStrength;
+        bool _strokeActive;
 
         Vector3 _lastAimDirection = Vector3.forward;
+
+        public bool IsStrokeActive => _strokeActive;
+
+        public void SetPullFromSlider(float normalizedPull)
+        {
+            sliderPull01 = Mathf.Clamp01(normalizedPull);
+        }
+
+        public void TriggerShotStroke(float normalizedStrength = 1f)
+        {
+            _strokeStrength = Mathf.Clamp01(normalizedStrength);
+            _strokeTimer = 0f;
+            _strokeActive = true;
+        }
 
         void Update()
         {
@@ -38,8 +74,7 @@ namespace Aiming
                     dir.Normalize();
                     _lastAimDirection = dir;
 
-                    float animationPhase = (Mathf.Sin(Time.time * animationSpeed) + 1f) * 0.5f;
-                    float pullback = animationPhase * animationPullbackDistance;
+                    float pullback = ResolvePullback(Time.deltaTime);
                     transform.position = sol.aimStart - dir * (cueDistanceFromBall + pullback);
                     transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
                     if (cueTip != null)
@@ -52,6 +87,56 @@ namespace Aiming
             {
                 transform.rotation = Quaternion.LookRotation(_lastAimDirection, Vector3.up);
             }
+        }
+
+        float ResolvePullback(float deltaTime)
+        {
+            float basePull = sliderPull01;
+            if (autoPreviewInEditor && !_strokeActive)
+            {
+                basePull = Mathf.PingPong(Time.time * animationSpeed, 1f);
+            }
+
+            if (_strokeActive)
+            {
+                float duration = Mathf.Max(0.02f, strokeDuration);
+                _strokeTimer += deltaTime;
+                float t = Mathf.Clamp01(_strokeTimer / duration);
+                float shapedT = strokeCurve != null ? Mathf.Clamp01(strokeCurve.Evaluate(t)) : t;
+                basePull = Mathf.Lerp(sliderPull01, 0f, shapedT * _strokeStrength);
+                if (t >= 1f)
+                {
+                    _strokeActive = false;
+                    basePull = 0f;
+                }
+            }
+
+            float resolvedPull;
+            switch (animationTechnique)
+            {
+                case CueAnimationTechnique.SmoothDamp:
+                    resolvedPull = Mathf.SmoothDamp(_smoothedPull, basePull, ref _smoothVelocity, 0.08f, Mathf.Infinity, deltaTime);
+                    break;
+                case CueAnimationTechnique.SpringDamper:
+                    float force = (basePull - _smoothedPull) * 90f;
+                    _springVelocity = (_springVelocity + force * deltaTime) * 0.82f;
+                    resolvedPull = Mathf.Clamp01(_smoothedPull + _springVelocity * deltaTime);
+                    break;
+                case CueAnimationTechnique.CurveDriven:
+                    float curved = Mathf.SmoothStep(0f, 1f, basePull);
+                    resolvedPull = curved * curved;
+                    break;
+                case CueAnimationTechnique.ImpulseOvershoot:
+                    float impulse = _strokeActive ? Mathf.Sin(Mathf.Clamp01(_strokeTimer / Mathf.Max(0.02f, strokeDuration)) * Mathf.PI) * 0.2f : 0f;
+                    resolvedPull = Mathf.Clamp01(basePull + impulse);
+                    break;
+                default:
+                    resolvedPull = basePull;
+                    break;
+            }
+
+            _smoothedPull = resolvedPull;
+            return resolvedPull * animationPullbackDistance;
         }
     }
 }

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -1,5 +1,6 @@
 #if UNITY_5_3_OR_NEWER
 using UnityEngine;
+using Aiming;
 
 /// <summary>
 /// Broadcast-oriented cue camera that stays locked to the short rails. The
@@ -153,6 +154,14 @@ public class CueCamera : MonoBehaviour
     public float broadcastLookDownOffset = 0.02f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
+    [Header("Shot camera transition")]
+    // Keeps the cue/standing camera alive briefly after a shot is triggered so
+    // the player sees the cue push through the cue ball before the cut.
+    public float cueCameraHoldAfterShot = 0.12f;
+    // Fallback timeout so we still transition even if physics starts late.
+    public float maxCueCameraHold = 0.5f;
+    // Optional cue controller used to wait until the forward stroke ends.
+    public CueController cueController;
     // How quickly the camera aligns to the stored shot angle.
     public float shotSnapSpeed = 6f;
     // Speed used when easing between cue and broadcast framing while balls roll.
@@ -231,6 +240,8 @@ public class CueCamera : MonoBehaviour
     private bool cachedStandingCamera;
     private bool pocketCameraAwaitingDrop;
     private bool pocketDropDetected;
+    private bool waitingForCueStrike;
+    private float shotStartTime;
     private float pocketCameraStartTime;
     private float pocketCameraReleaseTime;
     private Vector3 trackedCornerPocket;
@@ -291,6 +302,8 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
+        waitingForCueStrike = true;
+        shotStartTime = Time.time;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -354,8 +367,37 @@ public class CueCamera : MonoBehaviour
         }
         else
         {
-            UpdateBroadcastCamera();
+            if (waitingForCueStrike)
+            {
+                UpdateCueAimCamera();
+                if (ReadyToSwitchFromCueCamera())
+                {
+                    waitingForCueStrike = false;
+                }
+            }
+            else
+            {
+                UpdateBroadcastCamera();
+            }
         }
+    }
+
+    private bool ReadyToSwitchFromCueCamera()
+    {
+        float elapsed = Time.time - shotStartTime;
+        if (elapsed < Mathf.Max(0f, cueCameraHoldAfterShot))
+        {
+            return false;
+        }
+
+        bool cueStrokeCompleted = cueController == null || !cueController.IsStrokeActive;
+        bool cueBallStarted = IsMoving(CueBall);
+        if (cueStrokeCompleted && cueBallStarted)
+        {
+            return true;
+        }
+
+        return elapsed >= Mathf.Max(cueCameraHoldAfterShot, maxCueCameraHold);
     }
 
     private void UpdateCueAimCamera()
@@ -1190,6 +1232,7 @@ public class CueCamera : MonoBehaviour
     {
         shotInProgress = false;
         usingTargetCamera = false;
+        waitingForCueStrike = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;


### PR DESCRIPTION
### Motivation
- Improve visual clarity of pulling-and-striking the cue by adding multiple distinct cuestick motion techniques selectable from the UI and by keeping the cue/standing camera visible briefly through the forward strike so the player sees the cue contact the cue ball before a broadcast cut.
- Provide a reusable interface so the power slider and shot trigger can drive the same cuestick motion while allowing different animation styles for testing and polish.

### Description
- Added a `CueAnimationTechnique` enum and inspector-configurable menu to `Assets/Scripts/Gameplay/CueController.cs` with five techniques: `DirectLerp`, `SmoothDamp`, `SpringDamper`, `CurveDriven`, and `ImpulseOvershoot`.
- Replaced the single sine-based preview with `ResolvePullback(...)` in `CueController` that reads `sliderPull01`, supports editor preview, and implements the five different motion resolution techniques plus a forward `TriggerShotStroke(...)` phase and `IsStrokeActive` flag.
- Exposed APIs `SetPullFromSlider(float)` and `TriggerShotStroke(float)` on `CueController` so UI slider and shot trigger can drive pullback and forward stroke respectively.
- Updated `billiards.Unity/CueCamera.cs` to optionally hold the cue/standing camera after `BeginShot(...)` until a minimum hold time has elapsed and the cue stroke has completed and the cue ball starts moving, with a `maxCueCameraHold` fallback; added inspector fields `cueCameraHoldAfterShot`, `maxCueCameraHold`, and a `CueController` reference to coordinate the timing.

### Testing
- Ran repository consistency and diff checks on the modified files and inspected the changes, with no style or whitespace issues detected.
- Performed static searches to confirm new symbols (`CueAnimationTechnique`, `ResolvePullback`, `TriggerShotStroke`, `IsStrokeActive`) are defined and referenced correctly across the affected scripts.
- No automated Unity playmode/unit tests were added or executed as part of this change; recommend running the project in the Unity editor and existing playmode tests (`Assets/Tests/PlayMode`) to validate runtime camera/cue interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5305e7da88329b3d0a7eb4624f9c8)