### PR TITLE
Fix Domino Royal GLTF texture resolution (Poly Haven include mapping)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2310,7 +2310,48 @@ const CHAIR_THEME_OPTIONS = Object.freeze(
 
 const CHAIR_MODEL_URLS = Object.freeze([]);
 const polyhavenModelCache = new Map();
+const polyhavenFilesManifestCache = new Map();
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+
+async function getPolyhavenFilesManifest(assetId) {
+  if (!assetId) return null;
+  const key = String(assetId).toLowerCase();
+  if (polyhavenFilesManifestCache.has(key)) {
+    return polyhavenFilesManifestCache.get(key);
+  }
+  const promise = (async () => {
+    try {
+      const response = await fetch(`https://api.polyhaven.com/files/${assetId}`, {
+        mode: 'cors',
+        credentials: 'omit'
+      });
+      if (!response.ok) {
+        throw new Error(`Poly Haven files API ${response.status}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.warn('Failed to load Poly Haven file manifest', assetId, error);
+      return null;
+    }
+  })();
+  polyhavenFilesManifestCache.set(key, promise);
+  return promise;
+}
+
+function extractPolyhavenIncludeUrlMap(manifest, resolution = '2k') {
+  const include = manifest?.gltf?.[resolution]?.gltf?.include;
+  if (!include || typeof include !== 'object') return null;
+  const map = new Map();
+  Object.entries(include).forEach(([relativePath, entry]) => {
+    if (!relativePath || typeof relativePath !== 'string') return;
+    const fileUrl = entry?.url;
+    if (!fileUrl || typeof fileUrl !== 'string') return;
+    map.set(relativePath, fileUrl);
+    map.set(relativePath.replace(/^\.\//, ''), fileUrl);
+    map.set(relativePath.split('/').pop() || relativePath, fileUrl);
+  });
+  return map;
+}
 
 function applySRGBColorSpace(texture) {
   if (!texture) return;
@@ -2391,8 +2432,22 @@ function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) 
   });
 }
 
-function createPolyhavenGltfLoader() {
-  const loader = new GLTFLoader();
+function createPolyhavenGltfLoader(includeUrlMap = null) {
+  const manager = new THREE.LoadingManager();
+  if (includeUrlMap?.size) {
+    manager.setURLModifier((requestUrl = '') => {
+      const cleanUrl = String(requestUrl || '').split('?')[0];
+      const normalized = cleanUrl.replace(/^\.\//, '');
+      const fileName = normalized.split('/').pop();
+      return (
+        includeUrlMap.get(cleanUrl) ||
+        includeUrlMap.get(normalized) ||
+        includeUrlMap.get(fileName) ||
+        requestUrl
+      );
+    });
+  }
+  const loader = new GLTFLoader(manager);
   const draco = new DRACOLoader();
   draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setCrossOrigin('anonymous');
@@ -2431,11 +2486,19 @@ async function loadPolyhavenModel(
       ? ['1k']
       : ['2k', '1k'];
   const candidates = buildPolyhavenModelUrls(assetId, preferredResolutions);
-  const loader = createPolyhavenGltfLoader();
+  const filesManifest = await getPolyhavenFilesManifest(assetId);
   let lastError = null;
 
   for (const candidateUrl of candidates) {
     try {
+      const resolutionMatch = candidateUrl.match(/\/(1k|2k)\//i);
+      const resolution =
+        resolutionMatch?.[1]?.toLowerCase?.() || preferredResolutions[0] || '2k';
+      const includeUrlMap = extractPolyhavenIncludeUrlMap(
+        filesManifest,
+        resolution
+      );
+      const loader = createPolyhavenGltfLoader(includeUrlMap);
       const resolvedUrl = new URL(
         candidateUrl,
         typeof window !== 'undefined' ? window.location?.href : candidateUrl


### PR DESCRIPTION
### Motivation
- Table and chair GLTFs from Poly Haven used relative include paths (e.g. `textures/...`) that were not resolving to the CDN URLs, causing materials to fall back to procedural/textured-less appearances.
- The loader must resolve model include assets (textures, bin buffers) to concrete CDN URLs so Three.js can fetch the correct images and normal/arm/roughness maps.
- Provide a resilient solution that preserves existing fallback behavior when remote assets fail.

### Description
- Added a small Poly Haven files-manifest cache and fetcher (`polyhavenFilesManifestCache` + `getPolyhavenFilesManifest`) that queries `https://api.polyhaven.com/files/{assetId}` to discover canonical URLs for model includes. (file: `webapp/public/domino-royal-game.js`)
- Implemented `extractPolyhavenIncludeUrlMap` to build a resolution-aware mapping of relative include paths to absolute CDN URLs from the manifest.
- Updated GLTF loader creation to `createPolyhavenGltfLoader(includeUrlMap)` using `THREE.LoadingManager.setURLModifier` so requests for `textures/...`, `./...` and filename-only paths are remapped to manifest-provided URLs when available.
- Wired `loadPolyhavenModel` to request the manifest per asset and resolution (e.g. `2k`/`1k`), pass the include map into the loader, and retain prior fallbacks if loading fails.

### Testing
- Ran a static syntax check with `node --check webapp/public/domino-royal-game.js`, which completed successfully.
- Started the dev server via `npm run dev` and verified the app boots successfully and serves the Domino Royal route.
- Automated visual smoke run using Playwright to open `/games/domino-royal` and capture a screenshot; the run completed and produced a screenshot artifact for manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5484b3f2083298041091cf5b4db6d)