### PR TITLE
Align Domino DPR labels and texture sizes; match octagon table finish UV to Texas Hold'em

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -38,7 +38,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 90,
     renderScale: 0.98,
     pixelRatioCap: 1.3,
-    resolution: 'QHD smooth render • DPR 1.4 cap',
+    resolution: 'QHD smooth render • DPR 1.3 cap',
     description: 'Sharper 90 Hz profile for capable devices.'
   },
   {
@@ -47,7 +47,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.02,
     pixelRatioCap: 1.4,
-    resolution: 'UHD turbo render • DPR 1.5 cap',
+    resolution: 'UHD turbo render • DPR 1.4 cap',
     description: 'Highest quality profile for flagship and desktop GPUs.'
   },
   {
@@ -56,7 +56,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 144,
     renderScale: 1.04,
     pixelRatioCap: 1.45,
-    resolution: 'Desktop ultra render • DPR 1.55 cap',
+    resolution: 'Desktop ultra render • DPR 1.45 cap',
     description: 'Unlocked 144 Hz profile for high-end desktop hardware.'
   }
 ]);
@@ -91,11 +91,11 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
 });
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
-  fhd60: 1536,
-  qhd90: 2048,
-  uhd120: 3072,
-  ultra144: 3072
+  hd50: 1536,
+  fhd60: 2048,
+  qhd90: 3072,
+  uhd120: 4096,
+  ultra144: 4096
 });
 
 function getAdaptiveTextureSize(baseSize = 2048) {
@@ -3050,13 +3050,13 @@ const WOOD_GRAIN_OPTIONS = Object.freeze([
     id: 'rosewood_veneer_01',
     label: 'Rosewood Veneer 01',
     rail: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.7, y: 0.7 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: 1, y: 1 },
+      repeat: { x: 0.72, y: 0.72 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')


### PR DESCRIPTION
### Motivation
- Fix mismatch between Domino Royal graphics menu DPR labels and the configured `pixelRatioCap`/texture sizes so selected presets reflect actual render quality. 
- Ensure the octagon (Murlan) procedural table uses the same wood finish UV/mapping scale used by the Texas Hold’em default finishes so GLTF finish textures look consistent across games.

### Description
- Updated graphics preset labels in `domino-royal-game.js` so the displayed DPR caps match the configured `pixelRatioCap` for `qhd90`, `uhd120`, and `ultra144`. 
- Increased the adaptive texture-size mapping in `FRAME_RATE_TEXTURE_SIZE_MAP` so `hd50`, `fhd60`, `qhd90`, `uhd120`, and `ultra144` map to higher texture sizes (`1536`, `2048`, `3072`, `4096`, `4096`) to better match menu quality expectations. 
- Adjusted the `rosewood_veneer_01` wood grain UV repeats for the octagon/procedural table from `{x:1,y:1}` to `{x:0.7,y:0.7}` (rail) and `{x:0.72,y:0.72}` (frame) to match Texas Hold’em table finish mapping. 
- Changes are limited to `webapp/public/domino-royal-game.js` and adjust runtime texture allocation and UV repeat values used when applying finishes.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without syntax errors. 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the site served successfully. 
- Executed a headless Playwright script to load the Domino lobby page and capture a screenshot, which completed successfully and produced a rendered snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae89b7e0d48329b143b9ef5d7d26b7)