### PR TITLE
Fix Chess Battle Royal online lobby identity mismatch

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -171,6 +171,13 @@ export default function ChessBattleRoyalLobby() {
           accountId: trackedAccountId,
         });
       } catch {}
+
+      if (!trackedAccountId) {
+        setMatchError('Unable to resolve your player account. Reopen Telegram and try again.');
+        setMatching(false);
+        setMatchStatus('');
+        return;
+      }
     }
 
     if (!isOnline) {
@@ -214,7 +221,7 @@ export default function ChessBattleRoyalLobby() {
 
     socket.on('gameStart', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
-    socket.emit('register', { playerId: trackedAccountId || accountId });
+    socket.emit('register', { playerId: trackedAccountId });
 
     const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
     socket.emit(
@@ -237,7 +244,7 @@ export default function ChessBattleRoyalLobby() {
         pendingTableRef.current = res.tableId;
         setMatchStatus('Waiting for another player…');
         socket.emit('confirmReady', {
-          accountId: trackedAccountId || accountId,
+          accountId: trackedAccountId,
           tableId: res.tableId
         });
       }


### PR DESCRIPTION
### Motivation
- Prevent a scenario where two players appear to be queued but the match never starts because the server rejects mismatched identities during lobby registration and readiness.
- Ensure the client uses a single resolved account identity for the full online join flow so server-side `ensureRegistered` checks succeed.

### Description
- Require a resolved account id from `ensureAccountId()` before continuing into online matchmaking and surface an error via `setMatchError` when resolution fails, returning early instead of continuing with an inconsistent identity.
- Always register the socket with the resolved `trackedAccountId` by emitting `socket.emit('register', { playerId: trackedAccountId })` so server identity checks match the later events.
- Send `confirmReady` using the same resolved `trackedAccountId` to ensure the server sees a consistent identity when marking the player ready, avoiding readiness mismatches that block `gameStart`.
- Modified file: `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js` and the suite passed (2 tests, 1 file) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea962857c8329ab8557f39c941dcc)