### PR TITLE
Ensure TikTokTaskVideo waits for actual embed iframe before hiding fallback

### DIFF
--- a/webapp/src/components/TikTokTaskVideo.jsx
+++ b/webapp/src/components/TikTokTaskVideo.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 function getVideoId(urlOrId) {
   if (!urlOrId) return '';
@@ -40,6 +40,7 @@ export default function TikTokTaskVideo({
   const [open, setOpen] = useState(false);
   const [showFallback, setShowFallback] = useState(false);
   const [oEmbedReady, setOEmbedReady] = useState(false);
+  const embedRef = useRef(null);
 
   const videoId = useMemo(() => getVideoId(videoUrl), [videoUrl]);
   const canonicalVideoUrl = useMemo(() => {
@@ -64,16 +65,18 @@ export default function TikTokTaskVideo({
     setOEmbedReady(false);
     ensureTikTokEmbedScript();
 
-    const id = window.setTimeout(() => {
-      setShowFallback(true);
-    }, 4500);
-
     const renderTicker = window.setTimeout(() => {
       if (typeof window.tiktokEmbedLoad === 'function') {
         window.tiktokEmbedLoad();
       }
-      setOEmbedReady(true);
     }, 120);
+
+    const id = window.setTimeout(() => {
+      const iframeInEmbed = embedRef.current?.querySelector('iframe');
+      const loaded = Boolean(iframeInEmbed);
+      setOEmbedReady(loaded);
+      setShowFallback(!loaded);
+    }, 1500);
 
     return () => {
       clearTimeout(id);
@@ -105,6 +108,7 @@ export default function TikTokTaskVideo({
             {canonicalVideoUrl ? (
               <div className="relative flex-1 min-h-0 p-1">
                 <blockquote
+                  ref={embedRef}
                   className="tiktok-embed absolute inset-0 m-0 h-full w-full"
                   cite={canonicalVideoUrl}
                   data-video-id={videoId}


### PR DESCRIPTION
### Motivation
- Mining page uses the same `TikTokTaskVideo` component for multiple cards and the previous timer-based readiness logic could hide the fallback player before the oEmbed actually rendered, causing some cards to appear blank instead of showing the video.

### Description
- Update `webapp/src/components/TikTokTaskVideo.jsx` to add a `ref` for the oEmbed block and change readiness logic to detect an actual `<iframe>` inside the embed; keep the fallback iframe visible until an embed iframe is found.

### Testing
- Ran `npx eslint webapp/src/components/TikTokTaskVideo.jsx` (no errors; repo ignore warning only). 
- Ran `npm run build` which failed due to an existing unrelated TypeScript error in `SnookerRoyalRules.ts` and not due to this change. 
- Started the web app with `npm --prefix webapp run dev` and performed a visual validation by capturing a mobile-viewport screenshot of `/mining` with Playwright (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed5bb9d2c8329b2059609c8e946af)