### PR TITLE
Align Domino default table with Chess and include full Murlan table/chair set in Ludo store

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -1,0 +1,32 @@
+import {
+  CHESS_BATTLE_DEFAULT_UNLOCKS,
+  CHESS_TABLE_OPTIONS
+} from '../webapp/src/config/chessBattleInventoryConfig.js';
+import {
+  DOMINO_ROYAL_DEFAULT_UNLOCKS,
+  DOMINO_ROYAL_OPTION_SETS
+} from '../webapp/src/config/dominoRoyalInventoryConfig.js';
+import {
+  LUDO_BATTLE_STORE_ITEMS
+} from '../webapp/src/config/ludoBattleInventoryConfig.js';
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
+
+describe('cross-game inventory alignment', () => {
+  test('domino default table follows chess default murlan table', () => {
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(CHESS_TABLE_OPTIONS[0]?.id);
+    expect(DOMINO_ROYAL_DEFAULT_UNLOCKS.tableTheme[0]).toBe(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]);
+    expect(DOMINO_ROYAL_DEFAULT_UNLOCKS.tableTheme[0]).toBe(DOMINO_ROYAL_OPTION_SETS.tableTheme[0]?.id);
+  });
+
+  test('ludo store contains every murlan table and chair theme', () => {
+    const tableIds = new Set(
+      LUDO_BATTLE_STORE_ITEMS.filter((item) => item.type === 'tables').map((item) => item.optionId)
+    );
+    const stoolIds = new Set(
+      LUDO_BATTLE_STORE_ITEMS.filter((item) => item.type === 'stools').map((item) => item.optionId)
+    );
+
+    expect(tableIds).toEqual(new Set(MURLAN_TABLE_THEMES.map((theme) => theme.id)));
+    expect(stoolIds).toEqual(new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id)));
+  });
+});

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -79,24 +79,9 @@ const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
 });
 
 const getDefaultOptionId = (options) => options?.[0]?.id;
-const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'CoffeeTable_01';
-const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
-
 const getDominoDefaultOptionId = (type) => {
   const options = DOMINO_ROYAL_OPTION_SETS[type] || [];
   if (!options.length) return undefined;
-  if (type === 'tableTheme') {
-    return (
-      options.find((option) => option.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID)?.id ||
-      getDefaultOptionId(options)
-    );
-  }
-  if (type === 'chairTheme') {
-    return (
-      options.find((option) => option.id === LUDO_MATCH_DEFAULT_CHAIR_THEME_ID)?.id ||
-      getDefaultOptionId(options)
-    );
-  }
   return getDefaultOptionId(options);
 };
 

--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -56,7 +56,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
-  ...MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  ...MURLAN_TABLE_THEMES.map((theme, idx) => ({
     id: `ludo-table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,
@@ -65,7 +65,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
     thumbnail: theme.thumbnail
   })),
-  ...MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  ...MURLAN_STOOL_THEMES.map((theme, idx) => ({
     id: `ludo-stool-${theme.id}`,
     type: 'stools',
     optionId: theme.id,


### PR DESCRIPTION
### Motivation

- Ensure cross-game visual consistency by making the Domino Royal default table use the same Murlan default table source as Chess Battle Royal. 
- Provide full access to the Murlan Royale 3D furniture collection in Ludo so all tables and stools/chairs are available in-store. 

### Description

- Updated `webapp/src/config/dominoRoyalInventoryConfig.js` to remove the hardcoded Ludo-specific default table/chair override and make `getDominoDefaultOptionId` return the first option (matching the Chess default source). 
- Expanded `webapp/src/config/ludoBattleInventoryConfig.js` so `LUDO_BATTLE_STORE_ITEMS` includes every entry from `MURLAN_TABLE_THEMES` and `MURLAN_STOOL_THEMES` (previously filtered to exclude defaults). 
- Added `test/inventoryCrossGameConfig.test.js` which verifies Domino's default `tableTheme` aligns with the Chess default and that the Ludo store contains every Murlan table and stool theme ID. 

### Testing

- Ran the new test suite with `npm test -- test/inventoryCrossGameConfig.test.js`. 
- Result: tests passed (`PASS test/inventoryCrossGameConfig.test.js`, 2 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6625b18ac8329b8e823fde16b2724)