### PR TITLE
Set Domino default table to shared octagon GLTF theme

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2262,11 +2262,11 @@ const MURLAN_TABLE_THEMES = Object.freeze(
       id: 'murlan-default',
       label: 'Murlan Default Table',
       source: 'polyhaven',
-      assetId: 'CoffeeTable_01',
+      assetId: 'WoodenTable_02',
       price: 0,
-      thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+      thumbnail: POLYHAVEN_THUMB('WoodenTable_02'),
       description:
-        'Standard Murlan Royale table using the default GLTF texture set.'
+        'Standard octagon table shared with Chess, Texas Hold\'em, and Ludo Battle Royale using the default GLTF texture set.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },


### PR DESCRIPTION
### Motivation
- Use the same octagon GLTF-backed table and texture set for Domino Royal as is used by Chess, Texas Hold'em and Ludo Battle Royale instead of the procedural table so the table visuals match across battle-royale table games.

### Description
- Updated `webapp/public/domino-royal-game.js` to change the `MURLAN_TABLE_THEMES` `murlan-default` entry to point at the PolyHaven GLTF asset `WoodenTable_02` (updated `assetId`, `thumbnail` and description) while keeping the same theme id so existing inventory/default wiring remains compatible.

### Testing
- Ran `npm test -- test/inventoryCrossGameConfig.test.js` which passed successfully, and launched the webapp dev server then captured a Playwright screenshot of `http://127.0.0.1:4173/games/domino-royal` to validate the runtime rendering path loaded with the updated default table theme.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4a112eb08329b594dc0c2d47a181)