### PR TITLE
Show power slider only on player turn and nudge 2D top-view framing (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5293,14 +5293,14 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.06; // lift the 2D camera a touch so the table sits slightly higher on screen
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // lift the 2D camera a touch more for a slightly higher overhead framing
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.06; // keep 2D framing a little higher for portrait readability
+const TOP_VIEW_RADIUS_SCALE = 1.08; // keep 2D framing a little higher for portrait readability
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
-  x: PLAY_W * -0.02, // keep the 2D table a touch more to the right while preserving slider clearance
-  z: PLAY_H * -0.018 // lift the 2D table slightly higher on portrait screens
+  x: PLAY_W * 0.006, // nudge the 2D table a touch left on portrait screens
+  z: PLAY_H * 0.012 // nudge the 2D table a touch lower on portrait screens
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -30876,7 +30876,7 @@ const powerRef = useRef(hud.power);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
-  const showPowerSlider = !hud.over && !replayActive;
+  const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive;
   useEffect(() => {
     if (!showPowerSlider) {
       return undefined;


### PR DESCRIPTION
### Motivation
- Ensure the power slider is visible only when the local player is about to shoot so the control doesn't distract when it is the opponent's turn or during replay/game-over. 
- Make small visual adjustments to the 2D/top-down framing so the table appears slightly higher, a touch more left, and slightly lower on portrait screens to match the portrait calibration guidance.

### Description
- Restrict the power slider visibility by changing the slider condition to `hud.turn === 0 && !hud.over && !replayActive` so the slider only mounts for the local player's turn. 
- Increase `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` from `1.06` to `1.08` to lift the 2D/top-down camera framing slightly. 
- Adjust `TOP_VIEW_SCREEN_OFFSET.x` from `PLAY_W * -0.02` to `PLAY_W * 0.006` and `TOP_VIEW_SCREEN_OFFSET.z` from `PLAY_H * -0.018` to `PLAY_H * 0.012` to nudge the table a bit left and a bit lower on portrait screens. 
- Changes made in `webapp/src/pages/Games/PoolRoyale.jsx` where the power slider is created and top-view constants are defined.

### Testing
- Ran `npm --prefix webapp run build` and the webapp build completed successfully. 
- Attempted an automated Playwright screenshot to validate the visual layout, but the headless screenshot run timed out in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb1b7a8388329a889cf8216639a42)