### PR TITLE
Enhance developer control panel and add mining-video task flow (mobile-friendly)

### DIFF
--- a/bot/models/CustomTask.js
+++ b/bot/models/CustomTask.js
@@ -8,7 +8,18 @@ const customTaskSchema = new mongoose.Schema({
   },
   reward: { type: Number, required: true },
   link: { type: String, required: true },
-  description: { type: String }
+  description: { type: String },
+  section: {
+    type: String,
+    enum: ['tasks', 'mining'],
+    default: 'tasks'
+  },
+  videoProvider: {
+    type: String,
+    enum: ['youtube', 'tiktok', null],
+    default: null
+  },
+  videoDurationSec: { type: Number, default: 0 }
 });
 
 export default mongoose.model('CustomTask', customTaskSchema);

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -60,6 +60,36 @@ function parseTelegramLink(link) {
   };
 }
 
+
+function toEmbedVideo(link = '', provider = '') {
+  const raw = String(link || '').trim();
+  if (!raw) return null;
+
+  if (provider === 'youtube' || /youtu\.be|youtube\.com/i.test(raw)) {
+    const direct = raw.match(/youtube\.com\/embed\/([A-Za-z0-9_-]{6,})/i);
+    const short = raw.match(/youtu\.be\/([A-Za-z0-9_-]{6,})/i);
+    const watch = raw.match(/[?&]v=([A-Za-z0-9_-]{6,})/i);
+    const id = (direct && direct[1]) || (short && short[1]) || (watch && watch[1]);
+    if (!id) return null;
+    return {
+      provider: 'youtube',
+      embedUrl: `https://www.youtube.com/embed/${id}?rel=0&modestbranding=1`,
+    };
+  }
+
+  if (provider === 'tiktok' || /tiktok\.com/i.test(raw)) {
+    const m = raw.match(/tiktok\.com\/@[^/]+\/video\/(\d+)/i);
+    const id = m && m[1];
+    if (!id) return null;
+    return {
+      provider: 'tiktok',
+      embedUrl: `https://www.tiktok.com/embed/v2/${id}`,
+    };
+  }
+
+  return null;
+}
+
 router.post('/list', authenticate, async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
@@ -90,6 +120,7 @@ router.post('/list', authenticate, async (req, res) => {
     customList.map(async (t) => {
       const taskId = `custom_${t._id}`;
       const rec = await Task.findOne({ telegramId, taskId });
+      const embed = toEmbedVideo(t.link, t.videoProvider);
       return {
         id: taskId,
         description: t.description || `Task on ${t.platform}`,
@@ -97,7 +128,15 @@ router.post('/list', authenticate, async (req, res) => {
         icon: PLATFORM_ICONS[t.platform] || t.platform,
         link: t.link,
         completed: !!rec,
-        cooldown: 0
+        cooldown: 0,
+        section: t.section || 'tasks',
+        video: embed
+          ? {
+              provider: embed.provider,
+              embedUrl: embed.embedUrl,
+              durationSec: Number(t.videoDurationSec) || 0
+            }
+          : null
       };
     })
   );
@@ -422,23 +461,39 @@ router.post('/admin/list', async (req, res) => {
 
 router.post('/admin/create', async (req, res) => {
   if (!isAuthorized(req)) return res.status(403).json({ error: 'unauthorized' });
-  const { platform, reward, link, description } = req.body;
+  const { platform, reward, link, description, section, videoProvider, videoDurationSec } = req.body;
   if (!platform || !reward || !link) {
     return res
       .status(400)
       .json({ error: 'platform, reward and link required' });
   }
-  const task = await CustomTask.create({ platform, reward, link, description });
+  const task = await CustomTask.create({
+    platform,
+    reward,
+    link,
+    description,
+    section: section || 'tasks',
+    videoProvider: videoProvider || null,
+    videoDurationSec: Number(videoDurationSec) || 0
+  });
   res.json(task);
 });
 
 router.post('/admin/update', async (req, res) => {
   if (!isAuthorized(req)) return res.status(403).json({ error: 'unauthorized' });
-  const { id, platform, reward, link, description } = req.body;
+  const { id, platform, reward, link, description, section, videoProvider, videoDurationSec } = req.body;
   if (!id) return res.status(400).json({ error: 'id required' });
   const task = await CustomTask.findByIdAndUpdate(
     id,
-    { platform, reward, link, description },
+    {
+      platform,
+      reward,
+      link,
+      description,
+      section: section || 'tasks',
+      videoProvider: videoProvider || null,
+      videoDurationSec: Number(videoDurationSec) || 0
+    },
     { new: true }
   );
   if (!task) return res.status(404).json({ error: 'not found' });

--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   adminListTasks,
@@ -7,15 +7,24 @@ import {
   adminDeleteTask
 } from '../utils/api.js';
 import { normalizeTasksResponse } from '../utils/taskUtils.js';
-import { FiEdit, FiTrash2 } from 'react-icons/fi';
+import { FiEdit, FiTrash2, FiRefreshCw, FiVideo } from 'react-icons/fi';
 
-export default function DevTasksModal({ open, onClose }) {
+const defaultForm = {
+  section: 'tasks',
+  platform: 'tiktok',
+  reward: '',
+  link: '',
+  description: '',
+  videoProvider: 'none',
+  videoDurationSec: '30'
+};
+
+export default function DevTasksModal({ open, onClose, initialSection = 'tasks' }) {
   const [tasks, setTasks] = useState([]);
-  const [platform, setPlatform] = useState('tiktok');
-  const [reward, setReward] = useState('');
-  const [link, setLink] = useState('');
-  const [description, setDescription] = useState('');
   const [editing, setEditing] = useState(null);
+  const [activeSection, setActiveSection] = useState('tasks');
+  const [form, setForm] = useState(defaultForm);
+  const [saving, setSaving] = useState(false);
 
   const load = async () => {
     const data = await adminListTasks();
@@ -23,133 +32,258 @@ export default function DevTasksModal({ open, onClose }) {
   };
 
   useEffect(() => {
-    if (open) load();
-  }, [open]);
-
-  const handleAdd = async () => {
-    const r = parseInt(reward, 10);
-    if (!platform || !r || !link || !description) return;
-    if (editing) {
-      await adminUpdateTask(editing, platform, r, link, description);
-    } else {
-      await adminCreateTask(platform, r, link, description);
+    if (open) {
+      setActiveSection(initialSection || 'tasks');
+      resetForm(initialSection || 'tasks');
+      load();
     }
-    setPlatform('tiktok');
-    setReward('');
-    setLink('');
-    setDescription('');
+  }, [open, initialSection]);
+
+  const visibleTasks = useMemo(
+    () => tasks.filter((t) => (t.section || 'tasks') === activeSection),
+    [tasks, activeSection]
+  );
+
+  const updateForm = (key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const resetForm = (section = activeSection) => {
     setEditing(null);
-    load();
-    window.dispatchEvent(new Event('tasksUpdated'));
+    setForm({ ...defaultForm, section });
+  };
+
+  const parseVideoProvider = (link = '') => {
+    if (/youtube\.com|youtu\.be/i.test(link)) return 'youtube';
+    if (/tiktok\.com/i.test(link)) return 'tiktok';
+    return 'none';
+  };
+
+  const handleSave = async () => {
+    const rewardInt = parseInt(form.reward, 10);
+    if (!form.platform || !rewardInt || !form.link || !form.description) return;
+
+    const payload = {
+      platform: form.platform,
+      reward: rewardInt,
+      link: form.link.trim(),
+      description: form.description.trim(),
+      section: form.section,
+      videoProvider: form.videoProvider === 'none' ? null : form.videoProvider,
+      videoDurationSec:
+        form.videoProvider === 'none' ? 0 : Math.max(5, Number(form.videoDurationSec) || 30)
+    };
+
+    setSaving(true);
+    try {
+      if (editing) {
+        await adminUpdateTask({ id: editing, ...payload });
+      } else {
+        await adminCreateTask(payload);
+      }
+      resetForm(form.section);
+      await load();
+      window.dispatchEvent(new Event('tasksUpdated'));
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleEdit = (task) => {
-    setPlatform(task.platform);
-    setReward(String(task.reward));
-    setLink(task.link);
-    setDescription(task.description || '');
+    const section = task.section || 'tasks';
+    setActiveSection(section);
     setEditing(task._id);
+    setForm({
+      section,
+      platform: task.platform || 'tiktok',
+      reward: String(task.reward || ''),
+      link: task.link || '',
+      description: task.description || '',
+      videoProvider: task.videoProvider || parseVideoProvider(task.link || ''),
+      videoDurationSec: String(task.videoDurationSec || 30)
+    });
   };
 
   const handleDelete = async (id) => {
-    if (!window.confirm('Are you sure you want to delete this task?')) return;
+    if (!window.confirm('Delete this task?')) return;
     await adminDeleteTask(id);
-    load();
+    await load();
     window.dispatchEvent(new Event('tasksUpdated'));
   };
+
+  const isMiningSection = form.section === 'mining';
 
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 bg-black bg-opacity-70 z-50 overflow-auto flex flex-col">
-      <div className="bg-surface text-text p-4 flex-1">
-        <h3 className="text-lg font-bold mb-4 text-center">Manage Tasks</h3>
-        <div className="space-y-2 mb-4">
-          <select
-            value={platform}
-            onChange={(e) => setPlatform(e.target.value)}
-            className="border p-1 rounded w-full text-black"
+    <div className="fixed inset-0 bg-black/75 z-50 overflow-auto">
+      <div className="min-h-full w-full max-w-3xl mx-auto bg-surface text-text p-3 sm:p-4 space-y-3">
+        <div className="flex items-center justify-between gap-2 sticky top-0 bg-surface py-1 z-10">
+          <h3 className="text-base sm:text-lg font-bold">Developer Task Manager</h3>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded bg-primary hover:bg-primary-hover text-background text-sm"
           >
-            <option value="tiktok">TikTok</option>
-            <option value="x">X</option>
-            <option value="telegram">Telegram</option>
-            <option value="discord">Discord</option>
-            <option value="youtube">YouTube</option>
-            <option value="facebook">Facebook</option>
-            <option value="instagram">Instagram</option>
-          </select>
-          <input
-            type="number"
-            placeholder="Reward (TPC)"
-            value={reward}
-            onChange={(e) => setReward(e.target.value)}
-            className="border p-1 rounded w-full text-black"
-          />
+            Close
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          {[
+            { key: 'tasks', label: 'Tasks page' },
+            { key: 'mining', label: 'Mining page' }
+          ].map((item) => (
+            <button
+              key={item.key}
+              onClick={() => {
+                setActiveSection(item.key);
+                resetForm(item.key);
+              }}
+              className={`px-3 py-2 rounded border text-sm font-semibold ${
+                activeSection === item.key
+                  ? 'bg-primary text-background border-primary'
+                  : 'bg-background/60 border-border text-white'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="rounded-xl border border-border bg-background/60 p-3 space-y-2">
+          <p className="text-sm font-semibold text-white">
+            {editing ? 'Edit task' : 'Create new task'}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <select
+              value={form.platform}
+              onChange={(e) => updateForm('platform', e.target.value)}
+              className="border p-2 rounded w-full text-black"
+            >
+              <option value="tiktok">TikTok</option>
+              <option value="x">X</option>
+              <option value="telegram">Telegram</option>
+              <option value="discord">Discord</option>
+              <option value="youtube">YouTube</option>
+              <option value="facebook">Facebook</option>
+              <option value="instagram">Instagram</option>
+            </select>
+            <input
+              type="number"
+              placeholder="Reward (TPC)"
+              value={form.reward}
+              onChange={(e) => updateForm('reward', e.target.value)}
+              className="border p-2 rounded w-full text-black"
+            />
+          </div>
+
           <input
             type="text"
-            placeholder="Link"
-            value={link}
-            onChange={(e) => setLink(e.target.value)}
-            className="border p-1 rounded w-full text-black"
+            placeholder={isMiningSection ? 'TikTok or YouTube video link' : 'Task link'}
+            value={form.link}
+            onChange={(e) => updateForm('link', e.target.value)}
+            className="border p-2 rounded w-full text-black"
           />
+
           <input
             type="text"
             placeholder="Description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className="border p-1 rounded w-full text-black"
+            value={form.description}
+            onChange={(e) => updateForm('description', e.target.value)}
+            className="border p-2 rounded w-full text-black"
           />
-          <button
-            onClick={handleAdd}
-            className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-background w-full"
-          >
-            {editing ? 'Save Task' : 'Add Task'}
-          </button>
-          {editing && (
-            <button
-              onClick={() => {
-                setEditing(null);
-                setPlatform('tiktok');
-                setReward('');
-                setLink('');
-                setDescription('');
-              }}
-              className="px-3 py-1 bg-red-600 text-background rounded w-full"
-            >
-              Cancel Edit
-            </button>
-          )}
-        </div>
-        <ul className="space-y-2">
-          {tasks.map((t) => (
-            <li key={t._id} className="lobby-tile space-y-1">
-              <div className="text-sm break-all">{t.description}</div>
-              <div className="text-xs break-all">
-                {t.platform} - {t.reward} TPC
+
+          {isMiningSection && (
+            <div className="rounded-lg border border-primary/40 bg-primary/10 p-2 space-y-2">
+              <p className="text-xs sm:text-sm text-primary font-semibold flex items-center gap-1">
+                <FiVideo className="w-4 h-4" /> Mining video config
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <select
+                  value={form.videoProvider}
+                  onChange={(e) => updateForm('videoProvider', e.target.value)}
+                  className="border p-2 rounded w-full text-black"
+                >
+                  <option value="none">No embedded video</option>
+                  <option value="youtube">YouTube embed</option>
+                  <option value="tiktok">TikTok embed</option>
+                </select>
+                <input
+                  type="number"
+                  min="5"
+                  value={form.videoDurationSec}
+                  onChange={(e) => updateForm('videoDurationSec', e.target.value)}
+                  className="border p-2 rounded w-full text-black"
+                  placeholder="Auto-complete after seconds"
+                />
               </div>
-              <div className="text-xs break-all">{t.link}</div>
-              <div className="flex gap-4 mt-1 justify-center">
-                <FiEdit
-                  className="w-4 h-4 cursor-pointer text-primary"
+              <p className="text-[11px] text-subtext">
+                For mining video tasks, reward is auto-claimed after the video timer ends.
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full text-sm font-semibold disabled:opacity-60"
+            >
+              {saving ? 'Saving...' : editing ? 'Save Task' : 'Add Task'}
+            </button>
+            <button
+              onClick={() => resetForm(activeSection)}
+              className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm"
+            >
+              Reset
+            </button>
+            <button
+              onClick={load}
+              className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm inline-flex items-center justify-center gap-1"
+            >
+              <FiRefreshCw className="w-4 h-4" /> Refresh
+            </button>
+          </div>
+        </div>
+
+        <ul className="space-y-2 pb-6">
+          {visibleTasks.map((t) => (
+            <li key={t._id} className="rounded-lg border border-border bg-background/60 p-2.5 space-y-1.5">
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-white break-words">{t.description}</p>
+                <span className="text-[11px] uppercase rounded bg-primary/15 text-primary px-2 py-0.5 shrink-0">
+                  {t.platform}
+                </span>
+              </div>
+              <div className="text-xs text-subtext break-all">{t.link}</div>
+              <div className="flex items-center gap-2 text-xs text-subtext">
+                <span>{t.reward} TPC</span>
+                {(t.videoProvider || t.video?.provider) && (
+                  <span className="rounded bg-primary/15 text-primary px-1.5 py-0.5">
+                    {t.videoProvider || t.video.provider} video
+                  </span>
+                )}
+              </div>
+              <div className="flex gap-2 justify-end">
+                <button
+                  className="px-2 py-1 rounded bg-primary/20 text-primary inline-flex items-center gap-1"
                   onClick={() => handleEdit(t)}
-                />
-                <FiTrash2
-                  className="w-4 h-4 cursor-pointer text-red-600"
+                >
+                  <FiEdit className="w-4 h-4" /> Edit
+                </button>
+                <button
+                  className="px-2 py-1 rounded bg-red-500/20 text-red-300 inline-flex items-center gap-1"
                   onClick={() => handleDelete(t._id)}
-                />
+                >
+                  <FiTrash2 className="w-4 h-4" /> Delete
+                </button>
               </div>
             </li>
           ))}
-          {tasks.length === 0 && (
-            <p className="text-center text-subtext text-sm">No tasks.</p>
+          {visibleTasks.length === 0 && (
+            <p className="text-center text-subtext text-sm py-2">No tasks in this section.</p>
           )}
         </ul>
-        <button
-          onClick={onClose}
-          className="mt-4 px-3 py-1 bg-primary hover:bg-primary-hover text-background rounded w-full"
-        >
-          Close
-        </button>
       </div>
     </div>,
     document.body

--- a/webapp/src/pages/MyAccount.jsx
+++ b/webapp/src/pages/MyAccount.jsx
@@ -52,7 +52,8 @@ import {
   FiBell,
   FiList,
   FiDollarSign,
-  FiCheckSquare
+  FiCheckSquare,
+  FiVideo
 } from 'react-icons/fi';
 
 export default function MyAccount() {
@@ -106,6 +107,7 @@ export default function MyAccount() {
   const [notifyStatus, setNotifyStatus] = useState('');
   const [showNotifyModal, setShowNotifyModal] = useState(false);
   const [showTasksModal, setShowTasksModal] = useState(false);
+  const [devTaskSection, setDevTaskSection] = useState('tasks');
   const [twitterError, setTwitterError] = useState('');
   const [twitterLink, setTwitterLink] = useState('');
   const [unread, setUnread] = useState(0);
@@ -414,6 +416,11 @@ export default function MyAccount() {
       label: 'Manage tasks',
       value: 'Create, update, and remove quests',
       icon: FiList
+    },
+    {
+      label: 'Mining videos',
+      value: 'TikTok/YouTube iframe tasks with auto rewards',
+      icon: FiVideo
     },
     {
       label: 'Claims',
@@ -944,20 +951,33 @@ export default function MyAccount() {
               </button>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
               <button
                 onClick={() => setShowNotifyModal(true)}
                 className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
               >
                 <FiBell className="w-4 h-4" />
-                Open Notify Center
+                Notify
               </button>
               <button
-                onClick={() => setShowTasksModal(true)}
+                onClick={() => {
+                  setDevTaskSection('tasks');
+                  setShowTasksModal(true);
+                }}
                 className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
               >
                 <FiList className="w-4 h-4" />
-                Open Task Manager
+                Tasks
+              </button>
+              <button
+                onClick={() => {
+                  setDevTaskSection('mining');
+                  setShowTasksModal(true);
+                }}
+                className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full inline-flex items-center justify-center gap-2"
+              >
+                <FiVideo className="w-4 h-4" />
+                Mining Videos
               </button>
             </div>
 
@@ -999,6 +1019,7 @@ export default function MyAccount() {
       <DevTasksModal
         open={showTasksModal}
         onClose={() => setShowTasksModal(false)}
+        initialSection={devTaskSection}
       />
       <InfoPopup
         open={showSaved}

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
   listTasks,
@@ -43,6 +43,58 @@ const INFLUENCER_REWARDS = [
 const ONE_DAY = 24 * 60 * 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
 
+
+function MiningVideoModal({ open, task, onClose, onComplete }) {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (!open || !task?.video?.embedUrl) return;
+    const duration = Math.max(5, Number(task.video.durationSec) || 30);
+    setRemaining(duration);
+    const startedAt = Date.now();
+    const id = setInterval(() => {
+      const passed = Math.floor((Date.now() - startedAt) / 1000);
+      const left = Math.max(0, duration - passed);
+      setRemaining(left);
+      if (left <= 0) {
+        clearInterval(id);
+        onComplete();
+      }
+    }, 250);
+    return () => clearInterval(id);
+  }, [open, task, onComplete]);
+
+  if (!open || !task) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/80 z-50 p-3 flex items-center justify-center">
+      <div className="w-full max-w-md bg-surface border border-border rounded-xl p-3 space-y-3">
+        <p className="font-semibold text-white text-sm">Mining Video Task</p>
+        <p className="text-xs text-subtext">Watch until timer ends to auto-claim reward.</p>
+        <div className="rounded-lg overflow-hidden border border-border bg-black aspect-video">
+          <iframe
+            src={task.video.embedUrl}
+            title={task.description}
+            className="w-full h-full"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-subtext">Auto-close in</span>
+          <span className="font-semibold text-primary">{remaining}s</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="w-full px-3 py-2 rounded bg-background border border-border text-white text-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function Tasks() {
   useTelegramBackButton();
   let telegramId;
@@ -68,6 +120,7 @@ export default function Tasks() {
   const [videoUrl, setVideoUrl] = useState('');
   const [myVideos, setMyVideos] = useState([]);
   const [streak, setStreak] = useState(1);
+  const [activeMiningVideoTask, setActiveMiningVideoTask] = useState(null);
   const [lastCheck, setLastCheck] = useState(() => {
     const ts = localStorage.getItem('lastCheckIn');
     return ts ? parseInt(ts, 10) : null;
@@ -142,6 +195,12 @@ export default function Tasks() {
       setShowTwitterInfo(true);
       return;
     }
+
+    if (task.section === 'mining' && task.video?.embedUrl) {
+      setActiveMiningVideoTask(task);
+      return;
+    }
+
     if (task.link) {
       window.open(task.link, '_blank');
     }
@@ -206,6 +265,13 @@ export default function Tasks() {
     return `${hh}${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   };
 
+  const handleCompleteMiningVideo = async () => {
+    if (!activeMiningVideoTask) return;
+    await completeTask(telegramId, activeMiningVideoTask.id);
+    setActiveMiningVideoTask(null);
+    load();
+  };
+
   const handleVideoSubmit = async () => {
     if (!videoUrl) return;
     await submitInfluencerVideo(telegramId, platform, videoUrl);
@@ -221,6 +287,15 @@ export default function Tasks() {
       alt="X"
       className="w-5 h-5"
     />
+  );
+
+  const tonPlaygramTasks = useMemo(
+    () => tasks.filter((task) => (task.section || 'tasks') !== 'mining'),
+    [tasks]
+  );
+  const miningTasks = useMemo(
+    () => tasks.filter((task) => (task.section || 'tasks') === 'mining'),
+    [tasks]
   );
 
   const ICONS = {
@@ -253,7 +328,7 @@ export default function Tasks() {
     <div className="relative p-4 space-y-2 text-text flex flex-col items-center wide-card">
       <h2 className="text-xl font-bold">Tasks</h2>
       <div className="flex justify-center space-x-2">
-        {['TonPlaygram', 'Influencer', 'Partners'].map((c) => (
+        {['TonPlaygram', 'Mining', 'Influencer', 'Partners'].map((c) => (
           <button
             key={c}
             onClick={() => setCategory(c)}
@@ -283,7 +358,7 @@ export default function Tasks() {
                   )}
                 </div>
               </li>
-          {tasks.map((t) => (
+          {tonPlaygramTasks.map((t) => (
             <li key={t.id} className="lobby-tile w-full">
               <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
                 {ICONS[t.id] || ICONS[t.icon] || <FiLink className="w-5 h-5" />}
@@ -359,6 +434,39 @@ export default function Tasks() {
       </ul>
         </>
       )}
+
+      {category === 'Mining' && (
+        <div className="w-full space-y-2">
+          <p className="text-xs text-subtext text-center">
+            Mining tasks with video embed auto-close and auto-claim flow.
+          </p>
+          <ul className="space-y-2">
+            {miningTasks.map((t) => (
+              <li key={t.id} className="lobby-tile w-full">
+                <div className="grid grid-cols-[20px_1fr_auto_auto] items-center gap-2 w-full">
+                  {ICONS[t.id] || ICONS[t.icon] || <FiVideo className="w-5 h-5" />}
+                  <span className="text-sm">{t.description}</span>
+                  <span className="text-xs text-subtext flex items-center gap-1">{t.reward} <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-4 h-4" /></span>
+                  {t.completed ? (
+                    <span className="text-green-500 font-semibold text-sm">Completed</span>
+                  ) : (
+                    <button
+                      onClick={() => handleClaim(t)}
+                      className="px-2 py-1 bg-primary hover:bg-primary-hover text-white-shadow text-sm rounded"
+                    >
+                      {t.video?.embedUrl ? 'Watch' : 'Claim'}
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+            {miningTasks.length === 0 && (
+              <p className="text-center text-subtext text-sm">No mining tasks yet.</p>
+            )}
+          </ul>
+        </div>
+      )}
+
       {category === 'Influencer' && (
         <div className="w-full space-y-2">
           <div className="flex justify-center space-x-2">
@@ -465,6 +573,12 @@ export default function Tasks() {
         onClose={() => setShowNew(false)}
         title="New Tasks"
         info="We've added new tasks!"
+      />
+      <MiningVideoModal
+        open={!!activeMiningVideoTask}
+        task={activeMiningVideoTask}
+        onClose={() => setActiveMiningVideoTask(null)}
+        onComplete={handleCompleteMiningVideo}
       />
 
     </div>

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -242,20 +242,12 @@ export function adminListTasks() {
   return post('/api/tasks/admin/list', {}, API_AUTH_TOKEN || undefined);
 }
 
-export function adminCreateTask(platform, reward, link, description) {
-  return post(
-    '/api/tasks/admin/create',
-    { platform, reward, link, description },
-    API_AUTH_TOKEN || undefined
-  );
+export function adminCreateTask(payload) {
+  return post('/api/tasks/admin/create', payload, API_AUTH_TOKEN || undefined);
 }
 
-export function adminUpdateTask(id, platform, reward, link, description) {
-  return post(
-    '/api/tasks/admin/update',
-    { id, platform, reward, link, description },
-    API_AUTH_TOKEN || undefined
-  );
+export function adminUpdateTask(payload) {
+  return post('/api/tasks/admin/update', payload, API_AUTH_TOKEN || undefined);
 }
 
 export function adminDeleteTask(id) {


### PR DESCRIPTION
### Motivation
- Make the Developer Control Panel more powerful and easier to use on mobile (portrait) by exposing a richer task manager and a dedicated mining section. 
- Allow devs to add TikTok/YouTube video tasks that render in an iframe on the mining page and auto-complete/reward users after the video finishes.

### Description
- Expanded the custom task model to include `section`, `videoProvider`, and `videoDurationSec`, and updated admin APIs to accept and persist these fields (`bot/models/CustomTask.js`, `bot/routes/tasks.js`).
- Added `toEmbedVideo` helper to normalize YouTube/TikTok links and return an `embedUrl`, and included `video` metadata in the `/api/tasks/list` response for custom tasks (`bot/routes/tasks.js`).
- Reworked the developer task manager UI into `DevTasksModal` with a section switcher (Tasks / Mining), unified create/edit form, mining-specific video controls (provider + duration), and improved mobile-first layout (`webapp/src/components/DevTasksModal.jsx`).
- Added quick actions on the profile dev control panel for direct entry to Tasks and Mining Video management, and passed an `initialSection` to open the modal in the chosen section (`webapp/src/pages/MyAccount.jsx`).
- Implemented client-side changes on the Tasks page: new `Mining` tab, filtered mining task list, a `MiningVideoModal` which embeds the iframe, and an auto-close/countdown that calls `completeTask` to award the reward when the timer elapses (`webapp/src/pages/Tasks.jsx`).
- Updated web API client helpers to accept payload objects for admin create/update operations (`webapp/src/utils/api.js`).
- Captured a mobile-portrait screenshot of the Developer Control Panel before creating the PR (artifact captured during validation).

### Testing
- Ran `npm --prefix webapp run build` and the webapp built successfully (Vite emitted existing chunk-size warnings, build completed). PASS.
- Performed quick Node syntax checks with `node --check` for modified backend files (`bot/routes/tasks.js` and `bot/models/CustomTask.js`) and they passed. PASS.
- Ran the dev server and used a Playwright script to navigate to the profile page and capture a mobile-portrait screenshot for verification (screenshot artifact produced). PASS.
- Ran ESLint and observed repository ignore rules/linters skipped or reported many issues for the full frontend bundle in this environment, so lint output is not a reliable pass indicator here (informational). WARNING/INFO.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa9b2e9048329b4a6522744c5797a)