### PR TITLE
Improve TikTok embed handling and fallbacks for reward videos

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-const AD_IFRAME_URL = 'https://www.tiktok.com/embed/v2/7515418978852781329';
-const AD_FALLBACK_URL = 'https://vt.tiktok.com/ZSuREWyqx/';
+const AD_VIDEO_ID = '7614838290667031816';
+const AD_PLAYER_URL = `https://www.tiktok.com/player/v1/${AD_VIDEO_ID}?autoplay=1&rel=0`;
+const AD_CANONICAL_URL = `https://www.tiktok.com/@tonplaygram/video/${AD_VIDEO_ID}`;
 const REWARD_DELAY_MS = 15_000;
 
 interface AdModalProps {
@@ -13,11 +14,13 @@ interface AdModalProps {
 export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
   const rewardIssuedRef = useRef(false);
   const [remainingMs, setRemainingMs] = useState(REWARD_DELAY_MS);
+  const [showOpenLinkHint, setShowOpenLinkHint] = useState(false);
 
   useEffect(() => {
     if (!open) {
       rewardIssuedRef.current = false;
       setRemainingMs(REWARD_DELAY_MS);
+      setShowOpenLinkHint(false);
       return;
     }
 
@@ -32,7 +35,14 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
       }
     }, 250);
 
-    return () => window.clearInterval(intervalId);
+    const fallbackHintId = window.setTimeout(() => {
+      setShowOpenLinkHint(true);
+    }, 4000);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.clearTimeout(fallbackHintId);
+    };
   }, [open, onComplete]);
 
   const remainingSeconds = useMemo(
@@ -64,18 +74,26 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
           </p>
         </div>
 
-        <div className="aspect-[9/16] w-full overflow-hidden rounded-lg border border-border bg-black">
+        <div className="aspect-[9/16] w-full overflow-hidden rounded-lg border border-border bg-black relative">
           <iframe
-            src={AD_IFRAME_URL}
+            src={AD_PLAYER_URL}
             title="Rewarded TikTok"
             className="w-full h-full"
             allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
             allowFullScreen
+            loading="lazy"
+            referrerPolicy="strict-origin-when-cross-origin"
           />
         </div>
 
+        {showOpenLinkHint && (
+          <p className="text-center text-[11px] text-yellow-300">
+            If your device blocks preview playback, open the video directly in TikTok.
+          </p>
+        )}
+
         <a
-          href={AD_FALLBACK_URL}
+          href={AD_CANONICAL_URL}
           target="_blank"
           rel="noreferrer"
           className="block text-center text-xs text-blue-300 underline"

--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -7,11 +7,10 @@ function getVideoId(urlOrId) {
   const match = raw.match(/\/video\/(\d+)/);
   if (match) return match[1];
 
-  const embedMatch = raw.match(/\/embed\/(?:v2\/)?(\d+)/);
+  const embedMatch = raw.match(/\/(?:embed\/(?:v2\/)?|player\/v1\/)(\d+)/);
   if (embedMatch) return embedMatch[1];
 
   const normalized = raw.endsWith('/') ? raw : `${raw}/`;
-
   const shortLinkVideoMap = {
     'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
     'https://vt.tiktok.com/ZSujaPuVF/': '7614600402654252296',
@@ -19,6 +18,17 @@ function getVideoId(urlOrId) {
     'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
   };
   return shortLinkVideoMap[raw] || shortLinkVideoMap[normalized] || '';
+}
+
+function ensureTikTokEmbedScript() {
+  const src = 'https://www.tiktok.com/embed.js';
+  let script = document.querySelector(`script[src="${src}"]`);
+  if (!script) {
+    script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    document.body.appendChild(script);
+  }
 }
 
 export default function TikTokTaskVideo({
@@ -29,33 +39,47 @@ export default function TikTokTaskVideo({
 }) {
   const [open, setOpen] = useState(false);
   const [showFallback, setShowFallback] = useState(false);
+  const [oEmbedReady, setOEmbedReady] = useState(false);
+
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
-  const embedUrl = useMemo(() => {
-    if (!videoId) return '';
-    return `https://www.tiktok.com/embed/v2/${videoId}?autoplay=1&rel=0`;
-  }, [videoId]);
-  const legacyEmbedUrl = useMemo(() => {
-    if (!videoId) return '';
-    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
-  }, [videoId]);
   const canonicalVideoUrl = useMemo(() => {
     if (!videoId) return videoUrl || '';
     return `https://www.tiktok.com/@tonplaygram/video/${videoId}`;
   }, [videoId, videoUrl]);
+  const playerUrl = useMemo(() => {
+    if (!videoId) return '';
+    return `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&rel=0`;
+  }, [videoId]);
 
   useEffect(() => {
-    if (!autoOpen || !embedUrl || !storageKey) return;
+    if (!autoOpen || !playerUrl || !storageKey) return;
     if (localStorage.getItem(storageKey) === '1') return;
     setOpen(true);
     localStorage.setItem(storageKey, '1');
-  }, [autoOpen, embedUrl, storageKey]);
+  }, [autoOpen, playerUrl, storageKey]);
 
   useEffect(() => {
-    if (!open || !embedUrl) return;
+    if (!open || !canonicalVideoUrl) return;
     setShowFallback(false);
-    const id = setTimeout(() => setShowFallback(true), 4000);
-    return () => clearTimeout(id);
-  }, [open, embedUrl]);
+    setOEmbedReady(false);
+    ensureTikTokEmbedScript();
+
+    const id = window.setTimeout(() => {
+      setShowFallback(true);
+    }, 4500);
+
+    const renderTicker = window.setTimeout(() => {
+      if (typeof window.tiktokEmbedLoad === 'function') {
+        window.tiktokEmbedLoad();
+      }
+      setOEmbedReady(true);
+    }, 120);
+
+    return () => {
+      clearTimeout(id);
+      clearTimeout(renderTicker);
+    };
+  }, [open, canonicalVideoUrl]);
 
   return (
     <>
@@ -78,35 +102,34 @@ export default function TikTokTaskVideo({
                 Close
               </button>
             </div>
-            {embedUrl ? (
-              <div className="relative flex-1 min-h-0">
-                <iframe
-                  title={title}
-                  src={embedUrl}
-                  className="absolute inset-0 w-full h-full"
-                  allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
-                  allowFullScreen
-                  loading="lazy"
-                  referrerPolicy="strict-origin-when-cross-origin"
-                  onLoad={() => setShowFallback(false)}
-                />
+            {canonicalVideoUrl ? (
+              <div className="relative flex-1 min-h-0 p-1">
+                <blockquote
+                  className="tiktok-embed absolute inset-0 m-0 h-full w-full"
+                  cite={canonicalVideoUrl}
+                  data-video-id={videoId}
+                  style={{ maxWidth: '100%', minWidth: '100%', margin: 0 }}
+                >
+                  <section />
+                </blockquote>
+                {!oEmbedReady && playerUrl && (
+                  <iframe
+                    title={`${title} fallback player`}
+                    src={playerUrl}
+                    className="absolute inset-0 w-full h-full"
+                    allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+                    allowFullScreen
+                    loading="lazy"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                  />
+                )}
               </div>
             ) : (
               <div className="p-4 text-sm text-subtext">Invalid TikTok video URL.</div>
             )}
             {showFallback && (
-              <div className="px-3 pt-2 text-center text-[11px] text-yellow-300 space-y-1">
-                <p>Video preview can be blocked in some devices. Open it directly in TikTok.</p>
-                {legacyEmbedUrl && (
-                  <a
-                    href={legacyEmbedUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-block underline"
-                  >
-                    Try alternative TikTok player
-                  </a>
-                )}
+              <div className="px-3 pt-2 text-center text-[11px] text-yellow-300">
+                Video preview can be blocked in some devices. Use the direct TikTok link below.
               </div>
             )}
             <a


### PR DESCRIPTION
### Motivation

- Replace brittle legacy embed URLs and improve playback reliability and fallback behavior for TikTok reward and task videos.
- Provide a clearer fallback path and hint when device/preview playback is blocked by rendering a canonical link and a direct player fallback.
- Ensure the TikTok oEmbed script is loaded when needed so embedded blockquotes render correctly across devices.

### Description

- Replace hardcoded embed URLs in `AdModal.tsx` with a player URL (`player/v1`) and canonical video URL, add `loading="lazy"` and `referrerPolicy` to the iframe, and show a timed hint to open the video directly if preview is blocked.
- Add `showOpenLinkHint` state and a timeout to reveal the hint after 4s, and clear timeouts/intervals on unmount in `AdModal.tsx`.
- Update `getVideoId` in `TikTokTaskVideo.jsx` to parse `player/v1` paths in addition to `embed` and short links, and add a small short-link mapping for known cases.
- Introduce `ensureTikTokEmbedScript` and `oEmbedReady` state to load `https://www.tiktok.com/embed.js` and let the script render a `blockquote.tiktok-embed` when available, while showing a `player/v1` iframe fallback until the oEmbed script runs.
- Adjust auto-open logic to use the new `playerUrl` and use `localStorage` gating as before, and simplify fallback messaging and links to always point to the canonical TikTok video URL.

### Testing

- Ran the frontend test suite with `yarn test` and the run completed successfully. 
- Built the frontend with `yarn build` and the production build completed without errors.
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb936ba5483299d939dbabd88385a)