### PR TITLE
Adjust Pool Royale portrait HUD and rail-overhead camera framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5302,6 +5302,10 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * 0.006, // nudge the 2D table a touch left on portrait screens
   z: PLAY_H * 0.006 // keep the 2D table slightly higher on portrait screens
 });
+const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
+  x: TOP_VIEW_SCREEN_OFFSET.x,
+  z: PLAY_H * 0.012 // push rail overhead framing slightly higher on portrait so bottom pockets stay visible
+});
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
@@ -5328,7 +5332,7 @@ const BROADCAST_TOP_VIEW_VARIANTS = Object.freeze({
     minRadiusScale: BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE,
     radiusScale: BROADCAST_TOP_VIEW_RADIUS_SCALE,
     phi: BROADCAST_TOP_VIEW_RESOLVED_PHI,
-    screenOffset: BROADCAST_TOP_VIEW_SCREEN_OFFSET
+    screenOffset: RAIL_OVERHEAD_SCREEN_OFFSET
   }),
   snooker2d: Object.freeze({
     margin: BROADCAST_SNOOKER_TOP_VIEW_MARGIN,
@@ -5394,6 +5398,7 @@ const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor whi
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.02; // pitch the rail-overhead broadcast a little more downward during aim assists
+const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
 const AIM_SPIN_PREVIEW_FORWARD = 0.18;
@@ -19220,7 +19225,7 @@ const powerRef = useRef(hud.power);
           if (target) {
             const toTarget = target.clone().sub(position);
             position.addScaledVector(toTarget, 0.08);
-            position.y = Math.max((minTargetY ?? baseSurfaceWorldY) + BALL_R * 8.6, position.y - BALL_R * 2.4);
+            position.y = Math.max((minTargetY ?? baseSurfaceWorldY) + BALL_R * 9.4, position.y + BALL_R * 1.2); // lift rail-overhead camera and steepen the downward look
           }
           return { position, target, fov: STANDING_VIEW_FOV, minTargetY };
         };
@@ -20062,12 +20067,14 @@ const powerRef = useRef(hud.power);
         focusTarget.multiplyScalar(worldScaleFactor);
         lookTarget = focusTarget;
         if (topViewRef.current) {
-          const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
-            playerOffsetRef.current + TOP_VIEW_SCREEN_OFFSET.x,
-            ORBIT_FOCUS_BASE_Y,
-            TOP_VIEW_SCREEN_OFFSET.z
-          ).multiplyScalar(worldScaleFactor);
           const overheadVariant = overheadBroadcastVariantRef.current ?? 'rail';
+          const activeTopViewOffset =
+            overheadVariant === 'rail' ? RAIL_OVERHEAD_SCREEN_OFFSET : TOP_VIEW_SCREEN_OFFSET;
+          const topFocusTarget = TMP_VEC3_TOP_VIEW.set(
+            playerOffsetRef.current + activeTopViewOffset.x,
+            ORBIT_FOCUS_BASE_Y,
+            activeTopViewOffset.z
+          ).multiplyScalar(worldScaleFactor);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
           let overheadApplied = false;
@@ -33034,7 +33041,7 @@ const powerRef = useRef(hud.power);
       {isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
         <div
           className="pointer-events-auto fixed left-1/2 z-50 flex -translate-x-1/2 items-center gap-4"
-          style={{ top: `calc(env(safe-area-inset-top, 0px) + 0.35rem)` }}
+          style={{ top: `calc(env(safe-area-inset-top, 0px) + ${PORTRAIT_TOP_ACTION_BAR_DROP_REM}rem)` }}
         >
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Improve portrait-mode UX by lowering the top action bar (gift/menu/chat) so controls feel less cramped against the status/safe-area. 
- Make the rail-overhead broadcast camera better match the 2D/top view positioning while showing more of the bottom pockets in portrait broadcasts.

### Description
- Added `RAIL_OVERHEAD_SCREEN_OFFSET` and wired the broadcast top-view variant to use this offset so rail-overhead framing aligns with 2D placement but sits slightly higher (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Raised and tilted the rail-overhead camera target in the rail-overhead resolver so the rig looks down more and exposes the two bottom pockets (`resolveRailOverheadReplayCamera` position adjustment in `PoolRoyale.jsx`).
- Introduced `PORTRAIT_TOP_ACTION_BAR_DROP_REM` and applied it to the portrait top action bar container so gift/menu/chat icons sit a bit lower on portrait screens (`PoolRoyale.jsx`).
- Small formatting/whitespace cleanups to keep the edited file consistent with project style (`PoolRoyale.jsx`).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished with chunk warnings only). 
- Ran `npx prettier --check` and `npx prettier --write` on the file to normalize formatting and confirmed the file matches Prettier style. 
- Ran `npx eslint` (with `--no-ignore`) which reported only the usual ignore-warning for the large file and no new errors. 
- Attempted a Playwright screenshot to validate visual changes, but the screenshot run timed out in this environment (Playwright capture failed due to a timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac0b1e752c832982514eb3c8eb1097)