### PR TITLE
Domino: use Murlan GLTF table as default and keep user-selected graphics quality

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -70,7 +70,7 @@ const FRAME_DROP_THRESHOLD = 1.35;
 const FRAME_DROP_WINDOW_MS = 3200;
 const FRAME_FAILSAFE_COOLDOWN_MS = 9000;
 const FRAME_MANUAL_OVERRIDE_GRACE_MS = 20000;
-const ALLOW_AUTO_QUALITY_DOWNGRADE = true;
+const ALLOW_AUTO_QUALITY_DOWNGRADE = false;
 const FEEDBACK_STORAGE_KEY = 'dominoRoyalFeedback';
 
 function isTelegramRuntime() {
@@ -2261,11 +2261,12 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Murlan Default Table',
-      source: 'procedural',
+      source: 'polyhaven',
+      assetId: 'CoffeeTable_01',
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+        'Standard Murlan Royale table using the default GLTF texture set.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -7410,13 +7411,10 @@ function handleWebglContextLoss(event) {
 function handleWebglContextRestored() {
   contextLost = false;
   clearContextLossTimer();
-  const fallbackFrameRateId = findFallbackFrameRateId(frameQuality?.id);
-  if (fallbackFrameRateId && fallbackFrameRateId !== frameQuality?.id) {
-    applyFrameRateSelection(fallbackFrameRateId, {
-      refreshUi: true,
-      source: 'context-recovery'
-    });
-  }
+  applyFrameRateSelection(frameRateId, {
+    refreshUi: true,
+    source: 'context-recovery'
+  });
   setStatus('Graphics restored.');
   setControlEnabled(false);
 }


### PR DESCRIPTION
### Motivation
- Make the Domino default table visually match the Murlan Royale default by using the same GLTF/textures instead of the procedural fallback. 
- Prevent the runtime from automatically lowering graphics quality when a player chooses a setting in the menu so the user selection is respected.
- Ensure WebGL context-restored handling reapplies the current selection rather than forcing a lower fallback profile.

### Description
- Set `ALLOW_AUTO_QUALITY_DOWNGRADE = false` to disable automatic runtime downshifts of graphics quality.
- Change the `murlan-default` table entry from procedural to Poly Haven GLTF by setting `source: 'polyhaven'` and `assetId: 'CoffeeTable_01'` so the default uses the GLTF material/texture set.
- Update `handleWebglContextRestored()` to re-apply the currently selected `frameRateId` (via `applyFrameRateSelection(frameRateId, {...})`) instead of selecting a lower fallback tier.
- All changes were made in `webapp/public/domino-royal-game.js`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without errors.
- Launched a local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` for manual verification and the server started successfully.
- Performed an automated Playwright visual check by loading the Domino scene at `/?mode=local&players=4&frameRateId=fhd60` (mobile portrait viewport) and captured a screenshot for verification, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69d707e0c8329a9a78315581d1a8c)