### PR TITLE
Lock Texas Hold'em to landscape and adjust camera framing

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.94, landscape: 0.82 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.24 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.94, landscape: 0.74 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.16 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
@@ -4199,6 +4199,7 @@ function TexasHoldemArena({ search }) {
   useEffect(() => {
     const mount = mountRef.current;
     if (!mount) return;
+    screen.orientation?.lock?.('landscape').catch(() => {});
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
     applyRendererSRGB(renderer);
     renderer.shadowMap.enabled = true;


### PR DESCRIPTION
### Motivation
- Ensure the Texas Hold'em arena opens in landscape-only so the table UI matches the requested orientation and onboarding expectations.
- Improve visual framing by bringing the seated camera slightly closer to the table and a bit lower for better player focus in landscape mode.

### Description
- Added an orientation lock on mount using `screen.orientation?.lock?.('landscape')` inside the Texas Hold'em arena mount `useEffect` to prefer landscape presentation. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Reduced the seated landscape retreat offset from `0.82` to `0.74` in `CAMERA_RETREAT_OFFSETS` to move the camera closer to the table. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Reduced the seated landscape elevation offset from `1.24` to `1.16` in `CAMERA_ELEVATION_OFFSETS` to lower the camera slightly. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)

### Testing
- Ran the unit tests with `npm test -- --runInBand test/texasHoldemGame.test.js`, and the suite passed. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx`, which returned only repository-ignore warnings and no lint errors.
- Launched the dev server and captured a headless browser screenshot of `/games/texasholdem` to validate the landscape framing visually using an automated Playwright script, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6915a00888329a72fb22f9dc83d2f)