### PR TITLE
Fix Pool power slider commit behavior and mobile touch handling

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -10,6 +10,7 @@ export class PowerSlider {
       onChange,
       onStart,
       onCommit,
+      commitThresholdRatio = 0.02,
       theme = 'default',
       labels = false
     } = opts;
@@ -23,6 +24,7 @@ export class PowerSlider {
     this.onChange = onChange;
     this.onStart = onStart;
     this.onCommit = onCommit;
+    this.commitThresholdRatio = Math.min(Math.max(commitThresholdRatio, 0), 1);
     this.locked = false;
 
     this.el = document.createElement('div');
@@ -87,6 +89,7 @@ export class PowerSlider {
     this._onPointerDown = this._pointerDown.bind(this);
     this._onPointerMove = this._pointerMove.bind(this);
     this._onPointerUp = this._pointerUp.bind(this);
+    this._onPointerCancel = this._pointerCancel.bind(this);
     this._onWheel = this._wheel.bind(this);
     this._onKeyDown = this._keyDown.bind(this);
     this.el.addEventListener('pointerdown', this._onPointerDown);
@@ -207,6 +210,7 @@ export class PowerSlider {
     e.preventDefault();
     this.dragging = true;
     this.dragMoved = false;
+    this._updateFromClientY(e.clientY);
     this.dragStartValue = this.value;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
@@ -214,6 +218,7 @@ export class PowerSlider {
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.addEventListener('pointermove', this._onPointerMove);
     this.el.addEventListener('pointerup', this._onPointerUp);
+    this.el.addEventListener('pointercancel', this._onPointerCancel);
   }
 
   _pointerMove(e) {
@@ -230,13 +235,21 @@ export class PowerSlider {
     this.el.releasePointerCapture(e.pointerId);
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);
+    this.el.removeEventListener('pointercancel', this._onPointerCancel);
     this.el.classList.remove('ps-no-animate');
+    const range = Math.max(this.max - this.min, 1);
+    const ratio = (this.value - this.min) / range;
     const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
-    if (!moved) {
+    const shouldCommit = moved || ratio > this.commitThresholdRatio;
+    if (!shouldCommit) {
       this.set(this.dragStartValue, { animate: true });
       return;
     }
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
+  }
+
+  _pointerCancel(e) {
+    this._pointerUp(e);
   }
 
   _wheel(e) {


### PR DESCRIPTION
### Motivation
- Touch releases on mobile could fail to trigger a shot when the user tapped or set power without a significant drag, causing the cue ball not to move; the slider should mirror the cue-stick pull/release semantics used in the Pool Royale UI.

### Description
- Update `PowerSlider` to apply the slider value immediately on pointer down so the pull starts from the exact touch point and the cue anchor aligns to that value (`_updateFromClientY` called in `_pointerDown`).
- Add a configurable `commitThresholdRatio` option (default `0.02`) so releasing with a meaningful power commits the shot even if there was little or no drag, and only revert when under threshold; this uses `commitThresholdRatio` in `_pointerUp` to decide `onCommit` vs revert.
- Handle `pointercancel` consistently by wiring a `_pointerCancel` handler that routes to the same release/commit path to avoid lost commits on interrupted touch sequences.

Files changed: `power-slider.js` (PowerSlider enhancements and pointercancel handling).

### Testing
- Performed a production build with `cd webapp && npm run -s build`, which completed successfully (Vite produced only non-blocking warnings about large chunks).
- No automated unit tests were present/modified for this UI widget; validation covered integration by building the web app and ensuring no runtime/build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d581e41883299508ba7c1b998fbf)