### PR TITLE
Fix Pool Royale cue shot fallback so cue ball always launches

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,35 @@
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,11 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -24707,12 +24712,7 @@ const powerRef = useRef(hud.power);
         }
         return { side, vert, hasSpin };
       };
-      const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
-      };
+      const applyShotAtImpact = (payload) => applyShotImpact(payload);
 
       const animatePowerSliderReturn = (durationMs = 320) => {
         const slider = sliderInstanceRef.current;
@@ -25092,10 +25092,11 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            startTime + Math.max(40, strikeDuration * 0.85)
+          );
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,22 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+


### PR DESCRIPTION
### Motivation
- The cue-ball sometimes failed to launch because the cue-stroke impact callback could be missed, leaving the shot un-applied and the cue ball stationary. 
- Make shot application robust and idempotent so a missed animation callback cannot prevent the physics impulse from being applied.

### Description
- Added a small helper module `webapp/src/pages/Games/cueShotImpact.js` exposing `createShotImpactPayload`, `applyShotImpact`, and `createShotImpactFallback` to centralize idempotent shot launch logic. 
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to use the new helper and register a timed fallback (`pendingImpactRef.current`) when a shot starts so the launch is applied even if the stroke impact event is missed. 
- Added `test/cueShotImpact.test.js`, a focused Jest unit test verifying the shot launch is applied exactly once and that the fallback applies the queued shot idempotently. 

### Testing
- Ran the targeted unit test with `npm test -- --runInBand test/cueShotImpact.test.js`, and the test suite passed.  
- Verified the test results: 1 test suite, 2 tests passed (idempotent apply + fallback behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)