### PR TITLE
Make Murlan default table procedural and bump default table migration key to V3

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2261,12 +2261,12 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Murlan Default Table',
-      source: 'polyhaven',
-      assetId: 'CoffeeTable_01',
+      source: 'procedural',
+      assetId: null,
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Standard Murlan Royale table using the default GLTF texture set.'
+        'Shared Battle Royale octagon table baseline used across Chess, Ludo, Texas, and Domino.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -4114,7 +4114,7 @@ const DEFAULT_APPEARANCE = Object.freeze(
 );
 const APPEARANCE_STORAGE_KEY = 'dominoRoyalArenaAppearanceV3';
 const LEGACY_APPEARANCE_KEYS = ['dominoRoyalArenaAppearanceV2', 'dominoRoyalArenaAppearance'];
-const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV1';
+const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV3';
 let appearance = { ...DEFAULT_APPEARANCE };
 let dominoInventory = getDominoInventory();
 


### PR DESCRIPTION
### Motivation
- Replace the Murlan default table so it uses a shared procedural baseline instead of a Polyhaven asset to standardize the octagon table across game modes.
- Ensure user appearances that rely on the previous default are re-evaluated by bumping the migration key.

### Description
- Change the Murlan default table entry to use `source: 'procedural'` and `assetId: null` so it no longer treats the default as a Polyhaven asset. 
- Update the default table description to reflect that it is a shared Battle Royale octagon table baseline used across Chess, Ludo, Texas, and Domino. 
- Update `DEFAULT_TABLE_MIGRATION_KEY` from `dominoRoyalMurlanDefaultTableMigrationV1` to `dominoRoyalMurlanDefaultTableMigrationV3` to force migration/re-evaluation of saved appearances.

### Testing
- Ran the frontend build with `yarn build` to verify the bundle compiles successfully and the file changes do not break the build; build succeeded. 
- Executed the test suite with `yarn test` to ensure no regressions in unit tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4a112eb08329b594dc0c2d47a181)