### PR TITLE
Fix unavailable TikTok rewarded video on Mining page

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,7 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-const AD_IFRAME_URL = 'https://www.tiktok.com/embed/v2/7515418978852781329';
-const AD_FALLBACK_URL = 'https://vt.tiktok.com/ZSuREWyqx/';
+const AD_VIDEOS = [
+  {
+    iframeUrl: 'https://www.tiktok.com/embed/v2/7614860616703986951',
+    fallbackUrl: 'https://vt.tiktok.com/ZSujaXgpP/',
+  },
+  {
+    iframeUrl: 'https://www.tiktok.com/embed/v2/7614600402654252296',
+    fallbackUrl: 'https://vt.tiktok.com/ZSujaPuVF/',
+  },
+  {
+    iframeUrl: 'https://www.tiktok.com/embed/v2/7614503027684216071',
+    fallbackUrl: 'https://vt.tiktok.com/ZSujagfxp/',
+  },
+];
 const REWARD_DELAY_MS = 15_000;
 
 interface AdModalProps {
@@ -13,6 +25,7 @@ interface AdModalProps {
 export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
   const rewardIssuedRef = useRef(false);
   const [remainingMs, setRemainingMs] = useState(REWARD_DELAY_MS);
+  const [videoIndex, setVideoIndex] = useState(0);
 
   useEffect(() => {
     if (!open) {
@@ -20,6 +33,8 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
       setRemainingMs(REWARD_DELAY_MS);
       return;
     }
+
+    setVideoIndex(Math.floor(Math.random() * AD_VIDEOS.length));
 
     const startedAt = Date.now();
     const intervalId = window.setInterval(() => {
@@ -39,6 +54,7 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
     () => Math.ceil(remainingMs / 1000),
     [remainingMs],
   );
+  const selectedVideo = AD_VIDEOS[videoIndex] || AD_VIDEOS[0];
 
   if (!open) return null;
 
@@ -66,7 +82,7 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
 
         <div className="aspect-[9/16] w-full overflow-hidden rounded-lg border border-border bg-black">
           <iframe
-            src={AD_IFRAME_URL}
+            src={selectedVideo.iframeUrl}
             title="Rewarded TikTok"
             className="w-full h-full"
             allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
@@ -74,8 +90,16 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
           />
         </div>
 
+        <button
+          type="button"
+          onClick={() => setVideoIndex((current) => (current + 1) % AD_VIDEOS.length)}
+          className="text-center text-xs text-brand-gold underline"
+        >
+          Video unavailable? Try another one
+        </button>
+
         <a
-          href={AD_FALLBACK_URL}
+          href={selectedVideo.fallbackUrl}
           target="_blank"
           rel="noreferrer"
           className="block text-center text-xs text-blue-300 underline"


### PR DESCRIPTION
### Motivation
- The rewarded-video modal relied on a single hardcoded TikTok embed which could be removed/private/region-blocked and produced a persistent "Video currently unavailable" experience for users.

### Description
- Replaced the single hardcoded embed with an `AD_VIDEOS` array containing multiple `{ iframeUrl, fallbackUrl }` candidates in `webapp/src/components/AdModal.tsx`.
- When the modal opens it picks a random candidate (`videoIndex`) and uses that candidate's iframe and fallback URL for the modal.
- Added a `Video unavailable? Try another one` button that cycles to the next candidate so users can switch without closing the modal.
- Kept the existing reward timer and completion logic unchanged.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Ran the dev server and exercised the Mining flow by opening `/mining?tg=12345`, triggering the Lucky Card rewarded modal, and captured a Playwright screenshot of the modal; the modal opened and the screenshot was produced.
- Verified the updated `AdModal` compiles and the iframe/fallback are wired to the selected candidate (manual verification during dev server run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7fbce48c8329898edc00ecd5e462)