### PR TITLE
Texas Hold'em: use Dancing Hall HDRI by default, prioritize HDRI preload, and tighten camera framing

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -4,7 +4,6 @@ import { CARD_THEMES } from '../utils/cards3d.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from './texasHoldemOptions.js';
 import { polyHavenThumb } from './storeThumbnails.js';
 import {
-  POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_OPTION_LABELS
 } from './poolRoyaleInventoryConfig.js';
@@ -19,6 +18,8 @@ export const TEXAS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
 }));
+
+export const TEXAS_DEFAULT_HDRI_ID = 'dancingHall';
 
 export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
   {
@@ -93,7 +94,7 @@ export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
   }
 ]);
 
-const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID));
+const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) => variant.id === TEXAS_DEFAULT_HDRI_ID));
 
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0]?.id],
@@ -104,7 +105,7 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableTheme: [TEXAS_TABLE_THEME_OPTIONS[0]?.id],
   tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
   cards: [CARD_THEMES[0]?.id],
-  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
+  environmentHdri: [TEXAS_DEFAULT_HDRI_ID]
 });
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
@@ -225,7 +226,7 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
   { type: 'cards', optionId: CARD_THEMES[0]?.id, label: `${CARD_THEMES[0]?.label} Cards` },
   {
     type: 'environmentHdri',
-    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
-    label: TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[POOL_ROYALE_DEFAULT_HDRI_ID] || TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
+    optionId: TEXAS_DEFAULT_HDRI_ID,
+    label: TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[TEXAS_DEFAULT_HDRI_ID] || TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
   }
 ];

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -46,9 +46,8 @@ import {
   primeSpeechSynthesis,
   speakCommentaryLines
 } from '../../utils/textToSpeech.js';
-import { TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
+import { TEXAS_DEFAULT_HDRI_ID, TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
 import { resolveTexasHoldemHdriUrl } from '../../utils/texasHoldemHdriPreload.js';
-import { POOL_ROYALE_DEFAULT_HDRI_ID } from '../../config/poolRoyaleInventoryConfig.js';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -390,7 +389,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.42 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.62, landscape: -0.02 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.69, landscape: 0.05 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = CARD_W * 0.2;
@@ -471,7 +470,7 @@ const DEFAULT_TABLE_THEME_ID = TEXAS_TABLE_THEME_OPTIONS[0]?.id ?? 'murlan-defau
 const TEXAS_DEFAULT_HDRI_INDEX = Math.max(
   0,
   TEXAS_HDRI_OPTIONS.findIndex(
-    (variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID || PREFERRED_HDRI_RESOLUTIONS.includes(variant?.fallbackResolution ?? '4k')
+    (variant) => variant.id === TEXAS_DEFAULT_HDRI_ID || PREFERRED_HDRI_RESOLUTIONS.includes(variant?.fallbackResolution ?? '4k')
   )
 );
 let sharedKtx2Loader = null;

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -1,9 +1,18 @@
-import { TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
+import { TEXAS_DEFAULT_HDRI_ID, TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
 
 const DEFAULT_RESOLUTIONS = Object.freeze(['4k']);
 const hdriUrlCache = new Map();
 const hdriJsonPromiseCache = new Map();
 const hdriWarmPromiseCache = new Map();
+
+function prioritizeDefaultHdri(options = TEXAS_HDRI_OPTIONS) {
+  const variants = Array.isArray(options) ? options.filter(Boolean) : [];
+  const defaultIndex = variants.findIndex((variant) => variant?.id === TEXAS_DEFAULT_HDRI_ID);
+  if (defaultIndex <= 0) return variants;
+  const prioritized = variants.slice();
+  const [defaultVariant] = prioritized.splice(defaultIndex, 1);
+  return [defaultVariant, ...prioritized];
+}
 
 function pickPolyHavenHdriUrl(fileMap, preferredResolutions = DEFAULT_RESOLUTIONS) {
   if (!fileMap || typeof fileMap !== 'object') return null;
@@ -79,7 +88,7 @@ export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT
 
 export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS) {
   if (typeof window === 'undefined' || typeof fetch !== 'function') return Promise.resolve();
-  const variants = Array.isArray(options) ? options.filter(Boolean) : [];
+  const variants = prioritizeDefaultHdri(options);
   const jobs = variants.map((variant) => {
     const key = variant?.id || variant?.assetId || variant?.fallbackUrl;
     if (!key) return Promise.resolve();


### PR DESCRIPTION
### Motivation
- Make the Texas Hold'em arena use the Dancing Hall HDRI by default and start preloading it as soon as the player enters the lobby for a faster, consistent visual experience.
- Move the camera view slightly closer to the table center to improve visual focus on gameplay on phone portrait screens.

### Description
- Added a Texas-specific default HDRI constant `TEXAS_DEFAULT_HDRI_ID = 'dancingHall'` and wired it into the Hold'em config so new sessions and the default loadout use Dancing Hall by default (`webapp/src/config/texasHoldemInventoryConfig.js`).
- Switched arena default selection logic to prefer the Texas HDRI constant instead of the Pool Royale default (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Prioritized warm-up preloading so the default HDRI is fetched first when entering the lobby by adding `prioritizeDefaultHdri` and using it in the lobby warm-up flow (`webapp/src/utils/texasHoldemHdriPreload.js`).
- Nudged the seated camera framing closer to the table by adjusting `CAMERA_RETREAT_OFFSETS` for portrait and landscape to tighten the view toward the table center (`webapp/src/pages/Games/TexasHoldemArena.jsx`).

### Testing
- Built the web app with `cd webapp && npm run build`, which completed successfully (production build produced without errors).
- Started the dev server (`npm run dev`) to validate runtime startup; Vite served the app but a headless Playwright screenshot attempt timed out in this environment while capturing lobby/arena frames.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7f2520608329baef05759d784554)