### PR TITLE
Animate placed domino from player's hand when hand mesh is missing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8244,7 +8244,7 @@ function takeTileMeshForAnimation(tile) {
 function spawnPlacementAnimation(
   tile,
   segment,
-  { duration = PLACE_ANIM_DURATION, mesh: providedMesh } = {}
+  { duration = PLACE_ANIM_DURATION, mesh: providedMesh, sourceSeat = current } = {}
 ) {
   if (!segment) {
     return;
@@ -8252,15 +8252,40 @@ function spawnPlacementAnimation(
   let mesh = providedMesh;
   if (!mesh) {
     mesh = takeTileMeshForAnimation(tile);
-  } else {
-    if (tile && tile.mesh === mesh) {
-      tile.mesh = null;
+  }
+  if (!mesh && isValidTile(tile)) {
+    const sourceHand = players[sourceSeat]?.hand;
+    const sourceCount = Math.max(1, Array.isArray(sourceHand) ? sourceHand.length : 1);
+    const sourceSlot = Math.max(0, sourceCount - 1);
+    mesh = makeDomino(tile.a, tile.b, {
+      flat: cameraViewMode === VIEW_MODES.twoD,
+      faceUp: true
+    });
+    const sourcePos = computeHandSlotPosition(sourceSeat, sourceSlot, sourceCount, {
+      isTopDown: cameraViewMode === VIEW_MODES.twoD
+    });
+    mesh.position.copy(sourcePos);
+    const [seatX, seatZ] = layoutSeat(sourceSeat);
+    const yawTowardCenter = Math.atan2(-seatX, -seatZ);
+    if (cameraViewMode === VIEW_MODES.twoD) {
+      orientDominoFlat(mesh, sourceSeat === human ? Math.PI / 2 : yawTowardCenter);
+    } else {
+      mesh.rotation.set(0, sourceSeat === human ? 0 : yawTowardCenter, 0);
     }
     const data = mesh.userData || (mesh.userData = {});
-    delete data.owner;
-    delete data.tile;
     data.animating = true;
-    attachMeshPreserveWorld(mesh);
+    piecesG.add(mesh);
+  } else {
+    if (mesh === providedMesh) {
+      if (tile && tile.mesh === mesh) {
+        tile.mesh = null;
+      }
+      const data = mesh.userData || (mesh.userData = {});
+      delete data.owner;
+      delete data.tile;
+      data.animating = true;
+      attachMeshPreserveWorld(mesh);
+    }
   }
   if (!mesh) {
     segment.animating = false;


### PR DESCRIPTION
### Motivation

- Improve visual feedback when a player places a domino so the tile visibly travels from the player's hand/seat to the board instead of instantly appearing on the chain.

### Description

- Added an optional `sourceSeat` parameter to `spawnPlacementAnimation` with default `current` so the origin seat can be specified during placement.
- Implemented a fallback path that creates a temporary domino mesh at the source player's hand slot using `makeDomino` and `computeHandSlotPosition` when the tile's hand mesh is not available, and then animates it to the target `segment`.
- Preserved the original behavior for existing animation meshes and hand-owned meshes by continuing to use `takeTileMeshForAnimation`, `attachMeshPreserveWorld`, and the prior animation flow when those are present.
- Change localized to `webapp/public/domino-royal-game.js` and uses existing helpers (`orientDominoFlat`, `layoutSeat`, `piecesG`, `placementAnimations`) to keep transforms and render ordering consistent.

### Testing

- Ran `node --check webapp/public/domino-royal-game.js` and it succeeded.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the app served successfully (dev server ready), but in-environment UI screenshot capture timed out.
- Attempted an automated Playwright run against `http://127.0.0.1:4173/games/domino-royal?players=4` to validate the visual behavior, but the browser/script timed out in this environment and no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b063a3fd0c832987941b1341059edd)