### PR TITLE
Pool Royale: nudge HUD icons and auto-enable 2D in landscape

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13499,10 +13499,10 @@ function PoolRoyaleGame({
   const sharedHudLiftPx = 30;
   const spinControllerLiftPx = 28;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
-  const menuButtonTopNudgePx = 5;
+  const menuButtonTopNudgePx = 2;
   const menuButtonCenterNudgePx = 0;
   const sideActionButtonsLiftPx = 10;
-  const sideActionButtonsDropPx = 18;
+  const sideActionButtonsDropPx = 24;
   const rightHudShiftPx = -2;
   const bottomHudLeftPx = -22;
   const viewButtonsOffsetPx = 32;
@@ -13568,6 +13568,13 @@ function PoolRoyaleGame({
       topViewControlsRef.current.exit?.();
     }
   }, [isTopDownView]);
+
+  useEffect(() => {
+    if (isPortrait) return;
+    if (!isTopDownView) {
+      setIsTopDownView(true);
+    }
+  }, [isPortrait, isTopDownView]);
   const [activeChalkIndex, setActiveChalkIndex] = useState(null);
   const activeChalkIndexRef = useRef(null);
   const chalkAssistEnabledRef = useRef(false);
@@ -32935,8 +32942,8 @@ const powerRef = useRef(hud.power);
             muteIconOn="🔇"
             muteIconOff="🔊"
             actionOffsets={{
-              chat: 6,
-              gift: -6
+              chat: 10,
+              gift: 4
             }}
             showInfo={false}
             showMute={false}


### PR DESCRIPTION
### Motivation
- Improve mobile HUD placement so the menu sits slightly higher and the gift/chat buttons sit lower relative to the table for better visual balance on portrait screens.
- When the device is rotated to landscape, ensure the game automatically switches to the top-down 2D view (same behavior as pressing the `2D` view toggle) to improve playability in landscape.

### Description
- Adjusted HUD spacing constants in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `menuButtonTopNudgePx` from `5` to `2` to move the menu upward.  
- Lowered left-side quick-actions by increasing `sideActionButtonsDropPx` from `18` to `24` and updated `actionOffsets` for the left icons from `chat: 6, gift: -6` to `chat: 10, gift: 4` so the `chat` and `gift` icons are visually moved downward.  
- Added a new `useEffect` that monitors `isPortrait` and sets `isTopDownView` to `true` when entering landscape so the top-down (2D) view is automatically enabled and kept active while in landscape.  
- Changes are confined to `webapp/src/pages/Games/PoolRoyale.jsx` and only affect HUD positioning and orientation-driven view switching logic.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully (build warnings about chunk sizes noted but unrelated to this change).  
- Started the dev server (`vite`) and it reported ready on the configured host and port.  
- Attempted an automated Playwright screenshot to validate the UI placement but the browser script timed out in this environment, so a visual artifact could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8807c46848329aac8bcb0aa2ddd8c)