### PR TITLE
Make cue stroke direct forward-only push (no pullback) and adjust impact behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24525,16 +24525,16 @@ const powerRef = useRef(hud.power);
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         return {
           // Match the reference cue interaction: drag builds pull, release performs a
-          // short pullback + push stroke to contact, short hold, then instant snap back.
+          // direct push stroke to contact, short hold, then instant snap back.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration: 90,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 1,
-          forwardOnly: false,
+          impactThreshold: 0.9,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };
@@ -25305,7 +25305,8 @@ const powerRef = useRef(hud.power);
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: false,
-              impactOnRecover: triggerImpactOnIdle,
+              impactOnRecover:
+                Boolean(triggerImpactOnIdle) && !Boolean(strokeProfile.forwardOnly),
               shotApplied: false,
               onImpact: () => {
                 triggerShotImpact();


### PR DESCRIPTION
### Motivation

- Align cue strike behavior with a direct push interaction instead of a short pullback + push to make shot timing more immediate.
- Remove visual pullback so the cue feels like a single forward stroke and ensure camera/impact behavior matches that flow.

### Description

- Update `resolveCueStrokeProfile` to document the new motion and set `pullbackDuration: 0`, `impactThreshold: 0.9`, and `forwardOnly: true` to create a direct push stroke profile.
- Adjust impact logic when creating `cueStrokeStateRef.current` so `impactOnRecover` is disabled when `forwardOnly` is enabled by setting `impactOnRecover: Boolean(triggerImpactOnIdle) && !Boolean(strokeProfile.forwardOnly)`.
- Kept other stroke timing values (`strikeDuration`, `holdDuration`, etc.) unchanged to preserve existing timing characteristics.

### Testing

- Ran the project test suite with `yarn test` and found all tests passing.
- Ran lint checks with `yarn lint` and there were no reported lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa70d58e308329aaf8f635dddc5a43)