### PR TITLE
Add cue shot impact orchestration module and integrate into PoolRoyale shot lifecycle

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,0 +1,42 @@
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from '../webapp/src/pages/Games/cueShotImpact.js';
+
+describe('cue shot impact orchestration', () => {
+  test('applies shot exactly once when impact triggers', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+
+    expect(applyShotImpact(payload)).toBe(true);
+    expect(applyShotImpact(payload)).toBe(false);
+    expect(launchCount).toBe(1);
+  });
+
+  test('fallback executes queued shot and remains idempotent', () => {
+    let launchCount = 0;
+    const payload = createShotImpactPayload(() => {
+      launchCount += 1;
+    });
+    const fallback = createShotImpactFallback(payload, 1337);
+
+    expect(fallback).toBeTruthy();
+    expect(fallback.time).toBe(1337);
+
+    fallback.apply();
+    fallback.apply();
+
+    expect(launchCount).toBe(1);
+    expect(payload.applied).toBe(true);
+  });
+
+  test('resolves only after the shot impact was applied', () => {
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: false })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: true, shotApplied: true })).toBe(false);
+    expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: true })).toBe(true);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -112,6 +112,12 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload,
+  shouldResolveShot
+} from './cueShotImpact.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
@@ -15105,6 +15111,7 @@ const powerRef = useRef(hud.power);
     moved: false
   });
   const pendingImpactRef = useRef(null);
+  const shotImpactAppliedRef = useRef(false);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
@@ -24708,10 +24715,11 @@ const powerRef = useRef(hud.power);
         return { side, vert, hasSpin };
       };
       const applyShotAtImpact = (payload) => {
-        if (!payload || payload.applied) return;
-        payload.applied = true;
-        const { launchShot } = payload;
-        launchShot?.();
+        const applied = applyShotImpact(payload);
+        if (applied) {
+          shotImpactAppliedRef.current = true;
+        }
+        return applied;
       };
 
       const animatePowerSliderReturn = (durationMs = 320) => {
@@ -24807,6 +24815,7 @@ const powerRef = useRef(hud.power);
           }
         };
         setShootingState(true);
+        shotImpactAppliedRef.current = false;
         powerImpactHoldRef.current = Math.max(
           powerImpactHoldRef.current || 0,
           shotStartTime + CAMERA_SWITCH_MIN_HOLD_MS
@@ -25092,10 +25101,11 @@ const powerRef = useRef(hud.power);
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
           };
-          const shotImpactPayload = {
-            applied: false,
-            launchShot
-          };
+          const shotImpactPayload = createShotImpactPayload(launchShot);
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            startTime + Math.max(40, strikeDuration * 0.98)
+          );
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25325,8 +25335,8 @@ const powerRef = useRef(hud.power);
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
-              strikeImpactThreshold: 1,
-              forwardOnly: false,
+              strikeImpactThreshold: 0.98,
+              forwardOnly: true,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               onImpact: () => applyShotAtImpact(shotImpactPayload)
@@ -30427,7 +30437,10 @@ const powerRef = useRef(hud.power);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            if (shouldResolveShot({
+              hasAnyMotion: any,
+              shotApplied: shotImpactAppliedRef.current
+            })) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -1,0 +1,26 @@
+export function createShotImpactPayload(launchShot) {
+  return {
+    applied: false,
+    launchShot
+  };
+}
+
+export function applyShotImpact(payload) {
+  if (!payload || payload.applied) return false;
+  payload.applied = true;
+  payload.launchShot?.();
+  return true;
+}
+
+export function createShotImpactFallback(payload, impactAtMs) {
+  if (!Number.isFinite(impactAtMs)) return null;
+  return {
+    time: impactAtMs,
+    apply: () => applyShotImpact(payload)
+  };
+}
+
+
+export function shouldResolveShot({ hasAnyMotion, shotApplied }) {
+  return Boolean(shotApplied) && !Boolean(hasAnyMotion);
+}


### PR DESCRIPTION
### Motivation

- Make shot application idempotent and separable from animation timing so shots are launched exactly once even when triggered from multiple places.
- Provide a fallback timed application for impacts that must fire after a specified interval to avoid stuck shot states.
- Ensure shot resolution only happens when the shot was applied and all motion has stopped to avoid premature scene resolves.

### Description

- Added `webapp/src/pages/Games/cueShotImpact.js` containing `createShotImpactPayload`, `applyShotImpact`, `createShotImpactFallback`, and `shouldResolveShot` to encapsulate idempotent shot application and timed fallbacks.
- Integrated the new module into `PoolRoyale.jsx` by importing the functions, adding `shotImpactAppliedRef`, using `applyShotImpact` in `applyShotAtImpact`, creating a pending fallback via `createShotImpactFallback`, and resetting `shotImpactAppliedRef` when a shot starts.
- Updated cue stroke behavior by lowering `strikeImpactThreshold` to `0.98` and enabling `forwardOnly` for the stroke animation path.
- Replaced the previous motion-only resolve check with `shouldResolveShot({ hasAnyMotion, shotApplied })` so resolves occur only after the shot was applied and motion has ceased.

### Testing

- Added unit tests in `test/cueShotImpact.test.js` that exercise idempotent application, fallback execution, and the `shouldResolveShot` predicate.
- Ran the unit tests (targeting the cue shot impact tests) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667062e008329a787a231575023ed)