### PR TITLE
Pool Royale: cue clearance, quick-action alignment, spin boost, and flawless victory reward

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1735,7 +1735,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 900;
 const POCKET_VIEW_EARLY_HOLD_MS = 160;
-const SPIN_GLOBAL_SCALE = 0.72; // boost overall spin impact by 20%
+const SPIN_GLOBAL_SCALE = 0.864; // boost overall spin impact by another 20% over the current tuning
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1872,16 +1872,16 @@ const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
 const CUE_FRONT_SECTION_RATIO = 0.28;
-const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 3.15;
+const CUE_OBSTRUCTION_CLEARANCE = BALL_R * 3.45;
 const CUE_OBSTRUCTION_RANGE = BALL_R * 9;
-const CUE_OBSTRUCTION_LIFT = BALL_R * 0.68;
+const CUE_OBSTRUCTION_LIFT = BALL_R * 0.84;
 const CUE_OBSTRUCTION_TILT = THREE.MathUtils.degToRad(5.2);
-const CUE_OBSTRUCTION_RAIL_CLEARANCE = CUE_OBSTRUCTION_CLEARANCE * 0.72;
-const CUE_OBSTRUCTION_RAIL_INFLUENCE = 0.52;
-const CUE_OBSTRUCTION_SAMPLE_STEP = BALL_R * 0.6;
+const CUE_OBSTRUCTION_RAIL_CLEARANCE = CUE_OBSTRUCTION_CLEARANCE * 0.82;
+const CUE_OBSTRUCTION_RAIL_INFLUENCE = 0.62;
+const CUE_OBSTRUCTION_SAMPLE_STEP = BALL_R * 0.5;
 const CUE_OBSTRUCTION_SAMPLE_MIN = 6;
-const CUE_OBSTRUCTION_SAMPLE_MAX = 18;
-const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.2, CUE_TIP_RADIUS * 1.75);
+const CUE_OBSTRUCTION_SAMPLE_MAX = 24;
+const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.24, CUE_TIP_RADIUS * 1.9);
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * PHYSICS_PROFILE.maxTipOffsetRatio;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -12386,6 +12386,82 @@ function PoolRoyaleGame({
     }
     return rewards;
   }, [isCueFinishUnlocked, poolInventory, resolvedAccountId]);
+
+  const resolveRequiredClearancePots = useCallback((frameLike, seatId) => {
+    const variant = String(frameLike?.meta?.variant || activeVariantId || 'american').toLowerCase();
+    if (variant === '9ball') return 9;
+    if (variant === 'snooker') return 8;
+    const assignment = frameLike?.meta?.state?.assignments?.[seatId];
+    if (assignment === 'blue' || assignment === 'red') return 8;
+    return 8;
+  }, [activeVariantId]);
+
+  const awardFlawlessVictoryStoreReward = useCallback(async () => {
+    if (!resolvedAccountId) return null;
+    let currentInventory = poolInventory;
+    try {
+      const latest = await getPoolRoyalInventory(resolvedAccountId);
+      if (latest) currentInventory = latest;
+    } catch (err) {
+      console.warn('Pool Royale flawless reward fetch fallback to cache', err);
+    }
+
+    const rewardPools = [
+      {
+        type: 'tableFinish',
+        options: TABLE_FINISH_OPTIONS
+          .map((option) => ({ id: option.id, price: Number(option.price) || 0 }))
+          .filter((option) => option.id)
+      },
+      {
+        type: 'clothColor',
+        options: POOL_ROYALE_CLOTH_VARIANTS
+          .map((option) => ({ id: option.id, price: Number(option.price) || 0 }))
+          .filter((option) => option.id)
+      },
+      {
+        type: 'environmentHdri',
+        options: POOL_ROYALE_HDRI_VARIANTS
+          .map((option) => ({ id: option.id, price: Number(option.price) || 0 }))
+          .filter((option) => option.id)
+      }
+    ];
+
+    const allCandidates = rewardPools.flatMap((pool) =>
+      pool.options.map((option) => ({
+        type: pool.type,
+        optionId: option.id,
+        price: option.price,
+        unlocked: isPoolOptionUnlocked(pool.type, option.id, currentInventory)
+      }))
+    );
+
+    const locked = allCandidates.filter((entry) => !entry.unlocked);
+    const source = (locked.length ? locked : allCandidates)
+      .sort((a, b) => (b.price || 0) - (a.price || 0));
+    const picked = source[0] || null;
+    if (!picked) return null;
+
+    try {
+      currentInventory = await addPoolRoyalUnlock(picked.type, picked.optionId, resolvedAccountId);
+    } catch (err) {
+      console.warn('Pool Royale flawless reward unlock failed', err);
+    }
+
+    if (currentInventory) {
+      setPoolInventory(currentInventory);
+    }
+
+    return {
+      type: picked.type,
+      optionId: picked.optionId,
+      label:
+        POOL_ROYALE_OPTION_LABELS[picked.type]?.[picked.optionId] ||
+        picked.optionId,
+      flawlessAward: true
+    };
+  }, [poolInventory, resolvedAccountId]);
+
   const resolveStoredSelection = useCallback(
     (type, storageKey, isValid, fallbackId) => {
       const inventory = poolInventory;
@@ -13090,6 +13166,7 @@ function PoolRoyaleGame({
     setTrainingRoadmapOpen(false);
     setTrainingTaskTransition(null);
     setPottedBySeat({ A: [], B: [] });
+    flawlessRunRef.current = { A: { missed: false, potted: 0 }, B: { missed: false, potted: 0 } };
     lastPottedBySeatRef.current = { A: null, B: null };
     pocketDropRef.current.clear();
     pocketRestIndexRef.current.clear();
@@ -13299,6 +13376,7 @@ function PoolRoyaleGame({
     setTrainingTaskTransition(null);
     setRuleToast(null);
     setPottedBySeat({ A: [], B: [] });
+    flawlessRunRef.current = { A: { missed: false, potted: 0 }, B: { missed: false, potted: 0 } };
     lastPottedBySeatRef.current = { A: null, B: null };
     pocketDropRef.current.clear();
     pocketRestIndexRef.current.clear();
@@ -13332,6 +13410,7 @@ function PoolRoyaleGame({
     const activeLevel = trainingLevelRef.current || trainingLevel || 1;
     setRuleToast(null);
     setPottedBySeat({ A: [], B: [] });
+    flawlessRunRef.current = { A: { missed: false, potted: 0 }, B: { missed: false, potted: 0 } };
     lastPottedBySeatRef.current = { A: null, B: null };
     pocketDropRef.current.clear();
     pocketRestIndexRef.current.clear();
@@ -13531,6 +13610,7 @@ function PoolRoyaleGame({
   const [isTopDownView, setIsTopDownView] = useState(false);
   const [isRailOverheadView, setIsRailOverheadView] = useState(false);
   const usePortraitHudLayout = true;
+  const usePortraitQuickActionCoordinates = isPortrait || isTopDownView || isRailOverheadView;
   const [isLookMode, setIsLookMode] = useState(false);
   const lookModeRef = useRef(false);
   useEffect(() => {
@@ -14387,6 +14467,10 @@ useEffect(() => {
   }
 }, [hud.turn]);
 const [pottedBySeat, setPottedBySeat] = useState({ A: [], B: [] });
+  const flawlessRunRef = useRef({
+    A: { missed: false, potted: 0 },
+    B: { missed: false, potted: 0 }
+  });
 const lastPottedBySeatRef = useRef({ A: null, B: null });
 const lastAssignmentsRef = useRef({ A: null, B: null });
 const lastShotReminderRef = useRef({ A: 0, B: 0 });
@@ -14532,6 +14616,7 @@ const powerRef = useRef(hud.power);
     openingShotViewSuppressedRef.current = true;
     cueBallPlacedFromHandRef.current = !nextInHand;
     setPottedBySeat({ A: [], B: [] });
+    flawlessRunRef.current = { A: { missed: false, potted: 0 }, B: { missed: false, potted: 0 } };
     lastAssignmentsRef.current = { A: null, B: null };
     lastShotReminderRef.current = { A: 0, B: 0 };
     setTurnCycle(0);
@@ -15158,6 +15243,7 @@ const powerRef = useRef(hud.power);
       }));
       powerRef.current = 0;
       setPottedBySeat({ A: [], B: [] });
+      flawlessRunRef.current = { A: { missed: false, potted: 0 }, B: { missed: false, potted: 0 } };
       lastPottedBySeatRef.current = { A: null, B: null };
       lastAssignmentsRef.current = { A: null, B: null };
       lastShotReminderRef.current = { A: 0, B: 0 };
@@ -16395,11 +16481,20 @@ const powerRef = useRef(hud.power);
           lastPottedBySeatRef.current?.[userSeat] ??
           null;
         setFinalPotLabel(lastPot ? resolveBallLabel(lastPot) : '');
+
+        const shooterStats = flawlessRunRef.current?.[userSeat] || { missed: false, potted: 0 };
+        const requiredPots = resolveRequiredClearancePots(currentFrame, userSeat);
+        const flawlessClearance = userWon && !shooterStats.missed && shooterStats.potted >= requiredPots;
+        const flawlessReward = flawlessClearance ? await awardFlawlessVictoryStoreReward() : null;
+        const mergedRewards = [
+          ...(tournamentOutcome?.unlocks || []),
+          ...(flawlessReward ? [flawlessReward] : [])
+        ];
         const overlayData = {
           name: userWon ? player.name || 'You' : opponentDisplayName || 'Opponent',
           avatar: userWon ? resolvedPlayerAvatar : opponentDisplayAvatar || '/assets/icons/profile.svg',
           prizeText: prizeAmount > 0 ? `+${prizeAmount} ${stakeToken}` : '',
-          rewards: tournamentOutcome?.unlocks || [],
+          rewards: mergedRewards,
           nftReward: tournamentOutcome?.nftReward || null,
           userWon,
           tournamentAdvance: tournamentMode && userWon && !tournamentOutcome?.complete
@@ -16446,6 +16541,7 @@ const powerRef = useRef(hud.power);
   }, [
     frameState.frameOver,
     frameState.winner,
+    awardFlawlessVictoryStoreReward,
     handleTournamentResult,
     isTraining,
     localSeat,
@@ -16463,7 +16559,8 @@ const powerRef = useRef(hud.power);
     tournamentPlayers,
     triggerCoinBurst,
     waitForActiveReplay,
-    openRewardGift
+    openRewardGift,
+    resolveRequiredClearancePots
   ]);
   useEffect(() => {
     if (!rematchStatus?.expiresAt) {
@@ -27924,6 +28021,16 @@ const powerRef = useRef(hud.power);
           Boolean(replayDecision?.shouldReplay) &&
           (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
+        const shotMissed = !hadObjectPot || shotWasFoul || cueBallPotted;
+        if (shotMissed) {
+          flawlessRunRef.current = {
+            ...flawlessRunRef.current,
+            [shooterSeat]: {
+              ...(flawlessRunRef.current?.[shooterSeat] || { missed: false, potted: 0 }),
+              missed: true
+            }
+          };
+        }
         if (potted.length) {
           const newPots = potted.filter(
             (entry) => entry && entry.color && entry.color !== 'CUE'
@@ -27932,6 +28039,13 @@ const powerRef = useRef(hud.power);
             lastPottedBySeatRef.current = {
               ...lastPottedBySeatRef.current,
               [shooterSeat]: newPots[newPots.length - 1] ?? null
+            };
+            flawlessRunRef.current = {
+              ...flawlessRunRef.current,
+              [shooterSeat]: {
+                ...(flawlessRunRef.current?.[shooterSeat] || { missed: false, potted: 0 }),
+                potted: (flawlessRunRef.current?.[shooterSeat]?.potted || 0) + newPots.length
+              }
             };
             setPottedBySeat((prev) => ({
               ...prev,
@@ -32998,7 +33112,7 @@ const powerRef = useRef(hud.power);
         </div>
       </div>
 
-      {!isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
+      {!usePortraitQuickActionCoordinates && !replayActive && !isFreePractice && !hideNonEssentialHud && (
         <div className="pointer-events-auto">
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
@@ -33034,7 +33148,7 @@ const powerRef = useRef(hud.power);
         </div>
       )}
 
-      {isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
+      {usePortraitQuickActionCoordinates && !replayActive && !isFreePractice && !hideNonEssentialHud && (
         <div
           className="pointer-events-auto fixed left-1/2 z-50 flex -translate-x-1/2 items-center gap-4"
           style={{ top: `calc(env(safe-area-inset-top, 0px) + ${PORTRAIT_TOP_ACTION_BAR_DROP_REM}rem)` }}


### PR DESCRIPTION
### Motivation
- Reduce cue-stick clipping with balls/rails by raising the cue/helpers and improving obstruction checks during aim and stroke.
- Make quick-action icons (chat/gift) appear at the same coordinates in 2D/top-down/rail-overhead portrait layouts for a consistent UX on portrait phones.
- Increase overall visible/physical spin influence to make shots feel snappier across the game.
- Reward truly flawless wins (no missed shots and full clearance) with a high-value store unlock to incentivize perfect play.

### Description
- Tightened cue clearance and sampling: increased `CUE_OBSTRUCTION_CLEARANCE`, `CUE_OBSTRUCTION_LIFT`, decreased sampling step and increased sample max, and adjusted rail clearance/influence to lift the cue earlier and sample more densely (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Increased spin strength by raising `SPIN_GLOBAL_SCALE` from `0.72` to `0.864` to give ~+20% overall spin impact (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Unified quick-action placement logic by introducing `usePortraitQuickActionCoordinates` and routing the HUD to use the same portrait coordinates for 2D and rail-overhead broadcast modes so chat/gift icons align with portrait placement (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added flawless-win reward flow: track per-seat flawless state (`flawlessRunRef`), increment potted counts, detect flawless clearance at match wrap-up, and award one high-value Pool Royale store unlock (table finish / cloth / HDRI) via `awardFlawlessVictoryStoreReward()` which merges into the winner overlay rewards (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Minor UI/flow touches: reset `flawlessRunRef` at layout/round resets and integrate the new reward into winner overlay logic so the player sees the awarded unlock and can open it.

### Testing
- Built the web app successfully with `npm --prefix webapp run build`; Vite produced a successful production build (non-blocking chunk-size warnings only). ✅
- Ran the dev server and captured a portrait-mode screenshot of the updated HUD using Playwright to validate quick-action placement; screenshot saved as `artifacts/poolroyale-quick-actions.png`. ✅
- Smoke-tested interactive behavior locally by starting `npm --prefix webapp run dev` and loading `/games/poolroyale` to verify no runtime errors during initial load. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1fd3cb048329b86d27195cc3975d)