### PR TITLE
Update Mining task TikTok videos to new short links

### DIFF
--- a/webapp/src/components/DailyCheckIn.jsx
+++ b/webapp/src/components/DailyCheckIn.jsx
@@ -188,7 +188,7 @@ export default function DailyCheckIn() {
       <h3 className="text-lg font-bold text-white">Daily Streaks</h3>
       <TikTokTaskVideo
         title="Daily Streaks Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hSaGs/"
+        videoUrl="https://vt.tiktok.com/ZSujamUuD/"
         storageKey="dailyStreaksVideoPopupSeen"
       />
 

--- a/webapp/src/components/LuckyNumber.jsx
+++ b/webapp/src/components/LuckyNumber.jsx
@@ -148,7 +148,7 @@ export default function LuckyNumber() {
       <h3 className="text-lg font-bold text-white">Lucky Card</h3>
       <TikTokTaskVideo
         title="Lucky Card Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hN8Xq/"
+        videoUrl="https://vt.tiktok.com/ZSujaXgpP/"
         storageKey="luckyCardVideoPopupSeen"
       />
       <div className="grid grid-cols-3 gap-2 justify-items-center relative">

--- a/webapp/src/components/RouletteMini.jsx
+++ b/webapp/src/components/RouletteMini.jsx
@@ -271,7 +271,7 @@ export default function RouletteMini() {
       <h3 className="text-lg font-bold text-white">Roulette Spin</h3>
       <TikTokTaskVideo
         title="Roulette Spin Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hc7YM/"
+        videoUrl="https://vt.tiktok.com/ZSujagfxp/"
         storageKey="rouletteVideoPopupSeen"
       />
       <div className="relative mx-auto w-72 h-72 sm:w-80 sm:h-80">

--- a/webapp/src/components/SpinGame.jsx
+++ b/webapp/src/components/SpinGame.jsx
@@ -266,7 +266,7 @@ export default function SpinGame() {
       <h3 className="text-lg font-bold text-white">Spin &amp; Win</h3>
       <TikTokTaskVideo
         title="Spin & Win Video"
-        videoUrl="https://vt.tiktok.com/ZSu8hAvuM/"
+        videoUrl="https://vt.tiktok.com/ZSujaPuVF/"
         storageKey="spinWinVideoPopupSeen"
       />
       <p className="text-sm text-subtext">Try your luck and win rewards!</p>

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -8,10 +8,10 @@ function getVideoId(urlOrId) {
   if (match) return match[1];
 
   const shortLinkVideoMap = {
-    'https://vt.tiktok.com/ZSu8hSaGs/': '7614140234548153607',
-    'https://vt.tiktok.com/ZSu8hAvuM/': '7614138222150847762',
-    'https://vt.tiktok.com/ZSu8hN8Xq/': '7614133483421584658',
-    'https://vt.tiktok.com/ZSu8hc7YM/': '7614119495149292818',
+    'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
+    'https://vt.tiktok.com/ZSujaPuVF/': '7614600402654252296',
+    'https://vt.tiktok.com/ZSujaXgpP/': '7614860616703986951',
+    'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
   };
   return shortLinkVideoMap[raw] || '';
 }


### PR DESCRIPTION
### Motivation
- Replace the TikTok videos shown in Mining-related tasks with the new short URLs provided so users see the requested videos when opening the task popups.
- Ensure the in-modal player starts playback automatically when the task popup is opened by the user.

### Description
- Added the four new short-link → video-id mappings in `webapp/src/components/TikTokTaskVideo.jsx` so short vt.tiktok.com links resolve to embed-able IDs.
- Replaced the `videoUrl` props in the Mining task components `DailyCheckIn.jsx`, `SpinGame.jsx`, `LuckyNumber.jsx` and `RouletteMini.jsx` to use the new short links you provided.
- Kept the existing embed behavior which constructs a TikTok player URL with `autoplay=1`, so the iframe starts playback automatically when the popup is opened.

### Testing
- Followed each short link with `curl -Ls -o /dev/null -w '%{url_effective}\n'` and verified they resolve to valid TikTok video URLs with IDs successfully.
- Used `rg` (ripgrep) across `webapp/src/components` to confirm the old short links were removed and the new short links are present in the four updated components.
- Verified `TikTokTaskVideo` still produces the expected embed URL format (`https://www.tiktok.com/player/v1/<id>?autoplay=1...`) so the modal iframe will autoplay when opened.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4c61ae5c8329bd967df8ff42dbab)