### PR TITLE
Fix TikTok promo video embeds on Mining page

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -7,6 +7,9 @@ function getVideoId(urlOrId) {
   const match = raw.match(/\/video\/(\d+)/);
   if (match) return match[1];
 
+  const embedMatch = raw.match(/\/embed\/(?:v2\/)?(\d+)/);
+  if (embedMatch) return embedMatch[1];
+
   const normalized = raw.endsWith('/') ? raw : `${raw}/`;
 
   const shortLinkVideoMap = {
@@ -29,7 +32,7 @@ export default function TikTokTaskVideo({
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/player/v1/${videoId}?controls=1&music_info=0&description=0`;
+    return `https://www.tiktok.com/embed/v2/${videoId}?autoplay=1&rel=0`;
   }, [videoId]);
   const canonicalVideoUrl = useMemo(() => {
     if (!videoId) return videoUrl || '';
@@ -77,7 +80,7 @@ export default function TikTokTaskVideo({
                   title={title}
                   src={embedUrl}
                   className="absolute inset-0 w-full h-full"
-                  allow="autoplay; encrypted-media; picture-in-picture"
+                  allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
                   allowFullScreen
                   loading="lazy"
                   referrerPolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
### Motivation
- Fix videos showing “unavailable” for the Mining page daily actions (Daily Streaks, Spin & Win, Lucky Card, Roulette) by making the TikTok embed behavior more reliable across link formats and in-app/mobile browsers.

### Description
- Update `TikTokTaskVideo.jsx` to detect `/embed/...` TikTok link forms and to use `https://www.tiktok.com/embed/v2/<id>?autoplay=1&rel=0` as the iframe `src`, and add `fullscreen` to the iframe `allow` attribute to improve playback compatibility.

### Testing
- Ran `npm --prefix webapp run build` successfully, started the dev server (`npm --prefix webapp run dev`) and executed a Playwright script that opened `/mining`, clicked the promo video button and captured a screenshot (succeeded), and ran `npx eslint webapp/src/components/TikTokTaskVideo.jsx` which reported the file is ignored by repo lint settings (warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae6110e4888329bb841ca69ec0196f)