### PR TITLE
Fix Pool Royale shot launch reliability and slow cue strike animation slightly

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1914,6 +1914,7 @@ const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point mo
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.4; // raise minimum forward push so every shot clearly shows the cue driving through
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 7.8; // extend top-end follow-through so powerful shots visibly punch forward
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
+const CUE_STROKE_DURATION_MULTIPLIER = 1.12; // slightly slow down the cue-stick strike animation for clearer shot timing
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -24694,6 +24695,7 @@ const powerRef = useRef(hud.power);
       const applyShotAtImpact = (payload) => {
         if (!payload || payload.applied) return;
         payload.applied = true;
+        pendingImpactRef.current = null;
         const { launchShot } = payload;
         launchShot?.();
       };
@@ -25174,7 +25176,13 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
+          const strikeDuration =
+            (strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS) *
+            CUE_STROKE_DURATION_MULTIPLIER;
+          pendingImpactRef.current = {
+            time: performance.now() + Math.max(strikeDuration + 120, 240),
+            apply: () => applyShotAtImpact(shotImpactPayload)
+          };
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
@@ -25309,7 +25317,7 @@ const powerRef = useRef(hud.power);
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
-              strikeImpactThreshold: 1,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.94,
               forwardOnly: false,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,


### PR DESCRIPTION
### Motivation
- Players reported the cue ball sometimes did not move after releasing the slider and the cue stroke felt too abrupt, so the shot application must be robust and the cue animation slightly slower for clearer feedback.

### Description
- Added `CUE_STROKE_DURATION_MULTIPLIER` and applied it to the computed strike duration so live cue strikes run ~12% slower (`strikeDuration` multiplied by `CUE_STROKE_DURATION_MULTIPLIER`).
- Schedule a fallback impact using `pendingImpactRef` when a shot is started so the shot still launches if the animation callback misses the exact impact frame (`pendingImpactRef.current = { time, apply }`).
- Ensure `applyShotAtImpact` clears `pendingImpactRef.current` before launching the shot to avoid stale pending-impact state interfering with shot application.
- Use the stroke profile impact threshold (`strokeProfile.impactThreshold ?? 0.94`) for the cue stroke state instead of a hardcoded `1` to improve consistency across stroke styles.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully.
- Started the dev server and performed an automated smoke navigation of the front-end with Playwright which loaded the app and produced a screenshot of the Pool Royale page (smoke test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ac52357c83299ebe09d6e14191e3)