### PR TITLE
Preserve player camera control on turn and show human hand upright in 2D (Domino Royal)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1928,6 +1928,10 @@ function positionCameraForViewport({ force = false } = {}) {
 }
 
 function updateTurnCameraFocus() {
+  if (current === human && cameraHasUserControl) {
+    return;
+  }
+
   if (cameraViewMode === VIEW_MODES.twoD || !Number.isInteger(current)) {
     turnFocusTarget.copy(getActiveCameraTarget());
     controls.target.lerp(turnFocusTarget, CAMERA_TURN_FOCUS_LERP);
@@ -1962,7 +1966,12 @@ function updateTurnCameraFocus() {
 }
 
 function enforceSeatedCameraLock() {
-  if (cameraViewMode === VIEW_MODES.twoD || entrySequenceActive) return;
+  if (
+    cameraViewMode === VIEW_MODES.twoD ||
+    entrySequenceActive ||
+    current === human
+  )
+    return;
   const lockedPosition = clampCameraPosition(computeDesiredCameraPosition(), getActiveCameraTarget());
   camera.position.copy(lockedPosition);
 }
@@ -7750,7 +7759,8 @@ function renderHands() {
       revealAllHands || isHuman || (gameFinished && pi === winnerIndex);
     const count = p.hand.length;
     const isSide = pi === 1 || pi === 3;
-    const openFlat = isTopDown && isHuman;
+    const openFlat = false;
+    const openFaceUpHand = isTopDown && isHuman;
 
     const gapBase = openFlat ? BASE_GAP * 1.04 : BASE_GAP * 0.94;
     const handY = openFlat ? CLOTH_TOP + 0.018 : HAND_Y;
@@ -7780,7 +7790,10 @@ function renderHands() {
     }
 
     p.hand.forEach((h, hi) => {
-      const m = makeDomino(h.a, h.b, { flat: openFlat, faceUp });
+      const m = makeDomino(h.a, h.b, {
+        flat: openFlat,
+        faceUp: faceUp || openFaceUpHand
+      });
       const offset = count > 1 ? start + gap * hi : 0;
       if (isHuman && !openFlat) {
         const handAnchorZ = z0 + HUMAN_HAND_OUTWARD_OFFSET;


### PR DESCRIPTION
### Motivation
- Ensure the human player keeps manual camera control during their turn instead of the game forcibly refocusing the camera. 
- Make the human player's dominoes visible and easy to read in 2D mode by arranging them in a horizontal bottom row while rendering them upright and face-up.

### Description
- Added an early-return in `updateTurnCameraFocus` to avoid overriding the camera when `current === human` and `cameraHasUserControl` is true. (`webapp/public/domino-royal-game.js`)
- Updated `enforceSeatedCameraLock` to skip automatic camera locking when it is the human player's turn. (`webapp/public/domino-royal-game.js`)
- Changed human hand rendering in `renderHands` so `openFlat` is disabled and introduced `openFaceUpHand`; passed `faceUp || openFaceUpHand` into `makeDomino` so the human's tiles in 2D remain upright (not flattened) and face-up for readability. (`webapp/public/domino-royal-game.js`)

### Testing
- Ran a syntax check with `node --check webapp/public/domino-royal-game.js` and it succeeded. 
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (Vite warnings about large chunks are informational only). 
- Launched the dev server and captured a mobile-portrait screenshot of the Domino Royal page via an automated Playwright script; the screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa98c1f3c832992668550261375ab)