### PR TITLE
Return cue stick to pull-start position on strike (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25131,26 +25131,11 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
-          const topspinFactor = THREE.MathUtils.clamp(
-            Math.max(0, appliedSpin?.y ?? 0) * powerStrength,
-            0,
-            1
-          );
           const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const idleGap = 0.01;
-          const contactEps = 0.001;
-          const followExtra = THREE.MathUtils.clamp(topspinFactor * 0.016, 0, 0.018);
-          const endDistanceFromBallCenter = Math.max(
-            BALL_R * 0.55,
-            BALL_R + contactEps - followExtra
-          );
-          const idleDistanceFromBallCenter = BALL_R + idleGap;
-          const forwardPush = Math.max(0, idleDistanceFromBallCenter - endDistanceFromBallCenter);
-          const impactPos = idlePos.clone().addScaledVector(dir, forwardPush);
+          const impactPos = idlePos.clone();
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;


### PR DESCRIPTION
### Motivation
- Ensure the visual cue stick behaviour matches expected pull-then-push: when a shot (player or AI) fires, the cue should push forward to the original pull-start contact point rather than overshooting past contact.

### Description
- Updated the Pool Royale shot animation to use the cue idle position as the impact target by setting `impactPos = idlePos.clone()` in `webapp/src/pages/Games/PoolRoyale.jsx` so the release phase returns the cue to the pull-start position.
- Removed the previous forward-push computation that computed an extra `forwardPush` distance (and related topspin/power math) so the visual strike no longer overshoots the idle contact point.
- Change applies to live shots, AI previews, replay recording and playback paths that share the same cue-stroke profile.

### Testing
- Ran the cue stroke timeline unit tests with `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js` and all tests passed.
- The UI was exercised locally via the webapp dev server to validate the visual cue behaviour (screenshot produced during verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84b5a387c832989ba5ea30d6d26c5)