### PR TITLE
Make Pool Royale settings menu open downward on mobile

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32026,9 +32026,8 @@ const powerRef = useRef(hud.power);
             id="snooker-config-panel"
             ref={configPanelRef}
             className={`pointer-events-auto w-72 max-w-[80vw] rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur ${
-              isPortrait ? 'mb-2 max-h-[68vh] overflow-y-auto' : 'mt-2'
+              isPortrait ? 'mt-2 max-h-[68vh] overflow-y-auto' : 'mt-2'
             }`}
-            style={isPortrait ? { order: -1 } : undefined}
           >
             <div className="flex items-center justify-between gap-4">
               <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">


### PR DESCRIPTION
### Motivation
- On portrait/mobile view the settings panel was positioned above the menu button which made the menu appear upward instead of downwards, so the UX needed the panel to render below the icon.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` replace the portrait spacing `mb-2` with `mt-2` and remove the `style={isPortrait ? { order: -1 } : undefined}` override so the config panel is rendered below the menu button in portrait mode.

### Testing
- Built the webapp with `npm -C webapp run build` which completed successfully, and an automated Playwright script was used to capture mobile viewport screenshots showing the updated menu positioning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4babc4908329968685c8c1107aa3)