### PR TITLE
Domino Royale: increase texture resolution, preserve GLTF mapping, and rename default table to Octagon Table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -85,9 +85,9 @@ function isTelegramRuntime() {
 
 const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
-  tableClothTextureSize: 1536,
-  chairClothTextureSize: 1536,
-  dominoTextureSize: 1536
+  tableClothTextureSize: 2048,
+  chairClothTextureSize: 2048,
+  dominoTextureSize: 2048
 });
 
 function detectCoarsePointer() {
@@ -2260,7 +2260,7 @@ const MURLAN_TABLE_THEMES = Object.freeze(
   [
     {
       id: 'murlan-default',
-      label: 'Murlan Default Table',
+      label: 'Octagon Table',
       source: 'procedural',
       assetId: null,
       price: 0,
@@ -2461,24 +2461,18 @@ function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) 
     mats.forEach((mat) => {
       if (!mat) return;
       if (preserveGltfTextureMapping) {
-        if (mat.map) mat.map.anisotropy = Math.max(mat.map.anisotropy ?? 1, maxAnisotropy);
-        if (mat.normalMap)
-          mat.normalMap.anisotropy = Math.max(
-            mat.normalMap.anisotropy ?? 1,
-            maxAnisotropy
-          );
-        if (mat.roughnessMap)
-          mat.roughnessMap.anisotropy = Math.max(
-            mat.roughnessMap.anisotropy ?? 1,
-            maxAnisotropy
-          );
-        if (mat.metalnessMap)
-          mat.metalnessMap.anisotropy = Math.max(
-            mat.metalnessMap.anisotropy ?? 1,
-            maxAnisotropy
-          );
-        if (mat.aoMap)
-          mat.aoMap.anisotropy = Math.max(mat.aoMap.anisotropy ?? 1, maxAnisotropy);
+        normalizePbrTexture(mat.map, {
+          isColor: true,
+          maxAnisotropy
+        });
+        normalizePbrTexture(mat.emissiveMap, {
+          isColor: true,
+          maxAnisotropy
+        });
+        normalizePbrTexture(mat.normalMap, { maxAnisotropy });
+        normalizePbrTexture(mat.roughnessMap, { maxAnisotropy });
+        normalizePbrTexture(mat.metalnessMap, { maxAnisotropy });
+        normalizePbrTexture(mat.aoMap, { maxAnisotropy });
         mat.needsUpdate = true;
         return;
       }

--- a/webapp/src/config/dominoRoyalThemeCatalog.js
+++ b/webapp/src/config/dominoRoyalThemeCatalog.js
@@ -114,7 +114,7 @@ const POLYHAVEN_TABLE_THEMES = [
 export const DOMINO_ROYAL_TABLE_THEMES = [
   {
     id: 'murlan-default',
-    label: 'Murlan Default Table',
+    label: 'Octagon Table',
     source: 'procedural',
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -165,7 +165,7 @@ const POLYHAVEN_TABLE_THEMES = [
 export const MURLAN_TABLE_THEMES = [
   {
     id: 'murlan-default',
-    label: 'Murlan Default Table',
+    label: 'Octagon Table',
     source: 'procedural',
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),


### PR DESCRIPTION
### Motivation
- Improve Domino visuals so domino tile textures match the fidelity of table and chair assets and preserve original GLTF texture mappings for procedural/PolyHaven tables; also make the default procedural table name clearer (Octagon Table used as the Battle Royale baseline).

### Description
- Increased the Domino/Chair/Table cloth texture budget by setting `MURLAN_3D_ASSET_RESOLUTION` sizes to `2048` in the runtime (`webapp/public/domino-royal-game.js`).
- Changed the default procedural table label from `Murlan Default Table` to `Octagon Table` in the runtime and shared catalogs (`webapp/public/domino-royal-game.js`, `webapp/src/config/murlanThemes.js`, `webapp/src/config/dominoRoyalThemeCatalog.js`).
- Improved GLTF preserve-mapping handling in `prepareLoadedModel` so preserved GLTF textures are normalized via `normalizePbrTexture` (color-space, filtering, mipmaps, anisotropy) including `emissiveMap` without altering UVs, replacing ad-hoc anisotropy-only tweaks to better match Pool Royale inventory mapping behavior.
- Synced the default table name change across the Domino theme/inventory configuration so UI/catalog entries remain consistent.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully (Vite chunk-size warnings are pre-existing and unrelated). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served locally. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/games/domino-royal` to validate the Octagon Table appearance and updated textures, and the capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae58af0cf08329a63855196ba126ff)