### PR TITLE
Make camera horizontal orbit follow portrait screen swipe direction

### DIFF
--- a/billiards.Unity/CameraController.cs
+++ b/billiards.Unity/CameraController.cs
@@ -75,6 +75,10 @@ public class CameraController : MonoBehaviour
     // way to the plastic cap at the end of the stick.
     [Range(0f, 1f)]
     public float cueViewMaxCueDistanceRatio = 0.65f;
+    // Keep horizontal orbit aligned with mobile portrait expectations where
+    // dragging left rotates the view left on screen and dragging right rotates
+    // the view right.
+    public bool matchScreenHorizontalDirection = true;
 
     private void LateUpdate()
     {
@@ -141,6 +145,11 @@ public class CameraController : MonoBehaviour
         }
 
         Vector3 flatDir = flatOffset.normalized;
+        if (matchScreenHorizontalDirection)
+        {
+            flatDir = -flatDir;
+        }
+
         Vector3 desiredFlat = pivotFlat + flatDir * currentDistance;
         if (player != null)
         {


### PR DESCRIPTION
### Motivation
- Align the camera's horizontal orbit with mobile portrait touch expectations so dragging left/right on the screen rotates the view left/right visually.

### Description
- Added a configurable flag `public bool matchScreenHorizontalDirection = true;` to `billiards.Unity/CameraController.cs` and inverted the computed horizontal orbit direction (`flatDir`) when the flag is enabled so on-screen swipes map to matching camera rotation.

### Testing
- Verified the change was applied and committed by running `git diff -- billiards.Unity/CameraController.cs`, `git status --short`, and `git show --stat --oneline HEAD`, all of which succeeded; no automated gameplay/unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2f4ffc548329bdf5dbb527b1d276)