### PR TITLE
Extract cue shot impact logic into module and integrate into PoolRoyale

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,42 @@
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+
+  test('resolves only after the shot impact was applied', () => {
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: false })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: true, shotApplied: true })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: true })).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,12 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -15105,6 +15111,7 @@ const powerRef = useRef(hud.power);
     moved: false
   });
   const pendingImpactRef = useRef(null);
+  const shotImpactAppliedRef = useRef(false);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
@@ -24708,10 +24715,11 @@ const powerRef = useRef(hud.power);
         return { side, vert, hasSpin };
       };
       const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
+        const applied = applyShotImpact(payload);
+        if (applied) {
+          shotImpactAppliedRef.current = true;
+        }
+        return applied;
       };
 
       const animatePowerSliderReturn = (durationMs = 320) => {
@@ -24807,6 +24815,7 @@ const powerRef = useRef(hud.power);
           }
         };
         setShootingState(true);
+        shotImpactAppliedRef.current = false;
         powerImpactHoldRef.current = Math.max(
           powerImpactHoldRef.current || 0,
           shotStartTime + CAMERA_SWITCH_MIN_HOLD_MS
@@ -25092,10 +25101,11 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            startTime + Math.max(40, strikeDuration * 0.85)
+          );
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -30427,7 +30437,10 @@ const powerRef = useRef(hud.power);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            if (shouldResolveShot({
+              hasAnyMotion: any,
+              shotApplied: shotImpactAppliedRef.current
+            })) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,26 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+
+
+export function shouldResolveShot({ hasAnyMotion, shotApplied }) {
+  return Boolean(shotApplied) && !Boolean(hasAnyMotion);
+}


### PR DESCRIPTION
### Motivation

- Centralize and harden the shot-impact orchestration so a queued shot is applied exactly once and resolution waits until the shot has been applied and motion has stopped.

### Description

- Add `webapp/src/pages/Games/cueShotImpact.js` exporting `createShotImpactPayload`, `applyShotImpact`, `createShotImpactFallback`, and `shouldResolveShot` to encapsulate idempotent shot application and time-based fallback behavior.
- Update `PoolRoyale.jsx` to import the new helpers, add `shotImpactAppliedRef`, use `applyShotImpact` inside `applyShotAtImpact`, reset the ref when a shot starts, and create the queued fallback with `createShotImpactFallback` and `createShotImpactPayload`.
- Replace the previous inline payload handling and the simple motion check with `shouldResolveShot({ hasAnyMotion, shotApplied })` to determine when to call `resolve`.
- Preserve existing behavior while making shot application idempotent and easier to reason about across the codebase.

### Testing

- Added unit tests in `test/cueShotImpact.test.js` that verify idempotent application, fallback execution, and `shouldResolveShot` decision logic.
- Ran the test suite with `npm test` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)