### PR TITLE
Fix mining promo videos: resilient TikTok embeds + fullscreen popup

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 function getVideoId(urlOrId) {
   if (!urlOrId) return '';
@@ -18,6 +18,16 @@ function getVideoId(urlOrId) {
   return shortLinkVideoMap[raw] || shortLinkVideoMap[normalized] || '';
 }
 
+function ensureTikTokEmbedScript() {
+  if (typeof document === 'undefined') return;
+  if (document.querySelector('script[data-tiktok-embed]')) return;
+  const script = document.createElement('script');
+  script.src = 'https://www.tiktok.com/embed.js';
+  script.async = true;
+  script.setAttribute('data-tiktok-embed', '1');
+  document.body.appendChild(script);
+}
+
 export default function TikTokTaskVideo({
   videoUrl,
   title = 'Watch Promo Video',
@@ -25,18 +35,33 @@ export default function TikTokTaskVideo({
   storageKey,
 }) {
   const [open, setOpen] = useState(false);
+  const [embedFailed, setEmbedFailed] = useState(false);
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
-  const embedUrl = useMemo(() => {
+  const canonicalVideoUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/embed/v2/${videoId}`;
+    return `https://www.tiktok.com/@tonplaygram/video/${videoId}`;
   }, [videoId]);
+  const embedRef = useRef(null);
 
   useEffect(() => {
-    if (!autoOpen || !embedUrl || !storageKey) return;
+    if (!autoOpen || !videoId || !storageKey) return;
     if (localStorage.getItem(storageKey) === '1') return;
     setOpen(true);
     localStorage.setItem(storageKey, '1');
-  }, [autoOpen, embedUrl, storageKey]);
+  }, [autoOpen, videoId, storageKey]);
+
+  useEffect(() => {
+    if (!open || !videoId || !embedRef.current) return;
+    setEmbedFailed(false);
+    ensureTikTokEmbedScript();
+
+    const timeout = setTimeout(() => {
+      const rendered = embedRef.current?.querySelector('iframe');
+      if (!rendered) setEmbedFailed(true);
+    }, 3500);
+
+    return () => clearTimeout(timeout);
+  }, [open, videoId]);
 
   return (
     <>
@@ -48,44 +73,43 @@ export default function TikTokTaskVideo({
       </button>
 
       {open && (
-        <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-          <div className="w-full max-w-sm rounded-xl overflow-hidden border border-white/20 bg-black">
-            <div className="flex items-center justify-between px-3 py-2 border-b border-white/15">
-              <span className="text-sm font-semibold text-white">{title}</span>
-              <button
-                onClick={() => setOpen(false)}
-                className="text-xs text-subtext hover:text-white"
-              >
-                Close
-              </button>
-            </div>
-            {embedUrl ? (
-              <div className="relative w-full pt-[177.78%]">
-                <iframe
-                  title={title}
-                  src={embedUrl}
-                  className="absolute inset-0 w-full h-full"
-                  allow="autoplay; encrypted-media; picture-in-picture"
-                  allowFullScreen
-                  loading="lazy"
-                  referrerPolicy="strict-origin-when-cross-origin"
-                />
-              </div>
-            ) : (
-              <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
-            )}
-            <p className="px-3 pt-2 text-center text-[11px] text-subtext">
-              If TikTok embed is unavailable on your device, use “Open on TikTok”.
-            </p>
-            <a
-              href={videoUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="block text-center text-xs text-subtext py-2"
+        <div className="fixed inset-0 z-50 bg-black flex flex-col">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/15">
+            <span className="text-sm font-semibold text-white">{title}</span>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-xs text-subtext hover:text-white"
             >
-              Open on TikTok
-            </a>
+              Close
+            </button>
           </div>
+
+          {videoId ? (
+            <div className="flex-1 overflow-auto p-2" ref={embedRef}>
+              <blockquote
+                className="tiktok-embed"
+                cite={canonicalVideoUrl || videoUrl}
+                data-video-id={videoId}
+                style={{ margin: 0, minWidth: '100%', maxWidth: '100%' }}
+              />
+              {embedFailed && (
+                <div className="p-4 text-sm text-subtext text-center">
+                  TikTok video is unavailable in this in-app browser.
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
+          )}
+
+          <a
+            href={canonicalVideoUrl || videoUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="block text-center text-sm text-brand-gold py-3 border-t border-white/15"
+          >
+            Open on TikTok
+          </a>
         </div>
       )}
     </>


### PR DESCRIPTION
### Motivation
- Mining page promo videos (Daily Streaks, Spin & Win lucky card, Roulette) were showing as unavailable due to fragile iframe embeds and the popup was too small for portrait mobile view.
- Provide a single, maintainable component-level fix so all mining-related video buttons benefit from a more resilient embed strategy and improved UX.

### Description
- Replaced fixed TikTok iframe embedding with TikTok `embed.js` + `blockquote` rendering and added `ensureTikTokEmbedScript()` to inject the script when needed in `webapp/src/components/TikTokTaskVideo.jsx`.
- Added canonical TikTok URL generation from resolved video IDs and a visible “Open on TikTok” fallback link when embed is blocked.
- Implemented embed availability detection via a `ref` and a timeout to show a friendly fallback message if the in-app browser blocks the embed.
- Switched the popup layout to a true fullscreen modal so videos open large on portrait phones and are immediately visible.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully.
- Launched the dev server with `npm -C webapp run dev` and executed an automated Playwright script that opened `/mining` in a 390×844 viewport and captured a screenshot of the video popup, which succeeded and produced the artifact.
- Verified the component change by inspecting the committed file `webapp/src/components/TikTokTaskVideo.jsx` and confirming the updated behavior during local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae595810048329a5cda24b7a3cb2eb)