### PR TITLE
Fix unavailable TikTok videos on Mining page promo modals

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -3,9 +3,11 @@ import { useEffect, useMemo, useState } from 'react';
 function getVideoId(urlOrId) {
   if (!urlOrId) return '';
   if (/^\d+$/.test(urlOrId)) return urlOrId;
-  const raw = String(urlOrId);
+  const raw = String(urlOrId).trim();
   const match = raw.match(/\/video\/(\d+)/);
   if (match) return match[1];
+
+  const normalized = raw.endsWith('/') ? raw : `${raw}/`;
 
   const shortLinkVideoMap = {
     'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
@@ -13,7 +15,7 @@ function getVideoId(urlOrId) {
     'https://vt.tiktok.com/ZSujaXgpP/': '7614860616703986951',
     'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
   };
-  return shortLinkVideoMap[raw] || '';
+  return shortLinkVideoMap[raw] || shortLinkVideoMap[normalized] || '';
 }
 
 export default function TikTokTaskVideo({
@@ -26,7 +28,7 @@ export default function TikTokTaskVideo({
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&loop=1&music_info=0&description=0&controls=1`;
+    return `https://www.tiktok.com/embed/v2/${videoId}`;
   }, [videoId]);
 
   useEffect(() => {
@@ -72,6 +74,9 @@ export default function TikTokTaskVideo({
             ) : (
               <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
             )}
+            <p className="px-3 pt-2 text-center text-[11px] text-subtext">
+              If TikTok embed is unavailable on your device, use “Open on TikTok”.
+            </p>
             <a
               href={videoUrl}
               target="_blank"


### PR DESCRIPTION
### Motivation

- Users reported that promo videos shown in the Mining page widgets (Daily Streaks, Spin & Win, Lucky Card, Roulette) displayed as unavailable because the shared video component produced invalid/unsupported embed URLs.

### Description

- Hardened `TikTokTaskVideo` URL parsing by trimming input and normalizing short-link variants with or without a trailing slash in `webapp/src/components/TikTokTaskVideo.jsx`.
- Switched the iframe source from `https://www.tiktok.com/player/v1/...` to `https://www.tiktok.com/embed/v2/...` to improve embed compatibility inside modal dialogs.
- Added a small in-modal fallback note prompting users to `Open on TikTok` when embeds are blocked or unavailable.

### Testing

- Built the frontend with `cd webapp && npm run -s build`, which completed successfully.
- Launched the dev server and ran an automated Playwright script to load `/mining` and capture the updated modal; the automated browser run produced a screenshot artifact and completed successfully (one earlier attempt timed out and a retry succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae548d7bf88329904aa5dc93d18c46)