### PR TITLE
Harden Pool Royale cue impact to reliably launch cue-ball (add idempotent impact + timed fallback)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -113,6 +113,11 @@ import {
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
+import {
+  applyShotImpact,
+  createShotImpactFallback,
+  createShotImpactPayload
+} from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -25036,7 +25041,7 @@ const committedShotPowerRef = useRef(0);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          const triggerShotImpact = () => {
+          const shotImpactPayload = createShotImpactPayload(() => {
             cue.vel.copy(base);
             if (cue.spin) {
               cue.spin.set(spinSide, spinTop);
@@ -25067,7 +25072,8 @@ const committedShotPowerRef = useRef(0);
             cue.lift = 0;
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
-          };
+          });
+          const triggerShotImpact = () => applyShotImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25176,6 +25182,16 @@ const committedShotPowerRef = useRef(0);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
+          const fallbackImpactTime =
+            startTime +
+            Math.max(
+              pullbackDuration + strikeDuration + followDurationResolved + recoverDuration + 40,
+              strikeDuration + 40
+            );
+          pendingImpactRef.current = createShotImpactFallback(
+            shotImpactPayload,
+            fallbackImpactTime
+          );
           const forwardPreviewHold =
             startTime +
             Math.max(
@@ -25321,6 +25337,7 @@ const committedShotPowerRef = useRef(0);
             };
           } else {
             triggerShotImpact();
+            pendingImpactRef.current = null;
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Players reported the cue ball sometimes did not start moving when a shot fired, so the shot application needs to be more robust while keeping existing cue pull/push visuals intact. 
- The goal is to ensure the physics impulse (velocity/spin/omega) for a shot is applied exactly once and to provide a fallback if the animation-based impact callback is delayed or not invoked. 

### Description
- Wrapped the cue-ball launch logic in an idempotent payload via `createShotImpactPayload` and trigger it through `applyShotImpact` instead of invoking the launch directly. This prevents missed or duplicate launches. 
- Added a timed fallback using `createShotImpactFallback` and stored it in `pendingImpactRef.current` so the shot impulse will be applied automatically if the animation callback does not run in time. 
- Cleared the pending fallback when the immediate-impact (non-animated) path is taken to avoid stale delayed triggers. All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and import the helper functions from `webapp/src/pages/Games/cueShotImpact.js`. 

### Testing
- Ran `npm test -- --runInBand test/cueShotImpact.test.js` and it passed (3 tests). 
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and it passed (4 tests). 
- Ran `npx eslint` which reported a repository ignore warning for the file (lint did not block the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaab6037808329b0982aa54bac320a)