### PR TITLE
Pool Royale: match cue pull/release/idle stroke behavior to reference logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21527,7 +21527,7 @@ const powerRef = useRef(hud.power);
                   return easedPush;
               }
             })();
-            cueStick.visible = !stroke.shotApplied;
+            cueStick.visible = true;
             cueStick.position.lerpVectors(pullPos, impactPos, motionPush);
             cueStick.position.y -= (strikeDip ?? 0.003) * motionPush;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
@@ -21551,7 +21551,7 @@ const powerRef = useRef(hud.power);
               stroke.onImpact?.();
             }
             syncCueShadow();
-            cueStick.visible = stroke.shotApplied ? false : true;
+            cueStick.visible = true;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
@@ -24536,18 +24536,19 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Match the reference pull/strike flow:
+          // drag controls pullback depth, strike is a fixed quick push,
+          // then hold briefly and snap straight back to idle.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
-          pullbackDuration,
+          strikeDuration: 120,
+          holdDuration: 50,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.88,
-          forwardOnly: false,
+          impactThreshold: 0.9,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };


### PR DESCRIPTION
### Motivation
- Align the in-game cue stroke timing and visible motion to the provided reference flow so pull → strike → idle behaves identically. 
- Make the forward strike deterministic (quick push + brief hold) and ensure the cue snaps back visually to idle rather than disappearing mid-cycle.

### Description
- Updated the cue stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `resolveCueStrokeProfile` to use `strikeDuration: 120`, `holdDuration: 50`, `pullbackDuration: 0`, `recoverDuration: 0`, `impactThreshold: 0.9`, and `forwardOnly: true` so the release is a forward-only push from the pulled position. 
- Ensured cue visibility during forward-only strokes by forcing `cueStick.visible = true` while the push and when snapping back to idle so the back-to-idle portion is preserved visually. 
- Left pull depth driven by the existing eased power curve (`pullRatio: easeOutCubic(p)`) so drag-powered pull depth remains intact while release timing matches the reference. 
- Changes are localized to the cue stroke/timeline logic and visual sync code in `PoolRoyale.jsx` (no physics model changes were made). 

### Testing
- Ran the unit test: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, and the suite passed (4 tests, all passed). 
- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully (site served), validating the app boots with the updated code. 
- Attempted an automated Playwright screenshot, but the Chromium process in this environment crashed (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9cdf5b1248329aaf9b14bc12268ca)