### PR TITLE
Fix Pool Royale 2D/watch control responsiveness and adjust HUD/table positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5299,7 +5299,7 @@ const TOP_VIEW_RADIUS_SCALE = 1.09; // keep 2D framing a bit higher for portrait
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.022, // shift the 2D table framing a touch more right on portrait screens
+  x: PLAY_W * -0.028, // shift the 2D table framing a touch more right on portrait screens
   z: PLAY_H * -0.022 // lift the 2D table framing a touch more toward the top edge
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -13510,7 +13510,7 @@ function PoolRoyaleGame({
   const spinControllerLiftPx = 28;
   const topDownSpinControllerDropPx = 10;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
-  const menuButtonTopNudgePx = -22;
+  const menuButtonTopNudgePx = -30;
   const menuButtonCenterNudgePx = 0;
   const sideActionButtonsLiftPx = 10;
   const sideActionButtonsDropPx = 18;
@@ -25062,9 +25062,15 @@ const powerRef = useRef(hud.power);
               enterTopView(true, { variant: 'replay' });
               setIsTopDownView(true);
             } else {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
+              const preservePlayerTopView = isPlayerTurn && topViewLockedRef.current;
+              if (preservePlayerTopView) {
+                enterTopView(true, { variant: 'top' });
+                setIsTopDownView(true);
+              } else {
+                topViewRef.current = false;
+                topViewLockedRef.current = false;
+                setIsTopDownView(false);
+              }
             }
             const sph = sphRef.current;
             const bounds = cameraBoundsRef.current;
@@ -32913,7 +32919,11 @@ const powerRef = useRef(hud.power);
         <button
           type="button"
           aria-pressed={isLookMode}
-          onClick={() => setIsLookMode((prev) => !prev)}
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setIsLookMode((prev) => !prev);
+          }}
           className={`pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full border text-xl font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
             isLookMode
               ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
@@ -32927,9 +32937,19 @@ const powerRef = useRef(hud.power);
         <button
           type="button"
           aria-pressed={isTopDownView}
-          onClick={() => {
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
             if (!isPortrait) return;
-            setIsTopDownView((prev) => !prev);
+            const nextState = !isTopDownView;
+            setIsTopDownView(nextState);
+            if (nextState) {
+              topViewLockedRef.current = true;
+              topViewControlsRef.current.enter?.(true, { variant: 'top' });
+            } else {
+              topViewLockedRef.current = false;
+              topViewControlsRef.current.exit?.(true);
+            }
           }}
           className={`pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full border text-[12px] font-semibold uppercase tracking-[0.28em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
             isTopDownView


### PR DESCRIPTION
### Motivation
- Mobile players reported needing to press the 2D and watch (eye) icons multiple times and HUD elements were slightly misaligned in portrait; the goal is to make the toggles responsive to single presses and adjust small HUD/table offsets without changing broadcast/AI flows.

### Description
- Changed the 2D/top-view and watch (eye) buttons to use pointer-down handlers with `preventDefault()`/`stopPropagation()` so single-touch presses register reliably on mobile (updated UI button handlers in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Made the 2D toggle apply immediate top-view enter/exit calls and explicitly set/clear `topViewLockedRef` so the view flips immediately and stays active during the player's turn when appropriate (preserve lock for `isPlayerTurn`), leaving broadcasting and AI paths untouched.
- Nudged portrait top-view framing right by changing `TOP_VIEW_SCREEN_OFFSET.x` from `PLAY_W * -0.022` to `PLAY_W * -0.028` and raised the menu button by altering `menuButtonTopNudgePx` from `-22` to `-30` to better match the requested layout.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully (no build errors).
- Started the dev server and captured a portrait screenshot of the updated UI to verify the 2D/watch toggles and HUD/table adjustments visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a926d290b8832999c141a211a5bdd7)