### PR TITLE
Pool Royale: adjust 2D framing, portrait orientation handling, and cue-shot sequencing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5299,8 +5299,8 @@ const TOP_VIEW_RADIUS_SCALE = 1.09; // keep 2D framing a bit higher for portrait
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.038, // shift the 2D table framing a touch more right on portrait screens
-  z: PLAY_H * -0.025 // lift the 2D table framing a touch more toward the top edge
+  x: PLAY_W * -0.045, // shift the 2D table framing a little more right on portrait screens
+  z: PLAY_H * -0.032 // lift the 2D table framing a little more toward the top edge
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -13510,7 +13510,7 @@ function PoolRoyaleGame({
   const spinControllerLiftPx = 28;
   const topDownSpinControllerDropPx = 10;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
-  const menuButtonTopNudgePx = -30;
+  const menuButtonTopNudgePx = -38;
   const menuButtonCenterNudgePx = 0;
   const sideActionButtonsLiftPx = 10;
   const sideActionButtonsDropPx = 18;
@@ -13535,8 +13535,16 @@ function PoolRoyaleGame({
       return undefined;
     }
     const updateScale = () => {
-      setUiScale(detectCoarsePointer() ? TOUCH_UI_SCALE : POINTER_UI_SCALE);
-      setIsPortrait(window.innerHeight >= window.innerWidth);
+      const coarsePointer = detectCoarsePointer();
+      const isLandscape = window.innerWidth > window.innerHeight;
+      const forcePortraitLayout = coarsePointer && isLandscape;
+      setUiScale(coarsePointer ? TOUCH_UI_SCALE : POINTER_UI_SCALE);
+      setIsPortrait(forcePortraitLayout ? true : window.innerHeight >= window.innerWidth);
+      if (forcePortraitLayout) {
+        topViewRef.current = true;
+        topViewLockedRef.current = true;
+        setIsTopDownView(true);
+      }
     };
     updateScale();
     window.addEventListener('resize', updateScale);
@@ -21518,7 +21526,7 @@ const powerRef = useRef(hud.power);
                   return easedPush;
               }
             })();
-            cueStick.visible = true;
+            cueStick.visible = !stroke.shotApplied;
             cueStick.position.lerpVectors(pullPos, impactPos, motionPush);
             cueStick.position.y -= (strikeDip ?? 0.003) * motionPush;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
@@ -21538,7 +21546,7 @@ const powerRef = useRef(hud.power);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
-            cueStick.visible = true;
+            cueStick.visible = stroke.shotApplied ? false : true;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
@@ -21565,7 +21573,7 @@ const powerRef = useRef(hud.power);
             recoverDuration,
             animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
           });
-          cueStick.visible = true;
+          cueStick.visible = !stroke.shotApplied;
           cueAnimating = !sample.done;
           if (!stroke.shotApplied && sample.hitArmed) {
             stroke.shotApplied = true;
@@ -21625,7 +21633,7 @@ const powerRef = useRef(hud.power);
           cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
           cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
           syncCueShadow();
-          cueStick.visible = true;
+          cueStick.visible = stroke.shotApplied ? false : true;
           cueAnimating = false;
           cuePullCurrentRef.current = 0;
           cuePullTargetRef.current = 0;
@@ -25022,36 +25030,38 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          const triggerShotImpact = () => {
+            cue.vel.copy(base);
+            if (cue.spin) {
+              cue.spin.set(spinSide, spinTop);
+            }
+            if (cue.omega) {
+              cue.omega.set(0, 0, 0);
+              TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
+              if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
+              TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
+              if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
+              TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
+              TMP_VEC3_C.y += scaledSpin.y * BALL_R;
+              const impulseMag = BALL_MASS * base.length();
+              TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+              TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+              cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+            }
+            if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+            cue.spinMode = 'standard';
+            cue.swerveStrength = 0;
+            cue.swervePowerStrength = 0;
+            resetSpinRef.current?.();
+            cueLiftRef.current.lift = 0;
+            cueLiftRef.current.startLift = 0;
+            cue.impacted = false;
+            cue.launchDir = shotAimDir.clone().normalize();
+            maxPowerLiftTriggered = false;
+            cue.lift = 0;
+            cue.liftVel = 0;
+            playCueHit(clampedPower * 0.6);
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25294,9 +25304,15 @@ const powerRef = useRef(hud.power);
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true
+              releaseStartsFromCurrentPull: true,
+              shotApplied: false,
+              onImpact: () => {
+                triggerShotImpact();
+                cueStick.visible = false;
+              }
             };
           } else {
+            triggerShotImpact();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -28328,7 +28344,6 @@ const powerRef = useRef(hud.power);
         const nowMs = now;
         updateCueStroke(nowMs);
         if (ENABLE_CUE_STROKE_ANIMATION && cueStick && cueStrokeStateRef.current) {
-          cueStick.visible = true;
           cueStick.position.y = Math.max(cueStick.position.y, CUE_Y + BALL_R * 0.06);
         }
         if (pendingInHandResetRef.current && hudRef.current?.inHand) {


### PR DESCRIPTION
### Motivation
- Improve 2D portrait composition so the table reads slightly higher and a bit more to the right for better mobile UX.
- Nudge the main menu control upward so it sits closer to the top of the screen.
- When a phone is rotated to landscape, keep the gameplay HUD in portrait-style and switch to the 2D/top-down camera so the player experience remains consistent.
- Ensure the cue-ball impulse is applied at the correct moment (when the cue fully returns to impact) and hide the cue-stick once the shot begins for a cleaner visual flow.

### Description
- Tweaked top-down framing constants by changing `TOP_VIEW_SCREEN_OFFSET.x` and `TOP_VIEW_SCREEN_OFFSET.z` to shift the 2D table framing slightly right and higher. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Raised the menu icon placement by increasing `menuButtonTopNudgePx` to move the menu button up on the page. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Added orientation/interaction logic in the resize handler to detect a `coarse` pointer on landscape devices and force a portrait HUD layout while enabling/locking the top-down view by setting `topViewRef.current`, `topViewLockedRef.current`, and `setIsTopDownView(true)`. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Reworked shot sequencing: introduced `triggerShotImpact()` and wired `cueStrokeStateRef.current.onImpact` so the cue-ball impulse is applied when the stroke reaches impact (or immediately for forward-only/no-animation paths), and set `shotApplied` to track shot state. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Updated cue-stick visibility to use the `shotApplied` flag so the cue becomes invisible when the shot is applied and remains hidden until the next setup; also adjusted several places where `cueStick.visible` was set to respect `stroke.shotApplied`. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)
- Cleaned up UI scale logic to reuse the detected `coarsePointer` result when calling `setUiScale`. (file: `webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Ran the cue stroke timeline unit test with `npm run -s test -- test/poolRoyaleCueStrokeTimeline.test.js`, which passed (4 tests, 1 suite).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which reported a single warning that the file is ignored by the ESLint ignore pattern (no errors).
- Attempted an automated UI screenshot via Playwright to validate visual changes, but navigation to the local dev server returned `ERR_EMPTY_RESPONSE` in this environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9532112d88329acd6f3ad74ee268d)