### PR TITLE
Adjust Pool Royale 2D camera, power slider and spin controller positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5293,13 +5293,13 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // lift the 2D camera a touch so the table sits slightly higher on screen
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.1; // lift the 2D camera a bit more so portrait framing sits higher on screen
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.06; // keep 2D framing a little higher for portrait readability
+const TOP_VIEW_RADIUS_SCALE = 1.1; // keep 2D framing slightly farther out so the camera reads higher in portrait
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
+  x: PLAY_W * -0.018, // keep the table slightly more to the right on portrait screens
   z: PLAY_H * -0.036 // nudge the table a little further down on portrait screens
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -33323,7 +33323,7 @@ const powerRef = useRef(hud.power);
       {/* Power Slider */}
       {showPowerSlider && !replayActive && !shotBroadcastActive && (
         <div
-          className="absolute right-3 top-[56%] -translate-y-1/2"
+          className="absolute right-3 top-1/2 z-50 -translate-y-1/2"
           data-ai-taking-shot={aiTakingShot ? 'true' : 'false'}
           data-player-turn={isPlayerTurn ? 'true' : 'false'}
         >
@@ -33346,7 +33346,7 @@ const powerRef = useRef(hud.power);
             ? {
                 left: '50%',
                 right: 'auto',
-                bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
+                bottom: `${2 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
                 transform: `translateX(-50%) scale(${uiScale * 0.88})`,
                 transformOrigin: 'bottom center'
               }


### PR DESCRIPTION
### Motivation
- Align the 2D (top-down) Pool Royale HUD with the normal game layout by keeping the power slider visible in the same right-side position, moving the spin controller slightly lower, and raising the top-down camera so the table sits a bit higher in portrait.
- Improve portrait framing so the table appears slightly more to the right and the controls remain clear and unobstructed on mobile screens.

### Description
- Increased top-view orbit framing by raising `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` from `1.06` to `1.1` to lift the 2D camera slightly (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Shifted the top-view horizontal offset by changing `TOP_VIEW_SCREEN_OFFSET.x` from `PLAY_W * -0.045` to `PLAY_W * -0.018` so the table appears a bit more to the right (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Kept the power slider anchored at the right-center and ensured it renders above overlays by updating the container to `className="absolute right-3 top-1/2 z-50 -translate-y-1/2"` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Lowered the top-down spin controller by reducing its `bottom` offset from `12 + ...` to `2 + ...` while leaving non-top-down placement unchanged (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Started the dev server with `npm --prefix webapp run dev` and the site served locally (Vite ready and listening).
- Attempted an automated browser screenshot via Playwright to validate visual placement, but the screenshot run timed out while rendering the WebGL game view.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a913ad12e0832990b8de03f8401fb2)