### PR TITLE
Update mining mini-game TikTok video links and autoplay mapping

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -188,7 +188,7 @@ export default function DailyCheckIn() {
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
       <TikTokTaskVideo
         title="Daily Streaks Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hSaGs/"
+        videoUrl="https://vt.tiktok.com/ZSujamUuD/"
         storageKey="dailyStreaksVideoPopupSeen"
       />
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -148,7 +148,7 @@ export default function LuckyNumber() {
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
       <TikTokTaskVideo
         title="Lucky Card Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hN8Xq/"
+        videoUrl="https://vt.tiktok.com/ZSujaXgpP/"
         storageKey="luckyCardVideoPopupSeen"
       />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -271,7 +271,7 @@ export default function RouletteMini() {
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
       <TikTokTaskVideo
         title="Roulette Spin Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hc7YM/"
+        videoUrl="https://vt.tiktok.com/ZSujagfxp/"
         storageKey="rouletteVideoPopupSeen"
       />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -266,7 +266,7 @@ export default function SpinGame() {
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
       <TikTokTaskVideo
         title="Spin & Win Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hAvuM/"
+        videoUrl="https://vt.tiktok.com/ZSujaPuVF/"
         storageKey="spinWinVideoPopupSeen"
       />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -4,16 +4,17 @@ function getVideoId(urlOrId) {
   if (!urlOrId) return '';
   if (/^\d+$/.test(urlOrId)) return urlOrId;
   const raw = String(urlOrId);
+  const normalized = raw.split('?')[0].replace(/\/+$/, '/');
   const match = raw.match(/\/video\/(\d+)/);
   if (match) return match[1];
 
   const shortLinkVideoMap = {
-    'https://vt.tiktok.com/ZSu8hSaGs/': '7614140234548153607',
-    'https://vt.tiktok.com/ZSu8hAvuM/': '7614138222150847762',
-    'https://vt.tiktok.com/ZSu8hN8Xq/': '7614133483421584658',
-    'https://vt.tiktok.com/ZSu8hc7YM/': '7614119495149292818',
+    'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
+    'https://vt.tiktok.com/ZSujaPuVF/': '7614600402654252296',
+    'https://vt.tiktok.com/ZSujaXgpP/': '7614860616703986951',
+    'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
   };
-  return shortLinkVideoMap[raw] || '';
+  return shortLinkVideoMap[normalized] || '';
 }
 
 export default function TikTokTaskVideo({
@@ -26,7 +27,7 @@ export default function TikTokTaskVideo({
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&loop=1&music_info=0&description=0&controls=1`;
+    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&muted=1&loop=1&music_info=0&description=0&controls=1`;
   }, [videoId]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Replace the short TikTok links used by Mining mini-game popups with the new videos provided so the correct clips play for each task.
- Improve embed reliability so the popup starts playback automatically in mobile/webview contexts.

### Description
- Replaced video short links in the mining UI components: `DailyCheckIn.jsx`, `SpinGame.jsx`, `LuckyNumber.jsx`, and `RouletteMini.jsx` to use the new URLs provided for Daily Streaks, Spin & Win, Lucky Card and Roulette Spin.
- Updated `webapp/src/components/TikTokTaskVideo.jsx` to include the new short-link → video-id mappings and to normalize incoming short URLs before lookup to handle query strings and trailing-slash variants.
- Changed the TikTok embed URL to include `autoplay=1` and `muted=1` so playback starts more reliably when the popup opens.

### Testing
- Resolved each provided short URL to its canonical `/video/<id>` using `curl -Ls -w '%{url_effective}'` and verified the mapping succeeded.
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Ran the dev server with `npm --prefix webapp run dev` and captured mobile-viewport screenshots via a Playwright script to validate the popup buttons and embeds render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4c61ae5c8329bd967df8ff42dbab)