### PR TITLE
Normalize high-spin magnitude and lift rail broadcast framing

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -119,8 +119,13 @@ namespace Aiming
             sol.recommendedPower01 = RecommendPower(info.distBucket, ctx.requiresPower);
             if (ctx.highSpin)
             {
-                float side = Mathf.Sign(Vector3.Cross(info.vOP, info.vOC).y) * config.sideSpinAmount;
-                float vert = config.verticalSpinAmount * (ctx.requiresPower ? 1f : 0.7f);
+                // Keep spin strength consistent across left/right and top/back so
+                // players get identical response regardless of spin direction.
+                float uniformSpin = Mathf.Min(
+                    Mathf.Abs(config.sideSpinAmount),
+                    Mathf.Abs(config.verticalSpinAmount));
+                float side = Mathf.Sign(Vector3.Cross(info.vOP, info.vOC).y) * uniformSpin;
+                float vert = Mathf.Sign(config.verticalSpinAmount) * uniformSpin;
                 sol.tipOffset = new Vector2(Mathf.Clamp(side, -config.tipOffsetMax, config.tipOffsetMax),
                     Mathf.Clamp(vert, -config.tipOffsetMax, config.tipOffsetMax));
                 sol.cueElevationDeg = (ctx.requiresPower && info.isRailShot) ? config.elevationForPower : 0f;

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -154,7 +154,7 @@ public class CueCamera : MonoBehaviour
     public float broadcastDistanceInset = 0.08f;
     // Additional downward look offset to tilt the broadcast camera a little more
     // toward the cloth.
-    public float broadcastLookDownOffset = 0.02f;
+    public float broadcastLookDownOffset = 0.06f;
     // Minimum squared velocity to consider a ball as moving.
     public float velocityThreshold = 0.01f;
     // How quickly the camera aligns to the stored shot angle.


### PR DESCRIPTION
### Motivation
- Ensure spin behaves identically in all directions by making side and vertical spin use the same magnitude, and move the rail broadcast framing so the table appears higher in the overhead/rail camera.

### Description
- Compute a `uniformSpin` in `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs` and apply it to both side and vertical tip offsets so left/right and top/back spins have equal strength.
- Increase the short-rail broadcast camera downward-look offset in `billiards.Unity/CueCamera.cs` by changing `broadcastLookDownOffset` from `0.02f` to `0.06f` to raise the table in the frame.

### Testing
- Ran `git -C /workspace/TonPlaygramWebApp diff --check` and it reported no whitespace or diff issues (success). 
- Ran `git -C /workspace/TonPlaygramWebApp status --short` and verified the two modified files are staged and committed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af26bd2e8083298ce505278b6a1654)