### PR TITLE
Fix Pool Royale online matchmaking for partial lobby metadata

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -473,9 +473,20 @@ function normalizeMatchMeta(rawMeta = {}) {
 }
 
 function isMatchMetaCompatible(existing = {}, requested = {}) {
-  const entries = Object.entries(requested);
-  if (!entries.length) return true;
-  return entries.every(([key, value]) => (existing?.[key] || '') === value);
+  return MATCH_META_KEYS.every((key) => {
+    const existingValue = existing?.[key] || '';
+    const requestedValue = requested?.[key] || '';
+    if (!existingValue || !requestedValue) return true;
+    return existingValue === requestedValue;
+  });
+}
+
+function mergeMatchMeta(existing = {}, requested = {}) {
+  const merged = { ...existing };
+  MATCH_META_KEYS.forEach((key) => {
+    if (!merged[key] && requested[key]) merged[key] = requested[key];
+  });
+  return merged;
 }
 
 function isRateLimited(socket, key, cooldownMs) {
@@ -710,9 +721,7 @@ async function seatTableSocket(
   console.log(`Player ${playerName || accountId} joined table ${tableId}`);
   socket?.join(tableId);
   table.ready.delete(String(accountId));
-  if (!table.meta) {
-    table.meta = normalizeMatchMeta(matchMeta);
-  }
+  table.meta = mergeMatchMeta(table.meta, normalizeMatchMeta(matchMeta));
   io.to(tableId).emit('lobbyUpdate', {
     tableId,
     players: table.players,

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function connectClient(port) {
+  return io(`http://localhost:${port}`, { auth: { token: apiToken } });
+}
+
+test('pool royale players with partially-filled matching meta share same table', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3207',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3207);
+  const s2 = connectClient(3207);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-1' });
+    s2.emit('register', { playerId: 'acct-2' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit('seatTable', {
+        accountId: 'acct-1',
+        gameType: 'poolroyale',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        playType: 'regular',
+        playerName: 'P1'
+      }, resolve);
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit('seatTable', {
+        accountId: 'acct-2',
+        gameType: 'poolroyale',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        playType: 'regular',
+        tableSize: 'pro',
+        playerName: 'P2'
+      }, resolve);
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});


### PR DESCRIPTION
### Motivation
- Players could not be matched into the same Pool Royale table when one player supplied optional match metadata (e.g. `tableSize`) and the other did not, because missing fields were treated as hard mismatches.
- The goal is to allow players with the same core criteria to be matched even when optional metadata is partially filled, and to let the table metadata be enriched over time.

### Description
- Changed `isMatchMetaCompatible` in `bot/server.js` to only enforce equality for a meta key when both the existing table value and the requested value are present, allowing missing/optional fields to not block matches.
- Added `mergeMatchMeta(existing, requested)` in `bot/server.js` and applied it from `seatTableSocket` so a table's `meta` is progressively enriched with non-empty normalized fields from subsequent seat requests.
- Applied normalized metadata via `normalizeMatchMeta` and used the new merge when a player seats, replacing the previous logic that locked meta to the first seat.
- Added a regression test `test/poolRoyaleMatchmakingMeta.test.js` that verifies two Pool Royale players with matching core criteria but partially-filled metadata are seated into the same table.

### Testing
- Ran `npm test -- test/poolRoyaleMatchmakingMeta.test.js test/poolRoyaleOnlineFlow.test.js --runInBand`, and both tests passed.
- Ran `npm test -- test/lobbyWait.test.js test/onlineRoutes.test.js test/poolRoyaleOnlineFlow.test.js --runInBand`, and all suites passed.
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` earlier for quick validation, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea92e94308329b83e8ccb1856e690)