### PR TITLE
Extract cue shot impact logic, add fallback and unit tests

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,42 @@
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  resolveShotImpactTime
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('impact fallback timing uses start + 85% strike duration with floor', () => {
+    expect(resolveShotImpactTime(1000, 200)).toBe(1170);
+    expect(resolveShotImpactTime(1000, 10)).toBe(1040);
+    expect(resolveShotImpactTime(Number.NaN, 200)).toBeNull();
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,12 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  resolveShotImpactTime
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -24707,12 +24713,7 @@ const powerRef = useRef(hud.power);
         }
         return { side, vert, hasSpin };
       };
-      const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
-      };
+      const applyShotAtImpact = (payload) => applyShotImpact(payload);
 
       const animatePowerSliderReturn = (durationMs = 320) => {
         const slider = sliderInstanceRef.current;
@@ -25092,10 +25093,7 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25194,6 +25192,10 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            resolveShotImpactTime(startTime, strikeDuration)
+          );
           const impactPos = idlePos.clone();
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,28 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function resolveShotImpactTime(startTimeMs, strikeDurationMs) {
+  if (!Number.isFinite(startTimeMs)) return null;
+  const strikeDuration = Number.isFinite(strikeDurationMs) ? strikeDurationMs : 0;
+  return startTimeMs + Math.max(40, strikeDuration * 0.85);
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+


### PR DESCRIPTION
### Motivation

- Centralize and reuse the cue shot impact behavior that was previously implemented inline in `PoolRoyale.jsx` to reduce duplication and improve testability.
- Ensure the shot application is idempotent so a queued shot cannot be launched more than once.
- Provide a deterministic fallback timing calculation for impact-based queuing to avoid missing an impact when timing values are noisy.

### Description

- Added a new module `webapp/src/pages/Games/cueShotImpact.js` that exports `createShotImpactPayload`, `applyShotImpact`, `resolveShotImpactTime`, and `createShotImpactFallback` to encapsulate impact payload creation, idempotent application, timing resolution, and fallback objects.
- Replaced the inline `applyShotAtImpact` helper and the ad-hoc `shotImpactPayload` object in `PoolRoyale.jsx` with calls to `applyShotImpact` and `createShotImpactPayload`, and wire `pendingImpactRef.current` using `createShotImpactFallback` and `resolveShotImpactTime`.
- Added unit tests in `test/cueShotImpact.test.js` that validate single-application behavior, timing computation (85% of strike duration with a 40ms floor), and fallback execution/idempotency.

### Testing

- Ran the new unit tests with `yarn test test/cueShotImpact.test.js` and the tests for `cueShotImpact` passed. 
- Executed the project test suite with `yarn test` and the full suite completed successfully (no regressions found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)