### PR TITLE
Adjust Pool Royale HUD & Spin Controller for Portrait and 2D Views

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13506,8 +13506,9 @@ function PoolRoyaleGame({
     const isTelegram = isTelegramWebView();
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
-  const sharedHudLiftPx = 30;
-  const spinControllerLiftPx = 20;
+  const portraitViewport = typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth;
+  const sharedHudLiftPx = portraitViewport ? 40 : 30;
+  const spinControllerLiftPx = portraitViewport ? 24 : 20;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -31911,6 +31912,7 @@ const powerRef = useRef(hud.power);
         </>
       )}
 
+      {!isPortrait && (
       <div
         className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
@@ -32525,6 +32527,7 @@ const powerRef = useRef(hud.power);
           </div>
         )}
       </div>
+      )}
 
       {isTraining && !replayActive && (
         <div
@@ -32948,7 +32951,7 @@ const powerRef = useRef(hud.power);
         </button>
       </div>
 
-      {!replayActive && !isFreePractice && !hideNonEssentialHud && (
+      {!isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
         <div className="pointer-events-auto">
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
@@ -32981,6 +32984,41 @@ const powerRef = useRef(hud.power);
             showInfo={false}
             showMute={false}
           />
+        </div>
+      )}
+
+      {isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
+        <div
+          className="pointer-events-auto fixed left-1/2 z-50 flex -translate-x-1/2 items-center gap-4"
+          style={{ bottom: `${12 + chromeUiLiftPx}px` }}
+        >
+          <button
+            type="button"
+            onClick={() => setShowGift(true)}
+            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+            aria-label="Open gifts"
+          >
+            <span aria-hidden="true">🎁</span>
+          </button>
+          <button
+            ref={configButtonRef}
+            type="button"
+            onClick={() => setConfigOpen((prev) => !prev)}
+            aria-expanded={configOpen}
+            aria-controls="snooker-config-panel"
+            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+            aria-label={configOpen ? 'Close game settings menu' : 'Open game settings menu'}
+          >
+            <span aria-hidden="true">☰</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowChat(true)}
+            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+            aria-label="Open chat"
+          >
+            <span aria-hidden="true">💬</span>
+          </button>
         </div>
       )}
 
@@ -33362,9 +33400,10 @@ const powerRef = useRef(hud.power);
             ? {
                 left: '50%',
                 right: 'auto',
-                bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
+                top: topControlsOffset,
+                bottom: 'auto',
                 transform: `translateX(-50%) scale(${uiScale * 0.88})`,
-                transformOrigin: 'bottom center'
+                transformOrigin: 'top center'
               }
             : {
                 right: `${rightHudShiftPx}px`,


### PR DESCRIPTION
### Motivation
- Make the spin controller appear at the very top/center in the 2D/top-down view and move portrait UI controls into a single horizontal row under the avatars for clearer mobile portrait UX.
- Raise portrait HUD spacing so the avatar frame, spin control and HUD elements sit slightly closer to player avatars on mobile portrait screens.
- Keep the original left-side stacked `BottomLeftIcons` behaviour for non-portrait layouts to avoid regressions on larger screens.

### Description
- Updated portrait layout constants so HUD & spin lift values are slightly increased for portrait screens (`sharedHudLiftPx`, `spinControllerLiftPx`) in `PoolRoyale.jsx`.
- Repositioned the 2D/top-down spin controller from the bottom HUD lane to the top controls lane by changing its top/bottom positioning and transform origin so it centers at the top in 2D view (`top: topControlsOffset` + `transformOrigin: 'top center'`).
- Restricted the existing vertical floating menu and `BottomLeftIcons` stack to non-portrait mode so they do not appear on portrait screens.
- Added a portrait-only, centered horizontal icon row under the player HUD containing the gift (left), menu (center), and chat (right) icons with compact touch-sized buttons and appropriate `aria-label`s.
- Changes applied in: `webapp/src/pages/Games/PoolRoyale.jsx` (layout/positioning + small formatting tweaks).

### Testing
- Ran `npm --prefix webapp run build` to validate the webapp build artifacts; the build completed successfully.
- Ran `prettier --write` on the modified file to enforce formatting; formatting checks now pass for the file.
- Ran `eslint` (file ignored by repo ignore settings in this environment) which produced an ignore warning but did not block the change in CI-like checks here.
- Attempted an automated UI capture via Playwright to validate the portrait rendering, but the screenshot run timed out in this environment and was not completed; layout changes were validated by running the production build and static inspection of the rendered markup/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc1f7a7c48329afc74de69afe5fd1)