### PR TITLE
Texas Hold'em: add seated camera pitch (look up/down) and seated zoom (wheel & pinch)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -388,7 +388,12 @@ const CAMERA_HEAD_TURN_LIMIT = THREE.MathUtils.degToRad(175);
 const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(8);
 const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
-const HEAD_PITCH_SENSITIVITY = 0;
+const HEAD_PITCH_SENSITIVITY = 0.0034;
+const SEATED_ZOOM_DEFAULT = 1;
+const SEATED_ZOOM_MIN = 0.82;
+const SEATED_ZOOM_MAX = 1.18;
+const SEATED_WHEEL_ZOOM_STEP = 0.055;
+const SEATED_PINCH_SENSITIVITY = 0.0026;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.58, landscape: 0.66 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
@@ -2973,6 +2978,10 @@ function TexasHoldemArena({ search }) {
   const [sliderValue, setSliderValue] = useState(0);
   const [overheadView, setOverheadView] = useState(false);
   const [overheadZoom, setOverheadZoom] = useState(OVERHEAD_ZOOM_DEFAULT);
+  const [seatedZoom, setSeatedZoom] = useState(SEATED_ZOOM_DEFAULT);
+  const overheadViewRef = useRef(overheadView);
+  const overheadZoomRef = useRef(overheadZoom);
+  const seatedZoomRef = useRef(seatedZoom);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -3178,6 +3187,18 @@ function TexasHoldemArena({ search }) {
     commentarySpeakerIndexRef.current = index + 1;
     return commentarySpeakers[index % commentarySpeakers.length] || TEXAS_HOLDEM_SPEAKERS.analyst;
   }, [commentarySpeakers]);
+
+  useEffect(() => {
+    overheadViewRef.current = overheadView;
+  }, [overheadView]);
+
+  useEffect(() => {
+    overheadZoomRef.current = overheadZoom;
+  }, [overheadZoom]);
+
+  useEffect(() => {
+    seatedZoomRef.current = seatedZoom;
+  }, [seatedZoom]);
 
   useEffect(() => {
     const updateSupport = () => setCommentarySupported(getSpeechSupport());
@@ -4322,10 +4343,11 @@ function TexasHoldemArena({ search }) {
     const applySeatedCamera = (width, height, options = {}) => {
       if (!humanSeat) return;
       const animate = Boolean(options.animate);
+      const zoom = THREE.MathUtils.clamp(options.zoom ?? SEATED_ZOOM_DEFAULT, SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
       const portrait = height > width;
       const lateralOffset = portrait ? CAMERA_LATERAL_OFFSETS.portrait : CAMERA_LATERAL_OFFSETS.landscape;
-      const retreatOffset = portrait ? CAMERA_RETREAT_OFFSETS.portrait : CAMERA_RETREAT_OFFSETS.landscape;
-      const elevation = portrait ? CAMERA_ELEVATION_OFFSETS.portrait : CAMERA_ELEVATION_OFFSETS.landscape;
+      const retreatOffset = (portrait ? CAMERA_RETREAT_OFFSETS.portrait : CAMERA_RETREAT_OFFSETS.landscape) * zoom;
+      const elevation = (portrait ? CAMERA_ELEVATION_OFFSETS.portrait : CAMERA_ELEVATION_OFFSETS.landscape) * zoom;
       const position = humanSeat.stoolAnchor
         .clone()
         .addScaledVector(humanSeat.forward, -retreatOffset)
@@ -4381,7 +4403,11 @@ function TexasHoldemArena({ search }) {
         -CAMERA_HEAD_TURN_LIMIT,
         CAMERA_HEAD_TURN_LIMIT
       );
-      headAnglesRef.current.pitch = 0;
+      headAnglesRef.current.pitch = THREE.MathUtils.clamp(
+        headAnglesRef.current.pitch,
+        pitchLimits.min,
+        pitchLimits.max
+      );
       const finalize = () => {
         camera.position.copy(position);
         camera.quaternion.copy(targetQuaternion);
@@ -4443,7 +4469,7 @@ function TexasHoldemArena({ search }) {
     if (overheadView) {
       applyOverheadCamera({ zoom: overheadZoom });
     } else {
-      applySeatedCamera(mount.clientWidth, mount.clientHeight);
+      applySeatedCamera(mount.clientWidth, mount.clientHeight, { zoom: seatedZoomRef.current });
     }
 
     (async () => {
@@ -4877,13 +4903,13 @@ function TexasHoldemArena({ search }) {
         active: false,
         pointerIds: [],
         startDistance: 0,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
     };
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4897,7 +4923,7 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadViewRef.current ? overheadZoomRef.current : seatedZoomRef.current
       };
       resetPointerState();
       applyHoverTarget(null);
@@ -4913,13 +4939,23 @@ function TexasHoldemArena({ search }) {
       if (!first || !second) return;
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
       if (currentDistance <= 0) return;
-      const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
-      const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
-      );
-      setOverheadZoom(nextZoom);
+      if (overheadViewRef.current) {
+        const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
+        const nextZoom = THREE.MathUtils.clamp(
+          +(pinch.startZoom - zoomDelta).toFixed(3),
+          OVERHEAD_ZOOM_MIN,
+          OVERHEAD_ZOOM_MAX
+        );
+        setOverheadZoom(nextZoom);
+      } else {
+        const zoomDelta = (currentDistance - pinch.startDistance) * SEATED_PINCH_SENSITIVITY;
+        const nextZoom = THREE.MathUtils.clamp(
+          +(pinch.startZoom - zoomDelta).toFixed(3),
+          SEATED_ZOOM_MIN,
+          SEATED_ZOOM_MAX
+        );
+        setSeatedZoom(nextZoom);
+      }
     };
 
     const handlePointerDown = (event) => {
@@ -4929,7 +4965,7 @@ function TexasHoldemArena({ search }) {
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -5002,15 +5038,21 @@ function TexasHoldemArena({ search }) {
       }
       if (state.mode === 'camera') {
         const dx = event.clientX - state.startX;
-        if (!state.dragged && Math.abs(dx) > 3) {
+        const dy = event.clientY - state.startY;
+        if (!state.dragged && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
           state.dragged = true;
         }
+        const pitchLimits = cameraBasisRef.current?.pitchLimits ?? DEFAULT_PITCH_LIMITS;
         headAnglesRef.current.yaw = THREE.MathUtils.clamp(
           state.startYaw - dx * HEAD_YAW_SENSITIVITY,
           -CAMERA_HEAD_TURN_LIMIT,
           CAMERA_HEAD_TURN_LIMIT
         );
-        headAnglesRef.current.pitch = 0;
+        headAnglesRef.current.pitch = THREE.MathUtils.clamp(
+          state.startPitch + dy * HEAD_PITCH_SENSITIVITY,
+          pitchLimits.min,
+          pitchLimits.max
+        );
         applyHeadOrientation();
         return;
       }
@@ -5050,6 +5092,31 @@ function TexasHoldemArena({ search }) {
     element.addEventListener('pointercancel', handlePointerUp);
     element.addEventListener('pointerleave', handlePointerUp);
 
+    const handleWheel = (event) => {
+      event.preventDefault();
+      if (overheadViewRef.current) {
+        const direction = Math.sign(event.deltaY);
+        if (direction === 0) return;
+        const nextZoom = THREE.MathUtils.clamp(
+          +(overheadZoomRef.current + direction * 0.035).toFixed(3),
+          OVERHEAD_ZOOM_MIN,
+          OVERHEAD_ZOOM_MAX
+        );
+        setOverheadZoom(nextZoom);
+        return;
+      }
+      const direction = Math.sign(event.deltaY);
+      if (direction === 0) return;
+      const nextZoom = THREE.MathUtils.clamp(
+        +(seatedZoomRef.current + direction * SEATED_WHEEL_ZOOM_STEP).toFixed(3),
+        SEATED_ZOOM_MIN,
+        SEATED_ZOOM_MAX
+      );
+      setSeatedZoom(nextZoom);
+    };
+
+    element.addEventListener('wheel', handleWheel, { passive: false });
+
     const handleResize = () => {
       if (!mount || !threeRef.current) return;
       const { camera: cam } = threeRef.current;
@@ -5060,7 +5127,7 @@ function TexasHoldemArena({ search }) {
       if (overheadViewRef.current) {
         viewControlsRef.current?.applyOverheadCamera?.({ zoom: overheadZoomRef.current });
       } else {
-        viewControlsRef.current?.applySeatedCamera?.(clientWidth, clientHeight);
+        viewControlsRef.current?.applySeatedCamera?.(clientWidth, clientHeight, { zoom: seatedZoomRef.current });
       }
     };
 
@@ -5114,6 +5181,7 @@ function TexasHoldemArena({ search }) {
       element.removeEventListener('pointerup', handlePointerUp);
       element.removeEventListener('pointercancel', handlePointerUp);
       element.removeEventListener('pointerleave', handlePointerUp);
+      element.removeEventListener('wheel', handleWheel);
       activePointersRef.current.clear();
       resetPinchState();
       if (threeRef.current) {
@@ -6118,9 +6186,9 @@ function TexasHoldemArena({ search }) {
     } else {
       const width = mount?.clientWidth ?? window.innerWidth;
       const height = mount?.clientHeight ?? window.innerHeight;
-      controls.applySeatedCamera?.(width, height, { animate });
+      controls.applySeatedCamera?.(width, height, { animate, zoom: seatedZoom });
     }
-  }, [overheadView, overheadZoom]);
+  }, [overheadView, overheadZoom, seatedZoom]);
 
 
   return (


### PR DESCRIPTION
### Motivation
- Improve player camera control in the Texas Hold'em arena by allowing the human (seated) camera to look vertically (up/down) and to zoom independently from the overhead view.
- Keep the existing single camera setup and preserve existing overhead zoom behavior while adding responsive controls for touch pinch and mouse wheel.

### Description
- Enabled vertical head pitch input by setting a non-zero `HEAD_PITCH_SENSITIVITY` and using pointer vertical delta to update `headAnglesRef.current.pitch`, clamped to the computed camera `pitchLimits` instead of forcing pitch to `0`.
- Added seated zoom support with new constants `SEATED_ZOOM_DEFAULT`, `SEATED_ZOOM_MIN`, `SEATED_ZOOM_MAX`, `SEATED_WHEEL_ZOOM_STEP`, and `SEATED_PINCH_SENSITIVITY` and a state variable `seatedZoom` plus `seatedZoomRef` to avoid stale values in event handlers.
- Wired `seatedZoom` into `applySeatedCamera` and into places where the seated camera is applied (initial placement, resize handling, view toggle updates) so zoom affects camera position/elevation consistently.
- Extended input handling: unified pinch logic to apply either overhead or seated pinch sensitivity, added a `wheel` handler for desktop wheel zoom (seated or overhead depending on mode), and added cleanup for the wheel listener; synced `overheadView`/`overheadZoom`/`seatedZoom` via refs for reliable pointer/resize handlers.
- File changed: `webapp/src/pages/Games/TexasHoldemArena.jsx` (camera constants, state/refs, pointer/pinch/wheel handlers, camera application paths).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (✅).
- Started the dev server and used Playwright to load the app root and capture a screenshot; the root screenshot was produced successfully (✅).
- Attempted to capture the exact game route `http://127.0.0.1:4173/games/texasholdem` via the browser tool but that specific navigation timed out in the session (⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5693224288329bec4c0b93953d87e)