### PR TITLE
Improve cue stroke visibility and AI pre-shot aiming in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1844,8 +1844,8 @@ const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera l
 const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.9; // trim pullback depth so backward cue travel remains tighter
-const CUE_PULL_RETURN_PUSH = 0.92; // push the cue forward to its start point more decisively after a pull
+const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.76; // shorten cue pullback depth so backward travel is tighter than before
+const CUE_PULL_RETURN_PUSH = 1; // snap the cue forward to its starting pose right after release
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.4; // raise minimum forward push so every shot clearly shows the cue driving through
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 7.8; // extend top-end follow-through so powerful shots visibly punch forward
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
@@ -5474,6 +5474,7 @@ const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
 const REPLAY_CUE_MIN_RELEASE_MS = 620; // keep forward cue strike visible for a clear cue-ball hit
+const REPLAY_CUE_PULL_START_PROGRESS = 0.12; // start replay with the cue already in early pullback motion
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -21306,7 +21307,10 @@ const powerRef = useRef(hud.power);
                 0
             ) * replayScale;
           const startOffset = Math.max(0, stroke.startOffset ?? 0);
-          const localTime = targetTime - Math.max(0, startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
+          const baseLocalTime =
+            targetTime - Math.max(0, startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
+          const replayPullStartFloor = pullback * REPLAY_CUE_PULL_START_PROGRESS;
+          const localTime = Math.max(baseLocalTime, replayPullStartFloor);
           const playbackWindow = Number.isFinite(playback?.duration)
             ? Math.max(playback.duration, 1400)
             : 1400;
@@ -27357,7 +27361,7 @@ const powerRef = useRef(hud.power);
         startAiThinkingRef.current = startAiThinking;
         startUserSuggestionRef.current = updateUserSuggestion;
 
-        const animateAiSpinAdjustment = (targetSpin, durationMs, aimDir) => {
+        const animateAiSpinAdjustment = (targetSpin, durationMs, aimDir, { onComplete } = {}) => {
           cancelAiSpinAdjust();
           const startTime = performance.now();
           const startSpin = spinRef.current ?? { x: 0, y: 0 };
@@ -27385,6 +27389,9 @@ const powerRef = useRef(hud.power);
               aiSpinAdjustRef.current = requestAnimationFrame(animate);
             } else {
               aiSpinAdjustRef.current = null;
+              if (typeof onComplete === 'function') {
+                onComplete();
+              }
             }
           };
           aiSpinAdjustRef.current = requestAnimationFrame(animate);
@@ -27570,7 +27577,26 @@ const powerRef = useRef(hud.power);
               aiCueViewBlendRef.current = AI_CAMERA_DROP_BLEND;
               aiCuePullReadyAtRef.current = performance.now() + AI_SPIN_ADJUST_DELAY_MS;
               tweenCameraBlend(aiCueViewBlendRef.current, AI_CAMERA_DROP_DURATION_MS);
-              animateAiSpinAdjustment(spinToApply, AI_SPIN_ADJUST_DELAY_MS, dir);
+              // Keep the same visual flow as suggested line preview, then let AI
+              // refine aim before/after spin so the final line stays pot-focused.
+              if (previewAimDir.lengthSq() > 1e-6) {
+                aimDirRef.current.copy(previewAimDir);
+                alignStandingCameraToAim(cue, previewAimDir, { preserveOrbit: false });
+              }
+              window.setTimeout(() => {
+                aimDirRef.current.copy(dir);
+                alignStandingCameraToAim(cue, dir, { preserveOrbit: false });
+                applyCameraBlend(aiCueViewBlendRef.current ?? AI_CAMERA_DROP_BLEND);
+                updateCamera();
+              }, Math.max(80, AI_SPIN_ADJUST_DELAY_MS * 0.12));
+              animateAiSpinAdjustment(spinToApply, AI_SPIN_ADJUST_DELAY_MS, dir, {
+                onComplete: () => {
+                  aimDirRef.current.copy(dir);
+                  alignStandingCameraToAim(cue, dir, { preserveOrbit: false });
+                  applyCameraBlend(aiCueViewBlendRef.current ?? AI_CAMERA_DROP_BLEND);
+                  updateCamera();
+                }
+              });
               if (aiShotTimeoutRef.current) {
                 clearTimeout(aiShotTimeoutRef.current);
               }


### PR DESCRIPTION
### Motivation
- Reduce the visual over-extension of the cue pull so the backward wind-up reads tighter and the forward strike is clearer.
- Make replays start showing the cue already pulling back (instead of starting from an idle frame) so the wind-up is visible in the replay preview.
- Ensure AI follows the suggested aiming flow but still refines the aiming line to a pot-focused final line before and after spin adjustments so shots remain aimed to pot.

### Description
- Tuned live stroke parameters by lowering `CUE_PULL_GLOBAL_VISIBILITY_BOOST` from `0.9` to `0.76` and changing `CUE_PULL_RETURN_PUSH` from `0.92` to `1` so the cue returns to start more decisively.
- Added `REPLAY_CUE_PULL_START_PROGRESS` and changed replay timing so `localTime` is floored to a small pullback progress, causing replays to begin with visible pullback motion.
- Extended `animateAiSpinAdjustment` to accept an optional `onComplete` callback and invoke it when the spin adjustment animation finishes.
- Updated AI pre-shot choreography to use the suggestion preview flow, copy the preview aim into `aimDir` for the cue view, then re-align to the AI final aim both shortly before spin adjustment and again when spin adjustment completes, prior to firing.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed; ESLint reported the existing ignore-pattern warning for this file but no blocking errors.
- Started the local webapp with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the dev server came up successfully.
- Executed a Playwright script to load the app in a portrait viewport and capture a screenshot for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6acc822448329b94acb14607ae15f)