### PR TITLE
Tune Pool Royale aim suggestion, topspin, rail overhead camera, and ball-in-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1905,7 +1905,7 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.35;
 const SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
 const SIDE_SPIN_MULTIPLIER = 1.5 * SPIN_GLOBAL_BOOST_MULTIPLIER;
 const BACKSPIN_MULTIPLIER = 2.6 * SPIN_GLOBAL_BOOST_MULTIPLIER;
-const TOPSPIN_MULTIPLIER = 1.5 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const TOPSPIN_MULTIPLIER = 1.62 * SPIN_GLOBAL_BOOST_MULTIPLIER;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -5312,10 +5312,10 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
-  z: TOP_VIEW_SCREEN_OFFSET.z // keep rail-overhead controls/camera coordinates identical to portrait 2D view
+  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.01 // nudge rail-overhead framing slightly inward toward table center
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
-const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
+const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.035; // lift rail-overhead camera slightly higher for clearer broadcast context
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const REPLAY_TOP_VIEW_PHI = TOP_VIEW_PHI;
@@ -5405,7 +5405,7 @@ const CUE_VIEW_AIM_LINE_LERP = 0.1; // aiming line interpolation factor while th
 const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor while the camera is near standing view
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
-const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.02; // pitch the rail-overhead broadcast a little more downward during aim assists
+const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -24068,8 +24068,17 @@ const powerRef = useRef(hud.power);
         const frameSnapshot = frameRef.current ?? frameState;
         const variant =
           frameSnapshot?.meta?.variant ?? activeVariantRef.current?.id ?? variantKey;
-        if (hudRef.current?.inHand || isTraining) {
+        const metaState = frameSnapshot?.meta?.state ?? {};
+        const breakPlacementRestricted = Boolean(
+          metaState.mustPlayFromBaulk ||
+            metaState.breakInProgress ||
+            frameSnapshot?.meta?.breakInProgress
+        );
+        if (isTraining) {
           return true;
+        }
+        if (breakPlacementRestricted) {
+          return false;
         }
         return variant !== 'uk';
       };
@@ -24187,11 +24196,20 @@ const powerRef = useRef(hud.power);
       const tryUpdatePlacement = (raw, commit = false) => {
         const currentHud = hudRef.current;
         if (!(currentHud?.inHand)) return false;
-        const clamped = resolveInHandPlacement(raw);
-        if (!clamped) return false;
+        const directClamped = clampInHandPosition(raw);
+        if (!directClamped) return false;
+        let next = null;
+        if (isSpotFree(directClamped)) {
+          next = directClamped;
+        } else if (commit) {
+          next = resolveInHandPlacement(raw);
+        } else {
+          next = inHandDrag.lastPos?.clone?.() ?? null;
+        }
+        if (!next) return false;
         cue.active = true;
-        updateCuePlacement(clamped);
-        inHandDrag.lastPos = clamped;
+        updateCuePlacement(next);
+        inHandDrag.lastPos = next;
         if (commit) {
           inHandDrag.lastPos = null;
           cueBallPlacedFromHandRef.current = true;
@@ -27422,11 +27440,27 @@ const powerRef = useRef(hud.power);
             }
           }
           if (plan?.targetBall && cue?.pos) {
-            const directDir = new THREE.Vector2(
-              plan.targetBall.pos.x - cue.pos.x,
-              plan.targetBall.pos.y - cue.pos.y
-            );
-            if (applyAimDirection(directDir, suggestionKey)) {
+            let suggestedDir = null;
+            if (plan?.pocketCenter && plan?.targetBall?.pos) {
+              const compensatedAim = resolveAiPotGhostAim({
+                cuePos: cue.pos,
+                targetPos: plan.targetBall.pos,
+                pocketPos: plan.pocketCenter,
+                ballRadius: BALL_R,
+                spin: plan.spin,
+                power: plan.power
+              });
+              if (compensatedAim?.aimDir?.lengthSq?.() > 1e-6) {
+                suggestedDir = compensatedAim.aimDir.clone();
+              }
+            }
+            if (!suggestedDir) {
+              suggestedDir = new THREE.Vector2(
+                plan.targetBall.pos.x - cue.pos.x,
+                plan.targetBall.pos.y - cue.pos.y
+              );
+            }
+            if (applyAimDirection(suggestedDir, suggestionKey)) {
               return;
             }
           }


### PR DESCRIPTION
### Motivation
- Improve post-suggestion aiming so the visible guide better matches the AI-compensated ghost-ball direction for higher pot probability.
- Increase only the topspin forward transfer so the cue ball rolls forward a bit more when topspin is applied without touching other spin axes.
- Adjust the rail-overhead broadcast framing to sit slightly higher, a touch closer to the table, and a little more downward during assisted aims for clearer broadcast presentation.
- Make ball-in-hand / break placement stricter (stay behind the baulk/white line) and make the on-screen drag placement feel extremely precise and predictable.

### Description
- Prefer the AI-compensated ghost-ball aim when applying a user suggestion by using `resolveAiPotGhostAim` before falling back to direct centre-ball aim in `updateUserSuggestion`. (edited `webapp/src/pages/Games/PoolRoyale.jsx`)
- Increase only topspin strength by raising `TOPSPIN_MULTIPLIER` to `1.62 * SPIN_GLOBAL_BOOST_MULTIPLIER`, leaving side/backspin multipliers unchanged. (edited `webapp/src/pages/Games/PoolRoyale.jsx`)
- Tweak rail-overhead broadcast constants by nudging `RAIL_OVERHEAD_SCREEN_OFFSET.z` inward, multiplying `RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE` by `1.035`, and reducing `RAIL_OVERHEAD_AIM_PHI_LIFT` to `0.014` for a slightly higher/closer and subtly more downward aim framing. (edited `webapp/src/pages/Games/PoolRoyale.jsx`)
- Tighten in-hand placement logic so `allowFullTableInHand()` respects break/baulk state (prevents full-table placement when restricted) and `tryUpdatePlacement()` now follows direct clamped pointer motion during drag and only runs the more aggressive collision-resolving placement (`resolveInHandPlacement`) when the placement is committed. (edited `webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleAiAimCompensation.test.js test/poolRoyaleSpinController.test.js` and both suites passed.  (2 suites / 7 tests passed)
- Launched the webapp (`npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`) and captured a Playwright screenshot for visual verification of camera/placement behavior; the dev server started successfully and the screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4b32a9408329a5b45edc7ed1a922)