### PR TITLE
Show cue stick during live shots and start replays in charging phase (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21305,7 +21305,11 @@ const powerRef = useRef(hud.power);
                 0
             ) * replayScale;
           const startOffset = Math.max(0, stroke.startOffset ?? 0);
-          const localTime = targetTime - Math.max(0, startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
+          // Allow replay lead-in to advance the cue stroke timeline even when
+          // the recorded stroke offset is short, so replays open on visible
+          // cue charging instead of a static idle pose.
+          const localTime =
+            targetTime - (startOffset - REPLAY_CUE_STROKE_LEAD_IN_MS);
           const playbackWindow = Number.isFinite(playback?.duration)
             ? Math.max(playback.duration, 1400)
             : 1400;
@@ -29363,6 +29367,8 @@ const powerRef = useRef(hud.power);
           if (
             !cueAnimating &&
             !replayActive &&
+            !shooting &&
+            !aiTakingShot &&
             !(ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current)
           ) {
             cueStick.visible = false;


### PR DESCRIPTION
### Motivation
- Replays should open showing the cue charging/pullback so the strike is readable, and the cue stick must remain visible during both player and AI shots so the strike animation is always seen.

### Description
- Adjusted replay timeline calculation in `webapp/src/pages/Games/PoolRoyale.jsx` so `REPLAY_CUE_STROKE_LEAD_IN_MS` is applied even when the recorded `startOffset` is short, causing replays to begin in the charge/pullback phase.
- Prevented the cue from auto-hiding during active shots by adding `!shooting && !aiTakingShot` checks to the cue visibility logic in the same file.
- Added a clarifying comment explaining the replay lead-in behavior.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (file-level lint completed; repo lint ignore produced a warning).
- Ran full lint `npm run -s lint` which failed due to extensive pre-existing repo-wide lint issues unrelated to these changes.
- Launched the webapp dev server with `npm --prefix webapp run dev` and executed a Playwright script to load the app and capture a screenshot (`artifacts/pool-royale-cue-visibility.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83b5985bc832982b321524b0db00c)