### PR TITLE
Align Pool Royale cue stroke to pull → release → hold → done (remove recover)

### DIFF
--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -4,8 +4,7 @@ describe('Pool Royale cue stroke timeline', () => {
   const options = {
     pullbackDuration: 200,
     strikeDuration: 100,
-    holdDuration: 80,
-    recoverDuration: 120
+    holdDuration: 80
   };
 
   it('starts in pullback phase', () => {
@@ -33,13 +32,11 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(early.t).toBeLessThanOrEqual(middle.t + 1e-9);
     expect(middle.t).toBeLessThanOrEqual(late.t + 1e-9);
   });
-
-
-  it('enters recover then done', () => {
-    const recovering = sampleCueStrokeTimeline({ elapsed: 430, ...options });
-    const done = sampleCueStrokeTimeline({ elapsed: 510, ...options });
-    expect(recovering.phase).toBe('recover');
-    expect(recovering.done).toBe(false);
+  it('snaps to done once hold finishes (no recover phase)', () => {
+    const holding = sampleCueStrokeTimeline({ elapsed: 379, ...options });
+    const done = sampleCueStrokeTimeline({ elapsed: 381, ...options });
+    expect(holding.phase).toBe('hold');
+    expect(holding.done).toBe(false);
     expect(done.phase).toBe('done');
     expect(done.done).toBe(true);
   });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21378,7 +21378,7 @@ const powerRef = useRef(hud.power);
               0,
               1
             );
-            const eased = easeInOutCubic(t);
+            const eased = easeOutCubic(t);
             tmpReplayCueA.copy(tmpReplayCueB);
             tmpReplayCueB.set(impactSnap.x, impactSnap.y, impactSnap.z);
             cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
@@ -21399,23 +21399,9 @@ const powerRef = useRef(hud.power);
             syncCueShadow();
             return;
           }
-          if (localTime <= recoverEnd && recoverTime > 0) {
-            const t = THREE.MathUtils.clamp(
-              (localTime - followEnd) / Math.max(recoverTime, 1e-6),
-              0,
-              1
-            );
-            const eased = easeInOutCubic(t);
-            tmpReplayCueA.set(followSnap.x, followSnap.y, followSnap.z);
-            tmpReplayCueB.set(idleSnap.x, idleSnap.y, idleSnap.z);
-            cueStick.visible = true;
-            cueStick.position.lerpVectors(tmpReplayCueA, tmpReplayCueB, eased);
-            syncCueShadow();
-            return;
-          }
           const replayHoldWindow = Number.isFinite(playback?.duration)
             ? playback.duration
-            : recoverEnd;
+            : followEnd;
           if (localTime <= replayHoldWindow) {
             cueStick.visible = true;
             cueStick.position.set(idleSnap.x, idleSnap.y, idleSnap.z);
@@ -21608,7 +21594,7 @@ const powerRef = useRef(hud.power);
                 }
                 case 'classic':
                 default:
-                  return easeInOutCubic(sample.t);
+                  return easeOutCubic(sample.t);
               }
             })();
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -5,19 +5,16 @@ export const sampleCueStrokeTimeline = ({
   pullbackDuration = 0,
   strikeDuration = 120,
   holdDuration = 50,
-  recoverDuration = 130,
   animationStyle = 'classic'
 } = {}) => {
   const pullback = Math.max(0, pullbackDuration ?? 0)
   const release = Math.max(0, strikeDuration ?? 120)
   const hold = Math.max(0, holdDuration ?? 50)
-  const recover = Math.max(0, recoverDuration ?? 130)
   const safeElapsed = Math.max(0, elapsed)
 
   const pullEnd = pullback
   const releaseEnd = pullEnd + release
   const holdEnd = releaseEnd + hold
-  const recoverEnd = holdEnd + recover
 
   if (safeElapsed <= pullEnd && pullback > 0) {
     return { phase: 'pullback', t: THREE.MathUtils.clamp(safeElapsed / Math.max(pullback, 1e-6), 0, 1), hitArmed: false, done: false }
@@ -54,9 +51,6 @@ export const sampleCueStrokeTimeline = ({
   }
   if (safeElapsed <= holdEnd && hold > 0) {
     return { phase: 'hold', t: THREE.MathUtils.clamp((safeElapsed - releaseEnd) / Math.max(hold, 1e-6), 0, 1), hitArmed: true, done: false }
-  }
-  if (safeElapsed <= recoverEnd && recover > 0) {
-    return { phase: 'recover', t: THREE.MathUtils.clamp((safeElapsed - holdEnd) / Math.max(recover, 1e-6), 0, 1), hitArmed: true, done: false }
   }
   return { phase: 'done', t: 1, hitArmed: true, done: true }
 }


### PR DESCRIPTION
### Motivation

- Align the in-game cue stroke timeline and replay to the reference pull/push/idle behavior so the shooting mechanism matches the provided implementation and player expectation. 

### Description

- Removed the `recoverDuration` handling and the `recover` phase from the timeline sampler in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` so the timeline transitions `pullback -> release -> hold -> done`.
- Updated replay/live cue interpolation in `webapp/src/pages/Games/PoolRoyale.jsx` to use an ease-out release curve for the push and to remove the replay recover interpolation, making replays snap back to idle after the hold by using `followEnd` as the hold cutoff.
- Changed the default "classic" release easing path to use `easeOutCubic` for more accurate push timing.
- Updated unit test `test/poolRoyaleCueStrokeTimeline.test.js` to assert the new no-recover behavior.

### Testing

- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, which passed (4 tests, all passed).
- Ran `npm test -- test/cueShotImpact.test.js --runInBand`, which passed (3 tests, all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9dd2e257c832997186b83269d1094)