### PR TITLE
Pool Royale: Fix cue pullback → push stroke animation and impact timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21572,7 +21572,8 @@ const powerRef = useRef(hud.power);
           }
           if (sample.phase === 'pullback') {
             const eased = easeInOutCubic(sample.t);
-            cueStick.position.lerpVectors(idlePos, pullPos, eased);
+            const pullbackStartPos = stroke.startPos ?? idlePos;
+            cueStick.position.lerpVectors(pullbackStartPos, pullPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -24524,16 +24525,16 @@ const powerRef = useRef(hud.power);
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
           // Match the reference cue interaction: drag builds pull, release performs a
-          // direct push to contact, short hold, then instant snap back to idle.
+          // short pullback + push stroke to contact, short hold, then instant snap back.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration: 0,
+          pullbackDuration: 90,
           recoverDuration: 0,
-          impactThreshold: 0.9,
-          forwardOnly: true,
+          impactThreshold: 1,
+          forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };
@@ -25286,6 +25287,7 @@ const powerRef = useRef(hud.power);
             };
             cueStrokeStateRef.current = {
               startTime,
+              startPos: cueStick.position.clone(),
               idlePos: idlePos.clone(),
               pullPos: pullPos.clone(),
               impactPos: impactPos.clone(),
@@ -25302,7 +25304,7 @@ const powerRef = useRef(hud.power);
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true,
+              releaseStartsFromCurrentPull: false,
               impactOnRecover: triggerImpactOnIdle,
               shotApplied: false,
               onImpact: () => {


### PR DESCRIPTION
### Motivation
- Improve shooting feel by making the cue visually perform a real pullback then push instead of a forward-only motion, matching the documented `power → pull distance → impulse` model.
- Ensure impact (physics impulse) is armed only when the forward release completes so visuals and physics remain consistent and the cue does not snap backward during release.

### Description
- Updated `resolveCueStrokeProfile` to enable a pullback phase by setting `pullbackDuration: 90`, raising `impactThreshold` to `1`, and switching `forwardOnly` to `false` so the stroke uses `pullback → release → hold` semantics.
- Record the live cue start position at shot trigger as `startPos` and set `releaseStartsFromCurrentPull: false` so the timeline uses the captured origin rather than starting the release from the current interpolated pull.
- Use `stroke.startPos` as the pullback origin inside the cue stroke update so the cue visibly draws back from the actual live pose and then pushes to `impactPos`.

### Testing
- Executed unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js --runInBand` and both test suites passed (2 suites, 7 tests total, all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6aa0f29083299d31cae7cd04a324)