### PR TITLE
Adjust Texas Hold'em camera framing and rail chip layout

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -539,7 +539,7 @@ const CAMERA_LATERAL_OFFSETS = Object.freeze({
 });
 const CAMERA_RETREAT_OFFSETS = Object.freeze({
   portrait: 0.8,
-  landscape: 0.04
+  landscape: -0.1
 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({
   portrait: 1.55,
@@ -613,7 +613,7 @@ const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
-const SHOWDOWN_SEATED_CAMERA_ZOOM_OUT = 1.24;
+const SHOWDOWN_SEATED_CAMERA_ZOOM_OUT = 1;
 
 const shouldForcePortraitMode = () => {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -5426,7 +5426,7 @@ function TexasHoldemArena({ search }) {
         };
 
         const chipStack = chipFactory.createStack(0, {
-          mode: 'stack',
+          mode: 'scatter',
           layout: railLayout
         });
         chipStack.position.copy(seat.chipRailAnchor);
@@ -5572,7 +5572,7 @@ function TexasHoldemArena({ search }) {
           });
           const initialChips = Math.max(0, Math.round(player.chips ?? 0));
           chipFactory.setAmount(chipStack, initialChips, {
-            mode: 'stack',
+            mode: 'scatter',
             layout: railLayout
           });
           chipStack.visible = true;
@@ -6520,7 +6520,7 @@ function TexasHoldemArena({ search }) {
         : chipsAmount;
       seat.chipStack.visible = seat.showRailChips !== false;
       chipFactory.setAmount(seat.chipStack, displayChips, {
-        mode: 'stack',
+        mode: 'scatter',
         layout: seat.railLayout
       });
 
@@ -7013,7 +7013,7 @@ function TexasHoldemArena({ search }) {
               );
               if (showdownAnimationRef.current.seatPending[seatIndex] <= 0) {
                 chipFactory.setAmount(seat.chipStack, targetChips, {
-                  mode: 'stack',
+                  mode: 'scatter',
                   layout: seat.railLayout
                 });
               }


### PR DESCRIPTION
### Motivation
- Prevent the seated camera from zooming out at the end of a hand so the view remains the same as at hand start and reveal feels stable.
- Pull the landscape seated camera slightly closer toward the top-seat players so they appear nearer on landscape layouts while preserving portrait framing.
- Make rail chip visuals reflect the expected 3x3-style piles on the wooden rails and keep table/pot bets as single cylindrical stack piles when placed on the table.

### Description
- Set `SHOWDOWN_SEATED_CAMERA_ZOOM_OUT` from `1.24` to `1` to remove the end-of-hand zoom multiplier and keep the seated camera framing unchanged during showdown (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Adjusted the landscape seated camera retreat offset by changing `CAMERA_RETREAT_OFFSETS.landscape` from `0.04` to `-0.1` to pull the camera slightly closer for landscape views (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Restored rail/player chip stacks to use the 3x3-style scatter layout by switching rail chip groups from `mode: 'stack'` to `mode: 'scatter'` when creating and updating seat rail chip groups and during showdown replenishment, while leaving table/pot piles and transfer end layouts in `stack`/`POT_CHIP_MODE` so each bet still becomes a single cylindrical pile on the table/pot (`webapp/src/pages/Games/TexasHoldemArena.jsx` and existing chip factory behavior in `webapp/src/utils/chips3d.js`).

### Testing
- Ran unit tests with `npm test -- --runInBand test/texasHoldemGame.test.js`, which passed (2 tests, 1 suite).
- Attempted an automated UI screenshot via Playwright to validate landscape rendering, but the headless Chromium process crashed in this environment (SIGSEGV) and no screenshot artifact was produced; the crash is environmental and unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90f2211b48329bd75c58e4fb7be52)