### PR TITLE
Domino: use GLTF Battle Royale table as default theme

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2262,11 +2262,11 @@ const MURLAN_TABLE_THEMES = Object.freeze(
       id: 'murlan-default',
       label: 'Murlan Default Table',
       source: 'polyhaven',
-      assetId: 'CoffeeTable_01',
+      assetId: 'round_wooden_table_02',
       price: 0,
-      thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+      thumbnail: POLYHAVEN_THUMB('round_wooden_table_02'),
       description:
-        'Standard Murlan Royale table using the default GLTF texture set.'
+        'Battle Royale octagon-ready table using the same GLTF texture workflow as Chess, Ludo, and Texas.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -4114,7 +4114,7 @@ const DEFAULT_APPEARANCE = Object.freeze(
 );
 const APPEARANCE_STORAGE_KEY = 'dominoRoyalArenaAppearanceV3';
 const LEGACY_APPEARANCE_KEYS = ['dominoRoyalArenaAppearanceV2', 'dominoRoyalArenaAppearance'];
-const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV1';
+const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV2';
 let appearance = { ...DEFAULT_APPEARANCE };
 let dominoInventory = getDominoInventory();
 


### PR DESCRIPTION
### Motivation

- Make the Domino Battle Royal arena use the same GLTF-backed table and texture workflow used by other Battle Royale games (Chess, Ludo, Texas) instead of the procedural default.
- Ensure existing saved Domino appearances are re-normalized to the new default so players see the intended GLTF table without manual opt-in.

### Description

- Switched the Domino `murlan-default` table entry to use the GLTF asset `round_wooden_table_02` and updated its thumbnail and description in `webapp/public/domino-royal-game.js`.
- Bumped the local migration key from `dominoRoyalMurlanDefaultTableMigrationV1` to `dominoRoyalMurlanDefaultTableMigrationV2` so stored appearances are migrated to the new default.
- No gameplay logic was changed; this only replaces the default theme metadata so the GLTF loading path and shared texture handling are used for Domino as with other BR games.

### Testing

- Ran `node --check webapp/public/domino-royal-game.js` to validate the modified JS syntax, which succeeded.
- Started the webapp with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the dev server booted successfully.
- Automated visual verification using Playwright to open `/games/domino-royal` at a mobile viewport and capture a screenshot, which completed and produced the artifact shown in the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4a112eb08329b594dc0c2d47a181)