### PR TITLE
Fix Domino Royale camera yaw drag direction

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2010,7 +2010,7 @@ function handleCameraLookDrag(deltaX = 0) {
     return;
   }
   cameraLookYaw = THREE.MathUtils.clamp(
-    cameraLookYaw - deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
+    cameraLookYaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
     -CAMERA_LOOK_YAW_LIMIT,
     CAMERA_LOOK_YAW_LIMIT
   );


### PR DESCRIPTION
### Motivation
- Align 3D camera look behavior with on-screen horizontal drag so dragging left rotates the camera left and dragging right rotates it right in the Domino Royale arena.

### Description
- Adjusted `handleCameraLookDrag` in `webapp/public/domino-royal-game.js` to accumulate yaw with `+ deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR` instead of `- deltaX * ...` so screen movement maps intuitively to camera yaw.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully.
- Captured a mobile-portrait screenshot via an automated Playwright script against the local dev server to validate the visual behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2f4ffc548329bdf5dbb527b1d276)