### PR TITLE
Anchor bottom player's hole cards to camera and fix community card order

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -419,6 +419,9 @@ const COMMUNITY_CARD_SCALE = 1.08;
 const HUMAN_CHIP_SCALE = 1;
 const HUMAN_CARD_FACE_TILT = Math.PI * 0.08;
 const HUMAN_CARD_LOWER_OFFSET = CARD_H * 0.37;
+const HUMAN_CARD_SCREEN_SPACING = HOLE_SPACING * 0.86;
+const HUMAN_CARD_CAMERA_DISTANCE = TABLE_RADIUS * 0.46;
+const HUMAN_CARD_CAMERA_VERTICAL_OFFSET = -TABLE_RADIUS * 0.26;
 const POT_PLAYER_PILE_RADIUS = CARD_W * 1.02;
 const POT_TWO_PILE_SIDE_OFFSET = CARD_W * 0.4;
 const POT_TWO_PILE_FORWARD_STEP = CARD_D * 1.5;
@@ -4845,22 +4848,21 @@ function TexasHoldemArena({ search }) {
         const humanSeatGroup = seatGroups.find((seat) => seat.isHuman);
         if (!humanSeatGroup) return;
 
-          const baseAnchor =
-            getHumanCardAnchor(humanSeatGroup) ??
-            humanSeatGroup.cardRailAnchor?.clone() ??
-            humanSeatGroup.chipRailAnchor?.clone() ??
-            humanSeatGroup.chipAnchor.clone();
-          const right = humanSeatGroup.right.clone();
+          const cameraForward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion).normalize();
+          const cameraRight = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion).normalize();
+          const cameraUp = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize();
+          const baseAnchor = camera.position
+            .clone()
+            .addScaledVector(cameraForward, HUMAN_CARD_CAMERA_DISTANCE)
+            .addScaledVector(cameraUp, HUMAN_CARD_CAMERA_VERTICAL_OFFSET);
 
           humanSeatGroup.cardMeshes.forEach((mesh, idx) => {
-            const position = baseAnchor.clone().add(right.clone().multiplyScalar((idx - 0.5) * HOLE_SPACING));
+            const position = baseAnchor
+              .clone()
+              .addScaledVector(cameraRight, (idx - 0.5) * HUMAN_CARD_SCREEN_SPACING);
             mesh.position.copy(position);
 
-            const lookTarget = baseAnchor
-              .clone()
-              .addScaledVector(humanSeatGroup.forward, 2.4 * MODEL_SCALE)
-              .add(right.clone().multiplyScalar((idx - 0.5) * HUMAN_CARD_LOOK_SPLAY));
-            lookTarget.y = position.y;
+            const lookTarget = position.clone().add(cameraForward);
             orientCard(mesh, lookTarget, { face: 'front', flat: false });
             mesh.rotateX(HUMAN_CARD_FACE_TILT);
             setCardFace(mesh, 'front');
@@ -5625,8 +5627,8 @@ function TexasHoldemArena({ search }) {
 
     const newlyRevealedCommunity = [];
     communityMeshes.forEach((mesh, idx) => {
-      const sourceIdx = communityMeshes.length - 1 - idx;
-      const card = state.community[sourceIdx];
+      const sourceIdx = idx;
+      const card = state.community[idx];
       if (!card) {
         mesh.position.copy(deckAnchor);
         mesh.visible = false;


### PR DESCRIPTION
### Motivation
- Keep the human (bottom) hole cards visually fixed on screen when the camera moves so the bottom hand does not appear to move with camera orbit. 
- Bring the bottom player cards slightly closer together for a tighter visual layout. 
- Ensure community cards use the same left→right ordering convention as the bottom player's cards so revealed community layout matches expectations.

### Description
- Reworked human card anchoring by positioning the bottom hand from the camera basis instead of the table/world anchors and orienting each card to face the camera; introduced camera-based vectors `cameraForward`, `cameraRight`, and `cameraUp` to compute the base anchor. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Added constants `HUMAN_CARD_SCREEN_SPACING`, `HUMAN_CARD_CAMERA_DISTANCE` and `HUMAN_CARD_CAMERA_VERTICAL_OFFSET` and applied `HUMAN_CARD_SCREEN_SPACING` (reduced spacing) when placing bottom cards to make them sit closer together. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)
- Changed community mesh mapping to use the direct `state.community[index]` order (previous code used a reversed source index) so community reveal and layout order matches the bottom-hand ordering. (file: `webapp/src/pages/Games/TexasHoldemArena.jsx`)

### Testing
- Ran `npm run build` in `webapp/` and the Vite production build completed successfully (warnings about chunk sizes were reported but build succeeded). 
- Started the dev server with `npm run dev` to smoke-check runtime; the server came up and served the app. 
- Attempted an automated Playwright screenshot to visually validate the camera/card behavior, but the Chromium process crashed (`SIGSEGV`) in this environment so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69affe31a7e88329b70904ae7478143d)