### PR TITLE
Adjust landscape seated camera and add 2D top-view toggle for Texas Hold'em

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -390,8 +390,8 @@ const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(12);
 const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
-const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.6 });
-const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 1.12 });
+const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.46 });
+const CAMERA_RETREAT_OFFSETS = Object.freeze({ portrait: 0.8, landscape: 0.84 });
 const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72 });
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
@@ -2887,6 +2887,8 @@ function TexasHoldemArena({ search }) {
   const humanSeatRef = useRef(null);
   const seatTopPointRef = useRef(null);
   const viewControlsRef = useRef({ applySeatedCamera: null, applyOverheadCamera: null });
+  const overheadViewRef = useRef(false);
+  const overheadZoomRef = useRef(OVERHEAD_ZOOM_DEFAULT);
   const lastViewRef = useRef(false);
   const cameraBasisRef = useRef({
     position: new THREE.Vector3(),
@@ -3009,6 +3011,13 @@ function TexasHoldemArena({ search }) {
   const [sliderValue, setSliderValue] = useState(0);
   const [overheadView, setOverheadView] = useState(false);
   const [overheadZoom, setOverheadZoom] = useState(OVERHEAD_ZOOM_DEFAULT);
+  useEffect(() => {
+    overheadViewRef.current = overheadView;
+  }, [overheadView]);
+
+  useEffect(() => {
+    overheadZoomRef.current = overheadZoom;
+  }, [overheadZoom]);
   const [appearance, setAppearance] = useState(() => {
     if (typeof window === 'undefined') return { ...DEFAULT_APPEARANCE };
     try {
@@ -5440,17 +5449,21 @@ function TexasHoldemArena({ search }) {
         }
         mesh.position.copy(position);
         const humanActiveTurn = seat.isHuman && state.stage !== 'showdown' && idx === state.actionIndex;
+        const isOverheadView = overheadViewRef.current;
         const showdownFacing = humanSeatRef.current?.forward
           ? humanSeatRef.current.forward.clone()
           : new THREE.Vector3(0, 0, 1);
         const isShowdownReveal = state.showdown;
         const lookTarget = isShowdownReveal
           ? position.clone().add(showdownFacing)
+          : seat.isHuman && isOverheadView
+            ? position.clone().add(seat.forward.clone())
           : seat.isHuman
             ? seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
             : position.clone().add(seat.forward.clone());
         const face = seat.isHuman || isShowdownReveal ? 'front' : 'back';
-        orientCard(mesh, lookTarget, { face, flat: !isShowdownReveal });
+        const flatCard = isShowdownReveal ? false : (seat.isHuman && isOverheadView ? true : !isShowdownReveal);
+        orientCard(mesh, lookTarget, { face, flat: flatCard });
         if (!seat.isHuman && face === 'back' && !isShowdownReveal) {
           mesh.rotateZ(HIDDEN_CARD_BACK_ALIGNMENT_ROTATION);
         }
@@ -5459,7 +5472,7 @@ function TexasHoldemArena({ search }) {
         }
         if (isShowdownReveal) {
           mesh.rotateX(SHOWDOWN_CARD_STAND_TILT);
-        } else if (seat.isHuman) {
+        } else if (seat.isHuman && !isOverheadView) {
           animateHumanCardPosture(mesh, humanActiveTurn ? HUMAN_CARD_FACE_TILT : 0);
         }
         setCardFace(mesh, face);
@@ -6494,6 +6507,19 @@ function TexasHoldemArena({ search }) {
         </div>
       )}
       <div className="pointer-events-auto">
+        <button
+          type="button"
+          onClick={() => setOverheadView((prev) => !prev)}
+          className="fixed right-[0.45rem] bottom-[calc(env(safe-area-inset-bottom,0px)+1.6rem)] z-20 flex h-[3.15rem] w-[3.15rem] flex-col items-center justify-center gap-0.5 rounded-[14px] border border-white/20 bg-black/35 p-0 text-white shadow-[0_6px_12px_rgba(0,0,0,0.25)]"
+          aria-label={overheadView ? 'Switch to 3D camera view' : 'Switch to 2D top camera view'}
+          title={overheadView ? '3D View' : '2D View'}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.5A2.5 2.5 0 0 1 5.5 6h3.3l1.2-1.6A2 2 0 0 1 11.6 4h.8a2 2 0 0 1 1.6.8L15.2 6h3.3A2.5 2.5 0 0 1 21 8.5v8A2.5 2.5 0 0 1 18.5 19h-13A2.5 2.5 0 0 1 3 16.5z" />
+            <circle cx="12" cy="12" r="3.4" />
+          </svg>
+          <span className="text-[0.58rem] font-extrabold uppercase tracking-[0.08em]">{overheadView ? '3D' : '2D'}</span>
+        </button>
         <BottomLeftIcons
           onChat={() => setShowChat(true)}
           showInfo={false}


### PR DESCRIPTION
### Motivation
- Improve the seated camera framing in landscape so the view is closer to the center of the table while leaving portrait behavior unchanged.
- Provide a 2D top-down camera mode so players can inspect the table from above with the human player's hole cards laid flat and revealed.
- Make overhead state available to runtime handlers so pointer/resize logic consistently applies the active camera mode.

### Description
- Tightened landscape camera constants in `webapp/src/pages/Games/TexasHoldemArena.jsx` by changing `CAMERA_LATERAL_OFFSETS.landscape` and `CAMERA_RETREAT_OFFSETS.landscape` to bring the seated camera closer to the table center.
- Added `overheadViewRef` and `overheadZoomRef` refs and synchronized them with React state via `useEffect` so runtime code (resize/pointer/animation) can read the current overhead state reliably.
- Updated card rendering logic in `webapp/src/pages/Games/TexasHoldemArena.jsx` so that when overhead (2D) view is active the human (bottom) player's hole cards are laid flat and shown face-up, while other players' cards remain unchanged.
- Added a HUD button (camera icon + label) to toggle between 2D top view and 3D seated view in the same file, wired to the `overheadView` state.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully.
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot to validate the new 2D toggle and table framing in the Texas Hold'em arena.
- No existing automated unit tests were modified; validation was performed via build and manual UI inspection (screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff790bd38832984f6c0ade0d076ba)