### PR TITLE
Fix Pool Royale cue-ball launch timing at cue-stick contact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21665,6 +21665,11 @@ const powerRef = useRef(hud.power);
             cueStick.position.y -= (strikeDip ?? 0.003) * eased;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = (baseRotationY ?? cueStick.rotation.y) + wobble;
+            const releaseCompleteByPosition = cueStick.position.distanceToSquared(impactPos) <= 1e-8;
+            if (!stroke.shotApplied && (sample.hitArmed || releaseCompleteByPosition)) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
             syncCueShadow();
             return true;
           }


### PR DESCRIPTION
### Motivation
- Ensure the shot is actually applied when the cue-stick visually returns to the original contact/start position so the cue-ball receives the power applied on the slider and avoids missed launches due to timing/frame pacing.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` adjust the release-phase logic to trigger the shot when either the timeline `hitArmed` is true or the cue-stick position has reached the `impactPos` by checking `cueStick.position.distanceToSquared(impactPos) <= 1e-8`, then mark `stroke.shotApplied = true` and call the stroke `onImpact` handler.

### Testing
- Ran the unit test `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` which passed (all tests in that suite succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e76727c883298b37b872256aeabc)