### PR TITLE
Extract cue shot impact logic into cueShotImpact module and add unit tests

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,46 @@
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+
+  test('does not resolve shot while cue impact is still pending', () => {
+    expect(shouldResolveShot({ anyBallMoving: false, impactPending: true })).toBe(false);
+    expect(shouldResolveShot({ anyBallMoving: true, impactPending: true })).toBe(false);
+  });
+
+  test('resolves only after impact is applied and all balls are stopped', () => {
+    expect(shouldResolveShot({ anyBallMoving: true, impactPending: false })).toBe(false);
+    expect(shouldResolveShot({ anyBallMoving: false, impactPending: false })).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,12 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -24707,12 +24713,7 @@ const powerRef = useRef(hud.power);
         }
         return { side, vert, hasSpin };
       };
-      const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
-      };
+      const applyShotAtImpact = (payload) => applyShotImpact(payload);
 
       const animatePowerSliderReturn = (durationMs = 320) => {
         const slider = sliderInstanceRef.current;
@@ -25092,10 +25093,11 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            startTime + Math.max(40, strikeDuration * 0.85)
+          );
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -30427,7 +30429,11 @@ const powerRef = useRef(hud.power);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            const stroke = cueStrokeStateRef.current;
+            const impactPending = Boolean(
+              pendingImpactRef.current || (stroke && !stroke.shotApplied)
+            );
+            if (shouldResolveShot({ anyBallMoving: any, impactPending })) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,27 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+
+
+export function shouldResolveShot({ anyBallMoving, impactPending }) {
+  if (impactPending) return false;
+  return !anyBallMoving;
+}


### PR DESCRIPTION
### Motivation

- Centralize cue-shot impact orchestration into a small reusable module to simplify `PoolRoyale` shot handling and make impact behavior easier to test.
- Replace inline impact payload/fallback logic with explicit helpers to improve readability and reduce duplication.
- Make shot resolution logic explicit by accounting for pending impact state when deciding to call `resolve()`.

### Description

- Added a new module `webapp/src/pages/Games/cueShotImpact.js` that exports `createShotImpactPayload`, `applyShotImpact`, `createShotImpactFallback`, and `shouldResolveShot` to encapsulate impact payload creation, application, fallback scheduling, and resolution checks.
- Updated `PoolRoyale.jsx` to import and use the new helpers: `applyShotImpact` replaces the inline `applyShotAtImpact`, impact payloads are created with `createShotImpactPayload`, pending fallbacks are constructed with `createShotImpactFallback`, and shot resolution uses `shouldResolveShot` to consider whether an impact is still pending.
- Added unit tests in `test/cueShotImpact.test.js` covering payload creation, idempotent application, fallback behavior, and the `shouldResolveShot` decision logic.

### Testing

- Added `test/cueShotImpact.test.js` with Jest unit tests for the new impact helpers and orchestration scenarios.
- Ran the test suite with `npm test` (Jest); the new `cueShotImpact` tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)