### PR TITLE
Add autoplay TikTok promo video to mining task cards

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -8,6 +8,7 @@ import { dailyCheckIn, getProfile } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 
 import LoginOptions from './LoginOptions.jsx';
+import TaskPromoVideo from './TaskPromoVideo.jsx';
 
 const REWARDS = Array.from({ length: 30 }, (_, i) => 100 + i * 20);
 
@@ -185,6 +186,7 @@ export default function DailyCheckIn() {
       />
 
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
+      <TaskPromoVideo />
 
       <div className="flex space-x-2 justify-center">{progress}</div>
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -7,6 +7,7 @@ import LoginOptions from './LoginOptions.jsx';
 import { getWalletBalance, updateBalance, addTransaction } from '../utils/api.js';
 import coinConfetti from '../utils/coinConfetti';
 import { getGameVolume } from '../utils/sound.js';
+import TaskPromoVideo from './TaskPromoVideo.jsx';
 
 const todayKey = () => new Date().toISOString().slice(0, 10);
 
@@ -145,6 +146,7 @@ export default function LuckyNumber() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
+      <TaskPromoVideo />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">
         {cards.map((card, i) => (
           <div

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -4,6 +4,7 @@ import { getTelegramId } from '../utils/telegram.js';
 import { getWalletBalance, updateBalance, addTransaction } from '../utils/api.js';
 import coinConfetti from '../utils/coinConfetti';
 import { getGameVolume } from '../utils/sound.js';
+import TaskPromoVideo from './TaskPromoVideo.jsx';
 
 const ROULETTE_ORDER = [
   0,
@@ -268,6 +269,7 @@ export default function RouletteMini() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
+      <TaskPromoVideo />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">
         <div className="absolute left-1/2 -translate-x-1/2 -top-2 z-20 flex flex-col items-center">
           <div className="w-0 h-0 border-l-[10px] border-r-[10px] border-t-[18px] border-l-transparent border-r-transparent border-t-yellow-400 drop-shadow" />

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -11,6 +11,7 @@ import {
 import { getTelegramId } from '../utils/telegram.js';
 import { getGameVolume } from '../utils/sound.js';
 import LoginOptions from './LoginOptions.jsx';
+import TaskPromoVideo from './TaskPromoVideo.jsx';
 
 export default function SpinGame() {
   let telegramId;
@@ -263,6 +264,7 @@ export default function SpinGame() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
+      <TaskPromoVideo />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       {!bonusMode ? (
         <div className="flex items-start justify-center">

--- a/webapp/src/components/TaskPromoVideo.jsx
+++ b/webapp/src/components/TaskPromoVideo.jsx
@@ -1,0 +1,32 @@
+const TASK_VIDEO = {
+  shortUrl: 'https://vt.tiktok.com/ZSuREWyqx/',
+  canonicalUrl: 'https://www.tiktok.com/@tonplaygram/video/7538028530903387448',
+  embedUrl:
+    'https://www.tiktok.com/embed/v2/7538028530903387448?autoplay=1&mute=1&loop=1',
+};
+
+export default function TaskPromoVideo({ className = '' }) {
+  return (
+    <div className={`w-full max-w-sm mx-auto ${className}`.trim()}>
+      <div className="rounded-xl overflow-hidden border border-border bg-black/40">
+        <iframe
+          src={TASK_VIDEO.embedUrl}
+          title="TonPlaygram TikTok task video"
+          className="w-full h-[360px]"
+          allow="autoplay; encrypted-media; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+      <a
+        href={TASK_VIDEO.canonicalUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block text-xs text-subtext hover:text-white"
+      >
+        Open on TikTok ↗
+      </a>
+    </div>
+  );
+}
+
+export { TASK_VIDEO };


### PR DESCRIPTION
### Motivation
- Surface the requested TikTok video in the mining task area so users see the promo while interacting with daily streaks and mini-games. 
- Use a single reusable component to keep the embed consistent across multiple task cards (Daily Streaks, Spin & Win, Lucky Card, Roulette Spin).

### Description
- Added a new component `webapp/src/components/TaskPromoVideo.jsx` that exposes the TikTok canonical/embed URLs and renders an `<iframe>` with `autoplay=1&mute=1&loop=1` for maximum autoplay compatibility. 
- Injected `TaskPromoVideo` into the four task UI cards by importing and rendering it in `DailyCheckIn.jsx`, `SpinGame.jsx`, `LuckyNumber.jsx`, and `RouletteMini.jsx`. 
- The embed includes `allow="autoplay; encrypted-media; picture-in-picture"` and a direct link to open the canonical TikTok post for fallback. 
- No server or API changes were made and the integration is purely client-side.

### Testing
- Verified the TikTok short URL responds with a redirect using `curl -sI https://vt.tiktok.com/ZSuREWyqx/`, which returned an HTTP redirect to the canonical TikTok video. 
- Successfully built the webapp with `npm --prefix webapp run build` and observed a successful Vite production build. 
- Ran a headless UI validation using Playwright against the running dev server and captured mobile-portrait screenshots showing the embedded video container (screenshot artifacts produced during the run); the scripted screenshots confirmed the component renders in the mining Daily Streaks area.

Note: actual autoplay behavior may still vary by browser and platform autplay policies; the embed is configured muted and looped to maximize playback compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac620cfb483299ef40e7816c39994)