### PR TITLE
Domino Royal: enforce GLTF table theme for classic octagon

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4013,6 +4013,21 @@ const LUDO_MATCH_DEFAULT_TABLE_THEME_ID = 'murlan-default';
 const LUDO_MATCH_DEFAULT_TABLE_SHAPE_ID = 'classicOctagon';
 const LUDO_MATCH_DEFAULT_TABLE_CLOTH_ID = 'emerald';
 const LUDO_MATCH_DEFAULT_CHAIR_THEME_ID = 'dining_chair_02';
+const TEXAS_HOLDEM_OCTAGON_GLTF_THEME_ID = 'murlan-default';
+
+function resolveTableThemeById(themeId) {
+  if (!themeId) return null;
+  return TABLE_THEME_OPTIONS.find((option) => option?.id === themeId) ?? null;
+}
+
+function resolveTexasOctagonGltfTheme() {
+  return (
+    resolveTableThemeById(TEXAS_HOLDEM_OCTAGON_GLTF_THEME_ID) ||
+    TABLE_THEME_OPTIONS.find((option) => option?.assetId) ||
+    DEFAULT_TABLE_THEME_OPTION ||
+    null
+  );
+}
 
 function resolveDefaultOptionId(key, options = []) {
   if (!Array.isArray(options) || options.length === 0) return null;
@@ -4184,6 +4199,19 @@ function normalizeAppearance(raw) {
       'tableTheme',
       LUDO_MATCH_DEFAULT_TABLE_THEME_ID
     );
+  }
+
+  const selectedShape = TABLE_SHAPE_OPTIONS[normalized.tableShape];
+  if (selectedShape?.id === 'classicOctagon') {
+    const texasOctagonTheme = resolveTexasOctagonGltfTheme();
+    if (texasOctagonTheme?.id && !texasOctagonTheme?.assetId) {
+      const firstGltfTheme = TABLE_THEME_OPTIONS.find((option) => option?.assetId);
+      if (firstGltfTheme?.id) {
+        normalized.tableTheme = findDominoOptionIndex('tableTheme', firstGltfTheme.id);
+      }
+    } else if (texasOctagonTheme?.id) {
+      normalized.tableTheme = findDominoOptionIndex('tableTheme', texasOctagonTheme.id);
+    }
   }
 
   const selectedChairTheme = CHAIR_THEME_OPTIONS[normalized.chairTheme];
@@ -5653,7 +5681,10 @@ function setProceduralTableVisible(flag = true) {
 async function applyTableTheme(
   option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
 ) {
-  const theme = option || DEFAULT_TABLE_THEME_OPTION;
+  const shapeOption = TABLE_SHAPE_OPTIONS[appearance.tableShape] ?? TABLE_SHAPE_OPTIONS[0];
+  const enforcedTheme =
+    shapeOption?.id === 'classicOctagon' ? resolveTexasOctagonGltfTheme() : null;
+  const theme = enforcedTheme || option || DEFAULT_TABLE_THEME_OPTION;
   tableThemeG.visible = false;
   while (tableThemeG.children.length) {
     const child = tableThemeG.children.pop();


### PR DESCRIPTION
### Motivation
- Ensure the Domino Royal octagon table uses the same GLTF assets and original GLTF texture mapping as the Texas Hold'em octagon table instead of falling back to procedural textures.

### Description
- Added a resolver (`resolveTableThemeById` / `resolveTexasOctagonGltfTheme`) to pick a Texas-aligned GLTF-backed table theme with sensible fallbacks. 
- When normalizing appearance, remapped `classicOctagon` shape users to a GLTF-capable `tableTheme` so octagon shape prefers GLTF assets. 
- Enforced the GLTF-backed theme at runtime in `applyTableTheme` for `classicOctagon` so loaded models preserve original GLTF texture mapping (`preserveGltfTextureMapping`).
- Modified file: `webapp/public/domino-royal-game.js` to implement the above logic.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without syntax errors. 
- Started the webapp dev server with `npm --prefix webapp run dev` and Vite reported the site ready on the expected port. 
- Attempted an automated UI screenshot with Playwright to visually validate the GLTF octagon, but Chromium crashed (SIGSEGV) and Firefox timed out in this environment, so visual smoke test could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abfe9e29388329be4b3de1eba0b5a3)