### PR TITLE
Restore Snake & Ladder dice-roll audio to prior mix level

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1812,7 +1812,6 @@ export default function SnakeAndLadder() {
     timerSoundRef.current = new Audio(SNAKE_SFX.timer);
     timerSoundRef.current.volume = vol;
     diceRollSoundRef.current = createDiceRollAudio({ muted });
-    if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -2170,7 +2169,6 @@ export default function SnakeAndLadder() {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       if (!muted && diceRollSoundRef.current) {
-        if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
         diceRollSoundRef.current.currentTime = 0;
         diceRollSoundRef.current.play().catch(() => {});
       }


### PR DESCRIPTION
### Motivation
- Preserve the previously balanced dice-roll audio mix by removing recent hard-coded loudness overrides so dice SFX follow the shared game volume pipeline.

### Description
- Removed the forced `diceRollSoundRef.current.volume = 1` assignment during audio setup and the repeated forced volume set in the roll handler so dice playback uses the `createDiceRollAudio()` default (which calls `getGameVolume()`).

### Testing
- Ran `npx -y eslint webapp/src/pages/Games/SnakeAndLadder.jsx` which reported the file is ignored by lint config (no errors produced).
- Ran `npx -y eslint --no-ignore webapp/src/pages/Games/SnakeAndLadder.jsx` (same ignore warning, no errors).
- Ran `npm -C webapp run -s lint` which exited with code 1 in this environment (lint step failed globally; not caused by the change to dice volume lines).
- Verified the change diff affects only the dice roll volume assignments in `webapp/src/pages/Games/SnakeAndLadder.jsx` and committed the patch as `Restore snake dice roll audio level to baseline mix`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad06f6fcc08329b30582b824bbd16f)