### PR TITLE
Align Domino graphics textures with quality presets and match lobby layout to Snake & Ladder

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -90,6 +90,22 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   dominoTextureSize: 2048
 });
 
+const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
+  hd50: 1024,
+  fhd60: 1536,
+  qhd90: 2048,
+  uhd120: 3072,
+  ultra144: 3072
+});
+
+function getAdaptiveTextureSize(baseSize = 2048) {
+  const mappedSize =
+    FRAME_RATE_TEXTURE_SIZE_MAP[frameRateId] ??
+    FRAME_RATE_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
+    baseSize;
+  return Math.max(768, Math.min(4096, mappedSize));
+}
+
 function detectCoarsePointer() {
   if (typeof window === 'undefined') {
     return false;
@@ -2097,8 +2113,6 @@ const getPoolCarpetTextures = (() => {
   };
 })();
 
-const CHAIR_CLOTH_TEXTURE_SIZE =
-  MURLAN_3D_ASSET_RESOLUTION.chairClothTextureSize;
 const CHAIR_CLOTH_REPEAT = 12;
 const DEFAULT_CHAIR_THEME = Object.freeze({
   id: 'crimsonVelvet',
@@ -4445,8 +4459,11 @@ function createChairClothTexture(option, renderer) {
   const primary = option?.seatColor ?? '#8b0000';
   const accent = adjustHexColor(primary, -0.28);
   const highlight = option?.highlight ?? adjustHexColor(primary, 0.22);
+  const chairClothTextureSize = getAdaptiveTextureSize(
+    MURLAN_3D_ASSET_RESOLUTION.chairClothTextureSize
+  );
   const canvas = document.createElement('canvas');
-  canvas.width = canvas.height = CHAIR_CLOTH_TEXTURE_SIZE;
+  canvas.width = canvas.height = chairClothTextureSize;
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -6200,14 +6217,26 @@ function buildDominoMaterial(options = {}, defaults = {}) {
 
 const getDominoSurfaceTextures = (() => {
   let cache = null;
+  let cachedSize = 0;
+  const disposeCachedTextures = () => {
+    if (!cache) return;
+    cache.porcelainMap?.dispose?.();
+    cache.porcelainRoughness?.dispose?.();
+    cache.pipMap?.dispose?.();
+    cache = null;
+  };
   return () => {
-    if (cache) return cache;
+    const targetSize = getAdaptiveTextureSize(
+      MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize
+    );
+    if (cache && cachedSize === targetSize) return cache;
+    disposeCachedTextures();
     if (typeof document === 'undefined') {
       cache = { porcelainMap: null, porcelainRoughness: null, pipMap: null };
       return cache;
     }
     const sizeCap = getRendererTextureSizeCap();
-    const preferredSize = Math.max(1024, Math.min(sizeCap, MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize));
+    const preferredSize = Math.max(1024, Math.min(sizeCap, targetSize));
     const lowMemoryDevice =
       isLowProfileDevice ||
       (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
@@ -6284,6 +6313,7 @@ const getDominoSurfaceTextures = (() => {
     pipMap.generateMipmaps = true;
 
     cache = { porcelainMap, porcelainRoughness, pipMap };
+    cachedSize = size;
     return cache;
   };
 })();
@@ -6569,6 +6599,12 @@ function applyFrameRateSelection(
     ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
       ENVIRONMENT_HDRI_OPTIONS[0]
   );
+  applyDominoStyle(currentDominoStyleOption);
+  buildChairs(
+    CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME
+  );
+  renderChain();
+  renderBoneyardStack();
   if (refreshUi) {
     refreshConfigUI();
   }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -326,50 +326,12 @@ export default function DominoRoyalLobby() {
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Players</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-              Seats
-            </span>
-          </div>
-          <div className="grid grid-cols-3 gap-3">
-            {PLAYER_OPTIONS.map((value) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setPlayerCount(value)}
-                className={`lobby-option-card ${
-                  playerCount === value
-                    ? 'lobby-option-card-active'
-                    : 'lobby-option-card-inactive'
-                }`}
-              >
-                <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
-                  <div className="lobby-option-thumb-inner">
-                    <OptionIcon
-                      src={getLobbyIcon('domino-royal', `players-${value}`)}
-                      alt={`${value} players`}
-                      fallback={HUMAN_ICON_FALLBACK}
-                      className="lobby-option-icon"
-                    />
-                  </div>
-                </div>
-                <div className="text-center">
-                  <p className="lobby-option-label">{value} Players</p>
-                  <p className="lobby-option-subtitle">Local table seats</p>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Mode</h3>
+            <h3 className="font-semibold text-white">Match Mode</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
               Queue
             </span>
           </div>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 gap-3">
             {[
               {
                 id: 'local',
@@ -428,6 +390,46 @@ export default function DominoRoyalLobby() {
           <p className="text-xs text-white/60 text-center">
             Online status: {readiness.label}. Queue and matchmaking are now live.
           </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Vs how many players</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Seats
+            </span>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="grid grid-cols-3 gap-3">
+              {PLAYER_OPTIONS.map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setPlayerCount(value)}
+                  className={`lobby-option-card ${
+                    playerCount === value
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-slate-400/30 via-slate-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('domino-royal', `players-${value}`)}
+                        alt={`${value} players`}
+                        fallback={HUMAN_ICON_FALLBACK}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{value} Players</p>
+                    <p className="lobby-option-subtitle">Local table seats</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
 
         <button


### PR DESCRIPTION
### Motivation
- Make Domino tile and chair textures follow the same graphics-quality selection so domino visuals match chair visuals when the user changes graphics settings.
- Make the Domino Battle Royal lobby UI match the existing Snake & Ladder lobby flow and thumbnail style for a consistent UX.

### Description
- Added `FRAME_RATE_TEXTURE_SIZE_MAP` and `getAdaptiveTextureSize()` so texture generation uses a size mapped to the active graphics/frame-rate preset (`hd50`, `fhd60`, `qhd90`, `uhd120`, `ultra144`).
- Made domino texture generation adaptive by integrating the adaptive size into `getDominoSurfaceTextures()` and added cache size tracking and disposal (`cachedSize`, `disposeCachedTextures`) so textures are recreated when quality changes.
- Made chair cloth texture generation use `getAdaptiveTextureSize()` (used in `createChairClothTexture`) so chair and domino textures stay in sync with graphics options.
- Updated runtime graphics switching (`applyFrameRateSelection`) to reapply domino materials and rebuild chairs, and to refresh chain/boneyard rendering immediately when the user picks a new graphics option.
- Reworked the Domino lobby layout in `DominoRoyalLobby.jsx` to mirror Snake & Ladder: `Match Mode` is first in a 2-column card grid and `Vs how many players` is a separate bordered section with thumbnail cards.

### Testing
- `npm run build` (from `webapp/`) completed successfully with Vite build warnings only about large chunks (build succeeded).
- Automated Playwright script loaded the local dev site and produced a mobile-portrait screenshot (`artifacts/domino-lobby-updated.png`) to validate the updated lobby layout and appearance (script ran successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae622e48b88329af858c47be5b0f5e)