### PR TITLE
Fix Pool Royale shot release to reliably trigger cue-ball launch

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -232,7 +232,15 @@ export class PowerSlider {
   _pointerUp(e) {
     if (!this.dragging) return;
     this.dragging = false;
-    this.el.releasePointerCapture(e.pointerId);
+    try {
+      if (e?.pointerId != null && this.el.hasPointerCapture?.(e.pointerId)) {
+        this.el.releasePointerCapture(e.pointerId);
+      }
+    } catch {
+      // Some mobile browsers can emit pointerup/pointercancel after capture has
+      // already been released. We still need to finish the commit path so shots
+      // fire reliably when the player releases the slider.
+    }
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.removeEventListener('pointercancel', this._onPointerCancel);

--- a/test/powerSlider.test.js
+++ b/test/powerSlider.test.js
@@ -1,0 +1,47 @@
+import { PowerSlider } from '../power-slider.js';
+
+describe('PowerSlider pointer release commit path', () => {
+  const buildSlider = ({ throwOnRelease = false } = {}) => {
+    const listeners = new Map();
+    const committed = [];
+    const slider = Object.create(PowerSlider.prototype);
+    slider.dragging = true;
+    slider.dragMoved = true;
+    slider.dragStartValue = 0;
+    slider.value = 60;
+    slider.min = 0;
+    slider.max = 100;
+    slider.onCommit = (value) => committed.push(value);
+    slider.set = jest.fn();
+    slider.el = {
+      hasPointerCapture: jest.fn(() => true),
+      releasePointerCapture: jest.fn(() => {
+        if (throwOnRelease) {
+          throw new Error('capture missing');
+        }
+      }),
+      removeEventListener: jest.fn((type, cb) => {
+        listeners.set(type, cb);
+      }),
+      classList: {
+        remove: jest.fn()
+      }
+    };
+    slider._onPointerMove = () => {};
+    slider._onPointerUp = () => {};
+    slider._onPointerCancel = () => {};
+    return { slider, committed };
+  };
+
+  test('commits shot when pointer capture releases normally', () => {
+    const { slider, committed } = buildSlider();
+    slider._pointerUp({ pointerId: 11 });
+    expect(committed).toEqual([60]);
+  });
+
+  test('still commits shot when releasePointerCapture throws', () => {
+    const { slider, committed } = buildSlider({ throwOnRelease: true });
+    expect(() => slider._pointerUp({ pointerId: 7 })).not.toThrow();
+    expect(committed).toEqual([60]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Players reported the cue ball sometimes stayed still because releasing the power slider did not always trigger the shot, caused by pointer-capture release edge-cases on some browsers/devices.

### Description
- Guard `releasePointerCapture` in `PowerSlider._pointerUp` with a `hasPointerCapture` check and `try/catch` so exceptions no longer abort the release cleanup or the commit path.
- Ensure cleanup (`removeEventListener`, `classList` updates) and the commit decision always run after pointer release even if `releasePointerCapture` throws.
- Add a focused unit test `test/powerSlider.test.js` that verifies `onCommit` is invoked both when `releasePointerCapture` succeeds and when it throws.

### Testing
- Ran `npm test -- powerSlider.test.js --runInBand` and the suite passed (both tests passed).
- Ran `npm test -- poolRoyaleCueStrokeTimeline.test.js --runInBand` and the cue stroke timeline tests passed.
- Ran `npm test -- poolAi.test.js -t "cue ball remains within table bounds" --runInBand` and the targeted AI cue-ball bounds test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)