### PR TITLE
Tune Texas Hold'em seated camera, community card lift, and HDRI startup initialization

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -352,7 +352,8 @@ const COMMUNITY_CARD_FORWARD_OFFSET = TABLE_CARD_AREA_FORWARD_SHIFT;
 const COMMUNITY_CARD_LIFT = CARD_D * 3.2;
 const COMMUNITY_CARD_LOOK_LIFT = CARD_H * 0.06;
 const COMMUNITY_CARD_TILT = 0;
-const COMMUNITY_CARD_LANDSCAPE_TOP_LIFT = 0.085;
+const COMMUNITY_CARD_LANDSCAPE_TOP_LIFT = 0.105;
+const COMMUNITY_CARD_PORTRAIT_TOP_LIFT = 0.055;
 const COMMUNITY_ROW_ROTATION = 0;
 const COMMUNITY_CARD_POSITIONS = [-2, -1, 0, 1, 2].map((index) =>
   new THREE.Vector3(
@@ -390,7 +391,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.6 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.8 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.92 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
@@ -4908,6 +4909,7 @@ function TexasHoldemArena({ search }) {
       });
 
       orientHumanCards();
+      void applyHdriEnvironment(initialEnvironment);
     })().catch((error) => console.error('Failed to set up Texas Hold\'em arena', error));
 
     const element = renderer.domElement;
@@ -5651,6 +5653,8 @@ function TexasHoldemArena({ search }) {
       }
       if (isLandscape) {
         mesh.rotateX(COMMUNITY_CARD_LANDSCAPE_TOP_LIFT);
+      } else {
+        mesh.rotateX(COMMUNITY_CARD_PORTRAIT_TOP_LIFT);
       }
       setCardFace(mesh, 'front');
       const communityKey = cardKey(card);


### PR DESCRIPTION
### Motivation
- Improve the seated camera framing on landscape so the human player view sits slightly closer to the table center while keeping portrait unchanged.
- Raise the top edge of community cards a bit in landscape and also provide a small top-edge lift for portrait so cards are visually clearer.
- Ensure the HDRI environment loads automatically at game boot so users do not need to select an HDRI manually from the menu.

### Description
- Increased the landscape seated camera retreat to bring the seated camera a bit closer by changing `CAMERA_RETREAT_OFFSETS.landscape` from `0.8` to `0.92` in `TexasHoldemArena.jsx`.
- Tuned community card top-edge lift by bumping `COMMUNITY_CARD_LANDSCAPE_TOP_LIFT` (`0.085 -> 0.105`) and adding `COMMUNITY_CARD_PORTRAIT_TOP_LIFT = 0.055`.
- Applied the portrait top-lift when renderer reports a portrait canvas by using `COMMUNITY_CARD_PORTRAIT_TOP_LIFT` in the community card placement codepath.
- Re-applied the resolved initial HDRI after Three.js scene/camera/refs finish initialization by calling `applyHdriEnvironment(initialEnvironment)` once the arena boot sequence completes.
- File changed: `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which produced a repo ignore warning but no new lint errors from the change (warning only).
- Ran the TypeScript build with `npm run build`, which failed due to a pre-existing unrelated type error in `src/rules/SnookerRoyalRules.ts` (failure is not caused by this change).
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and validated the page rendering (server started successfully).
- Captured automated screenshots for landscape and portrait via Playwright to visually validate the camera and community card changes; screenshots were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af20d8841c8329b728fe177d7efc9b)