### PR TITLE
Align Domino Royal default table cloth inventory with Texas Hold'em

### DIFF
--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,8 +1,8 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
-import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
+import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: MURLAN_TABLE_FINISHES.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
@@ -13,12 +13,16 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     thumbnail,
     woodOption
   })),
-  tableCloth: POOL_ROYALE_CLOTH_VARIANTS.map(({ id, name, price = 0, description, swatches }) => ({
+  tableCloth: TABLE_CLOTH_OPTIONS.map(({ id, label, price = 0, description, swatches, sourceId, feltTop, feltBottom, emissive }) => ({
     id,
-    label: name,
+    label,
     price,
     description,
-    swatches
+    swatches:
+      swatches && swatches.length
+        ? swatches
+        : [feltTop, feltBottom, emissive].filter(Boolean),
+    sourceId
   })),
   tableTheme: MURLAN_TABLE_THEMES.map(({ id, label, price = 0, description, source, assetId, preserveMaterials }) => ({
     id,
@@ -81,7 +85,7 @@ const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
 const DOMINO_DEFAULT_IDS = Object.freeze({
   tableTheme: 'murlan-default',
   tableWood: 'peelingPaintWeathered',
-  tableCloth: 'emerald',
+  tableCloth: TABLE_CLOTH_OPTIONS[0]?.id,
   chairTheme: 'dining_chair_02'
 });
 


### PR DESCRIPTION
### Motivation
- Ensure Domino Royal uses the same table cloth/material definitions as Texas Hold'em so table finish, cloth textures and metadata are identical across both games.
- Reduce duplication and keep default cloth selection synchronized between games for consistent visuals and asset mapping.

### Description
- Switch `tableCloth` source to the shared `TABLE_CLOTH_OPTIONS` (imported from `../utils/tableCustomizationOptions.js`) so Domino reuses the same cloth definitions used by Texas Hold'em.
- Map cloth fields to preserve existing UI/store behavior and add a swatches fallback that derives `[feltTop, feltBottom, emissive]` when explicit `swatches` are missing, and expose `sourceId` for texture lookups.
- Update the Domino default cloth ID to use the first shared cloth option (`TABLE_CLOTH_OPTIONS[0]?.id`) so defaults stay in sync.

### Testing
- Ran a module import smoke check with `node -e "import('./webapp/src/config/dominoRoyalInventoryConfig.js').then(m=>console.log('tableCloth options', m.DOMINO_ROYAL_OPTION_SETS.tableCloth.length, 'default', m.DOMINO_ROYAL_DEFAULT_LOADOUT.find(x=>x.type==='tableCloth')?.optionId)).catch(e=>{console.error(e);process.exit(1);})"` and the config loaded successfully, reporting the expected cloth options and resolved default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea404afe8832985e18ad0d190bdac)