### PR TITLE
Make cue impact arming configurable and update default cue profile (with tests)

### DIFF
--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -22,6 +22,16 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(atHit.hitArmed).toBe(true);
   });
 
+
+  it('arms impact at the configured release threshold (reference strike at 90%)', () => {
+    const pre = sampleCueStrokeTimeline({ elapsed: 289, ...options, impactThreshold: 0.9 });
+    const at = sampleCueStrokeTimeline({ elapsed: 290, ...options, impactThreshold: 0.9 });
+    expect(pre.phase).toBe('release');
+    expect(pre.hitArmed).toBe(false);
+    expect(at.phase).toBe('release');
+    expect(at.hitArmed).toBe(true);
+  });
+
   it('keeps spring release monotonic so cue does not snap backward mid-push', () => {
     const early = sampleCueStrokeTimeline({ elapsed: 230, ...options, animationStyle: 'spring' });
     const middle = sampleCueStrokeTimeline({ elapsed: 260, ...options, animationStyle: 'spring' });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21562,6 +21562,7 @@ const powerRef = useRef(hud.power);
             strikeDuration,
             holdDuration,
             recoverDuration,
+            impactThreshold: strikeImpactThreshold,
             animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
           });
           cueStick.visible = !stroke.shotApplied;
@@ -24525,15 +24526,15 @@ const powerRef = useRef(hud.power);
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
           // Match the reference cue interaction: drag builds pull, release performs a
-          // short pullback + push stroke to contact, short hold, then instant snap back.
+          // direct push stroke to contact, short hold, then instant snap back.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration: 90,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 1,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -5,12 +5,14 @@ export const sampleCueStrokeTimeline = ({
   pullbackDuration = 0,
   strikeDuration = 120,
   holdDuration = 50,
+  impactThreshold = 1,
   animationStyle = 'classic'
 } = {}) => {
   const pullback = Math.max(0, pullbackDuration ?? 0)
   const release = Math.max(0, strikeDuration ?? 120)
   const hold = Math.max(0, holdDuration ?? 50)
   const safeElapsed = Math.max(0, elapsed)
+  const impactArm = THREE.MathUtils.clamp(impactThreshold ?? 1, 0, 1)
 
   const pullEnd = pullback
   const releaseEnd = pullEnd + release
@@ -45,7 +47,7 @@ export const sampleCueStrokeTimeline = ({
       phase: 'release',
       t: styleT,
       // Cue-ball movement starts only after the cue returns to the start contact point.
-      hitArmed: safeElapsed >= pullEnd + release,
+      hitArmed: baseT >= impactArm || safeElapsed >= pullEnd + release,
       done: false
     }
   }


### PR DESCRIPTION
### Motivation

- Make the moment the cue impact is armed configurable so different stroke profiles can trigger impact before the full release completes. 
- Adjust the default in-game cue profile to match the reference interaction (direct push to contact with slightly earlier impact). 

### Description

- Add an `impactThreshold` parameter to `sampleCueStrokeTimeline` and clamp it via `impactArm`, and change `hitArmed` logic to arm when `baseT >= impactArm` or when the release fully completes. 
- Propagate the configured `impactThreshold` from the gameplay code by passing `impactThreshold: strikeImpactThreshold` into `sampleCueStrokeTimeline`. 
- Update the default cue profile returned by `resolveCueStrokeProfile` to remove pullback (`pullbackDuration: 0`) and set `impactThreshold: 0.9`, and update the accompanying comment. 
- Add a unit test in `test/poolRoyaleCueStrokeTimeline.test.js` that verifies arming occurs at the configured release threshold (reference strike at 90%).

### Testing

- Ran the unit test suite (`test/poolRoyaleCueStrokeTimeline.test.js`) which includes the new `arms impact at the configured release threshold` test. All tests passed. 
- Existing timeline behavior tests (pullback, release monotonicity, hold->done transitions) were also exercised and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa70d58e308329aaf8f635dddc5a43)