### PR TITLE
Adjust Texas Hold'em landscape camera proximity and vertical look range

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,9 +390,11 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.94, landscape: 0.9 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.94, landscape: 0.82 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.24 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
+const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
+const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
 const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * 0.52, landscape: -CARD_W * 0.52 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
@@ -4377,7 +4379,13 @@ function TexasHoldemArena({ search }) {
       const targetUp = WORLD_UP.clone().applyQuaternion(targetQuaternion).normalize();
       const targetForward = focus.clone().sub(position).normalize();
       const targetRight = new THREE.Vector3().crossVectors(targetForward, targetUp).normalize();
-      const pitchLimits = computeCameraPitchLimits(position, targetForward, { seatTopPoint });
+      const computedPitchLimits = computeCameraPitchLimits(position, targetForward, { seatTopPoint });
+      const pitchLimits = portrait
+        ? computedPitchLimits
+        : {
+          min: Math.min(computedPitchLimits.min, -CAMERA_LANDSCAPE_MIN_LOOK_UP),
+          max: Math.max(computedPitchLimits.max, CAMERA_LANDSCAPE_MAX_LOOK_DOWN)
+        };
       cameraBasisRef.current = {
         position: position.clone(),
         baseForward: targetForward,


### PR DESCRIPTION
### Motivation

- Landscape seated view should sit slightly closer to the table for a better at-table feel while leaving portrait behavior untouched.
- Players must be able to look up and down when seated in landscape mode to improve viewing flexibility and UX.

### Description

- Reduced the landscape seated camera retreat offset in `webapp/src/pages/Games/TexasHoldemArena.jsx` from `0.90` to `0.82` to pull the camera a bit closer to the table.
- Added `CAMERA_LANDSCAPE_MIN_LOOK_UP` and `CAMERA_LANDSCAPE_MAX_LOOK_DOWN` constants and applied them so landscape pitch bounds are explicitly expanded while portrait limits remain unchanged.
- Kept portrait offsets and pitch computation path untouched and only override pitch limits when `portrait === false` to preserve existing portrait behavior.

### Testing

- Ran `npx vite build` in `webapp/` which completed successfully.
- Ran `npm run build` (project build) which also completed successfully.
- Attempted an automated headless screenshot via Playwright to validate the visual change, but the Playwright run timed out in this environment (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a68abbcccc8329bfeecf57ae324f49)