### PR TITLE
Pool Royale: portrait HUD icon order and human-turn power slider visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13521,6 +13521,8 @@ function PoolRoyaleGame({
   const sideControlsBottomPx =
     SPIN_CONTROL_DIAMETER_PX + 2 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - viewButtonsOffsetPx;
   const rightControlsLiftPx = 2;
+  const portraitMenuBottomOffsetPx =
+    sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx - sideActionButtonsDropPx + bottomLeftChatGiftLiftPx + 10;
   const sharedBottomControlsDropPx = 8;
   const [isPortrait, setIsPortrait] = useState(
     () => (typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth)
@@ -30876,7 +30878,6 @@ const powerRef = useRef(hud.power);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
-  const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive;
   useEffect(() => {
     if (!showPowerSlider) {
       return undefined;
@@ -30924,6 +30925,7 @@ const powerRef = useRef(hud.power);
   const topDownMinimalUi = isTopDownView;
   const hideNonEssentialHud = shotBroadcastActive || topDownMinimalUi;
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
+  const showPowerSlider = showPlayerControls;
   const showSpinController =
     !hud.over && !replayActive && !shotBroadcastActive && (isPlayerTurn || aiTakingShot);
   const canRepositionCueBall = useMemo(
@@ -31912,11 +31914,16 @@ const powerRef = useRef(hud.power);
 
       <div
         className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
-        style={{
-          top: `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
-          left: `calc(50% + ${menuButtonCenterNudgePx}px)`,
-          transform: 'translateX(-50%)'
-        }}
+        style={isPortrait
+          ? {
+              left: '-0.5rem',
+              bottom: `${portraitMenuBottomOffsetPx}px`
+            }
+          : {
+              top: `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
+              left: `calc(50% + ${menuButtonCenterNudgePx}px)`,
+              transform: 'translateX(-50%)'
+            }}
       >
         <button
           ref={configButtonRef}
@@ -32957,9 +32964,10 @@ const powerRef = useRef(hud.power);
             infoIcon="ℹ️"
             muteIconOn="🔇"
             muteIconOff="🔊"
+            order={['gift', 'chat']}
             actionOffsets={{
-              chat: 10,
-              gift: 6
+              chat: 0,
+              gift: 0
             }}
             showInfo={false}
             showMute={false}


### PR DESCRIPTION
### Motivation
- Improve portrait HUD usability by aligning the menu, gift and chat icons into a single vertical stack for consistent reach and appearance. 
- Ensure the power slider is reliably visible to the human player whenever they have control so pulling/firing works in portrait and 2D camera modes.

### Description
- Move the settings/menu button into the left-side icon column in portrait layout and compute a `portraitMenuBottomOffsetPx` to position it near the chat/gift column in portrait by updating `webapp/src/pages/Games/PoolRoyale.jsx`.
- Reorder the left action icons so the gift icon appears above the chat icon by changing the `BottomLeftIcons` props to `order={['gift','chat']}` and zeroing portrait action offsets in `PoolRoyale.jsx`.
- Make power slider visibility follow player control visibility by replacing the previous `showPowerSlider` expression with `const showPowerSlider = showPlayerControls;` so the slider appears whenever `showPlayerControls` is true.

### Testing
- Built the web app successfully using `npm --prefix webapp run build`, which completed without errors. 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and visually inspected the page. 
- Captured a portrait screenshot of `/games/poolroyale` with Playwright to validate the new icon stack and slider placement (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb90f495883299aacd2e683482616)