### PR TITLE
Reduce GPU memory pressure in Pool Royale and speed HDRI/texture switching

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -54,7 +54,8 @@ import { giftSounds } from '../../utils/giftSounds.js';
 import { NFT_GIFTS } from '../../utils/nftGifts.js';
 import {
   createBallPreviewDataUrl,
-  getBallMaterial as getBilliardBallMaterial
+  getBallMaterial as getBilliardBallMaterial,
+  setBallMaterialAnisotropy
 } from '../../utils/ballMaterialFactory.js';
 import { selectShot as selectUkAiShot } from '../../../../lib/poolUkAdvancedAi.js';
 import planShot from '../../../../lib/poolAi.js';
@@ -369,6 +370,7 @@ function isWebGLAvailable() {
 
 let rendererAnisotropyCap = 16;
 setWoodTextureAnisotropyCap(rendererAnisotropyCap);
+setBallMaterialAnisotropy(Math.min(12, rendererAnisotropyCap));
 const updateRendererAnisotropyCap = (renderer) => {
   if (renderer?.capabilities?.getMaxAnisotropy) {
     const max = renderer.capabilities.getMaxAnisotropy();
@@ -377,6 +379,7 @@ const updateRendererAnisotropyCap = (renderer) => {
     }
   }
   setWoodTextureAnisotropyCap(rendererAnisotropyCap);
+  setBallMaterialAnisotropy(Math.min(12, rendererAnisotropyCap));
 };
 const resolveTextureAnisotropy = (fallback = 1) =>
   Math.max(rendererAnisotropyCap, Number.isFinite(fallback) ? fallback : 1);
@@ -4738,6 +4741,8 @@ const HDRI_GROUNDED_RESOLUTION = 256;
 const HDRI_CAMERA_SCALE_MIN = 0.78;
 const HDRI_CAMERA_SCALE_MAX = 1.32;
 const HDRI_CAMERA_SCALE_LERP = 0.18;
+const HDRI_URL_CACHE = new Map();
+const HDRI_PREFETCH_CACHE = new Map();
 
 function resolveHdriResolutionForTable(tableSizeMeta) {
   const widthMm = tableSizeMeta?.playfield?.widthMm;
@@ -4775,6 +4780,10 @@ function pickPolyHavenHdriUrl(apiJson, preferredResolutions = []) {
 }
 
 async function resolvePolyHavenHdriUrl(config = {}) {
+  const cacheKey = `${config?.assetId ?? 'fallback'}|${(config?.preferredResolutions || []).join(',')}|${config?.fallbackResolution ?? ''}`;
+  if (HDRI_URL_CACHE.has(cacheKey)) {
+    return HDRI_URL_CACHE.get(cacheKey);
+  }
   const preferred = Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
     ? config.preferredResolutions
     : DEFAULT_HDRI_RESOLUTIONS;
@@ -4784,23 +4793,53 @@ async function resolvePolyHavenHdriUrl(config = {}) {
     `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;
   if (config?.assetUrls && typeof config.assetUrls === 'object') {
     for (const res of preferred) {
-      if (config.assetUrls[res]) return config.assetUrls[res];
+      if (config.assetUrls[res]) {
+        HDRI_URL_CACHE.set(cacheKey, config.assetUrls[res]);
+        return config.assetUrls[res];
+      }
     }
     const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
-    if (manual) return manual;
+    if (manual) {
+      HDRI_URL_CACHE.set(cacheKey, manual);
+      return manual;
+    }
   }
-  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) return config.assetUrl;
-  if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
-  try {
-    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
-    if (!response?.ok) return fallbackUrl;
-    const json = await response.json();
-    const picked = pickPolyHavenHdriUrl(json, preferred);
-    return picked || fallbackUrl;
-  } catch (error) {
-    console.warn('Failed to resolve Poly Haven HDRI url', error);
+  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) {
+    HDRI_URL_CACHE.set(cacheKey, config.assetUrl);
+    return config.assetUrl;
+  }
+  if (!config?.assetId || typeof fetch !== 'function') {
+    HDRI_URL_CACHE.set(cacheKey, fallbackUrl);
     return fallbackUrl;
   }
+  try {
+    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
+    if (!response?.ok) {
+      HDRI_URL_CACHE.set(cacheKey, fallbackUrl);
+      return fallbackUrl;
+    }
+    const json = await response.json();
+    const picked = pickPolyHavenHdriUrl(json, preferred);
+    const resolvedUrl = picked || fallbackUrl;
+    HDRI_URL_CACHE.set(cacheKey, resolvedUrl);
+    return resolvedUrl;
+  } catch (error) {
+    console.warn('Failed to resolve Poly Haven HDRI url', error);
+    HDRI_URL_CACHE.set(cacheKey, fallbackUrl);
+    return fallbackUrl;
+  }
+}
+
+async function prefetchHdriVariant(config = {}) {
+  const key = `${config?.assetId ?? 'fallback'}|${(config?.preferredResolutions || []).join(',')}|${config?.fallbackResolution ?? ''}`;
+  if (HDRI_PREFETCH_CACHE.has(key)) return HDRI_PREFETCH_CACHE.get(key);
+  const request = (async () => {
+    const url = await resolvePolyHavenHdriUrl(config);
+    if (!url || typeof fetch !== 'function') return;
+    await fetch(url, { cache: 'force-cache' });
+  })().catch(() => {});
+  HDRI_PREFETCH_CACHE.set(key, request);
+  return request;
 }
 
 async function createFallbackHdriEnvironment(renderer) {
@@ -14039,6 +14078,29 @@ function PoolRoyaleGame({
     environmentHdriRef.current = environmentHdriId;
     activeEnvironmentVariantRef.current = activeEnvironmentHdri;
   }, [activeEnvironmentHdri, environmentHdriId]);
+  useEffect(() => {
+    const queue = availableEnvironmentHdris
+      .filter((variant) => variant.id !== environmentHdriId)
+      .slice(0, 2)
+      .map((variant) => {
+        const basePreferred =
+          Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
+            ? variant.preferredResolutions
+            : DEFAULT_HDRI_RESOLUTIONS;
+        const resolved = resolvedHdriResolution ?? basePreferred[0];
+        const preferredResolutions = resolved
+          ? [resolved, ...basePreferred.filter((res) => res !== resolved)]
+          : basePreferred;
+        return {
+          ...variant,
+          preferredResolutions,
+          fallbackResolution: resolved
+        };
+      });
+    queue.forEach((variant) => {
+      void prefetchHdriVariant(variant);
+    });
+  }, [availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]);
   useEffect(() => {
     if (typeof updateEnvironmentRef.current === 'function') {
       updateEnvironmentRef.current(activeEnvironmentVariantRef.current);

--- a/webapp/src/utils/ballMaterialFactory.js
+++ b/webapp/src/utils/ballMaterialFactory.js
@@ -7,7 +7,24 @@ import { applySRGBColorSpace } from './colorSpace.js';
 const BALL_TEXTURE_SIZE = 1024;
 const BALL_TEXTURE_CACHE = new Map();
 const BALL_MATERIAL_CACHE = new Map();
+const MAX_BALL_CACHE_ENTRIES = 48;
 const CUE_TIP_RADIUS_RATIO = 0.155;
+let ballTextureAnisotropy = 8;
+
+function touchCacheEntry(cache, key, value) {
+  cache.delete(key);
+  cache.set(key, value);
+}
+
+function clampBallCache(cache, maxEntries, disposeValue) {
+  while (cache.size > maxEntries) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) break;
+    const oldestValue = cache.get(oldestKey);
+    cache.delete(oldestKey);
+    disposeValue?.(oldestValue);
+  }
+}
 
 function clamp01(value) {
   return Math.min(1, Math.max(0, value));
@@ -314,7 +331,9 @@ function drawDefaultBallTexture(ctx, size, baseColor, pattern, number) {
 function createBallTexture({ baseColor, pattern, number, variantKey }) {
   const key = `${variantKey}|${pattern}|${number ?? 'none'}|${new THREE.Color(baseColor).getHexString()}`;
   if (BALL_TEXTURE_CACHE.has(key)) {
-    return BALL_TEXTURE_CACHE.get(key);
+    const cachedTexture = BALL_TEXTURE_CACHE.get(key);
+    touchCacheEntry(BALL_TEXTURE_CACHE, key, cachedTexture);
+    return cachedTexture;
   }
 
   const canvas = document.createElement('canvas');
@@ -330,7 +349,7 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   }
 
   const texture = new THREE.CanvasTexture(canvas);
-  texture.anisotropy = 32;
+  texture.anisotropy = ballTextureAnisotropy;
   texture.minFilter = THREE.LinearMipMapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
@@ -338,7 +357,15 @@ function createBallTexture({ baseColor, pattern, number, variantKey }) {
   texture.needsUpdate = true;
 
   BALL_TEXTURE_CACHE.set(key, texture);
+  clampBallCache(BALL_TEXTURE_CACHE, MAX_BALL_CACHE_ENTRIES, (cachedTexture) => {
+    cachedTexture?.dispose?.();
+  });
   return texture;
+}
+
+export function setBallMaterialAnisotropy(maxAnisotropy = 8) {
+  if (!Number.isFinite(maxAnisotropy) || maxAnisotropy <= 0) return;
+  ballTextureAnisotropy = Math.max(1, Math.min(16, Math.floor(maxAnisotropy)));
 }
 
 export function createBallPreviewDataUrl({
@@ -372,7 +399,9 @@ export function getBallMaterial({
   const baseColor = color ?? 0xffffff;
   const cacheKey = `${variantKey}|${pattern}|${number ?? 'none'}|${new THREE.Color(baseColor).getHexString()}`;
   if (BALL_MATERIAL_CACHE.has(cacheKey)) {
-    return BALL_MATERIAL_CACHE.get(cacheKey);
+    const cachedMaterial = BALL_MATERIAL_CACHE.get(cacheKey);
+    touchCacheEntry(BALL_MATERIAL_CACHE, cacheKey, cachedMaterial);
+    return cachedMaterial;
   }
 
   const map = createBallTexture({
@@ -396,10 +425,19 @@ export function getBallMaterial({
   });
   material.needsUpdate = true;
   BALL_MATERIAL_CACHE.set(cacheKey, material);
+  clampBallCache(BALL_MATERIAL_CACHE, MAX_BALL_CACHE_ENTRIES, (cachedMaterial) => {
+    cachedMaterial?.dispose?.();
+  });
   return material;
 }
 
 export function clearBallMaterialCache() {
+  BALL_MATERIAL_CACHE.forEach((material) => {
+    material?.dispose?.();
+  });
+  BALL_TEXTURE_CACHE.forEach((texture) => {
+    texture?.dispose?.();
+  });
   BALL_MATERIAL_CACHE.clear();
   BALL_TEXTURE_CACHE.clear();
 }


### PR DESCRIPTION
### Motivation
- Crashes were traced to unbounded generation of ball textures/materials and high GPU memory use when players rapidly switch skins, so caches need bounds and proper disposal. 
- Switching HDRI environments and loading remote HDRI files caused sluggish menu responsiveness due to repeated URL resolution and network fetches. 

### Description
- Add bounded LRU-style caches for ball textures and materials with `MAX_BALL_CACHE_ENTRIES` and eviction to prevent unbounded GPU memory growth (changes in `webapp/src/utils/ballMaterialFactory.js`).
- Dispose evicted and cleared textures/materials explicitly in `clearBallMaterialCache` to free GPU resources and reduce renderer crashes. 
- Replace hard-coded ball texture anisotropy with a configurable cap via `setBallMaterialAnisotropy` and wire it to renderer capability detection (updates in `webapp/src/pages/Games/PoolRoyale.jsx`), capping to a safer range to reduce mobile GPU pressure. 
- Add HDRI URL memoization and lightweight prefetching (`HDRI_URL_CACHE`, `HDRI_PREFETCH_CACHE`, and `prefetchHdriVariant`) and warm a small queue of nearby unlocked HDRI variants to improve perceived responsiveness when switching environments (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran the production build with `npm run build` in `webapp/`, which completed successfully and produced the application bundles. 
- The build reported existing Vite chunk-size/dynamic-import warnings unrelated to this change, and no build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5a10c2888329959b3515f7de5ece)