### PR TITLE
Lock Domino Royale camera and fix horizontal look direction

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1760,18 +1760,20 @@ controls.enableDamping = true;
 controls.dampingFactor = 0.08;
 controls.enableZoom = false;
 controls.zoomSpeed = 0;
-controls.enablePan = true;
-controls.panSpeed = 0.9;
-controls.screenSpacePanning = true;
+controls.enablePan = false;
+controls.panSpeed = 0;
+controls.screenSpacePanning = false;
 controls.enableRotate = false;
 controls.minDistance = CAMERA_MIN_RADIUS;
 controls.maxDistance = CAMERA_MAX_RADIUS;
 controls.minPolarAngle = CAMERA_MIN_POLAR;
 controls.maxPolarAngle = CAMERA_MAX_POLAR;
-controls.touches.ONE = THREE.TOUCH.PAN;
-controls.touches.TWO = THREE.TOUCH.DOLLY_PAN;
-controls.touches.THREE = THREE.TOUCH.PAN;
-controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
+controls.touches.ONE = THREE.TOUCH.NONE;
+controls.touches.TWO = THREE.TOUCH.NONE;
+controls.touches.THREE = THREE.TOUCH.NONE;
+controls.mouseButtons.LEFT = THREE.MOUSE.NONE;
+controls.mouseButtons.MIDDLE = THREE.MOUSE.NONE;
+controls.mouseButtons.RIGHT = THREE.MOUSE.NONE;
 controls.target.copy(CAMERA_TARGET);
 const turnFocusTarget = controls.target.clone();
 const turnSeatTarget = new THREE.Vector3();
@@ -1961,7 +1963,7 @@ function updateTurnCameraFocus() {
     const toTarget = turnFocusTarget.clone().sub(camera.position);
     const horizontalLength = Math.hypot(toTarget.x, toTarget.z);
     if (horizontalLength > 0.0001) {
-      const lateral = new THREE.Vector3(-toTarget.z, 0, toTarget.x).normalize();
+      const lateral = new THREE.Vector3(toTarget.z, 0, -toTarget.x).normalize();
       const yawOffset = Math.tan(cameraLookYaw) * horizontalLength;
       turnFocusTarget.addScaledVector(lateral, yawOffset);
     }


### PR DESCRIPTION
### Motivation
- Prevent unintended camera movement when players look left/right so the camera stays fixed on the table in both 3D and 2D modes while preserving a visual look offset in 3D.

### Description
- Disabled panning/gesture translation on `OrbitControls` by setting `controls.enablePan = false`, `controls.panSpeed = 0`, and `controls.screenSpacePanning = false` in `webapp/public/domino-royal-game.js`.
- Cleared touch and mouse button mappings by assigning `THREE.TOUCH.NONE` and `THREE.MOUSE.NONE` to `controls.touches` and `controls.mouseButtons` so pointer gestures no longer move the camera.
- Corrected the horizontal look mapping by flipping the lateral vector sign in `updateTurnCameraFocus` so left/right drag visually matches on-screen direction.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite warnings only). 
- Launched the dev server and ran an automated Playwright script to load `/domino-royal-game.html` in a portrait viewport and capture a screenshot to validate camera behavior (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe48d5e1483299fb22860ece98781)