### PR TITLE
Fix Pool Royale pre-impact English deflection

### DIFF
--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -19,7 +19,7 @@ describe('Pool Royale AI aim compensation', () => {
     expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeGreaterThan(0.04);
   });
 
-  it('applies side-spin compensation as a measurable aim shift', () => {
+  it('keeps pre-impact aim unchanged when only side spin changes', () => {
     const neutral = resolveAiPotGhostAim({
       cuePos,
       targetPos,
@@ -37,6 +37,6 @@ describe('Pool Royale AI aim compensation', () => {
       power: 0.8
     });
     expect(withSide).toBeTruthy();
-    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeGreaterThan(0.001);
+    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeLessThan(1e-6);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -29585,8 +29585,14 @@ const powerRef = useRef(hud.power);
                 TMP_VEC3_C.copy(TMP_VEC3_A).multiplyScalar(-BALL_R);
                 TMP_VEC3_D.set(a.vel.x, 0, a.vel.y);
                 TMP_VEC3_E.set(b.vel.x, 0, b.vel.y);
-                const omegaA = a.omega ?? TMP_VEC3_F.set(0, 0, 0);
-                const omegaB = b.omega ?? TMP_VEC3_G.set(0, 0, 0);
+                const cueSpinSuppressedA = a.id === 'cue' && !a.impacted;
+                const cueSpinSuppressedB = b.id === 'cue' && !b.impacted;
+                const omegaA = cueSpinSuppressedA
+                  ? TMP_VEC3_F.set(0, 0, 0)
+                  : a.omega ?? TMP_VEC3_F.set(0, 0, 0);
+                const omegaB = cueSpinSuppressedB
+                  ? TMP_VEC3_G.set(0, 0, 0)
+                  : b.omega ?? TMP_VEC3_G.set(0, 0, 0);
                 TMP_VEC3_H.copy(omegaA).cross(TMP_VEC3_B).add(TMP_VEC3_D);
                 TMP_VEC3_F.copy(omegaB).cross(TMP_VEC3_C).add(TMP_VEC3_E);
                 TMP_VEC3_F.sub(TMP_VEC3_H);

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -16,13 +16,13 @@ export const resolveAiPotGhostAim = ({
   if (toPocket.lengthSq() <= MIN_VECTOR_EPS) return null;
 
   const toPocketDir = toPocket.normalize();
-  const sideSpin = THREE.MathUtils.clamp(spin?.x ?? 0, -1, 1);
   const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
   const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
 
-  // Small compensation for squirt/throw so AI can still target the center pocket entry.
-  const compensationAngle = sideSpin * power01 * 0.085;
-  // Slightly adjust contact depth with top/back spin to account for throw speed changes.
+  // Keep cue-ball approach aligned to the geometric ghost-ball line.
+  // Spin is still used after contact by the runtime physics, but it should not
+  // change the pre-impact aiming direction.
+  // Slightly adjust contact depth with top/back spin to account for post-impact speed changes.
   const contactDepth = radius * 2 * (1 + topBackSpin * power01 * 0.07);
   const ghost = new THREE.Vector2()
     .copy(targetPos)
@@ -30,7 +30,6 @@ export const resolveAiPotGhostAim = ({
 
   const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
   if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;
-  finalCueVector.rotateAround(new THREE.Vector2(0, 0), -compensationAngle);
 
   return {
     aimDir: finalCueVector.normalize(),


### PR DESCRIPTION
### Motivation
- Prevent side-spin (English) from changing the pre-impact cue-ball approach so the visible aiming line and ghost target match the actual contact geometry. 
- Keep the visual/spin effect active after the collision so post-impact behaviour (swerve/throw/roll) remains realistic.

### Description
- Suppress cue angular-velocity contribution to ball-ball collision pre-impact by using zeroed `omega` for cue balls that have not yet been marked `impacted` in the collision resolver (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Remove AI pre-impact side-spin aim rotation from `resolveAiPotGhostAim` so the ghost-ball aim is computed purely from geometric contact and no longer rotates by a compensation angle (`webapp/src/pages/Games/poolRoyaleAiAimCompensation.js`).
- Preserve top/back spin influence on contact depth (used for post-impact speed/roll) while ensuring side-spin does not alter pre-impact aim.
- Update the unit test to assert pre-impact aim is unchanged when only side spin changes (`test/poolRoyaleAiAimCompensation.test.js`).

### Testing
- Ran the focused Jest suites with `npm test -- test/poolRoyaleAiAimCompensation.test.js test/cueShotImpact.test.js --runInBand` and both test suites passed.
- Test summary: 2 test suites passed, 5 tests passed, command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eb80e210832984b1c8c4c5da583e)