### PR TITLE
Refine cue aiming, pullback and strike behaviour for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1846,6 +1846,7 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.2; // ensure every stroke pulls farther back for readability at all angles
 const CUE_PULL_RETURN_PUSH = 0.97; // push the cue forward to contact more decisively after pullback
+const CUE_PULL_LINEAR_BLEND = 0.82; // keep pullback mostly linear with a tiny easing tail for mobile feel
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pushing through the cue ball
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
@@ -15016,6 +15017,8 @@ const powerRef = useRef(hud.power);
   const aimCurveControlRef = useRef(new THREE.Vector3());
   const cuePullTargetRef = useRef(0);
   const cuePullCurrentRef = useRef(0);
+  const cuePowerDragActiveRef = useRef(false);
+  const cueAimLockRef = useRef(null);
   const cueStickAnchorRef = useRef(new THREE.Vector3(0, BALL_CENTER_Y, 0));
   const cueLiftRef = useRef({
     active: false,
@@ -21477,7 +21480,7 @@ const powerRef = useRef(hud.power);
                   return Math.pow(pushT, 0.68);
                 case 'classic':
                 default:
-                  return easeOutCubic(pushT);
+                  return easeInCubic(pushT);
               }
             })();
             const motionPush = (() => {
@@ -21522,7 +21525,7 @@ const powerRef = useRef(hud.power);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
-            cueStick.visible = true;
+            cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
@@ -24592,16 +24595,20 @@ const powerRef = useRef(hud.power);
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const style = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
-        const styleRatio = resolveCueStrokeProfile(style, ratio).pullRatio;
+        const easedRatio = THREE.MathUtils.lerp(
+          ratio,
+          easeOutCubic(ratio),
+          1 - CUE_PULL_LINEAR_BLEND
+        );
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
         const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
         const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
         const target =
-          amplifiedMax * styleRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
+          amplifiedMax * easedRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
         return Math.min(target, visualMax);
       };
       // Easing adapted from easings.net (MIT) for a smoother pull/release cue stroke.
+      const easeInCubic = (t) => t * t * t;
       const easeInOutCubic = (t) =>
         t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
@@ -28449,8 +28456,12 @@ const powerRef = useRef(hud.power);
           : shouldAutoAimAi
             ? resolveAutoAimDirection({ turnOwner: 'ai', cycleToNext: false })
             : null;
+        const chargingCue = Boolean(cuePowerDragActiveRef.current);
         if (!lookModeRef.current) {
-          if (shouldLockAiAim) {
+          if (chargingCue && cueAimLockRef.current?.lengthSq?.() > 1e-6) {
+            aimDir.copy(cueAimLockRef.current);
+            aimDir.normalize();
+          } else if (shouldLockAiAim) {
             aimDir.copy(activeAiPlan.aimDir);
             if (aimDir.lengthSq() > 1e-6) {
               aimDir.normalize();
@@ -28894,16 +28905,19 @@ const powerRef = useRef(hud.power);
             cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE,
             powerRef.current ?? 0
           );
+          const sliderDragging = Boolean(sliderInstanceRef.current?.dragging);
           const aiPullReady =
             !isAiTurn ||
             (aiCueViewActive && now >= (aiCuePullReadyAtRef.current ?? 0));
-          const desiredPull = aiPullReady
-            ? computePullTargetFromPower(powerRef.current, maxPull)
-            : 0;
+          const desiredPull = isAiTurn
+            ? aiPullReady
+              ? computePullTargetFromPower(powerRef.current, maxPull)
+              : 0
+            : sliderDragging
+              ? computePullTargetFromPower(powerRef.current, maxPull)
+              : 0;
           const pull = computeCuePull(desiredPull, maxPull, {
-            instant:
-              Boolean(sliderInstanceRef.current?.dragging) ||
-              (isAiTurn && !aiPullReady),
+            instant: sliderDragging || (isAiTurn && !aiPullReady),
             smoothingOverride: pullProfile.pullSmoothing
           });
           const visualPull = applyVisualPullCompensation(pull, dir);
@@ -30882,8 +30896,16 @@ const powerRef = useRef(hud.power);
       onChange: (v) => applyPower(v / 100),
       onStart: () => {
         captureCueStickAnchor();
+        cuePowerDragActiveRef.current = true;
+        const lockedAim = aimDirRef.current?.clone?.();
+        cueAimLockRef.current =
+          lockedAim && lockedAim.lengthSq() > 1e-6
+            ? lockedAim.normalize()
+            : new THREE.Vector2(0, 1);
       },
       onCommit: () => {
+        cuePowerDragActiveRef.current = false;
+        cueAimLockRef.current = null;
         fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
@@ -30894,6 +30916,8 @@ const powerRef = useRef(hud.power);
     sliderInstanceRef.current = slider;
     applySliderLock();
     return () => {
+      cuePowerDragActiveRef.current = false;
+      cueAimLockRef.current = null;
       sliderInstanceRef.current = null;
       slider.destroy();
     };
@@ -30904,6 +30928,8 @@ const powerRef = useRef(hud.power);
     if (slider) {
       slider.set(slider.min, { animate: true });
     }
+    cuePowerDragActiveRef.current = false;
+    cueAimLockRef.current = null;
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;


### PR DESCRIPTION
### Motivation
- Improve mobile cue feel: lock aim while charging, make pullback behave like a rigid stick sliding along its axis, and give the strike a fast ease-in snap with immediate hide after impact.
- Prevent visual jitter and stale aim locks by ensuring charge/lock state is reset when the slider is torn down or the turn changes.

### Description
- Added a small control constant `CUE_PULL_LINEAR_BLEND` to make pullback mostly linear with a subtle easing tail for a mobile feel and introduced `easeInCubic` for strike acceleration tuning.
- Captured/locked the current aim when the power slider drag starts and held that aim during charge using `cuePowerDragActiveRef` and `cueAimLockRef`, preventing unintended rotation while pulling back (changes in `PoolRoyale.jsx`).
- Changed pull target computation to use a mostly-linear eased ratio (`computePullTargetFromPower`) so visual pullback translates along the cue axis while dragging only when the slider is active.
- Adjusted strike forward easing to use an ease-in (`easeInCubic`) for a quicker acceleration into impact and immediately hide the cue after the strike animation completes to match the described visual behaviour.
- Added cleanup to clear `cuePowerDragActiveRef`/`cueAimLockRef` on slider teardown and turn/shot resets to avoid stale locks and jitter.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (Vite build completed and bundles were produced). Success.
- Ran ESLint `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which returned a repository ignore warning in this environment (no actionable lints reported for the change). Warning.
- Attempted an automated Playwright screenshot of the running dev server to visually validate the cue, but the headless browser navigation/screenshot timed out in this environment, so no screenshot artifact was produced. Timed out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f55c68448329a74d907c4de11183)