### PR TITLE
Revert "Allow `variant` in Pool Royale online matchmaking metadata"

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -8,7 +8,7 @@ const BASE_SECURITY_CONTROLS = Object.freeze([
 ]);
 
 const GAME_ONLINE_POLICY = Object.freeze({
-  poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'] },
+  poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'ballSet', 'token'] },
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -14,7 +14,6 @@ describe('online game policy', () => {
       maxPlayers: 2,
       matchMeta: {
         mode: 'Ranked',
-        variant: 'UK',
         tableSize: '9ft',
         token: 'TPC',
         unexpected: 'ignore-me'
@@ -24,12 +23,7 @@ describe('online game policy', () => {
     expect(result.ok).toBe(true);
     expect(result.normalizedStake).toBe(25);
     expect(result.normalizedMaxPlayers).toBe(2);
-    expect(result.safeMatchMeta).toEqual({
-      mode: 'Ranked',
-      variant: 'UK',
-      tableSize: '9ft',
-      token: 'TPC'
-    });
+    expect(result.safeMatchMeta).toEqual({ mode: 'Ranked', tableSize: '9ft', token: 'TPC' });
   });
 
   test('rejects unsupported game and invalid max players', () => {


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#16493