### PR TITLE
Adjust Pool Royale HUD positions: center menu, nudge chat/gift, move spin controller

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -24,7 +24,8 @@ export default function BottomLeftIcons({
   muteIconOff,
   cameraIcon,
   cameraLabel = '2D',
-  order = ['chat', 'gift', 'info', 'mute']
+  order = ['chat', 'gift', 'info', 'mute'],
+  actionOffsets = {}
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -98,7 +99,12 @@ export default function BottomLeftIcons({
         .map((key) => ({ key, node: actions[key] }))
         .filter(({ node }) => node)
         .map(({ key, node }) => (
-          <div key={key}>{node}</div>
+          <div
+            key={key}
+            style={{ transform: `translateY(${Number(actionOffsets?.[key]) || 0}px)` }}
+          >
+            {node}
+          </div>
         ))}
     </div>
   );

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13497,13 +13497,13 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const sharedHudLiftPx = 30;
-  const spinControllerLiftPx = 20;
+  const spinControllerLiftPx = 28;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = 5;
-  const menuButtonLeftNudgePx = -4;
+  const menuButtonCenterNudgePx = 0;
   const sideActionButtonsLiftPx = 10;
   const sideActionButtonsDropPx = 18;
-  const rightHudShiftPx = 4;
+  const rightHudShiftPx = -2;
   const bottomHudLeftPx = -22;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
@@ -31896,7 +31896,8 @@ const powerRef = useRef(hud.power);
         className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
           top: `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
-          left: `calc(0.75rem + env(safe-area-inset-left, 0px) + ${menuButtonLeftNudgePx}px)`
+          left: `calc(50% + ${menuButtonCenterNudgePx}px)`,
+          transform: 'translateX(-50%)'
         }}
       >
         <button
@@ -32933,6 +32934,10 @@ const powerRef = useRef(hud.power);
             infoIcon="ℹ️"
             muteIconOn="🔇"
             muteIconOff="🔊"
+            actionOffsets={{
+              chat: 6,
+              gift: -6
+            }}
             showInfo={false}
             showMute={false}
           />


### PR DESCRIPTION
### Motivation
- Align the top menu with the commentary row and tweak HUD controls so icons match the requested visual positions on portrait mobile (menu centered on the same top line as commentary, chat slightly lower, gift slightly higher, spin controller up and a bit right). 

### Description
- Repositioned the Pool Royale menu to the top-center by computing `left: calc(50% + ${menuButtonCenterNudgePx}px)` and applying `transform: translateX(-50%)` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Raised the spin controller and shifted its horizontal anchor by changing `spinControllerLiftPx` from `20` to `28` and `rightHudShiftPx` from `4` to `-2` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added an `actionOffsets` prop to `BottomLeftIcons` in `webapp/src/components/BottomLeftIcons.jsx` to allow per-icon vertical nudges and applied `{ chat: 6, gift: -6 }` for the Pool Royale layout. 
- Kept existing layout behavior and icon order while introducing lightweight per-action translateY adjustments so future tweaks are simple and localized.

### Testing
- Ran the unit test suite for the spin controller with `npm test -- test/poolRoyaleSpinController.test.js --runInBand` and the suite passed (`5 passed`).
- Attempted linting (`npx eslint`) but the workspace lint config reported the edited files as ignored, producing warnings rather than blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87b9932d083298e58cb0c34bb2f41)