### PR TITLE
Align Pool Royale cue pull/strike animation with reference behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24536,18 +24536,18 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Match the reference cue interaction: drag builds pull, release performs a
+          // direct push to contact, short hold, then instant snap back to idle.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
-          pullbackDuration,
+          strikeDuration: 120,
+          holdDuration: 50,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.88,
-          forwardOnly: false,
+          impactThreshold: 0.9,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };
@@ -25121,7 +25121,7 @@ const powerRef = useRef(hud.power);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
           // Mirror the reference stroke pullback curve exactly:
           // pull = pullRange * easeOutCubic(power), then push forward on strike.
-          const pullRange = 0.24;
+          const pullRange = 0.34;
           const pullTarget = pullRange * strokeProfile.pullRatio;
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
@@ -30928,7 +30928,9 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: () => {
-        fireRef.current?.();
+        if (powerRef.current > 0.02) {
+          fireRef.current?.();
+        }
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation

- Make the in-game cue pull/release and follow-through match the reference interaction: visible pull while dragging, a direct forward strike on release, a short post-impact hold, then immediate snap back to idle.
- Increase the visible pull distance so the player-perceived travel matches the referenced cadence and feel.
- Prevent accidental shots from extremely small slider nudges by gating commits under a minimal power threshold.

### Description

- Updated the cue stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` to use a direct forward strike with `strikeDuration: 120`, `holdDuration: 50`, `pullbackDuration: 0`, `impactThreshold: 0.9`, and `forwardOnly: true` to mirror the reference push-and-hold flow.
- Increased the visual pull range from `0.24` to `0.34` so dragging produces a larger pullback feel before release.
- Added a minimum power check on the power slider commit so the slider only triggers `fire()` when `powerRef.current > 0.02` to avoid firing on micro-pulls.
- Minor comment and behavior clarifications near the stroke/profile logic to document the chosen interaction semantics.

### Testing

- Built the web app with `npm -C webapp run build` and the build completed successfully.
- Started the dev server with `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and verified the runtime; a portrait screenshot was captured to validate the updated cue visuals.
- No automated unit tests were modified; the changes were validated via the production build and a local runtime smoke check (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9cdf5b1248329aaf9b14bc12268ca)