### PR TITLE
Add seated pinch-to-zoom support and adjust camera/seat offsets

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,13 +390,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.4 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.48 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.24 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.62 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
-const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const SEATED_ZOOM_DEFAULT = 1;
 const SEATED_ZOOM_MIN = 0.86;
@@ -4905,7 +4904,7 @@ function TexasHoldemArena({ search }) {
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4919,7 +4918,7 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
       resetPointerState();
       applyHoverTarget(null);
@@ -4935,13 +4934,26 @@ function TexasHoldemArena({ search }) {
       if (!first || !second) return;
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
       if (currentDistance <= 0) return;
-      const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
+      const zoomScale = currentDistance / pinch.startDistance;
+      if (!Number.isFinite(zoomScale) || zoomScale <= 0) return;
+      if (overheadViewRef.current) {
+        const nextZoom = THREE.MathUtils.clamp(
+          +(pinch.startZoom / zoomScale).toFixed(3),
+          OVERHEAD_ZOOM_MIN,
+          OVERHEAD_ZOOM_MAX
+        );
+        setOverheadZoom(nextZoom);
+        return;
+      }
       const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
+        +(pinch.startZoom / zoomScale).toFixed(3),
+        SEATED_ZOOM_MIN,
+        SEATED_ZOOM_MAX
       );
-      setOverheadZoom(nextZoom);
+      setSeatedZoom(nextZoom);
+      const mountWidth = mount?.clientWidth ?? window.innerWidth;
+      const mountHeight = mount?.clientHeight ?? window.innerHeight;
+      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: nextZoom });
     };
 
     const handlePointerDown = (event) => {
@@ -4951,7 +4963,7 @@ function TexasHoldemArena({ search }) {
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -5051,7 +5063,7 @@ function TexasHoldemArena({ search }) {
     const handlePointerUp = (event) => {
       activePointersRef.current.delete(event.pointerId);
       if (pinchZoomRef.current.active) {
-        if (activePointersRef.current.size >= 2 && overheadView) {
+        if (activePointersRef.current.size >= 2) {
           beginPinchZoom();
         } else {
           resetPinchState();


### PR DESCRIPTION
### Motivation
- Enable multi-touch pinch zoom for both overhead and seated views and improve camera/seat framing in landscape mode.

### Description
- Replace the distance-delta pinch logic with a ratio-based `zoomScale` and remove `OVERHEAD_PINCH_SENSITIVITY`, clamping zoom per-view using `OVERHEAD_ZOOM_*` and `SEATED_ZOOM_*` ranges.
- Start pinch handling whenever two pointers are active and initialize `startZoom` from `overheadZoomRef.current` or `seatedZoomRef.current` depending on `overheadViewRef.current`.
- Apply seated pinch results via `setSeatedZoom(nextZoom)` and call `viewControlsRef.current.applySeatedCamera(mountWidth, mountHeight, { zoom: nextZoom })` to update the seated camera immediately.
- Adjust camera/seat layout constants: `CAMERA_RETREAT_OFFSETS` (landscape), `CAMERA_ELEVATION_OFFSETS` (landscape), and `HUMAN_SEAT_INWARD_OFFSETS` (landscape) to improve visual composition.

### Testing
- Ran the existing automated test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a534ae6b148329bf80f48588a3e9f1)