### PR TITLE
Adjust Texas Holdem seat anchoring and camera distance for mobile orientations

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(52);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.03, landscape: 0.3 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.56, landscape: 0.64 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.28, landscape: 1.44 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.34, landscape: 0.42 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.18, landscape: 1.3 });
 const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: -CARD_W * 0.24, landscape: -CARD_W * 0.4 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
@@ -932,7 +932,7 @@ function buildSeatAnchors(count) {
   const radiusY = 32;
   const anchors = [];
   for (let i = 0; i < safeCount; i += 1) {
-    const angle = -Math.PI / 2 + (i / safeCount) * Math.PI * 2;
+    const angle = Math.PI / 2 + (i / safeCount) * Math.PI * 2;
     anchors.push({
       left: `${centerX + Math.cos(angle) * radiusX}%`,
       top: `${centerY + Math.sin(angle) * radiusY}%`


### PR DESCRIPTION
### Motivation
- Make the human player's chair render at the bottom of the portrait viewport and tighten camera framing so the user feels visually closer to the table in both portrait and landscape.
- Keep the change minimal and local to the arena camera / seat-anchor math for predictable mobile-first UX.

### Description
- Reduced the camera retreat distances and lowered elevation targets by updating `CAMERA_RETREAT_OFFSETS` and `CAMERA_ELEVATION_OFFSETS` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to pull the camera closer for both portrait and landscape.
- Moved the seat-anchor starting angle in `buildSeatAnchors` from `-Math.PI / 2` to `Math.PI / 2` so seat index `0` (the human player) appears at the bottom of the screen in portrait.
- Changes are limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and committed with a concise message describing the UX tuning.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully.
- Executed an automated Playwright script that opened `http://127.0.0.1:4173/games/texasholdem` at mobile viewport `430x932` and produced `artifacts/texas-holdem-camera-portrait.png`, confirming the portrait framing and seat placement visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d5f6f9408329ad79255f811ec293)