### PR TITLE
Frame full table in Texas Hold'em overhead zoom

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -400,6 +400,8 @@ const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
 const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
+const OVERHEAD_VIEW_RADIUS = CHAIR_RADIUS + Math.max(SEAT_DEPTH, CARD_H) * 1.45;
+const OVERHEAD_VIEW_PADDING = 1.08;
 const SEATED_ZOOM_DEFAULT = 1;
 const SEATED_ZOOM_MIN = 0.74;
 const SEATED_ZOOM_MAX = 1.3;
@@ -4439,7 +4441,14 @@ function TexasHoldemArena({ search }) {
     const applyOverheadCamera = (options = {}) => {
       const animate = Boolean(options.animate);
       const zoom = THREE.MathUtils.clamp(options.zoom ?? OVERHEAD_ZOOM_DEFAULT, OVERHEAD_ZOOM_MIN, OVERHEAD_ZOOM_MAX);
-      const height = TABLE_HEIGHT + BOARD_SIZE * 0.88 * zoom;
+      const mountWidth = Math.max(1, mount?.clientWidth ?? window.innerWidth ?? 1);
+      const mountHeight = Math.max(1, mount?.clientHeight ?? window.innerHeight ?? 1);
+      const aspect = mountWidth / mountHeight;
+      const verticalFov = THREE.MathUtils.degToRad(camera.fov);
+      const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * aspect);
+      const limitingHalfFov = Math.max(0.05, Math.min(verticalFov, horizontalFov) / 2);
+      const fitDistance = (OVERHEAD_VIEW_RADIUS * OVERHEAD_VIEW_PADDING) / Math.tan(limitingHalfFov);
+      const height = TABLE_HEIGHT + fitDistance * zoom;
       const lateralPull = humanSeat?.forward.clone().setY(0).normalize().multiplyScalar(TABLE_RADIUS * 0.12) ??
         new THREE.Vector3();
       const targetPosition = new THREE.Vector3(lateralPull.x, height, lateralPull.z + 0.001);


### PR DESCRIPTION
### Motivation
- Ensure the overhead zoom frames the entire play area (table, chairs, cards, chips) across portrait/landscape and different viewport sizes instead of only board bounds.
- Make pinch/toolbar zoom behave consistently by computing camera distance from actual camera FOV and viewport aspect ratio.

### Description
- Added `OVERHEAD_VIEW_RADIUS` and `OVERHEAD_VIEW_PADDING` constants to express the table footprint to fit (chairs/cards/chips).
- Replaced the fixed overhead height formula with a FOV+viewport-based fit distance computed from `camera.fov`, mount `clientWidth`/`clientHeight` and aspect ratio, then multiplied by the `zoom` value to compute camera `height`.
- Preserved existing zoom clamps and pinch sensitivities (`OVERHEAD_ZOOM_*`, `SEATED_ZOOM_*`, pinch handlers) so user controls remain unchanged.
- Modified file: `webapp/src/pages/Games/TexasHoldemArena.jsx` (overhead camera calculation in `applyOverheadCamera`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite warnings about large chunks are pre-existing); build succeeded.
- Launched the dev server and captured a portrait viewport screenshot using Playwright; screenshot artifact: `browser:/tmp/codex_browser_invocations/65e14856d09ce027/artifacts/artifacts/texas-overhead-zoom.png`.
- Verified interactive pinch/zoom and resize code paths were left intact and the overhead camera is applied on resize and view toggles (visual confirmation via the screenshot and local dev run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ddc18390832982863581981db945)