### PR TITLE
Restore server behavior to fix Profile page access

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -454,7 +454,6 @@ const tableWatchers = new Map();
 const lobbyTables = {};
 const tableMap = new Map();
 const poolStates = new Map();
-const goalRushStates = new Map();
 const snookerStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
@@ -474,20 +473,9 @@ function normalizeMatchMeta(rawMeta = {}) {
 }
 
 function isMatchMetaCompatible(existing = {}, requested = {}) {
-  return MATCH_META_KEYS.every((key) => {
-    const existingValue = existing?.[key] || '';
-    const requestedValue = requested?.[key] || '';
-    if (!existingValue || !requestedValue) return true;
-    return existingValue === requestedValue;
-  });
-}
-
-function mergeMatchMeta(existing = {}, requested = {}) {
-  const merged = { ...existing };
-  MATCH_META_KEYS.forEach((key) => {
-    if (!merged[key] && requested[key]) merged[key] = requested[key];
-  });
-  return merged;
+  const entries = Object.entries(requested);
+  if (!entries.length) return true;
+  return entries.every(([key, value]) => (existing?.[key] || '') === value);
 }
 
 function isRateLimited(socket, key, cooldownMs) {
@@ -722,7 +710,9 @@ async function seatTableSocket(
   console.log(`Player ${playerName || accountId} joined table ${tableId}`);
   socket?.join(tableId);
   table.ready.delete(String(accountId));
-  table.meta = mergeMatchMeta(table.meta, normalizeMatchMeta(matchMeta));
+  if (!table.meta) {
+    table.meta = normalizeMatchMeta(matchMeta);
+  }
   io.to(tableId).emit('lobbyUpdate', {
     tableId,
     players: table.players,
@@ -1573,75 +1563,6 @@ io.on('connection', (socket) => {
         updatedAt: cached.ts
       });
     }
-  });
-
-  socket.on('joinGoalRushTable', async ({ tableId, accountId }) => {
-    if (!tableId) return;
-    if (accountId && !ensureRegistered(socket, accountId)) return;
-    socket.join(tableId);
-    if (accountId) {
-      await registerConnection({
-        userId: String(accountId),
-        roomId: tableId,
-        socketId: socket.id
-      });
-    }
-    const table = tableMap.get(tableId);
-    const players = Array.isArray(table?.players) ? table.players : [];
-    const sideIndex = players.findIndex((player) => String(player.id) === String(accountId));
-    socket.emit('goalRushSeat', {
-      tableId,
-      players,
-      side: sideIndex === 1 ? 'top' : 'bottom',
-      isHost: sideIndex <= 0
-    });
-    const cached = goalRushStates.get(tableId);
-    if (cached?.state) {
-      socket.emit('goalRushState', {
-        tableId,
-        state: cached.state,
-        updatedAt: cached.ts,
-        hostId: cached.hostId || null
-      });
-    }
-  });
-
-  socket.on('goalRushSyncRequest', ({ tableId }) => {
-    if (!tableId) return;
-    const cached = goalRushStates.get(tableId);
-    if (!cached?.state) return;
-    socket.emit('goalRushState', {
-      tableId,
-      state: cached.state,
-      updatedAt: cached.ts,
-      hostId: cached.hostId || null
-    });
-  });
-
-  socket.on('goalRushInput', ({ tableId, accountId, input }) => {
-    if (!tableId || !input) return;
-    socket.to(tableId).emit('goalRushInput', {
-      tableId,
-      accountId: accountId || null,
-      input,
-      updatedAt: Date.now()
-    });
-  });
-
-  socket.on('goalRushState', ({ tableId, accountId, state }) => {
-    if (!tableId || !state) return;
-    const ts = Date.now();
-    goalRushStates.set(tableId, {
-      state,
-      ts,
-      hostId: accountId || null
-    });
-    socket.to(tableId).emit('goalRushState', {
-      tableId,
-      state,
-      updatedAt: ts,
-      hostId: accountId || null
-    });
   });
 
   socket.on('poolSyncRequest', ({ tableId }) => {


### PR DESCRIPTION
### Motivation
- Recent server-side additions for Goal Rush realtime state and metadata merging caused a regression that prevented the Profile page from loading as expected. 
- The change reverts those runtime socket handlers and metadata merging so the server behaves like the known-good morning baseline. 

### Description
- Removed the Goal Rush in-memory cache (`goalRushStates`) and socket handlers: `joinGoalRushTable`, `goalRushSyncRequest`, `goalRushInput`, and `goalRushState`. 
- Replaced the previous `mergeMatchMeta`/broad-match logic with a simpler compatibility check in `isMatchMetaCompatible` that validates requested entries directly via `Object.entries`. 
- Restored table meta assignment to only initialize meta when missing inside `seatTableSocket` by setting `table.meta = normalizeMatchMeta(matchMeta)` only if `!table.meta`. 
- Cleaned up related helper function removal and adjusted the `seatTableSocket` flow to avoid merging new match meta into existing meta. 

### Testing
- Ran the targeted unit tests with `npm test -- --runTestsByPath test/simpleOnlineFlow.test.js` and all tests passed (2 passed). 
- Performed a syntax check with `node --check bot/server.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeafa92f048329829966f22f4c58fc)