### PR TITLE
Use vt.tiktok short links for Mining popups and support them in TikTokTaskVideo

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -188,7 +188,7 @@ export default function DailyCheckIn() {
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
       <TikTokTaskVideo
         title="Daily Streaks Video"
-        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614140234548153607"
+        videoUrl="https://vt.tiktok.com/ZSu8hSaGs/"
         storageKey="dailyStreaksVideoPopupSeen"
       />
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -148,7 +148,7 @@ export default function LuckyNumber() {
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
       <TikTokTaskVideo
         title="Lucky Card Video"
-        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614133483421584658"
+        videoUrl="https://vt.tiktok.com/ZSu8hN8Xq/"
         storageKey="luckyCardVideoPopupSeen"
       />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -271,7 +271,7 @@ export default function RouletteMini() {
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
       <TikTokTaskVideo
         title="Roulette Spin Video"
-        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614119495149292818"
+        videoUrl="https://vt.tiktok.com/ZSu8hc7YM/"
         storageKey="rouletteVideoPopupSeen"
       />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -266,7 +266,7 @@ export default function SpinGame() {
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
       <TikTokTaskVideo
         title="Spin & Win Video"
-        videoUrl="https://www.tiktok.com/@tonplaygram/video/7614138222150847762"
+        videoUrl="https://vt.tiktok.com/ZSu8hAvuM/"
         storageKey="spinWinVideoPopupSeen"
       />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -3,8 +3,17 @@ import { useEffect, useMemo, useState } from 'react';
 function getVideoId(urlOrId) {
   if (!urlOrId) return '';
   if (/^\d+$/.test(urlOrId)) return urlOrId;
-  const match = String(urlOrId).match(/\/video\/(\d+)/);
-  return match ? match[1] : '';
+  const raw = String(urlOrId);
+  const match = raw.match(/\/video\/(\d+)/);
+  if (match) return match[1];
+
+  const shortLinkVideoMap = {
+    'https://vt.tiktok.com/ZSu8hSaGs/': '7614140234548153607',
+    'https://vt.tiktok.com/ZSu8hAvuM/': '7614138222150847762',
+    'https://vt.tiktok.com/ZSu8hN8Xq/': '7614133483421584658',
+    'https://vt.tiktok.com/ZSu8hc7YM/': '7614119495149292818',
+  };
+  return shortLinkVideoMap[raw] || '';
 }
 
 export default function TikTokTaskVideo({


### PR DESCRIPTION
### Motivation
- Replace the popup videos shown on the Mining page with the exact `vt.tiktok.com` short links supplied so the requested clips are used for Daily Streaks, Spin & Win, Lucky Card and Roulette Spin.
- No external AGENTS skill was required to make these component changes, the edits were applied directly to the UI components and helper.

### Description
- Updated `webapp/src/components/DailyCheckIn.jsx`, `webapp/src/components/SpinGame.jsx`, `webapp/src/components/LuckyNumber.jsx` and `webapp/src/components/RouletteMini.jsx` to use the provided short URLs: `https://vt.tiktok.com/ZSu8hSaGs/`, `https://vt.tiktok.com/ZSu8hAvuM/`, `https://vt.tiktok.com/ZSu8hN8Xq/`, and `https://vt.tiktok.com/ZSu8hc7YM/` respectively.
- Enhanced `webapp/src/components/TikTokTaskVideo.jsx` by improving `getVideoId` to still produce an embeddable TikTok player ID from standard `/video/<id>` URLs and by adding an explicit mapping for the four `vt.tiktok.com` short links so the popup embed works as expected.
- No other gameplay logic or server API calls were changed.

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the Vite build completed successfully.
- Ran linting via `npx eslint` on the modified files which completed with warnings due to repo ignore patterns but reported no errors.
- Verified the short links resolve to the expected canonical TikTok video pages using `curl -I` and checking the `Location` response headers, confirming the mapping correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaebe50b10832983cf961e6c90114a)