### PR TITLE
Add TikTokTaskVideo component and embed promotional videos in mini-games

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -8,6 +8,7 @@ import { dailyCheckIn, getProfile } from '../utils/api.js';
 import { getTelegramId } from '../utils/telegram.js';
 
 import LoginOptions from './LoginOptions.jsx';
+import TikTokTaskVideo from './TikTokTaskVideo.jsx';
 
 const REWARDS = Array.from({ length: 30 }, (_, i) => 100 + i * 20);
 
@@ -185,6 +186,11 @@ export default function DailyCheckIn() {
       />
 
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
+      <TikTokTaskVideo
+        title="Daily Streaks Video"
+        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614140234548153607"
+        storageKey="dailyStreaksVideoPopupSeen"
+      />
 
       <div className="flex space-x-2 justify-center">{progress}</div>
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -4,6 +4,7 @@ import AdModal from './AdModal.tsx';
 import CardSpinner from './CardSpinner.jsx';
 import { getTelegramId } from '../utils/telegram.js';
 import LoginOptions from './LoginOptions.jsx';
+import TikTokTaskVideo from './TikTokTaskVideo.jsx';
 import { getWalletBalance, updateBalance, addTransaction } from '../utils/api.js';
 import coinConfetti from '../utils/coinConfetti';
 import { getGameVolume } from '../utils/sound.js';
@@ -145,6 +146,11 @@ export default function LuckyNumber() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
+      <TikTokTaskVideo
+        title="Lucky Card Video"
+        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614133483421584658"
+        storageKey="luckyCardVideoPopupSeen"
+      />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">
         {cards.map((card, i) => (
           <div

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -1,3 +1,4 @@
+import TikTokTaskVideo from './TikTokTaskVideo.jsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import AdModal from './AdModal.tsx';
 import { getTelegramId } from '../utils/telegram.js';
@@ -268,6 +269,11 @@ export default function RouletteMini() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
+      <TikTokTaskVideo
+        title="Roulette Spin Video"
+        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614119495149292818"
+        storageKey="rouletteVideoPopupSeen"
+      />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">
         <div className="absolute left-1/2 -translate-x-1/2 -top-2 z-20 flex flex-col items-center">
           <div className="w-0 h-0 border-l-[10px] border-r-[10px] border-t-[18px] border-l-transparent border-r-transparent border-t-yellow-400 drop-shadow" />

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -11,6 +11,7 @@ import {
 import { getTelegramId } from '../utils/telegram.js';
 import { getGameVolume } from '../utils/sound.js';
 import LoginOptions from './LoginOptions.jsx';
+import TikTokTaskVideo from './TikTokTaskVideo.jsx';
 
 export default function SpinGame() {
   let telegramId;
@@ -263,6 +264,11 @@ export default function SpinGame() {
         }}
       />
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
+      <TikTokTaskVideo
+        title="Spin & Win Video"
+        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614138222150847762"
+        storageKey="spinWinVideoPopupSeen"
+      />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>
       {!bonusMode ? (
         <div className="flex items-start justify-center">

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function getVideoId(urlOrId) {
+  if (!urlOrId) return '';
+  if (/^\d+$/.test(urlOrId)) return urlOrId;
+  const match = String(urlOrId).match(/\/video\/(\d+)/);
+  return match ? match[1] : '';
+}
+
+export default function TikTokTaskVideo({
+  videoUrl,
+  title = 'Watch Promo Video',
+  autoOpen = false,
+  storageKey,
+}) {
+  const [open, setOpen] = useState(false);
+  const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
+  const embedUrl = useMemo(() => {
+    if (!videoId) return '';
+    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&loop=1&music_info=0&description=0&controls=1`;
+  }, [videoId]);
+
+  useEffect(() => {
+    if (!autoOpen || !embedUrl || !storageKey) return;
+    if (localStorage.getItem(storageKey) === '1') return;
+    setOpen(true);
+    localStorage.setItem(storageKey, '1');
+  }, [autoOpen, embedUrl, storageKey]);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="w-full rounded-lg border border-brand-gold/60 bg-black/40 px-3 py-2 text-sm font-semibold text-brand-gold"
+      >
+        {title}
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
+          <div className="w-full max-w-sm rounded-xl overflow-hidden border border-white/20 bg-black">
+            <div className="flex items-center justify-between px-3 py-2 border-b border-white/15">
+              <span className="text-sm font-semibold text-white">{title}</span>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-xs text-subtext hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+            {embedUrl ? (
+              <div className="relative w-full pt-[177.78%]">
+                <iframe
+                  title={title}
+                  src={embedUrl}
+                  className="absolute inset-0 w-full h-full"
+                  allow="autoplay; encrypted-media; picture-in-picture"
+                  allowFullScreen
+                  loading="lazy"
+                  referrerPolicy="strict-origin-when-cross-origin"
+                />
+              </div>
+            ) : (
+              <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
+            )}
+            <a
+              href={videoUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="block text-center text-xs text-subtext py-2"
+            >
+              Open on TikTok
+            </a>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable UI widget to surface promotional TikTok videos inside several mini-games to increase engagement and optionally auto-open the video once per user session via localStorage.

### Description
- Add a new `TikTokTaskVideo.jsx` component that extracts a TikTok video id from a URL or id, builds a player `iframe` embed URL, supports an `autoOpen` flow and remembers shown state using a `storageKey` in `localStorage`.
- Integrate `TikTokTaskVideo` into `DailyCheckIn.jsx`, `LuckyNumber.jsx`, `RouletteMini.jsx`, and `SpinGame.jsx` and add the corresponding imports and per-screen `videoUrl` and `storageKey` props.
- The component falls back to a simple error message when the video URL is invalid and provides an "Open on TikTok" link that opens the original URL in a new tab.

### Testing
- Built the webapp with `yarn build` which completed successfully. 
- Ran the project's automated test suite with `yarn test` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac620cfb483299ef40e7816c39994)