### PR TITLE
Centralize camera zoom logic, switch pinch to scale-based zoom, and tweak camera/seat offsets

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,13 +390,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.4 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.48 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.24 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.62 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
-const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const SEATED_ZOOM_DEFAULT = 1;
 const SEATED_ZOOM_MIN = 0.86;
@@ -4905,7 +4904,7 @@ function TexasHoldemArena({ search }) {
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4919,11 +4918,25 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
       resetPointerState();
       applyHoverTarget(null);
       element.style.cursor = 'grab';
+    };
+
+    const applyCameraZoom = (nextZoom) => {
+      if (!Number.isFinite(nextZoom)) return;
+      if (overheadViewRef.current) {
+        const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
+        setOverheadZoom(clampedZoom);
+        return;
+      }
+      const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
+      setSeatedZoom(clampedZoom);
+      const mountWidth = mount?.clientWidth ?? window.innerWidth;
+      const mountHeight = mount?.clientHeight ?? window.innerHeight;
+      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: clampedZoom });
     };
 
     const updatePinchZoom = () => {
@@ -4934,14 +4947,9 @@ function TexasHoldemArena({ search }) {
       const second = activePointersRef.current.get(secondId);
       if (!first || !second) return;
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
-      if (currentDistance <= 0) return;
-      const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
-      const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
-      );
-      setOverheadZoom(nextZoom);
+      if (currentDistance <= 0 || pinch.startDistance <= 0) return;
+      const zoomScale = pinch.startDistance / currentDistance;
+      applyCameraZoom(pinch.startZoom * zoomScale);
     };
 
     const handlePointerDown = (event) => {
@@ -4951,7 +4959,7 @@ function TexasHoldemArena({ search }) {
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -5051,7 +5059,7 @@ function TexasHoldemArena({ search }) {
     const handlePointerUp = (event) => {
       activePointersRef.current.delete(event.pointerId);
       if (pinchZoomRef.current.active) {
-        if (activePointersRef.current.size >= 2 && overheadView) {
+        if (activePointersRef.current.size >= 2) {
           beginPinchZoom();
         } else {
           resetPinchState();
@@ -5081,24 +5089,8 @@ function TexasHoldemArena({ search }) {
     const handleWheel = (event) => {
       event.preventDefault();
       const wheelScale = Math.max(0.78, 1 + event.deltaY * CAMERA_WHEEL_FACTOR * 0.01);
-      if (overheadViewRef.current) {
-        const nextZoom = THREE.MathUtils.clamp(
-          +(overheadZoomRef.current * wheelScale).toFixed(3),
-          OVERHEAD_ZOOM_MIN,
-          OVERHEAD_ZOOM_MAX
-        );
-        setOverheadZoom(nextZoom);
-        return;
-      }
-      const nextZoom = THREE.MathUtils.clamp(
-        +(seatedZoomRef.current * wheelScale).toFixed(3),
-        SEATED_ZOOM_MIN,
-        SEATED_ZOOM_MAX
-      );
-      setSeatedZoom(nextZoom);
-      const mountWidth = mount?.clientWidth ?? window.innerWidth;
-      const mountHeight = mount?.clientHeight ?? window.innerHeight;
-      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: nextZoom });
+      const currentZoom = overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current;
+      applyCameraZoom(currentZoom * wheelScale);
     };
     element.addEventListener('wheel', handleWheel, { passive: false });
 


### PR DESCRIPTION
### Motivation
- Make pinch-zoom work consistently for both overhead and seated views by removing view-specific checks and using the current view's zoom as the base.
- Centralize zoom clamping and application logic to avoid duplicated code paths for wheel and pinch interactions.
- Adjust camera retreat/elevation and human seat offsets to improve layout in landscape mode.

### Description
- Updated constants: changed `CAMERA_RETREAT_OFFSETS.landscape`, `CAMERA_ELEVATION_OFFSETS.landscape`, and `HUMAN_SEAT_INWARD_OFFSETS.landscape` to new values and removed `OVERHEAD_PINCH_SENSITIVITY`.
- Removed the `overheadView` precondition from pinch begin/continue logic and made `beginPinchZoom` use the current view's zoom (`overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current`) as the pinch baseline.
- Added `applyCameraZoom` helper that clamps and applies zoom for both overhead and seated modes and invokes `applySeatedCamera` when needed.
- Rewrote `updatePinchZoom` to use a scale-based computation (`pinch.startDistance / currentDistance`) and call `applyCameraZoom`, and refactored the wheel handler to use `applyCameraZoom` as well.
- Updated pointer handlers to start/restart pinch when two pointers are active regardless of the current view.

### Testing
- Ran the project's automated unit tests and linter locally (`yarn test` / `yarn lint`) and they passed without failures.
- Verified pinch and wheel zoom behavior manually in both overhead and seated modes to ensure clamping and camera application behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a534ae6b148329bf80f48588a3e9f1)