### PR TITLE
Restore legacy dice-roll sound with embedded-data fallback

### DIFF
--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -1,10 +1,18 @@
 import { diceSound } from '../assets/soundData.js'
 import { getGameVolume } from './sound.js'
 
+const LEGACY_DICE_ROLL_SOUND = '/assets/sounds/2FilesMerged_20250717_131957.mp3'
+
 export function createDiceRollAudio ({ muted = false } = {}) {
-  const audio = new Audio(diceSound)
+  const audio = new Audio(LEGACY_DICE_ROLL_SOUND)
   audio.preload = 'auto'
   audio.muted = muted
   audio.volume = getGameVolume()
+  audio.addEventListener('error', () => {
+    if (audio.src !== diceSound) {
+      audio.src = diceSound
+      audio.load()
+    }
+  }, { once: true })
   return audio
 }


### PR DESCRIPTION
### Motivation
- Restore the exact dice-roll SFX users expect for Snake & Ladder by preferring the original hosted clip instead of the embedded data URI. 
- Provide a robust fallback so the game still plays a roll sound if the hosted clip fails to load. 
- Keep existing volume/mute behavior and avoid changing other game audio wiring.

### Description
- Updated `createDiceRollAudio` in `webapp/src/utils/diceAudio.js` to prefer the legacy clip at `/assets/sounds/2FilesMerged_20250717_131957.mp3` when constructing the `Audio` object. 
- Added a one-time `error` listener that falls back to the embedded `diceSound` data URI if the legacy clip cannot load. 
- Preserved the existing `muted` and `getGameVolume()` handling and did not modify other callers (e.g., `DiceRoller` / `SnakeAndLadder`).

### Testing
- Ran a production build with `cd webapp && npm run -s build`, which completed successfully (Vite build finished and outputs generated). 
- Verified the application bundles and that `webapp/src/utils/diceAudio.js` now initializes `Audio` with the legacy clip and includes the fallback logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad06f6fcc08329b30582b824bbd16f)