### PR TITLE
Add Domino table-shape options (classic octagon default + grand oval) and runtime support

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3676,6 +3676,27 @@ const TABLE_THEME_OPTIONS = MURLAN_TABLE_THEMES.map((theme) => ({
   ...theme,
   label: theme.label || theme.name || theme.id
 }));
+
+const TABLE_SHAPE_OPTIONS = Object.freeze([
+  {
+    id: 'classicOctagon',
+    label: 'Classic Octagon',
+    preview: {
+      clipPath:
+        'polygon(50% 0%, 80% 10%, 100% 40%, 100% 60%, 80% 90%, 50% 100%, 20% 90%, 0% 60%, 0% 40%, 20% 10%)'
+    },
+    thumbnail: SWATCH_THUMB(['#0f172a', '#1f2937', '#38bdf8'])
+  },
+  {
+    id: 'grandOval',
+    label: 'Grand Oval',
+    preview: {
+      borderRadius: '50% / 35%'
+    },
+    thumbnail: SWATCH_THUMB(['#0b1220', '#111827', '#f97316'])
+  }
+]);
+
 const DEFAULT_TABLE_THEME_OPTION = TABLE_THEME_OPTIONS[0] || null;
 const ENVIRONMENT_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
@@ -3964,6 +3985,7 @@ const TABLE_SETUP_SECTIONS = [
     options: ENVIRONMENT_HDRI_OPTIONS
   },
   { key: 'tableTheme', label: 'Table Theme', options: TABLE_THEME_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'tableWood', label: 'Table Finish', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'dominoStyle', label: 'Domino', options: DOMINO_STYLE_OPTIONS },
@@ -3978,6 +4000,7 @@ const TABLE_SETUP_SECTIONS = [
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   environmentHdri: ENVIRONMENT_HDRI_OPTIONS,
   tableTheme: TABLE_THEME_OPTIONS,
+  tableShape: TABLE_SHAPE_OPTIONS,
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
   dominoStyle: DOMINO_STYLE_OPTIONS,
@@ -3987,6 +4010,7 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
 
 
 const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'murlan-default';
+const LUDO_MATCH_DEFAULT_TABLE_SHAPE_ID = 'classicOctagon';
 const LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID = 'emerald';
 const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
 
@@ -3995,6 +4019,13 @@ function resolveDefaultOptionId(key, options = []) {
   if (key === 'tableTheme') {
     return (
       options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_THEME_ID)?.id ||
+      options[0]?.id ||
+      null
+    );
+  }
+  if (key === 'tableShape') {
+    return (
+      options.find((option) => option?.id === LUDO_MATCH_DEFAULT_TABLE_SHAPE_ID)?.id ||
       options[0]?.id ||
       null
     );
@@ -4124,6 +4155,7 @@ function normalizeAppearance(raw) {
   const limits = [
     ['environmentHdri', ENVIRONMENT_HDRI_OPTIONS.length],
     ['tableTheme', TABLE_THEME_OPTIONS.length],
+    ['tableShape', TABLE_SHAPE_OPTIONS.length],
     ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['dominoStyle', DOMINO_STYLE_OPTIONS.length],
@@ -4184,6 +4216,10 @@ function forceMurlanDefaultTableAppearance(rawAppearance) {
   next.tableTheme = findDominoOptionIndex(
     'tableTheme',
     LUDO_MATCH_DEFAULT_TABLE_THEME_ID
+  );
+  next.tableShape = findDominoOptionIndex(
+    'tableShape',
+    LUDO_MATCH_DEFAULT_TABLE_SHAPE_ID
   );
   next.tableWood = findDominoOptionIndex(
     'tableWood',
@@ -5398,6 +5434,23 @@ function createRegularPolygonShape(sides = 8, radius = 1) {
   return shape;
 }
 
+function createOvalShape(width = 1, height = 1, segments = 64) {
+  const shape = new THREE.Shape();
+  const total = Math.max(24, Math.floor(segments));
+  for (let i = 0; i <= total; i += 1) {
+    const angle = (i / total) * Math.PI * 2;
+    const x = Math.cos(angle) * (width / 2);
+    const y = Math.sin(angle) * (height / 2);
+    if (i === 0) {
+      shape.moveTo(x, y);
+    } else {
+      shape.lineTo(x, y);
+    }
+  }
+  shape.closePath();
+  return shape;
+}
+
 function makeClothTexture({
   top = '#155c2a',
   bottom = '#0b3a1d',
@@ -6014,11 +6067,41 @@ const TABLE_BASE_Y = TABLE_HEIGHT - TABLE_TOP_DEPTH;
 const CLOTH_TOP = TABLE_HEIGHT;
 const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
-(function buildTable() {
+function buildTableShapes(shapeOption) {
+  if (shapeOption?.id === 'grandOval') {
+    const outerWidth = TABLE_OUTER_RADIUS * 2.1;
+    const outerHeight = TABLE_OUTER_RADIUS * 1.45;
+    const innerWidth = TABLE_INNER_RADIUS * 2.1;
+    const innerHeight = TABLE_INNER_RADIUS * 1.45;
+    const clothWidth = CLOTH_RADIUS * 2.1;
+    const clothHeight = CLOTH_RADIUS * 1.45;
+    return {
+      topShape: createOvalShape(outerWidth, outerHeight, 72),
+      feltShape: createOvalShape(clothWidth, clothHeight, 72),
+      rimInnerShape: createOvalShape(innerWidth, innerHeight, 72)
+    };
+  }
   const sides = 8;
-  const topShape = createRegularPolygonShape(sides, TABLE_OUTER_RADIUS);
-  const feltShape = createRegularPolygonShape(sides, CLOTH_RADIUS);
-  const rimInnerShape = createRegularPolygonShape(sides, TABLE_INNER_RADIUS);
+  return {
+    topShape: createRegularPolygonShape(sides, TABLE_OUTER_RADIUS),
+    feltShape: createRegularPolygonShape(sides, CLOTH_RADIUS),
+    rimInnerShape: createRegularPolygonShape(sides, TABLE_INNER_RADIUS)
+  };
+}
+
+function clearProceduralTableParts() {
+  while (proceduralTableParts.length) {
+    const mesh = proceduralTableParts.pop();
+    if (!mesh) continue;
+    mesh.parent?.remove(mesh);
+    mesh.geometry?.dispose?.();
+  }
+}
+
+function rebuildProceduralTable() {
+  const shapeOption = TABLE_SHAPE_OPTIONS[appearance.tableShape] ?? TABLE_SHAPE_OPTIONS[0];
+  const { topShape, feltShape, rimInnerShape } = buildTableShapes(shapeOption);
+  clearProceduralTableParts();
 
   const topShapeWithHole = topShape.clone();
   topShapeWithHole.holes.push(feltShape);
@@ -6097,9 +6180,9 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   tableG.add(column);
   tableParts.column = column;
   proceduralTableParts.push(column);
+}
 
-  // Base and trim intentionally omitted to remove the oversized pedestal.
-})();
+rebuildProceduralTable();
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SCALE = 1.5 * 1.22; // upscale tiles for stronger readability
@@ -6522,6 +6605,7 @@ function applyAppearanceChange({ refresh = true } = {}) {
   applyTableTheme(
     TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TABLE_THEME_OPTIONS[0]
   );
+  rebuildProceduralTable();
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(
@@ -6644,6 +6728,25 @@ function createOptionPreview(key, option) {
       label.style.fontWeight = '700';
       label.style.letterSpacing = '0.04em';
       swatch.appendChild(label);
+      break;
+    }
+    case 'tableShape': {
+      swatch.style.background = 'linear-gradient(135deg, #0b1220, #111827)';
+      swatch.style.height = '2rem';
+      const inset = document.createElement('div');
+      inset.style.position = 'absolute';
+      inset.style.left = '16%';
+      inset.style.right = '16%';
+      inset.style.top = '18%';
+      inset.style.bottom = '18%';
+      inset.style.background = 'rgba(249,115,22,0.82)';
+      inset.style.border = '1px solid rgba(255,255,255,0.3)';
+      inset.style.borderRadius = option?.id === 'grandOval' ? '50% / 35%' : '12%';
+      if (option?.id === 'classicOctagon') {
+        inset.style.clipPath =
+          'polygon(50% 0%, 80% 10%, 100% 40%, 100% 60%, 80% 90%, 50% 100%, 20% 90%, 0% 60%, 0% 40%, 20% 10%)';
+      }
+      swatch.appendChild(inset);
       break;
     }
     case 'tableWood':

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -4,6 +4,23 @@ import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
+const DOMINO_TABLE_SHAPE_OPTIONS = Object.freeze([
+  {
+    id: 'classicOctagon',
+    label: 'Classic Octagon',
+    price: 0,
+    description: 'Default octagon battle table matching Texas Hold\'em 3D silhouette.',
+    thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8'])
+  },
+  {
+    id: 'grandOval',
+    label: 'Grand Oval',
+    price: 760,
+    description: 'Oval battle table variant from the Texas Hold\'em 3D lineup.',
+    thumbnail: swatchThumbnail(['#0b1220', '#111827', '#f97316'])
+  }
+]);
+
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: MURLAN_TABLE_FINISHES.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
     id,
@@ -29,6 +46,7 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     preserveMaterials,
     description: description || `${label} table from Murlan Royale`
   })),
+  tableShape: DOMINO_TABLE_SHAPE_OPTIONS,
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map(({ id, name }) => ({ id, label: `${name} HDRI` })),
   dominoStyle: [
     { id: 'imperialIvory', label: 'Imperial Ivory' },
@@ -82,6 +100,7 @@ const DOMINO_DEFAULT_IDS = Object.freeze({
   tableTheme: 'murlan-default',
   tableWood: 'peelingPaintWeathered',
   tableCloth: 'emerald',
+  tableShape: 'classicOctagon',
   chairTheme: 'dining_chair_02'
 });
 
@@ -146,6 +165,15 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     description: option.description || 'Apply the Murlan Royale table collection to Domino.',
     thumbnail: MURLAN_TABLE_THEMES.find((theme) => theme.id === option.id)?.thumbnail
   })),
+  ...DOMINO_ROYAL_OPTION_SETS.tableShape.slice(1).map((option, idx) => ({
+    id: `domino-table-shape-${option.id}`,
+    type: 'tableShape',
+    optionId: option.id,
+    name: option.label,
+    price: option.price || 720 + idx * 80,
+    description: option.description || 'Switch the Domino Royal table silhouette.',
+    thumbnail: option.thumbnail
+  })),
   ...DOMINO_ROYAL_OPTION_SETS.environmentHdri.slice(1).map((option, idx) => ({
     id: `domino-hdri-${option.id}`,
     type: 'environmentHdri',
@@ -204,6 +232,11 @@ export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
     type: 'tableTheme',
     optionId: getDominoDefaultOptionId('tableTheme'),
     label: getLabelForOption('tableTheme', getDominoDefaultOptionId('tableTheme'))
+  },
+  {
+    type: 'tableShape',
+    optionId: getDominoDefaultOptionId('tableShape'),
+    label: getLabelForOption('tableShape', getDominoDefaultOptionId('tableShape'))
   },
   {
     type: 'environmentHdri',


### PR DESCRIPTION
### Motivation
- Provide Domino Royal with the same table silhouettes used by Texas Hold'em (octagon and oval) while keeping per-game table option sets and assets separate. 
- Allow players to pick or buy a Domino-specific oval table from Store/Inventory and ensure procedural geometry updates in-game when the shape changes.

### Description
- Added a Domino-specific `tableShape` option set and default to `classicOctagon`, plus `grandOval` as a purchasable store item in `webapp/src/config/dominoRoyalInventoryConfig.js`. 
- Exposed `TABLE_SHAPE_OPTIONS` and integrated it into the Domino setup sections, option maps, default IDs, normalization/migration and default loadout in `webapp/public/domino-royal-game.js`. 
- Implemented procedural table geometry switching by adding `createOvalShape`, shape builders (`buildTableShapes`), `clearProceduralTableParts`, and `rebuildProceduralTable`, and wired `rebuildProceduralTable()` to run on appearance changes so the visible table updates live. 
- Added UI preview rendering for `tableShape` in the config panel and store metadata mapping so table shapes appear correctly in Store/Inventory.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and `node --check webapp/src/config/dominoRoyalInventoryConfig.js`, both succeeded. 
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` for visual validation and successfully captured a screenshot using a Playwright script, confirming the updated table UI rendered as expected. 
- No unit tests were added; changes were validated via static checks and a manual/automated visual smoke test (Playwright screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb51b1bf88329b4caff58ba7f4035)