### PR TITLE
Fix Domino Royale default table selection to shared GLTF table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3980,7 +3980,7 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
 });
 
 
-const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'CoffeeTable_01';
+const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'murlan-default';
 const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
 
 function resolveDefaultOptionId(key, options = []) {
@@ -4126,6 +4126,12 @@ function normalizeAppearance(raw) {
   });
 
   const selectedTableTheme = TABLE_THEME_OPTIONS[normalized.tableTheme];
+  if (selectedTableTheme?.id === 'CoffeeTable_01') {
+    normalized.tableTheme = findDominoOptionIndex(
+      'tableTheme',
+      LUDO_MATCH_DEFAULT_TABLE_THEME_ID
+    );
+  }
   if (selectedTableTheme?.source === 'procedural' && selectedTableTheme?.id === 'murlan-default') {
     normalized.tableTheme = findDominoOptionIndex(
       'tableTheme',


### PR DESCRIPTION
### Motivation
- Domino Royale was falling back to procedural table visuals and not matching the GLTF-based table used across other games, causing inconsistent look and lack of proper GLTF textures by default.

### Description
- Changed the domino default table identifier by updating `LUDO_MATCH_DEFAULT_TABLE_THEME_ID` from `CoffeeTable_01` to `murlan-default` in `webapp/public/domino-royal-game.js` so Domino uses the shared GLTF table asset.
- Added a normalization step in `normalizeAppearance` that remaps legacy `CoffeeTable_01` selections to the `murlan-default` option so existing saved appearances will adopt the shared GLTF table.
- The change keeps the procedural table path only as a fallback and forces the default to the GLTF/preserved-material path used by other games.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without syntax errors.
- Launched a local dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the app served successfully for manual verification.
- Performed an automated visual validation by loading `/games/domino-royal` in a headless browser and capturing a screenshot, confirming the default table now uses the shared GLTF theme.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a3343dec83298d7196952713347d)