### PR TITLE
Lock Texas Hold'em to portrait, keep seated showdown camera, and nudge HUD positions

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -613,6 +613,14 @@ const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
+const SHOWDOWN_SEATED_CAMERA_ZOOM_OUT = 1.24;
+
+const shouldForcePortraitMode = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(pointer: coarse) and (max-width: 1024px)').matches;
+};
 
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
@@ -4946,7 +4954,7 @@ function TexasHoldemArena({ search }) {
   useEffect(() => {
     const mount = mountRef.current;
     if (!mount) return;
-    screen.orientation?.lock?.('landscape').catch(() => {});
+    screen.orientation?.lock?.('portrait').catch(() => {});
     const renderer = new THREE.WebGLRenderer({
       antialias: true,
       alpha: false,
@@ -5135,7 +5143,13 @@ function TexasHoldemArena({ search }) {
     const applySeatedCamera = (width, height, options = {}) => {
       if (!humanSeat) return;
       const animate = Boolean(options.animate);
-      const portrait = height > width;
+      const forcePortrait = shouldForcePortraitMode();
+      const portrait = height > width || forcePortrait;
+      const seatedZoomOut = THREE.MathUtils.clamp(
+        options.zoomOut ?? 1,
+        1,
+        1.6
+      );
       const lateralOffset = portrait
         ? CAMERA_LATERAL_OFFSETS.portrait
         : CAMERA_LATERAL_OFFSETS.landscape;
@@ -5147,10 +5161,13 @@ function TexasHoldemArena({ search }) {
         : CAMERA_ELEVATION_OFFSETS.landscape;
       const position = humanSeat.stoolAnchor
         .clone()
-        .addScaledVector(humanSeat.forward, -retreatOffset)
+        .addScaledVector(humanSeat.forward, -retreatOffset * seatedZoomOut)
         .addScaledVector(humanSeat.right, lateralOffset);
       const maxCameraHeight = ARENA_WALL_TOP_Y - CAMERA_WALL_HEIGHT_MARGIN;
-      position.y = Math.min(humanSeat.stoolHeight + elevation, maxCameraHeight);
+      position.y = Math.min(
+        humanSeat.stoolHeight + elevation * seatedZoomOut,
+        maxCameraHeight
+      );
       const focusBase = cameraTarget
         .clone()
         .add(new THREE.Vector3(0, CAMERA_FOCUS_CENTER_LIFT, 0));
@@ -6816,10 +6833,14 @@ function TexasHoldemArena({ search }) {
       if (indicator) {
         indicator.visible = false;
       }
-      viewControlsRef.current?.applyOverheadCamera?.({
+      viewControlsRef.current?.applySeatedCamera?.(
+        mountRef.current?.clientWidth ?? window.innerWidth,
+        mountRef.current?.clientHeight ?? window.innerHeight,
+        {
         animate: true,
-        zoom: SHOWDOWN_OVERHEAD_ZOOM
-      });
+          zoomOut: SHOWDOWN_SEATED_CAMERA_ZOOM_OUT
+        }
+      );
       return;
     }
     if (typeof currentActionIndex !== 'number') return;
@@ -7484,7 +7505,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.5rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+5.6rem)] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+1.2rem)]">
+      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.25rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+6.05rem)]">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -7495,7 +7516,7 @@ function TexasHoldemArena({ search }) {
                 ? 'Close game settings menu'
                 : 'Open game settings menu'
             }
-            className={`pointer-events-auto fixed left-[calc(0.3rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+1.3rem)] landscape:left-[calc(0.55rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.35rem)] flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+            className={`pointer-events-auto fixed left-[calc(0.15rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+2.05rem)] flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
               configOpen
                 ? 'border-white/35 text-white'
                 : 'hover:border-white/30 hover:text-white'
@@ -7741,7 +7762,7 @@ function TexasHoldemArena({ search }) {
         </div>
       </div>
       {sliderVisible && (
-        <div className="pointer-events-auto absolute right-2 bottom-32 z-10 flex flex-col items-center gap-3 text-white landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.1rem)] sm:right-6 sm:bottom-36 sm:landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+0.35rem)]">
+        <div className="pointer-events-auto absolute right-4 bottom-36 z-10 flex flex-col items-center gap-3 text-white sm:right-6 sm:bottom-40">
           <div className="flex flex-col items-center gap-3">
             <input
               type="range"
@@ -7805,14 +7826,14 @@ function TexasHoldemArena({ search }) {
           onChat={() => setShowChat(true)}
           showInfo={false}
           order={['gift', 'chat', 'mute']}
-          className="fixed left-[calc(0.3rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] landscape:left-[calc(0.55rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+1.1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed left-[calc(0.15rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+6.15rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
         />
       </div>
       {actor?.isHuman && gameState.stage !== 'showdown' && (
-        <div className="absolute bottom-16 left-1/2 -translate-x-1/2 flex items-center justify-center gap-3">
+        <div className="absolute bottom-[4.4rem] left-1/2 -translate-x-1/2 flex items-center justify-center gap-3">
           <button
             type="button"
             onClick={handleUndoChip}


### PR DESCRIPTION
### Motivation
- Fix incorrect zoom/overhead camera at the end of a hand so the reveal keeps the seated start framing and simply zooms out for the winner reveal.
- Ensure mobile gameplay stays in portrait mode even if the device is rotated, preventing landscape framing on phones.
- Adjust UI positions so bottom-left icons, bottom action buttons, and the right-side spin/raise controller are slightly closer to requested edges and lifted a bit for better ergonomics.

### Description
- Force mobile portrait behavior by switching orientation lock to `screen.orientation?.lock('portrait')` and adding `shouldForcePortraitMode()` which uses `matchMedia('(pointer: coarse) and (max-width: 1024px)')` to keep portrait camera framing on coarse-pointer small screens.
- Replace the showdown transition from calling the overhead camera to calling the seated camera with a modest zoom-out by adding `SHOWDOWN_SEATED_CAMERA_ZOOM_OUT` and passing a `zoomOut` option to `applySeatedCamera` so the reveal keeps the initial seating orientation.
- Add `seatedZoomOut` handling inside `applySeatedCamera` to honor `options.zoomOut` when computing `position` and `elevation` so zoomed reveals remain seated and return correctly.
- Tweak HUD/Tailwind classes in `TexasHoldemArena.jsx` to nudge controls: left-side menu and bottom-left icons closer to the left edge and slightly higher, bottom action buttons moved up, and the right-side slider/raise control moved slightly up and left from the edge.

### Testing
- Ran `npm run build` (from `webapp/`) which completed successfully and produced the production `dist/` artifacts without failing the build.
- Started a preview (`vite preview`) and captured an automated portrait screenshot of the updated UI (artifact: `artifacts/texas-holdem-portrait-controls.png`) to validate control placements and portrait behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9080fd42c832998c70e4287089943)