### PR TITLE
Pool Royale: lift balls onto cloth and increase spin strength

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1444,7 +1444,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = 0; // keep ball centers exactly one radius above the cloth surface
+const BALL_CENTER_LIFT = BALL_R * 0.012; // lift balls by ~1.2% radius so their bottom rides precisely on top of the cloth without visual clipping
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1745,7 +1745,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 900;
 const POCKET_VIEW_EARLY_HOLD_MS = 160;
-const SPIN_GLOBAL_SCALE = 0.72; // boost overall spin impact by 20%
+const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;


### PR DESCRIPTION
### Motivation
- Ensure cue and object balls visually sit on the cloth (bottom of balls roll on top surface) and increase perceived spin responsiveness to match requested +25% spin effect.

### Description
- Adjusted ball rendering / placement by changing `BALL_CENTER_LIFT` from `0` to `BALL_R * 0.012` so ball bottoms rest precisely on the cloth; change made in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Increased overall spin tuning by changing `SPIN_GLOBAL_SCALE` from `0.72` to `0.9` (≈25% increase) in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully.
- Started the dev server with `npm --prefix webapp run dev` (server came up), and an automated Playwright screenshot attempt of `/games/poolroyale` timed out in this environment (no screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acfd66d5c0832989ef380e00823743)