### PR TITLE
Improve pinch/wheel zoom and pointer capture handling; tweak camera/seat offsets in TexasHoldemArena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,13 +390,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.4 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.48 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.24 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.62 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
-const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const SEATED_ZOOM_DEFAULT = 1;
 const SEATED_ZOOM_MIN = 0.86;
@@ -4905,7 +4904,7 @@ function TexasHoldemArena({ search }) {
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4919,11 +4918,29 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
+      const activePointerId = pointerStateRef.current.pointerId;
+      if (activePointerId != null && element.hasPointerCapture(activePointerId)) {
+        element.releasePointerCapture(activePointerId);
+      }
       resetPointerState();
       applyHoverTarget(null);
       element.style.cursor = 'grab';
+    };
+
+    const applyCameraZoom = (nextZoom) => {
+      if (!Number.isFinite(nextZoom)) return;
+      if (overheadViewRef.current) {
+        const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
+        setOverheadZoom(clampedZoom);
+        return;
+      }
+      const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
+      setSeatedZoom(clampedZoom);
+      const mountWidth = mount?.clientWidth ?? window.innerWidth;
+      const mountHeight = mount?.clientHeight ?? window.innerHeight;
+      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: clampedZoom });
     };
 
     const updatePinchZoom = () => {
@@ -4934,24 +4951,20 @@ function TexasHoldemArena({ search }) {
       const second = activePointersRef.current.get(secondId);
       if (!first || !second) return;
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
-      if (currentDistance <= 0) return;
-      const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
-      const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
-      );
-      setOverheadZoom(nextZoom);
+      if (currentDistance <= 0 || pinch.startDistance <= 0) return;
+      const zoomScale = pinch.startDistance / currentDistance;
+      applyCameraZoom(pinch.startZoom * zoomScale);
     };
 
     const handlePointerDown = (event) => {
       event.preventDefault();
+      const shouldCapturePointer = event.pointerType !== 'touch';
       activePointersRef.current.set(event.pointerId, {
         pointerId: event.pointerId,
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -4975,7 +4988,9 @@ function TexasHoldemArena({ search }) {
           buttonAction: target.userData?.action ?? null,
           dragged: false
         };
-        element.setPointerCapture(event.pointerId);
+        if (shouldCapturePointer) {
+          element.setPointerCapture(event.pointerId);
+        }
         if (type === 'chip-button') {
           interactionsRef.current.onChip?.(target.userData.value);
         } else if (type === 'button') {
@@ -4994,7 +5009,9 @@ function TexasHoldemArena({ search }) {
         buttonAction: null,
         dragged: false
       };
-      element.setPointerCapture(event.pointerId);
+      if (shouldCapturePointer) {
+        element.setPointerCapture(event.pointerId);
+      }
       element.style.cursor = 'grabbing';
     };
 
@@ -5051,7 +5068,7 @@ function TexasHoldemArena({ search }) {
     const handlePointerUp = (event) => {
       activePointersRef.current.delete(event.pointerId);
       if (pinchZoomRef.current.active) {
-        if (activePointersRef.current.size >= 2 && overheadView) {
+        if (activePointersRef.current.size >= 2) {
           beginPinchZoom();
         } else {
           resetPinchState();
@@ -5081,24 +5098,8 @@ function TexasHoldemArena({ search }) {
     const handleWheel = (event) => {
       event.preventDefault();
       const wheelScale = Math.max(0.78, 1 + event.deltaY * CAMERA_WHEEL_FACTOR * 0.01);
-      if (overheadViewRef.current) {
-        const nextZoom = THREE.MathUtils.clamp(
-          +(overheadZoomRef.current * wheelScale).toFixed(3),
-          OVERHEAD_ZOOM_MIN,
-          OVERHEAD_ZOOM_MAX
-        );
-        setOverheadZoom(nextZoom);
-        return;
-      }
-      const nextZoom = THREE.MathUtils.clamp(
-        +(seatedZoomRef.current * wheelScale).toFixed(3),
-        SEATED_ZOOM_MIN,
-        SEATED_ZOOM_MAX
-      );
-      setSeatedZoom(nextZoom);
-      const mountWidth = mount?.clientWidth ?? window.innerWidth;
-      const mountHeight = mount?.clientHeight ?? window.innerHeight;
-      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: nextZoom });
+      const currentZoom = overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current;
+      applyCameraZoom(currentZoom * wheelScale);
     };
     element.addEventListener('wheel', handleWheel, { passive: false });
 


### PR DESCRIPTION
### Motivation
- Make pinch-to-zoom work reliably for both overhead and seated views and avoid broken start-zoom values.
- Prevent pointer capture from interfering with multi-touch gestures and touch interactions.
- Tweak camera retreat/elevation and human seat offsets to improve framing and layout.

### Description
- Adjusted layout constants: updated `CAMERA_RETREAT_OFFSETS`, `CAMERA_ELEVATION_OFFSETS`, and `HUMAN_SEAT_INWARD_OFFSETS` to refine camera/seat positioning.
- Reworked pinch zoom logic by removing `OVERHEAD_PINCH_SENSITIVITY` and changing to a scale-based approach that computes `zoomScale = startDistance / currentDistance` and applies `startZoom * zoomScale`.
- Added `applyCameraZoom` helper to centralize clamping and apply zoom to overhead (`OVERHEAD_ZOOM_MIN`/`MAX`) or seated (`SEATED_ZOOM_MIN`/`MAX`) modes and to call `viewControlsRef.current.applySeatedCamera` for seated updates.
- Improved pointer handling: begin pinch regardless of `overheadView`, use the appropriate `startZoom` from refs, release any active pointer capture when starting pinch, and only call `setPointerCapture` for non-touch pointers; wheel zoom now delegates to `applyCameraZoom`.

### Testing
- Ran unit tests with `yarn test` and they passed.
- Ran linting with `yarn lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a534ae6b148329bf80f48588a3e9f1)