### PR TITLE
Fix Domino Royal startup black screen and use GLTF octagon table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3677,6 +3677,21 @@ const TABLE_THEME_OPTIONS = MURLAN_TABLE_THEMES.map((theme) => ({
   label: theme.label || theme.name || theme.id
 }));
 
+const SWATCH_THUMB = (colors = ['#0f172a', '#1f2937']) => {
+  const stops = colors.filter(Boolean);
+  if (!stops.length) {
+    return '';
+  }
+  const step = 100 / Math.max(stops.length - 1, 1);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 96" preserveAspectRatio="none"><defs><linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">${stops
+    .map(
+      (color, index) =>
+        `<stop offset="${(index * step).toFixed(2)}%" stop-color="${color}" />`
+    )
+    .join('')}</linearGradient></defs><rect width="160" height="96" rx="14" ry="14" fill="url(#g)" /><rect x="6" y="6" width="148" height="84" rx="10" ry="10" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="2" /></svg>`;
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+};
+
 const TABLE_SHAPE_OPTIONS = Object.freeze([
   {
     id: 'classicOctagon',
@@ -6098,6 +6113,11 @@ function clearProceduralTableParts() {
   }
 }
 
+function shouldUseProceduralTable(shapeIndex = appearance.tableShape) {
+  const selectedShape = TABLE_SHAPE_OPTIONS[shapeIndex] ?? TABLE_SHAPE_OPTIONS[0];
+  return selectedShape?.id === 'grandOval';
+}
+
 function rebuildProceduralTable() {
   const shapeOption = TABLE_SHAPE_OPTIONS[appearance.tableShape] ?? TABLE_SHAPE_OPTIONS[0];
   const { topShape, feltShape, rimInnerShape } = buildTableShapes(shapeOption);
@@ -6598,16 +6618,33 @@ function saveAppearance() {
 
 function applyAppearanceChange({ refresh = true } = {}) {
   appearance = sanitizeAppearance(appearance);
+  const useProceduralTable = shouldUseProceduralTable(appearance.tableShape);
   applyEnvironmentHdri(
     ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
       ENVIRONMENT_HDRI_OPTIONS[0]
   );
-  applyTableTheme(
-    TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TABLE_THEME_OPTIONS[0]
-  );
-  rebuildProceduralTable();
+  if (useProceduralTable) {
+    tableThemeToken += 1;
+    tableThemeG.visible = false;
+    while (tableThemeG.children.length) {
+      const child = tableThemeG.children.pop();
+      disposeObjectResources(child, { disposeTextures: false });
+      child?.removeFromParent?.();
+    }
+    activeTableThemeId = null;
+    rebuildProceduralTable();
+    setProceduralTableVisible(true);
+  } else {
+    clearProceduralTableParts();
+    setProceduralTableVisible(false);
+    applyTableTheme(
+      TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TABLE_THEME_OPTIONS[0]
+    );
+  }
   clearExistingDominoMeshes();
-  updateTableMaterials();
+  if (useProceduralTable) {
+    updateTableMaterials();
+  }
   applyDominoStyle(
     DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]
   );


### PR DESCRIPTION
### Motivation
- The Domino Royal page failed to initialize due to a missing swatch helper used while building `TABLE_SHAPE_OPTIONS`, causing a runtime `ReferenceError` and a black page. 
- The octagon table should render using the original GLTF model/textures rather than the procedural mesh to preserve authored materials and visual fidelity.

### Description
- Added a small `SWATCH_THUMB` helper (data-URI SVG) placed before `TABLE_SHAPE_OPTIONS` to eliminate the `SWATCH_THUMB is not defined` runtime error. (file: `webapp/public/domino-royal-game.js`)
- Introduced `shouldUseProceduralTable` and adjusted table selection logic so procedural geometry is produced only for the `grandOval` shape, while the Classic Octagon uses the GLTF table theme path (preserving GLTF textures). (file: `webapp/public/domino-royal-game.js`)
- Updated `applyAppearanceChange` to clear/create procedural parts conditionally and to avoid unnecessary procedural material rebuilds when a GLTF table is active. (file: `webapp/public/domino-royal-game.js`)

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully. (success)
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and performed a browser smoke test using Playwright on `/games/domino-royal`; the page reached `Ready` and the `SWATCH_THUMB is not defined` error no longer appears. (success)
- Captured before/after screenshots during validation; the final screenshot shows the Domino Royal page rendering without the previous black screen. (artifact produced)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdfeb95848329acbc9993fd07d5b2)