### PR TITLE
Center rail-overhead camera for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5304,7 +5304,7 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
-  z: PLAY_H * 0.012 // push rail overhead framing slightly higher on portrait so bottom pockets stay visible
+  z: 0 // center the rail overhead broadcast frame directly over the table midpoint
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
@@ -5398,6 +5398,8 @@ const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor whi
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.02; // pitch the rail-overhead broadcast a little more downward during aim assists
+const RAIL_OVERHEAD_CENTER_PULL = 0.16; // slide the rail camera further inward toward table center for a truer overhead feel
+const RAIL_OVERHEAD_EXTRA_HEIGHT = BALL_R * 11.2; // lift the rail overhead camera to keep the full table inside the frame
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -19224,8 +19226,11 @@ const powerRef = useRef(hud.power);
           }
           if (target) {
             const toTarget = target.clone().sub(position);
-            position.addScaledVector(toTarget, 0.08);
-            position.y = Math.max((minTargetY ?? baseSurfaceWorldY) + BALL_R * 9.4, position.y + BALL_R * 1.2); // lift rail-overhead camera and steepen the downward look
+            position.addScaledVector(toTarget, RAIL_OVERHEAD_CENTER_PULL);
+            position.y = Math.max(
+              (minTargetY ?? baseSurfaceWorldY) + RAIL_OVERHEAD_EXTRA_HEIGHT,
+              position.y + BALL_R * 1.2
+            ); // keep the rail-overhead camera inward while preserving whole-table coverage
           }
           return { position, target, fov: STANDING_VIEW_FOV, minTargetY };
         };


### PR DESCRIPTION
### Motivation
- The rail-overhead broadcast framing was biased slightly upward and did not reliably centre on the table midpoint, which reduced consistency of the broadcast/overhead view.
- The change aims to move the overhead camera visually toward the table center while keeping the entire playfield in frame on portrait mobile screens.

### Description
- Updated rail overhead screen offset in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `RAIL_OVERHEAD_SCREEN_OFFSET.z` to `0` to centre the overhead frame over the table midpoint.
- Introduced two new tuning constants: `RAIL_OVERHEAD_CENTER_PULL` to pull the rail camera inward toward the table center and `RAIL_OVERHEAD_EXTRA_HEIGHT` to raise the rail camera height to preserve full-table coverage.
- Applied the new constants in the rail-overhead replay resolver (`resolveRailOverheadReplayCamera`) so the computed `position` is pulled toward the focus target and lifted to ensure the whole table stays visible.

### Testing
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx --no-warn-ignored`, which completed (no blocking errors reported for this file invocation).
- Built the web app with `npm --prefix webapp run build`, which succeeded (Vite emitted chunk-size/dynamic-import warnings but the build completed).
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of the running app to validate the adjusted overhead framing; the server started successfully and the screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac183b911483298ddb3c84cc5f0439)