### PR TITLE
Restore two-phase cue stroke (pullback + push) for Pool Royale cue stick animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24522,18 +24522,29 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
+        const pullRatio = easeOutCubic(p);
+        const pullbackDuration = THREE.MathUtils.lerp(
+          PLAYER_CUE_PULLBACK_DURATION_MS * 0.6,
+          PLAYER_CUE_PULLBACK_DURATION_MS,
+          pullRatio
+        );
+        const strikeDuration = THREE.MathUtils.lerp(
+          LIVE_CUE_FORWARD_DURATION_MS,
+          PLAYER_CUE_RELEASE_DURATION_MS * 0.26,
+          pullRatio
+        );
         return {
-          // Match the reference cue interaction: drag builds pull, release performs a
-          // direct push to contact, short hold, then instant snap back to idle.
+          // Keep a visible two-phase cue stroke: pull back while charging, then
+          // push through the cue ball on release.
           motion: 'classic',
-          pullRatio: easeOutCubic(p),
+          pullRatio,
           pullSmoothing: 1,
-          strikeDuration: 120,
-          holdDuration: 50,
-          pullbackDuration: 0,
+          strikeDuration,
+          holdDuration: LIVE_CUE_IMPACT_HOLD_MS,
+          pullbackDuration,
           recoverDuration: 0,
           impactThreshold: 0.9,
-          forwardOnly: true,
+          forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };


### PR DESCRIPTION
### Motivation
- The shooting feel and cuestick animation should show a clear wind-up (pullback) and a visible push-through on release so shots read better to the player. 
- Fixes the shooting mechanism to ensure the visual stroke corresponds to the charged power and improves animation readability during impact.

### Description
- Updated `resolveCueStrokeProfile` in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a `pullRatio` and derive `pullbackDuration` and `strikeDuration` from the shot power so pullback scales with power. 
- Switched `pullRatio` usage into the returned profile and set `holdDuration` to `LIVE_CUE_IMPACT_HOLD_MS` and `pullbackDuration` to the computed value so the timeline shows both phases. 
- Set `forwardOnly: false` so the timeline will actually perform pullback then release (instead of a single forward-only push), and preserved `impactThreshold`/`spinScale` tuning.

### Testing
- Ran the unit test `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (4 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6aa0f29083299d31cae7cd04a324)