### PR TITLE
Reset Domino Royale table themes to Murlan default and reseed inventories

### DIFF
--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -99,7 +99,7 @@ const getDominoDefaultOptionId = (type) => {
 export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze({
   tableWood: [getDominoDefaultOptionId('tableWood')].filter(Boolean),
   tableCloth: [getDominoDefaultOptionId('tableCloth')].filter(Boolean),
-  tableTheme: DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option) => option.id),
+  tableTheme: [getDominoDefaultOptionId('tableTheme')].filter(Boolean),
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id),
   dominoStyle: [getDominoDefaultOptionId('dominoStyle')].filter(Boolean),
   highlightStyle: [getDominoDefaultOptionId('highlightStyle')].filter(Boolean),
@@ -137,7 +137,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     description: option.description || 'Unlock a new felt tone for the Domino Royal table surface.',
     thumbnail: option.swatches?.length ? swatchThumbnail(option.swatches) : DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
   })),
-  ...DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option, idx) => ({
+  ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
     id: `domino-table-theme-${option.id}`,
     type: 'tableTheme',
     optionId: option.id,

--- a/webapp/src/utils/dominoRoyalInventory.js
+++ b/webapp/src/utils/dominoRoyalInventory.js
@@ -5,6 +5,7 @@ import {
 } from '../config/dominoRoyalInventoryConfig.js';
 
 const STORAGE_KEY = 'dominoRoyalInventoryByAccount';
+const TABLE_RESET_TYPES = new Set(['tableTheme']);
 
 const copyDefaults = () =>
   Object.entries(DOMINO_ROYAL_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
@@ -50,6 +51,10 @@ const normalizeInventory = (rawInventory) => {
   if (!rawInventory || typeof rawInventory !== 'object') return base;
   const merged = { ...base };
   Object.entries(rawInventory).forEach(([key, value]) => {
+    if (TABLE_RESET_TYPES.has(key)) {
+      merged[key] = [...(base[key] || [])];
+      return;
+    }
     if (!Array.isArray(value)) return;
     merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
   });


### PR DESCRIPTION
### Motivation

- Align Domino Royale table theme behavior with Murlan Royale so players start with the same default table theme and unlock additional themes via the store.
- Ensure existing Domino inventories that previously had all table themes unlocked are reseeded to the new baseline so the default table is the only initial owned table.

### Description

- Updated `webapp/src/config/dominoRoyalInventoryConfig.js` so `DOMINO_ROYAL_DEFAULT_UNLOCKS.tableTheme` contains only the Murlan default id instead of pre-unlocking all table themes.
- Changed store item generation in `webapp/src/config/dominoRoyalInventoryConfig.js` to exclude the default table by using `tableTheme.slice(1)` so the default is not offered for purchase.
- Added `TABLE_RESET_TYPES` and normalization logic to `webapp/src/utils/dominoRoyalInventory.js` so `tableTheme` entries in persisted inventories are reset to the default baseline on load, reseeding legacy inventories.

### Testing

- Built the webapp with `npm run build` (run in `webapp/`), which completed successfully (production build with standard warnings about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a921a2085c8329a1e0cda9933fc5fa)