### PR TITLE
Match Pool Royale slider release and cue shot timing to reference

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -206,36 +206,32 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this.dragging = true;
-    this.dragMoved = false;
-    this.dragStartValue = this.value;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
-    this.pointerStartY = e.clientY;
     if (typeof this.onStart === 'function') this.onStart(this.value);
+    this._updateFromClientY(e.clientY);
     this.el.addEventListener('pointermove', this._onPointerMove);
     this.el.addEventListener('pointerup', this._onPointerUp);
+    this.el.addEventListener('pointercancel', this._onPointerUp);
   }
 
   _pointerMove(e) {
     if (!this.dragging) return;
-    if (!this.dragMoved && Math.abs(e.clientY - this.pointerStartY) > 1) {
-      this.dragMoved = true;
-    }
     this._updateFromClientY(e.clientY);
   }
 
   _pointerUp(e) {
     if (!this.dragging) return;
     this.dragging = false;
-    this.el.releasePointerCapture(e.pointerId);
+    try {
+      this.el.releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore
+    }
     this.el.removeEventListener('pointermove', this._onPointerMove);
     this.el.removeEventListener('pointerup', this._onPointerUp);
+    this.el.removeEventListener('pointercancel', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
-    const moved = this.dragMoved || Math.abs(this.value - this.dragStartValue) > 0;
-    if (!moved) {
-      this.set(this.dragStartValue, { animate: true });
-      return;
-    }
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
   }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30929,10 +30929,23 @@ const committedShotPowerRef = useRef(0);
         } else {
           committedShotPowerRef.current = 0;
         }
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
+        const fromPower = clampPower(powerRef.current, 0);
+        const start = performance.now();
+        const durationMs = 160;
+        const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+        const tick = () => {
+          const t = Math.min(1, Math.max(0, (performance.now() - start) / durationMs));
+          const nextPower = fromPower + (0 - fromPower) * easeOutCubic(t);
+          slider.set(nextPower * 100, { animate: false });
+          applyPower(nextPower);
+          if (t < 1) {
+            requestAnimationFrame(tick);
+          } else {
+            slider.set(slider.min, { animate: false });
+            applyPower(0);
+          }
+        };
+        requestAnimationFrame(tick);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Make the in-game cue stick and vertical power slider behave identically to the provided reference demo so shot timing, pull speed, and release feel match 100%.
- Ensure the slider reliably arms and triggers the cue stroke even across pointercancel/release edge cases so mobile touch interactions are deterministic.

### Description
- Changed `PowerSlider` pointer handling in `power-slider.js` to immediately sample pointer position on `pointerdown`, always commit on `pointerup`, and handle `pointercancel` consistently, while removing the previous "dragMoved/dragStartValue" fallback behavior.
- Hardened pointer release cleanup by wrapping `releasePointerCapture` in a try/catch and removing duplicate/remove-listener paths to ensure robust pointer lifecycle management.
- Replaced the one-frame reset in `webapp/src/pages/Games/PoolRoyale.jsx` slider `onCommit` with a frame-driven 160ms `easeOutCubic` decay that updates both the slider UI and `applyPower` each frame to mirror the reference demo's post-release power curve and timing while preserving the existing shot trigger threshold and cue anchor capture.

### Testing
- Ran the cue-stroke timeline unit test: `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js`, which passed (4 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9c373b44832992d9281a34df3543)