### PR TITLE
Adjust Texas Hold'em portrait menu offset and tighten landscape camera framing

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.86, landscape: 0.58 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 0.98 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.86, landscape: 0.5 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 0.93 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
@@ -6150,7 +6150,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.7rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.6rem+env(safe-area-inset-top,0px))]">
+      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.95rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.6rem+env(safe-area-inset-top,0px))]">
         <div className="flex items-center gap-2">
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Improve UX: nudge the in-game menu slightly lower in portrait so it doesn't overlap visual elements, and pull the landscape camera closer/lower to make community cards more readable.

### Description
- Tweak layout and camera constants in `webapp/src/pages/Games/TexasHoldemArena.jsx`: set `CAMERA_RETREAT_OFFSETS.landscape` from `0.58` to `0.5`, set `CAMERA_ELEVATION_OFFSETS.landscape` from `0.98` to `0.93`, and increase the portrait menu `top` offset from `5.7rem` to `5.95rem`.

### Testing
- Built the webapp with `npm --prefix webapp run build` which completed successfully.
- Captured automated screenshots for portrait and landscape using a Playwright script which produced updated images.
- Attempted root dev run (`npm run dev`) but the concurrent root process failed due to a missing dependency in the bot (`bot/server.js` required package `undici`), while the webapp dev server started normally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a0caddcc8329aaf81aa2196088ad)