### PR TITLE
Fix Pool Royale shot trigger timing for power-slider releases

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25021,9 +25021,9 @@ const committedShotPowerRef = useRef(0);
             x: (physicsSpin.x ?? 0) * SPIN_GLOBAL_SCALE,
             y: (physicsSpin.y ?? 0) * SPIN_GLOBAL_SCALE
           };
-          // Fire the physics impulse during the release phase so a slider release
-          // always launches the cue ball immediately.
-          const triggerImpactOnIdle = false;
+          // Fire the physics impulse when the cue has returned to its idle/contact
+          // position so the shot timing matches the visible cue strike.
+          const triggerImpactOnIdle = true;
           const baseSide = scaledSpin.x * (ranges.side ?? 0);
           let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
           let spinTop = scaledSpin.y * (ranges.forward ?? 0) * powerSpinScale;


### PR DESCRIPTION
### Motivation
- Ensure the visible cue-stick strike and the physics impulse align for slider-driven shots so the committed slider power is applied when the cue returns to its idle/contact position rather than mid-release.

### Description
- Toggle `triggerImpactOnIdle` to `true` in `webapp/src/pages/Games/PoolRoyale.jsx` so the cue-ball impulse is applied when the cue reaches its idle/contact pose, keeping the use of the committed slider power (`committedShotPowerRef`).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa4b877dc8329af5064b57b0e446b)