### PR TITLE
Domino Royal: tighten hand spacing and improve domino tile resolution

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,10 +99,10 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 768,
-  fhd60: 1536,
-  qhd90: 2560,
-  uhd120: 3584,
+  hd50: 1024,
+  fhd60: 1792,
+  qhd90: 2816,
+  uhd120: 3840,
   ultra144: 4096
 });
 
@@ -6231,8 +6231,7 @@ const DOMINO_WIDTH = DOMINO_WORLD_SCALE * 0.1;
 const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.03;
-const STEP = DOMINO_LENGTH + DOMINO_CHAIN_GAP;
-const DOMINO_HAND_GAP = DOMINO_LENGTH * 0.58;
+const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
 const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 2.6;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.18;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE;
@@ -8264,7 +8263,6 @@ function startGame() {
     double: firstTile.a === firstTile.b
   });
   usedTileKeys.add(tileKey(firstTile));
-  const step = STEP;
   const isDoubleStart = firstTile.a === firstTile.b;
   if (!flipDir) {
     if (isDoubleStart) {
@@ -8290,7 +8288,7 @@ function startGame() {
       ends = {
         L: {
           v: firstTile.a,
-          x: -step,
+          x: 0,
           z: 0,
           dir: [-1, 0],
           orient: Math.PI,
@@ -8298,7 +8296,7 @@ function startGame() {
         },
         R: {
           v: firstTile.b,
-          x: step,
+          x: 0,
           z: 0,
           dir: [1, 0],
           orient: 0,
@@ -8330,7 +8328,7 @@ function startGame() {
       ends = {
         L: {
           v: firstTile.a,
-          x: step,
+          x: 0,
           z: 0,
           dir: [1, 0],
           orient: 0,
@@ -8338,7 +8336,7 @@ function startGame() {
         },
         R: {
           v: firstTile.b,
-          x: -step,
+          x: 0,
           z: 0,
           dir: [-1, 0],
           orient: Math.PI,


### PR DESCRIPTION
### Motivation
- Make domino pieces and player hands use a consistent, tighter gap so on-table and in-hand tiles match the smaller visual spacing. 
- Improve visible sharpness of domino faces on lower/mid graphics tiers so tiles look crisper on mobile and Telegram clients.

### Description
- Updated adaptive domino texture targets in `DOMINO_TEXTURE_SIZE_MAP` to increase sizes for `hd50`, `fhd60`, `qhd90`, and `uhd120` to yield clearer domino face textures. (file: `webapp/public/domino-royal-game.js`)
- Reduced hand spacing by setting `DOMINO_HAND_GAP` to `DOMINO_WIDTH + DOMINO_CHAIN_GAP` so player-hand layouts use the same tighter distance as table placements. (file: `webapp/public/domino-royal-game.js`)
- Fixed opening chain endpoint initialization for non-double starts so initial ends are placed at the center (`x: 0`) rather than an oversized offset, removing the larger early gap between the first placed pieces. (file: `webapp/public/domino-royal-game.js`)
- Committed only the single modified file `webapp/public/domino-royal-game.js` and adjusted related constants accordingly.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without syntax errors. (success)
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0` and used an automated Playwright script to navigate to `/games/domino-royal` and capture a portrait screenshot to validate spacing and visuals (screenshot captured). (success)
- Changes were committed with message: `Adjust Domino Royal spacing consistency and tile texture quality`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1dce4cbc8329899abd354b4bd86e)