### PR TITLE
Fix Pool Royale cue anchoring and idle-return behaviour

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21551,7 +21551,7 @@ const powerRef = useRef(hud.power);
               stroke.onImpact?.();
             }
             syncCueShadow();
-            cueStick.visible = stroke.shotApplied ? false : true;
+            cueStick.visible = true;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
@@ -21642,7 +21642,7 @@ const powerRef = useRef(hud.power);
             stroke.onImpact?.();
           }
           syncCueShadow();
-          cueStick.visible = stroke.shotApplied ? false : true;
+          cueStick.visible = true;
           cueAnimating = false;
           cuePullCurrentRef.current = 0;
           cuePullTargetRef.current = 0;
@@ -23395,11 +23395,17 @@ const powerRef = useRef(hud.power);
       };
       const resolveCueTipTarget = (dir, pullAmount, spinWorld, options = {}) => {
         const anchor = cueStickAnchorRef.current;
+        const cueMoving =
+          cue?.vel &&
+          Number.isFinite(cue.vel.x) &&
+          Number.isFinite(cue.vel.y) &&
+          cue.vel.lengthSq() > 0.0004;
         const useAnchor =
           Boolean(options.forceAnchor) ||
           Boolean(sliderInstanceRef.current?.dragging) ||
           shooting ||
-          cueAnimating;
+          cueAnimating ||
+          cueMoving;
         const baseX = useAnchor && Number.isFinite(anchor?.x) ? anchor.x : cue.pos.x;
         const baseZ = useAnchor && Number.isFinite(anchor?.z) ? anchor.z : cue.pos.y;
         return TMP_VEC3_CUE_TIP_TARGET.set(
@@ -25321,7 +25327,7 @@ const powerRef = useRef(hud.power);
               shotApplied: false,
               onImpact: () => {
                 triggerShotImpact();
-                cueStick.visible = false;
+                cueStick.visible = true;
               }
             };
           } else {
@@ -28558,7 +28564,8 @@ const powerRef = useRef(hud.power);
           cue?.pos &&
           !sliderInstanceRef.current?.dragging &&
           !shooting &&
-          !cueAnimating
+          !cueAnimating &&
+          allStopped(balls)
         ) {
           cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
         }


### PR DESCRIPTION
### Motivation
- The cue was disappearing or following the cue ball after a shot instead of remaining anchored and snapping back to the idle pose, producing an incorrect pull/strike/idle flow.
- The anchor was being refreshed too soon (while the ball still rolled), causing post-shot drift of cue placement.

### Description
- Keep the cue visible through stroke completion and during impact so it reliably snaps back to the idle pose (`cueStick.visible` forced `true` in the stroke completion paths in `PoolRoyale.jsx`).
- Preserve a fixed cue anchor while the cue ball is still moving by detecting `cueMoving` and treating that as a reason to use the stored anchor instead of the current ball position (`resolveCueTipTarget` now considers `cueMoving`).
- Only re-capture the cue anchor from the cue-ball position when all balls are stopped by gating the anchor refresh with `allStopped(balls)` to prevent post-shot anchor drift.
- Ensure the shot impact callback keeps cue visibility consistent so the cue does not immediately disappear on impact (`onImpact` now maintains visibility).

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully.
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and exercised the UI.
- Captured an automated Playwright screenshot of the running app to verify the cue behaviour visually; the run succeeded and produced the verification artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9dd2e257c832997186b83269d1094)