### PR TITLE
Use PolyHaven GLTF for Murlan default table, preserve materials, and adjust loading/scale

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2265,8 +2265,9 @@ const MURLAN_TABLE_THEMES = Object.freeze(
       assetId: 'CoffeeTable_01',
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+      preserveMaterials: true,
       description:
-        'Standard Murlan Royale table using the default GLTF texture set.'
+        'Standard Murlan Royale table using the same GLTF model and textures.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -3982,6 +3983,7 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
 
 const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'murlan-default';
 const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
+const MURLAN_DEFAULT_TABLE_SCALE = 1.15;
 
 function resolveDefaultOptionId(key, options = []) {
   if (!Array.isArray(options) || options.length === 0) return null;
@@ -4132,13 +4134,6 @@ function normalizeAppearance(raw) {
       LUDO_MATCH_DEFAULT_TABLE_THEME_ID
     );
   }
-  if (selectedTableTheme?.source === 'procedural' && selectedTableTheme?.id === 'murlan-default') {
-    normalized.tableTheme = findDominoOptionIndex(
-      'tableTheme',
-      LUDO_MATCH_DEFAULT_TABLE_THEME_ID
-    );
-  }
-
   const selectedChairTheme = CHAIR_THEME_OPTIONS[normalized.chairTheme];
   if (selectedChairTheme?.source !== 'polyhaven') {
     normalized.chairTheme = findDominoOptionIndex(
@@ -5587,7 +5582,9 @@ async function applyTableTheme(
     setProceduralTableVisible(true);
     return;
   }
-  setProceduralTableVisible(true);
+  const keepProceduralHiddenWhileLoading =
+    theme.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID && theme.source === 'polyhaven';
+  setProceduralTableVisible(!keepProceduralHiddenWhileLoading);
   try {
     const model = await loadPolyhavenModel(theme.assetId || theme.id, {
       preserveGltfTextureMapping: theme.preserveMaterials ?? true
@@ -5597,6 +5594,9 @@ async function applyTableTheme(
       return;
     }
     fitTableModelToFootprint(model);
+    if (theme.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID) {
+      model.scale.multiplyScalar(MURLAN_DEFAULT_TABLE_SCALE);
+    }
     tableThemeG.add(model);
     tableThemeG.visible = true;
     setProceduralTableVisible(false);
@@ -5614,14 +5614,23 @@ async function applyTableTheme(
           return;
         }
         fitTableModelToFootprint(fallbackModel);
+        if (DEFAULT_TABLE_THEME_OPTION.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID) {
+          fallbackModel.scale.multiplyScalar(MURLAN_DEFAULT_TABLE_SCALE);
+        }
         tableThemeG.add(fallbackModel);
         tableThemeG.visible = true;
         setProceduralTableVisible(false);
         activeTableThemeId = DEFAULT_TABLE_THEME_OPTION.id;
       } catch (fallbackError) {
         console.warn('Failed to load fallback Poly Haven table theme', fallbackError);
-        setProceduralTableVisible(true);
+        if (keepProceduralHiddenWhileLoading) {
+          setProceduralTableVisible(false);
+        } else {
+          setProceduralTableVisible(true);
+        }
       }
+    } else if (keepProceduralHiddenWhileLoading) {
+      setProceduralTableVisible(false);
     } else {
       setProceduralTableVisible(true);
     }

--- a/webapp/src/config/dominoRoyalThemeCatalog.js
+++ b/webapp/src/config/dominoRoyalThemeCatalog.js
@@ -115,10 +115,12 @@ export const DOMINO_ROYAL_TABLE_THEMES = [
   {
     id: 'murlan-default',
     label: 'Murlan Default Table',
-    source: 'procedural',
+    source: 'polyhaven',
+    assetId: 'CoffeeTable_01',
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
-    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    preserveMaterials: true,
+    description: 'Standard Murlan Royale table using the same GLTF model and textures.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];


### PR DESCRIPTION
### Motivation
- Replace the procedural Murlan default table with the actual PolyHaven GLTF so the default table uses the same model and textures as other PolyHaven table themes. 
- Preserve original GLTF texture/material mapping for PolyHaven assets to avoid visual regressions. 
- Keep procedural geometry hidden while the PolyHaven model is loading and apply a small scale tweak for visual fit.

### Description
- Updated `DOMINO_ROYAL_TABLE_THEMES` (`dominoRoyalThemeCatalog.js`) to set `murlan-default` `source` to `polyhaven`, add `assetId: 'CoffeeTable_01'`, and enable `preserveMaterials: true` while updating the description. 
- Marked the default Murlan table entry in `MURLAN_TABLE_THEMES` with `preserveMaterials: true` and adjusted its description in `domino-royal-game.js`. 
- Removed the special-case fallback in `normalizeAppearance` that forced the default table back to a procedural variant. 
- Added `MURLAN_DEFAULT_TABLE_SCALE = 1.15` and updated `applyTableTheme` to: hide procedural parts while the default PolyHaven table is loading, multiply the loaded model scale by `MURLAN_DEFAULT_TABLE_SCALE` for the Murlan default, apply the same scale to the fallback model when appropriate, and ensure procedural visibility is restored correctly on success or failure. 

### Testing
- Ran the automated test suite with `npm test` and all tests completed successfully. 
- Built the webapp with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a725d5034c8329a6dc8d142c7e69b1)