### PR TITLE
Chess Battle Royal: increase board/piece scale and enable 2D camera zoom

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.048;
+const BOARD_SCALE = 0.0576;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -1810,9 +1810,9 @@ const CAMERA_TOPDOWN_MIN_RADIUS = CAMERA_BASE_RADIUS * 1.05;
 const CAMERA_TOPDOWN_MAX_RADIUS = CAMERA_BASE_RADIUS * 1.9;
 const CAMERA_3D_MIN_RADIUS = CAMERA_SAFE_MAX_RADIUS * 0.65;
 const CAMERA_3D_MAX_RADIUS = CAMERA_SAFE_MAX_RADIUS * 1.35;
-const CAMERA_2D_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS * 1.08;
-const CAMERA_2D_MIN_RADIUS = CAMERA_2D_RADIUS;
-const CAMERA_2D_MAX_RADIUS = CAMERA_2D_RADIUS;
+const CAMERA_2D_RADIUS = CAMERA_TOPDOWN_MAX_RADIUS * 1.14;
+const CAMERA_2D_MIN_RADIUS = CAMERA_2D_RADIUS * 0.8;
+const CAMERA_2D_MAX_RADIUS = CAMERA_2D_RADIUS * 1.4;
 const CAM = {
   fov: ARENA_CAMERA_DEFAULTS.fov,
   near: ARENA_CAMERA_DEFAULTS.near,
@@ -7750,10 +7750,10 @@ function Chess3D({
       if (mode === '2d') {
         cameraMemory.last3d = current;
         controls.target.copy(boardLookTarget);
-        controls.enabled = false;
+        controls.enabled = true;
         controls.enableRotate = false;
         controls.enablePan = false;
-        controls.enableZoom = false;
+        controls.enableZoom = true;
         controls.minPolarAngle = CAMERA_TOPDOWN_LOCK;
         controls.maxPolarAngle = CAMERA_TOPDOWN_LOCK;
         controls.minDistance = CAMERA_2D_MIN_RADIUS;


### PR DESCRIPTION
### Motivation
- Make the Chess Battle Royal view visually closer and more readable by raising the top-down camera slightly while preserving the same focus point.  
- Allow users to zoom in/out in the 2D/top-down view without changing the board focus.  
- Increase board and piece presentation by 20% so tokens and tiles are larger on small (portrait) screens.  

### Description
- Increased the global board scale from `0.048` to `0.0576` so the board (and board-mounted pieces) render ~20% larger (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).  
- Raised the locked 2D/top-down camera baseline by increasing `CAMERA_2D_RADIUS` and introduced flexible zoom bounds via `CAMERA_2D_MIN_RADIUS` and `CAMERA_2D_MAX_RADIUS` to permit zooming around the same focus.  
- Enabled zoom while in 2D mode (keeps rotate/pan locked and `controls.target` copied to the board focus) by toggling `controls.enabled`/`controls.enableZoom` appropriately in the 2D branch.  

### Testing
- Built the webapp successfully with `npm --prefix webapp run build` (vite production build completed).  
- Ran linter with `npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx`, which reported the file is ignored by the current eslint ignore settings (no blocking errors).  
- Performed an automated headless UI check using Playwright to open `/games/chessbattleroyal` (mobile portrait viewport) and capture a screenshot, which completed successfully and produced a verification image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f823d54483299ad8608445479147)