### PR TITLE
Pool Royale: cue stick returns to original pullback after shot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21522,7 +21522,7 @@ const powerRef = useRef(hud.power);
               syncCueShadow();
               return true;
             }
-            cueStick.position.copy(idlePos);
+            cueStick.position.copy(pullPos ?? idlePos);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -21600,13 +21600,17 @@ const powerRef = useRef(hud.power);
           }
           if (sample.phase === 'recover') {
             const eased = easeInOutCubic(sample.t);
-            cueStick.position.lerpVectors(followPos ?? impactPos, idlePos, eased);
+            cueStick.position.lerpVectors(
+              followPos ?? impactPos,
+              pullPos ?? idlePos,
+              eased
+            );
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
             return true;
           }
-          cueStick.position.copy(idlePos);
+          cueStick.position.copy(pullPos ?? idlePos);
           cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
           cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
           syncCueShadow();
@@ -24513,7 +24517,9 @@ const powerRef = useRef(hud.power);
           strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
           holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
           pullbackDuration,
-          recoverDuration: 0,
+          // Show a visible recoil so the cue returns toward the same
+          // pullback origin before settling.
+          recoverDuration: Math.max(120, pullbackDuration * 0.85),
           impactThreshold: 0.88,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
@@ -25080,7 +25086,7 @@ const powerRef = useRef(hud.power);
           // pull = pullRange * easeOutCubic(power), then push forward on strike.
           const pullRange = 0.24;
           const pullTarget = pullRange * strokeProfile.pullRatio;
-          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
+          const pulledNow = Math.max(cuePullCurrentRef.current ?? 0, pullTarget);
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
           cuePullCurrentRef.current = startPull;


### PR DESCRIPTION
### Motivation
- Improve visual clarity of cue stroke by making the cue visibly recoil back toward the same pullback origin after a shot so player and AI strokes are easier to read.

### Description
- Set `recoverDuration` in the cue stroke profile to a non-zero value (`Math.max(120, pullbackDuration * 0.85)`) so the stick shows a visible recoil window instead of ending immediately. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Ensure shot setup uses at least the computed pull target by replacing `cuePullCurrentRef.current ?? pullTarget` with `Math.max(cuePullCurrentRef.current ?? 0, pullTarget)` so shots start from a visible pulled-back state for both player and AI. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Change stroke completion and recover behavior to return toward the pullback origin by using `pullPos ?? idlePos` in end/callback/recover paths instead of snapping straight to `idlePos`. (`webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed with a workspace ignore warning but no errors. (warning)
- Launched the web app with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully for a visual check. (success)
- Captured a Playwright screenshot against the running dev server to validate the build and rendering. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84b5a387c832989ba5ea30d6d26c5)