### PR TITLE
Ensure cue shot fires if cue mesh is unavailable and use strike hold in live stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21484,8 +21484,22 @@ const powerRef = useRef(hud.power);
 
         const updateCueStroke = (now) => {
           const stroke = cueStrokeStateRef.current;
-          if (!stroke || !cueStick) {
+          if (!stroke) {
             return Boolean(cueAnimating);
+          }
+          if (!cueStick) {
+            // Safety fallback: if the cue mesh is temporarily unavailable (asset streaming,
+            // scene refresh), still apply the shot so the cue ball always launches.
+            if (!stroke.shotApplied) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
+            cueAnimating = false;
+            cuePullCurrentRef.current = 0;
+            cuePullTargetRef.current = 0;
+            cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
+            return false;
           }
           if (!ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = false;
@@ -25180,7 +25194,7 @@ const powerRef = useRef(hud.power);
           const startTime = performance.now();
           const impactPos = idlePos.clone();
           const followPos = impactPos.clone();
-          const followDurationResolved = 0;
+          const followDurationResolved = strikeHoldDuration;
           const recoverDuration = 0;
           animatePowerSliderReturn(strikeDuration);
           const forwardPreviewHold =


### PR DESCRIPTION
### Motivation
- Prevent situations where the cue-ball never launches because the cue-stick mesh is temporarily unavailable during the stroke animation, and make the live forward stroke read less abrupt by honoring the configured hold time.

### Description
- Add a safety fallback in `updateCueStroke` that applies the impact callback (`stroke.onImpact`) and clears stroke state when `cueStick` is missing so the shot still executes and the state does not get stuck. 
- Use the configured `strikeHoldDuration` for live strokes by setting `followDurationResolved = strikeHoldDuration` so the visible forward stroke holds for the expected duration instead of using `0`.
- Changes are in `webapp/src/pages/Games/PoolRoyale.jsx` inside the `updateCueStroke` and shot-launch logic.

### Testing
- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (3 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ac52357c83299ebe09d6e14191e3)