### PR TITLE
Restore Pool Royale power slider release-driven shot flow

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30937,10 +30937,23 @@ const committedShotPowerRef = useRef(0);
         } else {
           committedShotPowerRef.current = 0;
         }
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
+        const fromPower = clampPower(powerRef.current, 0);
+        const start = performance.now();
+        const durationMs = 160;
+        const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+        const tick = () => {
+          const t = Math.min(1, Math.max(0, (performance.now() - start) / durationMs));
+          const nextPower = fromPower + (0 - fromPower) * easeOutCubic(t);
+          slider.set(nextPower * 100, { animate: false });
+          applyPower(nextPower);
+          if (t < 1) {
+            requestAnimationFrame(tick);
+          } else {
+            slider.set(slider.min, { animate: false });
+            applyPower(0);
+          }
+        };
+        requestAnimationFrame(tick);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation

- The power slider shot flow was expected to fire on release and keep the released power visible for a short eased reset so the cue impact timing matches the prior (reference) behavior. 
- The change restores the pull/release feel users had earlier (capture committed power on `onCommit`, fire from that value, and smoothly return the slider to zero).

### Description

- Updated the `onCommit` handler in `webapp/src/pages/Games/PoolRoyale.jsx` to capture `committedShotPowerRef.current`, call `fireRef.current()` when appropriate, and then run a 160ms cubic ease-out animation that updates the slider and `applyPower` until the slider resets to `min` instead of snapping immediately. 
- The easing loop uses `requestAnimationFrame` and an `easeOutCubic` timing function and calls `slider.set(nextPower * 100, { animate: false })` and `applyPower(nextPower)` on each frame. 
- Left the shot trigger logic (firing from the committed value) intact so the shot timing remains tied to the slider `onCommit` path.

### Testing

- Ran `npm -C webapp run build` to verify the webapp compiles and bundles, and the build completed successfully (Vite reported non-blocking chunk-size/dynamic-import warnings but the build succeeded). 
- Committed the change as `Restore Pool Royale slider release shot flow` and validated the modified file `webapp/src/pages/Games/PoolRoyale.jsx` was updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab10e924dc8329b4cc3e5d11a08398)