### PR TITLE
Fix Domino graphics DPR labels and switch octagon table to GLTF finish

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -38,7 +38,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 90,
     renderScale: 0.98,
     pixelRatioCap: 1.3,
-    resolution: 'QHD smooth render • DPR 1.4 cap',
+    resolution: 'QHD smooth render • DPR 1.3 cap',
     description: 'Sharper 90 Hz profile for capable devices.'
   },
   {
@@ -47,7 +47,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.02,
     pixelRatioCap: 1.4,
-    resolution: 'UHD turbo render • DPR 1.5 cap',
+    resolution: 'UHD turbo render • DPR 1.4 cap',
     description: 'Highest quality profile for flagship and desktop GPUs.'
   },
   {
@@ -56,7 +56,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 144,
     renderScale: 1.04,
     pixelRatioCap: 1.45,
-    resolution: 'Desktop ultra render • DPR 1.55 cap',
+    resolution: 'Desktop ultra render • DPR 1.45 cap',
     description: 'Unlocked 144 Hz profile for high-end desktop hardware.'
   }
 ]);
@@ -2275,12 +2275,12 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     {
       id: 'murlan-default',
       label: 'Octagon Table',
-      source: 'procedural',
-      assetId: null,
+      source: 'polyhaven',
+      assetId: 'CoffeeTable_01',
       price: 0,
       thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
       description:
-        'Shared Battle Royale octagon table baseline used across Chess, Ludo, Texas, and Domino.'
+        'Shared Battle Royale octagon table baseline using Texas Hold\'em default GLTF finish mapping.'
     },
     { id: 'CoffeeTable_01', label: 'Coffee Table 01' },
     { id: 'WoodenTable_02', label: 'Wooden Table 02' },


### PR DESCRIPTION
### Motivation
- Resolve mismatch between graphics menu text and actual DPR caps so players see accurate quality descriptions.
- Make the default Octagon Table use the same GLTF-backed table finishes/mapping as Texas Hold'em instead of falling back to procedural textures.

### Description
- Updated DPR/resolution strings for QHD/UDH/Ultra presets so the displayed `resolution` text matches the configured `pixelRatioCap` values in `webapp/public/domino-royal-game.js`.
- Changed the `murlan-default` (Octagon Table) entry from `source: 'procedural'` to `source: 'polyhaven'` and set `assetId: 'CoffeeTable_01'` so the default octagon uses the GLTF Poly Haven model and its material mapping.
- Reworded the default table description to indicate the GLTF/Texas Hold'em aligned finish mapping.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and it launched successfully.
- Captured a mobile-viewport screenshot of `http://127.0.0.1:4173/games/domino-royal` via Playwright to validate the octagon table and graphics labels, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae89b7e0d48329b143b9ef5d7d26b7)