### PR TITLE
Lock Domino Royal camera translation and fix look direction for 2D/3D views

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1534,8 +1534,8 @@ const CAMERA_TOPDOWN_MAX_RADIUS = TABLE_RADIUS * 3.6;
 const CAMERA_TOPDOWN_MIN_POLAR = THREE.MathUtils.degToRad(2);
 const CAMERA_TOPDOWN_MAX_POLAR = THREE.MathUtils.degToRad(18);
 const CAMERA_TOPDOWN_FRAMING = Object.freeze({
-  portrait: { right: TABLE_RADIUS * 0.12, forward: TABLE_RADIUS * 0.08 },
-  landscape: { right: TABLE_RADIUS * 0.07, forward: TABLE_RADIUS * 0.05 }
+  portrait: { right: 0, forward: 0 },
+  landscape: { right: 0, forward: 0 }
 });
 const CAMERA_TURN_FOCUS_LERP = 0.07;
 const CAMERA_TURN_SEAT_WEIGHT = 0.42;
@@ -1760,7 +1760,7 @@ controls.enableDamping = true;
 controls.dampingFactor = 0.08;
 controls.enableZoom = false;
 controls.zoomSpeed = 0;
-controls.enablePan = true;
+controls.enablePan = false;
 controls.panSpeed = 0.9;
 controls.screenSpacePanning = true;
 controls.enableRotate = false;
@@ -1835,9 +1835,6 @@ function getTopDownFramingOffset() {
 }
 
 function getActiveCameraTarget() {
-  if (cameraViewMode === VIEW_MODES.twoD) {
-    return CAMERA_TARGET.clone().add(getTopDownFramingOffset());
-  }
   return CAMERA_TARGET.clone();
 }
 
@@ -2024,7 +2021,7 @@ function handleCameraLookDrag(deltaX = 0) {
     return;
   }
   cameraLookYaw = THREE.MathUtils.clamp(
-    cameraLookYaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
+    cameraLookYaw - deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
     -CAMERA_LOOK_YAW_LIMIT,
     CAMERA_LOOK_YAW_LIMIT
   );


### PR DESCRIPTION
### Motivation
- Ensure camera behavior matches gameplay UX: looking left/right should rotate the view without translating the camera, and the 2D/top-down view must remain centered on the table (no framing drift). 

### Description
- Set `CAMERA_TOPDOWN_FRAMING` to zero so the top-down camera targets the table center with no lateral/forward offset (`webapp/public/domino-royal-game.js`).
- Disable panning on the `OrbitControls` by setting `controls.enablePan = false` so look gestures no longer move camera position.
- Remove the top-down framing addition in `getActiveCameraTarget()` so 2D view consistently uses the table center as the target.
- Invert the horizontal look drag sign in `handleCameraLookDrag` so left/right swipes rotate the view to match on-screen directions (`cameraLookYaw - deltaX * ...`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which succeeded.
- Started a local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server launched successfully for smoke testing.
- Attempted automated browser validation with Playwright but Chromium crashed in this environment (SIGSEGV), so no headless screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe48d5e1483299fb22860ece98781)