### PR TITLE
Fix Pool Royale cue stroke release when cue is already pulled

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25086,7 +25086,11 @@ const powerRef = useRef(hud.power);
           );
           const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
-          const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
+          // The cue is already visually pulled before fire(), so release should start immediately.
+          const pullbackDuration =
+            startPull > 1e-4
+              ? 0
+              : strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const idleGap = 0.01;
           const contactEps = 0.001;


### PR DESCRIPTION
### Motivation

- Players reported that when they fired while the cue was already pulled back the cue stick remained visually pulled backwards instead of pushing forward to the impact pose, making shots look stuck.

### Description

- Change the computed `pullbackDuration` in `webapp/src/pages/Games/PoolRoyale.jsx` so that when the cue has a pre-shot pull (`startPull > 1e-4`) the release starts immediately by setting `pullbackDuration` to `0`.
- Preserve the previous pullback behavior as a fallback when there is effectively no pre-shot pull by using `strokeProfile.pullbackDuration` only when `startPull` is near zero.
- The adjusted `pullbackDuration` continues to feed the existing timing logic (camera hold, replay serialization and cue stroke sampling) so visuals and replays remain aligned with the updated behavior.

### Testing

- Ran the focused unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and all tests passed (3 tests, 1 suite).
- The change only modified `webapp/src/pages/Games/PoolRoyale.jsx` and the test suite covering the cue stroke timeline succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a26d1ba48329bc5a1b4845b286d1)