### PR TITLE
Adjust Texas Hold'em HUD layout and bring portrait camera closer

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -391,7 +391,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.04 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.72, landscape: 0.04 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = CARD_W * 0.2;
@@ -6115,7 +6115,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="absolute z-20 flex flex-col items-start gap-2 left-[calc(0.35rem+env(safe-area-inset-left,0px))] landscape:left-[calc(0.75rem+env(safe-area-inset-left,0px))] top-[calc(5.55rem+env(safe-area-inset-top,0px))] landscape:top-[calc(4.2rem+env(safe-area-inset-top,0px))]">
+      <div className="fixed z-20 flex flex-col-reverse items-start gap-2 left-[calc(0.45rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+1.6rem)] landscape:left-[calc(0.45rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+1.6rem)]">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -6367,7 +6367,7 @@ function TexasHoldemArena({ search }) {
           showInfo={false}
           showGift={false}
           showMute={false}
-          className="fixed left-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+1.1rem)] flex flex-col gap-2.5 z-20"
+          className="fixed left-[0.45rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
@@ -6379,7 +6379,7 @@ function TexasHoldemArena({ search }) {
           showChat={false}
           showMute={false}
           order={['gift']}
-          className="fixed right-[0.75rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] landscape:left-[0.75rem] landscape:right-auto landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+4.9rem)] flex flex-col gap-2.5 z-20"
+          className="fixed right-[0.45rem] bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] landscape:left-auto landscape:right-[0.45rem] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+5.3rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"
@@ -6390,7 +6390,7 @@ function TexasHoldemArena({ search }) {
           showChat={false}
           showGift={false}
           order={['mute']}
-          className="fixed right-[0.75rem] top-[calc(env(safe-area-inset-top,0px)+5.2rem)] landscape:left-[0.75rem] landscape:right-auto landscape:top-auto landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+8.85rem)] flex flex-col gap-2.5 z-20"
+          className="fixed right-[0.45rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1.6rem)] landscape:left-auto landscape:right-[0.45rem] landscape:top-auto landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+1.6rem)] flex flex-col gap-2.5 z-20"
           buttonClassName="flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-1 rounded-[14px] border border-white/20 bg-transparent p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
           iconClassName="text-lg leading-none"
           labelClassName="text-[0.6rem] font-extrabold uppercase tracking-[0.08em]"


### PR DESCRIPTION
### Motivation
- Improve the portrait UX of the Texas Hold'em arena by nudging the chat/gift icons slightly farther toward screen edges, aligning the menu under the chat icon and the mute under the gift icon, and moving the seated portrait camera a bit closer to the top player for better framing.

### Description
- Updated `webapp/src/pages/Games/TexasHoldemArena.jsx` to reduce `CAMERA_RETREAT_OFFSETS.portrait` from `0.8` to `0.72` so the seated camera sits slightly closer to the player; and adjusted HUD containers and classNames (replaced an absolute menu container with a `fixed` bottom-left stacked container and reduced horizontal insets from `0.75rem` to `0.45rem`) so chat/gift/menu/mute icons align as requested.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully, ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which returned a project ignore warning for that file, started the dev server (`vite`) and used a Playwright script to capture a screenshot of `/games/texasholdem` to visually validate the adjusted HUD and camera (screenshot succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb354ffb083298d8970d8a9604142)