### PR TITLE
Match Pool Royale cue stroke and power slider release behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24531,9 +24531,9 @@ const powerRef = useRef(hud.power);
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration: 90,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 1,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -30909,6 +30909,7 @@ const powerRef = useRef(hud.power);
     const slider = new PoolRoyalePowerSlider({
       mount,
       value: powerRef.current * 100,
+      step: 0.01,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
       onChange: (v) => applyPower(v / 100),
@@ -30916,13 +30917,27 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: () => {
+        const releaseStart = performance.now();
+        const releaseFrom = powerRef.current;
+        const releaseDurationMs = 160;
+        const tickRelease = () => {
+          const t = THREE.MathUtils.clamp(
+            (performance.now() - releaseStart) / releaseDurationMs,
+            0,
+            1
+          );
+          const eased = easeOutCubic(t);
+          const nextPower = THREE.MathUtils.lerp(releaseFrom, 0, eased);
+          slider.set(nextPower * 100);
+          applyPower(nextPower);
+          if (t < 1) {
+            requestAnimationFrame(tickRelease);
+          }
+        };
         if (powerRef.current > 0.02) {
           fireRef.current?.();
         }
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
+        requestAnimationFrame(tickRelease);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Make the cue stick and vertical power slider replicate the referenced demo behavior exactly by matching pull/release timing, easing and visual reset so shot timing and speed feel identical.
- Improve slider precision so power sampling during drag more closely matches the continuous reference input.
- Keep UI reset smooth on release while still triggering the shot immediately when release power crosses the threshold.

### Description
- Adjusted the cue stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` by removing the pre-strike pullback (`pullbackDuration: 0`) and lowering the impact timing threshold to `impactThreshold: 0.9` to align impact timing with the reference stroke curve.
- Increased slider resolution by adding `step: 0.01` to the `PoolRoyalePowerSlider` instantiation so power values are captured with near-continuous precision.
- Reworked slider `onCommit` handling to animate the displayed power from the current value back to zero over `160ms` using `easeOutCubic` while still calling the shot trigger (`fireRef.current`) immediately when the release power exceeds `0.02`.
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and use existing helper easing functions (`easeOutCubic`) and `THREE.MathUtils` utilities for interpolation.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed but the repo lint config reports this file as ignored (no blocking errors reported).
- Started the dev server with `npm --prefix webapp run dev` and Vite started successfully and served the app locally.
- Attempted a Playwright screenshot of `/games/poolroyale` to validate visual behavior, but the headless Chromium process crashed in this environment (SIGSEGV) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa70d58e308329aaf8f635dddc5a43)