### PR TITLE
Extend Pool Royale cue stroke timings and start replay with cue charge

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24500,14 +24500,15 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
+        const pullbackDuration = THREE.MathUtils.lerp(150, 260, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Keep the strike readable on phone portrait framing by extending the
+          // visible pull/release timing for both player and AI turns.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
+          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 260),
+          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 120),
           pullbackDuration,
           recoverDuration: 0,
           impactThreshold: 0.88,
@@ -25243,7 +25244,8 @@ const powerRef = useRef(hud.power);
           }
           openingShotViewSuppressedRef.current = false;
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
-            const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
+            const strokeStartOffset =
+              REPLAY_CUE_START_HOLD_MS + REPLAY_CUE_STROKE_LEAD_IN_MS;
             shotRecording.cueStroke = {
               idle: serializeVector3Snapshot(idlePos),
               pull: serializeVector3Snapshot(pullPos),


### PR DESCRIPTION
### Motivation

- Improve visual readability of the cue strike on phone portrait screens by making the cue pullback, strike and hold easier to perceive for both player and AI shots.
- Ensure replays begin from the cue charging phase so the user sees the full wind-up and impact rather than jumping near impact.

### Description

- Increased the live cue `pullbackDuration` range and raised the minimum `strikeDuration` and `holdDuration` in `resolveCueStrokeProfile` to lengthen the visible pull/release cycle in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Updated replay recording so `startOffset` for `shotRecording.cueStroke` includes the lead-in window by adding `REPLAY_CUE_STROKE_LEAD_IN_MS` to `REPLAY_CUE_START_HOLD_MS`.
- Kept changes scoped to a single file: `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing

- Ran project lint (`npm run lint`) which surfaced many pre-existing unrelated errors in the monorepo (not caused by this change) and therefore reported failures for the full repo.
- Ran file-lint with `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which executed and produced only the expected ignore-warning with no syntax errors in the modified file.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` which launched successfully and a Playwright screenshot was captured (`artifacts/poolroyale-home.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83b5985bc832982b321524b0db00c)