### PR TITLE
Prevent shot resolving before cue impact in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30424,12 +30424,20 @@ const committedShotPowerRef = useRef(0);
             recordReplayFrame(now);
           }
           if (shooting) {
+            const awaitingCueImpact = Boolean(
+              (ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current && !cueStrokeStateRef.current.shotApplied) ||
+              pendingImpactRef.current
+            );
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            if (!any && !awaitingCueImpact) {
               resolve();
-            } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
+            } else if (
+              !awaitingCueImpact &&
+              shotStartedAt > 0 &&
+              now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS
+            ) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
               balls.forEach((ball) => {
                 if (!ball) return;


### PR DESCRIPTION
### Motivation
- Fix a bug where the cue ball sometimes did not move because the frame loop could call `resolve()` (ending the shot) before the cue-stroke animation or deferred impact was applied. 

### Description
- Add an `awaitingCueImpact` guard that checks `(ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current && !cueStrokeStateRef.current.shotApplied) || pendingImpactRef.current` to detect pending visual/impact application. 
- Gate both the regular `resolve()` path and the stuck-shot timeout cleanup behind the new `awaitingCueImpact` check so the physics impulse is applied first. 
- Change made in `webapp/src/pages/Games/PoolRoyale.jsx` to ensure cue-ball velocity/spin impulses are applied before the loop concludes the shot. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which returned the repo ignore warning for this file (no errors). 
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app started successfully. 
- Captured a browser screenshot of the running app to validate the page renders (artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac32019a48329bbf412349ffdb221)