### PR TITLE
Fix TikTok video availability issues on Mining page modal

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -29,6 +29,7 @@ export default function TikTokTaskVideo({
 }) {
   const [open, setOpen] = useState(false);
   const [showFallback, setShowFallback] = useState(false);
+  const [useAltPlayer, setUseAltPlayer] = useState(false);
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const embedUrl = useMemo(() => {
     if (!videoId) return '';
@@ -38,6 +39,10 @@ export default function TikTokTaskVideo({
     if (!videoId) return '';
     return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
   }, [videoId]);
+  const activeEmbedUrl = useMemo(
+    () => (useAltPlayer ? embedUrl : legacyEmbedUrl),
+    [embedUrl, legacyEmbedUrl, useAltPlayer],
+  );
   const canonicalVideoUrl = useMemo(() => {
     if (!videoId) return videoUrl || '';
     return `https://www.tiktok.com/@tonplaygram/video/${videoId}`;
@@ -51,11 +56,16 @@ export default function TikTokTaskVideo({
   }, [autoOpen, embedUrl, storageKey]);
 
   useEffect(() => {
-    if (!open || !embedUrl) return;
+    if (!open || !activeEmbedUrl) return;
     setShowFallback(false);
     const id = setTimeout(() => setShowFallback(true), 4000);
     return () => clearTimeout(id);
-  }, [open, embedUrl]);
+  }, [open, activeEmbedUrl]);
+
+  useEffect(() => {
+    if (!open) return;
+    setUseAltPlayer(false);
+  }, [open, videoId]);
 
   return (
     <>
@@ -78,11 +88,11 @@ export default function TikTokTaskVideo({
                 Close
               </button>
             </div>
-            {embedUrl ? (
+            {activeEmbedUrl ? (
               <div className="relative flex-1 min-h-0">
                 <iframe
                   title={title}
-                  src={embedUrl}
+                  src={activeEmbedUrl}
                   className="absolute inset-0 w-full h-full"
                   allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
                   allowFullScreen
@@ -97,14 +107,17 @@ export default function TikTokTaskVideo({
             {showFallback && (
               <div className="px-3 pt-2 text-center text-[11px] text-yellow-300 space-y-1">
                 <p>Video preview can be blocked in some devices. Open it directly in TikTok.</p>
-                {legacyEmbedUrl && (
+                {embedUrl && legacyEmbedUrl && (
                   <a
-                    href={legacyEmbedUrl}
-                    target="_blank"
-                    rel="noreferrer"
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setUseAltPlayer((prev) => !prev);
+                      setShowFallback(false);
+                    }}
                     className="inline-block underline"
                   >
-                    Try alternative TikTok player
+                    Try {useAltPlayer ? 'classic player' : 'embed'} player
                   </a>
                 )}
               </div>


### PR DESCRIPTION
### Motivation
- Users saw TikTok videos marked unavailable in the Mining modal because some environments block or mis-handle the embed endpoint, so the modal needs a more reliable player flow.
- Provide an in-modal way to switch players and a predictable reset so the UX is consistent across opens.

### Description
- Updated `TikTokTaskVideo` to prefer the classic TikTok player path (`/player/v1/{id}`) and added `useAltPlayer` state to toggle between the classic and embed endpoints without leaving the modal.
- Introduced `activeEmbedUrl` which selects the active player URL, and wired the iframe `src` to use `activeEmbedUrl` so player switching happens in-place.
- Added logic to reset `useAltPlayer` on each modal open and moved the fallback timeout to watch `activeEmbedUrl` instead of a single URL.
- Replaced the fallback link to toggle playback mode inside the modal and retained the canonical `Open on TikTok` link as a final fallback.

### Testing
- Built the webapp successfully with `cd webapp && npm run build` and the build completed without errors.
- Verified TikTok redirect behavior via `curl -I` against short links which returned redirects to canonical video pages as expected.
- Ran a browser automation script that opened `/mining`, clicked the "Daily Streaks Video" button, and captured a screenshot (`artifacts/mining-tiktok-loaded.png`), confirming the modal loaded video content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb936ba5483299d939dbabd88385a)