### PR TITLE
Unify WebGL decoder configuration for royale game clients

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2,6 +2,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { bombSound, chatBeep } from '../assets/soundData.js';
 import GiftPopup from './GiftPopup.jsx';
@@ -45,6 +48,8 @@ const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 const resolveNumber = (...values) => values.find((value) => typeof value === 'number' && !Number.isNaN(value));
 
 const DEFAULT_RENDER_PIXEL_RATIO_CAP = 1.25;
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const RENDER_PIXEL_RATIO_SCALE = 1.0;
 const MIN_RENDER_PIXEL_RATIO = 0.85;
 const GRAPHICS_STORAGE_KEY = 'airHockeyGraphics';
@@ -232,6 +237,7 @@ const LOCK_POOL_ROYALE_TABLE_STYLE = false;
 const PREFERRED_MARBLE_TEXTURE_SIZES = ['2k', '1k'];
 const MARBLE_TEXTURE_CACHE = new Map();
 const GLTF_MATERIAL_CACHE = new Map();
+let sharedKtx2Loader = null;
 const POOL_BALL_MARBLE_FINISH = Object.freeze({
   clearcoat: 1,
   clearcoatRoughness: 0.03,
@@ -350,6 +356,30 @@ const loadMarbleTextureSet = (fieldOption) => {
   return promise;
 };
 
+const createConfiguredGltfLoader = (renderer = null) => {
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('Air Hockey KTX2 support detection failed', error);
+    }
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+};
+
 const loadGltfMaterialSet = (fieldOption) => {
   const urls = fieldOption?.gltfUrls;
   const cacheKey = fieldOption?.id || urls?.[0];
@@ -357,7 +387,7 @@ const loadGltfMaterialSet = (fieldOption) => {
   if (GLTF_MATERIAL_CACHE.has(cacheKey)) return GLTF_MATERIAL_CACHE.get(cacheKey);
 
   const promise = (async () => {
-    const loader = new GLTFLoader();
+    const loader = createConfiguredGltfLoader();
     let gltf = null;
     for (const url of urls) {
       try {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -6,6 +6,7 @@ import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
 import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
 import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 import { EXRLoader } from 'three/addons/loaders/EXRLoader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 
 import {
@@ -24,7 +25,7 @@ import { applyRendererSRGB, applySRGBColorSpace } from '../utils/colorSpace.js';
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const clamp01 = (v) => clamp(v, 0, 1);
 
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DEFAULT_HDRI_RESOLUTIONS = ['4k'];
 
@@ -1022,21 +1023,28 @@ function disposeChairMaterial(material) {
   material.dispose();
 }
 
+let sharedKtx2Loader = null;
+
 function createConfiguredGLTFLoader(renderer = null) {
   const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
   const draco = new DRACOLoader();
   draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setDRACOLoader(draco);
-  const ktx2 = new KTX2Loader();
-  ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
   if (renderer) {
     try {
-      ktx2.detectSupport(renderer);
+      sharedKtx2Loader.detectSupport(renderer);
     } catch (error) {
       console.warn('KTX2 detection failed', error);
     }
   }
-  loader.setKTX2Loader(ktx2);
+  loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
 }
 

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -85,6 +85,8 @@ const clamp01 = (value, fallback = 0) => {
   if (!Number.isFinite(value)) return fallback;
   return Math.min(1, Math.max(0, value));
 };
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
 const BASE_BOARD_THEME = Object.freeze({
   light: '#e7e2d3',
@@ -1969,7 +1971,7 @@ function applyChairThemeMaterials(chairAssets, theme) {
 async function loadGltfChair() {
   const loader = new GLTFLoader();
   const draco = new DRACOLoader();
-  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+  draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setDRACOLoader(draco);
 
   let gltf = null;
@@ -2741,15 +2743,13 @@ function createConfiguredGLTFLoader(renderer = null) {
   const loader = new GLTFLoader();
   loader.setCrossOrigin('anonymous');
   const draco = new DRACOLoader();
-  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+  draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setDRACOLoader(draco);
   loader.setMeshoptDecoder(MeshoptDecoder);
 
   if (!sharedKTX2Loader) {
     sharedKTX2Loader = new KTX2Loader();
-    sharedKTX2Loader.setTranscoderPath(
-      'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/'
-    );
+    sharedKTX2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
     const supportRenderer = renderer || (typeof document !== 'undefined'
       ? new THREE.WebGLRenderer({ antialias: false, alpha: true })
       : null);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -407,7 +407,7 @@ const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
 const POLYHAVEN_MODEL_CACHE = new Map();
 const resolveHdriVariant = (index) => {
@@ -718,7 +718,7 @@ async function getAbgAssets() {
     const loader = new GLTFLoader();
     loader.setCrossOrigin('anonymous');
     const draco = new DRACOLoader();
-    draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+    draco.setDecoderPath(DRACO_DECODER_PATH);
     loader.setDRACOLoader(draco);
 
     let root = null;
@@ -1260,7 +1260,7 @@ function applyChairThemeMaterials(three, theme) {
 async function loadGltfChair() {
   const loader = new GLTFLoader();
   const draco = new DRACOLoader();
-  draco.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+  draco.setDecoderPath(DRACO_DECODER_PATH);
   loader.setDRACOLoader(draco);
 
   let gltf = null;

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -310,7 +310,7 @@ const CHAIR_MODEL_URLS = [
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
 const POLYHAVEN_MODEL_CACHE = new Map();
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 
 let sharedKtx2Loader = null;
 


### PR DESCRIPTION
### Motivation
- Ensure all royale/arena games use the same GLTF decoding stack (Draco + Meshopt + KTX2) that was added for Domino Royal to avoid inconsistent model decoding and duplicated transcoder workers.
- Standardize decoder endpoints and loader configuration so remote GLTF/GLB assets load reliably across `chess`, `ludo`, `murlan`, `snake`, and `air hockey` arenas.

### Description
- Replaced in-file hardcoded Draco endpoints with a shared constant `DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/'` in `LudoBattleRoyal`, `ChessBattleRoyal`, `MurlanRoyaleArena`, `SnakeBoard3D`, and `AirHockey3D`.
- Imported and wired `MeshoptDecoder` and ensured each GLTF loader calls `loader.setMeshoptDecoder(MeshoptDecoder)` where compressed assets are expected.
- Added/reused a shared `KTX2Loader` instance and `loader.setKTX2Loader(sharedKtx2Loader)` pattern (with `setTranscoderPath`) to detect KTX2 support through a renderer and avoid duplicated workers in `SnakeBoard3D` and `AirHockey3D`.
- Introduced `createConfiguredGltfLoader` helper in `AirHockey3D.jsx` (and standardized similar loaders in other files) that sets `DRACOLoader` with `draco.setDecoderPath(DRACO_DECODER_PATH)`, `loader.setCrossOrigin('anonymous')`, `loader.setMeshoptDecoder(...)`, and attaches the shared KTX2 loader.
- Files modified: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, `webapp/src/pages/Games/ChessBattleRoyal.jsx`, `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, `webapp/src/components/SnakeBoard3D.jsx`, and `webapp/src/components/AirHockey3D.jsx`.

### Testing
- Ran `npx eslint` on the changed files which returned only warnings related to repo ignore configuration and no new lint errors (warnings reported when using `--no-ignore`).
- Ran the TypeScript build with `npm run build`, which failed due to an existing unrelated type error in `src/rules/SnookerRoyalRules.ts` and not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6643828d4832987039c1b4e1042d1)