### PR TITLE
Tune Pool Royale cue/camera replay flow and cushion bounce

### DIFF
--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -5,7 +5,7 @@ public static class PhysicsConstants
 {
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.915;           // elastic coefficient (clean cushion hits 0.85–0.92)
-    public const double CushionRestitution = Restitution; // use the same restitution for cushions
+    public const double CushionRestitution = 0.93; // slightly livelier cushions for a touch more bounce
     // connectors retain only a quarter of the cushion bounce (lose ~75% of speed)
     public const double ConnectorRestitution = CushionRestitution * 0.25;
     // pocket edges fully absorb balls (no bounce)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5431,7 +5431,7 @@ const REPLAY_BANNER_VARIANTS = {
 const REPLAY_TRAIL_HEIGHT = BALL_CENTER_Y + BALL_R * 0.3;
 const REPLAY_TRAIL_COLOR = 0xffffff;
 const REPLAY_CUE_RETURN_WINDOW_MS = 480;
-const REPLAY_CUE_START_HOLD_MS = 320;
+const REPLAY_CUE_START_HOLD_MS = 420;
 const RAIL_NEAR_BUFFER = BALL_R * 3.5;
 const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 12; // keep camera in standing view for close shots
 const SHORT_RAIL_POCKET_TRIGGER =
@@ -5468,7 +5468,8 @@ const PLAYER_CUE_RELEASE_DURATION_MS = 1320;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
 const REPLAY_CUE_STROKE_SLOWDOWN = 2.25;
-const REPLAY_CUE_STROKE_LEAD_IN_MS = 340; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
+const REPLAY_CUE_STROKE_LEAD_IN_MS = 420; // start replay cue motion earlier so pullback is clearly visible from the first replay frame
+const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1.25; // slightly stretch the forward push so the strike is readable in replay
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
@@ -21136,7 +21137,7 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return true;
           };
-          if (hasCueSnapshots) {
+          if (hasCueSnapshots && !stroke) {
             applyCueSnapshot();
             return;
           }
@@ -21282,7 +21283,7 @@ const powerRef = useRef(hud.power);
                   stroke.forward ??
                   stroke.forwardDuration ??
                   0
-              ) * replayScale
+              ) * replayScale * REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER
             );
           let followTime =
             Math.max(
@@ -21750,6 +21751,21 @@ const powerRef = useRef(hud.power);
 
         const primeReplayCueStick = (playback) => {
           if (!cueStick) return;
+          const cueSnapshot = playback?.frames?.[0]?.cue ?? null;
+          if (cueSnapshot?.position) {
+            const pos = normalizeVector3Snapshot(cueSnapshot.position);
+            if (pos) {
+              cueStick.position.set(pos.x, pos.y, pos.z);
+              const quat = normalizeQuaternionSnapshot(cueSnapshot.rotation);
+              if (quat) {
+                cueStick.quaternion.set(quat.x, quat.y, quat.z, quat.w);
+              }
+              cueStick.visible = cueSnapshot.visible ?? true;
+              cueAnimating = cueStick.visible;
+              syncCueShadow();
+              return;
+            }
+          }
           const stroke = playback?.cueStroke ?? null;
           if (stroke) {
             const idleSnap =
@@ -21765,21 +21781,6 @@ const powerRef = useRef(hud.power);
               }
               cueStick.visible = true;
               cueAnimating = true;
-              syncCueShadow();
-              return;
-            }
-          }
-          const cueSnapshot = playback?.frames?.[0]?.cue ?? null;
-          if (cueSnapshot?.position) {
-            const pos = normalizeVector3Snapshot(cueSnapshot.position);
-            if (pos) {
-              cueStick.position.set(pos.x, pos.y, pos.z);
-              const quat = normalizeQuaternionSnapshot(cueSnapshot.rotation);
-              if (quat) {
-                cueStick.quaternion.set(quat.x, quat.y, quat.z, quat.w);
-              }
-              cueStick.visible = cueSnapshot.visible ?? true;
-              cueAnimating = cueStick.visible;
               syncCueShadow();
               return;
             }
@@ -25159,10 +25160,9 @@ const powerRef = useRef(hud.power);
               forceImmediateRailOverheadView ||
               (!earlyPocketView && !suppressPocketCameras);
             const shouldActivateActionView =
-              forceImmediateRailOverheadView ||
-              (!requiresCueBallMovementTrigger &&
-                (!isLongShot || forceActionActivation) &&
-                !isMaxPowerShot);
+              !requiresCueBallMovementTrigger &&
+              (!isLongShot || forceActionActivation) &&
+              !isMaxPowerShot;
             if (shouldActivateActionView && (!holdActive || forceImmediateRailOverheadView)) {
               actionView.pendingActivation = false;
               actionView.activationDelay = null;
@@ -28167,7 +28167,9 @@ const powerRef = useRef(hud.power);
               startAiThinkingRef.current?.();
             }
           }, 0);
-          if (cameraRef.current && sphRef.current) {
+          const shouldAutoRecenterAfterShot =
+            !(hudRef.current?.turn === 0 && !hudRef.current?.over);
+          if (shouldAutoRecenterAfterShot && cameraRef.current && sphRef.current) {
             const cuePos = cue?.pos
               ? new THREE.Vector2(cue.pos.x, cue.pos.y)
               : new THREE.Vector2();
@@ -29944,49 +29946,6 @@ const powerRef = useRef(hud.power);
                 0,
                 1
               );
-              const shouldForceCornerPocketView =
-                !suppressPocketCameras &&
-                !topViewRef.current &&
-                pocketIndex < 4;
-              if (shouldForceCornerPocketView) {
-                const sph = sphRef.current;
-                const resumeView = sph
-                  ? { orbitSnapshot: { radius: sph.radius, phi: sph.phi, theta: sph.theta } }
-                  : null;
-                const forcedCornerView = makePocketCameraView(b.id, resumeView, {
-                  forceCornerCapture: true,
-                  pocketCenterOverride: c
-                });
-                const shouldSwapView =
-                  forcedCornerView &&
-                  (!activeShotView ||
-                    activeShotView.mode !== 'pocket' ||
-                    activeShotView.ballId !== b.id);
-                if (shouldSwapView) {
-                  forcedCornerView.lastUpdate = performance.now();
-                  if (cameraRef.current) {
-                    const cam = cameraRef.current;
-                    forcedCornerView.smoothedPos = cam.position.clone();
-                    const storedTarget = lastCameraTargetRef.current?.clone();
-                    if (storedTarget) {
-                      forcedCornerView.smoothedTarget = storedTarget;
-                    }
-                  }
-                  if (pocketHoldActive) {
-                    queuedPocketView = forcedCornerView;
-                    queuedPocketView.pendingActivation = true;
-                  } else {
-                    if (activeShotView?.mode === 'action') {
-                      suspendedActionView = activeShotView;
-                      forcedCornerView.resumeAction = activeShotView;
-                    } else if (suspendedActionView?.mode === 'action') {
-                      forcedCornerView.resumeAction = suspendedActionView;
-                    }
-                    updatePocketCameraState(true);
-                    activeShotView = forcedCornerView;
-                  }
-                }
-              }
               if (pottedIds.has(b.id)) {
                 continue;
               }
@@ -30083,6 +30042,44 @@ const powerRef = useRef(hud.power);
                   mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
                 potted.push({ id: b.id, color: colorId, pocket: pocketId });
                 pottedIds.add(b.id);
+                const shouldForceCornerPocketView =
+                  !suppressPocketCameras &&
+                  !topViewRef.current &&
+                  pocketIndex < 4;
+                if (shouldForceCornerPocketView) {
+                  const sph = sphRef.current;
+                  const resumeView = sph
+                    ? { orbitSnapshot: { radius: sph.radius, phi: sph.phi, theta: sph.theta } }
+                    : null;
+                  const forcedCornerView = makePocketCameraView(b.id, resumeView, {
+                    forceCornerCapture: true,
+                    pocketCenterOverride: c
+                  });
+                  const shouldSwapView =
+                    forcedCornerView &&
+                    (!activeShotView ||
+                      activeShotView.mode !== 'pocket' ||
+                      activeShotView.ballId !== b.id);
+                  if (shouldSwapView) {
+                    forcedCornerView.lastUpdate = performance.now();
+                    if (cameraRef.current) {
+                      const cam = cameraRef.current;
+                      forcedCornerView.smoothedPos = cam.position.clone();
+                      const storedTarget = lastCameraTargetRef.current?.clone();
+                      if (storedTarget) {
+                        forcedCornerView.smoothedTarget = storedTarget;
+                      }
+                    }
+                    if (activeShotView?.mode === 'action') {
+                      suspendedActionView = activeShotView;
+                      forcedCornerView.resumeAction = activeShotView;
+                    } else if (suspendedActionView?.mode === 'action') {
+                      forcedCornerView.resumeAction = suspendedActionView;
+                    }
+                    updatePocketCameraState(true);
+                    activeShotView = forcedCornerView;
+                  }
+                }
                 if (
                   activeShotView?.mode === 'pocket' &&
                   activeShotView.ballId === b.id
@@ -30233,6 +30230,44 @@ const powerRef = useRef(hud.power);
                 mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
               potted.push({ id: b.id, color: colorId, pocket: pocketId });
               pottedIds.add(b.id);
+              const shouldForceCornerPocketView =
+                !suppressPocketCameras &&
+                !topViewRef.current &&
+                pocketIndex < 4;
+              if (shouldForceCornerPocketView) {
+                const sph = sphRef.current;
+                const resumeView = sph
+                  ? { orbitSnapshot: { radius: sph.radius, phi: sph.phi, theta: sph.theta } }
+                  : null;
+                const forcedCornerView = makePocketCameraView(b.id, resumeView, {
+                  forceCornerCapture: true,
+                  pocketCenterOverride: c
+                });
+                const shouldSwapView =
+                  forcedCornerView &&
+                  (!activeShotView ||
+                    activeShotView.mode !== 'pocket' ||
+                    activeShotView.ballId !== b.id);
+                if (shouldSwapView) {
+                  forcedCornerView.lastUpdate = performance.now();
+                  if (cameraRef.current) {
+                    const cam = cameraRef.current;
+                    forcedCornerView.smoothedPos = cam.position.clone();
+                    const storedTarget = lastCameraTargetRef.current?.clone();
+                    if (storedTarget) {
+                      forcedCornerView.smoothedTarget = storedTarget;
+                    }
+                  }
+                  if (activeShotView?.mode === 'action') {
+                    suspendedActionView = activeShotView;
+                    forcedCornerView.resumeAction = activeShotView;
+                  } else if (suspendedActionView?.mode === 'action') {
+                    forcedCornerView.resumeAction = suspendedActionView;
+                  }
+                  updatePocketCameraState(true);
+                  activeShotView = forcedCornerView;
+                }
+              }
               if (
                 activeShotView?.mode === 'pocket' &&
                 activeShotView.ballId === b.id


### PR DESCRIPTION
### Motivation
- Improve play feel and replay clarity by making cushions slightly bouncier and making the replay cue/ camera behaviour match live play and suggestion flow more reliably.
- Prevent unpleasant double camera moves after a shot and avoid premature pocket-camera cuts during approach.

### Description
- Bumped cushion restitution to 0.93 to give cushions a bit more bounce (`billiards/PhysicsConstants.cs`).
- Replay cue adjustments in `webapp/src/pages/Games/PoolRoyale.jsx`: increased `REPLAY_CUE_START_HOLD_MS` and `REPLAY_CUE_STROKE_LEAD_IN_MS`, introduced `REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER` and applied it to replay release duration so the forward push is more readable.
- Prefer stroke timeline playback when available and only use static cue snapshots as a fallback by checking `hasCueSnapshots && !stroke` when applying cue snapshots.
- Prime replay cue placement from the first recorded cue frame (if present) before falling back to stroke/cuePath, improving visual alignment between live play and replay.
- Reduce post-shot camera double-move by skipping automatic recenter when the player retains turn (added `shouldAutoRecenterAfterShot` guard) so suggestion-driven aim/camera can take priority.
- Adjust pocket camera activation logic so forced corner pocket switching is handled on confirmed potted handling paths (moved/conditioned pocket-camera swap to pot-confirmation flow) and make action-camera activation wait on movement-trigger logic.

### Testing
- Ran `npx eslint` and `npx eslint --no-ignore` on the changed file (workspace lint config ignores large game file; linter returned only ignore warning). — success (no blocking errors).
- Launched the webapp dev server with `npm --prefix webapp run dev` and confirmed the server started and served the app. — success.
- Captured a visual smoke-check screenshot of the running app using Playwright to validate UI loads (`artifacts/pool-royale-home.png`). — success.
- Changes were committed (`git commit`) with the message "Tune Pool Royale rebound, replay cue, and camera transitions". — success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a692de222c8329ad8609ac73aa9dc9)