### PR TITLE
Improve Domino visuals, fix hand rendering glitches, and add VS-AI endgame overlay

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,10 +99,10 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
-  fhd60: 1792,
-  qhd90: 2816,
-  uhd120: 3840,
+  hd50: 1536,
+  fhd60: 2560,
+  qhd90: 3328,
+  uhd120: 4096,
   ultra144: 4096
 });
 
@@ -1564,6 +1564,8 @@ function normalizeAvatarSource(src = '') {
 }
 
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
+const gameMode = (urlParams.get('mode') || 'local').toLowerCase();
+const isVsAiMatch = gameMode === 'local';
 const shouldRunHallwayEntry = !USE_MINIMAL_STAGE && entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
@@ -7514,6 +7516,68 @@ const giftClose = document.getElementById('giftClose');
 const muteButton = document.getElementById('muteButton');
 const muteIcon = document.getElementById('muteIcon');
 const muteLabel = document.getElementById('muteLabel');
+const winnerOverlay = document.getElementById('winnerOverlay');
+const winnerOverlayAvatar = document.getElementById('winnerAvatar');
+const winnerOverlayName = document.getElementById('winnerName');
+const winnerOverlayReason = document.getElementById('winnerReason');
+const winnerPlayAgainButton = document.getElementById('winnerPlayAgain');
+const winnerReturnLobbyButton = document.getElementById('winnerReturnLobby');
+const winnerCoinBurst = document.getElementById('winnerCoinBurst');
+
+function hideWinnerOverlay() {
+  if (!winnerOverlay) return;
+  winnerOverlay.classList.remove('active');
+  winnerOverlay.setAttribute('aria-hidden', 'true');
+}
+
+function showWinnerOverlay({ winner = null, reason = '' } = {}) {
+  if (!winnerOverlay || !isVsAiMatch) return;
+  const names = getSeatUsernames(N);
+  const avatars = buildSeatAvatarSources(N);
+  const safeWinner = Number.isInteger(winner) && winner >= 0 ? winner : human;
+  if (winnerOverlayName) {
+    winnerOverlayName.textContent =
+      safeWinner === human ? 'You win!' : `${names[safeWinner] || `Player ${safeWinner + 1}`} wins!`;
+  }
+  if (winnerOverlayReason) {
+    winnerOverlayReason.textContent = reason || 'Round finished.';
+  }
+  if (winnerOverlayAvatar) {
+    const source = avatars[safeWinner] || DEFAULT_AVATAR_EMOJI;
+    winnerOverlayAvatar.classList.remove('has-photo');
+    winnerOverlayAvatar.style.backgroundImage = '';
+    winnerOverlayAvatar.textContent = source;
+    if (isAvatarUrl(source)) {
+      winnerOverlayAvatar.classList.add('has-photo');
+      winnerOverlayAvatar.style.backgroundImage = `url(${source})`;
+      winnerOverlayAvatar.textContent = '';
+    }
+  }
+  if (winnerCoinBurst) {
+    winnerCoinBurst.innerHTML = '';
+    for (let i = 0; i < 20; i += 1) {
+      const coin = document.createElement('span');
+      coin.className = 'winner-coin';
+      coin.textContent = 'TPC';
+      coin.style.setProperty('--angle', `${(360 / 20) * i}deg`);
+      coin.style.setProperty('--distance', `${52 + (i % 4) * 14}px`);
+      coin.style.setProperty('--delay', `${i * 30}ms`);
+      winnerCoinBurst.appendChild(coin);
+    }
+  }
+  winnerOverlay.classList.add('active');
+  winnerOverlay.setAttribute('aria-hidden', 'false');
+}
+
+winnerPlayAgainButton?.addEventListener('click', () => {
+  hideWinnerOverlay();
+  startGame();
+});
+
+winnerReturnLobbyButton?.addEventListener('click', () => {
+  hideWinnerOverlay();
+  window.location.assign('/games/domino-royal/lobby');
+});
 
 let statusPrefix = '';
 let ends = null; // {L:{v,x,z,dir:[dx,dz]}, R:{...}}
@@ -7533,6 +7597,7 @@ let winnerHighlight = null;
 let winnerHighlightStart = 0;
 let cpuMoveTimeout = null;
 let pendingTurnAdvanceTimeout = null;
+const activeHandMeshes = new Set();
 
 function tileKey(tile) {
   const ct = canonTile(tile);
@@ -7660,14 +7725,15 @@ function layoutSeat(idx) {
 }
 
 function renderHands() {
-  players.forEach((p) =>
+  activeHandMeshes.forEach((mesh) => {
+    piecesG.remove(mesh);
+  });
+  activeHandMeshes.clear();
+  players.forEach((p) => {
     p.hand.forEach((h) => {
-      if (h.mesh) {
-        piecesG.remove(h.mesh);
-        h.mesh = null;
-      }
-    })
-  );
+      h.mesh = null;
+    });
+  });
   clearSelectedHighlight();
 
   const EDGE_SPAN = CLOTH_RADIUS - 0.28;
@@ -7686,7 +7752,7 @@ function renderHands() {
     const isSide = pi === 1 || pi === 3;
     const openFlat = isTopDown && isHuman;
 
-    const gapBase = openFlat ? BASE_GAP * 1.12 : BASE_GAP;
+    const gapBase = openFlat ? BASE_GAP * 1.04 : BASE_GAP * 0.94;
     const handY = openFlat ? CLOTH_TOP + 0.018 : HAND_Y;
 
     let span = 0;
@@ -7737,6 +7803,7 @@ function renderHands() {
         m.rotation.z += Math.random() * 0.006 - 0.003;
       }
       h.mesh = m;
+      activeHandMeshes.add(m);
       m.userData = { tile: h, owner: pi };
       piecesG.add(m);
       if (selectedTile === h) {
@@ -8213,6 +8280,7 @@ function startGame() {
   revealAllHands = false;
   lastAnnouncedTurn = null;
   clearWinnerHighlight();
+  hideWinnerOverlay();
   if (cpuMoveTimeout) {
     clearTimeout(cpuMoveTimeout);
     cpuMoveTimeout = null;
@@ -9096,6 +9164,7 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}) {
   } else {
     SFX.drawGame();
   }
+  showWinnerOverlay({ winner: winnerIndex, reason });
 }
 
 function checkForBlockedGame() {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -119,6 +119,68 @@ export default function DominoRoyalArena() {
         #quickActions .quick-action[data-action="chat"] {
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
         }
+        #winnerOverlay {
+          position: fixed;
+          inset: 0;
+          z-index: 20;
+          display: none;
+          align-items: center;
+          justify-content: center;
+          background: rgba(2, 6, 23, 0.7);
+          backdrop-filter: blur(6px);
+          padding: 1rem;
+        }
+        #winnerOverlay.active { display: flex; }
+        .winner-card {
+          width: min(92vw, 360px);
+          border-radius: 22px;
+          padding: 1.1rem 1rem 1rem;
+          border: 1px solid rgba(148, 163, 184, 0.4);
+          background: linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.9));
+          text-align: center;
+          color: #f8fafc;
+        }
+        #winnerAvatar {
+          width: 5.25rem;
+          height: 5.25rem;
+          margin: 0 auto 0.6rem;
+          border-radius: 999px;
+          display: grid;
+          place-items: center;
+          font-size: 2rem;
+          font-weight: 800;
+          background: linear-gradient(145deg, #22c55e, #38bdf8);
+          border: 2px solid rgba(255, 255, 255, 0.55);
+          background-size: cover;
+          background-position: center;
+        }
+        #winnerCoinBurst { position: relative; height: 0; }
+        .winner-coin {
+          position: absolute;
+          top: -2.8rem;
+          left: 50%;
+          transform: translate(-50%, 0) rotate(var(--angle)) translateY(calc(var(--distance) * -1));
+          font-size: 0.54rem;
+          letter-spacing: 0.06em;
+          color: #fde68a;
+          text-shadow: 0 0 8px rgba(251, 191, 36, 0.8);
+          opacity: 0;
+          animation: winner-coin-burst 740ms ease-out var(--delay) forwards;
+        }
+        @keyframes winner-coin-burst {
+          0% { opacity: 0; }
+          20% { opacity: 1; }
+          100% {
+            opacity: 0;
+            transform: translate(-50%, 0) rotate(var(--angle)) translateY(calc((var(--distance) + 52px) * -1));
+          }
+        }
+        .winner-actions {
+          display: grid;
+          gap: 0.6rem;
+          margin-top: 0.95rem;
+        }
+        .winner-actions button { width: 100%; }
       `}</style>
       <div id="topRightActions" aria-label="Top actions">
         <button id="viewToggle" type="button" aria-label="Switch view" title="Switch view" />
@@ -183,6 +245,18 @@ export default function DominoRoyalArena() {
           </div>
           <button className="modal-primary" id="giftSend" type="button">Send Gift</button>
           <p className="gift-note">10% charge and the amount of the gift will be deducted from your balance.</p>
+        </div>
+      </div>
+      <div id="winnerOverlay" aria-hidden="true">
+        <div className="winner-card" role="dialog" aria-modal="true" aria-labelledby="winnerName">
+          <div id="winnerCoinBurst" />
+          <div id="winnerAvatar">🏆</div>
+          <h3 id="winnerName">Winner</h3>
+          <p id="winnerReason">Round complete.</p>
+          <div className="winner-actions">
+            <button id="winnerPlayAgain" type="button">Play Again</button>
+            <button id="winnerReturnLobby" type="button">Return Lobby</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Improve tile clarity so domino pips and faces render with higher visual fidelity on higher-quality presets.
- Eliminate ghost / stale domino meshes in player hands that cause visual glitches and incorrect tiles to appear.
- Provide a clear end-of-game presentation for local (vs AI) matches so players see the winner avatar, get rewarding feedback (TPC coin burst), and have quick actions to replay or return to the lobby.

### Description
- Bumped adaptive domino texture sizes in `DOMINO_TEXTURE_SIZE_MAP` to increase face/pip resolution across presets (`webapp/public/domino-royal-game.js`).
- Reworked hand rendering to track active hand meshes with an `activeHandMeshes` Set, clearing previous meshes before re-render to prevent stale/overlapping mesh artifacts (`renderHands` changes in `webapp/public/domino-royal-game.js`).
- Tightened player hand spacing by adjusting hand gap multipliers so player dominoes sit visually closer (`BASE_GAP` multiplier tweak in `renderHands`).
- Added an end-of-game overlay for local (vs AI) matches: DOM elements and styles in `DominoRoyalArena.jsx`, and overlay wiring (show/hide, avatar, TPC coin burst, `Play Again` / `Return Lobby` handlers) plus lifecycle hooks to hide on round start and show at `finishGame` in `webapp/public/domino-royal-game.js`.

### Testing
- Ran unit tests with `npm test -- --runTestsByPath test/inventoryCrossGameConfig.test.js` and they passed (3 tests, 0 failures).
- Ran ESLint checks; `npx eslint --no-ignore webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` executed but reported pre-existing style/lint issues in the large runtime file (no functional failures introduced by this PR).
- Launched the web dev server (`npm --prefix webapp run dev`) and captured a visual smoke test of `/games/domino-royal?mode=local&players=2&entry=hallway` via a Playwright script; the screenshot (winner overlay) was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af24aa0f448329acaf90144bcd9f57)