### PR TITLE
Fix Pool Royale power slider commit and cue firing on touch devices

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -87,6 +87,7 @@ export class PowerSlider {
     this._onPointerDown = this._pointerDown.bind(this);
     this._onPointerMove = this._pointerMove.bind(this);
     this._onPointerUp = this._pointerUp.bind(this);
+    this._onPointerCancel = this._pointerUp.bind(this);
     this._onWheel = this._wheel.bind(this);
     this._onKeyDown = this._keyDown.bind(this);
     this.el.addEventListener('pointerdown', this._onPointerDown);
@@ -210,10 +211,12 @@ export class PowerSlider {
     this.dragStartValue = this.value;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
+    this._updateFromClientY(e.clientY);
     this.pointerStartY = e.clientY;
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.addEventListener('pointermove', this._onPointerMove);
     this.el.addEventListener('pointerup', this._onPointerUp);
+    this.el.addEventListener('pointercancel', this._onPointerCancel);
   }
 
   _pointerMove(e) {
@@ -227,12 +230,17 @@ export class PowerSlider {
   _pointerUp(e) {
     if (!this.dragging) return;
     this.dragging = false;
-    this.el.releasePointerCapture(e.pointerId);
+    if (e?.clientY != null) this._updateFromClientY(e.clientY);
+    try {
+      this.el.releasePointerCapture(e.pointerId);
+    } catch {}
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);
+    this.el.removeEventListener('pointercancel', this._onPointerCancel);
     this.el.classList.remove('ps-no-animate');
     const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
-    if (!moved) {
+    const hasPower = this.value > this.min + 0.01;
+    if (!moved && !hasPower) {
       this.set(this.dragStartValue, { animate: true });
       return;
     }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30926,8 +30926,12 @@ const powerRef = useRef(hud.power);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-        fireRef.current?.();
+      onCommit: (v) => {
+        const normalizedPower = THREE.MathUtils.clamp((v ?? 0) / 100, 0, 1);
+        applyPower(normalizedPower);
+        if (normalizedPower > 0.02) {
+          fireRef.current?.();
+        }
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Users reported the cue visually pulled but the shot did not launch, especially on mobile/touch devices, so the slider commit flow needed to be more reliable and tied to the actual committed value.

### Description
- Hardened `PowerSlider` input handling in `power-slider.js` by syncing the slider on `pointerdown`/`pointerup`, adding `pointercancel` support, and safely releasing pointer capture to avoid stuck/uncertain drag state.
- Updated `_pointerDown` to call `_updateFromClientY` immediately so the slider value reflects the initial touch position, and updated `_pointerUp` to also update from the final `clientY` before commit.
- Relaxed the movement threshold so a commit will occur when there is meaningful power even if drag distance was small, and removed unsafe pointer capture releases (now wrapped in try/catch).
- Changed Pool Royale slider commit handling in `webapp/src/pages/Games/PoolRoyale.jsx` to accept the committed slider value (`v`), clamp it, call `applyPower` with the normalized value and only call the `fire` shot routine if `power > 0.02` so shots are triggered only when there is real pull power.

### Testing
- Built the web app with `npm run build` from `webapp/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d581e41883299508ba7c1b998fbf)