### PR TITLE
Adjust Pool Royale HUD positions for portrait layout

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13507,8 +13507,8 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const portraitViewport = typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth;
-  const sharedHudLiftPx = portraitViewport ? 40 : 30;
-  const spinControllerLiftPx = portraitViewport ? 24 : 20;
+  const sharedHudLiftPx = portraitViewport ? 46 : 30;
+  const spinControllerLiftPx = portraitViewport ? 30 : 20;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -13516,8 +13516,9 @@ function PoolRoyaleGame({
   const sideActionButtonsDropPx = 18;
   const bottomLeftChatGiftLiftPx = 12;
   const sideActionButtonStepPx = 60;
-  const rightHudShiftPx = -2;
-  const bottomHudLeftPx = -22;
+  const rightHudShiftPx = 8;
+  const bottomHudLeftPx = -30;
+  const portraitActionIconsLiftPx = 6;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -32990,7 +32991,7 @@ const powerRef = useRef(hud.power);
       {isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
         <div
           className="pointer-events-auto fixed left-1/2 z-50 flex -translate-x-1/2 items-center gap-4"
-          style={{ bottom: `${12 + chromeUiLiftPx}px` }}
+          style={{ bottom: `${12 + chromeUiLiftPx + portraitActionIconsLiftPx}px` }}
         >
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Improve visual layout on phones in portrait: nudge the bottom player frame (avatars/usernames/points/balls) and the spin controller slightly upward and a bit left, and lift the portrait action icons (gift/menu/chat) toward the top for better spacing.

### Description
- Tuned portrait HUD constants in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing `sharedHudLiftPx` and `spinControllerLiftPx` to lift the HUD and spin control when in portrait mode.
- Shifted the right-side HUD cluster by changing `rightHudShiftPx` and adjusted the bottom HUD X-offset via `bottomHudLeftPx` to visually move the frame left.
- Added `portraitActionIconsLiftPx` and applied it to the portrait action icon row to raise the gift/menu/chat buttons a few pixels.
- All changes are contained in `PoolRoyale.jsx` and are limited to layout/positioning constants and one inline style usage for the portrait action icon bottom offset.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the page loaded.
- Captured an automated screenshot via Playwright using Firefox which succeeded and produced an artifact; a Chromium headless launch attempt failed in this environment with a SIGSEGV (environment issue) but did not affect the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe06f77388329aa2be02a272132dc)