### PR TITLE
Murlan Royale: unify card-back logo with Texas Hold'em and tweak bottom-player hand layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -18,6 +18,7 @@ import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.j
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
 import { applyTableMaterials, createMurlanStyleTable } from '../../utils/murlanTable.js';
 import { CARD_THEMES } from '../../utils/cardThemes.js';
+import { makeCardBackTexture as makeSharedCardBackTexture } from '../../utils/cards3d.js';
 import { chatBeep, bombSound } from '../../assets/soundData.js';
 import {
   getMurlanInventory,
@@ -1267,7 +1268,7 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     roughness: 0.55,
     metalness: 0.1
   });
-  const backTexture = makeCardBackTexture(cardTheme);
+  const backTexture = makeSharedCardBackTexture(cardTheme);
   const managedTextures = [backTexture];
   const managedMaterials = [edgeMaterial];
 
@@ -1935,7 +1936,7 @@ const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.02, landscape:
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.12, landscape: 0.86 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
-const HUMAN_HAND_CARD_SCALE = 1.15;
+const HUMAN_HAND_CARD_SCALE = 1.22;
 const COMMUNITY_CARD_TOP_TILT = 0.12;
 const COMMUNITY_CARD_SCALE = HUMAN_HAND_CARD_SCALE;
 const COMMUNITY_CARD_SPACING_MULTIPLIER = 1.18;
@@ -4174,8 +4175,8 @@ export default function MurlanRoyaleArena({ search }) {
           right,
           focus,
           radius: (isHumanSeat ? 2.7 : 3.25) * MODEL_SCALE,
-          spacing: 0.12 * MODEL_SCALE,
-          maxSpread: 2.1 * MODEL_SCALE,
+          spacing: 0.107 * MODEL_SCALE,
+          maxSpread: 1.88 * MODEL_SCALE,
           stoolPosition,
           stoolHeight
         });
@@ -5608,7 +5609,7 @@ function createCardMesh(card, geometry, cache, theme) {
     metalness: 0.08,
     color: new THREE.Color('#ffffff')
   });
-  const backTexture = makeCardBackTexture(theme);
+  const backTexture = makeSharedCardBackTexture(theme);
   const backMat = new THREE.MeshStandardMaterial({
     map: backTexture,
     color: new THREE.Color('#ffffff'),
@@ -5690,78 +5691,6 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   return tex;
 }
 
-function makeCardBackTexture(theme, w = 512, h = 720) {
-  void theme;
-  const canvas = document.createElement('canvas');
-  canvas.width = w;
-  canvas.height = h;
-  const ctx = canvas.getContext('2d');
-
-  // Match murlan-royale.html exactly.
-  const refCardWidth = 92;
-  const stripePx = Math.max(1, Math.round((w * 6) / refCardWidth));
-  const borderPx = Math.max(1, Math.round((w * 2) / refCardWidth));
-  const insetPx = Math.max(1, Math.round((w * 6) / refCardWidth));
-  const cardRadius = Math.max(4, Math.round((w * 10) / refCardWidth));
-  const innerRadius = Math.max(3, Math.round((w * 8) / refCardWidth));
-
-  const drawBack = (logoImage = null) => {
-    ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = '#122';
-    ctx.fillRect(0, 0, w, h);
-    ctx.fillStyle = '#233';
-    for (let x = -h; x < w + h; x += stripePx * 2) {
-      ctx.save();
-      ctx.translate(x, 0);
-      ctx.rotate(Math.PI / 4);
-      ctx.fillRect(0, -h, stripePx, h * 3);
-      ctx.restore();
-    }
-
-    if (logoImage) {
-      const drawWidth = Math.round(w * 0.6);
-      const ratio = logoImage.height / Math.max(logoImage.width, 1);
-      const drawHeight = Math.round(drawWidth * ratio);
-      ctx.drawImage(logoImage, (w - drawWidth) / 2, (h - drawHeight) / 2, drawWidth, drawHeight);
-    }
-
-    ctx.strokeStyle = 'rgba(255,255,255,0.5)';
-    ctx.lineWidth = borderPx;
-    roundRect(ctx, borderPx / 2, borderPx / 2, w - borderPx, h - borderPx, cardRadius);
-    ctx.stroke();
-
-    ctx.strokeStyle = 'rgba(255,255,255,0.35)';
-    ctx.lineWidth = borderPx;
-    ctx.setLineDash([borderPx * 2, borderPx * 2]);
-    roundRect(
-      ctx,
-      insetPx,
-      insetPx,
-      w - insetPx * 2,
-      h - insetPx * 2,
-      innerRadius
-    );
-    ctx.stroke();
-    ctx.setLineDash([]);
-  };
-
-  drawBack();
-
-  const texture = new THREE.CanvasTexture(canvas);
-  applySRGBColorSpace(texture);
-  texture.anisotropy = 8;
-
-  const logo = new Image();
-  logo.crossOrigin = 'anonymous';
-  logo.onload = () => {
-    drawBack(logo);
-    texture.needsUpdate = true;
-  };
-  logo.src = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
-
-  return texture;
-}
-
 function applyChairThemeMaterials(three, theme) {
   const mats = three?.chairMaterials;
   if (!mats) return;
@@ -5834,7 +5763,7 @@ function applyCardThemeMaterials(three, theme, force = false) {
     frontMaterial.map = faceTexture;
     frontMaterial.color?.set?.('#ffffff');
     frontMaterial.needsUpdate = true;
-    const backTexture = makeCardBackTexture(theme);
+    const backTexture = makeSharedCardBackTexture(theme);
     mesh.userData.backTexture = backTexture;
     backMaterial.map = backTexture;
     backMaterial.color?.set?.('#ffffff');

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -146,7 +146,7 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   return texture;
 }
 
-function makeCardBackTexture(theme, w = 3072, h = 4320) {
+export function makeCardBackTexture(theme, w = 3072, h = 4320) {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;


### PR DESCRIPTION
### Motivation
- Make Murlan Royale card backs and discard/used piles visually identical to the Texas Hold'em 3D cards (same logo and pattern). 
- Improve the visual presentation of the human player's cards at the bottom of the portrait viewport so they sit cleaner and more readable. 
- Remove duplicated local card-back rendering to centralize card-back logic and avoid drift between game variants.

### Description
- Exported the shared `makeCardBackTexture` from `webapp/src/utils/cards3d.js` so it can be reused across games. 
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to import and use the shared `makeCardBackTexture` (`makeSharedCardBackTexture`) for character-held cards, card meshes, and theme application. 
- Removed the now-unused local legacy Murlan card-back renderer from the arena page. 
- Adjusted bottom-player presentation constants in `MurlanRoyaleArena.jsx` by increasing `HUMAN_HAND_CARD_SCALE` from `1.15` to `1.22` and tightening `spacing` and `maxSpread` to `0.107 * MODEL_SCALE` and `1.88 * MODEL_SCALE` respectively to reduce over-spread in portrait.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully. 
- Launched the dev server and executed an automated Playwright script that loaded `/games/murlanroyale?username=Tester` in a portrait viewport and saved a screenshot to verify the visual changes. 
- Verified the app builds and the shared card-back texture loads at runtime (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbf13849c83299cfc6217939fab7b)