### PR TITLE
Apply power slider at end of cue stroke (triggerImpactOnIdle = true)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25021,9 +25021,9 @@ const committedShotPowerRef = useRef(0);
             x: (physicsSpin.x ?? 0) * SPIN_GLOBAL_SCALE,
             y: (physicsSpin.y ?? 0) * SPIN_GLOBAL_SCALE
           };
-          // Fire the physics impulse during the release phase so a slider release
-          // always launches the cue ball immediately.
-          const triggerImpactOnIdle = false;
+          // Delay the physics impulse until the cue returns to idle so the shot
+          // power from the slider is applied exactly when the full stroke finishes.
+          const triggerImpactOnIdle = true;
           const baseSide = scaledSpin.x * (ranges.side ?? 0);
           let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
           let spinTop = scaledSpin.y * (ranges.forward ?? 0) * powerSpinScale;


### PR DESCRIPTION
### Motivation
- Shots were firing during the cue release phase which caused the cue ball to sometimes not move or receive the correct power value from the slider, so the physics impulse must be applied when the cue returns to its idle pose.

### Description
- Changed the impact timing flag in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `triggerImpactOnIdle` from `false` to `true` so the physics impulse is applied when the stroke finishes. 
- Updated the inline comment to explain that the shot impulse is delayed until the cue reaches idle, ensuring the committed slider power is used at the true strike moment.

### Testing
- Ran `npm run lint -- webapp/src/pages/Games/PoolRoyale.jsx` which produced a React-version warning but no lint errors for the modified logic. 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which emitted a file-ignore warning (environment lint config) and exited non-zero due to warnings. 
- Verified `git diff --check` showed no whitespace or diff-check issues and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa4b877dc8329af5064b57b0e446b)