### PR TITLE
Fix Pool Royale shot resolve before cue impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30434,8 +30434,15 @@ const powerRef = useRef(hud.power);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
+            const strokePendingImpact = Boolean(
+              cueStrokeStateRef.current && !cueStrokeStateRef.current.shotApplied
+            );
+            const waitingForImpact =
+              strokePendingImpact || Boolean(pendingImpactRef.current);
             if (!any) {
-              resolve();
+              if (!waitingForImpact) {
+                resolve();
+              }
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
               balls.forEach((ball) => {


### PR DESCRIPTION
### Motivation
- Prevent shots from resolving before the cue stick animation actually applies impact to the cue ball, which could let the shot lifecycle end without transferring the intended force to the cue ball.

### Description
- Add a guard in the shot-end loop that checks whether the cue stroke still has an armed impact or a pending impact (`cueStrokeStateRef.current.shotApplied` and `pendingImpactRef.current`) and defer calling `resolve()` until impact has been applied.
- Change applied in `webapp/src/pages/Games/PoolRoyale.jsx` near the main render/update loop so both player and AI shots (which share the same `fire()` + cue stroke pipeline) wait for impact before resolving.
- Keeps existing cue-stroke timeline and replay recording behavior; only prevents premature resolution when the cue animation hasn't yet delivered the hit.

### Testing
- Ran unit tests: `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, and the suite passed (3 tests, 3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e76727c883298b37b872256aeabc)