### PR TITLE
Update mining task TikTok video links and embed mapping

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -188,7 +188,7 @@ export default function DailyCheckIn() {
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
       <TikTokTaskVideo
         title="Daily Streaks Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hSaGs/"
+        videoUrl="https://vt.tiktok.com/ZSujamUuD/"
         storageKey="dailyStreaksVideoPopupSeen"
       />
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -148,7 +148,7 @@ export default function LuckyNumber() {
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
       <TikTokTaskVideo
         title="Lucky Card Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hN8Xq/"
+        videoUrl="https://vt.tiktok.com/ZSujaXgpP/"
         storageKey="luckyCardVideoPopupSeen"
       />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -271,7 +271,7 @@ export default function RouletteMini() {
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
       <TikTokTaskVideo
         title="Roulette Spin Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hc7YM/"
+        videoUrl="https://vt.tiktok.com/ZSujagfxp/"
         storageKey="rouletteVideoPopupSeen"
       />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -266,7 +266,7 @@ export default function SpinGame() {
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
       <TikTokTaskVideo
         title="Spin & Win Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hAvuM/"
+        videoUrl="https://vt.tiktok.com/ZSujaPuVF/"
         storageKey="spinWinVideoPopupSeen"
       />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -8,10 +8,14 @@ function getVideoId(urlOrId) {
   if (match) return match[1];
 
   const shortLinkVideoMap = {
-    'https://vt.tiktok.com/ZSu8hSaGs/': '7614140234548153607',
-    'https://vt.tiktok.com/ZSu8hAvuM/': '7614138222150847762',
-    'https://vt.tiktok.com/ZSu8hN8Xq/': '7614133483421584658',
-    'https://vt.tiktok.com/ZSu8hc7YM/': '7614119495149292818',
+    'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
+    'https://vt.tiktok.com/ZSujamUuD': '7614838290667031816',
+    'https://vt.tiktok.com/ZSujaPuVF/': '7614600402654252296',
+    'https://vt.tiktok.com/ZSujaPuVF': '7614600402654252296',
+    'https://vt.tiktok.com/ZSujaXgpP/': '7614860616703986951',
+    'https://vt.tiktok.com/ZSujaXgpP': '7614860616703986951',
+    'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
+    'https://vt.tiktok.com/ZSujagfxp': '7614503027684216071',
   };
   return shortLinkVideoMap[raw] || '';
 }


### PR DESCRIPTION
### Motivation
- Replace the promo videos used by the Mining mini-games with the new TikTok short links so the task popups play the requested videos automatically.
- Ensure the in-app TikTok embed resolver can handle the provided `vt.tiktok.com` short URLs so the popup iframe can autoplay the correct video.

### Description
- Replaced the `videoUrl` props in the Mining-related components to the new short links for Daily Streaks, Spin & Win, Lucky Card and Roulette Spin (`DailyCheckIn.jsx`, `SpinGame.jsx`, `LuckyNumber.jsx`, `RouletteMini.jsx`).
- Extended the short-link mapping in `TikTokTaskVideo.jsx` so each new `vt.tiktok.com` short URL (with and without trailing slash) resolves to the correct numeric TikTok video id used by the embed.
- Kept the embed autoplay configuration (`autoplay=1`) and the popup open logic so the iframe begins playback automatically when the user opens the task popup.

### Testing
- Verified each short link resolves to the canonical TikTok URL using `curl -Ls -o /dev/null -w '%{url_effective}\n' <short-url>` and confirmed expected redirects succeeded.
- Built the webapp production bundle with `npm run build` (from `webapp/`) and the build completed successfully.
- Launched the dev server and used a Playwright script to open `/mining` in a mobile viewport and capture a screenshot to validate the new task buttons and popups rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4c61ae5c8329bd967df8ff42dbab)