### PR TITLE
Make Octagon Table the default (preserve GLTF UVs) and bump domino texture resolution to 2048

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -87,7 +87,7 @@ const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 1536,
   chairClothTextureSize: 1536,
-  dominoTextureSize: 1536
+  dominoTextureSize: 2048
 });
 
 function detectCoarsePointer() {
@@ -2260,13 +2260,14 @@ const MURLAN_TABLE_THEMES = Object.freeze(
   [
     {
       id: 'murlan-default',
-      label: 'Murlan Default Table',
-      source: 'procedural',
-      assetId: null,
+      label: 'Octagon Table',
+      source: 'polyhaven',
       price: 0,
+      assetId: 'CoffeeTable_01',
+      preserveMaterials: true,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Shared Battle Royale octagon table baseline used across Chess, Ludo, Texas, and Domino.'
+        'Shared Battle Royale octagon table with original Pool Royale GLTF UV mapping.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },

--- a/webapp/src/config/dominoRoyalThemeCatalog.js
+++ b/webapp/src/config/dominoRoyalThemeCatalog.js
@@ -114,11 +114,13 @@ const POLYHAVEN_TABLE_THEMES = [
 export const DOMINO_ROYAL_TABLE_THEMES = [
   {
     id: 'murlan-default',
-    label: 'Murlan Default Table',
-    source: 'procedural',
+    label: 'Octagon Table',
+    source: 'polyhaven',
     price: 0,
+    assetId: 'CoffeeTable_01',
+    preserveMaterials: true,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
-    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    description: 'Shared Battle Royale octagon table with original Pool Royale GLTF UV mapping.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -165,11 +165,13 @@ const POLYHAVEN_TABLE_THEMES = [
 export const MURLAN_TABLE_THEMES = [
   {
     id: 'murlan-default',
-    label: 'Murlan Default Table',
-    source: 'procedural',
+    label: 'Octagon Table',
+    source: 'polyhaven',
     price: 0,
+    assetId: 'CoffeeTable_01',
+    preserveMaterials: true,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
-    description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+    description: 'Shared Battle Royale octagon table with original Pool Royale GLTF UV mapping.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];


### PR DESCRIPTION
### Motivation
- Ensure Domino tiles have visual fidelity matching the table and chairs by using the same GLTF table asset and preserving its original UV/material mapping. 
- Make the shared Battle Royale table name clearer (Octagon) and align Domino’s default theme with Pool Royale inventory mapping for consistent visuals.

### Description
- Renamed the shared default `murlan-default` table label to **Octagon Table** and set it to use the Poly Haven GLTF asset `CoffeeTable_01` with `preserveMaterials: true` in `webapp/src/config/murlanThemes.js` and `webapp/src/config/dominoRoyalThemeCatalog.js`. 
- Applied the same default-table naming and `preserveMaterials` settings to the in-game runtime bundle in `webapp/public/domino-royal-game.js` so the Domino runtime loads the GLTF with original UV mapping. 
- Increased `MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize` from `1536` to `2048` in `webapp/public/domino-royal-game.js` so domino tile textures better match table/chair resolution.
- Minor description/thumbnail updates to reflect the Octagon table and preserved GLTF mapping across the catalog and runtime.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and `node --check webapp/src/config/*.js` which completed without errors. 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served successfully. 
- Captured a visual verification screenshot of the Domino Royal lobby using a Playwright script (artifact: `browser:/tmp/codex_browser_invocations/38f8c4c017bf04d7/artifacts/artifacts/domino-royal-lobby.png`). 
- No unit tests were added or run for these config/runtime edits; runtime checks and visual verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae58af0cf08329a63855196ba126ff)