### PR TITLE
Match Pool Royale cue pull/push stroke timing to reference behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21185,10 +21185,10 @@ const powerRef = useRef(hud.power);
               : REPLAY_CUE_STICK_HOLD_MS;
             const fallbackPullback = CUE_PULL_BASE * 0.35;
             const fallbackForward = CUE_PULL_BASE * 0.18;
-            const pullbackTime = 160;
-            const forwardTime = 210;
-            const settleTime = 120;
-            const returnTime = REPLAY_CUE_RETURN_WINDOW_MS;
+            const pullbackTime = 0;
+            const forwardTime = 120;
+            const settleTime = 50;
+            const returnTime = 0;
             const totalStroke = pullbackTime + forwardTime + settleTime + returnTime;
             const holdWindow = Math.max(replayHoldWindow, totalStroke);
             const showCue = targetTime <= holdWindow;
@@ -21561,27 +21561,9 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'release') {
-            const animationStyle = stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
-            const eased = (() => {
-              switch (animationStyle) {
-                case 'linear':
-                  return sample.t;
-                case 'snap':
-                  return Math.ceil(sample.t * 4) / 4;
-                case 'whip':
-                  return Math.pow(sample.t, 0.62);
-                case 'spring': {
-                  const damped = 1 - Math.exp(-7.4 * sample.t) * (1 + 7.4 * sample.t);
-                  return THREE.MathUtils.clamp(damped, 0, 1);
-                }
-                case 'classic':
-                default:
-                  return easeInOutCubic(sample.t);
-              }
-            })();
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
-            cueStick.position.lerpVectors(pullPos, impactPos, eased);
-            cueStick.position.y -= (strikeDip ?? 0.003) * eased;
+            cueStick.position.lerpVectors(pullPos, impactPos, sample.t);
+            cueStick.position.y -= (strikeDip ?? 0.003) * sample.t;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = (baseRotationY ?? cueStick.rotation.y) + wobble;
             syncCueShadow();
@@ -24501,16 +24483,18 @@ const powerRef = useRef(hud.power);
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
-          motion: 'featherLine',
-          pullRatio: 1 - Math.pow(1 - p, 2.4),
+          motion: 'classic',
+          pullRatio: 1 - Math.pow(1 - p, 3),
           pullSmoothing: 0.14,
-          strikeDuration: THREE.MathUtils.lerp(520, 380, p),
-          holdDuration: 340,
-          pullbackDuration: THREE.MathUtils.lerp(760, 620, p),
-          recoverDuration: 180,
-          impactThreshold: 0.94,
+          // Match the reference stroke timing: release from pulled cue position,
+          // quick contact push, tiny hold, then snap back to idle.
+          strikeDuration: 120,
+          holdDuration: 50,
+          pullbackDuration: 0,
+          recoverDuration: 0,
+          impactThreshold: 0.9,
           forwardOnly: false,
-          cameraExtraHoldMs: 900,
+          cameraExtraHoldMs: 320,
           spinScale: 0.22
         };
       };


### PR DESCRIPTION
### Motivation
- The live cue stroke and replay cue animation needed to match a provided reference pull→push feel so the cue tip behavior (pull, contact push, micro follow-through, and snap-back) is perceptually identical to the sample implementation.

### Description
- Tuned the cue stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `resolveCueStrokeProfile` to use a short, direct stroke (`strikeDuration: 120`, `holdDuration: 50`, `pullbackDuration: 0`, `recoverDuration: 0`) and adjusted `pullRatio`/`motion` for the reference feel.
- Aligned replay fallback stroke timings to the same cadence (0ms pullback, 120ms forward, 50ms hold, 0ms return) so replay frames match live shot feel when no recorded stroke timeline is present.
- Simplified the live release interpolation logic to use the timeline's direct release progression (`sample.t`) instead of the previous style-dependent eased mapping so the cue push motion tracks the reference push more exactly.
- Minor camera/hold tuning: reduced `cameraExtraHoldMs` for the stroke profile to shorten the post-impact camera-hold to the updated timing.

### Testing
- Ran the targeted unit tests with `npm -s test -- poolRoyaleCareerProgress.test.js` and they passed.
- Started the webapp dev server with `npm --prefix webapp run dev` and confirmed the app serves for visual verification.
- Captured a visual snapshot of the home page via a Playwright run to verify the build/dev server started and UI rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d137107c83299d30844110f33f7c)