### PR TITLE
Domino Royal: add Domino-specific octagon default and unlockable oval table themes

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -125,7 +125,11 @@ function detectHighRefreshDisplay() {
   ) {
     return false;
   }
-  const queries = ['(min-refresh-rate: 143hz)', '(min-refresh-rate: 120hz)', '(min-refresh-rate: 90hz)'];
+  const queries = [
+    '(min-refresh-rate: 143hz)',
+    '(min-refresh-rate: 120hz)',
+    '(min-refresh-rate: 90hz)'
+  ];
   for (const query of queries) {
     try {
       if (window.matchMedia(query).matches) {
@@ -1884,7 +1888,8 @@ function updateTurnCameraFocus() {
   turnSeatTarget
     .copy(focusCenter)
     .lerp(focusSeat.position, CAMERA_TURN_SEAT_WEIGHT);
-  turnSeatTarget.y = TABLE_HEIGHT + CAMERA_TARGET_LIFT + CAMERA_TARGET_EXTRA * 0.5;
+  turnSeatTarget.y =
+    TABLE_HEIGHT + CAMERA_TARGET_LIFT + CAMERA_TARGET_EXTRA * 0.5;
 
   const now = performance.now();
   if (now < turnDominoFocusUntil) {
@@ -2259,14 +2264,24 @@ const MURLAN_STOOL_THEMES = Object.freeze([
 const MURLAN_TABLE_THEMES = Object.freeze(
   [
     {
-      id: 'murlan-default',
-      label: 'Murlan Default Table',
-      source: 'polyhaven',
-      assetId: 'CoffeeTable_01',
+      id: 'domino-octagon-pro',
+      label: 'Octagon Pro',
+      source: 'procedural',
+      shapeId: 'classicOctagon',
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Standard Murlan Royale table using the default GLTF texture set.'
+        'Default Domino Battle Royal octagon table with dedicated Domino materials.'
+    },
+    {
+      id: 'domino-oval-pro',
+      label: 'Oval Pro',
+      source: 'procedural',
+      shapeId: 'grandOval',
+      price: 1040,
+      thumbnail: POLYHAVEN_THUMB('coffee_table_round_01'),
+      description:
+        "Texas Hold'em-style oval profile rebuilt for Domino Battle Royal."
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -2314,8 +2329,10 @@ const CHAIR_THEME_OPTIONS = Object.freeze(
 const CHAIR_MODEL_URLS = Object.freeze([]);
 const polyhavenModelCache = new Map();
 const polyhavenFilesManifestCache = new Map();
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
-const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const DRACO_DECODER_PATH =
+  'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH =
+  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 let sharedKtx2Loader = null;
 let hasDetectedKtx2Support = false;
 
@@ -2354,10 +2371,13 @@ async function getPolyhavenFilesManifest(assetId) {
   }
   const promise = (async () => {
     try {
-      const response = await fetch(`https://api.polyhaven.com/files/${assetId}`, {
-        mode: 'cors',
-        credentials: 'omit'
-      });
+      const response = await fetch(
+        `https://api.polyhaven.com/files/${assetId}`,
+        {
+          mode: 'cors',
+          credentials: 'omit'
+        }
+      );
       if (!response.ok) {
         throw new Error(`Poly Haven files API ${response.status}`);
       }
@@ -2414,7 +2434,10 @@ function applySRGBColorSpace(texture) {
   texture.needsUpdate = true;
 }
 
-function normalizePbrTexture(texture, { isColor = false, maxAnisotropy = 1 } = {}) {
+function normalizePbrTexture(
+  texture,
+  { isColor = false, maxAnisotropy = 1 } = {}
+) {
   if (!texture) return;
   if (isColor) {
     applySRGBColorSpace(texture);
@@ -2450,7 +2473,10 @@ function getRendererTextureSizeCap() {
   return renderer?.capabilities?.maxTextureSize ?? 8192;
 }
 
-function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) {
+function prepareLoadedModel(
+  model,
+  { preserveGltfTextureMapping = false } = {}
+) {
   if (!model) return;
   const maxAnisotropy = getRendererAnisotropyCap();
   model.traverse((obj) => {
@@ -2461,7 +2487,8 @@ function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) 
     mats.forEach((mat) => {
       if (!mat) return;
       if (preserveGltfTextureMapping) {
-        if (mat.map) mat.map.anisotropy = Math.max(mat.map.anisotropy ?? 1, maxAnisotropy);
+        if (mat.map)
+          mat.map.anisotropy = Math.max(mat.map.anisotropy ?? 1, maxAnisotropy);
         if (mat.normalMap)
           mat.normalMap.anisotropy = Math.max(
             mat.normalMap.anisotropy ?? 1,
@@ -2478,7 +2505,10 @@ function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) 
             maxAnisotropy
           );
         if (mat.aoMap)
-          mat.aoMap.anisotropy = Math.max(mat.aoMap.anisotropy ?? 1, maxAnisotropy);
+          mat.aoMap.anisotropy = Math.max(
+            mat.aoMap.anisotropy ?? 1,
+            maxAnisotropy
+          );
         mat.needsUpdate = true;
         return;
       }
@@ -2540,13 +2570,14 @@ async function loadPolyhavenModel(
     filesManifest,
     preferredResolutions
   );
-  const fallbackCandidates = buildPolyhavenModelUrls(assetId, preferredResolutions).map(
-    (url) => ({
-      url,
-      resolution: url.match(/\/(1k|2k)\//i)?.[1]?.toLowerCase?.() || '2k',
-      includeUrlMap: null
-    })
-  );
+  const fallbackCandidates = buildPolyhavenModelUrls(
+    assetId,
+    preferredResolutions
+  ).map((url) => ({
+    url,
+    resolution: url.match(/\/(1k|2k)\//i)?.[1]?.toLowerCase?.() || '2k',
+    includeUrlMap: null
+  }));
   const candidates = [...manifestCandidates, ...fallbackCandidates];
   let lastError = null;
 
@@ -2565,7 +2596,10 @@ async function loadPolyhavenModel(
         candidateUrl,
         typeof window !== 'undefined' ? window.location?.href : candidateUrl
       ).href;
-      const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+      const resourcePath = resolvedUrl.substring(
+        0,
+        resolvedUrl.lastIndexOf('/') + 1
+      );
       loader.setResourcePath(resourcePath);
       loader.setPath('');
       // eslint-disable-next-line no-await-in-loop
@@ -2581,7 +2615,9 @@ async function loadPolyhavenModel(
     }
   }
 
-  throw lastError || new Error(`Failed to load Poly Haven model for ${assetId}`);
+  throw (
+    lastError || new Error(`Failed to load Poly Haven model for ${assetId}`)
+  );
 }
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679,
@@ -2743,7 +2779,10 @@ async function ensureMurlanChairTemplate(theme = null) {
       }
     }
     if (!gltf) {
-      console.warn('Failed to load remote chair model, using procedural chair', lastError);
+      console.warn(
+        'Failed to load remote chair model, using procedural chair',
+        lastError
+      );
       return buildProceduralChairTemplate();
     }
 
@@ -3396,7 +3435,14 @@ function applyWoodTextures(
   return { map: material.map, roughnessMap: material.roughnessMap };
 }
 
-function makeTableWoodOption({ id, label, presetId, grainId, price, description }) {
+function makeTableWoodOption({
+  id,
+  label,
+  presetId,
+  grainId,
+  price,
+  description
+}) {
   const fallbackPreset = WOOD_PRESETS_BY_ID.walnut ?? WOOD_FINISH_PRESETS[0];
   const preset = (presetId && WOOD_PRESETS_BY_ID[presetId]) || fallbackPreset;
   return Object.freeze({
@@ -3489,24 +3535,132 @@ const TABLE_WOOD_OPTIONS = Object.freeze([
 ]);
 
 const POOL_ROYALE_DOMINO_CLOTH_PALETTE = Object.freeze([
-  { id: 'emerald', label: 'Emerald Cloth', feltTop: '#0f6a2f', feltBottom: '#054d24', border: '#021a0b' },
-  { id: 'crimson', label: 'Crimson Cloth', feltTop: '#960019', feltBottom: '#4a0012', border: '#210308' },
-  { id: 'arctic', label: 'Arctic Cloth', feltTop: '#2563eb', feltBottom: '#1d4ed8', border: '#071a42' },
-  { id: 'sunset', label: 'Sunset Cloth', feltTop: '#ea580c', feltBottom: '#c2410c', border: '#320e03' },
-  { id: 'violet', label: 'Violet Cloth', feltTop: '#7c3aed', feltBottom: '#5b21b6', border: '#1f0a47' },
-  { id: 'amber', label: 'Amber Cloth', feltTop: '#b7791f', feltBottom: '#92571a', border: '#2b1402' },
-  { id: 'cabanGreenMeadow', label: 'Caban Wool — Green Meadow', feltTop: '#33b46a', feltBottom: '#2ca85f', border: '#1f6a3f' },
-  { id: 'cabanGreenSpruce', label: 'Caban Wool — Green Spruce', feltTop: '#2ca85f', feltBottom: '#238f4a', border: '#1a5d35' },
-  { id: 'cabanBlueHarbor', label: 'Caban Wool — Blue Harbor', feltTop: '#0b74c6', feltBottom: '#0a6eb8', border: '#0a355a' },
-  { id: 'cabanBlueFjord', label: 'Caban Wool — Blue Fjord', feltTop: '#1589e6', feltBottom: '#0b74c6', border: '#0a355a' },
-  { id: 'polarFleeceGreenMeadow', label: 'Polar Fleece — Green Meadow', feltTop: '#33b46a', feltBottom: '#2ca85f', border: '#205f40' },
-  { id: 'polarFleeceBlueHarbor', label: 'Polar Fleece — Blue Harbor', feltTop: '#0b74c6', feltBottom: '#0a6eb8', border: '#0b365e' },
-  { id: 'polarFleecePlushGreenMeadow', label: 'Polar Fleece Plush — Green Meadow', feltTop: '#42c47a', feltBottom: '#2ca85f', border: '#1f6b40' },
-  { id: 'polarFleecePlushBlueHarbor', label: 'Polar Fleece Plush — Blue Harbor', feltTop: '#1fa3ff', feltBottom: '#0b74c6', border: '#0b3c66' },
-  { id: 'polarFleeceNatureOceanGreenFern', label: 'Polar Fleece Nature & Ocean — Green Fern', feltTop: '#33b46a', feltBottom: '#238f4a', border: '#1c5a37' },
-  { id: 'polarFleeceNatureOceanBlueCrest', label: 'Polar Fleece Nature & Ocean — Blue Crest', feltTop: '#1589e6', feltBottom: '#095fa4', border: '#0a3458' },
-  { id: 'terryClothGreenMeadow', label: 'Polyhaven Terry Cloth — Green Meadow', feltTop: '#42c47a', feltBottom: '#2ca85f', border: '#1d603b' },
-  { id: 'terryClothBlueHarbor', label: 'Polyhaven Terry Cloth — Blue Harbor', feltTop: '#1fa3ff', feltBottom: '#0b74c6', border: '#0b365f' }
+  {
+    id: 'emerald',
+    label: 'Emerald Cloth',
+    feltTop: '#0f6a2f',
+    feltBottom: '#054d24',
+    border: '#021a0b'
+  },
+  {
+    id: 'crimson',
+    label: 'Crimson Cloth',
+    feltTop: '#960019',
+    feltBottom: '#4a0012',
+    border: '#210308'
+  },
+  {
+    id: 'arctic',
+    label: 'Arctic Cloth',
+    feltTop: '#2563eb',
+    feltBottom: '#1d4ed8',
+    border: '#071a42'
+  },
+  {
+    id: 'sunset',
+    label: 'Sunset Cloth',
+    feltTop: '#ea580c',
+    feltBottom: '#c2410c',
+    border: '#320e03'
+  },
+  {
+    id: 'violet',
+    label: 'Violet Cloth',
+    feltTop: '#7c3aed',
+    feltBottom: '#5b21b6',
+    border: '#1f0a47'
+  },
+  {
+    id: 'amber',
+    label: 'Amber Cloth',
+    feltTop: '#b7791f',
+    feltBottom: '#92571a',
+    border: '#2b1402'
+  },
+  {
+    id: 'cabanGreenMeadow',
+    label: 'Caban Wool — Green Meadow',
+    feltTop: '#33b46a',
+    feltBottom: '#2ca85f',
+    border: '#1f6a3f'
+  },
+  {
+    id: 'cabanGreenSpruce',
+    label: 'Caban Wool — Green Spruce',
+    feltTop: '#2ca85f',
+    feltBottom: '#238f4a',
+    border: '#1a5d35'
+  },
+  {
+    id: 'cabanBlueHarbor',
+    label: 'Caban Wool — Blue Harbor',
+    feltTop: '#0b74c6',
+    feltBottom: '#0a6eb8',
+    border: '#0a355a'
+  },
+  {
+    id: 'cabanBlueFjord',
+    label: 'Caban Wool — Blue Fjord',
+    feltTop: '#1589e6',
+    feltBottom: '#0b74c6',
+    border: '#0a355a'
+  },
+  {
+    id: 'polarFleeceGreenMeadow',
+    label: 'Polar Fleece — Green Meadow',
+    feltTop: '#33b46a',
+    feltBottom: '#2ca85f',
+    border: '#205f40'
+  },
+  {
+    id: 'polarFleeceBlueHarbor',
+    label: 'Polar Fleece — Blue Harbor',
+    feltTop: '#0b74c6',
+    feltBottom: '#0a6eb8',
+    border: '#0b365e'
+  },
+  {
+    id: 'polarFleecePlushGreenMeadow',
+    label: 'Polar Fleece Plush — Green Meadow',
+    feltTop: '#42c47a',
+    feltBottom: '#2ca85f',
+    border: '#1f6b40'
+  },
+  {
+    id: 'polarFleecePlushBlueHarbor',
+    label: 'Polar Fleece Plush — Blue Harbor',
+    feltTop: '#1fa3ff',
+    feltBottom: '#0b74c6',
+    border: '#0b3c66'
+  },
+  {
+    id: 'polarFleeceNatureOceanGreenFern',
+    label: 'Polar Fleece Nature & Ocean — Green Fern',
+    feltTop: '#33b46a',
+    feltBottom: '#238f4a',
+    border: '#1c5a37'
+  },
+  {
+    id: 'polarFleeceNatureOceanBlueCrest',
+    label: 'Polar Fleece Nature & Ocean — Blue Crest',
+    feltTop: '#1589e6',
+    feltBottom: '#095fa4',
+    border: '#0a3458'
+  },
+  {
+    id: 'terryClothGreenMeadow',
+    label: 'Polyhaven Terry Cloth — Green Meadow',
+    feltTop: '#42c47a',
+    feltBottom: '#2ca85f',
+    border: '#1d603b'
+  },
+  {
+    id: 'terryClothBlueHarbor',
+    label: 'Polyhaven Terry Cloth — Blue Harbor',
+    feltTop: '#1fa3ff',
+    feltBottom: '#0b74c6',
+    border: '#0b365f'
+  }
 ]);
 
 const TABLE_CLOTH_OPTIONS = Object.freeze(
@@ -3517,7 +3671,6 @@ const TABLE_CLOTH_OPTIONS = Object.freeze(
     swatches: [option.feltTop, option.feltBottom, option.border]
   }))
 );
-
 
 const TABLE_BASE_OPTIONS = Object.freeze([
   {
@@ -3985,8 +4138,7 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   chairTheme: CHAIR_THEME_OPTIONS
 });
 
-
-const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'murlan-default';
+const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'domino-octagon-pro';
 const LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID = 'emerald';
 const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
 
@@ -3994,21 +4146,24 @@ function resolveDefaultOptionId(key, options = []) {
   if (!Array.isArray(options) || options.length === 0) return null;
   if (key === 'tableTheme') {
     return (
-      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID)?.id ||
+      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID)
+        ?.id ||
       options[0]?.id ||
       null
     );
   }
   if (key === 'tableCloth') {
     return (
-      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID)?.id ||
+      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID)
+        ?.id ||
       options[0]?.id ||
       null
     );
   }
   if (key === 'chairTheme') {
     return (
-      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_CHAIR_THEME_ID)?.id ||
+      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_CHAIR_THEME_ID)
+        ?.id ||
       options[0]?.id ||
       null
     );
@@ -4113,7 +4268,10 @@ const DEFAULT_APPEARANCE = Object.freeze(
   }, {})
 );
 const APPEARANCE_STORAGE_KEY = 'dominoRoyalArenaAppearanceV3';
-const LEGACY_APPEARANCE_KEYS = ['dominoRoyalArenaAppearanceV2', 'dominoRoyalArenaAppearance'];
+const LEGACY_APPEARANCE_KEYS = [
+  'dominoRoyalArenaAppearanceV2',
+  'dominoRoyalArenaAppearance'
+];
 const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV1';
 let appearance = { ...DEFAULT_APPEARANCE };
 let dominoInventory = getDominoInventory();
@@ -4147,7 +4305,10 @@ function normalizeAppearance(raw) {
       LUDO_MATCH_DEFAULT_TABLE_THEME_ID
     );
   }
-  if (selectedTableTheme?.source === 'procedural' && selectedTableTheme?.id === 'murlan-default') {
+  if (
+    selectedTableTheme?.source === 'procedural' &&
+    selectedTableTheme?.id !== 'domino-octagon-pro'
+  ) {
     normalized.tableTheme = findDominoOptionIndex(
       'tableTheme',
       LUDO_MATCH_DEFAULT_TABLE_THEME_ID
@@ -4178,17 +4339,13 @@ function sanitizeAppearance(rawAppearance, inventory = dominoInventory) {
   return next;
 }
 
-
 function forceMurlanDefaultTableAppearance(rawAppearance) {
   const next = { ...(rawAppearance || {}) };
   next.tableTheme = findDominoOptionIndex(
     'tableTheme',
     LUDO_MATCH_DEFAULT_TABLE_THEME_ID
   );
-  next.tableWood = findDominoOptionIndex(
-    'tableWood',
-    'peelingPaintWeathered'
-  );
+  next.tableWood = findDominoOptionIndex('tableWood', 'peelingPaintWeathered');
   next.tableCloth = findDominoOptionIndex(
     'tableCloth',
     LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID
@@ -4346,7 +4503,9 @@ try {
   const hasMigratedDefaultTable =
     window.localStorage?.getItem(DEFAULT_TABLE_MIGRATION_KEY) === '1';
   if (!hasMigratedDefaultTable) {
-    appearance = sanitizeAppearance(forceMurlanDefaultTableAppearance(appearance));
+    appearance = sanitizeAppearance(
+      forceMurlanDefaultTableAppearance(appearance)
+    );
     window.localStorage?.setItem(
       APPEARANCE_STORAGE_KEY,
       JSON.stringify(appearance)
@@ -5398,6 +5557,22 @@ function createRegularPolygonShape(sides = 8, radius = 1) {
   return shape;
 }
 
+function createOvalShape(width, height, segments = 64) {
+  const shape = new THREE.Shape();
+  for (let i = 0; i <= segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    const x = Math.cos(angle) * (width / 2);
+    const y = Math.sin(angle) * (height / 2);
+    if (i === 0) {
+      shape.moveTo(x, y);
+    } else {
+      shape.lineTo(x, y);
+    }
+  }
+  shape.closePath();
+  return shape;
+}
+
 function makeClothTexture({
   top = '#155c2a',
   bottom = '#0b3a1d',
@@ -5598,9 +5773,13 @@ function setProceduralTableVisible(flag = true) {
 }
 
 async function applyTableTheme(
-  option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
+  option = TABLE_THEME_OPTIONS[appearance.tableTheme] ??
+    DEFAULT_TABLE_THEME_OPTION
 ) {
   const theme = option || DEFAULT_TABLE_THEME_OPTION;
+  if (theme?.source === 'procedural') {
+    rebuildProceduralTableGeometry(theme);
+  }
   tableThemeG.visible = false;
   while (tableThemeG.children.length) {
     const child = tableThemeG.children.pop();
@@ -5629,7 +5808,11 @@ async function applyTableTheme(
     activeTableThemeId = theme.id;
   } catch (error) {
     console.warn('Failed to load table theme', error);
-    if (theme.id !== DEFAULT_TABLE_THEME_OPTION?.id && DEFAULT_TABLE_THEME_OPTION?.assetId) {
+    if (
+      theme.source !== 'procedural' &&
+      theme.id !== DEFAULT_TABLE_THEME_OPTION?.id &&
+      DEFAULT_TABLE_THEME_OPTION?.assetId
+    ) {
       try {
         const fallbackModel = await loadPolyhavenModel(
           DEFAULT_TABLE_THEME_OPTION.assetId,
@@ -5645,7 +5828,10 @@ async function applyTableTheme(
         setProceduralTableVisible(false);
         activeTableThemeId = DEFAULT_TABLE_THEME_OPTION.id;
       } catch (fallbackError) {
-        console.warn('Failed to load fallback Poly Haven table theme', fallbackError);
+        console.warn(
+          'Failed to load fallback Poly Haven table theme',
+          fallbackError
+        );
         setProceduralTableVisible(true);
       }
     } else {
@@ -6014,11 +6200,36 @@ const TABLE_BASE_Y = TABLE_HEIGHT - TABLE_TOP_DEPTH;
 const CLOTH_TOP = TABLE_HEIGHT;
 const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
-(function buildTable() {
+function getProceduralShapeSet(tableThemeOption) {
+  const shapeId = tableThemeOption?.shapeId || 'classicOctagon';
+  if (shapeId === 'grandOval') {
+    const topShape = createOvalShape(
+      TABLE_OUTER_RADIUS * 2.14,
+      TABLE_OUTER_RADIUS * 1.54,
+      72
+    );
+    const feltShape = createOvalShape(
+      CLOTH_RADIUS * 2.16,
+      CLOTH_RADIUS * 1.56,
+      72
+    );
+    const rimInnerShape = createOvalShape(
+      TABLE_INNER_RADIUS * 2.16,
+      TABLE_INNER_RADIUS * 1.56,
+      72
+    );
+    return { topShape, feltShape, rimInnerShape };
+  }
   const sides = 8;
   const topShape = createRegularPolygonShape(sides, TABLE_OUTER_RADIUS);
   const feltShape = createRegularPolygonShape(sides, CLOTH_RADIUS);
   const rimInnerShape = createRegularPolygonShape(sides, TABLE_INNER_RADIUS);
+  return { topShape, feltShape, rimInnerShape };
+}
+
+function rebuildProceduralTableGeometry(tableThemeOption) {
+  const { topShape, feltShape, rimInnerShape } =
+    getProceduralShapeSet(tableThemeOption);
 
   const topShapeWithHole = topShape.clone();
   topShapeWithHole.holes.push(feltShape);
@@ -6030,25 +6241,16 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
     bevelSegments: 8
   });
   topGeo.rotateX(-Math.PI / 2);
-  const topMesh = new THREE.Mesh(topGeo, tableMaterials.top);
-  topMesh.position.y = TABLE_BASE_Y;
-  topMesh.castShadow = true;
-  topMesh.receiveShadow = true;
-  tableG.add(topMesh);
-  tableParts.top = topMesh;
-  proceduralTableParts.push(topMesh);
+  if (tableParts.top?.geometry) tableParts.top.geometry.dispose();
+  tableParts.top.geometry = topGeo;
 
   const feltGeo = new THREE.ExtrudeGeometry(feltShape, {
     depth: 0.01,
     bevelEnabled: false
   });
   feltGeo.rotateX(-Math.PI / 2);
-  const feltMesh = new THREE.Mesh(feltGeo, tableMaterials.felt);
-  feltMesh.position.y = CLOTH_TOP + 0.0025;
-  feltMesh.receiveShadow = true;
-  tableG.add(feltMesh);
-  tableParts.felt = feltMesh;
-  proceduralTableParts.push(feltMesh);
+  if (tableParts.felt?.geometry) tableParts.felt.geometry.dispose();
+  tableParts.felt.geometry = feltGeo;
 
   const rimShape = topShape.clone();
   rimShape.holes.push(rimInnerShape);
@@ -6060,13 +6262,8 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
     bevelSegments: 6
   });
   rimGeo.rotateX(-Math.PI / 2);
-  const rimMesh = new THREE.Mesh(rimGeo, tableMaterials.rim);
-  rimMesh.position.y = TABLE_BASE_Y + TABLE_TOP_DEPTH * 0.55;
-  rimMesh.castShadow = true;
-  rimMesh.receiveShadow = true;
-  tableG.add(rimMesh);
-  tableParts.rim = rimMesh;
-  proceduralTableParts.push(rimMesh);
+  if (tableParts.rim?.geometry) tableParts.rim.geometry.dispose();
+  tableParts.rim.geometry = rimGeo;
 
   const accentShape = rimInnerShape.clone();
   accentShape.holes.push(feltShape);
@@ -6075,7 +6272,47 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
     bevelEnabled: false
   });
   accentGeo.rotateX(-Math.PI / 2);
-  const accentMesh = new THREE.Mesh(accentGeo, tableMaterials.accent);
+  if (tableParts.accent?.geometry) tableParts.accent.geometry.dispose();
+  tableParts.accent.geometry = accentGeo;
+}
+
+(function buildTable() {
+  const topMesh = new THREE.Mesh(
+    new THREE.BufferGeometry(),
+    tableMaterials.top
+  );
+  topMesh.position.y = TABLE_BASE_Y;
+  topMesh.castShadow = true;
+  topMesh.receiveShadow = true;
+  tableG.add(topMesh);
+  tableParts.top = topMesh;
+  proceduralTableParts.push(topMesh);
+
+  const feltMesh = new THREE.Mesh(
+    new THREE.BufferGeometry(),
+    tableMaterials.felt
+  );
+  feltMesh.position.y = CLOTH_TOP + 0.0025;
+  feltMesh.receiveShadow = true;
+  tableG.add(feltMesh);
+  tableParts.felt = feltMesh;
+  proceduralTableParts.push(feltMesh);
+
+  const rimMesh = new THREE.Mesh(
+    new THREE.BufferGeometry(),
+    tableMaterials.rim
+  );
+  rimMesh.position.y = TABLE_BASE_Y + TABLE_TOP_DEPTH * 0.55;
+  rimMesh.castShadow = true;
+  rimMesh.receiveShadow = true;
+  tableG.add(rimMesh);
+  tableParts.rim = rimMesh;
+  proceduralTableParts.push(rimMesh);
+
+  const accentMesh = new THREE.Mesh(
+    new THREE.BufferGeometry(),
+    tableMaterials.accent
+  );
   accentMesh.position.y = CLOTH_TOP - 0.003;
   tableG.add(accentMesh);
   tableParts.accent = accentMesh;
@@ -6097,6 +6334,10 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   tableG.add(column);
   tableParts.column = column;
   proceduralTableParts.push(column);
+
+  rebuildProceduralTableGeometry(
+    TABLE_THEME_OPTIONS[DEFAULT_APPEARANCE.tableTheme] ?? TABLE_THEME_OPTIONS[0]
+  );
 
   // Base and trim intentionally omitted to remove the oversized pedestal.
 })();
@@ -6203,7 +6444,6 @@ function buildDominoMaterial(options = {}, defaults = {}) {
   return material;
 }
 
-
 const getDominoSurfaceTextures = (() => {
   let cache = null;
   return () => {
@@ -6213,10 +6453,15 @@ const getDominoSurfaceTextures = (() => {
       return cache;
     }
     const sizeCap = getRendererTextureSizeCap();
-    const preferredSize = Math.max(1024, Math.min(sizeCap, MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize));
+    const preferredSize = Math.max(
+      1024,
+      Math.min(sizeCap, MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize)
+    );
     const lowMemoryDevice =
       isLowProfileDevice ||
-      (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
+      (typeof navigator !== 'undefined' &&
+        typeof navigator.deviceMemory === 'number' &&
+        navigator.deviceMemory <= 4);
     let size = lowMemoryDevice ? Math.min(preferredSize, 1024) : preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
@@ -6850,7 +7095,8 @@ function refreshConfigUI() {
     wrapper.appendChild(label);
     const optionsGrid = document.createElement('div');
     optionsGrid.className = 'config-options';
-    optionsGrid.style.gridTemplateColumns = 'repeat(auto-fill, minmax(110px, 1fr))';
+    optionsGrid.style.gridTemplateColumns =
+      'repeat(auto-fill, minmax(110px, 1fr))';
     const availableOptions = getUnlockedOptions(section.key, dominoInventory);
     availableOptions.forEach((option) => {
       const idx = findDominoOptionIndex(section.key, option.id);
@@ -6986,7 +7232,10 @@ function refreshConfigUI() {
     }
     button.addEventListener('click', () => {
       if (frameRateId === option.id) return;
-      applyFrameRateSelection(option.id, { refreshUi: false, source: 'manual' });
+      applyFrameRateSelection(option.id, {
+        refreshUi: false,
+        source: 'manual'
+      });
       refreshConfigUI();
     });
     graphicsGrid.appendChild(button);
@@ -8789,13 +9038,19 @@ function scheduleCpuPlay(delay = CPU_PLAY_DELAY) {
   }, safeDelay);
 }
 
-function scheduleTurnAdvanceAfterPlacement(segment, delayMs = TURN_ADVANCE_AFTER_PLACEMENT_MS) {
+function scheduleTurnAdvanceAfterPlacement(
+  segment,
+  delayMs = TURN_ADVANCE_AFTER_PLACEMENT_MS
+) {
   queueDominoCameraFocus(segment);
   if (pendingTurnAdvanceTimeout) {
     clearTimeout(pendingTurnAdvanceTimeout);
     pendingTurnAdvanceTimeout = null;
   }
-  const safeDelay = Math.max(0, Number.isFinite(delayMs) ? delayMs : TURN_ADVANCE_AFTER_PLACEMENT_MS);
+  const safeDelay = Math.max(
+    0,
+    Number.isFinite(delayMs) ? delayMs : TURN_ADVANCE_AFTER_PLACEMENT_MS
+  );
   pendingTurnAdvanceTimeout = setTimeout(() => {
     pendingTurnAdvanceTimeout = null;
     if (!gameFinished) {
@@ -9564,10 +9819,16 @@ let runtimeListenersDetached = false;
 
 const runtimeMessageHandler = (event) => {
   const message = event?.data;
-  if (typeof message === 'string' && /domino-royal:(close|exit|disconnect)/i.test(message)) {
+  if (
+    typeof message === 'string' &&
+    /domino-royal:(close|exit|disconnect)/i.test(message)
+  ) {
     shutdownDominoRoyal('message-close');
   }
-  if (message?.type && /domino-royal:(close|exit|disconnect)/i.test(String(message.type))) {
+  if (
+    message?.type &&
+    /domino-royal:(close|exit|disconnect)/i.test(String(message.type))
+  ) {
     shutdownDominoRoyal('message-close-type');
   }
 };

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,35 +1,81 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
-  tableWood: MURLAN_TABLE_FINISHES.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
+  tableWood: MURLAN_TABLE_FINISHES.map(
+    ({ id, label, price = 0, description, thumbnail, woodOption }) => ({
+      id,
+      label,
+      price,
+      description,
+      thumbnail,
+      woodOption
+    })
+  ),
+  tableCloth: POOL_ROYALE_CLOTH_VARIANTS.map(
+    ({ id, name, price = 0, description, swatches }) => ({
+      id,
+      label: name,
+      price,
+      description,
+      swatches
+    })
+  ),
+  tableTheme: [
+    {
+      id: 'domino-octagon-pro',
+      label: 'Octagon Pro',
+      price: 0,
+      source: 'procedural',
+      shapeId: 'classicOctagon',
+      thumbnail: swatchThumbnail(['#0b1220', '#14532d', '#38bdf8']),
+      description:
+        'Default Domino Battle Royal octagon table using dedicated Domino materials.'
+    },
+    {
+      id: 'domino-oval-pro',
+      label: 'Oval Pro',
+      price: 1040,
+      source: 'procedural',
+      shapeId: 'grandOval',
+      thumbnail: swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316']),
+      description:
+        'Texas Hold’em-style oval profile rebuilt for Domino Battle Royal.'
+    },
+    ...MURLAN_TABLE_THEMES.filter((theme) => theme.id !== 'murlan-default')
+  ].map(
+    ({
+      id,
+      label,
+      price = 0,
+      description,
+      source,
+      assetId,
+      preserveMaterials,
+      shapeId,
+      thumbnail
+    }) => ({
+      id,
+      label,
+      price,
+      source,
+      assetId,
+      shapeId,
+      thumbnail,
+      preserveMaterials,
+      description: description || `${label} table from Murlan Royale`
+    })
+  ),
+  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map(({ id, name }) => ({
     id,
-    label,
-    price,
-    description,
-    thumbnail,
-    woodOption
+    label: `${name} HDRI`
   })),
-  tableCloth: POOL_ROYALE_CLOTH_VARIANTS.map(({ id, name, price = 0, description, swatches }) => ({
-    id,
-    label: name,
-    price,
-    description,
-    swatches
-  })),
-  tableTheme: MURLAN_TABLE_THEMES.map(({ id, label, price = 0, description, source, assetId, preserveMaterials }) => ({
-    id,
-    label,
-    price,
-    source,
-    assetId,
-    preserveMaterials,
-    description: description || `${label} table from Murlan Royale`
-  })),
-  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map(({ id, name }) => ({ id, label: `${name} HDRI` })),
   dominoStyle: [
     { id: 'imperialIvory', label: 'Imperial Ivory' },
     { id: 'obsidianPlatinum', label: 'Obsidian Platinum' },
@@ -44,14 +90,15 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'iceTracer', label: 'Ice Tracer' },
     { id: 'violetPulse', label: 'Violet Pulse' }
   ],
-  chairTheme: MURLAN_STOOL_THEMES.map(({ id, label, price = 0, description }) => ({
-    id,
-    label,
-    price,
-    description: description || `${label} seating set from Murlan Royale`
-  }))
+  chairTheme: MURLAN_STOOL_THEMES.map(
+    ({ id, label, price = 0, description }) => ({
+      id,
+      label,
+      price,
+      description: description || `${label} seating set from Murlan Royale`
+    })
+  )
 });
-
 
 const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
   crimson: swatchThumbnail(['#960019', '#4a0012', '#fecaca']),
@@ -79,7 +126,7 @@ const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
 });
 
 const DOMINO_DEFAULT_IDS = Object.freeze({
-  tableTheme: 'murlan-default',
+  tableTheme: 'domino-octagon-pro',
   tableWood: 'peelingPaintWeathered',
   tableCloth: 'emerald',
   chairTheme: 'dining_chair_02'
@@ -125,7 +172,9 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 980 + idx * 40,
-    description: option.description || 'Table finish from the Ludo/Murlan Royale collection.',
+    description:
+      option.description ||
+      'Table finish from the Ludo/Murlan Royale collection.',
     thumbnail: option.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableCloth.slice(1).map((option, idx) => ({
@@ -134,8 +183,12 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 340 + idx * 30,
-    description: option.description || 'Unlock a new felt tone for the Domino Royal table surface.',
-    thumbnail: option.swatches?.length ? swatchThumbnail(option.swatches) : DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
+    description:
+      option.description ||
+      'Unlock a new felt tone for the Domino Royal table surface.',
+    thumbnail: option.swatches?.length
+      ? swatchThumbnail(option.swatches)
+      : DOMINO_TABLE_CLOTH_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.tableTheme.slice(1).map((option, idx) => ({
     id: `domino-table-theme-${option.id}`,
@@ -143,8 +196,11 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 900 + idx * 45,
-    description: option.description || 'Apply the Murlan Royale table collection to Domino.',
-    thumbnail: MURLAN_TABLE_THEMES.find((theme) => theme.id === option.id)?.thumbnail
+    description:
+      option.description ||
+      'Apply the Murlan Royale table collection to Domino.',
+    thumbnail: MURLAN_TABLE_THEMES.find((theme) => theme.id === option.id)
+      ?.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.environmentHdri.slice(1).map((option, idx) => ({
     id: `domino-hdri-${option.id}`,
@@ -153,7 +209,9 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     name: option.label,
     price: POOL_ROYALE_HDRI_VARIANTS[idx + 1]?.price || 1200 + idx * 80,
     description: 'HDRI environment from the Pool/Murlan Royale library.',
-    thumbnail: POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === option.id)?.thumbnail
+    thumbnail: POOL_ROYALE_HDRI_VARIANTS.find(
+      (variant) => variant.id === option.id
+    )?.thumbnail
   })),
   ...DOMINO_ROYAL_OPTION_SETS.dominoStyle.slice(1).map((option, idx) => ({
     id: `domino-style-${option.id}`,
@@ -179,14 +237,17 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: option.price || 300 + idx * 25,
-    description: option.description || 'Murlan Royale seating set for Domino Royal.',
-    thumbnail: MURLAN_STOOL_THEMES.find((theme) => theme.id === option.id)?.thumbnail
+    description:
+      option.description || 'Murlan Royale seating set for Domino Royal.',
+    thumbnail: MURLAN_STOOL_THEMES.find((theme) => theme.id === option.id)
+      ?.thumbnail
   }))
 ];
 
 const getLabelForOption = (type, optionId) =>
   DOMINO_ROYAL_OPTION_LABELS[type]?.[optionId] ||
-  DOMINO_ROYAL_OPTION_SETS[type]?.find((option) => option.id === optionId)?.label ||
+  DOMINO_ROYAL_OPTION_SETS[type]?.find((option) => option.id === optionId)
+    ?.label ||
   optionId;
 
 export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
@@ -198,12 +259,18 @@ export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
   {
     type: 'tableCloth',
     optionId: getDominoDefaultOptionId('tableCloth'),
-    label: getLabelForOption('tableCloth', getDominoDefaultOptionId('tableCloth'))
+    label: getLabelForOption(
+      'tableCloth',
+      getDominoDefaultOptionId('tableCloth')
+    )
   },
   {
     type: 'tableTheme',
     optionId: getDominoDefaultOptionId('tableTheme'),
-    label: getLabelForOption('tableTheme', getDominoDefaultOptionId('tableTheme'))
+    label: getLabelForOption(
+      'tableTheme',
+      getDominoDefaultOptionId('tableTheme')
+    )
   },
   {
     type: 'environmentHdri',
@@ -213,16 +280,25 @@ export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
   {
     type: 'dominoStyle',
     optionId: getDominoDefaultOptionId('dominoStyle'),
-    label: getLabelForOption('dominoStyle', getDominoDefaultOptionId('dominoStyle'))
+    label: getLabelForOption(
+      'dominoStyle',
+      getDominoDefaultOptionId('dominoStyle')
+    )
   },
   {
     type: 'highlightStyle',
     optionId: getDominoDefaultOptionId('highlightStyle'),
-    label: getLabelForOption('highlightStyle', getDominoDefaultOptionId('highlightStyle'))
+    label: getLabelForOption(
+      'highlightStyle',
+      getDominoDefaultOptionId('highlightStyle')
+    )
   },
   {
     type: 'chairTheme',
     optionId: getDominoDefaultOptionId('chairTheme'),
-    label: getLabelForOption('chairTheme', getDominoDefaultOptionId('chairTheme'))
+    label: getLabelForOption(
+      'chairTheme',
+      getDominoDefaultOptionId('chairTheme')
+    )
   }
 ];


### PR DESCRIPTION
### Motivation
- Provide Domino Battle Royal with its own procedural octagon table as the default and add an oval table option in the store, while keeping table models/textures separate from Texas Hold'em.
- Ensure procedural table shapes (octagon and oval) can drive runtime geometry so Domino has the same type of table silhouettes and texture handling as the Texas Hold'em implementation but with dedicated Domino assets.

### Description
- Added two Domino table theme entries (`domino-octagon-pro`, `domino-oval-pro`) and set `domino-octagon-pro` as the Domino default in `webapp/src/config/dominoRoyalInventoryConfig.js` so the store/inventory expose Domino-specific table themes.
- Extended the runtime table code in `webapp/public/domino-royal-game.js` with `createOvalShape`, `getProceduralShapeSet`, `rebuildProceduralTableGeometry`, and updated `applyTableTheme` and the procedural `buildTable` to rebuild procedural geometry when a procedural Domino table theme is selected.
- Kept Domino table definitions and thumbnails separate (new `shapeId` + thumbnail fields) and preserved fallbacks for non-procedural Poly Haven themes.
- Small formatting/robustness cleanups (minor line-wrap/structure changes) and migration of the default table id so existing Domino appearances map to the new Domino default.

### Testing
- Ran syntax checks with `node --check webapp/src/config/dominoRoyalInventoryConfig.js` and `node --check webapp/public/domino-royal-game.js`, which passed.
- Ran `npx prettier --write` on the modified files and `npx eslint` which reported only ignore-file warnings (no blocking errors).
- Launched the local dev server via `npm --prefix webapp run dev` and captured a Playwright screenshot of `/games/domino-royal` to validate the procedural table appears; the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb51b1bf88329b4caff58ba7f4035)