### PR TITLE
Use Texas Hold'em GLTF table mapping for Domino default octagon table

### DIFF
--- a/webapp/src/config/dominoRoyalThemeCatalog.js
+++ b/webapp/src/config/dominoRoyalThemeCatalog.js
@@ -115,10 +115,12 @@ export const DOMINO_ROYAL_TABLE_THEMES = [
   {
     id: 'murlan-default',
     label: 'Murlan Default Table',
-    source: 'procedural',
+    source: 'polyhaven',
+    assetId: 'CoffeeTable_01',
+    preserveMaterials: true,
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
-    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    description: 'Standard Murlan Royale table using the default GLTF texture set.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -166,10 +166,12 @@ export const MURLAN_TABLE_THEMES = [
   {
     id: 'murlan-default',
     label: 'Murlan Default Table',
-    source: 'procedural',
+    source: 'polyhaven',
+    assetId: 'CoffeeTable_01',
+    preserveMaterials: true,
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
-    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    description: 'Standard Murlan Royale table using the default GLTF texture set.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];


### PR DESCRIPTION
### Motivation
- Ensure the Domino Royal octagon table uses the same GLTF texture/UV mapping as the Texas Hold'em table so the table uses original GLTF textures instead of procedural textures.

### Description
- Switched the shared `murlan-default` table theme from `source: 'procedural'` to `source: 'polyhaven'` and set `assetId: 'CoffeeTable_01'` and `preserveMaterials: true` in `webapp/src/config/murlanThemes.js` so the default Murlan table uses the GLTF material mapping.
- Applied the same change to Domino-specific catalog entry in `webapp/src/config/dominoRoyalThemeCatalog.js` so Domino Royal's default octagon table resolves to the GLTF-backed table.
- Updated the theme `description` to reflect the GLTF-backed default and kept thumbnails and pricing unchanged.

### Testing
- Ran `npx eslint` against the modified config files which completed with warnings only due to project ignore patterns.
- Started the web app locally with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the dev server reported ready (success).
- Executed a Playwright script to load `/games/domino-royal` and capture a screenshot which completed and produced an artifact confirming the GLTF table loading path was exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abfe9e29388329be4b3de1eba0b5a3)