### PR TITLE
Add points-race handling and leaderboard updates for Domino Royal

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7567,15 +7567,23 @@ function updateLeaderboardCard() {
       name: names[idx] || `Player ${idx + 1}`,
       avatar: avatars[idx] || DEFAULT_AVATAR_EMOJI,
       piecesLeft: player?.hand?.length ?? 0,
-      pointsLeft: computePipTotal(player?.hand || [])
+      pointsLeft: computePipTotal(player?.hand || []),
+      raceTotal: Number.isFinite(racePenaltyTotals[idx]) ? racePenaltyTotals[idx] : 0,
+      disqualified: Boolean(raceDisqualifiedPlayers[idx])
     }))
     .sort((a, b) => {
       if (isPointsRace) {
-        return a.pointsLeft - b.pointsLeft || a.piecesLeft - b.piecesLeft;
+        if (gameFinished && Number.isInteger(lastHandWinnerIndex)) {
+          if (a.idx === lastHandWinnerIndex && b.idx !== lastHandWinnerIndex) return -1;
+          if (b.idx === lastHandWinnerIndex && a.idx !== lastHandWinnerIndex) return 1;
+        }
+        if (a.disqualified !== b.disqualified) {
+          return a.disqualified ? 1 : -1;
+        }
+        return a.raceTotal - b.raceTotal || a.pointsLeft - b.pointsLeft || a.piecesLeft - b.piecesLeft;
       }
       return a.piecesLeft - b.piecesLeft || a.pointsLeft - b.pointsLeft;
     });
-
   rowsHost.innerHTML = rows
     .map((entry, rank) => {
       const avatarClass = isAvatarUrl(entry.avatar)
@@ -7585,7 +7593,7 @@ function updateLeaderboardCard() {
         ? ` style="background-image:url('${entry.avatar}')"`
         : '';
       const scoreColumn = isPointsRace
-        ? `<span class="leaderboard-stat">${entry.pointsLeft} pts</span>`
+        ? `<span class="leaderboard-stat">${entry.raceTotal} pts${entry.disqualified ? ' • DQ' : ''}</span>`
         : '';
       const avatarLabel = isAvatarUrl(entry.avatar)
         ? ''
@@ -7671,6 +7679,10 @@ let flipDir = false; // alternate chain direction after each game
 const usedTileKeys = new Set();
 let gameFinished = false;
 let winnerIndex = null;
+let lastHandWinnerIndex = null;
+let racePenaltyTotals = [];
+let raceDisqualifiedPlayers = [];
+let raceRoundNumber = 1;
 let revealAllHands = false;
 let winnerHighlight = null;
 let winnerHighlightStart = 0;
@@ -8362,7 +8374,7 @@ function cpuDrawUntilPlayable(player) {
   return drew;
 }
 
-function startGame() {
+function startGame({ resetRace = true } = {}) {
   clearMarkers();
   clearExistingDominoMeshes();
   selectedTile = null;
@@ -8372,6 +8384,7 @@ function startGame() {
   usedTileKeys.clear();
   gameFinished = false;
   winnerIndex = null;
+  lastHandWinnerIndex = null;
   revealAllHands = false;
   lastAnnouncedTurn = null;
   clearWinnerHighlight();
@@ -8387,6 +8400,17 @@ function startGame() {
   flipDir = !flipDir;
   const numericN = Number.isFinite(N) ? Math.round(N) : 4;
   N = Math.max(2, Math.min(4, numericN));
+  if (isPointsRace) {
+    if (resetRace || racePenaltyTotals.length !== N) {
+      racePenaltyTotals = Array.from({ length: N }, () => 0);
+      raceDisqualifiedPlayers = Array.from({ length: N }, () => false);
+      raceRoundNumber = 1;
+    }
+  } else {
+    racePenaltyTotals = [];
+    raceDisqualifiedPlayers = [];
+    raceRoundNumber = 1;
+  }
   refreshSeatAvatars();
   players = Array.from({ length: N }, (_, i) => ({ id: i, hand: [] }));
   boneyard = shuffle(genSet());
@@ -9262,13 +9286,66 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}) {
   showWinnerOverlay({ winner: winnerIndex, reason });
 }
 
+
+function finishPointsRaceHand({ winner = null, reason = '' } = {}) {
+  const handScores = players.map((p) => pipSum(p.hand));
+  racePenaltyTotals = handScores.map(
+    (score, idx) =>
+      (Number.isFinite(racePenaltyTotals[idx]) ? racePenaltyTotals[idx] : 0) + score
+  );
+  lastHandWinnerIndex = Number.isInteger(winner) ? winner : null;
+  raceDisqualifiedPlayers = racePenaltyTotals.map(
+    (total) => total >= raceTargetPoints
+  );
+  const eliminated = raceDisqualifiedPlayers
+    .map((isOut, idx) => (isOut ? idx : -1))
+    .filter((idx) => idx >= 0);
+
+  if (!eliminated.length) {
+    const nextRound = raceRoundNumber + 1;
+    const roundSummary = handScores
+      .map((score, idx) => `P${idx + 1}: +${score} (${racePenaltyTotals[idx]})`)
+      .join(' • ');
+    setStatus(
+      `Round ${raceRoundNumber} over. ${roundSummary}. Round ${nextRound} starts…`
+    );
+    gameFinished = true;
+    revealAllHands = true;
+    renderHands();
+    renderChain();
+    updateLeaderboardCard();
+    setTimeout(() => {
+      raceRoundNumber = nextRound;
+      startGame({ resetRace: false });
+    }, 1800);
+    return;
+  }
+
+  const dqLabel = eliminated.map((idx) => `Player ${idx + 1}`).join(', ');
+  finishGame({
+    winner,
+    revealAll: true,
+    reason:
+      reason ||
+      `${dqLabel} reached ${raceTargetPoints} points and is disqualified. Lowest points wins.`
+  });
+}
+
+function concludeHand({ winner = null, reason = '', revealAll = false } = {}) {
+  if (isPointsRace) {
+    finishPointsRaceHand({ winner, reason });
+    return;
+  }
+  finishGame({ winner, reason, revealAll });
+}
+
 function checkForBlockedGame() {
   if (gameFinished) {
     return true;
   }
   const blk = blockedAndWinner();
   if (blk) {
-    finishGame({ winner: blk.winner, reason: blk.reason, revealAll: true });
+    concludeHand({ winner: blk.winner, reason: blk.reason, revealAll: true });
     return true;
   }
   return false;
@@ -9297,7 +9374,7 @@ function nextTurn() {
   }
   const player = players[current];
   if (player && player.hand.length === 0) {
-    finishGame({
+    concludeHand({
       winner: current,
       reason: current === human ? 'You won!' : `Player ${current + 1} won!`
     });
@@ -9374,7 +9451,7 @@ function cpuPlay() {
         );
       }
       if (player.hand.length === 0) {
-        finishGame({
+        concludeHand({
           winner: current,
           reason: current === human ? 'You won!' : `Player ${current + 1} won!`
         });

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -121,10 +121,10 @@ export default function DominoRoyalArena() {
         }
         #dominoLeaderboardCard {
           position: fixed;
-          top: calc(5.35rem + env(safe-area-inset-top, 0px));
+          top: calc(3.9rem + env(safe-area-inset-top, 0px));
           left: 50%;
           transform: translateX(-50%);
-          width: min(86vw, 21rem);
+          width: min(72vw, 15.5rem);
           z-index: 5;
           border-radius: 12px;
           border: 1px solid rgba(148, 163, 184, 0.34);


### PR DESCRIPTION
### Motivation
- Introduce and correctly track a multi-round "points race" mode where players accumulate penalty points across hands and may be disqualified when exceeding the race target.
- Reflect race state in the leaderboard UI and ensure hand/conclusion logic handles race-specific transitions and disqualifications.

### Description
- Added race state variables: `racePenaltyTotals`, `raceDisqualifiedPlayers`, `raceRoundNumber`, and `lastHandWinnerIndex`, and initialized them in `startGame` with optional `resetRace` behavior via `startGame({ resetRace = true })`.
- Implemented `finishPointsRaceHand` to accumulate hand penalty points (`pipSum`), mark disqualified players, advance rounds when nobody is eliminated, or finish the match when disqualifications occur, and wired it into a new wrapper `concludeHand` used in place of `finishGame` for end-of-hand flows.
- Updated leaderboard generation (`updateLeaderboardCard`) to include `raceTotal` and disqualification status, change sorting rules to prefer `lastHandWinnerIndex` on a finished game, prioritize non-disqualified players, and sort by `raceTotal` then `pointsLeft` and `piecesLeft` for points races.
- Adjusted UI layout for the leaderboard card in `DominoRoyalArena.jsx` (top offset and reduced width) and minor code tidy-ups around trailing commas and state resets.

### Testing
- Ran automated unit tests with `yarn test` and they completed successfully.
- Ran a CI-style build with `yarn build` and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc62d220c83299ec923e4d0abc232)