### PR TITLE
Adjust Pool Royale portrait HUD layout and 2D camera / spin-controller positioning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5293,14 +5293,14 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.08; // lift the 2D camera a touch more for a slightly higher overhead framing
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.11; // lift the 2D camera slightly higher so portrait top view reads more elevated
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.08; // keep 2D framing a little higher for portrait readability
+const TOP_VIEW_RADIUS_SCALE = 1.11; // keep 2D framing a little higher so the camera sits a bit farther up
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * 0.006, // nudge the 2D table a touch left on portrait screens
-  z: PLAY_H * 0.012 // nudge the 2D table a touch lower on portrait screens
+  z: PLAY_H * 0.006 // keep the 2D table slightly higher on portrait screens
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -13507,8 +13507,8 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const portraitViewport = typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth;
-  const sharedHudLiftPx = portraitViewport ? 46 : 30;
-  const spinControllerLiftPx = portraitViewport ? 30 : 20;
+  const sharedHudLiftPx = portraitViewport ? 32 : 30;
+  const spinControllerLiftPx = portraitViewport ? 18 : 20;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -13518,7 +13518,7 @@ function PoolRoyaleGame({
   const sideActionButtonStepPx = 60;
   const rightHudShiftPx = 8;
   const bottomHudLeftPx = -30;
-  const portraitActionIconsLiftPx = 6;
+  const portraitActionIconsLiftPx = 52;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -33401,10 +33401,10 @@ const powerRef = useRef(hud.power);
             ? {
                 left: '50%',
                 right: 'auto',
-                top: topControlsOffset,
-                bottom: 'auto',
+                top: 'auto',
+                bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
                 transform: `translateX(-50%) scale(${uiScale * 0.88})`,
-                transformOrigin: 'top center'
+                transformOrigin: 'bottom center'
               }
             : {
                 right: `${rightHudShiftPx}px`,


### PR DESCRIPTION
### Motivation
- Improve portrait-mode composition so the spin controller sits closer to the avatar frame and the three action icons are positioned above that frame, matching designer directions for mobile portrait layouts. 
- Keep the 2D (top-down) spin controller anchored at the bottom center and lift the top-down camera slightly so the table appears a bit higher on portrait screens.

### Description
- Tuned top-down camera framing constants in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` to `1.11` and reducing the vertical table offset (`TOP_VIEW_SCREEN_OFFSET.z`) so the 2D table appears higher on portrait screens. 
- Adjusted HUD spacing variables inside `PoolRoyale.jsx`: reduced `sharedHudLiftPx` and `spinControllerLiftPx` for portrait to bring the spin controller closer to the avatar frame, and increased `portraitActionIconsLiftPx` so the three action icons sit above the avatar frame. 
- Changed the spin controller placement for top-down (`isTopDownView`) to anchor at the bottom center instead of top, by moving the `top`/`bottom` logic and shifting `transformOrigin` to `bottom center` while preserving the existing right/bottom placement for non-top-down views. 
- All edits are localized to `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran the dev server with `npm --prefix webapp run dev` and captured a portrait screenshot of `/games/pool-royale` using an automated Playwright script, producing `artifacts/pool-royale-layout.png`, which validated the visual placement change (screenshot generation succeeded). 
- Built the production bundle with `npm --prefix webapp run build`, which completed successfully (no build errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf79d496c83299ded9c81eb79f932)