### PR TITLE
Fix mining promo video embeds and fullscreen popup behavior

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -25,11 +25,16 @@ export default function TikTokTaskVideo({
   storageKey,
 }) {
   const [open, setOpen] = useState(false);
+  const [showFallback, setShowFallback] = useState(false);
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/embed/v2/${videoId}`;
+    return `https://www.tiktok.com/player/v1/${videoId}?controls=1&music_info=0&description=0`;
   }, [videoId]);
+  const canonicalVideoUrl = useMemo(() => {
+    if (!videoId) return videoUrl || '';
+    return `https://www.tiktok.com/@tonplaygram/video/${videoId}`;
+  }, [videoId, videoUrl]);
 
   useEffect(() => {
     if (!autoOpen || !embedUrl || !storageKey) return;
@@ -37,6 +42,13 @@ export default function TikTokTaskVideo({
     setOpen(true);
     localStorage.setItem(storageKey, '1');
   }, [autoOpen, embedUrl, storageKey]);
+
+  useEffect(() => {
+    if (!open || !embedUrl) return;
+    setShowFallback(false);
+    const id = setTimeout(() => setShowFallback(true), 4000);
+    return () => clearTimeout(id);
+  }, [open, embedUrl]);
 
   return (
     <>
@@ -48,8 +60,8 @@ export default function TikTokTaskVideo({
       </button>
 
       {open && (
-        <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-          <div className="w-full max-w-sm rounded-xl overflow-hidden border border-white/20 bg-black">
+        <div className="fixed inset-0 z-50 bg-black/95 flex items-stretch justify-center">
+          <div className="w-full h-full overflow-hidden border border-white/10 bg-black flex flex-col">
             <div className="flex items-center justify-between px-3 py-2 border-b border-white/15">
               <span className="text-sm font-semibold text-white">{title}</span>
               <button
@@ -60,7 +72,7 @@ export default function TikTokTaskVideo({
               </button>
             </div>
             {embedUrl ? (
-              <div className="relative w-full pt-[177.78%]">
+              <div className="relative flex-1 min-h-0">
                 <iframe
                   title={title}
                   src={embedUrl}
@@ -69,19 +81,22 @@ export default function TikTokTaskVideo({
                   allowFullScreen
                   loading="lazy"
                   referrerPolicy="strict-origin-when-cross-origin"
+                  onLoad={() => setShowFallback(false)}
                 />
               </div>
             ) : (
               <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
             )}
-            <p className="px-3 pt-2 text-center text-[11px] text-subtext">
-              If TikTok embed is unavailable on your device, use “Open on TikTok”.
-            </p>
+            {showFallback && (
+              <p className="px-3 pt-2 text-center text-[11px] text-yellow-300">
+                Video preview can be blocked in some devices. Open it directly in TikTok.
+              </p>
+            )}
             <a
-              href={videoUrl}
+              href={canonicalVideoUrl}
               target="_blank"
               rel="noreferrer"
-              className="block text-center text-xs text-subtext py-2"
+              className="block text-center text-sm font-semibold text-brand-gold py-3"
             >
               Open on TikTok
             </a>


### PR DESCRIPTION
### Motivation
- Users saw "video unavailable" and small popups for the Daily Streaks / Spin & Win / Lucky Card / Roulette promo videos, so the embed handling and popup layout needed better compatibility and a fullscreen presentation. 

### Description
- Switched TikTok embed URL to the `player/v1` endpoint to improve playback availability in mobile/webview contexts in `webapp/src/components/TikTokTaskVideo.jsx`. 
- Added canonical deep-link generation (`canonicalVideoUrl`) so the fallback "Open on TikTok" always opens the exact video. 
- Reworked the popup container to occupy full screen and made the iframe fill the available space, and added a timed fallback hint plus an `onLoad` hook to hide the hint when the iframe succeeds. 
- Small UI tweaks to button/fallback text to make the fallback more visible on mobile.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Ran the monorepo linter via `npm run lint`, which failed due to many pre-existing repo-wide lint issues (the failure is unrelated to the small component change). 
- Performed an automated Playwright visual check against the running dev site and captured screenshots of the `/mining` page and the opened video popup confirming fullscreen popup rendering and video iframe presence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae595810048329a5cda24b7a3cb2eb)