### PR TITLE
Adjust Domino Royale portrait HUD alignment

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -121,8 +121,8 @@ export default function DominoRoyalArena() {
         }
         #dominoLeaderboardCard {
           position: fixed;
-          top: calc(3.9rem + env(safe-area-inset-top, 0px));
-          left: 57%;
+          top: calc(3.55rem + env(safe-area-inset-top, 0px));
+          left: 56.4%;
           transform: translateX(-50%);
           width: min(72vw, 15.5rem);
           z-index: 5;
@@ -203,6 +203,21 @@ export default function DominoRoyalArena() {
           white-space: nowrap;
           font-size: 0.61rem;
           letter-spacing: 0.01em;
+        }
+        @media (orientation: portrait) {
+          #configButton {
+            left: calc(0.45rem + env(safe-area-inset-left, 0px)) !important;
+          }
+          #status {
+            top: auto !important;
+            bottom: calc(
+              env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
+                clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
+            ) !important;
+            left: 50% !important;
+            transform: translateX(-50%) !important;
+            z-index: 7 !important;
+          }
         }
         #winnerOverlay {
           position: fixed;


### PR DESCRIPTION
### Motivation
- Improve portrait HUD layout for the Domino Royale arena so the menu icon sits closer to the left edge, the commentary/status element sits with the quick-actions row, and the leaderboard is slightly lifted and nudged toward the menu for better visual alignment.

### Description
- Adjusted leaderboard positioning by changing `#dominoLeaderboardCard` `top` and `left` values in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `top: calc(3.55rem + env(safe-area-inset-top, 0px))` and `left: 56.4%`.
- Added a portrait media-query in `webapp/src/pages/Games/DominoRoyalArena.jsx` to nudge the menu button left with `#configButton { left: calc(0.45rem + env(safe-area-inset-left, 0px)) !important; }` for portrait screens.
- Repositioned the status/commentary pill to the lower HUD row for portrait via the same media-query by moving `#status` to a bottom centered position above quick actions.
- Committed the change with message: `Adjust Domino Royale portrait HUD alignment`.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully (vite build passed).
- Launched a dev server and used an automated Playwright script to load `/games/domino-royal` on an iPhone 12 device profile and captured a portrait screenshot, which completed successfully.
- Verified the updated file `webapp/src/pages/Games/DominoRoyalArena.jsx` was staged and committed (commit was created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02b6ecaa88329b0c6c98fbfed910f)