### PR TITLE
Subtle landscape-only top lift for Texas Hold'em community cards

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -351,6 +351,7 @@ const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
+const COMMUNITY_CARD_LANDSCAPE_TOP_LIFT = CARD_H * 0.035;
 const COMMUNITY_CARD_TILT = 0;
 const COMMUNITY_ROW_ROTATION = 0;
 const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
@@ -5571,6 +5572,11 @@ function TexasHoldemArena({ search }) {
     three.orientHumanCards?.();
 
     const newlyRevealedCommunity = [];
+    const viewportWidth = three.renderer?.domElement?.clientWidth ?? 0;
+    const viewportHeight = three.renderer?.domElement?.clientHeight ?? 0;
+    const isLandscapeViewport = viewportWidth > viewportHeight;
+    const communityCardLookLift =
+      COMMUNITY_CARD_LOOK_LIFT + (isLandscapeViewport ? COMMUNITY_CARD_LANDSCAPE_TOP_LIFT : 0);
     communityMeshes.forEach((mesh, idx) => {
       const sourceIdx = communityMeshes.length - 1 - idx;
       const card = state.community[sourceIdx];
@@ -5595,7 +5601,7 @@ function TexasHoldemArena({ search }) {
       }
       const lookTarget = slotPosition
         .clone()
-        .add(new THREE.Vector3(0, COMMUNITY_CARD_LOOK_LIFT, 0))
+        .add(new THREE.Vector3(0, communityCardLookLift, 0))
         .add(forward);
       orientCard(mesh, lookTarget, { face: 'front', flat: true });
       if (COMMUNITY_CARD_TILT) {


### PR DESCRIPTION
### Motivation
- Ensure the top edge of community cards is lifted slightly when playing in landscape so the top side appears higher while the bottom remains anchored, matching the requested visual tweak.

### Description
- Added `COMMUNITY_CARD_LANDSCAPE_TOP_LIFT` and compute `communityCardLookLift` based on viewport orientation, then use it in the community card `lookTarget` calculation in `webapp/src/pages/Games/TexasHoldemArena.jsx` so the extra lift applies only when `clientWidth > clientHeight`.

### Testing
- Built the webapp successfully using `npm --prefix webapp run build` (Vite build completed).
- Ran a Playwright script to load `/games/texasholdem` in a landscape viewport and capture a screenshot to verify the visual adjustment (script completed and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebf973fb08329a5685bc325aef114)