### PR TITLE
Add Domino points-race lobby options and 2D leaderboard overlay

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7533,6 +7533,52 @@ const winnerOverlayReason = document.getElementById('winnerReason');
 const winnerPlayAgainButton = document.getElementById('winnerPlayAgain');
 const winnerReturnLobbyButton = document.getElementById('winnerReturnLobby');
 const winnerCoinBurst = document.getElementById('winnerCoinBurst');
+const leaderboardCard = document.createElement('div');
+leaderboardCard.id = 'dominoLeaderboardCard';
+leaderboardCard.setAttribute('aria-live', 'polite');
+leaderboardCard.innerHTML =
+  '<div class="leaderboard-title">Leaderboard</div><div class="leaderboard-rows"></div>';
+document.body.appendChild(leaderboardCard);
+
+function computePipTotal(hand = []) {
+  return hand.reduce(
+    (sum, tile) => sum + Number(tile?.a || 0) + Number(tile?.b || 0),
+    0
+  );
+}
+
+function updateLeaderboardCard() {
+  if (!leaderboardCard) return;
+  const titleEl = leaderboardCard.querySelector('.leaderboard-title');
+  const rowsHost = leaderboardCard.querySelector('.leaderboard-rows');
+  if (!rowsHost) return;
+  if (titleEl) {
+    titleEl.textContent = isPointsRace
+      ? `Leaderboard • Race to ${raceTargetPoints}`
+      : 'Leaderboard • Single Game';
+  }
+  const names = getSeatUsernames(N);
+  const rows = players
+    .map((player, idx) => ({
+      idx,
+      name: names[idx] || `Player ${idx + 1}`,
+      piecesLeft: player?.hand?.length ?? 0,
+      pointsLeft: computePipTotal(player?.hand || [])
+    }))
+    .sort((a, b) => a.pointsLeft - b.pointsLeft || a.piecesLeft - b.piecesLeft);
+
+  rowsHost.innerHTML = rows
+    .map(
+      (entry, rank) =>
+        `<div class="leaderboard-row ${entry.idx === human ? 'is-human' : ''}">` +
+        `<span class="leaderboard-rank">${rank + 1}</span>` +
+        `<span class="leaderboard-name">${entry.name}</span>` +
+        `<span class="leaderboard-stat">${entry.pointsLeft} pts</span>` +
+        `<span class="leaderboard-stat">${entry.piecesLeft} left</span>` +
+        '</div>'
+    )
+    .join('');
+}
 
 function hideWinnerOverlay() {
   if (!winnerOverlay) return;
@@ -7710,6 +7756,12 @@ const requestedPlayers = Number.parseInt(
   urlParams.get('players') || urlParams.get('playerCount') || '',
   10
 );
+const selectedGameType = (urlParams.get('game') || 'single').toLowerCase();
+const raceTargetPoints = Number.parseInt(urlParams.get('points') || '', 10);
+const isPointsRace =
+  selectedGameType === 'points' &&
+  Number.isFinite(raceTargetPoints) &&
+  raceTargetPoints > 0;
 if (requestedPlayers >= 2 && requestedPlayers <= 4) {
   N = requestedPlayers;
 }
@@ -7718,6 +7770,11 @@ const stakeToken = urlParams.get('token') || 'TPC';
 if (Number.isFinite(stakeAmount) && stakeAmount > 0) {
   statusPrefix = `Stake ${stakeAmount.toLocaleString('en-US')} ${stakeToken.toUpperCase()}`;
   setStatus('Ready');
+}
+if (isPointsRace) {
+  statusPrefix = statusPrefix
+    ? `${statusPrefix} • Race ${raceTargetPoints} pts`
+    : `Race ${raceTargetPoints} pts`;
 }
 
 applyAppearanceChange({ refresh: false });
@@ -7810,7 +7867,7 @@ function renderHands() {
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if (openFlat) {
-        const yaw = isHuman ? 0 : yawTowardCenter;
+        const yaw = isHuman ? Math.PI / 2 : yawTowardCenter;
         orientDominoFlat(m, yaw);
       } else {
         m.rotation.set(0, pi === human ? 0 : yawTowardCenter, 0);
@@ -7825,6 +7882,7 @@ function renderHands() {
       }
     });
   });
+  updateLeaderboardCard();
 }
 
 /* ---------- Chain Rendering ---------- */
@@ -9987,6 +10045,9 @@ function shutdownDominoRoyal(reason = 'unknown') {
     scene.visible = false;
     if (seatOverlay?.parentNode) {
       seatOverlay.parentNode.removeChild(seatOverlay);
+    }
+    if (leaderboardCard?.parentNode) {
+      leaderboardCard.parentNode.removeChild(leaderboardCard);
     }
     if (reason === 'react-unmount') {
       controls?.dispose?.();

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -119,6 +119,65 @@ export default function DominoRoyalArena() {
         #quickActions .quick-action[data-action="chat"] {
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
         }
+        #dominoLeaderboardCard {
+          position: fixed;
+          top: calc(6.15rem + env(safe-area-inset-top, 0px));
+          left: 50%;
+          transform: translateX(-50%);
+          width: min(90vw, 24rem);
+          z-index: 5;
+          border-radius: 14px;
+          border: 1px solid rgba(148, 163, 184, 0.35);
+          background: linear-gradient(180deg, rgba(15, 23, 42, 0.94), rgba(15, 23, 42, 0.82));
+          box-shadow: 0 12px 24px rgba(2, 6, 23, 0.42);
+          backdrop-filter: blur(8px);
+          color: #f8fafc;
+          padding: 0.5rem 0.55rem;
+          pointer-events: none;
+        }
+        #dominoLeaderboardCard .leaderboard-title {
+          font-size: 0.64rem;
+          letter-spacing: 0.16em;
+          text-transform: uppercase;
+          color: rgba(186, 230, 253, 0.9);
+          margin-bottom: 0.35rem;
+          text-align: center;
+        }
+        #dominoLeaderboardCard .leaderboard-rows {
+          display: grid;
+          gap: 0.2rem;
+        }
+        #dominoLeaderboardCard .leaderboard-row {
+          display: grid;
+          grid-template-columns: 1.05rem minmax(0, 1fr) auto auto;
+          align-items: center;
+          column-gap: 0.35rem;
+          border-radius: 9px;
+          border: 1px solid rgba(148, 163, 184, 0.18);
+          background: rgba(15, 23, 42, 0.6);
+          padding: 0.24rem 0.35rem;
+          font-size: 0.68rem;
+        }
+        #dominoLeaderboardCard .leaderboard-row.is-human {
+          border-color: rgba(56, 189, 248, 0.55);
+          background: rgba(14, 116, 144, 0.24);
+        }
+        #dominoLeaderboardCard .leaderboard-rank {
+          font-weight: 800;
+          text-align: center;
+          color: #fde68a;
+        }
+        #dominoLeaderboardCard .leaderboard-name {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          font-weight: 700;
+        }
+        #dominoLeaderboardCard .leaderboard-stat {
+          font-weight: 700;
+          color: rgba(226, 232, 240, 0.9);
+          white-space: nowrap;
+        }
         #winnerOverlay {
           position: fixed;
           inset: 0;

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -30,6 +30,23 @@ const CHESS_AI_FLAG_KEY = 'chessBattleRoyalAiFlag';
 
 const PLAYER_OPTIONS = [2, 3, 4];
 const HUMAN_ICON_FALLBACK = '🧑‍🤝‍🧑';
+const GAME_TYPE_OPTIONS = [
+  {
+    id: 'single',
+    label: 'Single Game',
+    desc: 'One round winner',
+    accent: 'from-purple-400/30 via-indigo-500/10 to-transparent',
+    icon: '🎴'
+  },
+  {
+    id: 'points',
+    label: 'Points Race',
+    desc: 'Race to target',
+    accent: 'from-pink-400/30 via-fuchsia-500/10 to-transparent',
+    icon: '🏁'
+  }
+];
+const TARGET_POINTS_OPTIONS = [51, 101];
 
 export default function DominoRoyalLobby() {
   const navigate = useNavigate();
@@ -39,6 +56,8 @@ export default function DominoRoyalLobby() {
   const [mode, setMode] = useState('local');
   const [avatar, setAvatar] = useState('');
   const [playerCount, setPlayerCount] = useState(4);
+  const [gameType, setGameType] = useState('single');
+  const [targetPoints, setTargetPoints] = useState(51);
   const [frameRateId, setFrameRateId] = useState(DEFAULT_FRAME_RATE_ID);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [flags, setFlags] = useState([]);
@@ -111,6 +130,8 @@ export default function DominoRoyalLobby() {
     const params = new URLSearchParams();
     params.set('mode', mode);
     params.set('players', String(totalPlayers));
+    params.set('game', gameType);
+    if (gameType === 'points') params.set('points', String(targetPoints));
     if (mode !== 'local' && token) params.set('token', token);
     if (mode !== 'local' && amount) params.set('amount', amount);
     if (avatar) params.set('avatar', avatar);
@@ -168,7 +189,9 @@ export default function DominoRoyalLobby() {
           playerName: getTelegramUsername() || 'Player',
           avatar,
           mode: 'online',
-          token: stake.token
+          token: stake.token,
+          game: gameType,
+          points: gameType === 'points' ? Number(targetPoints) : 0
         },
         (res = {}) => {
           if (!res.success || !res.tableId) {
@@ -214,7 +237,7 @@ export default function DominoRoyalLobby() {
     return () => {
       socket.off('gameStart', handleGameStart);
     };
-  }, [mode, stake.token, stake.amount, totalPlayers, avatar, flags]);
+  }, [mode, stake.token, stake.amount, totalPlayers, avatar, flags, gameType, targetPoints]);
 
   return (
     <div className="relative min-h-screen bg-[#070b16] text-text">
@@ -390,6 +413,78 @@ export default function DominoRoyalLobby() {
           <p className="text-xs text-white/60 text-center">
             Online status: {readiness.label}. Queue and matchmaking are now live.
           </p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Game Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Rules
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {GAME_TYPE_OPTIONS.map(({ id, label, desc, accent, icon }) => {
+              const active = gameType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setGameType(id)}
+                  className={`lobby-option-card ${
+                    active
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('domino-royal', `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {gameType === 'points' && (
+            <div className="grid grid-cols-2 gap-3">
+              {TARGET_POINTS_OPTIONS.map((pts) => (
+                <button
+                  key={pts}
+                  type="button"
+                  onClick={() => setTargetPoints(pts)}
+                  className={`lobby-option-card ${
+                    targetPoints === pts
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-pink-400/30 via-fuchsia-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('domino-royal', `points-${pts}`)}
+                        alt={`${pts} points`}
+                        fallback="🏁"
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{pts} pts</p>
+                    <p className="lobby-option-subtitle">Points to race</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Provide a points-based “race” mode in the Domino Battle Royal lobby to match the Murlan Royale lobby behavior and allow 51/101 point selection. 
- Surface a compact results/leaderboard frame in the 2D Domino view placed above the top player seating so players can see scores and pieces left during play. 
- Ensure the 2D hand tile orientation matches the visual direction used for table doubles so the player tiles read/align correctly in the top-down view. 

### Description
- Added game-type UI and target-point choices to the Domino lobby by introducing `GAME_TYPE_OPTIONS` and `TARGET_POINTS_OPTIONS` with state `gameType` and `targetPoints` in `webapp/src/pages/Games/DominoRoyalLobby.jsx`. 
- Propagated lobby selections into the game launch URL and online seat payload by setting `game` and `points` query params and socket `seatTable` payload keys. 
- Implemented a lightweight in-game leaderboard overlay in `webapp/public/domino-royal-game.js` that builds a DOM `#dominoLeaderboardCard`, computes pip totals (`computePipTotal`) and renders ranked rows via `updateLeaderboardCard`. 
- Added overlay styling and placement (centered above top seating) in `webapp/src/pages/Games/DominoRoyalArena.jsx` so the leaderboard appears as a framed card above player seating. 
- Adjusted 2D human-hand tile orientation so flat (open) human tiles use a vertical yaw (`Math.PI/2`) to match visual orientation of doubles in the table chain. 
- Cleaned up the leaderboard DOM on game shutdown/unmount to avoid leaks and updated `renderHands` to refresh the leaderboard each frame update. 

### Testing
- Ran a production build with `npm --prefix webapp run build` (Vite) which completed successfully. 
- Launched a headless browser script that opened the local dev site at `/games/domino-royal?mode=local&players=4&game=points&points=51&entry=hallway` and captured a before-PR screenshot which succeeded and produced `artifacts/domino-2d-before-pr.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb91e15f083298063aff2663ab01f)