### PR TITLE
Fix Pool Royale power slider commit to consistently trigger shot with slider value

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30930,13 +30930,13 @@ const committedShotPowerRef = useRef(0);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-        committedShotPowerRef.current = clampPower(powerRef.current, 0);
-        if (committedShotPowerRef.current > 0.02) {
-          fireRef.current?.();
-        } else {
-          committedShotPowerRef.current = 0;
-        }
+      onCommit: (value) => {
+        const committedPower = clampPower(
+          typeof value === 'number' ? value / 100 : powerRef.current,
+          0
+        );
+        committedShotPowerRef.current = committedPower;
+        fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Restore the intended "pull slider → release to shoot with the exact committed power" interaction so the UI-driven slider value is used directly to drive the shot power.

### Description
- Changed the Pool Royale power slider `onCommit` callback to accept the slider `value` and convert the percent into normalized power via `value / 100` before clamping with `clampPower`.
- Store the computed committed power in `committedShotPowerRef.current` so downstream shot logic reads the committed value.
- Always call `fireRef.current?.()` when the slider commits (removed the local `> 0.02` gating in the slider callback) while preserving existing downstream checks and shot validation.
- File modified: `webapp/src/pages/Games/PoolRoyale.jsx` (slider `onCommit` implementation updated).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js` and the suite passed (2 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab10e924dc8329b4cc3e5d11a08398)