### PR TITLE
Set Texas Hold'em default HDRI to Dancing Hall and move camera slightly closer

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -3,11 +3,7 @@ import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from './texasHoldemOptions.js';
 import { polyHavenThumb } from './storeThumbnails.js';
-import {
-  POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS,
-  POOL_ROYALE_OPTION_LABELS
-} from './poolRoyaleInventoryConfig.js';
+import { POOL_ROYALE_HDRI_VARIANTS, POOL_ROYALE_OPTION_LABELS } from './poolRoyaleInventoryConfig.js';
 
 const reduceLabels = (items) =>
   items.reduce((acc, option) => {
@@ -93,7 +89,12 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
   }
 ]);
 
-const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID));
+export const TEXAS_HOLDEM_DEFAULT_HDRI_ID = 'dancingHall';
+
+const DEFAULT_HDRI_INDEX = Math.max(
+  0,
+  TEXAS_HDRI_OPTIONS.findIndex((variant) => variant.id === TEXAS_HOLDEM_DEFAULT_HDRI_ID)
+);
 
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0]?.id],
@@ -104,7 +105,7 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableTheme: [TEXAS_TABLE_THEME_OPTIONS[0]?.id],
   tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
   cards: [CARD_THEMES[0]?.id],
-  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
+  environmentHdri: [TEXAS_HOLDEM_DEFAULT_HDRI_ID]
 });
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
@@ -225,7 +226,9 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
   { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` },
   {
     type: 'environmentHdri',
-    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
-    label: TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[POOL_ROYALE_DEFAULT_HDRI_ID] || TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
+    optionId: TEXAS_HOLDEM_DEFAULT_HDRI_ID,
+    label:
+      TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[TEXAS_HOLDEM_DEFAULT_HDRI_ID] ||
+      TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
   }
 ];

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -46,9 +46,12 @@ import {
   primeSpeechSynthesis,
   speakCommentaryLines
 } from '../../utils/textToSpeech.js';
-import { TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
+import {
+  TEXAS_HDRI_OPTIONS,
+  TEXAS_TABLE_FINISH_OPTIONS,
+  TEXAS_HOLDEM_DEFAULT_HDRI_ID
+} from '../../config/texasHoldemInventoryConfig.js';
 import { resolveTexasHoldemHdriUrl } from '../../utils/texasHoldemHdriPreload.js';
-import { POOL_ROYALE_DEFAULT_HDRI_ID } from '../../config/poolRoyaleInventoryConfig.js';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -390,7 +393,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.62, landscape: -0.02 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.5, landscape: -0.14 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = CARD_W * 0.2;
@@ -471,7 +474,7 @@ const DEFAULT_TABLE_THEME_ID = TEXAS_TABLE_THEME_OPTIONS[0]?.id ?? 'murlan-defau
 const TEXAS_DEFAULT_HDRI_INDEX = Math.max(
   0,
   TEXAS_HDRI_OPTIONS.findIndex(
-    (variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID || PREFERRED_HDRI_RESOLUTIONS.includes(variant?.fallbackResolution ?? '4k')
+    (variant) => variant.id === TEXAS_HOLDEM_DEFAULT_HDRI_ID || PREFERRED_HDRI_RESOLUTIONS.includes(variant?.fallbackResolution ?? '4k')
   )
 );
 let sharedKtx2Loader = null;
@@ -4244,7 +4247,7 @@ function TexasHoldemArena({ search }) {
       CAMERA_SETTINGS.near,
       CAMERA_SETTINGS.far
     );
-    camera.position.set(0, TABLE_HEIGHT * 2.85, TABLE_RADIUS * 3.9);
+    camera.position.set(0, TABLE_HEIGHT * 2.85, TABLE_RADIUS * 3.6);
     renderer.domElement.style.touchAction = 'none';
     renderer.domElement.style.cursor = 'grab';
 

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -1,4 +1,4 @@
-import { TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
+import { TEXAS_HDRI_OPTIONS, TEXAS_HOLDEM_DEFAULT_HDRI_ID } from '../config/texasHoldemInventoryConfig.js';
 
 const DEFAULT_RESOLUTIONS = Object.freeze(['4k']);
 const hdriUrlCache = new Map();
@@ -79,7 +79,11 @@ export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT
 
 export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS) {
   if (typeof window === 'undefined' || typeof fetch !== 'function') return Promise.resolve();
-  const variants = Array.isArray(options) ? options.filter(Boolean) : [];
+  const variants = (Array.isArray(options) ? options.filter(Boolean) : []).sort((a, b) => {
+    const aDefault = (a?.id || a?.assetId) === TEXAS_HOLDEM_DEFAULT_HDRI_ID ? 1 : 0;
+    const bDefault = (b?.id || b?.assetId) === TEXAS_HOLDEM_DEFAULT_HDRI_ID ? 1 : 0;
+    return bDefault - aDefault;
+  });
   const jobs = variants.map((variant) => {
     const key = variant?.id || variant?.assetId || variant?.fallbackUrl;
     if (!key) return Promise.resolve();


### PR DESCRIPTION
### Motivation
- Make the Texas Hold'em arena use the "Dancing Hall" HDRI by default and begin warming HDRIs from the lobby so the preferred environment is ready when a match starts. 
- Improve framing by nudging the table camera a bit closer to the table center for a tighter view on mobile portrait.

### Description
- Introduced `TEXAS_HOLDEM_DEFAULT_HDRI_ID = 'dancingHall'` and wired it into Texas defaults and loadouts so new/default appearance uses Dancing Hall (`webapp/src/config/texasHoldemInventoryConfig.js`).
- Switched arena HDRI selection logic to prefer `TEXAS_HOLDEM_DEFAULT_HDRI_ID` when resolving the preferred HDRI resolution (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Updated the lobby HDRI warm-up to prioritize the Texas default variant first so the default HDRI begins preloading when the user enters the lobby (`webapp/src/utils/texasHoldemHdriPreload.js`).
- Tightened camera framing by reducing `CAMERA_RETREAT_OFFSETS` and moving the initial camera Z position slightly closer (from `TABLE_RADIUS * 3.9` to `TABLE_RADIUS * 3.6`) to make the table appear a bit closer on screen (`webapp/src/pages/Games/TexasHoldemArena.jsx`).

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully.
- Launched the dev server (`npm run dev`) successfully, but an automated Playwright attempt to capture screenshots failed because Chromium crashed with `SIGSEGV` in this environment, so visual screenshot validation could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7f2520608329baef05759d784554)