### PR TITLE
Adjust Snake & Ladder board: widen octagon, hide pavement, rotate board content only

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -211,6 +211,7 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
+const SHOW_PAVEMENT_LAYER = false;
 const RAIL_HEIGHT = TILE_SIZE * 0.6;
 const RAIL_GAP_WIDTH = TILE_SIZE * 1.4;
 const RAIL_RADIUS = TILE_SIZE * 0.03;
@@ -2813,7 +2814,7 @@ function buildSnakeBoard(
       levelIndex
     });
 
-    if (levelIndex === 0) {
+    if (levelIndex === 0 && SHOW_PAVEMENT_LAYER) {
       const pavementSize = platformSize * PAVEMENT_EXTRA_SCALE;
       addPavementLayer(
         platformGroup,
@@ -3987,7 +3988,7 @@ export default function SnakeBoard3D({
       seatAnchors: arena.seatAnchors ?? []
     };
 
-    const boardRoot = arena.boardGroup;
+    const boardRotationRoot = board.root;
     const dragState = {
       pointerId: null,
       lastX: 0
@@ -4003,7 +4004,7 @@ export default function SnakeBoard3D({
       const deltaX = event.clientX - dragState.lastX;
       dragState.lastX = event.clientX;
       if (Math.abs(deltaX) < 0.25) return;
-      boardRoot.rotation.y += deltaX * BOARD_ROTATION_DRAG_SPEED;
+      boardRotationRoot.rotation.y += deltaX * BOARD_ROTATION_DRAG_SPEED;
     };
     const onPointerEnd = (event) => {
       if (dragState.pointerId !== event.pointerId) return;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -308,8 +308,9 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
-      const topShape = createRegularPolygonShape(8, radius);
-      const feltShape = createRegularPolygonShape(8, radius * 0.8);
+      const octagonSideStretch = 1.16;
+      const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
+      const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
       return { topShape, feltShape, rimInnerShape };
     }


### PR DESCRIPTION
### Motivation
- Make the default octagon table visually wider on the sides while preserving height so the playing surface reads wider on mobile portrait screens.
- Remove the visible gray pavement/base layer under the pyramid board so the table edge reads cleaner.
- Ensure off-board elements (resting tokens, dice, avatars on rails) remain stable while the board content rotates so UX feels physically consistent.

### Description
- Widened the classic octagon table shape by horizontally stretching the octagon shape generator in `webapp/src/utils/murlanTable.js` (added `octagonSideStretch` and `scaleShape2D` usage for `topShape` and `feltShape`).
- Added `SHOW_PAVEMENT_LAYER = false` and gated pavement creation in `webapp/src/components/SnakeBoard3D.jsx` to remove the lower gray pavement layer under level-0 by default.
- Changed the drag rotation anchor to rotate the board content root (`board.root`) instead of the broader arena/table group by introducing a `boardRotationRoot` local and applying pointer-drag rotation to it so on-board pieces rotate with the board but off-board resting tokens, dice and avatar anchors remain stable.
- Minor safety/cleanup touches around the pointer handlers and rendering loop to wire the new rotation target.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully (Vite emitted pre-existing chunk-size and dynamic-import warnings only).
- Started dev server with `npm -C webapp run dev` and the app served locally for manual inspection (dev server launched).
- Attempted an automated screenshot via Playwright to validate rendering, but Chromium crashed in this environment (`TargetClosedError` / `SIGSEGV`), so the visual smoke test could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0fadc90948329bf5fa21a8087e9f5)