### PR TITLE
Animate domino placement from hand and refine 3D camera framing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1518,8 +1518,8 @@ const CAMERA_MAX_RADIUS = CAMERA_BASE_RADIUS * 3.2;
 const CAMERA_DEFAULT_AZIMUTH =
   CHAIR_SEAT_ANGLES[HUMAN_SEAT_INDEX] ?? Math.PI / 2;
 const CAMERA_LATERAL_OFFSET = { portrait: 0, landscape: 0 };
-const CAMERA_REAR_OFFSET = { portrait: 1.28, landscape: 1.04 };
-const CAMERA_HEIGHT_BOOST = { portrait: 1.78, landscape: 1.46 };
+const CAMERA_REAR_OFFSET = { portrait: 1.14, landscape: 0.96 };
+const CAMERA_HEIGHT_BOOST = { portrait: 1.86, landscape: 1.52 };
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;
 const CAMERA_LOOK_YAW_RECENTER_SPEED = 0.055;
@@ -8233,6 +8233,7 @@ function takeTileMeshForAnimation(tile) {
   }
   const mesh = tile.mesh;
   tile.mesh = null;
+  activeHandMeshes.delete(mesh);
   const data = mesh.userData || (mesh.userData = {});
   delete data.owner;
   delete data.tile;


### PR DESCRIPTION
### Motivation
- Players should see domino tiles move from their hand to the exact placement on the table instead of instant-pop appearing. 
- On phone portrait view the camera should sit slightly closer to the table center and look a bit more down to improve visual clarity without changing gameplay framing.

### Description
- Remove the animated tile mesh from the hand mesh set by calling `activeHandMeshes.delete(mesh)` in `takeTileMeshForAnimation` so the mesh is not removed by `renderHands()` during animation. 
- Tweak seated 3D camera framing constants by adjusting `CAMERA_REAR_OFFSET` and `CAMERA_HEIGHT_BOOST` to bring the camera slightly closer and a touch more top-down. 
- Changes are limited to `webapp/public/domino-royal-game.js` and are minimal (mesh handoff and two camera constants).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without errors. 
- Started the dev server (`npm --prefix webapp run dev`) and captured a portrait viewport screenshot of `/games/domino-royal` using Playwright to validate visual placement and camera framing changes, which completed successfully. 
- No unit tests were modified; the patch only updates runtime rendering behavior in the Domino Royal client.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06b92488083298dd72457e7baccde)