### PR TITLE
Ensure cue-ball launches reliably by adding pending-impact fallback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25329,6 +25329,14 @@ const powerRef = useRef(hud.power);
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               onImpact: () => applyShotAtImpact(shotImpactPayload)
             };
+            const impactAt =
+              startTime +
+              Math.max(0, pullbackDuration) +
+              Math.max(1, strikeDuration);
+            pendingImpactRef.current = {
+              time: impactAt,
+              apply: () => applyShotAtImpact(shotImpactPayload)
+            };
           } else {
             applyShotAtImpact(shotImpactPayload);
             cueStick.visible = false;
@@ -25336,6 +25344,7 @@ const powerRef = useRef(hud.power);
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;


### PR DESCRIPTION
### Motivation
- Fix a bug where the cue-stick animation could play but the cue ball never received its launch impulse because the animation impact callback was missed.  
- Ensure shot execution is robust by scheduling a fallback application of the shot at the expected impact time when the animated stroke is used.

### Description
- When creating the live cue-stroke animation (`cueStrokeStateRef.current`) the code now computes an `impactAt` timestamp and sets `pendingImpactRef.current = { time, apply }` to call `applyShotAtImpact(shotImpactPayload)` at the expected impact time.  
- In the non-animated (instant) shot path the code clears `pendingImpactRef.current` to avoid stale delayed callbacks.  
- Changes are localized in `webapp/src/pages/Games/PoolRoyale.jsx` around the shot firing / cue-stroke creation logic where `cueStrokeStateRef.current` and impact handling are configured.  

### Testing
- Ran the existing unit test for the cue stroke timeline with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, and all tests passed.  
- Jest output: `PASS test/poolRoyaleCueStrokeTimeline.test.js` (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d1035d3483298e054245f79befa9)