### PR TITLE
Restore Pool Royale power slider release reset behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30937,23 +30937,10 @@ const committedShotPowerRef = useRef(0);
         } else {
           committedShotPowerRef.current = 0;
         }
-        const fromPower = clampPower(powerRef.current, 0);
-        const start = performance.now();
-        const durationMs = 160;
-        const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
-        const tick = () => {
-          const t = Math.min(1, Math.max(0, (performance.now() - start) / durationMs));
-          const nextPower = fromPower + (0 - fromPower) * easeOutCubic(t);
-          slider.set(nextPower * 100, { animate: false });
-          applyPower(nextPower);
-          if (t < 1) {
-            requestAnimationFrame(tick);
-          } else {
-            slider.set(slider.min, { animate: false });
-            applyPower(0);
-          }
-        };
-        requestAnimationFrame(tick);
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Restore the previous tactile/visual feel of the Pool Royale power slider by removing a recent custom eased decay and using the slider's built-in animated reset so the slider snap and immediate power-zeroing match the expected interaction while preserving the cue-stick animation pipeline.

### Description
- Replaced the 160ms custom ease-out tick loop in the slider `onCommit` handler with a next-frame call that runs `slider.set(slider.min, { animate: true })` and `applyPower(0)` in `webapp/src/pages/Games/PoolRoyale.jsx`, removing the manual animation code.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Attempted a Playwright UI screenshot to validate runtime visuals but Chromium crashed with a SIGSEGV in this environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaec9089a88329be4c361152d9366a)