### PR TITLE
Improve TikTok short-link parsing for mining page videos

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -3,21 +3,23 @@ import { useEffect, useMemo, useState } from 'react';
 function getVideoId(urlOrId) {
   if (!urlOrId) return '';
   if (/^\d+$/.test(urlOrId)) return urlOrId;
-  const raw = String(urlOrId).trim();
+  const raw = String(urlOrId).trim().replace(/[\s).,!?]+$/g, '');
   const match = raw.match(/\/video\/(\d+)/);
   if (match) return match[1];
 
   const embedMatch = raw.match(/\/(?:embed\/(?:v2\/)?|player\/v1\/)(\d+)/);
   if (embedMatch) return embedMatch[1];
 
-  const normalized = raw.endsWith('/') ? raw : `${raw}/`;
   const shortLinkVideoMap = {
-    'https://vt.tiktok.com/ZSujamUuD/': '7614838290667031816',
-    'https://vt.tiktok.com/ZSujaPuVF/': '7614600402654252296',
-    'https://vt.tiktok.com/ZSujaXgpP/': '7614860616703986951',
-    'https://vt.tiktok.com/ZSujagfxp/': '7614503027684216071',
+    ZSujamUuD: '7614838290667031816',
+    ZSujaPuVF: '7614600402654252296',
+    ZSujaXgpP: '7614860616703986951',
+    ZSujagfxp: '7614503027684216071',
   };
-  return shortLinkVideoMap[raw] || shortLinkVideoMap[normalized] || '';
+  const codeMatch = raw.match(/vt\.tiktok\.com\/(Z[A-Za-z0-9]+)\/?/i);
+  if (codeMatch) return shortLinkVideoMap[codeMatch[1]] || '';
+
+  return '';
 }
 
 function ensureTikTokEmbedScript() {


### PR DESCRIPTION
### Motivation
- The mining page uses four TikTok short links but some pasted variants (trailing punctuation/spacing or short-link formats) failed to resolve, causing only one video to appear.
- Make the shared TikTok embed component more robust so all four boost modules (Daily Streaks, Spin & Win, Lucky Card, Roulette Spin) resolve the same way the working video does.

### Description
- Updated `getVideoId` in `webapp/src/components/TikTokTaskVideo.jsx` to trim trailing punctuation/whitespace and tolerate pasted variants.
- Added a regex to extract the `vt.tiktok.com` short-code (the `Z...` token) and map it to the canonical numeric video IDs used by the embed fallback.
- Kept the existing embed flow and fallback iframe logic unchanged so behavior for full URLs and numeric IDs is preserved.
- No other components were modified; the four mining modules already reference the intended short links.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Verified the provided short links redirect to canonical URLs using `curl -Ls -o /dev/null -w '%{url_effective}'` for each `vt.tiktok.com` link and confirmed IDs align with the mapping.
- Started the dev server (`npm --prefix webapp run dev`) and captured Playwright screenshots of the mining route and home page to validate the UI and video modal rendering.
- Ran `npx eslint webapp/src/components/TikTokTaskVideo.jsx` which produced a repository ignore warning but no code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed5bb9d2c8329b2059609c8e946af)