### PR TITLE
Restore Pool Royale cue-shot impact fallback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25036,7 +25036,10 @@ const committedShotPowerRef = useRef(0);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
+          let shotImpactApplied = false;
           const triggerShotImpact = () => {
+            if (shotImpactApplied) return false;
+            shotImpactApplied = true;
             cue.vel.copy(base);
             if (cue.spin) {
               cue.spin.set(spinSide, spinTop);
@@ -25067,6 +25070,7 @@ const committedShotPowerRef = useRef(0);
             cue.lift = 0;
             cue.liftVel = 0;
             playCueHit(clampedPower * 0.6);
+            return true;
           };
 
           if (cameraRef.current && sphRef.current) {
@@ -25176,6 +25180,24 @@ const committedShotPowerRef = useRef(0);
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
+          const fallbackImpactTime =
+            startTime +
+            Math.max(0, pullbackDuration) +
+            Math.max(0, strikeDuration) +
+            Math.max(0, followDurationResolved) +
+            Math.max(0, recoverDuration) +
+            40;
+          pendingImpactRef.current = {
+            time: fallbackImpactTime,
+            apply: () => {
+              if (triggerShotImpact()) {
+                if (cueStrokeStateRef.current) {
+                  cueStrokeStateRef.current.shotApplied = true;
+                }
+                cueStick.visible = false;
+              }
+            }
+          };
           const forwardPreviewHold =
             startTime +
             Math.max(
@@ -25316,11 +25338,13 @@ const committedShotPowerRef = useRef(0);
               shotApplied: false,
               onImpact: () => {
                 triggerShotImpact();
+                pendingImpactRef.current = null;
                 cueStick.visible = false;
               }
             };
           } else {
             triggerShotImpact();
+            pendingImpactRef.current = null;
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Fix a regression where the cue ball sometimes never received the physics impulse when the cue animation callback was missed, causing a non-moving cueball on shot.
- Make shot impulse application idempotent so fallback and normal animation paths cannot apply the same impulse twice.

### Description
- Add a `shotImpactApplied` guard and make `triggerShotImpact` return a boolean so the impulse is applied at most once (`shotImpactApplied` + `triggerShotImpact`).
- Add a fallback `pendingImpactRef.current` scheduled at a computed `fallbackImpactTime` (based on `pullbackDuration`, `strikeDuration`, `followDuration`, `recoverDuration`) that calls `triggerShotImpact` if the animation callback doesn't run.
- Clear `pendingImpactRef.current` when the normal animation `onImpact` callback runs or when the non-animated shot path runs, and set `cueStrokeStateRef.current.shotApplied` and hide the cue stick to preserve the original visual flow.
- No changes to animation easing/curves or power→impulse mapping; the change preserves existing cue-stick timing and camera behavior.

### Testing
- Ran `npm -C webapp run build` which completed successfully (Vite production build and bundle generation).
- Confirmed the modified file `webapp/src/pages/Games/PoolRoyale.jsx` was committed with the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2168acbc8329854442b708ab77d7)