### PR TITLE
Lift top edge of Texas Hold'em community cards in landscape mode

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -352,6 +352,7 @@ const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
+const COMMUNITY_CARD_LANDSCAPE_TOP_LIFT = 0.085;
 const COMMUNITY_ROW_ROTATION = 0;
 const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
   new THREE.Vector3(
@@ -5598,8 +5599,15 @@ function TexasHoldemArena({ search }) {
         .add(new THREE.Vector3(0, COMMUNITY_CARD_LOOK_LIFT, 0))
         .add(forward);
       orientCard(mesh, lookTarget, { face: 'front', flat: true });
+      const rendererCanvas = three.renderer?.domElement;
+      const isLandscape =
+        (rendererCanvas?.clientWidth ?? window.innerWidth) >
+        (rendererCanvas?.clientHeight ?? window.innerHeight);
       if (COMMUNITY_CARD_TILT) {
         mesh.rotateX(COMMUNITY_CARD_TILT);
+      }
+      if (isLandscape) {
+        mesh.rotateX(COMMUNITY_CARD_LANDSCAPE_TOP_LIFT);
       }
       setCardFace(mesh, 'front');
       const communityKey = cardKey(card);


### PR DESCRIPTION
### Motivation
- Provide a subtle visual lift of the community cards' top edge when players view the Texas Hold'em arena in landscape, while keeping the bottom anchor and portrait rendering unchanged.

### Description
- Add a new constant `COMMUNITY_CARD_LANDSCAPE_TOP_LIFT` to control a small top-edge rotation for community cards and keep the effect minimal.
- Detect current orientation from the renderer canvas size and apply the landscape-only tilt at render time inside the community card update loop in `webapp/src/pages/Games/TexasHoldemArena.jsx` by calling `mesh.rotateX(COMMUNITY_CARD_LANDSCAPE_TOP_LIFT)` when in landscape.
- Preserve existing behavior for portrait mode and existing `COMMUNITY_CARD_TILT` handling so other card orientation logic remains unchanged.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` (file is ignored by repo ESLint config; no blocking errors, a project ignore warning was reported). 
- Ran `npm --prefix webapp run build` which completed successfully and produced a production build. 
- Started the dev server and executed a Playwright script to load `/games/texasholdem` in a landscape-sized viewport and captured a screenshot to validate the visual lift was applied (script ran and produced an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebf973fb08329a5685bc325aef114)