### PR TITLE
Allow `variant` in Pool Royale online matchmaking metadata

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -8,7 +8,7 @@ const BASE_SECURITY_CONTROLS = Object.freeze([
 ]);
 
 const GAME_ONLINE_POLICY = Object.freeze({
-  poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'ballSet', 'token'] },
+  poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'] },
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -14,6 +14,7 @@ describe('online game policy', () => {
       maxPlayers: 2,
       matchMeta: {
         mode: 'Ranked',
+        variant: 'UK',
         tableSize: '9ft',
         token: 'TPC',
         unexpected: 'ignore-me'
@@ -23,7 +24,12 @@ describe('online game policy', () => {
     expect(result.ok).toBe(true);
     expect(result.normalizedStake).toBe(25);
     expect(result.normalizedMaxPlayers).toBe(2);
-    expect(result.safeMatchMeta).toEqual({ mode: 'Ranked', tableSize: '9ft', token: 'TPC' });
+    expect(result.safeMatchMeta).toEqual({
+      mode: 'Ranked',
+      variant: 'UK',
+      tableSize: '9ft',
+      token: 'TPC'
+    });
   });
 
   test('rejects unsupported game and invalid max players', () => {


### PR DESCRIPTION
### Motivation
- The server-side matchmaking policy for Pool Royale was omitting the client `variant` metadata, which could split players who selected the same variant and other criteria into different lobby tables, so the policy must accept `variant` to restore correct pairing.

### Description
- Add `'variant'` to `GAME_ONLINE_POLICY.poolroyale.allowMatchMeta` in `bot/config/onlineGamePolicy.js` so `validateSeatTableRequest` preserves `variant` for table compatibility checks.
- Update `test/onlineGamePolicy.test.js` to include and assert that `variant` is accepted and sanitized in the resulting `safeMatchMeta`.

### Testing
- Ran unit tests with `npm test -- --runInBand test/onlineGamePolicy.test.js test/poolRoyaleOnlineFlow.test.js`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea92e94308329b83e8ccb1856e690)