### PR TITLE
Add mining-section video link controls in developer panel

### DIFF
--- a/bot/models/CustomTask.js
+++ b/bot/models/CustomTask.js
@@ -14,6 +14,11 @@ const customTaskSchema = new mongoose.Schema({
     enum: ['tasks', 'mining'],
     default: 'tasks'
   },
+  miningArea: {
+    type: String,
+    enum: ['daily_streaks', 'spin_and_win', 'lucky_card', 'roulette_spin', null],
+    default: null
+  },
   videoProvider: {
     type: String,
     enum: ['youtube', 'tiktok', null],

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -130,6 +130,7 @@ router.post('/list', authenticate, async (req, res) => {
         completed: !!rec,
         cooldown: 0,
         section: t.section || 'tasks',
+        miningArea: t.miningArea || null,
         video: embed
           ? {
               provider: embed.provider,
@@ -461,8 +462,8 @@ router.post('/admin/list', async (req, res) => {
 
 router.post('/admin/create', async (req, res) => {
   if (!isAuthorized(req)) return res.status(403).json({ error: 'unauthorized' });
-  const { platform, reward, link, description, section, videoProvider, videoDurationSec } = req.body;
-  if (!platform || !reward || !link) {
+  const { platform, reward, link, description, section, miningArea, videoProvider, videoDurationSec } = req.body;
+  if (!platform || reward === undefined || reward === null || !link) {
     return res
       .status(400)
       .json({ error: 'platform, reward and link required' });
@@ -473,6 +474,7 @@ router.post('/admin/create', async (req, res) => {
     link,
     description,
     section: section || 'tasks',
+    miningArea: miningArea || null,
     videoProvider: videoProvider || null,
     videoDurationSec: Number(videoDurationSec) || 0
   });
@@ -481,7 +483,7 @@ router.post('/admin/create', async (req, res) => {
 
 router.post('/admin/update', async (req, res) => {
   if (!isAuthorized(req)) return res.status(403).json({ error: 'unauthorized' });
-  const { id, platform, reward, link, description, section, videoProvider, videoDurationSec } = req.body;
+  const { id, platform, reward, link, description, section, miningArea, videoProvider, videoDurationSec } = req.body;
   if (!id) return res.status(400).json({ error: 'id required' });
   const task = await CustomTask.findByIdAndUpdate(
     id,
@@ -491,6 +493,7 @@ router.post('/admin/update', async (req, res) => {
       link,
       description,
       section: section || 'tasks',
+      miningArea: miningArea || null,
       videoProvider: videoProvider || null,
       videoDurationSec: Number(videoDurationSec) || 0
     },

--- a/webapp/src/components/DevTasksModal.jsx
+++ b/webapp/src/components/DevTasksModal.jsx
@@ -19,12 +19,21 @@ const defaultForm = {
   videoDurationSec: '30'
 };
 
+const MINING_AREAS = [
+  { key: 'daily_streaks', label: 'Daily Streaks' },
+  { key: 'spin_and_win', label: 'Spin and Win' },
+  { key: 'lucky_card', label: 'Lucky Card' },
+  { key: 'roulette_spin', label: 'Roulette Spin' }
+];
+
 export default function DevTasksModal({ open, onClose, initialSection = 'tasks' }) {
   const [tasks, setTasks] = useState([]);
   const [editing, setEditing] = useState(null);
   const [activeSection, setActiveSection] = useState('tasks');
   const [form, setForm] = useState(defaultForm);
   const [saving, setSaving] = useState(false);
+  const [miningLinks, setMiningLinks] = useState({});
+  const [miningSaving, setMiningSaving] = useState('');
 
   const load = async () => {
     const data = await adminListTasks();
@@ -38,6 +47,15 @@ export default function DevTasksModal({ open, onClose, initialSection = 'tasks' 
       load();
     }
   }, [open, initialSection]);
+
+  useEffect(() => {
+    const next = {};
+    for (const area of MINING_AREAS) {
+      const task = tasks.find((t) => (t.section || 'tasks') === 'mining' && t.miningArea === area.key);
+      next[area.key] = task?.link || '';
+    }
+    setMiningLinks(next);
+  }, [tasks]);
 
   const visibleTasks = useMemo(
     () => tasks.filter((t) => (t.section || 'tasks') === activeSection),
@@ -89,6 +107,39 @@ export default function DevTasksModal({ open, onClose, initialSection = 'tasks' 
     }
   };
 
+  const handleSaveMiningLink = async (areaKey) => {
+    const link = (miningLinks[areaKey] || '').trim();
+    if (!link) return;
+
+    const existing = tasks.find(
+      (t) => (t.section || 'tasks') === 'mining' && t.miningArea === areaKey
+    );
+
+    const payload = {
+      platform: parseVideoProvider(link) === 'youtube' ? 'youtube' : 'tiktok',
+      reward: 0,
+      link,
+      description: `${MINING_AREAS.find((a) => a.key === areaKey)?.label || 'Mining'} video`,
+      section: 'mining',
+      miningArea: areaKey,
+      videoProvider: parseVideoProvider(link) === 'none' ? null : parseVideoProvider(link),
+      videoDurationSec: 30
+    };
+
+    setMiningSaving(areaKey);
+    try {
+      if (existing?._id) {
+        await adminUpdateTask({ id: existing._id, ...payload });
+      } else {
+        await adminCreateTask(payload);
+      }
+      await load();
+      window.dispatchEvent(new Event('tasksUpdated'));
+    } finally {
+      setMiningSaving('');
+    }
+  };
+
   const handleEdit = (task) => {
     const section = task.section || 'tasks';
     setActiveSection(section);
@@ -111,7 +162,7 @@ export default function DevTasksModal({ open, onClose, initialSection = 'tasks' 
     window.dispatchEvent(new Event('tasksUpdated'));
   };
 
-  const isMiningSection = form.section === 'mining';
+  const isMiningSection = activeSection === 'mining';
 
   if (!open) return null;
 
@@ -150,140 +201,144 @@ export default function DevTasksModal({ open, onClose, initialSection = 'tasks' 
           ))}
         </div>
 
-        <div className="rounded-xl border border-border bg-background/60 p-3 space-y-2">
-          <p className="text-sm font-semibold text-white">
-            {editing ? 'Edit task' : 'Create new task'}
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <select
-              value={form.platform}
-              onChange={(e) => updateForm('platform', e.target.value)}
-              className="border p-2 rounded w-full text-black"
-            >
-              <option value="tiktok">TikTok</option>
-              <option value="x">X</option>
-              <option value="telegram">Telegram</option>
-              <option value="discord">Discord</option>
-              <option value="youtube">YouTube</option>
-              <option value="facebook">Facebook</option>
-              <option value="instagram">Instagram</option>
-            </select>
-            <input
-              type="number"
-              placeholder="Reward (TPC)"
-              value={form.reward}
-              onChange={(e) => updateForm('reward', e.target.value)}
-              className="border p-2 rounded w-full text-black"
-            />
+        {isMiningSection ? (
+          <div className="rounded-xl border border-border bg-background/60 p-3 space-y-2">
+            <p className="text-sm font-semibold text-white flex items-center gap-2">
+              <FiVideo className="w-4 h-4" /> Mining video links by section
+            </p>
+            <p className="text-xs text-subtext">
+              Rewards are already handled in the mining modules. Here you only attach one video link per section.
+            </p>
+
+            <div className="space-y-2">
+              {MINING_AREAS.map((area) => (
+                <div key={area.key} className="rounded-lg border border-border bg-surface/40 p-2.5 space-y-2">
+                  <label className="text-sm font-semibold text-white">{area.label}</label>
+                  <div className="flex flex-col sm:flex-row gap-2">
+                    <input
+                      type="text"
+                      placeholder="YouTube or TikTok link"
+                      value={miningLinks[area.key] || ''}
+                      onChange={(e) =>
+                        setMiningLinks((prev) => ({ ...prev, [area.key]: e.target.value }))
+                      }
+                      className="border p-2 rounded w-full text-black"
+                    />
+                    <button
+                      onClick={() => handleSaveMiningLink(area.key)}
+                      disabled={miningSaving === area.key}
+                      className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background text-sm font-semibold disabled:opacity-60"
+                    >
+                      {miningSaving === area.key ? 'Saving...' : 'Save link'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-
-          <input
-            type="text"
-            placeholder={isMiningSection ? 'TikTok or YouTube video link' : 'Task link'}
-            value={form.link}
-            onChange={(e) => updateForm('link', e.target.value)}
-            className="border p-2 rounded w-full text-black"
-          />
-
-          <input
-            type="text"
-            placeholder="Description"
-            value={form.description}
-            onChange={(e) => updateForm('description', e.target.value)}
-            className="border p-2 rounded w-full text-black"
-          />
-
-          {isMiningSection && (
-            <div className="rounded-lg border border-primary/40 bg-primary/10 p-2 space-y-2">
-              <p className="text-xs sm:text-sm text-primary font-semibold flex items-center gap-1">
-                <FiVideo className="w-4 h-4" /> Mining video config
+        ) : (
+          <>
+            <div className="rounded-xl border border-border bg-background/60 p-3 space-y-2">
+              <p className="text-sm font-semibold text-white">
+                {editing ? 'Edit task' : 'Create new task'}
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <select
-                  value={form.videoProvider}
-                  onChange={(e) => updateForm('videoProvider', e.target.value)}
+                  value={form.platform}
+                  onChange={(e) => updateForm('platform', e.target.value)}
                   className="border p-2 rounded w-full text-black"
                 >
-                  <option value="none">No embedded video</option>
-                  <option value="youtube">YouTube embed</option>
-                  <option value="tiktok">TikTok embed</option>
+                  <option value="tiktok">TikTok</option>
+                  <option value="x">X</option>
+                  <option value="telegram">Telegram</option>
+                  <option value="discord">Discord</option>
+                  <option value="youtube">YouTube</option>
+                  <option value="facebook">Facebook</option>
+                  <option value="instagram">Instagram</option>
                 </select>
                 <input
                   type="number"
-                  min="5"
-                  value={form.videoDurationSec}
-                  onChange={(e) => updateForm('videoDurationSec', e.target.value)}
+                  placeholder="Reward (TPC)"
+                  value={form.reward}
+                  onChange={(e) => updateForm('reward', e.target.value)}
                   className="border p-2 rounded w-full text-black"
-                  placeholder="Auto-complete after seconds"
                 />
               </div>
-              <p className="text-[11px] text-subtext">
-                For mining video tasks, reward is auto-claimed after the video timer ends.
-              </p>
+
+              <input
+                type="text"
+                placeholder="Task link"
+                value={form.link}
+                onChange={(e) => updateForm('link', e.target.value)}
+                className="border p-2 rounded w-full text-black"
+              />
+
+              <input
+                type="text"
+                placeholder="Description"
+                value={form.description}
+                onChange={(e) => updateForm('description', e.target.value)}
+                className="border p-2 rounded w-full text-black"
+              />
+
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full text-sm font-semibold disabled:opacity-60"
+                >
+                  {saving ? 'Saving...' : editing ? 'Save Task' : 'Add Task'}
+                </button>
+                <button
+                  onClick={() => resetForm(activeSection)}
+                  className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm"
+                >
+                  Reset
+                </button>
+                <button
+                  onClick={load}
+                  className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm inline-flex items-center justify-center gap-1"
+                >
+                  <FiRefreshCw className="w-4 h-4" /> Refresh
+                </button>
+              </div>
             </div>
-          )}
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="px-3 py-2 bg-primary hover:bg-primary-hover rounded text-background w-full text-sm font-semibold disabled:opacity-60"
-            >
-              {saving ? 'Saving...' : editing ? 'Save Task' : 'Add Task'}
-            </button>
-            <button
-              onClick={() => resetForm(activeSection)}
-              className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm"
-            >
-              Reset
-            </button>
-            <button
-              onClick={load}
-              className="px-3 py-2 bg-background border border-border rounded text-white w-full text-sm inline-flex items-center justify-center gap-1"
-            >
-              <FiRefreshCw className="w-4 h-4" /> Refresh
-            </button>
-          </div>
-        </div>
-
-        <ul className="space-y-2 pb-6">
-          {visibleTasks.map((t) => (
-            <li key={t._id} className="rounded-lg border border-border bg-background/60 p-2.5 space-y-1.5">
-              <div className="flex items-start justify-between gap-2">
-                <p className="text-sm font-semibold text-white break-words">{t.description}</p>
-                <span className="text-[11px] uppercase rounded bg-primary/15 text-primary px-2 py-0.5 shrink-0">
-                  {t.platform}
-                </span>
-              </div>
-              <div className="text-xs text-subtext break-all">{t.link}</div>
-              <div className="flex items-center gap-2 text-xs text-subtext">
-                <span>{t.reward} TPC</span>
-                {(t.videoProvider || t.video?.provider) && (
-                  <span className="rounded bg-primary/15 text-primary px-1.5 py-0.5">
-                    {t.videoProvider || t.video.provider} video
-                  </span>
-                )}
-              </div>
-              <div className="flex gap-2 justify-end">
-                <button
-                  className="px-2 py-1 rounded bg-primary/20 text-primary inline-flex items-center gap-1"
-                  onClick={() => handleEdit(t)}
-                >
-                  <FiEdit className="w-4 h-4" /> Edit
-                </button>
-                <button
-                  className="px-2 py-1 rounded bg-red-500/20 text-red-300 inline-flex items-center gap-1"
-                  onClick={() => handleDelete(t._id)}
-                >
-                  <FiTrash2 className="w-4 h-4" /> Delete
-                </button>
-              </div>
-            </li>
-          ))}
-          {visibleTasks.length === 0 && (
-            <p className="text-center text-subtext text-sm py-2">No tasks in this section.</p>
-          )}
-        </ul>
+            <ul className="space-y-2 pb-6">
+              {visibleTasks.map((t) => (
+                <li key={t._id} className="rounded-lg border border-border bg-background/60 p-2.5 space-y-1.5">
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="text-sm font-semibold text-white break-words">{t.description}</p>
+                    <span className="text-[11px] uppercase rounded bg-primary/15 text-primary px-2 py-0.5 shrink-0">
+                      {t.platform}
+                    </span>
+                  </div>
+                  <div className="text-xs text-subtext break-all">{t.link}</div>
+                  <div className="flex items-center gap-2 text-xs text-subtext">
+                    <span>{t.reward} TPC</span>
+                  </div>
+                  <div className="flex gap-2 justify-end">
+                    <button
+                      className="px-2 py-1 rounded bg-primary/20 text-primary inline-flex items-center gap-1"
+                      onClick={() => handleEdit(t)}
+                    >
+                      <FiEdit className="w-4 h-4" /> Edit
+                    </button>
+                    <button
+                      className="px-2 py-1 rounded bg-red-500/20 text-red-300 inline-flex items-center gap-1"
+                      onClick={() => handleDelete(t._id)}
+                    >
+                      <FiTrash2 className="w-4 h-4" /> Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+              {visibleTasks.length === 0 && (
+                <p className="text-center text-subtext text-sm py-2">No tasks in this section.</p>
+              )}
+            </ul>
+          </>
+        )}
       </div>
     </div>,
     document.body

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
@@ -19,7 +19,8 @@ import {
   listFriendRequests,
   acceptFriendRequest,
   getOnlineCount,
-  getOnlineUsers
+  getOnlineUsers,
+  listTasks
 } from '../utils/api.js';
 import UserSearchBar from '../components/UserSearchBar.jsx';
 import { BOT_USERNAME } from '../utils/constants.js';
@@ -27,6 +28,41 @@ import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
 import InvitePopup from '../components/InvitePopup.jsx';
 import PlayerInvitePopup from '../components/PlayerInvitePopup.jsx';
+import { normalizeTasksResponse } from '../utils/taskUtils.js';
+
+
+const MINING_VIDEO_AREAS = [
+  { key: 'daily_streaks', label: 'Daily Streaks' },
+  { key: 'spin_and_win', label: 'Spin and Win' },
+  { key: 'lucky_card', label: 'Lucky Card' },
+  { key: 'roulette_spin', label: 'Roulette Spin' }
+];
+
+function MiningVideoModal({ item, onClose }) {
+  if (!item) return null;
+  return (
+    <div className="fixed inset-0 bg-black/80 z-50 p-3 flex items-center justify-center">
+      <div className="w-full max-w-md bg-surface border border-border rounded-xl p-3 space-y-3">
+        <p className="font-semibold text-white text-sm">{item.label} Video</p>
+        <div className="rounded-lg overflow-hidden border border-border bg-black aspect-video">
+          <iframe
+            src={item.embedUrl}
+            title={item.label}
+            className="w-full h-full"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+        <button
+          onClick={onClose}
+          className="w-full px-3 py-2 rounded bg-background border border-border text-white text-sm"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
 
 function normalizeRequests(payload) {
   if (Array.isArray(payload)) return payload;
@@ -61,6 +97,8 @@ export default function Mining() {
   const [mode, setMode] = useState('1v1');
   const [selected, setSelected] = useState([]);
   const [groupPopup, setGroupPopup] = useState(false);
+  const [miningVideoItems, setMiningVideoItems] = useState([]);
+  const [activeMiningVideo, setActiveMiningVideo] = useState(null);
 
   useEffect(() => {
     getReferralInfo(telegramId).then(setReferral);
@@ -69,6 +107,14 @@ export default function Mining() {
       setRank(data.rank);
     });
     listFriendRequests(telegramId).then((requests) => setFriendRequests(normalizeRequests(requests)));
+    listTasks(telegramId).then((data) => {
+      const allTasks = normalizeTasksResponse(data);
+      const videos = MINING_VIDEO_AREAS.map((area) => {
+        const task = allTasks.find((t) => t.section === 'mining' && t.miningArea === area.key && t.video?.embedUrl);
+        return task ? { key: area.key, label: area.label, embedUrl: task.video.embedUrl } : null;
+      }).filter(Boolean);
+      setMiningVideoItems(videos);
+    }).catch(() => {});
 
     const saved = loadAvatar();
     if (saved) {
@@ -137,6 +183,12 @@ export default function Mining() {
   const totalBoost =
     (referral.bonusMiningRate || 0) + (referral.storeMiningRate || 0);
 
+  const miningVideoMap = useMemo(() => {
+    const map = {};
+    for (const item of miningVideoItems) map[item.key] = item;
+    return map;
+  }, [miningVideoItems]);
+
   return (
     <>
       <div className="mining-page-content">
@@ -200,9 +252,41 @@ export default function Mining() {
             These actions improve your consistency and help you compound mining rewards every day.
           </p>
           <DailyCheckIn />
+          {miningVideoMap.daily_streaks && (
+            <button
+              onClick={() => setActiveMiningVideo(miningVideoMap.daily_streaks)}
+              className="w-full -mt-2 mb-1 px-3 py-2 rounded border border-border bg-background/70 text-xs text-subtext hover:text-white"
+            >
+              Watch Daily Streaks video
+            </button>
+          )}
           <SpinGame />
+          {miningVideoMap.spin_and_win && (
+            <button
+              onClick={() => setActiveMiningVideo(miningVideoMap.spin_and_win)}
+              className="w-full -mt-2 mb-1 px-3 py-2 rounded border border-border bg-background/70 text-xs text-subtext hover:text-white"
+            >
+              Watch Spin and Win video
+            </button>
+          )}
           <LuckyNumber />
+          {miningVideoMap.lucky_card && (
+            <button
+              onClick={() => setActiveMiningVideo(miningVideoMap.lucky_card)}
+              className="w-full -mt-2 mb-1 px-3 py-2 rounded border border-border bg-background/70 text-xs text-subtext hover:text-white"
+            >
+              Watch Lucky Card video
+            </button>
+          )}
           <RouletteMini />
+          {miningVideoMap.roulette_spin && (
+            <button
+              onClick={() => setActiveMiningVideo(miningVideoMap.roulette_spin)}
+              className="w-full -mt-2 mb-1 px-3 py-2 rounded border border-border bg-background/70 text-xs text-subtext hover:text-white"
+            >
+              Watch Roulette Spin video
+            </button>
+          )}
         </section>
 
         <div className="relative bg-surface border border-border rounded-xl p-4 space-y-4 text-text overflow-hidden wide-card">
@@ -398,6 +482,7 @@ export default function Mining() {
           setSelected([]);
         }}
       />
+      <MiningVideoModal item={activeMiningVideo} onClose={() => setActiveMiningVideo(null)} />
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a simple developer UI to attach a single video (YouTube/TikTok iframe) per mining mini-game section without changing existing reward logic. 
- Keep rewards and claim flows in the game modules while letting devs manage only the video links from the controller panel.

### Description
- Add a `miningArea` field to the custom task schema so configs can be scoped to a mining section (`daily_streaks`, `spin_and_win`, `lucky_card`, `roulette_spin`) in `bot/models/CustomTask.js`.
- Return `miningArea` and video embed data from the tasks list and accept `miningArea` in admin create/update endpoints, and allow `reward: 0` for config-only entries in `bot/routes/tasks.js`.
- Replace the mining tab in the developer modal with a per-section link manager in `webapp/src/components/DevTasksModal.jsx` that shows four fixed areas and creates/updates a single `CustomTask` record per area when saving a link.
- Load those per-section configs on the Mining page in `webapp/src/pages/Mining.jsx`, show "Watch ... video" buttons next to the corresponding modules, and render the video in an iframe modal (`MiningVideoModal`).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (no runtime errors during build).
- Opened the local dev site and captured the Mining page to verify buttons/modal appeared using Playwright (screenshot artifact: `browser:/tmp/codex_browser_invocations/.../artifacts/mining-video-links.png`).
- No new unit tests were added; changes are limited to configuration storage, admin endpoints, and UI for linking videos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab170fd9083299fe278b45bd9103b)