### PR TITLE
Adjust Texas Holdem camera offsets and portrait menu position

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.94, landscape: 0.64 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.58, landscape: 1.06 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.86, landscape: 0.58 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 0.98 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
@@ -6150,7 +6150,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(6.2rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.6rem+env(safe-area-inset-top,0px))]">
+      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.7rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.6rem+env(safe-area-inset-top,0px))]">
         <div className="flex items-center gap-2">
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Make the Texas Hold’em table view match the requested visual adjustments by bringing the camera closer to the table, raising it slightly in portrait, lowering it slightly in landscape, and nudging the portrait menu icon upward on small screens.

### Description
- Tuned seated camera constants in `webapp/src/pages/Games/TexasHoldemArena.jsx` by changing `CAMERA_RETREAT_OFFSETS` to `{ portrait: 0.86, landscape: 0.58 }` so the camera sits closer to the table in both orientations.
- Adjusted `CAMERA_ELEVATION_OFFSETS` to `{ portrait: 1.7, landscape: 0.98 }` to raise the portrait camera and lower the landscape camera as requested.
- Moved the portrait menu block up by reducing the top offset in the menu container class from `top-[calc(6.2rem+env(safe-area-inset-top,0px))]` to `top-[calc(5.7rem+env(safe-area-inset-top,0px))]` in the same file.

### Testing
- Built the web app with `npm --prefix webapp run build`, which completed successfully.
- Ran the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the page renders.
- Captured Playwright screenshots of the updated Texas Hold’em route on a portrait viewport to validate the visual changes (screenshot generation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69ce04df48329b3e444776229b289)