### PR TITLE
Pool Royale: tweak 2D top-view framing and trigger shot on cue idle return

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5293,13 +5293,13 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.09; // lift the 2D camera a bit more so the table reads slightly higher on screen
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.12; // lift the 2D camera slightly more so the table reads higher on screen
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.09; // keep 2D framing a bit higher for portrait readability
+const TOP_VIEW_RADIUS_SCALE = 1.12; // keep 2D framing slightly farther from the cloth for better readability
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.045, // shift the 2D table framing a little more right on portrait screens
+  x: PLAY_W * -0.06, // shift the 2D table framing a little more toward screen-left
   z: PLAY_H * -0.032 // lift the 2D table framing a little more toward the top edge
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -21473,7 +21473,8 @@ const powerRef = useRef(hud.power);
             strikeDip,
             wobbleAmount,
             strikeImpactThreshold,
-            forwardOnly
+            forwardOnly,
+            impactPhase
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
@@ -21575,7 +21576,9 @@ const powerRef = useRef(hud.power);
           });
           cueStick.visible = !stroke.shotApplied;
           cueAnimating = !sample.done;
-          if (!stroke.shotApplied && sample.hitArmed) {
+          const triggerImpactAtIdle = impactPhase === 'idle';
+          const shouldApplyImpact = triggerImpactAtIdle ? sample.done : sample.hitArmed;
+          if (!stroke.shotApplied && shouldApplyImpact) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
           }
@@ -24709,7 +24712,7 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-      const fire = () => {
+      const fire = ({ impactPhase = 'release' } = {}) => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -25305,6 +25308,7 @@ const powerRef = useRef(hud.power);
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true,
+              impactPhase,
               shotApplied: false,
               onImpact: () => {
                 triggerShotImpact();
@@ -30915,7 +30919,7 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: () => {
-        fireRef.current?.();
+        fireRef.current?.({ impactPhase: 'idle' });
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Improve 2D/top-down framing so the table reads higher and slightly left on portrait screens for better visual balance. 
- Make the power-slider commit trigger the actual shot when the cue stick returns to its idle pose (matching the pull/return UX) rather than on forward release.

### Description
- Adjusted top-view framing constants: `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` increased to `1.12` and top-view screen offset `x` changed to `PLAY_W * -0.06` in `PoolRoyale.jsx` to lift the 2D camera and shift the table left. 
- Added an `impactPhase` parameter to `fire()` and stored it on the cue stroke state as `impactPhase` so stroke handling can decide when to apply impact. 
- Updated cue-stroke timeline handling in `updateCueStroke` to support two impact modes by applying impact at the normal `release` or when the stroke `sample.done` (idle) if `impactPhase === 'idle'`. 
- Wired the big pull power slider `onCommit` to call `fireRef.current({ impactPhase: 'idle' })` so slider commits apply power when the cue returns to its idle pose. 

### Testing
- Built the web app with `npm --prefix webapp run build` which completed successfully (Vite produced chunk-size warnings but build finished). 
- Started the dev server with `npm --prefix webapp run dev` and captured a portrait screenshot using a Playwright script to validate visual change (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95cfab1648329abce83f6ca4587f2)