### PR TITLE
Align hidden opponent card backs and increase landscape camera retreat offset

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -391,7 +391,7 @@ const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.6 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.92 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 1.12 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
@@ -457,6 +457,7 @@ const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
+const HIDDEN_CARD_BACK_ALIGNMENT_ROTATION = Math.PI;
 
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
@@ -5450,6 +5451,9 @@ function TexasHoldemArena({ search }) {
             : position.clone().add(seat.forward.clone());
         const face = seat.isHuman || isShowdownReveal ? 'front' : 'back';
         orientCard(mesh, lookTarget, { face, flat: !isShowdownReveal });
+        if (!seat.isHuman && face === 'back' && !isShowdownReveal) {
+          mesh.rotateZ(HIDDEN_CARD_BACK_ALIGNMENT_ROTATION);
+        }
         if (!seat.isHuman && face === 'front' && !isShowdownReveal) {
           mesh.rotateY(Math.PI);
         }


### PR DESCRIPTION
### Motivation
- Fix visual alignment of hidden (AI) player card backs so they appear correctly oriented relative to the table.  
- Improve camera framing in landscape mode by increasing the retreat offset to reduce clipping/overlap with the table.

### Description
- Increased the landscape value of `CAMERA_RETREAT_OFFSETS` from `0.92` to `1.12` to pull the camera back in landscape layout.  
- Added a new constant `HIDDEN_CARD_BACK_ALIGNMENT_ROTATION = Math.PI` to represent the rotation needed to align hidden card backs.  
- When rendering hole cards, apply `mesh.rotateZ(HIDDEN_CARD_BACK_ALIGNMENT_ROTATION)` for non-human seats whose `face` is `'back'` and when not in a showdown, so hidden cards are visually aligned.  
- Preserved existing `mesh.rotateY(Math.PI)` behavior for non-human `face === 'front'` and existing showdown/human posture logic.

### Testing
- Ran the test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.  
- Performed automated rendering/visual snapshot checks (headless) as part of CI, which passed without regression failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af25d339848329b41ed8d4cf5c4c1f)