### PR TITLE
Add 5 cue-stick animation attempts to Pool Royale settings menu

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1101,7 +1101,72 @@ const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
-const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
+const CUE_STROKE_STYLE_STORAGE_KEY = 'poolRoyaleCueStrokeStyle';
+const CUE_STROKE_ANIMATION_OPTIONS = Object.freeze([
+  { id: 'reference-attempt-1', label: 'Attempt 1' },
+  { id: 'reference-attempt-2', label: 'Attempt 2' },
+  { id: 'reference-attempt-3', label: 'Attempt 3' },
+  { id: 'reference-attempt-4', label: 'Attempt 4' },
+  { id: 'reference-attempt-5', label: 'Attempt 5' }
+]);
+const CUE_STROKE_PROFILE_BY_ID = Object.freeze({
+  'reference-attempt-1': Object.freeze({
+    motion: 'classic',
+    pullSmoothing: 0.14,
+    strikeDurationRange: [520, 380],
+    pullbackDurationRange: [760, 620],
+    holdDuration: 340,
+    recoverDuration: 180,
+    impactThreshold: 0.94,
+    cameraExtraHoldMs: 900,
+    spinScale: 0.22
+  }),
+  'reference-attempt-2': Object.freeze({
+    motion: 'linear',
+    pullSmoothing: 0.16,
+    strikeDurationRange: [500, 360],
+    pullbackDurationRange: [730, 590],
+    holdDuration: 300,
+    recoverDuration: 160,
+    impactThreshold: 0.93,
+    cameraExtraHoldMs: 860,
+    spinScale: 0.24
+  }),
+  'reference-attempt-3': Object.freeze({
+    motion: 'spring',
+    pullSmoothing: 0.13,
+    strikeDurationRange: [560, 410],
+    pullbackDurationRange: [800, 640],
+    holdDuration: 360,
+    recoverDuration: 190,
+    impactThreshold: 0.95,
+    cameraExtraHoldMs: 940,
+    spinScale: 0.2
+  }),
+  'reference-attempt-4': Object.freeze({
+    motion: 'snap',
+    pullSmoothing: 0.18,
+    strikeDurationRange: [470, 330],
+    pullbackDurationRange: [700, 560],
+    holdDuration: 280,
+    recoverDuration: 150,
+    impactThreshold: 0.92,
+    cameraExtraHoldMs: 820,
+    spinScale: 0.24
+  }),
+  'reference-attempt-5': Object.freeze({
+    motion: 'whip',
+    pullSmoothing: 0.15,
+    strikeDurationRange: [540, 390],
+    pullbackDurationRange: [780, 630],
+    holdDuration: 320,
+    recoverDuration: 170,
+    impactThreshold: 0.94,
+    cameraExtraHoldMs: 900,
+    spinScale: 0.21
+  })
+});
+const DEFAULT_CUE_STROKE_STYLE = CUE_STROKE_ANIMATION_OPTIONS[0].id;
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
 const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
@@ -12452,7 +12517,16 @@ function PoolRoyaleGame({
   });
   const skipReplayRef = useRef(() => {});
   const skipAllReplaysRef = useRef(skipAllReplays);
-  const cueStrokeAnimationStyleRef = useRef(DEFAULT_CUE_STROKE_STYLE);
+  const [cueStrokeAnimationStyle, setCueStrokeAnimationStyle] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(CUE_STROKE_STYLE_STORAGE_KEY);
+      if (stored && CUE_STROKE_PROFILE_BY_ID[stored]) {
+        return stored;
+      }
+    }
+    return DEFAULT_CUE_STROKE_STYLE;
+  });
+  const cueStrokeAnimationStyleRef = useRef(cueStrokeAnimationStyle);
   const commentaryMutedRef = useRef(commentaryMuted);
   const commentaryReadyRef = useRef(false);
   const commentaryQueueRef = useRef([]);
@@ -12468,6 +12542,12 @@ function PoolRoyaleGame({
       skipReplayRef.current?.();
     }
   }, [skipAllReplays]);
+  useEffect(() => {
+    cueStrokeAnimationStyleRef.current = cueStrokeAnimationStyle;
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(CUE_STROKE_STYLE_STORAGE_KEY, cueStrokeAnimationStyle);
+    }
+  }, [cueStrokeAnimationStyle]);
   useEffect(() => {
     commentaryMutedRef.current = commentaryMuted;
     if (commentaryMuted) {
@@ -24455,20 +24535,31 @@ const powerRef = useRef(hud.power);
         );
       };
 
-      const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
+      const resolveCueStrokeProfile = (styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
+        const profile = CUE_STROKE_PROFILE_BY_ID[styleId] ?? CUE_STROKE_PROFILE_BY_ID[DEFAULT_CUE_STROKE_STYLE];
         return {
-          motion: 'featherLine',
+          motion: profile.motion ?? 'classic',
           pullRatio: 1 - Math.pow(1 - p, 2.4),
-          pullSmoothing: 0.14,
-          strikeDuration: THREE.MathUtils.lerp(520, 380, p),
-          holdDuration: 340,
-          pullbackDuration: THREE.MathUtils.lerp(760, 620, p),
-          recoverDuration: 180,
-          impactThreshold: 0.94,
+          pullSmoothing: Number.isFinite(profile.pullSmoothing) ? profile.pullSmoothing : 0.14,
+          strikeDuration: THREE.MathUtils.lerp(
+            profile.strikeDurationRange?.[0] ?? 520,
+            profile.strikeDurationRange?.[1] ?? 380,
+            p
+          ),
+          holdDuration: Number.isFinite(profile.holdDuration) ? profile.holdDuration : 340,
+          pullbackDuration: THREE.MathUtils.lerp(
+            profile.pullbackDurationRange?.[0] ?? 760,
+            profile.pullbackDurationRange?.[1] ?? 620,
+            p
+          ),
+          recoverDuration: Number.isFinite(profile.recoverDuration) ? profile.recoverDuration : 180,
+          impactThreshold: Number.isFinite(profile.impactThreshold) ? profile.impactThreshold : 0.94,
           forwardOnly: false,
-          cameraExtraHoldMs: 900,
-          spinScale: 0.22
+          cameraExtraHoldMs: Number.isFinite(profile.cameraExtraHoldMs)
+            ? profile.cameraExtraHoldMs
+            : 900,
+          spinScale: Number.isFinite(profile.spinScale) ? profile.spinScale : 0.22
         };
       };
 
@@ -31885,6 +31976,34 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Cue Animation
+                </h3>
+                <div className="mt-2 grid grid-cols-1 gap-2">
+                  {CUE_STROKE_ANIMATION_OPTIONS.map((option) => {
+                    const active = cueStrokeAnimationStyle === option.id;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setCueStrokeAnimationStyle(option.id)}
+                        aria-pressed={active}
+                        className={`w-full rounded-full border px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-2 text-[10px] uppercase tracking-[0.2em] text-white/55">
+                  Reference cue motion in 5 selectable attempts.
+                </p>
+              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Replays


### PR DESCRIPTION
### Motivation
- The existing single cue-stroke animation was not matching the provided reference and needed to be replaced with selectable attempts so players can choose the exact reference motion (user requested 5 chances / attempts). 
- Make the cue animation mechanism declarative and persistent so playback and replay use the same source-of-truth for timing/motion parameters.

### Description
- Introduced 5 named cue animation options and profiles (`CUE_STROKE_ANIMATION_OPTIONS`, `CUE_STROKE_PROFILE_BY_ID`) with timing/motion parameters and a new storage key `poolRoyaleCueStrokeStyle` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Replaced the single hard-coded default stroke style with stateful selection (`cueStrokeAnimationStyle` + `cueStrokeAnimationStyleRef`) and added `useEffect` persistence to `localStorage` so selection survives sessions.
- Updated `resolveCueStrokeProfile` to resolve per-attempt profiles (motion, strike/pull durations, impact threshold, spin scale) while keeping the same pull→release→impact pipeline used by shots and replays.
- Added a new “Cue Animation” section at the top of the in-game settings menu that lists the 5 attempts and lets players switch the active cue stroke animation.

### Testing
- Built the webapp successfully with `npm run -s build` (webapp) and the production bundle completed without fatal errors.
- Launched the dev server (`vite`) to exercise the UI interaction during development and it started successfully.
- Attempted an automated Playwright screenshot to validate the menu UI, but the Playwright run timed out in this environment so no screenshot artifact was produced.
- `npm run -s lint` was not applicable in this workspace because a lint script is not defined in the webapp `package.json` (not a failure of the change itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56c2b458083299c46638bfc3c1fb6)