### PR TITLE
Match Pool Royale cue stroke pull/push to reference behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24501,16 +24501,18 @@ const powerRef = useRef(hud.power);
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
-          motion: 'featherLine',
-          pullRatio: 1 - Math.pow(1 - p, 2.4),
-          pullSmoothing: 0.14,
-          strikeDuration: THREE.MathUtils.lerp(520, 380, p),
-          holdDuration: 340,
-          pullbackDuration: THREE.MathUtils.lerp(760, 620, p),
-          recoverDuration: 180,
-          impactThreshold: 0.94,
-          forwardOnly: false,
-          cameraExtraHoldMs: 900,
+          // Match the reference cue stroke exactly:
+          // pull = pullRange * easeOutCubic(power), then a quick forward strike.
+          motion: 'classic',
+          pullRatio: easeOutCubic(p),
+          pullSmoothing: 1,
+          strikeDuration: LIVE_CUE_FORWARD_DURATION_MS,
+          holdDuration: LIVE_CUE_IMPACT_HOLD_MS,
+          pullbackDuration: 0,
+          recoverDuration: 0,
+          impactThreshold: 0.9,
+          forwardOnly: true,
+          cameraExtraHoldMs: 240,
           spinScale: 0.22
         };
       };


### PR DESCRIPTION
### Motivation
- The live cuestick motion needed to match the provided reference: a clear pull-back that scales with an eased curve and a decisive forward push on release (no cue following the ball). 

### Description
- Adjusted the cue stroke profile resolver in `webapp/src/pages/Games/PoolRoyale.jsx` to use the reference timing/curve (set `motion` to `classic`, `pullRatio` to `easeOutCubic(power)`, and `pullSmoothing` to `1`).
- Made the forward strike forward-only with short timing by setting `forwardOnly: true`, using `LIVE_CUE_FORWARD_DURATION_MS` / `LIVE_CUE_IMPACT_HOLD_MS` for `strikeDuration`/`holdDuration`, and removing pullback/recover phases (`pullbackDuration: 0`, `recoverDuration: 0`).
- Tweaked impact timing and camera-hold (`impactThreshold` and `cameraExtraHoldMs`) to align the visible push-through behavior with the reference while keeping existing spin handling (`spinScale`) intact.
- Change is isolated to the stroke profile logic used by the live shot animation and does not modify physics pathways.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; inspection completed but the file is excluded by repository ignore rules (warning only).
- Attempted `npm run build`; build failed due to a pre-existing, unrelated TypeScript error in `src/rules/SnookerRoyalRules.ts` (not caused by this change).
- Launched the webapp dev server (`npm --prefix webapp run dev`) and captured a portrait viewport screenshot using Playwright to visually validate the updated cuestroke animation, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d137107c83299d30844110f33f7c)