### PR TITLE
Add 15s rewarded TikTok iframe to AdModal for Mining tasks

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-// URL for the rewarded video ad
-const AD_VIDEO_URL =
-  'https://samplelib.com/lib/preview/mp4/sample-5s.mp4';
+const AD_IFRAME_URL = 'https://vt.tiktok.com/ZSuREWyqx/';
+const REWARD_SECONDS = 15;
 
 interface AdModalProps {
   open: boolean;
@@ -11,45 +10,66 @@ interface AdModalProps {
 }
 
 export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const [secondsLeft, setSecondsLeft] = useState(REWARD_SECONDS);
+  const [rewardIssued, setRewardIssued] = useState(false);
+  const [sessionId, setSessionId] = useState(0);
 
   useEffect(() => {
-    if (!open || !videoRef.current) return;
+    if (!open) return;
+    setSecondsLeft(REWARD_SECONDS);
+    setRewardIssued(false);
+    setSessionId((prev) => prev + 1);
+  }, [open]);
 
-    const video = videoRef.current;
+  useEffect(() => {
+    if (!open || rewardIssued) return;
 
-    const handleEnded = () => {
-      onComplete();
-    };
+    const interval = window.setInterval(() => {
+      setSecondsLeft((current) => {
+        if (current <= 1) {
+          window.clearInterval(interval);
+          if (!rewardIssued) {
+            setRewardIssued(true);
+            onComplete();
+          }
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1000);
 
-    video.addEventListener('ended', handleEnded);
-    video.play().catch(() => {});
+    return () => window.clearInterval(interval);
+  }, [open, onComplete, rewardIssued]);
 
-    return () => {
-      video.removeEventListener('ended', handleEnded);
-      video.pause();
-    };
-  }, [open, onComplete]);
+  const counterLabel = useMemo(() => {
+    if (rewardIssued) return 'Reward unlocked. You can close now or continue watching.';
+    return `Reward unlocks in ${secondsLeft}s`;
+  }, [rewardIssued, secondsLeft]);
 
   if (!open) return null;
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="relative w-[640px] h-[360px]">
+      <div className="relative w-[min(92vw,420px)] h-[min(72vh,740px)] rounded-2xl overflow-hidden border border-white/20 bg-black">
         {onClose && (
           <button
             onClick={onClose}
-            className="absolute top-2 right-2 bg-black bg-opacity-70 text-white rounded-full w-5 h-5 flex items-center justify-center"
+            className="absolute top-2 right-2 z-10 bg-black bg-opacity-70 text-white rounded-full w-7 h-7 flex items-center justify-center"
+            aria-label="Close ad"
           >
             &times;
           </button>
         )}
-        <video
-          ref={videoRef}
-          src={AD_VIDEO_URL}
-          className="w-[640px] h-[360px]"
-          controls
+        <iframe
+          key={sessionId}
+          src={AD_IFRAME_URL}
+          title="Rewarded ad"
+          className="w-full h-full"
+          allow="autoplay; encrypted-media; picture-in-picture; web-share"
         />
+        <div className="absolute bottom-0 inset-x-0 bg-black/75 text-white text-xs px-3 py-2 text-center">
+          {counterLabel}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Replace the previous sample video in the shared rewarded-ad modal with the requested TikTok URL and ensure rewards are granted after 15 seconds so daily mining actions can award users immediately while still allowing them to continue watching or close early.

### Description
- Updated `webapp/src/components/AdModal.tsx` to load the TikTok URL (`https://vt.tiktok.com/ZSuREWyqx/`) inside an `iframe` and introduced a `REWARD_SECONDS = 15` countdown that triggers `onComplete()` when it reaches zero.  
- The modal now shows a visible countdown message (`Reward unlocks in Xs`) and an unlocked message (`Reward unlocked. You can close now or continue watching.`) after the gate is reached, and the close button remains available.  
- This shared modal change automatically applies to the mining-related flows that already use `AdModal`, including Daily Streaks (`DailyCheckIn`), Spin & Win (`SpinGame`), Lucky Card (`LuckyNumber`), and Roulette Spin (`RouletteMini`).

### Testing
- Built the web app with `npm --prefix webapp run build` and the Vite production build completed successfully.  
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and used a Playwright script to open `http://127.0.0.1:4173/mining?tg=123456` and capture a screenshot of the opened rewarded-ad modal (`artifacts/mining-rewarded-video-modal.png`).  
- Ran `npx eslint webapp/src/components/AdModal.tsx` which reported the file is ignored by repo lint settings (warning only) but no runtime errors were observed during the build/dev validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac2df941c8329a55fa59ffd806114)