### PR TITLE
Fix TikTok rewarded video embed availability in mining flow

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -32,6 +32,10 @@ export default function TikTokTaskVideo({
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
+    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
+  }, [videoId]);
+  const legacyEmbedUrl = useMemo(() => {
+    if (!videoId) return '';
     return `https://www.tiktok.com/embed/v2/${videoId}?autoplay=1&rel=0`;
   }, [videoId]);
   const canonicalVideoUrl = useMemo(() => {
@@ -91,9 +95,19 @@ export default function TikTokTaskVideo({
               <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
             )}
             {showFallback && (
-              <p className="px-3 pt-2 text-center text-[11px] text-yellow-300">
-                Video preview can be blocked in some devices. Open it directly in TikTok.
-              </p>
+              <div className="px-3 pt-2 text-center text-[11px] text-yellow-300 space-y-1">
+                <p>Video preview can be blocked in some devices. Open it directly in TikTok.</p>
+                {legacyEmbedUrl && (
+                  <a
+                    href={legacyEmbedUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-block underline"
+                  >
+                    Try legacy TikTok embed
+                  </a>
+                )}
+              </div>
             )}
             <a
               href={canonicalVideoUrl}


### PR DESCRIPTION
### Motivation
- The TikTok iframe endpoint `embed/v2` was showing "Video currently unavailable" in some mobile WebViews, breaking rewarded-video previews in the mining/watch flow. 
- Provide a more reliable embed path and a fallback so users can still open the video when previews are blocked.

### Description
- Switch the player iframe source from `https://www.tiktok.com/embed/v2/{id}` to `https://www.tiktok.com/player/v1/{id}` for improved compatibility.  
- Add a `legacyEmbedUrl` and surface a "Try legacy TikTok embed" link in the fallback warning area so users can attempt the older embed endpoint if needed.  
- Keep the existing canonical "Open on TikTok" link unchanged to always allow opening the video in TikTok/web browser.  
- Modified file: `webapp/src/components/TikTokTaskVideo.jsx`.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.  
- Ran `npx eslint webapp/src/components/TikTokTaskVideo.jsx` which reported the file is ignored by the repo ESLint ignore pattern and produced no lint errors.  
- Launched the webapp in a headless browser and captured a mobile-viewport screenshot of the /mining page after opening the promo modal to validate the modal and fallback UI (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7fbce48c8329898edc00ecd5e462)