### PR TITLE
Pool Royale: gate early pocket camera to guaranteed corner pots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24798,16 +24798,22 @@ const powerRef = useRef(hud.power);
                   direction: shotPrediction.dir ?? new THREE.Vector2()
                 })
               : null;
-            pocketSwitchIntentRef.current = {
-              ballId: shotPrediction.ballId,
-              allowEarly: true,
-              forced: isDirectHit,
-              preferredPocketId:
-                cornerIntent && cornerIntent.score >= POCKET_CAM.dotThreshold
-                  ? cornerIntent.pocketId
-                  : null,
-              createdAt: intentTimestamp
-            };
+            const guaranteedCornerPocketId =
+              cornerIntent &&
+              cornerIntent.score >= POCKET_GUARANTEED_ALIGNMENT
+                ? cornerIntent.pocketId
+                : null;
+            pocketSwitchIntentRef.current = guaranteedCornerPocketId
+              ? {
+                  ballId: shotPrediction.ballId,
+                  // Early pocket-camera handoff is reserved for guaranteed corner pots.
+                  // Side (middle) pockets keep the existing camera behavior.
+                  allowEarly: true,
+                  forced: isDirectHit,
+                  preferredPocketId: guaranteedCornerPocketId,
+                  createdAt: intentTimestamp
+                }
+              : null;
           } else {
             pocketSwitchIntentRef.current = null;
           }


### PR DESCRIPTION
### Motivation
- Ensure the pocket camera only auto-switches for corner pockets when the shot prediction truly guarantees a corner pot, while leaving middle/side-pocket behavior unchanged.

### Description
- Updated the shot-intent logic in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a `guaranteedCornerPocketId` from `resolveCornerPocketIntent` and only set `pocketSwitchIntentRef.current` when `score >= POCKET_GUARANTEED_ALIGNMENT`.
- Replaced the previous looser promotion (which used `POCKET_CAM.dotThreshold`) with the stricter `POCKET_GUARANTEED_ALIGNMENT` check and clear the early pocket intent (`null`) when not guaranteed.
- Added an inline comment clarifying that side/middle pockets intentionally keep the existing camera flow.

### Testing
- Ran a production build with `npm -C webapp run build` which completed successfully.
- Started the dev server with `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully.
- Captured a UI screenshot of the running app using the Playwright script to validate the build/run surface and confirmed artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a723b4380c8329a512a6f1a08deb60)