### PR TITLE
Reset Pool Royale cue stick to pulled start after strike

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -26,6 +26,7 @@ namespace Aiming
         public float strikeDuration = 0.055f;
         public float recoilDistance = 0.015f;
         public float recoilDuration = 0.04f;
+        public float resetPullbackDuration = 0.08f;
         public float baseStrikeImpulse = 1.8f;
         public float maxStrikeImpulse = 6.5f;
         public AnimationCurve pullbackEasing = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
@@ -191,6 +192,21 @@ namespace Aiming
             _currentPullback = recoilDistance;
             UpdateCuePose();
             yield return new WaitForSeconds(recoilDuration);
+
+            elapsed = 0f;
+            float recoilStartPullback = _currentPullback;
+            while (elapsed < resetPullbackDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / Mathf.Max(resetPullbackDuration, 0.001f));
+                float eased = pullbackEasing.Evaluate(t);
+                _currentPullback = Mathf.Lerp(recoilStartPullback, startPullback, eased);
+                UpdateCuePose();
+                yield return null;
+            }
+
+            _currentPullback = startPullback;
+            UpdateCuePose();
 
             _currentPullback = 0f;
             _targetPullback = 0f;


### PR DESCRIPTION
### Motivation
- Ensure the cue stick visibly returns to the same pulled-start position after the forward strike and recoil so both player and AI shots preserve the expected pull→push→return visual flow.

### Description
- Added a new tunable `resetPullbackDuration` and updated `StrikeRoutine` in `Assets/Scripts/Gameplay/CueController.cs` to animate the cue from the recoil position back to the original `startPullback` before final reset.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js`, and the suite passed (4 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84b5a387c832989ba5ea30d6d26c5)