### PR TITLE
Fix Domino Royale glTF texture decoding pipeline

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5,6 +5,8 @@ import { RoundedBoxGeometry } from '/vendor/three/examples/jsm/geometries/Rounde
 import { GLTFLoader } from '/vendor/three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
 import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/meshopt_decoder.module.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -2312,6 +2314,32 @@ const CHAIR_MODEL_URLS = Object.freeze([]);
 const polyhavenModelCache = new Map();
 const polyhavenFilesManifestCache = new Map();
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const BASIS_TRANSCODER_PATH =
+  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+let sharedKtx2Loader = null;
+
+function createConfiguredGltfLoader(manager = null) {
+  const loader = manager ? new GLTFLoader(manager) : new GLTFLoader();
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setCrossOrigin('anonymous');
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('KTX2 support detection failed for Domino Royal', error);
+    }
+  }
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+}
 
 async function getPolyhavenFilesManifest(assetId) {
   if (!assetId) return null;
@@ -2469,12 +2497,7 @@ function createPolyhavenGltfLoader(includeUrlMap = null) {
       );
     });
   }
-  const loader = new GLTFLoader(manager);
-  const draco = new DRACOLoader();
-  draco.setDecoderPath(DRACO_DECODER_PATH);
-  loader.setCrossOrigin('anonymous');
-  loader.setDRACOLoader(draco);
-  return loader;
+  return createConfiguredGltfLoader(manager);
 }
 
 function buildPolyhavenModelUrls(assetId, resolutionOrder = ['2k', '1k']) {
@@ -2698,11 +2721,7 @@ async function ensureMurlanChairTemplate(theme = null) {
         preserveMaterials: theme.preserveMaterials ?? true
       };
     }
-    const loader = new GLTFLoader();
-    const draco = new DRACOLoader();
-    draco.setDecoderPath(DRACO_DECODER_PATH);
-    loader.setCrossOrigin('anonymous');
-    loader.setDRACOLoader(draco);
+    const loader = createConfiguredGltfLoader();
 
     if (!CHAIR_MODEL_URLS.length) {
       return buildProceduralChairTemplate();


### PR DESCRIPTION
### Motivation
- Domino Royale was falling back to procedural materials because compressed glTF texture/geometry decoders (KTX2 / Meshopt) were not wired into its loader chain like other games, preventing original textures from being applied.
- The goal is to match the decoding pipeline used by other scenes (Snake/Ludo/Pool/Snooker) so Poly Haven table and chair assets preserve their original GLTF texture mapping.

### Description
- Added `KTX2Loader` and `MeshoptDecoder` imports and a shared `createConfiguredGltfLoader()` helper that configures `DRACOLoader`, `KTX2Loader`, and `MeshoptDecoder` and reuses a shared KTX2 loader with `detectSupport` so compressed textures and optimized geometry can be decoded.
- Replaced direct `GLTFLoader` construction in Poly Haven table and chair flows to use `createConfiguredGltfLoader()` so `loadPolyhavenModel()` and chair template loading preserve original glTF materials and mappings. 
- Introduced `BASIS_TRANSCODER_PATH` and `sharedKtx2Loader` to centralize KTX2 transcoder configuration and avoid duplicated loader setup.
- Change is contained in `webapp/public/domino-royal-game.js` and keeps existing fallback behavior for procedural assets when remote models are unavailable.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without errors (success).
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` to validate runtime startup (dev server started successfully).
- Executed an automated Playwright run that opened `http://127.0.0.1:4173/games/domino-royal` in a mobile-sized viewport and captured a screenshot for visual verification at `artifacts/domino-texture-fix.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d6ba7afc8329b6d6d4bb0def60a7)