### PR TITLE
Use official TikTok embed endpoint for mining videos

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -32,11 +32,11 @@ export default function TikTokTaskVideo({
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
+    return `https://www.tiktok.com/embed/v2/${videoId}?autoplay=1&rel=0`;
   }, [videoId]);
   const legacyEmbedUrl = useMemo(() => {
     if (!videoId) return '';
-    return `https://www.tiktok.com/embed/v2/${videoId}?autoplay=1&rel=0`;
+    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
   }, [videoId]);
   const canonicalVideoUrl = useMemo(() => {
     if (!videoId) return videoUrl || '';
@@ -104,7 +104,7 @@ export default function TikTokTaskVideo({
                     rel="noreferrer"
                     className="inline-block underline"
                   >
-                    Try legacy TikTok embed
+                    Try alternative TikTok player
                   </a>
                 )}
               </div>


### PR DESCRIPTION
### Motivation
- TikTok inline previews could be blocked or shown as unavailable on the mining page, so the component should use the official embeddable format to improve inline playback compatibility.

### Description
- Updated `webapp/src/components/TikTokTaskVideo.jsx` to load `https://www.tiktok.com/embed/v2/{videoId}` as the primary iframe `src`, kept `https://www.tiktok.com/player/v1/{videoId}` as the fallback link, and adjusted the fallback CTA text to indicate an alternative TikTok player.

### Testing
- Ran `npm run build` in `webapp` which completed successfully, and started the dev server then executed a Playwright script to open `/mining` in a mobile viewport and capture a screenshot confirming the embed modal opened as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae8a1aee048329bc2032cfecbe8e8a)