### PR TITLE
Rotate Domino Royal octagon table to align flat sides with player seats

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4928,12 +4928,17 @@ function createDominoChair(option, renderer, sharedMaterials = null) {
 const arenaG = new THREE.Group();
 scene.add(arenaG);
 
+const TABLE_OCTAGON_ROTATION = Math.PI / 8;
 const tableG = new THREE.Group();
 arenaG.add(tableG);
 tableG.rotation.y = 0;
+const proceduralTableG = new THREE.Group();
+proceduralTableG.rotation.y = TABLE_OCTAGON_ROTATION;
+tableG.add(proceduralTableG);
 const piecesG = new THREE.Group();
 tableG.add(piecesG);
 const tableThemeG = new THREE.Group();
+tableThemeG.rotation.y = TABLE_OCTAGON_ROTATION;
 arenaG.add(tableThemeG);
 
 /* ---------- Arena Dressings (Carpet & Walls) ---------- */
@@ -6202,7 +6207,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   topMesh.position.y = TABLE_BASE_Y;
   topMesh.castShadow = true;
   topMesh.receiveShadow = true;
-  tableG.add(topMesh);
+  proceduralTableG.add(topMesh);
   tableParts.top = topMesh;
   proceduralTableParts.push(topMesh);
 
@@ -6214,7 +6219,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   const feltMesh = new THREE.Mesh(feltGeo, tableMaterials.felt);
   feltMesh.position.y = CLOTH_TOP + 0.0025;
   feltMesh.receiveShadow = true;
-  tableG.add(feltMesh);
+  proceduralTableG.add(feltMesh);
   tableParts.felt = feltMesh;
   proceduralTableParts.push(feltMesh);
 
@@ -6232,7 +6237,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   rimMesh.position.y = TABLE_BASE_Y + TABLE_TOP_DEPTH * 0.55;
   rimMesh.castShadow = true;
   rimMesh.receiveShadow = true;
-  tableG.add(rimMesh);
+  proceduralTableG.add(rimMesh);
   tableParts.rim = rimMesh;
   proceduralTableParts.push(rimMesh);
 
@@ -6245,7 +6250,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   accentGeo.rotateX(-Math.PI / 2);
   const accentMesh = new THREE.Mesh(accentGeo, tableMaterials.accent);
   accentMesh.position.y = CLOTH_TOP - 0.003;
-  tableG.add(accentMesh);
+  proceduralTableG.add(accentMesh);
   tableParts.accent = accentMesh;
   proceduralTableParts.push(accentMesh);
 
@@ -6262,7 +6267,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   column.position.y = TABLE_BASE_Y - columnHeight / 2;
   column.castShadow = true;
   column.receiveShadow = true;
-  tableG.add(column);
+  proceduralTableG.add(column);
   tableParts.column = column;
   proceduralTableParts.push(column);
 


### PR DESCRIPTION
### Motivation
- Align the octagonal Domino Royal table so its straight edges face top/bottom/left/right in portrait view so players are seated at flat sides instead of corners. 
- Make this visual-only change without moving chairs, domino pieces, anchors, or gameplay logic.

### Description
- Introduced a constant `TABLE_OCTAGON_ROTATION = Math.PI / 8` and a dedicated `proceduralTableG` container to hold procedural table meshes so the table can be rotated independently. 
- Applied the same rotation to the themed/table model container (`tableThemeG.rotation.y`) so both procedural and PolyHaven-themed tables share the visual alignment. 
- Reparented procedural meshes (`topMesh`, `feltMesh`, `rimMesh`, `accentMesh`, `column`) from `tableG` into `proceduralTableG` so only the table visuals rotate while chairs and `piecesG` remain unchanged. 
- Only file changed: `webapp/public/domino-royal-game.js`.

### Testing
- Ran the dev server (`vite`) and manually validated the running page rendered without errors. 
- Executed a production build with `npm --prefix webapp run build`, which completed successfully. 
- Captured an automated portrait viewport screenshot via Playwright to confirm the table rotation visually; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0016878308329a83b6e3255787aee)