### PR TITLE
Add cue shot impact orchestration and fallback timing to PoolRoyale

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,67 @@
+import {
+  applyShotImpact,
+  computeImpactFallbackTime,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+
+  test('resolves only after the shot impact was applied', () => {
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: false })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: true, shotApplied: true })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: true })).toBe(true);
+  });
+
+  test('computes fallback impact timing using pullback + strike threshold', () => {
+    const startTime = 1000;
+    const at = computeImpactFallbackTime({
+      startTime,
+      pullbackDuration: 60,
+      strikeDuration: 200,
+      impactThreshold: 0.92,
+      minDelayMs: 40
+    });
+    expect(at).toBe(1244);
+  });
+
+  test('fallback timing enforces minimum delay when stroke durations are tiny', () => {
+    const at = computeImpactFallbackTime({
+      startTime: 500,
+      pullbackDuration: 0,
+      strikeDuration: 10,
+      impactThreshold: 0.1,
+      minDelayMs: 40
+    });
+    expect(at).toBe(540);
+  });
+
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,13 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  computeImpactFallbackTime,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -15105,6 +15112,7 @@ const powerRef = useRef(hud.power);
     moved: false
   });
   const pendingImpactRef = useRef(null);
+  const shotImpactAppliedRef = useRef(false);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
@@ -24708,10 +24716,11 @@ const powerRef = useRef(hud.power);
         return { side, vert, hasSpin };
       };
       const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
+        const applied = applyShotImpact(payload);
+        if (applied) {
+          shotImpactAppliedRef.current = true;
+        }
+        return applied;
       };
 
       const animatePowerSliderReturn = (durationMs = 320) => {
@@ -24807,6 +24816,7 @@ const powerRef = useRef(hud.power);
           }
         };
         setShootingState(true);
+        shotImpactAppliedRef.current = false;
         powerImpactHoldRef.current = Math.max(
           powerImpactHoldRef.current || 0,
           shotStartTime + CAMERA_SWITCH_MIN_HOLD_MS
@@ -25092,10 +25102,18 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
+          const impactFallbackTime = computeImpactFallbackTime({
+            startTime,
+            pullbackDuration,
+            strikeDuration,
+            impactThreshold: 0.92,
+            minDelayMs: 40
+          });
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            impactFallbackTime
+          );
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25325,7 +25343,7 @@ const powerRef = useRef(hud.power);
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
-              strikeImpactThreshold: 1,
+              strikeImpactThreshold: 0.92,
               forwardOnly: false,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
@@ -30427,7 +30445,10 @@ const powerRef = useRef(hud.power);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            if (shouldResolveShot({
+              hasAnyMotion: any,
+              shotApplied: shotImpactAppliedRef.current
+            })) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,43 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+
+
+export function shouldResolveShot({ hasAnyMotion, shotApplied }) {
+  return Boolean(shotApplied) && !Boolean(hasAnyMotion);
+}
+
+export function computeImpactFallbackTime({
+  startTime,
+  pullbackDuration = 0,
+  strikeDuration = 0,
+  impactThreshold = 0.92,
+  minDelayMs = 40
+}) {
+  if (!Number.isFinite(startTime)) return null;
+  const safePullback = Number.isFinite(pullbackDuration) ? Math.max(0, pullbackDuration) : 0;
+  const safeStrike = Number.isFinite(strikeDuration) ? Math.max(0, strikeDuration) : 0;
+  const safeThreshold = Number.isFinite(impactThreshold)
+    ? Math.min(Math.max(impactThreshold, 0), 1)
+    : 0.92;
+  const safeMinDelay = Number.isFinite(minDelayMs) ? Math.max(0, minDelayMs) : 40;
+  return startTime + Math.max(safeMinDelay, safePullback + safeStrike * safeThreshold);
+}


### PR DESCRIPTION
### Motivation

- Centralize and harden the logic that triggers a shot launch on cue impact and provide a timing fallback to avoid stuck shots.
- Ensure the shot-launch is idempotent and that the game only resolves a shot after the impact has been applied and motion has ceased.

### Description

- Added a new module `webapp/src/pages/Games/cueShotImpact.js` exporting `createShotImpactPayload`, `applyShotImpact`, `createShotImpactFallback`, `computeImpactFallbackTime`, and `shouldResolveShot` to encapsulate payload creation, idempotent application, fallback scheduling, and resolve conditions. 
- Integrated the new module into `PoolRoyale.jsx` by importing the functions, replacing inline payload logic with `createShotImpactPayload`, using `applyShotImpact` inside `applyShotAtImpact`, and storing `pendingImpactRef` via `createShotImpactFallback` computed with `computeImpactFallbackTime`. 
- Added `shotImpactAppliedRef` to track whether the shot was applied, reset at shot start, and changed the shot resolution condition to use `shouldResolveShot` so a shot only resolves when applied and motion has stopped. 
- Tuned stroke impact threshold to `0.92` and enforced a minimum fallback delay via `computeImpactFallbackTime` to avoid premature fallback application.
- Added unit tests in `test/cueShotImpact.test.js` that cover idempotent application, fallback execution and timing, resolve condition behavior, and minimum delay enforcement.

### Testing

- Ran the new unit test file `test/cueShotImpact.test.js` under the Jest test runner, and all tests passed. 
- Existing behavior paths exercised by the test cover idempotence of `applyShotImpact`, fallback creation via `createShotImpactFallback`, `shouldResolveShot` logic, and `computeImpactFallbackTime` calculations which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)