### PR TITLE
Adjust Pool Royale 2D camera framing and HUD positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5293,14 +5293,14 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // lift the 2D camera a touch so the table sits slightly higher on screen
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.09; // lift the 2D camera a bit more so the table reads slightly higher on screen
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.06; // keep 2D framing a little higher for portrait readability
+const TOP_VIEW_RADIUS_SCALE = 1.09; // keep 2D framing a bit higher for portrait readability
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the top view slightly left away from the power slider
-  z: PLAY_H * -0.036 // nudge the table a little further down on portrait screens
+  x: PLAY_W * -0.018, // keep slight left offset while moving the table a bit more to the right on screen
+  z: PLAY_H * -0.018 // reduce downward bias so the table appears a little higher on portrait screens
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -13508,6 +13508,7 @@ function PoolRoyaleGame({
   }, []);
   const sharedHudLiftPx = 30;
   const spinControllerLiftPx = 28;
+  const topDownSpinControllerDropPx = 18;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -33323,7 +33324,7 @@ const powerRef = useRef(hud.power);
       {/* Power Slider */}
       {showPowerSlider && !replayActive && !shotBroadcastActive && (
         <div
-          className="absolute right-3 top-[56%] -translate-y-1/2"
+          className="absolute right-3 top-[56%] z-50 -translate-y-1/2"
           data-ai-taking-shot={aiTakingShot ? 'true' : 'false'}
           data-player-turn={isPlayerTurn ? 'true' : 'false'}
         >
@@ -33346,7 +33347,7 @@ const powerRef = useRef(hud.power);
             ? {
                 left: '50%',
                 right: 'auto',
-                bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
+                bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx - topDownSpinControllerDropPx}px`,
                 transform: `translateX(-50%) scale(${uiScale * 0.88})`,
                 transformOrigin: 'bottom center'
               }


### PR DESCRIPTION
### Motivation
- Improve Pool Royale 2D (top-down) layout so the power slider remains visible in its normal right-side location, the spin controller sits slightly lower on the screen, and the camera/table placement reads a bit higher and slightly to the right on portrait (phone) screens.

### Description
- Raised the 2D/top-view camera framing by increasing `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` from `1.06` to `1.09` in `webapp/src/pages/Games/PoolRoyale.jsx` to lift the table visually higher on portrait screens.
- Adjusted `TOP_VIEW_SCREEN_OFFSET` `x` and `z` values to move the table slightly to the right and a bit higher on the screen in 2D mode.
- Added a dedicated `topDownSpinControllerDropPx` offset and applied it to the spin controller bottom position in 2D so the spin control is lowered toward the bottom of the page while preserving its center alignment.
- Ensured the power slider overlay remains visible in the same right-side location by adding `z-50` to its container so it keeps priority over other HUD elements.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which returned only an ignore warning from the current ESLint config and no lint errors for the modified file.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the site served (Vite reported ready), but interactive visual validation was interrupted.
- Attempted an automated Playwright screenshot of `/games/poolroyale` in portrait viewport to validate the 2D layout, but the browser screenshot step timed out in this environment and did not produce an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a913ad12e0832990b8de03f8401fb2)