### PR TITLE
Restore cue stick to idle pose after shot (fix stuck pulled-back cue)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14278,6 +14278,7 @@ function PoolRoyaleGame({
   );
   const shotCameraHoldTimeoutRef = useRef(null);
   const cueStrokeStateRef = useRef(null);
+  const lastCueIdlePoseRef = useRef(null);
   const [inHandPlacementMode, setInHandPlacementMode] = useState(false);
   useEffect(
     () => () => {
@@ -21406,8 +21407,25 @@ const powerRef = useRef(hud.power);
 
         const updateCueStroke = (now) => {
           const stroke = cueStrokeStateRef.current;
-          if (!stroke || !cueStick) {
+          if (!cueStick) {
             return Boolean(cueAnimating);
+          }
+          if (!stroke) {
+            if (cueAnimating) {
+              const idlePose = lastCueIdlePoseRef.current;
+              if (idlePose?.position) {
+                cueStick.position.copy(idlePose.position);
+                cueStick.rotation.x = idlePose.rotationX ?? cueStick.rotation.x;
+                cueStick.rotation.y = idlePose.rotationY ?? cueStick.rotation.y;
+                cueStick.visible = true;
+                syncCueShadow();
+              }
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              pendingImpactRef.current = null;
+            }
+            return false;
           }
           if (!ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = false;
@@ -25212,6 +25230,11 @@ const powerRef = useRef(hud.power);
           if (ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = true;
             cueAnimating = true;
+            lastCueIdlePoseRef.current = {
+              position: idlePos.clone(),
+              rotationX: cueStick.rotation.x,
+              rotationY: cueStick.rotation.y
+            };
             cueStrokeStateRef.current = {
               startTime,
               idlePos: idlePos.clone(),


### PR DESCRIPTION
### Motivation
- The cue stick could remain visually pulled back after a shot when the stroke state was missing or interrupted while `cueAnimating` remained true, causing a stuck pulled-back appearance instead of returning to the pre-stroke idle pose.

### Description
- Added a `lastCueIdlePoseRef` (`useRef`) to persist the cue stick's idle position and rotation when a stroke animation is initialized in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Captured and stored the idle pose when starting a cue stroke so the original rest pose is available after animations complete.
- Updated `updateCueStroke` fallback logic to snap the cue stick back to the saved idle pose and clear pull/impact state when the stroke state is missing while animation is still flagged active.
- Reset `cuePullCurrentRef`, `cuePullTargetRef`, and `pendingImpactRef` in the fallback to ensure the cue is not left visually pulled back.

### Testing
- Ran the unit test `test/poolRoyaleCueStrokeTimeline.test.js` with `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (3 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a26d1ba48329bc5a1b4845b286d1)