### PR TITLE
Tune Murlan Royale camera, unify card inventory with Texas Hold'em, and adjust results frame

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -52,51 +52,15 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
-  {
-    id: 'cards-solstice',
+  ...CARD_THEMES.slice(1).map((option, idx) => ({
+    id: `murlan-card-${option.id}`,
     type: 'cards',
-    optionId: 'solstice',
-    name: 'Solstice Deck',
-    price: 260,
-    description: 'Sun-baked backs with warm metallic edgework.',
-    thumbnail: CARD_THEMES.find((theme) => theme.id === 'solstice')?.thumbnail
-  },
-  {
-    id: 'cards-nebula',
-    type: 'cards',
-    optionId: 'nebula',
-    name: 'Nebula Deck',
-    price: 300,
-    description: 'Cosmic purples with glowing starlit accents.',
-    thumbnail: CARD_THEMES.find((theme) => theme.id === 'nebula')?.thumbnail
-  },
-  {
-    id: 'cards-jade',
-    type: 'cards',
-    optionId: 'jade',
-    name: 'Jade Deck',
-    price: 280,
-    description: 'Emerald gradients with luminous jade borders.',
-    thumbnail: CARD_THEMES.find((theme) => theme.id === 'jade')?.thumbnail
-  },
-  {
-    id: 'cards-ember',
-    type: 'cards',
-    optionId: 'ember',
-    name: 'Ember Deck',
-    price: 320,
-    description: 'Fiery orange backs with charcoal cores.',
-    thumbnail: CARD_THEMES.find((theme) => theme.id === 'ember')?.thumbnail
-  },
-  {
-    id: 'cards-onyx',
-    type: 'cards',
-    optionId: 'onyx',
-    name: 'Onyx Deck',
-    price: 340,
-    description: 'Monochrome slate backs with steel edging.',
-    thumbnail: CARD_THEMES.find((theme) => theme.id === 'onyx')?.thumbnail
-  }
+    optionId: option.id,
+    name: `${option.label} Cards`,
+    price: 460 + idx * 35,
+    description: 'Add a fresh premium deck style to the arena.',
+    thumbnail: option.thumbnail
+  }))
 ].concat(
   MURLAN_TABLE_CLOTHS.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1931,7 +1931,7 @@ const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INW
 const CHAIR_SEAT_INWARD_FACTOR = 0.92;
 const CHAIR_VISUAL_SCALE = 1.12 * 1.15;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: -0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 1.02, landscape: 0.72 });
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.9, landscape: 0.62 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.12, landscape: 0.86 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
@@ -1959,7 +1959,7 @@ const CAMERA_TURN_DURATION_MS = 360;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
 const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
-const CAMERA_INWARD_RADIUS_FACTOR = 0.86;
+const CAMERA_INWARD_RADIUS_FACTOR = 0.8;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -4073,11 +4073,11 @@ export default function MurlanRoyaleArena({ search }) {
           toneMapped: false,
           depthWrite: false
         });
-        const scoreboardWidth = Math.min(innerHalfWidth * 0.9, 4.4 * MODEL_SCALE);
+        const scoreboardWidth = Math.min(innerHalfWidth * 0.84, 4.08 * MODEL_SCALE);
         const scoreboardHeight = scoreboardWidth * 0.42;
         const scoreboardGeometry = new THREE.PlaneGeometry(scoreboardWidth, scoreboardHeight);
         const scoreboardMesh = new THREE.Mesh(scoreboardGeometry, scoreboardMaterial);
-        const scoreboardY = TABLE_HEIGHT + 1.45 * MODEL_SCALE;
+        const scoreboardY = TABLE_HEIGHT + 1.58 * MODEL_SCALE;
         const scoreboardZ = -Math.max(TABLE_RADIUS * 2.2, floorRadius * 0.72);
         scoreboardMesh.position.set(0, scoreboardY, scoreboardZ);
         scoreboardMesh.lookAt(new THREE.Vector3(0, scoreboardMesh.position.y, 0));


### PR DESCRIPTION
### Motivation
- Improve visual composition by bringing the 3D camera visually closer to the table center for a tighter portrait/mobile experience.
- Ensure Murlan Royale uses the exact same card themes/assets as the Texas Hold'em inventory so decks are visually identical and selectable from the store.
- Make the in-scene results/leaderboard card slightly narrower and nudged upward for better screen fit.

### Description
- Reduced seated camera retreat offsets by updating `CAMERA_SEATED_RETREAT_OFFSETS` and tightened the orbit with `CAMERA_INWARD_RADIUS_FACTOR` to make the camera appear closer to the table (file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Reduced the scoreboard plane width and increased its vertical placement by changing the computed `scoreboardWidth` and `scoreboardY` to make the results frame slimmer and pushed upward (file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Replaced the hard-coded per-deck entries in Murlan store with a mapping over the shared `CARD_THEMES` so Murlan can expose the same deck types/assets as Texas Hold'em (now generates `murlan-card-<id>` entries from `CARD_THEMES`) (file: `webapp/src/config/murlanInventoryConfig.js`).
- Minor code adjustments to ensure card theme application paths remain consistent with the shared `CARD_THEMES` usage (no runtime API changes intended).

### Testing
- Ran `npx eslint` on the modified files which completed but the repo lint ignore rules emitted warnings for those paths (warnings only).
- Started the local dev server and exercised `/games/murlanroyale` to validate visual changes in-browser by capturing a mobile-viewport screenshot; a Firefox-based Playwright screenshot completed successfully and is available as an artifact (successful), while a Chromium run crashed in this environment with a SIGSEGV (environmental failure, not code regression). 
- Verified `git diff` locally to confirm only the intended files were changed and inspected the updated constants and inventory mapping (diff verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcaeb73d083298aeb432fe7e157f1)