### PR TITLE
Domino Royal: nudge camera right, extend placement animation, and increase domino texture resolution

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,9 +99,9 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1536,
-  fhd60: 2560,
-  qhd90: 3328,
+  hd50: 2048,
+  fhd60: 3072,
+  qhd90: 4096,
   uhd120: 4096,
   ultra144: 4096
 });
@@ -1517,7 +1517,7 @@ const CAMERA_MIN_RADIUS = CAMERA_BASE_RADIUS * 0.55;
 const CAMERA_MAX_RADIUS = CAMERA_BASE_RADIUS * 3.2;
 const CAMERA_DEFAULT_AZIMUTH =
   CHAIR_SEAT_ANGLES[HUMAN_SEAT_INDEX] ?? Math.PI / 2;
-const CAMERA_LATERAL_OFFSET = { portrait: 0.32, landscape: 0.24 };
+const CAMERA_LATERAL_OFFSET = { portrait: 0.4, landscape: 0.3 };
 const CAMERA_REAR_OFFSET = { portrait: 1.36, landscape: 1.04 };
 const CAMERA_HEIGHT_BOOST = { portrait: 1.78, landscape: 1.46 };
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
@@ -1536,8 +1536,8 @@ const CAMERA_TOPDOWN_MAX_POLAR = THREE.MathUtils.degToRad(18);
 const CAMERA_TOPDOWN_ZOOM_WHEEL_FACTOR = 0.0014;
 const CAMERA_TOPDOWN_ZOOM_PINCH_FACTOR = 0.01;
 const CAMERA_TOPDOWN_FRAMING = Object.freeze({
-  portrait: { right: TABLE_RADIUS * 0.06, forward: TABLE_RADIUS * 0.12 },
-  landscape: { right: TABLE_RADIUS * 0.07, forward: TABLE_RADIUS * 0.05 }
+  portrait: { right: TABLE_RADIUS * 0.09, forward: TABLE_RADIUS * 0.12 },
+  landscape: { right: TABLE_RADIUS * 0.1, forward: TABLE_RADIUS * 0.05 }
 });
 const CAMERA_TURN_FOCUS_LERP = 0.07;
 const CAMERA_TURN_SEAT_WEIGHT = 0.42;
@@ -6624,8 +6624,8 @@ let boneyardStackTopLocal = 0;
 const drawAnimations = [];
 const DRAW_ANIM_DURATION = 480;
 const placementAnimations = [];
-const PLACE_ANIM_DURATION = 640;
-const PLACE_ANIM_ARC = 0.05;
+const PLACE_ANIM_DURATION = 980;
+const PLACE_ANIM_ARC = 0.12;
 const CPU_PLAY_DELAY = 2600;
 
 const TMP_WORLD_POS = new THREE.Vector3();


### PR DESCRIPTION
### Motivation
- Move the in-game camera slightly to the right so the player's area is more visible on portrait mobile screens.
- Make the domino piece travel from player hand to table clearly visible during placement animations.
- Improve visual crispness of domino pieces only, without changing global graphics settings.

### Description
- Increased adaptive domino texture tiers for lower/medium presets in `DOMINO_TEXTURE_SIZE_MAP` so `hd50`, `fhd60`, and `qhd90` map to larger resolutions (improves domino piece detail only). 
- Shifted camera framing by raising `CAMERA_LATERAL_OFFSET` and increasing the `right` value in `CAMERA_TOPDOWN_FRAMING` to bias the view to the right in both portrait and landscape.
- Extended placement animation by increasing `PLACE_ANIM_DURATION` and `PLACE_ANIM_ARC` so tiles visibly travel from the hand area to the chain on the table.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without errors.
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 5173` and Vite reported the server ready.
- Executed a Playwright script to load `/games/domino-royal` in a mobile-portrait viewport and captured a screenshot (`artifacts/domino-royal-camera-update.png`) to validate camera/animation changes; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01827fbb88329bf7efa98fc3590a6)