### PR TITLE
Tune Texas Hold'em landscape camera/chair and preload HDRIs in lobby

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -47,6 +47,7 @@ import {
   speakCommentaryLines
 } from '../../utils/textToSpeech.js';
 import { TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
+import { resolveTexasHoldemHdriUrl } from '../../utils/texasHoldemHdriPreload.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID } from '../../config/poolRoyaleInventoryConfig.js';
 import { chatBeep } from '../../assets/soundData.js';
 import GiftPopup from '../../components/GiftPopup.jsx';
@@ -390,12 +391,12 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.7, landscape: -0.18 });
-const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.78 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.7, landscape: -0.28 });
+const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * -0.12, landscape: -CARD_W * 0.62 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * -0.12, landscape: -CARD_W * 0.78 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
@@ -1222,51 +1223,6 @@ async function buildTableForTheme({
   return tableInfo;
 }
 
-function pickPolyHavenHdriUrl(fileMap, preferredResolutions = PREFERRED_HDRI_RESOLUTIONS) {
-  if (!fileMap || typeof fileMap !== 'object') return null;
-  const exr = fileMap?.exr || {};
-  const hdr = fileMap?.hdr || {};
-  for (const res of preferredResolutions) {
-    if (exr[res]) return exr[res];
-    if (hdr[res]) return hdr[res];
-  }
-  const exrValues = Object.values(exr);
-  const hdrValues = Object.values(hdr);
-  return exrValues[0] || hdrValues[0] || null;
-}
-
-async function resolvePolyHavenHdriUrl(config = {}, preferred = PREFERRED_HDRI_RESOLUTIONS) {
-  const preferredResolutions =
-    Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
-      ? config.preferredResolutions
-      : preferred;
-  const fallbackResolution =
-    config?.fallbackResolution || preferredResolutions?.[0] || PREFERRED_HDRI_RESOLUTIONS[0] || '2k';
-  const assetId = config?.assetId || 'neon_photostudio';
-  const fallbackUrl =
-    config?.fallbackUrl ||
-    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackResolution}/${assetId}_${fallbackResolution}.hdr`;
-  if (config?.assetUrls && typeof config.assetUrls === 'object') {
-    for (const res of preferredResolutions) {
-      if (config.assetUrls[res]) return config.assetUrls[res];
-    }
-    const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
-    if (manual) return manual;
-  }
-  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) return config.assetUrl;
-  if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
-  try {
-    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
-    if (!response?.ok) return fallbackUrl;
-    const json = await response.json();
-    const picked = pickPolyHavenHdriUrl(json, preferredResolutions);
-    return picked || fallbackUrl;
-  } catch (error) {
-    console.warn('Failed to resolve Poly Haven HDRI url', error);
-    return fallbackUrl;
-  }
-}
-
 async function createFallbackHdriEnvironment(renderer) {
   if (!renderer) return null;
   const pmrem = new THREE.PMREMGenerator(renderer);
@@ -1290,7 +1246,7 @@ async function createFallbackHdriEnvironment(renderer) {
 
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
-  const url = await resolvePolyHavenHdriUrl(config);
+  const url = await resolveTexasHoldemHdriUrl(config, PREFERRED_HDRI_RESOLUTIONS);
   const resolveFallback = async () => {
     try {
       return await createFallbackHdriEnvironment(renderer);
@@ -6153,7 +6109,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.95rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.6rem+env(safe-area-inset-top,0px))]">
+      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.75rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.45rem+env(safe-area-inset-top,0px))]">
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -12,6 +12,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
 import { socket } from '../../utils/socket.js';
+import { warmTexasHoldemHdriFromLobby } from '../../utils/texasHoldemHdriPreload.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -51,6 +52,7 @@ export default function TexasHoldemLobby() {
 
   useEffect(() => {
     import('./TexasHoldem.jsx').catch(() => {});
+    warmTexasHoldemHdriFromLobby().catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -1,0 +1,99 @@
+import { TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
+
+const DEFAULT_RESOLUTIONS = Object.freeze(['4k']);
+const hdriUrlCache = new Map();
+const hdriJsonPromiseCache = new Map();
+const hdriWarmPromiseCache = new Map();
+
+function pickPolyHavenHdriUrl(fileMap, preferredResolutions = DEFAULT_RESOLUTIONS) {
+  if (!fileMap || typeof fileMap !== 'object') return null;
+  const exr = fileMap?.exr || {};
+  const hdr = fileMap?.hdr || {};
+  for (const res of preferredResolutions) {
+    if (typeof exr[res] === 'string' && exr[res]) return exr[res];
+    if (typeof hdr[res] === 'string' && hdr[res]) return hdr[res];
+  }
+  const exrValues = Object.values(exr);
+  const hdrValues = Object.values(hdr);
+  return exrValues[0] || hdrValues[0] || null;
+}
+
+function getFallbackHdriUrl(config = {}, preferredResolutions = DEFAULT_RESOLUTIONS) {
+  const fallbackResolution =
+    config?.fallbackResolution || preferredResolutions[0] || DEFAULT_RESOLUTIONS[0] || '2k';
+  const assetId = config?.assetId || 'neon_photostudio';
+  return (
+    config?.fallbackUrl ||
+    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackResolution}/${assetId}_${fallbackResolution}.hdr`
+  );
+}
+
+async function getPolyHavenFilesJson(assetId) {
+  if (!assetId || typeof fetch !== 'function') return null;
+  const key = String(assetId).toLowerCase();
+  let pending = hdriJsonPromiseCache.get(key);
+  if (!pending) {
+    pending = fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`)
+      .then((response) => (response?.ok ? response.json() : null))
+      .catch(() => null);
+    hdriJsonPromiseCache.set(key, pending);
+  }
+  return pending;
+}
+
+export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT_RESOLUTIONS) {
+  const preferredResolutions =
+    Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+      ? config.preferredResolutions
+      : preferred;
+  const cacheKey = String(config?.id || config?.assetId || getFallbackHdriUrl(config, preferredResolutions));
+  if (hdriUrlCache.has(cacheKey)) {
+    return hdriUrlCache.get(cacheKey);
+  }
+
+  if (config?.assetUrls && typeof config.assetUrls === 'object') {
+    for (const res of preferredResolutions) {
+      const url = config.assetUrls[res];
+      if (typeof url === 'string' && url) {
+        hdriUrlCache.set(cacheKey, url);
+        return url;
+      }
+    }
+    const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
+    if (manual) {
+      hdriUrlCache.set(cacheKey, manual);
+      return manual;
+    }
+  }
+  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) {
+    hdriUrlCache.set(cacheKey, config.assetUrl);
+    return config.assetUrl;
+  }
+
+  const fallbackUrl = getFallbackHdriUrl(config, preferredResolutions);
+  const filesJson = await getPolyHavenFilesJson(config?.assetId);
+  const picked = pickPolyHavenHdriUrl(filesJson, preferredResolutions) || fallbackUrl;
+  hdriUrlCache.set(cacheKey, picked);
+  return picked;
+}
+
+export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS) {
+  if (typeof window === 'undefined' || typeof fetch !== 'function') return Promise.resolve();
+  const variants = Array.isArray(options) ? options.filter(Boolean) : [];
+  const jobs = variants.map((variant) => {
+    const key = variant?.id || variant?.assetId || variant?.fallbackUrl;
+    if (!key) return Promise.resolve();
+    if (hdriWarmPromiseCache.has(key)) return hdriWarmPromiseCache.get(key);
+
+    const job = resolveTexasHoldemHdriUrl(variant)
+      .then((url) => {
+        if (!url) return null;
+        return fetch(url, { mode: 'cors', cache: 'force-cache' });
+      })
+      .catch(() => null);
+
+    hdriWarmPromiseCache.set(key, job);
+    return job;
+  });
+  return Promise.allSettled(jobs);
+}


### PR DESCRIPTION
### Motivation
- Improve player view in landscape: bring the bottom chair and camera visually closer to the table center and slightly lower for a better seated perspective. 
- Reduce perceived HDRI load time by starting HDRI fetches earlier (when the user opens the lobby) so environments are ready when the arena loads. 
- Nudge the in-game menu control slightly upward to better match UI layout. 

### Description
- Adjusted landscape-only camera offsets by changing `CAMERA_RETREAT_OFFSETS` and `CAMERA_ELEVATION_OFFSETS` and increased the landscape `HUMAN_SEAT_INWARD_OFFSETS` so the bottom chair appears more inward (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Nudged the top/menu control container coordinates in the arena JSX so the menu button group is slightly higher (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Added a new HDRI preload utility `webapp/src/utils/texasHoldemHdriPreload.js` that resolves Poly Haven HDRI URLs with caching and provides `warmTexasHoldemHdriFromLobby` to prefetch HDRI assets.
- Replaced the inline HDRI URL resolution in the arena with the shared `resolveTexasHoldemHdriUrl` from the new preload utility and wired the lobby `useEffect` to call `warmTexasHoldemHdriFromLobby()` so HDRIs start warming as soon as the lobby mounts (files: `webapp/src/pages/Games/TexasHoldemArena.jsx`, `webapp/src/pages/Games/TexasHoldemLobby.jsx`).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (Vite warnings about chunk sizes only, non-blocking). 
- Started the dev server and ran an automated Playwright script that loaded the lobby and the Texas Hold'em arena and captured screenshots, which completed successfully and produced visual artifacts for inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a879c682908329914ae0a4088ab69c)