### PR TITLE
Fix Domino Royale camera turn direction and default 4K domino textures

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -87,7 +87,7 @@ const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 2048,
   chairClothTextureSize: 2048,
-  dominoTextureSize: 2048
+  dominoTextureSize: 4096
 });
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
@@ -99,9 +99,9 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
-  fhd60: 2048,
-  qhd90: 3072,
+  hd50: 4096,
+  fhd60: 4096,
+  qhd90: 4096,
   uhd120: 4096,
   ultra144: 4096
 });
@@ -114,12 +114,12 @@ function getAdaptiveTextureSize(baseSize = 2048) {
   return Math.max(768, Math.min(4096, mappedSize));
 }
 
-function getAdaptiveDominoTextureSize(baseSize = 2048) {
+function getAdaptiveDominoTextureSize(baseSize = 4096) {
   const mappedSize =
     DOMINO_TEXTURE_SIZE_MAP[frameRateId] ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(1024, Math.min(4096, mappedSize));
+  return Math.max(2048, Math.min(4096, mappedSize));
 }
 
 function detectCoarsePointer() {
@@ -1992,7 +1992,7 @@ function handleCameraLookDrag(deltaX = 0) {
     return;
   }
   cameraLookYaw = THREE.MathUtils.clamp(
-    cameraLookYaw - deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
+    cameraLookYaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
     -CAMERA_LOOK_YAW_LIMIT,
     CAMERA_LOOK_YAW_LIMIT
   );
@@ -6333,11 +6333,11 @@ const getDominoSurfaceTextures = (() => {
       return cache;
     }
     const sizeCap = getRendererTextureSizeCap();
-    const preferredSize = Math.max(1024, Math.min(sizeCap, targetSize));
+    const preferredSize = Math.max(2048, Math.min(sizeCap, targetSize));
     const lowMemoryDevice =
       isLowProfileDevice ||
       (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
-    let size = lowMemoryDevice ? Math.min(preferredSize, 1024) : preferredSize;
+    let size = lowMemoryDevice ? Math.min(preferredSize, 2048) : preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
     let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });


### PR DESCRIPTION
### Motivation
- Camera horizontal drag felt inverted on-screen in 3D view and needed to match the user's drag direction for intuitive controls.
- Domino piece visuals should default to higher fidelity (4K) for flagship devices while still providing a reasonable fallback for constrained devices.

### Description
- Reversed the sign of the horizontal look-drag application so `handleCameraLookDrag` now applies `+ deltaX` to `cameraLookYaw` (fixes opposite turning in 3D). 
- Raised the domino asset default resolution by changing `MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize` to `4096` and updated `DOMINO_TEXTURE_SIZE_MAP` to prefer 4K for the common presets.
- Updated `getAdaptiveDominoTextureSize` default/base to `4096` and increased the minimum adaptive clamp to `2048` so the runtime targets 4K while enforcing a 2K fallback on low-memory devices.
- Adjusted generated canvas texture sizing logic so `preferredSize` and the low-memory fallback use 2048 instead of 1024, preserving quality on capable devices while limiting memory on constrained devices.

### Testing
- Ran static JS validation with `node --check webapp/public/domino-royal-game.js`, which completed successfully.
- Launched the web dev server via `npm --prefix webapp run dev` and captured the Domino page using an automated Playwright script, which loaded and rendered the page without runtime errors.
- Verified the modified camera drag behavior by exercising the page under automated browser capture (Playwright) to confirm horizontal drag now matches on-screen movement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed76f3b848329a28d6642d777052b)