### PR TITLE
Add selectable cue-stick stroke animations and extend shot camera hold

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1855,6 +1855,14 @@ const PLAYER_CUE_FORWARD_MIN_MS = 520;
 const PLAYER_CUE_FORWARD_MAX_MS = 920;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
 const CUE_STRIKE_HOLD_MS = 80;
+const CUE_STROKE_ANIMATION_OPTIONS = Object.freeze([
+  Object.freeze({ id: 'cinematic-cubic', label: 'Cinematic cubic', technique: 'cubic easing blend' }),
+  Object.freeze({ id: 'spring-snap', label: 'Spring snap', technique: 'damped spring release' }),
+  Object.freeze({ id: 'smoothstep-drive', label: 'Smoothstep drive', technique: 'smootherstep curve' }),
+  Object.freeze({ id: 'bezier-whip', label: 'Bezier whip', technique: 'custom cubic-bezier timing' }),
+  Object.freeze({ id: 'two-stage-punch', label: 'Two-stage punch', technique: 'piecewise keyframe acceleration' })
+]);
+const DEFAULT_CUE_STROKE_ANIMATION_ID = CUE_STROKE_ANIMATION_OPTIONS[0].id;
 const CUE_RETURN_SPEEDUP = 0.95;
 const CUE_FOLLOW_MIN_MS = 250;
 const CUE_FOLLOW_MAX_MS = 560;
@@ -14271,6 +14279,9 @@ function PoolRoyaleGame({
   );
   const shotCameraHoldTimeoutRef = useRef(null);
   const cueStrokeStateRef = useRef(null);
+  const shotCameraHoldUntilRef = useRef(0);
+  const cueStrokeTechniqueRef = useRef(DEFAULT_CUE_STROKE_ANIMATION_ID);
+  const [cueStrokeAnimationId, setCueStrokeAnimationId] = useState(DEFAULT_CUE_STROKE_ANIMATION_ID);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
   useEffect(
     () => () => {
@@ -14403,6 +14414,10 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     powerRef.current = hud.power;
   }, [hud.power]);
+  useEffect(() => {
+    cueStrokeTechniqueRef.current = cueStrokeAnimationId;
+  }, [cueStrokeAnimationId]);
+
   const hudRef = useRef(hud);
   useEffect(() => {
     hudRef.current = hud;
@@ -17142,13 +17157,21 @@ const powerRef = useRef(hud.power);
         if (shooting) {
           preShotTopViewRef.current = topViewRef.current;
           preShotTopViewLockRef.current = topViewLockedRef.current;
-          shotCameraHoldTimeoutRef.current = window.setTimeout(() => {
+          shotCameraHoldUntilRef.current = getNow() + SHOT_CAMERA_HOLD_MS;
+          const trySwitchToTopView = () => {
             shotCameraHoldTimeoutRef.current = null;
             if (!shooting) return;
+            const cueBallMoving = Math.hypot(cue?.vel?.x ?? 0, cue?.vel?.y ?? 0) > 0.02;
+            const holdExpired = getNow() >= (shotCameraHoldUntilRef.current || 0);
+            if (!cueBallMoving || !holdExpired) {
+              shotCameraHoldTimeoutRef.current = window.setTimeout(trySwitchToTopView, 80);
+              return;
+            }
             topViewRef.current = true;
             topViewLockedRef.current = true;
             enterTopView(true, { variant: 'replay' });
-          }, SHOT_CAMERA_HOLD_MS);
+          };
+          shotCameraHoldTimeoutRef.current = window.setTimeout(trySwitchToTopView, SHOT_CAMERA_HOLD_MS);
         } else if (!preShotTopViewRef.current) {
           exitTopView(true);
         } else {
@@ -21409,7 +21432,8 @@ const powerRef = useRef(hud.power);
             strikeDip,
             wobbleAmount,
             strikeImpactThreshold,
-            forwardOnly
+            forwardOnly,
+            techniqueId
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
@@ -21421,7 +21445,8 @@ const powerRef = useRef(hud.power);
               1
             );
             const pushT = THREE.MathUtils.clamp(elapsed / safeStrikeDuration, 0, 1);
-            const easedPush = easeOutCubic(pushT);
+            const strokeTechnique = resolveStrokeTechnique(techniqueId);
+            const easedPush = strokeTechnique.release(pushT);
             cueStick.visible = true;
             cueStick.position.lerpVectors(pullPos, impactPos, easedPush);
             cueStick.position.y -= (strikeDip ?? 0.003) * easedPush;
@@ -21472,7 +21497,8 @@ const powerRef = useRef(hud.power);
             stroke.onImpact?.();
           }
           if (sample.phase === 'pullback') {
-            const eased = easeInOutCubic(sample.t);
+            const strokeTechnique = resolveStrokeTechnique(techniqueId);
+            const eased = strokeTechnique.pullback(sample.t);
             cueStick.position.lerpVectors(idlePos, pullPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
@@ -21480,7 +21506,8 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'release') {
-            const eased = easeInOutCubic(sample.t);
+            const strokeTechnique = resolveStrokeTechnique(techniqueId);
+            const eased = strokeTechnique.release(sample.t);
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
             cueStick.position.y -= (strikeDip ?? 0.003) * eased;
@@ -24386,7 +24413,10 @@ const powerRef = useRef(hud.power);
         const desiredTarget = preserveLarger
           ? Math.max(cuePullCurrentRef.current ?? 0, pullTarget ?? 0)
           : pullTarget ?? 0;
-        const boostedTarget = desiredTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
+        const pullTechnique = resolveStrokeTechnique(cueStrokeTechniqueRef.current);
+        const normalizedDesired = effectiveMax > 1e-6 ? THREE.MathUtils.clamp(desiredTarget / effectiveMax, 0, 1) : 0;
+        const techniqueWeightedTarget = effectiveMax * pullTechnique.pullback(normalizedDesired);
+        const boostedTarget = techniqueWeightedTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
         const clampedTarget = THREE.MathUtils.clamp(boostedTarget, 0, effectiveMax);
         const smoothing = instant || dragging ? 1 : CUE_PULL_SMOOTHING;
         const isReturning =
@@ -24455,6 +24485,54 @@ const powerRef = useRef(hud.power);
       const easeInOutCubic = (t) =>
         t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const cubicBezier = (t, p1, p2) => {
+        const oneMinusT = 1 - t;
+        return 3 * oneMinusT * oneMinusT * t * p1 + 3 * oneMinusT * t * t * p2 + t * t * t;
+      };
+      const smootherStep = (t) => t * t * t * (t * (t * 6 - 15) + 10);
+      const springSnap = (t) => {
+        const damping = Math.exp(-5.4 * t);
+        const oscillation = Math.cos(9.2 * t);
+        return THREE.MathUtils.clamp(1 - damping * oscillation, 0, 1);
+      };
+      const twoStagePunch = (t) => {
+        if (t <= 0.35) {
+          const segment = t / 0.35;
+          return 0.58 * (segment * segment);
+        }
+        const segment = (t - 0.35) / 0.65;
+        return THREE.MathUtils.clamp(0.58 + 0.42 * (1 - Math.pow(1 - segment, 4)), 0, 1);
+      };
+      const resolveStrokeTechnique = (techniqueId) => {
+        switch (techniqueId) {
+          case 'spring-snap':
+            return {
+              pullback: (t) => THREE.MathUtils.clamp(Math.pow(t, 0.9), 0, 1),
+              release: (t) => springSnap(t)
+            };
+          case 'smoothstep-drive':
+            return {
+              pullback: (t) => smootherStep(t),
+              release: (t) => smootherStep(t)
+            };
+          case 'bezier-whip':
+            return {
+              pullback: (t) => cubicBezier(t, 0.22, 0.78),
+              release: (t) => cubicBezier(t, 0.82, 0.14)
+            };
+          case 'two-stage-punch':
+            return {
+              pullback: (t) => THREE.MathUtils.clamp(0.75 * Math.pow(t, 1.3) + 0.25 * t, 0, 1),
+              release: (t) => twoStagePunch(t)
+            };
+          case 'cinematic-cubic':
+          default:
+            return {
+              pullback: (t) => easeInOutCubic(t),
+              release: (t) => easeOutCubic(t)
+            };
+        }
+      };
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
         const horiz = Math.hypot(vec.x ?? 0, vec.z ?? 0);
@@ -25103,7 +25181,8 @@ const powerRef = useRef(hud.power);
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
               strikeImpactThreshold: 0.9,
-              forwardOnly: true
+              forwardOnly: true,
+              techniqueId: cueStrokeTechniqueRef.current || DEFAULT_CUE_STROKE_ANIMATION_ID
             };
           } else {
             cueStick.visible = false;
@@ -31738,6 +31817,42 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Cue animation
+                </h3>
+                <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-white/55">
+                  Pull + strike technique preset
+                </p>
+                <div className="mt-2 grid gap-2">
+                  {CUE_STROKE_ANIMATION_OPTIONS.map((option) => {
+                    const active = option.id === cueStrokeAnimationId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setCueStrokeAnimationId(option.id)}
+                        aria-pressed={active}
+                        className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
+                            : 'border-white/10 bg-white/5 text-white/80 hover:border-white/20'
+                        }`}
+                      >
+                        <span className="flex items-center justify-between gap-2">
+                          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white">{option.label}</span>
+                          {active ? (
+                            <span className="rounded-full border border-emerald-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-emerald-100">Active</span>
+                          ) : null}
+                        </span>
+                        <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                          {option.technique}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Replays


### PR DESCRIPTION
### Motivation
- Provide five distinct cue-stick stroke techniques so pullback and forward strike motions can use different interpolation styles and be chosen by players. 
- Keep the visual stroke consistent with recorded replays and the single source-of-truth mapping from power → pull → impulse. 
- Prevent premature camera switching by holding the cue/standing camera until the forward stroke completes and the cue ball has begun moving.

### Description
- Added a new `CUE_STROKE_ANIMATION_OPTIONS` list and `DEFAULT_CUE_STROKE_ANIMATION_ID` and exposed a small UI under the game settings menu (`Cue animation`) to pick one of five presets (`cinematic-cubic`, `spring-snap`, `smoothstep-drive`, `bezier-whip`, `two-stage-punch`).
- Implemented distinct technique implementations and helpers (`cubicBezier`, `smootherStep`, `springSnap`, `twoStagePunch`, and `resolveStrokeTechnique`) and wired them into stroke playback so `pullback` and `release` use the chosen technique.
- Hooked the selected technique into runtime cue logic by adding `cueStrokeTechniqueRef` / `cueStrokeAnimationId` state and passing a `techniqueId` into `cueStrokeStateRef.current` so both live shots and replays use the same technique; `computeCuePull` now applies the chosen pull curve when computing visual pull.
- Changed shot camera hold behavior in `setShootingState` to record a hold-until timestamp and only switch to the top/standing view after the minimum hold window has elapsed and the cue ball has actually started moving (small retry loop to wait for ball motion). 

### Testing
- Ran the timeline unit test: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and it passed (3 tests).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported the file is ignored by repo eslint settings (no errors raised for changed file under current config).
- Attempted a Playwright snapshot of the in-game menu to validate the UI, but the route timed out in this environment (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5305e7da88329b3d0a7eb4624f9c8)