### PR TITLE
Fix online matchmaking when socket starts disconnected

### DIFF
--- a/test/simpleOnlineFlow.test.js
+++ b/test/simpleOnlineFlow.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+import { runSimpleOnlineFlow } from '../webapp/src/utils/simpleOnlineFlow.js';
+
+class MockSocket extends EventEmitter {
+  constructor({ connected = false, connectSucceeds = true } = {}) {
+    super();
+    this.connected = connected;
+    this.connectSucceeds = connectSucceeds;
+    this.seatRequests = [];
+    this.leaveRequests = [];
+  }
+
+  connect() {
+    if (this.connectSucceeds) {
+      this.connected = true;
+      setTimeout(() => this.emit('connect'), 0);
+    }
+    return this;
+  }
+
+  emit(event, payload, cb) {
+    if (event === 'seatTable') {
+      this.seatRequests.push({ payload, cb });
+      cb?.({ success: true, tableId: 'goalrush-1' });
+      return true;
+    }
+    if (event === 'leaveLobby') {
+      this.leaveRequests.push(payload);
+      return true;
+    }
+    return super.emit(event, payload, cb);
+  }
+}
+
+function createState() {
+  const snapshot = {
+    matching: false,
+    matchStatus: '',
+    matchError: ''
+  };
+
+  return {
+    snapshot,
+    setMatching: (value) => { snapshot.matching = value; },
+    setMatchStatus: (value) => { snapshot.matchStatus = value; },
+    setMatchError: (value) => { snapshot.matchError = value; }
+  };
+}
+
+test('runSimpleOnlineFlow reconnects socket before joining a table', async () => {
+  const mockSocket = new MockSocket({ connected: false, connectSucceeds: true });
+  const state = createState();
+  const transactions = [];
+
+  const result = await runSimpleOnlineFlow({
+    gameType: 'goalrush',
+    stake: { token: 'TPC', amount: 100 },
+    state,
+    deps: {
+      ensureAccountId: () => Promise.resolve('acct-1'),
+      getAccountBalance: () => Promise.resolve({ balance: 500 }),
+      addTransaction: (...args) => {
+        transactions.push(args);
+        return Promise.resolve();
+      },
+      getTelegramId: () => 'tg-1',
+      socket: mockSocket
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(mockSocket.seatRequests.length, 1);
+  assert.equal(state.snapshot.matchError, '');
+  assert.equal(transactions.length, 1, 'debit should happen once and no refund should occur');
+  result.cleanup();
+});
+
+test('runSimpleOnlineFlow refunds stake when socket reconnection fails', async () => {
+  const mockSocket = new MockSocket({ connected: false, connectSucceeds: false });
+  const state = createState();
+  const transactions = [];
+
+  const result = await runSimpleOnlineFlow({
+    gameType: 'goalrush',
+    stake: { token: 'TPC', amount: 80 },
+    state,
+    timeoutMs: 100,
+    socketConnectTimeoutMs: 40,
+    deps: {
+      ensureAccountId: () => Promise.resolve('acct-2'),
+      getAccountBalance: () => Promise.resolve({ balance: 500 }),
+      addTransaction: (...args) => {
+        transactions.push(args);
+        return Promise.resolve();
+      },
+      getTelegramId: () => 'tg-2',
+      socket: mockSocket
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(state.snapshot.matchError, 'Socket not connected. Please retry.');
+  assert.equal(transactions.length, 2, 'debit should be refunded after failed socket reconnection');
+  assert.equal(transactions[0][1], -80);
+  assert.equal(transactions[1][1], 80);
+  assert.equal(transactions[1][2], 'stake_refund');
+  result.cleanup();
+});

--- a/webapp/src/utils/simpleOnlineFlow.js
+++ b/webapp/src/utils/simpleOnlineFlow.js
@@ -3,6 +3,41 @@ import { getAccountBalance, addTransaction } from './api.js';
 import { socket } from './socket.js';
 
 const DEFAULT_MATCH_TIMEOUT_MS = 35000;
+const SOCKET_CONNECT_TIMEOUT_MS = 8000;
+
+async function ensureSocketReady(socketInstance, timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
+  if (!socketInstance) return false;
+  if (socketInstance.connected) return true;
+
+  try {
+    socketInstance.connect?.();
+  } catch {
+    return false;
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socketInstance.off?.('connect', onConnect);
+      socketInstance.off?.('connect_error', onConnectError);
+      socketInstance.off?.('error', onConnectError);
+      resolve(ok);
+    };
+
+    const onConnect = () => finish(true);
+    const onConnectError = () => finish(false);
+
+    const timer = setTimeout(() => finish(socketInstance.connected), timeoutMs);
+
+    socketInstance.once?.('connect', onConnect);
+    socketInstance.once?.('connect_error', onConnectError);
+    socketInstance.once?.('error', onConnectError);
+  });
+}
 
 export async function runSimpleOnlineFlow({
   gameType,
@@ -15,6 +50,7 @@ export async function runSimpleOnlineFlow({
   onMatched,
   deps = {},
   timeoutMs = DEFAULT_MATCH_TIMEOUT_MS,
+  socketConnectTimeoutMs = SOCKET_CONNECT_TIMEOUT_MS,
 }) {
   const {
     setMatching,
@@ -104,10 +140,10 @@ export async function runSimpleOnlineFlow({
     });
     stakeDebited = true;
 
-    if (!socketInstance?.connected) {
+    const socketReady = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
+    if (!socketReady) {
       setMatchError('Socket not connected. Please retry.');
-      setMatching(false);
-      setMatchStatus('');
+      cleanup({ keepError: true, refund: stakeDebited });
       return { ok: false, cleanup };
     }
 


### PR DESCRIPTION
### Motivation

- Prevent Goal Rush lobby from showing "Socket not connected. Please retry." immediately when the client socket is temporarily disconnected but can reconnect shortly. 
- Avoid charging players when matchmaking fails due to a transient socket connection race. 

### Description

- Added `ensureSocketReady()` in `webapp/src/utils/simpleOnlineFlow.js` to attempt `socket.connect()` and wait briefly for `connect`/`connect_error` (configurable timeout) before failing. 
- Introduced `socketConnectTimeoutMs` (default `8000ms`) and used it in `runSimpleOnlineFlow` to control how long we wait for socket readiness. 
- On socket readiness failure, invoke the existing unified `cleanup()` path so any debited stake is refunded and matching state is cleared. 
- Added `test/simpleOnlineFlow.test.js` with two focused Jest cases covering successful reconnect and failed reconnect (refund) paths. 

### Testing

- Ran the focused test suite with `npm test -- test/simpleOnlineFlow.test.js` and both tests passed. 
- Test run shows the two added tests exercise the reconnect-success and reconnect-failure behaviors and validate stake debit/refund. 
- Note: Jest reported open-handle warnings in this environment after tests complete, but the tests themselves passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeada813f88329baded3c151e9e2db)