### PR TITLE
Add TikTok 15s rewarded ad iframe + unlock flow for mining mini-games

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-// URL for the rewarded video ad
-const AD_VIDEO_URL =
-  'https://samplelib.com/lib/preview/mp4/sample-5s.mp4';
+const AD_IFRAME_URL = 'https://www.tiktok.com/embed/v2/7515418978852781329';
+const AD_FALLBACK_URL = 'https://vt.tiktok.com/ZSuREWyqx/';
+const REWARD_DELAY_MS = 15_000;
 
 interface AdModalProps {
   open: boolean;
@@ -11,45 +11,77 @@ interface AdModalProps {
 }
 
 export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const rewardIssuedRef = useRef(false);
+  const [remainingMs, setRemainingMs] = useState(REWARD_DELAY_MS);
 
   useEffect(() => {
-    if (!open || !videoRef.current) return;
+    if (!open) {
+      rewardIssuedRef.current = false;
+      setRemainingMs(REWARD_DELAY_MS);
+      return;
+    }
 
-    const video = videoRef.current;
+    const startedAt = Date.now();
+    const intervalId = window.setInterval(() => {
+      const elapsed = Date.now() - startedAt;
+      const remaining = Math.max(REWARD_DELAY_MS - elapsed, 0);
+      setRemainingMs(remaining);
+      if (remaining === 0 && !rewardIssuedRef.current) {
+        rewardIssuedRef.current = true;
+        onComplete();
+      }
+    }, 250);
 
-    const handleEnded = () => {
-      onComplete();
-    };
-
-    video.addEventListener('ended', handleEnded);
-    video.play().catch(() => {});
-
-    return () => {
-      video.removeEventListener('ended', handleEnded);
-      video.pause();
-    };
+    return () => window.clearInterval(intervalId);
   }, [open, onComplete]);
+
+  const remainingSeconds = useMemo(
+    () => Math.ceil(remainingMs / 1000),
+    [remainingMs],
+  );
 
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="relative w-[640px] h-[360px]">
+    <div className="fixed inset-0 flex items-center justify-center bg-black/80 z-50 p-3">
+      <div className="relative w-full max-w-md rounded-xl border border-border bg-surface p-3 space-y-3">
         {onClose && (
           <button
             onClick={onClose}
-            className="absolute top-2 right-2 bg-black bg-opacity-70 text-white rounded-full w-5 h-5 flex items-center justify-center"
+            className="absolute top-2 right-2 bg-black/70 text-white rounded-full w-7 h-7 flex items-center justify-center"
+            aria-label="Close ad"
           >
             &times;
           </button>
         )}
-        <video
-          ref={videoRef}
-          src={AD_VIDEO_URL}
-          className="w-[640px] h-[360px]"
-          controls
-        />
+
+        <div className="pr-8">
+          <p className="text-sm font-semibold text-white">Rewarded video</p>
+          <p className="text-xs text-subtext">
+            {rewardIssuedRef.current
+              ? 'Reward unlocked. You can close now or keep watching.'
+              : `Stay for ${remainingSeconds}s to unlock your reward.`}
+          </p>
+        </div>
+
+        <div className="aspect-[9/16] w-full overflow-hidden rounded-lg border border-border bg-black">
+          <iframe
+            src={AD_IFRAME_URL}
+            title="Rewarded TikTok"
+            className="w-full h-full"
+            allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+
+        <a
+          href={AD_FALLBACK_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="block text-center text-xs text-blue-300 underline"
+        >
+          Open video directly if embed does not load
+        </a>
       </div>
     </div>
   );

--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -106,7 +106,6 @@ export default function DailyCheckIn() {
     const now = Date.now();
     localStorage.setItem('lastCheckAd', String(now));
     setAdWatched(true);
-    setShowAd(false);
     handleCheckIn();
   };
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -131,7 +131,6 @@ export default function LuckyNumber() {
 
   const handleAdComplete = () => {
     setAdWatched(true);
-    setShowAd(false);
     setTrigger((t) => t + 1);
   };
 

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -250,7 +250,6 @@ export default function RouletteMini() {
 
   const handleAdComplete = () => {
     setAdWatched(true);
-    setShowAd(false);
     startSpin();
   };
 

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -216,7 +216,6 @@ export default function SpinGame() {
     const now = Date.now();
     localStorage.setItem('lastSpinAd', String(now));
     setAdWatched(true);
-    setShowAd(false);
     triggerSpin();
   };
 


### PR DESCRIPTION
### Motivation
- Use the provided TikTok video as a rewarded ad across mining daily actions (daily streaks, Spin & Win, Lucky Card, Roulette) and issue the reward within the first 15s of the video. 
- Let users choose to close the ad after the reward unlocks or continue watching, instead of force-closing the modal.

### Description
- Replaced the previous `AdModal` video player with an iframe-based TikTok embed and fallback link and added a `REWARD_DELAY_MS = 15000` unlock timer in `webapp/src/components/AdModal.tsx`.
- The modal displays a countdown and marks the reward as unlocked after 15 seconds by calling the `onComplete` handler without forcing the modal to close.
- Updated flows to preserve completion behavior but not auto-close the ad by removing immediate `setShowAd(false)` calls in `DailyCheckIn.jsx`, `SpinGame.jsx`, `LuckyNumber.jsx`, and `RouletteMini.jsx` so users can continue watching after unlock.
- Kept existing reward paths: the components still credit balances and create transactions via the existing `updateBalance`/`addTransaction` logic when `onComplete` fires.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite emitted chunk-size warnings which are non-blocking).
- Launched the dev server with `npm --prefix webapp run dev` and captured a smoke screenshot of the `/mining` page via Playwright to validate the modal UI and placement (artifact saved during the run).
- No unit tests were changed; the change was validated via build and a manual smoke rendering check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac2df941c8329a55fa59ffd806114)