### PR TITLE
Add rail-overhead side toggle and preferred-rail handling for broadcast cameras

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4971,9 +4971,7 @@ function createBroadcastCameras({
     };
   };
 
-  if (!LOCK_RAIL_OVERHEAD_FRAME) {
-    cameras.front = createShortRailUnit(-1);
-  }
+  cameras.front = createShortRailUnit(-1);
   cameras.back = createShortRailUnit(1);
 
   return { group, cameras, slideLimit, cameraHeight, defaultFocus };
@@ -5351,7 +5349,7 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
-  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.01 // nudge rail-overhead framing slightly inward toward table center
+  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.014 // nudge rail-overhead framing a touch more inward so bottom pockets remain visible on portrait
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.035; // lift rail-overhead camera slightly higher for clearer broadcast context
@@ -5445,7 +5443,7 @@ const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor whi
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
-const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 4; // widen rail-overhead lens so near-rail pockets stay visible on portrait screens
+const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens a bit more so both bottom pockets stay visible on portrait screens
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -13594,9 +13592,11 @@ function PoolRoyaleGame({
   );
   const [isTopDownView, setIsTopDownView] = useState(false);
   const [isRailOverheadView, setIsRailOverheadView] = useState(false);
+  const [railOverheadSide, setRailOverheadSide] = useState('back');
   const usePortraitHudLayout = true;
   const [isLookMode, setIsLookMode] = useState(false);
   const lookModeRef = useRef(false);
+  const railOverheadSideRef = useRef('back');
   useEffect(() => {
     if (typeof window === 'undefined') {
       return undefined;
@@ -13638,6 +13638,11 @@ function PoolRoyaleGame({
     }
     cameraUpdateRef.current?.();
   }, [isLookMode]);
+
+  useEffect(() => {
+    railOverheadSideRef.current = railOverheadSide === 'front' ? 'front' : 'back';
+    cameraUpdateRef.current?.();
+  }, [railOverheadSide]);
 
   useEffect(() => {
     if (isTopDownView) {
@@ -19198,7 +19203,8 @@ const powerRef = useRef(hud.power);
           targetWorld = null,
           focusWorld = null,
           orbitWorld = null,
-          lerp = null
+          lerp = null,
+          preferredRail = null
         } = {}) => {
           const rig = broadcastCamerasRef.current;
           if (!rig || !rig.cameras) return;
@@ -19260,11 +19266,16 @@ const powerRef = useRef(hud.power);
               unit.head.lookAt(headTarget);
             }
           };
-          const useBack = LOCK_RAIL_OVERHEAD_FRAME ? true : railDir >= 0;
+          const resolvedPreferredRail = preferredRail === 'front' || preferredRail === 'back'
+            ? preferredRail
+            : null;
+          const useBack = resolvedPreferredRail
+            ? resolvedPreferredRail === 'back'
+            : LOCK_RAIL_OVERHEAD_FRAME
+              ? true
+              : railDir >= 0;
           applyPreset(useBack ? rig.cameras.back : rig.cameras.front, useBack ? 1 : -1);
-          if (!LOCK_RAIL_OVERHEAD_FRAME) {
-            applyPreset(useBack ? rig.cameras.front : rig.cameras.back, useBack ? -1 : 1);
-          }
+          applyPreset(useBack ? rig.cameras.front : rig.cameras.back, useBack ? -1 : 1);
           rig.activeRail = useBack ? 'back' : 'front';
         };
 
@@ -19317,14 +19328,19 @@ const powerRef = useRef(hud.power);
 
         const resolveRailOverheadReplayCamera = ({
           focusOverride = null,
-          minTargetY = null
+          minTargetY = null,
+          preferredRail = null
         } = {}) => {
           const rig = broadcastCamerasRef.current;
           if (!rig?.cameras) return null;
+          const requestedRail = preferredRail === 'front' || preferredRail === 'back'
+            ? preferredRail
+            : null;
+          const activeRailId = requestedRail ?? rig.activeRail;
           const activeRail =
-            rig.activeRail === 'front'
+            activeRailId === 'front'
               ? rig.cameras.front
-              : rig.activeRail === 'back'
+              : activeRailId === 'back'
                 ? rig.cameras.back
                 : rig.cameras.back ?? rig.cameras.front;
           const head = activeRail?.head ?? null;
@@ -20198,7 +20214,11 @@ const powerRef = useRef(hud.power);
           if (overheadVariant === 'replay' || overheadVariant === 'rail') {
             const overheadCamera = resolveRailOverheadReplayCamera({
               focusOverride: topFocusTarget,
-              minTargetY
+              minTargetY,
+              preferredRail:
+                overheadVariant === 'rail' || overheadVariant === 'replay'
+                  ? railOverheadSideRef.current
+                  : null
             });
             if (overheadCamera?.position) {
               const resolvedTarget = overheadCamera.target ?? topFocusTarget;
@@ -20215,6 +20235,7 @@ const powerRef = useRef(hud.power);
               broadcastArgs.focusWorld = resolvedTarget.clone();
               broadcastArgs.targetWorld = resolvedTarget.clone();
               broadcastArgs.orbitWorld = overheadCamera.position.clone();
+              broadcastArgs.preferredRail = railOverheadSideRef.current;
               if (broadcastCamerasRef.current) {
                 broadcastCamerasRef.current.defaultFocusWorld = resolvedTarget.clone();
               }
@@ -33154,17 +33175,22 @@ const powerRef = useRef(hud.power);
             aria-pressed={isTopDownView && isRailOverheadView}
             onClick={() => {
               if (!isPortrait) return;
+              const isActiveRailView = isTopDownView && isRailOverheadView;
               setIsRailOverheadView(true);
               setIsTopDownView(true);
+              setRailOverheadSide((prev) => (isActiveRailView ? (prev === 'back' ? 'front' : 'back') : 'back'));
             }}
-            className={`flex h-12 w-12 items-center justify-center rounded-full border text-[16px] font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+            className={`flex h-12 w-12 items-center justify-center rounded-full border text-[13px] font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
               isTopDownView && isRailOverheadView
                 ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
                 : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
             }`}
-            aria-label="Switch to rail overhead view"
+            aria-label="Switch rail overhead side"
           >
-            <span aria-hidden="true">▲</span>
+            <span aria-hidden="true" className="flex flex-col items-center leading-[0.8]">
+              <span className={railOverheadSide === 'back' ? 'text-emerald-100' : 'text-white/65'}>▲</span>
+              <span className={railOverheadSide === 'front' ? 'text-emerald-100' : 'text-white/65'}>▼</span>
+            </span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
### Motivation

- Improve rail-overhead top-down broadcast framing on portrait screens and allow switching which table rail (front/back) is used for overhead shots.
- Make the front rail camera always available regardless of `LOCK_RAIL_OVERHEAD_FRAME` so the system can choose/switch rails dynamically.

### Description

- Always create the front rail camera by setting `cameras.front = createShortRailUnit(-1)` unconditionally. 
- Expose a new UI state `railOverheadSide` with a ref `railOverheadSideRef` and a button to toggle the active rail side between `back` and `front` from the top-down control. 
- Add a `preferredRail` parameter across broadcast camera resolution functions and propagation (`updateBroadcastCameras`, `resolveRailOverheadReplayCamera`, and overhead camera resolution) to allow explicit selection of `front`/`back` when resolving rail overhead views. 
- Update selection logic in `updateBroadcastCameras` to respect `preferredRail` and fall back to `LOCK_RAIL_OVERHEAD_FRAME` or `railDir` when deciding `rig.activeRail`. 
- Increase `RAIL_OVERHEAD_SCREEN_OFFSET.z` slightly and widen `RAIL_OVERHEAD_REPLAY_FOV` to improve portrait framing so bottom pockets remain visible. 
- Update the rail-overhead button visuals and `aria-label` to indicate the two-sided toggle and highlight the active side.

### Testing

- Ran the frontend unit test suite with `yarn test` and all tests passed. 
- Built the webapp with `yarn build` to validate the bundle and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc2907bf48329afe3565037f7e5d7)