### PR TITLE
Fix Domino Royal camera turn direction and upgrade domino texture defaults

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -87,7 +87,7 @@ const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 2048,
   chairClothTextureSize: 2048,
-  dominoTextureSize: 2048
+  dominoTextureSize: 4096
 });
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
@@ -99,9 +99,9 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
+  hd50: 2048,
   fhd60: 2048,
-  qhd90: 3072,
+  qhd90: 4096,
   uhd120: 4096,
   ultra144: 4096
 });
@@ -114,12 +114,12 @@ function getAdaptiveTextureSize(baseSize = 2048) {
   return Math.max(768, Math.min(4096, mappedSize));
 }
 
-function getAdaptiveDominoTextureSize(baseSize = 2048) {
+function getAdaptiveDominoTextureSize(baseSize = 4096) {
   const mappedSize =
     DOMINO_TEXTURE_SIZE_MAP[frameRateId] ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(1024, Math.min(4096, mappedSize));
+  return Math.max(2048, Math.min(4096, mappedSize));
 }
 
 function detectCoarsePointer() {
@@ -1992,7 +1992,7 @@ function handleCameraLookDrag(deltaX = 0) {
     return;
   }
   cameraLookYaw = THREE.MathUtils.clamp(
-    cameraLookYaw - deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
+    cameraLookYaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
     -CAMERA_LOOK_YAW_LIMIT,
     CAMERA_LOOK_YAW_LIMIT
   );


### PR DESCRIPTION
### Motivation
- Players reported the 3D camera turning feels inverted compared to touch drag, and domino piece art should default to higher fidelity on capable devices while still providing a graceful fallback for lower-end devices.

### Description
- In `webapp/public/domino-royal-game.js` reversed the sign used when applying horizontal drag to camera yaw in `handleCameraLookDrag` so on-screen drags now move the camera in the expected direction.
- Increased default domino surface asset target to 4K by setting `MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize` to `4096`. 
- Adjusted adaptive domino texture mapping in `DOMINO_TEXTURE_SIZE_MAP` so lower-tier profiles use a 2K floor (`hd50: 2048`) and higher tiers use 4K (`qhd90: 4096`).
- Updated `getAdaptiveDominoTextureSize` to use a `4096` base and clamp the minimum to `2048` so textures fall back to 2K where necessary while preserving 4K on capable hardware.

### Testing
- Built the web app with Vite using `npm run build` in the `webapp/` folder and the build completed successfully. 
- Attempted an automated browser smoke check with Playwright to capture a screenshot, but Chromium crashed in this environment (SIGSEGV), so no browser artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed76f3b848329a28d6642d777052b)