### PR TITLE
Pool Royale: align cue stroke timing with reference slider release behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24525,16 +24525,16 @@ const powerRef = useRef(hud.power);
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
           // Match the reference cue interaction: drag builds pull, release performs a
-          // short pullback + push stroke to contact, short hold, then instant snap back.
+          // direct push stroke to contact, short hold, then instant snap back.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration: 90,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 1,
-          forwardOnly: false,
+          impactThreshold: 0.9,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };


### PR DESCRIPTION
### Motivation
- Ensure the in-game cue stick & power-slider interaction matches the reference release behavior so the cue triggers on slider release and performs an immediate forward push with identical timing.

### Description
- Updated `resolveCueStrokeProfile` in `webapp/src/pages/Games/PoolRoyale.jsx` to remove the pre-strike pullback by setting `pullbackDuration` to `0`, and adjusted the stroke to be forward-only with `forwardOnly: true` and `impactThreshold: 0.9`, while keeping `strikeDuration: 120` and `holdDuration: 50` to preserve release speed and hold cadence.

### Testing
- Ran the targeted unit test with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` which passed.
- Attempted an automated Playwright screenshot to validate the live slider but the capture timed out in this environment (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa70d58e308329aaf8f635dddc5a43)