### PR TITLE
Pool Royale: return cue stick to pull-start pose on shot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25131,26 +25131,14 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
-          const topspinFactor = THREE.MathUtils.clamp(
-            Math.max(0, appliedSpin?.y ?? 0) * powerStrength,
-            0,
-            1
-          );
           const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const idleGap = 0.01;
-          const contactEps = 0.001;
-          const followExtra = THREE.MathUtils.clamp(topspinFactor * 0.016, 0, 0.018);
-          const endDistanceFromBallCenter = Math.max(
-            BALL_R * 0.55,
-            BALL_R + contactEps - followExtra
-          );
-          const idleDistanceFromBallCenter = BALL_R + idleGap;
-          const forwardPush = Math.max(0, idleDistanceFromBallCenter - endDistanceFromBallCenter);
-          const impactPos = idlePos.clone().addScaledVector(dir, forwardPush);
+          // Keep the strike return anchored at the same pose where pullback starts.
+          // This preserves the visible pull gesture, then drives the cue forward back
+          // into the exact starting point for both player and AI shots.
+          const impactPos = idlePos.clone();
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;


### PR DESCRIPTION
### Motivation
- Fix visual/UX issue where the cue stick would overshoot its starting pose on release, making the pull gesture feel inconsistent for both player and AI shots.
- Preserve the visible pullback while ensuring the strike animation returns the cue to the exact pose it started from so aim/power feedback remains clear.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to anchor the strike impact/follow positions to the pull-start pose by setting `impactPos` to `idlePos` and using that same anchor for `followPos` instead of computing a forward follow-through offset. 
- Removed the small forward push calculation tied to topspin/power that previously pushed the cue past the pull-start anchor so both player and AI shots share the corrected behavior in the shared `fire()` path.

### Testing
- Ran `npm --prefix webapp run -s build` and the webapp build completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx --no-ignore` which surfaced the project ignore warning for this file but no new lint failures from the change in this environment. 
- Attempted an automated Playwright screenshot of `/games/poolroyale` to visually validate the change, but the screenshot timed out while rendering the heavy WebGL scene in this environment (capture failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84b5a387c832989ba5ea30d6d26c5)