### PR TITLE
Include all Murlan table and chair themes in Domino Royal store and defaults

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -10,6 +10,7 @@ import {
   LUDO_BATTLE_STORE_ITEMS
 } from '../webapp/src/config/ludoBattleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
+import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 
 describe('cross-game inventory alignment', () => {
   test('domino default table follows chess default murlan table', () => {
@@ -28,5 +29,23 @@ describe('cross-game inventory alignment', () => {
 
     expect(tableIds).toEqual(new Set(MURLAN_TABLE_THEMES.map((theme) => theme.id)));
     expect(stoolIds).toEqual(new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id)));
+  });
+
+  test('domino store and defaults contain every murlan table and chair theme', () => {
+    const tableStoreIds = new Set(
+      DOMINO_ROYAL_STORE_ITEMS.filter((item) => item.type === 'tableTheme').map((item) => item.optionId)
+    );
+    const chairStoreIds = new Set(
+      DOMINO_ROYAL_STORE_ITEMS.filter((item) => item.type === 'chairTheme').map((item) => item.optionId)
+    );
+
+    expect(tableStoreIds).toEqual(new Set(MURLAN_TABLE_THEMES.map((theme) => theme.id)));
+    expect(chairStoreIds).toEqual(new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id)));
+    expect(new Set(DOMINO_ROYAL_DEFAULT_UNLOCKS.tableTheme)).toEqual(
+      new Set(MURLAN_TABLE_THEMES.map((theme) => theme.id))
+    );
+    expect(new Set(DOMINO_ROYAL_DEFAULT_UNLOCKS.chairTheme)).toEqual(
+      new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id))
+    );
   });
 });

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -88,11 +88,11 @@ const getDominoDefaultOptionId = (type) => {
 export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze({
   tableWood: [getDominoDefaultOptionId('tableWood')].filter(Boolean),
   tableCloth: [getDominoDefaultOptionId('tableCloth')].filter(Boolean),
-  tableTheme: [getDominoDefaultOptionId('tableTheme')].filter(Boolean),
+  tableTheme: DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option) => option.id),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   dominoStyle: [getDominoDefaultOptionId('dominoStyle')].filter(Boolean),
   highlightStyle: [getDominoDefaultOptionId('highlightStyle')].filter(Boolean),
-  chairTheme: [getDominoDefaultOptionId('chairTheme')].filter(Boolean)
+  chairTheme: DOMINO_ROYAL_OPTION_SETS.chairTheme.map((option) => option.id)
 });
 
 export const DOMINO_ROYAL_OPTION_LABELS = Object.freeze(
@@ -126,7 +126,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     description: option.description || 'Unlock a new felt tone for the Domino Royal table surface.',
     thumbnail: option.swatches?.length ? swatchThumbnail(option.swatches) : DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
   })),
-  ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
+  ...DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option, idx) => ({
     id: `domino-table-theme-${option.id}`,
     type: 'tableTheme',
     optionId: option.id,
@@ -162,7 +162,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     description: 'Unlocks a new tracer highlight for the table setup.',
     thumbnail: DOMINO_HIGHLIGHT_THUMBNAILS[option.id]
   })),
-  ...DOMINO_ROYAL_OPTION_SETS.chairTheme.slice(1).map((option, idx) => ({
+  ...DOMINO_ROYAL_OPTION_SETS.chairTheme.map((option, idx) => ({
     id: `domino-chair-${option.id}`,
     type: 'chairTheme',
     optionId: option.id,


### PR DESCRIPTION
### Motivation
- Ensure Domino Royal exposes the same Murlan table and chair theme catalog as other games so players can access identical furniture sets across games.
- Prevent missing/default items in Domino store and inventory that cause cross-game inconsistency.

### Description
- Updated `webapp/src/config/dominoRoyalInventoryConfig.js` so `DOMINO_ROYAL_DEFAULT_UNLOCKS.tableTheme` and `chairTheme` map to the full Murlan option ID lists instead of a single default entry.
- Changed Domino store generation in `DOMINO_ROYAL_STORE_ITEMS` to include every `tableTheme` and `chairTheme` option (removed the `.slice(1)` that skipped defaults).
- Extended `test/inventoryCrossGameConfig.test.js` to import `DOMINO_ROYAL_STORE_ITEMS` and add assertions that Domino store items and default unlocks fully match `MURLAN_TABLE_THEMES` and `MURLAN_STOOL_THEMES`.

### Testing
- Ran the cross-game inventory tests with `npm test -- test/inventoryCrossGameConfig.test.js --runInBand` and observed all tests pass.
- Test results: `PASS test/inventoryCrossGameConfig.test.js` with 3 tests passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667a028b48329a4a964239e15d5bf)