### PR TITLE
Fix Texas Hold'em landscape camera framing and chip-button betting at hand start

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.86, landscape: 0.5 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 0.93 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.86, landscape: 0.24 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.7, landscape: 0.82 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
@@ -6079,13 +6079,16 @@ function TexasHoldemArena({ search }) {
   }, [sliderVisible, sliderMax]);
 
   const handleChipClick = (value) => {
-    if (!sliderInteractive) return;
+    if (!sliderVisible || sliderMax <= 0 || humanPlayer?.folded || humanPlayer?.allIn) return;
     setChipSelection((prev) => {
       const currentTotal = prev.reduce((sum, chip) => sum + chip, 0);
-      const nextTotal = currentTotal + value;
-      if (nextTotal > sliderMax) return prev;
+      const remaining = Math.max(0, sliderMax - currentTotal);
+      if (remaining <= 0) return prev;
+      const appliedValue = Math.min(value, remaining);
+      if (appliedValue <= 0) return prev;
+      const nextTotal = currentTotal + appliedValue;
       setSliderValue(nextTotal);
-      return [...prev, value];
+      return [...prev, appliedValue];
     });
   };
 


### PR DESCRIPTION
### Motivation
- Landscape seating felt too far from the table and left the wooden rail floating above the bottom of the screen, so the landscape camera needed to be brought closer while leaving portrait unchanged.
- 3x3 chip-button taps were not accepted at hand start in some cases, preventing users from placing manual chip bets immediately.
- Chip taps that exceeded the remaining raise capacity were being ignored instead of being applied up to the remaining amount.

### Description
- Adjusted landscape camera offsets by changing `CAMERA_RETREAT_OFFSETS.landscape` and `CAMERA_ELEVATION_OFFSETS.landscape` to bring the seated camera closer and slightly lower in landscape (portrait values unchanged) in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Reworked the chip-button handler `handleChipClick` to accept taps whenever the raise controls are visible and the player can act (uses `sliderVisible`/`sliderMax` and checks for folded/all-in) so chips are tappable from hand start.
- Made chip selection tolerant by clamping the tapped chip value to the remaining raise capacity and adding that clamped value to the selection instead of ignoring oversized taps.

### Testing
- Ran unit tests with `npm test -- --runInBand test/texasHoldemGame.test.js` and the suite passed (2 tests, all green).
- Launched the web app dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and exercised the Texas Hold'em route using an automated Playwright script to capture landscape screenshots, which completed and produced the updated screenshot artifact.
- The Playwright run initially timed out on a first attempt but a subsequent run succeeded in navigating and capturing the Texas Hold'em landscape view.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a878985c8329b68d166c3434e11d)