### PR TITLE
Fix Pool Royale shot trigger to fire on slider release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25027,7 +25027,9 @@ const powerRef = useRef(hud.power);
             x: (physicsSpin.x ?? 0) * SPIN_GLOBAL_SCALE,
             y: (physicsSpin.y ?? 0) * SPIN_GLOBAL_SCALE
           };
-          const triggerImpactOnIdle = currentHud?.turn === 0;
+          // Fire the physics impulse during the release phase so a slider release
+          // always launches the cue ball immediately.
+          const triggerImpactOnIdle = false;
           const baseSide = scaledSpin.x * (ranges.side ?? 0);
           let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
           let spinTop = scaledSpin.y * (ranges.forward ?? 0) * powerSpinScale;


### PR DESCRIPTION
### Motivation
- Slider release sometimes failed to launch the cue ball because the physics impact was deferred to idle/recover instead of being applied during the release phase.

### Description
- Set `triggerImpactOnIdle` to `false` in `webapp/src/pages/Games/PoolRoyale.jsx` so the cue-ball physics impulse is applied during the cue `release` phase, ensuring a slider release immediately fires the shot.

### Testing
- Ran `npm test -- test/cueShotImpact.test.js --runInBand` and `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ca1568f083298ab2e5d2fcf92004)