### PR TITLE
Align Snake & Ladder table layout with Ludo and restore in-asset SFX set

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -57,9 +57,9 @@ const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const DEFAULT_PLAYER_COUNT = 4;
 const CUSTOM_CHAIR_ANGLES = [
   THREE.MathUtils.degToRad(90),
-  THREE.MathUtils.degToRad(315),
+  THREE.MathUtils.degToRad(0),
   THREE.MathUtils.degToRad(270),
-  THREE.MathUtils.degToRad(225)
+  THREE.MathUtils.degToRad(180)
 ];
 
 const DEFAULT_CHAIR_OPTION = Object.freeze({
@@ -184,7 +184,7 @@ const TILE_100_SUPPORT_RADIUS = TILE_SIZE * 0.58;
 const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
 
 const TOKEN_RADIUS_SCALE = 1.19;
-const TOKEN_SCALE_MULTIPLIER = 1.7;
+const TOKEN_SCALE_MULTIPLIER = 1;
 const TOKEN_RADIUS = TILE_SIZE * 0.3 * TOKEN_RADIUS_SCALE * TOKEN_SCALE_MULTIPLIER;
 const TOKEN_HEIGHT = 0.09 * TOKEN_SCALE_MULTIPLIER;
 const CHESS_TOKEN_HEIGHT_SCALE = 1;
@@ -2705,6 +2705,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     updateCameraTarget,
     updateHdriZoom,
     controls,
+    tableInfo,
     seatAnchors: chairs.map(({ anchor }) => anchor)
   };
 }
@@ -3174,7 +3175,8 @@ function updateTokens(
     tokenPrototypes = null,
     seatAnchors = [],
     boardLookTarget = null,
-    boardRoot = null
+    boardRoot = null,
+    tableInfo = null
   } = {}
 ) {
   if (!tokensGroup) return;
@@ -3447,11 +3449,32 @@ function updateTokens(
           const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
           const seatDistance = seatWorld.distanceTo(boardLookTarget);
           const inwardInset = TOKEN_REST_RAIL_INSET_BY_SEAT[seatIndex] ?? TILE_SIZE * 1.35;
-          const restRadius = clamp(
+          let restRadius = clamp(
             seatDistance - inwardInset,
             TOKEN_REST_MIN_RADIUS,
             Math.max(TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.4, seatDistance - TOKEN_RADIUS * 0.55)
           );
+          if (tableInfo?.getInnerRadius) {
+            const inner = tableInfo.getInnerRadius(seatDirection);
+            if (Number.isFinite(inner) && inner > 0) {
+              const outer = tableInfo.getOuterRadius?.(seatDirection) ?? inner;
+              const rimInner = Math.min(inner, outer);
+              const rimOuter = Math.max(inner, outer);
+              const rimMid = rimInner + (rimOuter - rimInner) * 0.35;
+              restRadius = Math.max(restRadius, THREE.MathUtils.clamp(rimMid, rimInner + 0.05, rimOuter - 0.08));
+              restRadius = Math.max(restRadius, BOARD_RADIUS + TILE_SIZE * 1.1);
+              if (Number.isFinite(rimOuter)) {
+                restRadius = Math.min(restRadius, rimOuter - 0.12);
+              }
+            }
+          }
+          if (tableInfo?.getOuterRadius) {
+            const outer = tableInfo.getOuterRadius(seatDirection);
+            if (Number.isFinite(outer) && outer > 0) {
+              restRadius = Math.min(restRadius, outer - 0.14);
+            }
+          }
+          restRadius = Math.max(restRadius, TOKEN_REST_MIN_RADIUS);
           const railSpread = TOKEN_REST_LATERAL_BY_SEAT[seatIndex] ?? 0;
           const railWorld = boardLookTarget
             .clone()
@@ -4189,7 +4212,8 @@ export default function SnakeBoard3D({
       tokenPrototypes: board.tokenPrototypes,
       seatAnchors: board.seatAnchors,
       boardLookTarget: board.boardLookTarget,
-      boardRoot: board.root
+      boardRoot: board.root,
+      tableInfo: board.tableInfo
     });
 
     const sanitizedPositions = players.map((player) => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4,13 +4,6 @@ import DiceRoller from "../../components/DiceRoller.jsx";
 import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
 import { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
 import {
-  dropSound,
-  snakeSound,
-  ladderSound,
-  bombSound,
-  timerBeep,
-  badLuckSound,
-  cheerSound,
   chatBeep,
 } from "../../assets/soundData.js";
 import { AVATARS } from "../../components/AvatarPickerModal.jsx";
@@ -177,6 +170,15 @@ const PAWN_HEAD_PRESET_OPTIONS = Object.freeze([
 ]);
 
 const PLAYERS = 4;
+const SNAKE_SFX = Object.freeze({
+  move: '/assets/sounds/domino-pieces-1-32112 (mp3cut.net).mp3',
+  snake: '/assets/sounds/snake-hissing-high-quality-240154.mp3',
+  ladder: '/assets/sounds/successful.mp3',
+  bomb: '/assets/sounds/a-bomb-139689.mp3',
+  timer: '/assets/sounds/clock-ticking-60-second-countdown-118231.mp3',
+  badLuck: '/assets/sounds/no-luck-too-bad-disappointing-sound-effect-112943.mp3',
+  cheer: '/assets/sounds/crowd-cheering-383111.mp3'
+});
 // Adjusted board dimensions to show five columns
 // while keeping the total cell count at 100
 const FINAL_TILE = BOARD_FINAL_TILE;
@@ -1785,13 +1787,13 @@ export default function SnakeAndLadder() {
       })
       .catch(() => {});
     const vol = getGameVolume();
-    moveSoundRef.current = new Audio(dropSound);
+    moveSoundRef.current = new Audio(SNAKE_SFX.move);
     moveSoundRef.current.volume = vol;
-    snakeSoundRef.current = new Audio(snakeSound);
+    snakeSoundRef.current = new Audio(SNAKE_SFX.snake);
     snakeSoundRef.current.volume = vol;
-    oldSnakeSoundRef.current = new Audio(dropSound);
+    oldSnakeSoundRef.current = new Audio(SNAKE_SFX.move);
     oldSnakeSoundRef.current.volume = vol;
-    ladderSoundRef.current = new Audio(ladderSound);
+    ladderSoundRef.current = new Audio(SNAKE_SFX.ladder);
     ladderSoundRef.current.volume = vol;
     winSoundRef.current = new Audio("/assets/sounds/successful.mp3");
     winSoundRef.current.volume = vol;
@@ -1801,13 +1803,13 @@ export default function SnakeAndLadder() {
     yabbaSoundRef.current.volume = vol;
     hahaSoundRef.current = new Audio("/assets/sounds/Haha.mp3");
     hahaSoundRef.current.volume = vol;
-    bombSoundRef.current = new Audio(bombSound);
+    bombSoundRef.current = new Audio(SNAKE_SFX.bomb);
     bombSoundRef.current.volume = vol;
-    badLuckSoundRef.current = new Audio(badLuckSound);
+    badLuckSoundRef.current = new Audio(SNAKE_SFX.badLuck);
     badLuckSoundRef.current.volume = vol;
-    cheerSoundRef.current = new Audio(cheerSound);
+    cheerSoundRef.current = new Audio(SNAKE_SFX.cheer);
     cheerSoundRef.current.volume = vol;
-    timerSoundRef.current = new Audio(timerBeep);
+    timerSoundRef.current = new Audio(SNAKE_SFX.timer);
     timerSoundRef.current.volume = vol;
     diceRollSoundRef.current = createDiceRollAudio({ muted });
     if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder match the Ludo Battle Royal visual layout by aligning chair positions and token sizing so off-board tokens sit on the table rails like Ludo.
- Ensure the Snake & Ladder game uses the original in-repo sound assets for consistent audio feedback.

### Description
- Updated chair placement angles to a plus-style layout by changing `CUSTOM_CHAIR_ANGLES` in `SnakeBoard3D.jsx` to match the Ludo seating orientation (`90°, 0°, 270°, 180°`).
- Reduced token scale by setting `TOKEN_SCALE_MULTIPLIER` from `1.7` to `1` so token sizes match Ludo tokens.
- Plumbed `tableInfo` through the arena/board (`buildArena` return value) and into `updateTokens` so rail/rest placement can use the table's `getInnerRadius` / `getOuterRadius` helpers; updated `updateTokens` to compute `restRadius` using the table rim geometry and clamp tokens to the wooden rail footprint.
- Replaced runtime SFX imports in `SnakeAndLadder.jsx` with an explicit `SNAKE_SFX` map pointing to `/assets/sounds/*` and initialized audio using those paths so the game uses the existing in-repo sounds (move, snake, ladder, bomb, timer, bad-luck, cheer).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (vite build output). ✅
- Launched the dev server with `npm --prefix webapp run dev` and visually inspected the `/games/snake` page; captured a portrait screenshot for verification via Playwright. ✅
- Verified the updated files render without runtime errors in the dev server and tokens/seat anchors are computed with the new `tableInfo` logic. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acfce630288329a073db3327a391d5)