### PR TITLE
Fix Texas Hold'em card-back alignment and tighten landscape camera

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -391,7 +391,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.6 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.92 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.84 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
@@ -457,6 +457,7 @@ const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
+const HIDDEN_CARD_BACK_ALIGNMENT_ROTATION = Math.PI;
 
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
@@ -5450,6 +5451,9 @@ function TexasHoldemArena({ search }) {
             : position.clone().add(seat.forward.clone());
         const face = seat.isHuman || isShowdownReveal ? 'front' : 'back';
         orientCard(mesh, lookTarget, { face, flat: !isShowdownReveal });
+        if (!seat.isHuman && face === 'back' && !isShowdownReveal) {
+          mesh.rotateZ(HIDDEN_CARD_BACK_ALIGNMENT_ROTATION);
+        }
         if (!seat.isHuman && face === 'front' && !isShowdownReveal) {
           mesh.rotateY(Math.PI);
         }


### PR DESCRIPTION
### Motivation
- Opponent/hidden card backs were visually misaligned relative to the folded-card pile and needed to keep the same visible side while matching logo direction. 
- Landscape camera was slightly too far from the table center and required a minor retreat adjustment for tighter framing.

### Description
- Adjusted the landscape seated camera retreat offset from `0.92` to `0.84` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to bring the camera closer to the table center. 
- Added `HIDDEN_CARD_BACK_ALIGNMENT_ROTATION` and apply a `rotateZ` to non-human hidden/back-facing cards so the card-back logo direction matches the folded-card pile while keeping the back side visible (change applied in `webapp/src/pages/Games/TexasHoldemArena.jsx`).

### Testing
- Ran the production build with `npm run build` (from `webapp/`) and the build completed successfully. 
- Launched the dev server and executed an automated Playwright script to capture a visual screenshot for verification, which completed successfully and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af25d339848329b41ed8d4cf5c4c1f)