### PR TITLE
Fix Pool Royale portrait settings menu dropdown placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31991,16 +31991,16 @@ const powerRef = useRef(hud.power);
         </>
       )}
 
-      {!isPortrait && (
+      {(!isPortrait || (isPortrait && configOpen && !isFreePractice && !hideNonEssentialHud)) && (
       <div
-        className={`absolute z-50 flex flex-col items-start gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
+        className={`${isPortrait ? 'fixed left-1/2 -translate-x-1/2 items-center' : 'absolute items-start'} z-50 flex flex-col gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
-          top: isPortrait ? undefined : `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
-          left: isPortrait ? `calc(env(safe-area-inset-left, 0px) + 0.7rem)` : `calc(50% + ${menuButtonCenterNudgePx}px)`,
-          bottom: isPortrait
-            ? `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx - sideActionButtonsDropPx + bottomLeftChatGiftLiftPx}px`
-            : undefined,
-          transform: isPortrait ? 'translateX(-0.35rem)' : 'translateX(-50%)'
+          top: isPortrait
+            ? `calc(env(safe-area-inset-top, 0px) + ${PORTRAIT_TOP_ACTION_BAR_DROP_REM}rem + 3.9rem)`
+            : `calc(${topControlsOffset} + ${menuButtonTopNudgePx}px)`,
+          left: isPortrait ? '50%' : `calc(50% + ${menuButtonCenterNudgePx}px)`,
+          bottom: undefined,
+          transform: 'translateX(-50%)'
         }}
       >
         <button
@@ -32013,7 +32013,7 @@ const powerRef = useRef(hud.power);
             transform: `scale(${uiScale * 1.08})`,
             transformOrigin: isPortrait ? 'bottom left' : 'top left'
           }}
-          className={`pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+          className={`pointer-events-auto ${isPortrait ? 'hidden' : 'flex'} items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
             configOpen ? 'bg-black/60' : 'hover:bg-black/60'
           }`}
           aria-label={configOpen ? 'Close game settings menu' : 'Open game settings menu'}
@@ -32026,9 +32026,8 @@ const powerRef = useRef(hud.power);
             id="snooker-config-panel"
             ref={configPanelRef}
             className={`pointer-events-auto w-72 max-w-[80vw] rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur ${
-              isPortrait ? 'mb-2 max-h-[68vh] overflow-y-auto' : 'mt-2'
+              isPortrait ? 'mt-2 max-h-[56vh] overflow-y-auto' : 'mt-2'
             }`}
-            style={isPortrait ? { order: -1 } : undefined}
           >
             <div className="flex items-center justify-between gap-4">
               <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">


### PR DESCRIPTION
### Motivation
- The portrait (phone) menu in Pool Royale opened the settings panel in an undesired position (or not at all), so tapping the menu should show the panel downward under the icon in portrait orientation.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to allow the config/menu wrapper to render in portrait when `configOpen` is true and anchored to the top-center action row instead of the desktop-only placement. 
- Repositioned the portrait panel via inline styles to `top: calc(env(safe-area-inset-top, 0px) + ${PORTRAIT_TOP_ACTION_BAR_DROP_REM}rem + 3.9rem)` and centered it with `left: 50%` and `transform: translateX(-50%)` so it appears below the top menu icon.
- Hid the duplicate desktop-style Menu trigger in portrait by toggling its class (`hidden` in portrait) so only the portrait action-row control is used.
- Tuned panel sizing/scroll behavior by reducing portrait `max-height` to `56vh` and removed the previous ordering that made the panel appear above the trigger.

### Testing
- Ran `npm --prefix webapp run build` to verify production build artifacts and the change compiled successfully (build succeeded).
- Ran the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and used an automated Playwright script to open Pool Royale and the menu in a mobile viewport, producing a screenshot to confirm the panel appears under the icon (script and screenshot succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4babc4908329968685c8c1107aa3)