### PR TITLE
Fix Murlan Royale community card overlap and align card-back style with Texas Hold’em

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1938,7 +1938,8 @@ const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.15;
 const COMMUNITY_CARD_TOP_TILT = 0.08;
 const COMMUNITY_CARD_SCALE = HUMAN_HAND_CARD_SCALE;
-const COMMUNITY_CARD_SPACING_MULTIPLIER = 1;
+const COMMUNITY_CARD_SPACING = CARD_W * COMMUNITY_CARD_SCALE * 1.08;
+const COMMUNITY_CARD_MAX_SPREAD = COMMUNITY_CARD_SPACING * 4;
 const COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET = Math.sin(COMMUNITY_CARD_TOP_TILT) * CARD_H * 0.5;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
@@ -3180,10 +3181,10 @@ export default function MurlanRoyaleArena({ search }) {
     const tableAnchor = three.tableAnchor.clone();
     const tableCount = state.tableCards.length;
     const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
-    const bottomCardSpacing = humanSeat?.spacing ?? 0.12 * MODEL_SCALE;
-    const bottomCardMaxSpread = humanSeat?.maxSpread ?? 2.1 * MODEL_SCALE;
+    const bottomCardSpacing = Math.max(humanSeat?.spacing ?? 0, COMMUNITY_CARD_SPACING);
+    const bottomCardMaxSpread = Math.max(humanSeat?.maxSpread ?? 0, COMMUNITY_CARD_MAX_SPREAD);
     const tableSpread = tableCount > 1
-      ? Math.min((tableCount - 1) * bottomCardSpacing, bottomCardMaxSpread) * COMMUNITY_CARD_SPACING_MULTIPLIER
+      ? Math.min((tableCount - 1) * bottomCardSpacing, bottomCardMaxSpread)
       : 0;
     const tableSpacing = tableCount > 1 ? tableSpread / (tableCount - 1) : 0;
     const tableStartX = tableCount > 1 ? -tableSpread / 2 : 0;
@@ -5633,7 +5634,7 @@ function createCardMesh(card, geometry, cache, theme) {
   const backTexture = makeCardBackTexture(theme);
   const backMat = new THREE.MeshStandardMaterial({
     map: backTexture,
-    color: new THREE.Color(theme.backColor),
+    color: new THREE.Color('#ffffff'),
     roughness: 0.6,
     metalness: 0.15
   });
@@ -5714,9 +5715,7 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
   const refCardWidth = 92;
   const stripePx = Math.max(1, Math.round((w * 6) / refCardWidth));
   const borderPx = Math.max(1, Math.round((w * 2) / refCardWidth));
-  const insetPx = Math.max(1, Math.round((w * 6) / refCardWidth));
   const cardRadius = Math.max(4, Math.round((w * 10) / refCardWidth));
-  const innerRadius = Math.max(3, Math.round((w * 8) / refCardWidth));
 
   const drawBack = (logoImage = null) => {
     ctx.clearRect(0, 0, w, h);
@@ -5732,7 +5731,7 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
     }
 
     if (logoImage) {
-      const drawWidth = Math.round(w * 0.6);
+      const drawWidth = Math.round(w * 0.9);
       const ratio = logoImage.height / Math.max(logoImage.width, 1);
       const drawHeight = Math.round(drawWidth * ratio);
       ctx.drawImage(logoImage, (w - drawWidth) / 2, (h - drawHeight) / 2, drawWidth, drawHeight);
@@ -5742,20 +5741,6 @@ function makeCardBackTexture(theme, w = 512, h = 720) {
     ctx.lineWidth = borderPx;
     roundRect(ctx, borderPx / 2, borderPx / 2, w - borderPx, h - borderPx, cardRadius);
     ctx.stroke();
-
-    ctx.strokeStyle = 'rgba(255,255,255,0.35)';
-    ctx.lineWidth = borderPx;
-    ctx.setLineDash([borderPx * 2, borderPx * 2]);
-    roundRect(
-      ctx,
-      insetPx,
-      insetPx,
-      w - insetPx * 2,
-      h - insetPx * 2,
-      innerRadius
-    );
-    ctx.stroke();
-    ctx.setLineDash([]);
   };
 
   drawBack();


### PR DESCRIPTION
### Motivation
- Community cards on the Murlan Royale table were visually overlapping on smaller/portrait views and needed a larger, predictable spacing so the flop/turn/river are clearly separated.
- The back of the cards should match the Texas Hold’em visual treatment so the centered logo and colors render correctly and consistently across tables.

### Description
- Introduced `COMMUNITY_CARD_SPACING` and `COMMUNITY_CARD_MAX_SPREAD` and replaced the old spacing multiplier so community layout enforces a minimum spacing based on scaled `CARD_W` and card scale. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)
- Use `Math.max` to derive `bottomCardSpacing` and `bottomCardMaxSpread` from the human seat config and the new community spacing constants, and remove the previous multiplier when computing `tableSpread` so cards no longer overlap. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)
- Updated card-back material to avoid tinting (`color: '#ffffff'`) so back texture/logo colors are preserved, enlarged the centered back-logo draw area (from 60% to 90% of the card width), and removed the inner dashed frame to match the Texas Hold’em style. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced an ignore warning from repo config but no code errors. (warning)
- Built the webapp with `npm --prefix webapp run build` which completed successfully. (pass)
- Launched the dev server with `npm --prefix webapp run dev` and performed a visual validation using Playwright to capture a portrait/mobile screenshot of `/games/murlanroyale`, producing a verification artifact. (pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afdc6db0548329b578b7180657865e)