### PR TITLE
Implement mobile-style cue aiming, pullback and strike in CueController

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -1,23 +1,142 @@
+using System;
+using System.Collections;
 using UnityEngine;
 
 namespace Aiming
 {
     public class CueController : MonoBehaviour
     {
+        [Header("References")]
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
-        public Transform cueBall, objectBall, pocket;
+        public Transform cueBall;
+        public Transform objectBall;
+        public Transform pocket;
+        public Rigidbody cueBallBody;
+
+        [Header("Table")]
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
-        public float cueDistanceFromBall = 0.12f;
-        public float animationPullbackDistance = 0.045f;
-        public float animationSpeed = 4f;
 
-        Vector3 _lastAimDirection = Vector3.forward;
+        [Header("Cue Placement")]
+        [Tooltip("Fixed idle gap between cue tip and cue ball while aiming.")]
+        public float idleTipGap = 0.008f;
+        [Tooltip("Maximum backward travel while charging power.")]
+        public float maxPullbackDistance = 0.18f;
+
+        [Header("Aim Feel")]
+        [Tooltip("Higher value = more responsive, lower = heavier rotation.")]
+        public float aimSmoothing = 12f;
+
+        [Header("Strike")]
+        public float strikeDuration = 0.075f;
+        public float recoilDistance = 0.012f;
+        public float recoilDuration = 0.05f;
+        public float strikeImpulse = 3.5f;
+        public ForceMode strikeForceMode = ForceMode.Impulse;
+
+        [Header("Visibility")]
+        [Tooltip("If true, cue aim direction is automatically derived from aiming engine solution.")]
+        public bool autoAimFromSolution = true;
+
+        public event Action<float> OnCueStrike;
+
+        Vector3 _targetAimDirection = Vector3.forward;
+        Vector3 _smoothedAimDirection = Vector3.forward;
+
+        float _charge01;
+        float _currentPullback;
+        float _strikeOffset;
+
+        bool _isAiming;
+        bool _isStriking;
+
+        Coroutine _strikeRoutine;
+
+        void Awake()
+        {
+            SetCueVisible(false);
+        }
 
         void Update()
         {
-            if (aiming == null || cueBall == null || objectBall == null || pocket == null) return;
+            if (cueBall == null) return;
+
+            if (_isAiming && autoAimFromSolution)
+            {
+                UpdateTargetDirectionFromSolution();
+            }
+
+            if (_isAiming)
+            {
+                UpdateAimSmoothing();
+                UpdatePullback();
+                UpdateCueTransform();
+            }
+        }
+
+        public void BeginAim()
+        {
+            _isAiming = true;
+            _isStriking = false;
+            _charge01 = 0f;
+            _currentPullback = 0f;
+            _strikeOffset = 0f;
+            _smoothedAimDirection = _targetAimDirection.sqrMagnitude > 1e-6f ? _targetAimDirection.normalized : Vector3.forward;
+            SetCueVisible(true);
+            UpdateCueTransform();
+        }
+
+        public void EndAim()
+        {
+            _isAiming = false;
+            _isStriking = false;
+            _charge01 = 0f;
+            _currentPullback = 0f;
+            _strikeOffset = 0f;
+
+            if (_strikeRoutine != null)
+            {
+                StopCoroutine(_strikeRoutine);
+                _strikeRoutine = null;
+            }
+
+            SetCueVisible(false);
+        }
+
+        public void SetAimDirection(Vector3 direction)
+        {
+            if (direction.sqrMagnitude <= 1e-6f) return;
+            _targetAimDirection = direction.normalized;
+        }
+
+        public void BeginCharge()
+        {
+            if (!_isAiming || _isStriking) return;
+        }
+
+        public void SetCharge01(float charge01)
+        {
+            if (!_isAiming || _isStriking) return;
+            _charge01 = Mathf.Clamp01(charge01);
+        }
+
+        public void ReleaseShoot()
+        {
+            if (!_isAiming || _isStriking) return;
+
+            if (_strikeRoutine != null)
+            {
+                StopCoroutine(_strikeRoutine);
+            }
+
+            _strikeRoutine = StartCoroutine(StrikeRoutine(_charge01));
+        }
+
+        void UpdateTargetDirectionFromSolution()
+        {
+            if (aiming == null || objectBall == null || pocket == null) return;
+
             ShotContext ctx = new ShotContext
             {
                 cueBallPos = cueBall.position,
@@ -29,29 +148,118 @@ namespace Aiming
                 highSpin = false,
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
-            var sol = aiming.GetAimSolution(ctx);
-            if (sol.isValid)
-            {
-                Vector3 dir = (sol.aimEnd - sol.aimStart);
-                if (dir.sqrMagnitude > 1e-6f)
-                {
-                    dir.Normalize();
-                    _lastAimDirection = dir;
 
-                    float animationPhase = (Mathf.Sin(Time.time * animationSpeed) + 1f) * 0.5f;
-                    float pullback = animationPhase * animationPullbackDistance;
-                    transform.position = sol.aimStart - dir * (cueDistanceFromBall + pullback);
-                    transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
-                    if (cueTip != null)
-                    {
-                        cueTip.position = sol.aimStart;
-                    }
-                }
-            }
-            else
+            var sol = aiming.GetAimSolution(ctx);
+            if (!sol.isValid) return;
+
+            Vector3 dir = sol.aimEnd - sol.aimStart;
+            if (dir.sqrMagnitude <= 1e-6f) return;
+            SetAimDirection(dir);
+        }
+
+        void UpdateAimSmoothing()
+        {
+            float t = 1f - Mathf.Exp(-Mathf.Max(0.01f, aimSmoothing) * Time.deltaTime);
+            _smoothedAimDirection = Vector3.Slerp(_smoothedAimDirection, _targetAimDirection, t);
+            if (_smoothedAimDirection.sqrMagnitude <= 1e-6f)
             {
-                transform.rotation = Quaternion.LookRotation(_lastAimDirection, Vector3.up);
+                _smoothedAimDirection = _targetAimDirection;
             }
+            _smoothedAimDirection.Normalize();
+        }
+
+        void UpdatePullback()
+        {
+            if (_isStriking) return;
+
+            float targetPullback = EaseOutCubic(_charge01) * maxPullbackDistance;
+            float pullbackFollow = 1f - Mathf.Exp(-18f * Time.deltaTime);
+            _currentPullback = Mathf.Lerp(_currentPullback, targetPullback, pullbackFollow);
+        }
+
+        void UpdateCueTransform()
+        {
+            Vector3 dir = _smoothedAimDirection.sqrMagnitude > 1e-6f ? _smoothedAimDirection : Vector3.forward;
+
+            // Tip gap + power pullback + strike animation offset along cue axis.
+            float visualDistance = Mathf.Max(0f, idleTipGap + _currentPullback + _strikeOffset);
+            Vector3 cueBallCenter = cueBall.position;
+            transform.position = cueBallCenter - dir * visualDistance;
+            transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
+
+            if (cueTip != null)
+            {
+                cueTip.position = cueBallCenter - dir * visualDistance;
+            }
+        }
+
+        IEnumerator StrikeRoutine(float shotPower01)
+        {
+            _isStriking = true;
+
+            float startPullback = _currentPullback;
+            float elapsed = 0f;
+
+            while (elapsed < strikeDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / Mathf.Max(0.01f, strikeDuration));
+                float eased = EaseInQuad(t); // quick acceleration for snappy strike
+
+                _currentPullback = Mathf.Lerp(startPullback, 0f, eased);
+                _strikeOffset = Mathf.Lerp(0f, -idleTipGap, eased);
+                UpdateCueTransform();
+                yield return null;
+            }
+
+            _currentPullback = 0f;
+            _strikeOffset = -idleTipGap;
+            UpdateCueTransform();
+
+            float impulse = Mathf.Clamp01(shotPower01) * strikeImpulse;
+            if (cueBallBody != null)
+            {
+                cueBallBody.AddForce(_smoothedAimDirection * impulse, strikeForceMode);
+            }
+
+            OnCueStrike?.Invoke(impulse);
+
+            // Tiny visual recoil for impact feel.
+            elapsed = 0f;
+            while (elapsed < recoilDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / Mathf.Max(0.01f, recoilDuration));
+                _strikeOffset = Mathf.Lerp(-idleTipGap, recoilDistance, t);
+                UpdateCueTransform();
+                yield return null;
+            }
+
+            _strikeOffset = 0f;
+            _charge01 = 0f;
+            _currentPullback = 0f;
+            _isStriking = false;
+
+            // Hide cue while balls are moving.
+            EndAim();
+        }
+
+        static float EaseOutCubic(float t)
+        {
+            t = Mathf.Clamp01(t);
+            float inv = 1f - t;
+            return 1f - inv * inv * inv;
+        }
+
+        static float EaseInQuad(float t)
+        {
+            t = Mathf.Clamp01(t);
+            return t * t;
+        }
+
+        void SetCueVisible(bool visible)
+        {
+            gameObject.SetActive(visible);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a classic mobile pool cue feel: cue visible only while aiming, rigid rotation around the cue ball, fixed idle tip gap, smooth aiming rotation, linear/eased pullback for charging, and a fast forward strike with recoil and cue hide.
- Make the cue behaviour deterministic and modular so UI/input systems can drive states (`BeginAim` / `BeginCharge` / `SetCharge01` / `ReleaseShoot` / `EndAim`).

### Description
- Reworked `CueController` into an explicit cue lifecycle with public methods `BeginAim`, `SetAimDirection`, `BeginCharge`, `SetCharge01`, `ReleaseShoot`, and `EndAim` so the cue is only visible in aim state and hides after a shot.
- Added configurable parameters and fields: `idleTipGap`, `maxPullbackDistance`, `aimSmoothing`, `strikeDuration`, `recoilDistance`, `recoilDuration`, `strikeImpulse`, `strikeForceMode`, and `autoAimFromSolution` to tune feel and integration with `AdaptiveAimingEngine`.
- Implemented damped aim smoothing using exponential lerp + `Vector3.Slerp` so rotation feels slightly heavy but responsive and always rotates around the cue ball without bending.
- Implemented eased pullback mapping from `SetCharge01` using `EaseOutCubic` and `Mathf.Lerp` so power linearly translates to backward cue travel with smoothing, and ensured the cue only translates along its axis (no rotation during pullback).
- Implemented `StrikeRoutine` coroutine that eases the cue forward quickly (`EaseInQuad`), applies an impulse to `cueBallBody` via `Rigidbody.AddForce`, plays a tiny visual recoil, resets state, and hides the cue while balls move; ensured the visual tip never clips by clamping `visualDistance`.

### Testing
- Ran repository checks: `git diff --check && git status --short` which completed without errors.
- Verified commit metadata with `git show --stat --oneline -1` to confirm the file change was recorded.
- No Unity PlayMode or EditMode tests were executed in this environment because the Unity editor/runtime is unavailable here; integration must be validated in-editor and on-device (mobile) to confirm feel and timing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f55c68448329a74d907c4de11183)