### PR TITLE
Animate hole-card dealing from table center in Texas Hold'em 3D arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -457,6 +457,8 @@ const CARD_PEEK_OUTER_SWAY = CARD_W * 0.08;
 const CARD_PEEK_TOP_LIFT_ANGLE = THREE.MathUtils.degToRad(74);
 const CARD_PEEK_EDGE_PIVOT_FACTOR = 0.5;
 const FOLD_TO_PILE_ANIMATION_MS = 420;
+const DEAL_CARD_ANIMATION_MS = 340;
+const DEAL_CARD_STEP_DELAY_MS = 90;
 const HIDDEN_CARD_BACK_ALIGNMENT_ROTATION = Math.PI;
 
 const CHAIR_MODEL_URLS = [
@@ -3736,6 +3738,46 @@ function TexasHoldemArena({ search }) {
     mesh.userData.foldAnimFrame = requestAnimationFrame(tick);
   }, []);
 
+  const animateDealCardToSeat = useCallback((mesh, targetPosition, lookTarget, delayMs = 0) => {
+    if (!mesh?.position || !targetPosition?.isVector3) return;
+    const existingFrame = mesh.userData?.dealAnimFrame;
+    if (existingFrame) {
+      cancelAnimationFrame(existingFrame);
+    }
+    const existingDelayTimeout = mesh.userData?.dealDelayTimeout;
+    if (existingDelayTimeout) {
+      clearTimeout(existingDelayTimeout);
+      mesh.userData.dealDelayTimeout = null;
+    }
+
+    const runAnimation = () => {
+      const startPosition = mesh.position.clone();
+      const startTime = performance.now();
+      const tick = (now) => {
+        const t = Math.min(1, (now - startTime) / DEAL_CARD_ANIMATION_MS);
+        const eased = 1 - (1 - t) * (1 - t);
+        mesh.position.lerpVectors(startPosition, targetPosition, eased);
+        orientCard(mesh, lookTarget, { face: 'back', flat: true });
+        if (t < 1) {
+          mesh.userData.dealAnimFrame = requestAnimationFrame(tick);
+        } else {
+          mesh.userData.dealAnimFrame = null;
+        }
+      };
+      mesh.userData.dealAnimFrame = requestAnimationFrame(tick);
+    };
+
+    if (delayMs > 0) {
+      mesh.userData.dealDelayTimeout = setTimeout(() => {
+        mesh.userData.dealDelayTimeout = null;
+        runAnimation();
+      }, delayMs);
+      return;
+    }
+
+    runAnimation();
+  }, []);
+
   const animateHumanCardPosture = useCallback((mesh, targetTilt) => {
     if (!mesh) return;
     const frame = mesh.userData?.postureAnimFrame;
@@ -5438,7 +5480,21 @@ function TexasHoldemArena({ search }) {
           const clothY = (three.tableInfo?.surfaceY ?? TABLE_HEIGHT) + CARD_D * 0.4;
           position.y = seat.isHuman ? clothY : clothY + CARD_H * 0.48;
         }
-        mesh.position.copy(position);
+        const isNewHandCard = Boolean(card && !prevPlayer?.hand?.[cardIdx]);
+        const cardDealOrder = cardIdx * state.players.length + idx;
+        if (isNewHandCard && !state.showdown) {
+          mesh.position.copy(deckAnchor);
+          animateDealCardToSeat(
+            mesh,
+            position,
+            seat.isHuman
+              ? seat.seatPos.clone().add(new THREE.Vector3(0, CARD_LOOK_LIFT, 0))
+              : position.clone().add(seat.forward.clone()),
+            cardDealOrder * DEAL_CARD_STEP_DELAY_MS
+          );
+        } else if (!mesh.userData?.dealAnimFrame && !mesh.userData?.dealDelayTimeout) {
+          mesh.position.copy(position);
+        }
         const humanActiveTurn = seat.isHuman && state.stage !== 'showdown' && idx === state.actionIndex;
         const showdownFacing = humanSeatRef.current?.forward
           ? humanSeatRef.current.forward.clone()
@@ -5718,6 +5774,7 @@ function TexasHoldemArena({ search }) {
       actionIndex: state.actionIndex
     };
   }, [
+    animateDealCardToSeat,
     animateFoldCardToPile,
     animateHumanCardPosture,
     findSeatWithAvatar,


### PR DESCRIPTION
### Motivation
- Cards must be dealt visually from the center/deck to each player one-by-one at the start of each hand for a clear, cinematic dealing sequence.
- Animations must cancel cleanly so repeated hands or rapid state updates do not stack conflicting frames or timeouts.

### Description
- Added `DEAL_CARD_ANIMATION_MS` and `DEAL_CARD_STEP_DELAY_MS` timing constants and implemented `animateDealCardToSeat` as a cancel-safe `useCallback` that drives per-card lerp animation and supports an initial delay via `setTimeout`.
- Updated the hole-card placement/render logic to detect newly dealt hole cards and initialize them at `deckAnchor`, then call `animateDealCardToSeat` with a computed per-card delay so dealing occurs in round-robin order (first card to each seat, then second card).
- Preserved existing fold/showdown logic by only snapping cards to their final positions when there is no active deal animation on the mesh.
- Added `animateDealCardToSeat` to the render effect dependency list so the hook updates remain stable with React state changes.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`; the command completed but the file is ignored by the repository lint patterns (warning reported).
- Started the local dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the application came up successfully.
- Performed a visual verification by loading the Texas Hold'em page and capturing a screenshot via Playwright to confirm the dealing animation behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03e6457048329871906517a2956af)