### PR TITLE
Enable up/down look and seated pinch-zoom for Texas Hold'em 3D arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -399,6 +399,9 @@ const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * 0.52, lands
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
+const SEATED_ZOOM_DEFAULT = 1;
+const SEATED_ZOOM_MIN = 0.86;
+const SEATED_ZOOM_MAX = 1.22;
 const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * 0.02;
@@ -2913,7 +2916,8 @@ function TexasHoldemArena({ search }) {
     active: false,
     pointerIds: [],
     startDistance: 0,
-    startZoom: OVERHEAD_ZOOM_DEFAULT
+    startZoom: OVERHEAD_ZOOM_DEFAULT,
+    mode: 'overhead'
   });
   const pointerVectorRef = useRef(new THREE.Vector2());
   const interactionsRef = useRef({
@@ -2981,6 +2985,9 @@ function TexasHoldemArena({ search }) {
   const [sliderValue, setSliderValue] = useState(0);
   const [overheadView, setOverheadView] = useState(false);
   const [overheadZoom, setOverheadZoom] = useState(OVERHEAD_ZOOM_DEFAULT);
+  const [seatedZoom, setSeatedZoom] = useState(SEATED_ZOOM_DEFAULT);
+  const overheadViewRef = useRef(overheadView);
+  const overheadZoomRef = useRef(overheadZoom);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -2995,6 +3002,7 @@ function TexasHoldemArena({ search }) {
   });
   const [turnCountdown, setTurnCountdown] = useState(TURN_DURATION);
   const appearanceRef = useRef(appearance);
+  const seatedZoomRef = useRef(seatedZoom);
   const hdriVariantRef = useRef(TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ?? TEXAS_HDRI_OPTIONS[0] ?? null);
   const disposeEnvironmentRef = useRef(null);
   const envTextureRef = useRef(null);
@@ -4331,16 +4339,17 @@ function TexasHoldemArena({ search }) {
     const applySeatedCamera = (width, height, options = {}) => {
       if (!humanSeat) return;
       const animate = Boolean(options.animate);
+      const zoom = THREE.MathUtils.clamp(options.zoom ?? seatedZoomRef.current, SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
       const portrait = height > width;
       const lateralOffset = portrait ? CAMERA_LATERAL_OFFSETS.portrait : CAMERA_LATERAL_OFFSETS.landscape;
       const retreatOffset = portrait ? CAMERA_RETREAT_OFFSETS.portrait : CAMERA_RETREAT_OFFSETS.landscape;
       const elevation = portrait ? CAMERA_ELEVATION_OFFSETS.portrait : CAMERA_ELEVATION_OFFSETS.landscape;
       const position = humanSeat.stoolAnchor
         .clone()
-        .addScaledVector(humanSeat.forward, -retreatOffset)
+        .addScaledVector(humanSeat.forward, -retreatOffset * zoom)
         .addScaledVector(humanSeat.right, lateralOffset);
       const maxCameraHeight = ARENA_WALL_TOP_Y - CAMERA_WALL_HEIGHT_MARGIN;
-      position.y = Math.min(humanSeat.stoolHeight + elevation, maxCameraHeight);
+      position.y = Math.min(humanSeat.stoolHeight + elevation * zoom, maxCameraHeight);
       const focusBase = cameraTarget.clone().add(new THREE.Vector3(0, CAMERA_FOCUS_CENTER_LIFT, 0));
       const seatTopPoint = seatTopPointRef.current;
       const focusForwardPull = portrait
@@ -4895,13 +4904,14 @@ function TexasHoldemArena({ search }) {
         active: false,
         pointerIds: [],
         startDistance: 0,
-        startZoom: overheadZoom
+        startZoom: overheadView ? overheadZoom : seatedZoom,
+        mode: overheadView ? 'overhead' : 'seated'
       };
     };
 
     const beginPinchZoom = () => {
       const pointers = activePointersRef.current;
-      if (!overheadView || pointers.size < 2) {
+      if (pointers.size < 2) {
         resetPinchState();
         return;
       }
@@ -4915,7 +4925,8 @@ function TexasHoldemArena({ search }) {
         active: true,
         pointerIds: [first.pointerId, second.pointerId],
         startDistance,
-        startZoom: overheadZoom
+        startZoom: overheadView ? overheadZoom : seatedZoom,
+        mode: overheadView ? 'overhead' : 'seated'
       };
       resetPointerState();
       applyHoverTarget(null);
@@ -4932,12 +4943,14 @@ function TexasHoldemArena({ search }) {
       const currentDistance = Math.hypot(second.x - first.x, second.y - first.y);
       if (currentDistance <= 0) return;
       const zoomDelta = (currentDistance - pinch.startDistance) * OVERHEAD_PINCH_SENSITIVITY;
-      const nextZoom = THREE.MathUtils.clamp(
-        +(pinch.startZoom - zoomDelta).toFixed(3),
-        OVERHEAD_ZOOM_MIN,
-        OVERHEAD_ZOOM_MAX
-      );
-      setOverheadZoom(nextZoom);
+      const nextZoomRaw = +(pinch.startZoom - zoomDelta).toFixed(3);
+      if (pinch.mode === 'overhead') {
+        const nextZoom = THREE.MathUtils.clamp(nextZoomRaw, OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
+        setOverheadZoom(nextZoom);
+      } else {
+        const nextZoom = THREE.MathUtils.clamp(nextZoomRaw, SEATED_ZOOM_MIN, SEATED_ZOOM_MAX);
+        setSeatedZoom(nextZoom);
+      }
     };
 
     const handlePointerDown = (event) => {
@@ -4947,7 +4960,7 @@ function TexasHoldemArena({ search }) {
         x: event.clientX,
         y: event.clientY
       });
-      if (overheadView && activePointersRef.current.size >= 2) {
+      if (activePointersRef.current.size >= 2) {
         beginPinchZoom();
         return;
       }
@@ -5047,7 +5060,7 @@ function TexasHoldemArena({ search }) {
     const handlePointerUp = (event) => {
       activePointersRef.current.delete(event.pointerId);
       if (pinchZoomRef.current.active) {
-        if (activePointersRef.current.size >= 2 && overheadView) {
+        if (activePointersRef.current.size >= 2) {
           beginPinchZoom();
         } else {
           resetPinchState();
@@ -5109,7 +5122,6 @@ function TexasHoldemArena({ search }) {
         lastFrameRef.current = time - Math.max(0, deltaMs - appliedMs);
         const deltaSeconds = Math.max(0, Math.min(0.1, appliedMs / 1000));
         three.chipFactory.update(deltaSeconds);
-        headAnglesRef.current.pitch = 0;
         applyHeadOrientation();
         three.renderer.render(three.scene, three.camera);
       }
@@ -6122,14 +6134,28 @@ function TexasHoldemArena({ search }) {
   }, [handleChipClick, handleUndoChip]);
 
   useEffect(() => {
+    overheadViewRef.current = overheadView;
+  }, [overheadView]);
+
+  useEffect(() => {
+    overheadZoomRef.current = overheadZoom;
+  }, [overheadZoom]);
+
+  useEffect(() => {
+    seatedZoomRef.current = seatedZoom;
+    if (overheadViewRef.current) return;
+    const mount = mountRef.current;
+    viewControlsRef.current?.applySeatedCamera?.(
+      mount?.clientWidth ?? window.innerWidth,
+      mount?.clientHeight ?? window.innerHeight,
+      { zoom: seatedZoom }
+    );
+  }, [seatedZoom]);
+
+  useEffect(() => {
     const controls = viewControlsRef.current;
     const mount = mountRef.current;
     const three = threeRef.current;
-    if (!overheadView) {
-      activePointersRef.current.clear();
-      pinchZoomRef.current.active = false;
-      pinchZoomRef.current.pointerIds = [];
-    }
     if (!three?.camera) return;
     const animate = lastViewRef.current !== overheadView;
     lastViewRef.current = overheadView;
@@ -6145,9 +6171,9 @@ function TexasHoldemArena({ search }) {
     } else {
       const width = mount?.clientWidth ?? window.innerWidth;
       const height = mount?.clientHeight ?? window.innerHeight;
-      controls.applySeatedCamera?.(width, height, { animate });
+      controls.applySeatedCamera?.(width, height, { animate, zoom: seatedZoom });
     }
-  }, [overheadView, overheadZoom]);
+  }, [overheadView, overheadZoom, seatedZoom]);
 
 
   return (


### PR DESCRIPTION
### Motivation
- Make the mobile 3D Texas Hold'em camera match other games by allowing look up/down (pitch) via vertical drag and by letting pinch gestures scale the table/chairs/cards/chips without switching camera modes.
- Keep the seated (at-table) view interactive and mobile-friendly by supporting pinch-to-zoom in that context in the same style as existing games (e.g., Snake & Ladder, Ludo, Chess).

### Description
- Preserve vertical head orientation instead of forcing `pitch` to zero each frame so up/down dragging persists; this enables natural look up / look down behavior (`applyHeadOrientation` used directly in render loop). (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Add a seated zoom mode with constants `SEATED_ZOOM_DEFAULT`, `SEATED_ZOOM_MIN`, and `SEATED_ZOOM_MAX`, plus `seatedZoom` state and `seatedZoomRef` to track current seated zoom.
- Extend pinch handling (`pinchZoomRef`) to carry a `mode` (`'overhead' | 'seated'`) and route pinch delta updates to either `overheadZoom` or `seatedZoom`; clamp values against the appropriate min/max ranges.
- Apply seated zoom into `applySeatedCamera` so pinch in seated view scales the camera retreat and elevation (so the table, chairs, cards and chips appear bigger/smaller) without switching camera mode.
- Add small lifecycle/ref effects (`overheadViewRef`, `overheadZoomRef`, `seatedZoom` effect) so view/resize transitions apply the current zoom values immediately and remain stable.

### Testing
- Ran `npm run build` from `webapp/` and the build completed successfully (Vite build with existing chunk-size warnings unrelated to the change). — Success.
- Launched the dev server via `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served the Texas Hold'em route — server started successfully.
- Captured a mobile-viewport screenshot of the Texas Hold'em route using a Playwright script to validate the visual behavior after the change; the screenshot was produced successfully. — Success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d448e5d88329bf1a382957b6b207)