### PR TITLE
Domino Royal: align domino texture tiers and add seated left/right look

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -98,6 +98,14 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
   ultra144: 4096
 });
 
+const DOMINO_TEXTURE_RESOLUTION_BY_QUALITY = Object.freeze({
+  hd50: 1024,
+  fhd60: 2048,
+  qhd90: 3072,
+  uhd120: 4096,
+  ultra144: 4096
+});
+
 function getAdaptiveTextureSize(baseSize = 2048) {
   const mappedSize =
     FRAME_RATE_TEXTURE_SIZE_MAP[frameRateId] ??
@@ -1485,9 +1493,12 @@ const CAMERA_MIN_RADIUS = CAMERA_BASE_RADIUS * 0.55;
 const CAMERA_MAX_RADIUS = CAMERA_BASE_RADIUS * 3.2;
 const CAMERA_DEFAULT_AZIMUTH =
   CHAIR_SEAT_ANGLES[HUMAN_SEAT_INDEX] ?? Math.PI / 2;
-const CAMERA_LATERAL_OFFSET = { portrait: 0.78, landscape: 0.58 };
-const CAMERA_REAR_OFFSET = { portrait: 1.65, landscape: 1.22 };
+const CAMERA_LATERAL_OFFSET = { portrait: 0.56, landscape: 0.4 };
+const CAMERA_REAR_OFFSET = { portrait: 1.28, landscape: 0.96 };
 const CAMERA_HEIGHT_BOOST = { portrait: 1.78, landscape: 1.46 };
+const CAMERA_LOOK_MAX_YAW = THREE.MathUtils.degToRad(34);
+const CAMERA_LOOK_SENSITIVITY = 0.0048;
+const CAMERA_LOOK_RETURN_LERP = 0.22;
 const CAMERA_TARGET = new THREE.Vector3(
   0,
   TABLE_HEIGHT + CAMERA_TARGET_LIFT + CAMERA_TARGET_EXTRA,
@@ -1738,7 +1749,14 @@ controls.target.copy(CAMERA_TARGET);
 const turnFocusTarget = controls.target.clone();
 const turnSeatTarget = new THREE.Vector3();
 const turnDominoTarget = new THREE.Vector3();
+const turnFocusLookTarget = new THREE.Vector3();
+const cameraForwardDirection = new THREE.Vector3();
+const cameraLookOffset = new THREE.Vector3();
+const cameraYawAxis = new THREE.Vector3(0, 1, 0);
+const cameraFallbackDirection = new THREE.Vector3(0, 0, -1);
 let turnDominoFocusUntil = 0;
+let lookYawCurrent = 0;
+let lookYawTarget = 0;
 
 let cameraHasUserControl = false;
 controls.addEventListener('start', () => {
@@ -1843,6 +1861,33 @@ function applyCameraConstraints() {
   controls.minDistance = minRadius;
   controls.maxDistance = maxRadius;
   controls.enableRotate = false;
+  controls.enablePan = cameraViewMode === VIEW_MODES.twoD;
+}
+
+function applyCameraLookOffset(baseTarget) {
+  if (cameraViewMode === VIEW_MODES.twoD) {
+    lookYawCurrent = 0;
+    lookYawTarget = 0;
+    return baseTarget;
+  }
+  lookYawCurrent = THREE.MathUtils.lerp(
+    lookYawCurrent,
+    lookYawTarget,
+    CAMERA_LOOK_RETURN_LERP
+  );
+  cameraForwardDirection.copy(baseTarget).sub(camera.position);
+  if (cameraForwardDirection.lengthSq() < 1e-7) {
+    cameraForwardDirection.copy(cameraFallbackDirection);
+  }
+  cameraForwardDirection.y = 0;
+  if (cameraForwardDirection.lengthSq() < 1e-7) {
+    cameraForwardDirection.copy(cameraFallbackDirection);
+  }
+  cameraForwardDirection.normalize();
+  cameraForwardDirection.applyAxisAngle(cameraYawAxis, lookYawCurrent);
+  const focusDistance = Math.max(TABLE_RADIUS * 0.52, 0.8);
+  cameraLookOffset.copy(cameraForwardDirection).multiplyScalar(focusDistance);
+  return turnFocusLookTarget.copy(baseTarget).add(cameraLookOffset);
 }
 
 function clampCameraPosition(position, target = getActiveCameraTarget()) {
@@ -1884,8 +1929,9 @@ function positionCameraForViewport({ force = false } = {}) {
     camera.position.copy(clampCameraPosition(camera.position, target));
   }
 
-  controls.target.copy(target);
-  turnFocusTarget.copy(target);
+  const lookTarget = applyCameraLookOffset(target);
+  controls.target.copy(lookTarget);
+  turnFocusTarget.copy(lookTarget);
   controls.update();
 }
 
@@ -1909,7 +1955,8 @@ function updateTurnCameraFocus() {
   } else {
     turnFocusTarget.copy(turnSeatTarget);
   }
-  controls.target.lerp(turnFocusTarget, CAMERA_TURN_FOCUS_LERP);
+  const lookTarget = applyCameraLookOffset(turnFocusTarget);
+  controls.target.lerp(lookTarget, CAMERA_TURN_FOCUS_LERP);
 }
 
 function enforceSeatedCameraLock() {
@@ -1959,6 +2006,17 @@ function toggleCameraViewMode() {
   const next =
     cameraViewMode === VIEW_MODES.twoD ? VIEW_MODES.threeD : VIEW_MODES.twoD;
   setCameraViewMode(next);
+}
+
+function queueCameraLookDelta(deltaX = 0) {
+  if (cameraViewMode !== VIEW_MODES.threeD || !Number.isFinite(deltaX)) {
+    return;
+  }
+  lookYawTarget = THREE.MathUtils.clamp(
+    lookYawTarget + deltaX * CAMERA_LOOK_SENSITIVITY,
+    -CAMERA_LOOK_MAX_YAW,
+    CAMERA_LOOK_MAX_YAW
+  );
 }
 
 /* ---------- Lights ---------- */
@@ -6269,7 +6327,8 @@ const getDominoSurfaceTextures = (() => {
   return () => {
     const targetSize = Math.min(
       4096,
-      getAdaptiveTextureSize(MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize) + 256
+      DOMINO_TEXTURE_RESOLUTION_BY_QUALITY[frameRateId] ??
+        getAdaptiveTextureSize(MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize)
     );
     if (cache && cachedSize === targetSize) return cache;
     disposeCachedTextures();
@@ -7101,6 +7160,15 @@ document.addEventListener('click', (event) => {
 document.addEventListener('keydown', (event) => {
   if (event.key === 'Escape') {
     closeConfigPanel();
+    return;
+  }
+  if (cameraViewMode !== VIEW_MODES.threeD) {
+    return;
+  }
+  if (event.key === 'ArrowLeft') {
+    queueCameraLookDelta(42);
+  } else if (event.key === 'ArrowRight') {
+    queueCameraLookDelta(-42);
   }
 });
 
@@ -8676,6 +8744,8 @@ const updateRaycasterThreshold = () => {
 };
 updateRaycasterThreshold();
 const activePointers = new Set();
+let lookPointerId = null;
+let lookPointerX = 0;
 function findPickRoot(o) {
   let n = o;
   while (n) {
@@ -8695,6 +8765,15 @@ function humanPickTile(obj) {
 
 renderer.domElement.addEventListener('pointerdown', (ev) => {
   activePointers.add(ev.pointerId);
+  if (
+    cameraViewMode === VIEW_MODES.threeD &&
+    !gameFinished &&
+    lookPointerId === null &&
+    (ev.pointerType === 'touch' || ev.pointerType === 'pen')
+  ) {
+    lookPointerId = ev.pointerId;
+    lookPointerX = ev.clientX;
+  }
   if (gameFinished) {
     return;
   }
@@ -8757,14 +8836,33 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
     return;
   }
 });
+
+renderer.domElement.addEventListener('pointermove', (ev) => {
+  if (ev.pointerId !== lookPointerId) {
+    return;
+  }
+  const deltaX = ev.clientX - lookPointerX;
+  lookPointerX = ev.clientX;
+  queueCameraLookDelta(deltaX);
+});
+
 renderer.domElement.addEventListener('pointerup', (ev) => {
   activePointers.delete(ev.pointerId);
+  if (ev.pointerId === lookPointerId) {
+    lookPointerId = null;
+  }
 });
 renderer.domElement.addEventListener('pointercancel', (ev) => {
   activePointers.delete(ev.pointerId);
+  if (ev.pointerId === lookPointerId) {
+    lookPointerId = null;
+  }
 });
 renderer.domElement.addEventListener('pointerleave', (ev) => {
   activePointers.delete(ev.pointerId);
+  if (ev.pointerId === lookPointerId) {
+    lookPointerId = null;
+  }
 });
 
 btnDraw.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Domino tile surfaces appeared lower resolution than table and chairs and need to match existing graphics quality presets (1k/2k/3k/4k). 
- The seated 3D camera was framed too far back and needs to sit closer to table center for better visual alignment. 
- Players require an in-seat left/right look (rotation of view) similar to Texas Hold'em without moving the camera position. 

### Description
- Added `DOMINO_TEXTURE_RESOLUTION_BY_QUALITY` and wired it into domino texture generation so domino surfaces scale explicitly per quality preset (hd50→1k, fhd60→2k, qhd90→3k, uhd120/ultra144→4k) in `webapp/public/domino-royal-game.js`.
- Reduced seated framing offsets (`CAMERA_LATERAL_OFFSET` and `CAMERA_REAR_OFFSET`) so the camera sits closer to the table center when seated.
- Implemented a constrained, smoothed seated look offset (no camera position movement) via `applyCameraLookOffset`, `queueCameraLookDelta` and helper state (`lookYawCurrent`, `lookYawTarget`, etc.) and integrated it into camera target updates.
- Added input for look controls: horizontal touch/pen drag (pointerdown/pointermove/pointerup) and keyboard `ArrowLeft`/`ArrowRight`, and made pan enabled only in 2D mode to avoid seat translation in 3D.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Started the dev server with `npm --prefix webapp run dev` and the page loaded for manual/automated inspection.
- Captured an automated Playwright screenshot of `http://127.0.0.1:4173/games/domino-royal` (portrait viewport) which validated updated camera framing and texture appearance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aecf50b1788329aeff0f799cb2c7fd)