### PR TITLE
Improve touch pinch/zoom and pointer handling; centralize camera zoom/clamping and tweak camera offsets

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,13 +390,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = ARENA_CAMERA_DEFAULTS.verticalSensitivity;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.4 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.48 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.24 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.62 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
-const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const SEATED_ZOOM_DEFAULT = 1;
 const SEATED_ZOOM_MIN = 0.86;
@@ -4905,7 +4904,7 @@ function TexasHoldemArena({ search }) {
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4919,11 +4918,29 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
+      const activePointerId = pointerStateRef.current.pointerId;
+      if (activePointerId != null && element.hasPointerCapture(activePointerId)) {
+        element.releasePointerCapture(activePointerId);
+      }
       resetPointerState();
       applyHoverTarget(null);
       element.style.cursor = 'grab';
+    };
+
+    const applyCameraZoom = (nextZoom) => {
+      if (!Number.isFinite(nextZoom)) return;
+      if (overheadViewRef.current) {
+        const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
+        setOverheadZoom(clampedZoom);
+        return;
+      }
+      const clampedZoom = THREE.MathUtils.clamp(+nextZoom.toFixed(3), SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
+      setSeatedZoom(clampedZoom);
+      const mountWidth = mount?.clientWidth ?? window.innerWidth;
+      const mountHeight = mount?.clientHeight ?? window.innerHeight;
+      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: clampedZoom });
     };
 
     const updatePinchZoom = () => {
@@ -4934,24 +4951,20 @@ function TexasHoldemArena({ search }) {
       const second = activePointersRef.current.get(secondId);
       if (!first || !second) return;
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
-      if (currentDistance <= 0) return;
-      const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
-      const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
-      );
-      setOverheadZoom(nextZoom);
+      if (currentDistance <= 0 || pinch.startDistance <= 0) return;
+      const zoomScale = pinch.startDistance / currentDistance;
+      applyCameraZoom(pinch.startZoom * zoomScale);
     };
 
     const handlePointerDown = (event) => {
       event.preventDefault();
+      const shouldCapturePointer = event.pointerType !== 'touch';
       activePointersRef.current.set(event.pointerId, {
         pointerId: event.pointerId,
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -4975,7 +4988,9 @@ function TexasHoldemArena({ search }) {
           buttonAction: target.userData?.action ?? null,
           dragged: false
         };
-        element.setPointerCapture(event.pointerId);
+        if (shouldCapturePointer) {
+          element.setPointerCapture(event.pointerId);
+        }
         if (type === 'chip-button') {
           interactionsRef.current.onChip?.(target.userData.value);
         } else if (type === 'button') {
@@ -4986,7 +5001,7 @@ function TexasHoldemArena({ search }) {
       pointerStateRef.current = {
         active: true,
         pointerId: event.pointerId,
-        mode: 'camera',
+        mode: shouldCapturePointer ? 'camera' : 'touch-idle',
         startX: event.clientX,
         startY: event.clientY,
         startYaw: headAnglesRef.current.yaw,
@@ -4994,8 +5009,12 @@ function TexasHoldemArena({ search }) {
         buttonAction: null,
         dragged: false
       };
-      element.setPointerCapture(event.pointerId);
-      element.style.cursor = 'grabbing';
+      if (shouldCapturePointer) {
+        element.setPointerCapture(event.pointerId);
+        element.style.cursor = 'grabbing';
+      } else {
+        element.style.cursor = 'grab';
+      }
     };
 
     const handlePointerMove = (event) => {
@@ -5051,7 +5070,7 @@ function TexasHoldemArena({ search }) {
     const handlePointerUp = (event) => {
       activePointersRef.current.delete(event.pointerId);
       if (pinchZoomRef.current.active) {
-        if (activePointersRef.current.size >= 2 && overheadView) {
+        if (activePointersRef.current.size >= 2) {
           beginPinchZoom();
         } else {
           resetPinchState();
@@ -5081,24 +5100,8 @@ function TexasHoldemArena({ search }) {
     const handleWheel = (event) => {
       event.preventDefault();
       const wheelScale = Math.max(0.78, 1 + event.deltaY * CAMERA_WHEEL_FACTOR * 0.01);
-      if (overheadViewRef.current) {
-        const nextZoom = THREE.MathUtils.clamp(
-          +(overheadZoomRef.current * wheelScale).toFixed(3),
-          OVERHEAD_ZOOM_MIN,
-          OVERHEAD_ZOOM_MAX
-        );
-        setOverheadZoom(nextZoom);
-        return;
-      }
-      const nextZoom = THREE.MathUtils.clamp(
-        +(seatedZoomRef.current * wheelScale).toFixed(3),
-        SEATED_ZOOM_MIN,
-        SEATED_ZOOM_MAX
-      );
-      setSeatedZoom(nextZoom);
-      const mountWidth = mount?.clientWidth ?? window.innerWidth;
-      const mountHeight = mount?.clientHeight ?? window.innerHeight;
-      viewControlsRef.current?.applySeatedCamera?.(mountWidth, mountHeight, { zoom: nextZoom });
+      const currentZoom = overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current;
+      applyCameraZoom(currentZoom * wheelScale);
     };
     element.addEventListener('wheel', handleWheel, { passive: false });
 


### PR DESCRIPTION
### Motivation
- Make pinch-to-zoom more reliable and consistent across overhead and seated camera modes and avoid accidental pointer capture for touch interactions.
- Centralize zoom clamping and application so wheel and pinch zoom share the same behavior and seated camera updates are applied consistently.
- Adjust camera/seat layout offsets to better fit the landscape layout.

### Description
- Introduced `applyCameraZoom` helper to centralize zoom clamping and application for overhead and seated views and to trigger `applySeatedCamera` when needed.
- Reworked pinch logic to compute a zoom scale from `startDistance/currentDistance` and call `applyCameraZoom`, removed the old `OVERHEAD_PINCH_SENSITIVITY` constant, and added guards for invalid distances.
- Allowed pinch initiation without requiring the overhead view and ensure any active pointer capture is released when starting a pinch.
- Changed pointer capture behavior to avoid capturing touch pointers (`pointerType !== 'touch'`), set a `touch-idle` mode for touch drags, and adjust cursor semantics for touch vs non-touch pointers.
- Unified wheel zoom handling to use `applyCameraZoom` instead of duplicating zoom/clamp code.
- Adjusted layout constants: `CAMERA_RETREAT_OFFSETS.landscape`, `CAMERA_ELEVATION_OFFSETS.landscape`, and `HUMAN_SEAT_INWARD_OFFSETS.landscape` to new values.

### Testing
- Ran unit tests with `yarn test`, all tests passed.
- Ran linter with `yarn lint`, no lint errors reported.
- Built the webapp with `yarn build`, build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a534ae6b148329bf80f48588a3e9f1)