### PR TITLE
Fix Domino graphics resolution labels and octagon table GLTF finish mapping

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -38,7 +38,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 90,
     renderScale: 0.98,
     pixelRatioCap: 1.3,
-    resolution: 'QHD smooth render • DPR 1.4 cap',
+    resolution: 'QHD smooth render • DPR 1.3 cap',
     description: 'Sharper 90 Hz profile for capable devices.'
   },
   {
@@ -47,7 +47,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.02,
     pixelRatioCap: 1.4,
-    resolution: 'UHD turbo render • DPR 1.5 cap',
+    resolution: 'UHD turbo render • DPR 1.4 cap',
     description: 'Highest quality profile for flagship and desktop GPUs.'
   },
   {
@@ -56,7 +56,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 144,
     renderScale: 1.04,
     pixelRatioCap: 1.45,
-    resolution: 'Desktop ultra render • DPR 1.55 cap',
+    resolution: 'Desktop ultra render • DPR 1.45 cap',
     description: 'Unlocked 144 Hz profile for high-end desktop hardware.'
   }
 ]);
@@ -91,10 +91,10 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
 });
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
-  fhd60: 1536,
+  hd50: 1152,
+  fhd60: 1440,
   qhd90: 2048,
-  uhd120: 3072,
+  uhd120: 2560,
   ultra144: 3072
 });
 
@@ -2275,12 +2275,12 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Octagon Table',
-      source: 'procedural',
-      assetId: null,
+      source: 'polyhaven',
+      assetId: 'CoffeeTable_01',
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Shared Battle Royale octagon table baseline used across Chess, Ludo, Texas, and Domino.'
+        'Shared Battle Royale octagon baseline using the same GLTF finish texture workflow as Texas Holdem 3D.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },
@@ -5587,9 +5587,13 @@ function fitTableModelToFootprint(model) {
   const targetDiameter = TABLE_RADIUS * 2.1;
   const targetHeight = TABLE_HEIGHT * 1.05;
   const maxSide = Math.max(size.x, size.z, 0.0001);
-  const heightScale = targetHeight / Math.max(size.y, 0.0001);
-  const scale = Math.min(targetDiameter / maxSide, heightScale);
-  model.scale.multiplyScalar(scale);
+  const scaleXZ = targetDiameter / maxSide;
+  const scaleY = targetHeight / Math.max(size.y, 0.0001);
+  model.scale.set(
+    model.scale.x * scaleXZ,
+    model.scale.y * scaleY,
+    model.scale.z * scaleXZ
+  );
   const scaled = new THREE.Box3().setFromObject(model);
   const offset = new THREE.Vector3(
     -(scaled.min.x + scaled.max.x) / 2,


### PR DESCRIPTION
### Motivation
- Make the Domino graphics menu and quality tiers accurately describe the runtime DPR/pixel-capacity and texture sizing used by the renderer.
- Ensure the shared Battle‑Royale octagon table uses the same GLTF table-finish workflow as Texas Hold'em so GLTF textures are preserved instead of falling back to procedural materials.
- Improve model fitting so imported GLTF tables map and scale to the Domino footprint the same way Texas Hold'em models do.

### Description
- Updated `FRAME_RATE_OPTIONS` resolution strings so displayed DPR caps match the actual `pixelRatioCap` values for QHD/UHD/Ultra presets in `webapp/public/domino-royal-game.js`.
- Rebalanced `FRAME_RATE_TEXTURE_SIZE_MAP` to adjust adaptive texture sizes for `hd50`, `fhd60`, and `uhd120` to better align quality progression with menu tiers.
- Switched `murlan-default` (Octagon Table) from a `procedural` source to a `polyhaven` GLTF asset (`CoffeeTable_01`) so the octagon uses GLTF-preserved materials and the same finish mapping as Texas Hold'em.
- Changed `fitTableModelToFootprint` to apply independent XZ and Y scaling (`scaleXZ` and `scaleY`) instead of a single uniform scale, aligning model fitting behavior with Texas Hold'em logic.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without syntax errors (success).
- Launched the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and performed a visual verification by taking a screenshot of `/games/domino-royal` with Playwright; the page loaded and the screenshot was produced (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae89b7e0d48329b143b9ef5d7d26b7)