### PR TITLE
Adjust Pool Royale rail-overhead camera to center table framing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4868,11 +4868,7 @@ function createBroadcastCameras({
   const cameras = {};
   const headHeight = Math.max(1.45, cameraHeight - floorY);
 
-  const defaultFocus = new THREE.Vector3(
-    0,
-    TABLE_Y + TABLE.THICK + BALL_R * 2.1,
-    0
-  );
+  const defaultFocus = new THREE.Vector3(0, TABLE_Y + BALL_R * 0.7, 0);
 
   const fallbackDepth = Math.max(
     shortRailZ + BALL_R * 12,
@@ -4884,7 +4880,7 @@ function createBroadcastCameras({
   const requestedZ = Math.abs(shortRailZ) || fallbackDepth;
   const cameraCenterZOffset = Math.min(Math.max(requestedZ, fallbackDepth), maxDepth);
   const cameraScale = 1.2;
-  const cameraProximityScale = 0.54;
+  const cameraProximityScale = 0.68;
 
   const createShortRailUnit = (zSign) => {
     const direction = Math.sign(zSign) || 1;


### PR DESCRIPTION
### Motivation

- Improve the rail-overhead broadcast framing so the camera points more directly toward the middle of the table and keeps the full playfield visible on portrait broadcasts. 

### Description

- Lowered the broadcast camera default look target by changing `defaultFocus` in `webapp/src/pages/Games/PoolRoyale.jsx` so the lens aims closer to the table center (`TABLE_Y + BALL_R * 0.7`).
- Increased the rail camera inward push by raising `cameraProximityScale` from `0.54` to `0.68` so the short-rail mount sits closer to the table and preserves full-table framing on portrait views.

### Testing

- Ran `npm --prefix webapp run build` and the production build completed successfully (build warnings about large chunks were emitted but did not fail the build). 
- Started the dev server with `npm --prefix webapp run dev` to validate the page loads locally (server started and served the app). 
- Attempted an automated browser screenshot via Playwright at the Pool Royale route, but the screenshot run timed out in this environment (navigation/load screenshot attempt failed due to a `Page.screenshot` timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac183b911483298ddb3c84cc5f0439)