### PR TITLE
Tune Pool Royale camera toggles and portrait HUD alignment

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5299,8 +5299,8 @@ const TOP_VIEW_RADIUS_SCALE = 1.09; // keep 2D framing a bit higher for portrait
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.034, // shift the 2D table framing a touch more right on portrait screens
-  z: PLAY_H * -0.022 // lift the 2D table framing a touch more toward the top edge
+  x: PLAY_W * -0.038, // shift the 2D table framing a touch more right on portrait screens
+  z: PLAY_H * -0.025 // lift the 2D table framing a touch more toward the top edge
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -13516,7 +13516,7 @@ function PoolRoyaleGame({
   const sideActionButtonsDropPx = 18;
   const bottomLeftChatGiftLiftPx = 12;
   const rightHudShiftPx = -2;
-  const bottomHudLeftPx = -22;
+  const bottomHudLeftPx = 0;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -13575,7 +13575,7 @@ function PoolRoyaleGame({
   useEffect(() => {
     if (isTopDownView) {
       topViewLockedRef.current = true;
-      topViewControlsRef.current.enter?.(false, { variant: 'top' });
+      topViewControlsRef.current.enter?.(true, { variant: 'top' });
     } else {
       topViewLockedRef.current = false;
       topViewControlsRef.current.exit?.();
@@ -13583,15 +13583,6 @@ function PoolRoyaleGame({
   }, [isTopDownView]);
 
   const isMobileLike = uiScale === TOUCH_UI_SCALE;
-
-  useEffect(() => {
-    if (isPortrait || !isMobileLike || isTopDownView) {
-      return;
-    }
-    setIsTopDownView(true);
-    topViewLockedRef.current = true;
-    topViewControlsRef.current.enter?.(true, { variant: 'top' });
-  }, [isMobileLike, isPortrait, isTopDownView]);
   const [activeChalkIndex, setActiveChalkIndex] = useState(null);
   const activeChalkIndexRef = useRef(null);
   const chalkAssistEnabledRef = useRef(false);
@@ -19804,7 +19795,7 @@ const powerRef = useRef(hud.power);
                     broadcastArgs.focusWorld = resolvedTarget.clone();
                     broadcastArgs.targetWorld = resolvedTarget.clone();
                     broadcastArgs.orbitWorld = railReplayCamera.position.clone();
-                    broadcastArgs.lerp = 0.12;
+                    broadcastArgs.lerp = 0;
                     overheadApplied = true;
                   }
                 }
@@ -20090,7 +20081,7 @@ const powerRef = useRef(hud.power);
               if (broadcastCamerasRef.current) {
                 broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
               }
-              broadcastArgs.lerp = 0.12;
+              broadcastArgs.lerp = 0;
               overheadApplied = true;
             }
           }
@@ -20120,7 +20111,7 @@ const powerRef = useRef(hud.power);
               if (broadcastCamerasRef.current) {
                 broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
               }
-              broadcastArgs.lerp = 0.12;
+              broadcastArgs.lerp = 0;
             } else {
               const fallbackTarget =
                 lastCameraTargetRef.current?.clone?.() ?? topFocusTarget.clone();
@@ -32927,7 +32918,15 @@ const powerRef = useRef(hud.power);
           onPointerDown={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            setIsLookMode((prev) => !prev);
+            setIsLookMode((prev) => {
+              const next = !prev;
+              lookModeRef.current = next;
+              if (!next) {
+                aimFocusRef.current = null;
+              }
+              cameraUpdateRef.current?.();
+              return next;
+            });
           }}
           className={`pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full border text-xl font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
             isLookMode


### PR DESCRIPTION
### Motivation
- Ensure Pool Royale starts in the 3D/default view instead of forcing the 2D/top-down mode on portrait/mobile devices. 
- Make the 2D (top-down) and watch (look) camera switches feel noticeably faster and more responsive. 
- Nudge the 2D camera framing slightly upward and right for better portrait composition. 
- Restore the bottom HUD avatar/username/balls placement to the centered position it had previously.

### Description
- Adjusted the 2D framing offsets by changing `TOP_VIEW_SCREEN_OFFSET` (`x` and `z`) to shift the table a touch more right and slightly higher on portrait screens in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Restored bottom HUD horizontal alignment by setting `bottomHudLeftPx = 0` so the avatar/username/balls frame returns toward the earlier centered placement.
- Disabled the automatic portrait/mobile force-switch into top-down view (removed the auto-enter effect) so the game now starts in 3D and top-down is only entered via the view toggle.
- Made top-down/watch transitions immediate by calling `topViewControlsRef.current.enter` with `true` where appropriate and by setting `broadcastArgs.lerp = 0` on the top-view/overhead broadcast camera code-paths to remove eased blending.
- Improved the watch (eye) button behavior to update `lookModeRef` and call `cameraUpdateRef.current` immediately in the pointer handler for snappier response.

### Testing
- Ran lint: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` — command executed (file is ignored by the repo's lint ignore settings; no errors produced, one ignore warning).
- Launched the dev server: `npm --prefix webapp run dev` — dev server started and served the app locally (Vite ready).
- Attempted automated visual verification with Playwright to capture `/games/poolroyale` (mobile portrait viewport), but the Playwright screenshot attempt timed out in this environment so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93e2b82f8832980a2e9126b6057f2)