### PR TITLE
Fix Snake board rotation anchoring and add selectable dice-roll SFX

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -2700,11 +2700,17 @@ function buildSnakeBoard(
   const boardRoot = new THREE.Group();
   boardGroup.add(boardRoot);
 
+  const boardRotationRoot = new THREE.Group();
+  boardRoot.add(boardRotationRoot);
+
+  const boardStaticRoot = new THREE.Group();
+  boardRoot.add(boardStaticRoot);
+
   const platformGroup = new THREE.Group();
-  boardRoot.add(platformGroup);
+  boardRotationRoot.add(platformGroup);
 
   const tileGroup = new THREE.Group();
-  boardRoot.add(tileGroup);
+  boardRotationRoot.add(tileGroup);
 
   const boardTheme = appearanceOptions.board ?? {};
   const railTheme = appearanceOptions.rail ?? {};
@@ -2726,7 +2732,7 @@ function buildSnakeBoard(
   );
 
   const labelGroup = new THREE.Group();
-  boardRoot.add(labelGroup);
+  boardRotationRoot.add(labelGroup);
 
   const platformThickness = PYRAMID_PLATFORM_THICKNESS;
   const levelGap = PYRAMID_LEVEL_GAP;
@@ -3007,13 +3013,16 @@ function buildSnakeBoard(
   };
 
   const laddersGroup = new THREE.Group();
-  boardRoot.add(laddersGroup);
+  boardRotationRoot.add(laddersGroup);
 
   const snakesGroup = new THREE.Group();
-  boardRoot.add(snakesGroup);
+  boardRotationRoot.add(snakesGroup);
 
-  const tokensGroup = new THREE.Group();
-  boardRoot.add(tokensGroup);
+  const boardTokensGroup = new THREE.Group();
+  boardRotationRoot.add(boardTokensGroup);
+
+  const reserveTokensGroup = new THREE.Group();
+  boardStaticRoot.add(reserveTokensGroup);
 
   const potGroup = new THREE.Group();
   const coin = new THREE.Mesh(
@@ -3034,7 +3043,7 @@ function buildSnakeBoard(
   potGroup.userData.coin = coin;
   const potPos = serpentineIndexToXZ(TOTAL_BOARD_TILES);
   potGroup.position.set(potPos.x, potPos.y + COIN_RAISE, potPos.z);
-  boardRoot.add(potGroup);
+  boardRotationRoot.add(potGroup);
 
   const diceGroup = new THREE.Group();
   const baseLevelTop = levelPlacements[0].tileTopY;
@@ -3055,7 +3064,7 @@ function buildSnakeBoard(
     diceGroup.add(die);
     diceSet.push(die);
   }
-  boardRoot.add(diceGroup);
+  boardStaticRoot.add(diceGroup);
 
   disposeHandlers.push(() => {
     platformMeshes.forEach((mesh) => {
@@ -3090,11 +3099,14 @@ function buildSnakeBoard(
 
   return {
     root: boardRoot,
+    rotationRoot: boardRotationRoot,
+    staticRoot: boardStaticRoot,
     tileMeshes,
     indexToPosition,
     laddersGroup,
     snakesGroup,
-    tokensGroup,
+    boardTokensGroup,
+    reserveTokensGroup,
     serpentineIndexToXZ,
     potGroup,
     labelGroup,
@@ -3132,7 +3144,8 @@ function updateTilesHighlight(tileMeshes, highlight, trail, highlightColors = DE
 }
 
 function updateTokens(
-  tokensGroup,
+  boardTokensGroup,
+  reserveTokensGroup,
   players,
   indexToPosition,
   serpentineIndexToXZ,
@@ -3150,13 +3163,11 @@ function updateTokens(
     tableInfo = null
   } = {}
 ) {
-  if (!tokensGroup) return;
-  const existing = new Map();
-  tokensGroup.children.forEach((child) => {
-    if (child.userData && child.userData.playerIndex != null) {
-      existing.set(child.userData.playerIndex, child);
-    }
-  });
+  if (!boardTokensGroup || !reserveTokensGroup) return;
+  const existing = new Map([
+    ...boardTokensGroup.children.map((child) => [child.userData?.playerIndex, child]),
+    ...reserveTokensGroup.children.map((child) => [child.userData?.playerIndex, child])
+  ]);
 
   const occupancy = new Map();
   players.forEach((player, index) => {
@@ -3202,7 +3213,7 @@ function updateTokens(
         token.userData?.usesPrototype !== Boolean(basePiecePrototype) ||
         token.userData?.headPresetId !== headPresetId)
     ) {
-      tokensGroup.remove(token);
+      token.parent?.remove(token);
       token.traverse((obj) => {
         if (obj.isMesh) {
           obj.geometry.dispose();
@@ -3322,7 +3333,7 @@ function updateTokens(
         usesPrototype: Boolean(piecePrototype),
         headPresetId
       };
-      tokensGroup.add(token);
+      boardTokensGroup.add(token);
     }
 
     const mat = token.userData.coreMaterial || token.userData.material;
@@ -3463,6 +3474,11 @@ function updateTokens(
       }
     }
 
+    const targetGroup = hasBoardPosition ? boardTokensGroup : reserveTokensGroup;
+    if (token.parent !== targetGroup) {
+      targetGroup.add(token);
+    }
+
     if (!token.userData.isSliding && worldPos) {
       token.position.copy(worldPos);
     }
@@ -3470,7 +3486,7 @@ function updateTokens(
 
   existing.forEach((group, index) => {
     if (!keep.has(index)) {
-      tokensGroup.remove(group);
+      group.parent?.remove(group);
       group.traverse((obj) => {
         if (obj.isMesh) {
           obj.geometry.dispose();
@@ -3988,7 +4004,7 @@ export default function SnakeBoard3D({
       seatAnchors: arena.seatAnchors ?? []
     };
 
-    const boardRotationRoot = board.root;
+    const boardRotationRoot = board.rotationRoot || board.root;
     const dragState = {
       pointerId: null,
       lastX: 0
@@ -4208,7 +4224,7 @@ export default function SnakeBoard3D({
   useEffect(() => {
     if (!boardRef.current) return;
     const board = boardRef.current;
-    updateTokens(board.tokensGroup, players, board.indexToPosition, board.serpentineIndexToXZ, {
+    updateTokens(board.boardTokensGroup, board.reserveTokensGroup, players, board.indexToPosition, board.serpentineIndexToXZ, {
       burning,
       rollingIndex,
       currentTurn,
@@ -4304,12 +4320,9 @@ export default function SnakeBoard3D({
   useEffect(() => {
     if (!slide || !boardRef.current) return;
     const board = boardRef.current;
-    const tokensGroup = board.tokensGroup;
-    if (!tokensGroup) {
-      onSlideComplete?.(slide.id, false);
-      return;
-    }
-    const token = tokensGroup.children.find((child) => child.userData?.playerIndex === slide.playerIndex);
+    const token =
+      board.boardTokensGroup?.children?.find((child) => child.userData?.playerIndex === slide.playerIndex) ||
+      board.reserveTokensGroup?.children?.find((child) => child.userData?.playerIndex === slide.playerIndex);
     if (!token) {
       onSlideComplete?.(slide.id, false);
       return;
@@ -4320,8 +4333,8 @@ export default function SnakeBoard3D({
         : board.snakesGroup?.userData?.paths;
     const startBase = (board.indexToPosition.get(slide.from) || board.serpentineIndexToXZ(slide.from)).clone();
     const endBase = (board.indexToPosition.get(slide.to) || board.serpentineIndexToXZ(slide.to)).clone();
-    startBase.y = startBase.y ?? tokensGroup.position.y;
-    endBase.y = endBase.y ?? tokensGroup.position.y;
+    startBase.y = startBase.y ?? token.parent?.position?.y ?? 0;
+    endBase.y = endBase.y ?? token.parent?.position?.y ?? 0;
     let pathInfo = pathMap?.get(slide.from);
     if (!pathInfo) {
       const fallbackCurve = new THREE.LineCurve3(startBase.clone(), endBase.clone());

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4,8 +4,7 @@ import DiceRoller from "../../components/DiceRoller.jsx";
 import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
 import { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
 import {
-  chatBeep,
-  diceSound,
+  chatBeep
 } from "../../assets/soundData.js";
 import { AVATARS } from "../../components/AvatarPickerModal.jsx";
 import { FLAG_EMOJIS } from "../../utils/flagEmojis.js";
@@ -90,7 +89,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
-import { createDiceRollAudio } from "../../utils/diceAudio.js";
+import { createDiceRollAudio, DICE_SFX_PRESETS } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -191,6 +190,7 @@ const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
+const DICE_SFX_STORAGE_KEY = 'snakeDiceSfxPreset';
 const SNAKE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'english',
@@ -1213,6 +1213,15 @@ export default function SnakeAndLadder() {
     }
     return false;
   });
+  const [diceSfxPresetId, setDiceSfxPresetId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(DICE_SFX_STORAGE_KEY);
+      if (stored && DICE_SFX_PRESETS.some((preset) => preset.id === stored)) {
+        return stored;
+      }
+    }
+    return DICE_SFX_PRESETS[0]?.id || 'classic-wood';
+  });
   const [showConfig, setShowConfig] = useState(false);
   const [showTrailEnabled, setShowTrailEnabled] = useState(true);
   const [appearance, setAppearance] = useState(() => {
@@ -1373,6 +1382,12 @@ export default function SnakeAndLadder() {
       window.localStorage.setItem(COMMENTARY_MUTE_STORAGE_KEY, commentaryMuted ? '1' : '0');
     }
   }, [commentaryMuted]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DICE_SFX_STORAGE_KEY, diceSfxPresetId);
+    }
+  }, [diceSfxPresetId]);
   const playersRef = useRef([]);
   const refreshPlayersNeeded = useCallback(
     (playersList = playersRef.current, capacityValue) => {
@@ -1821,7 +1836,7 @@ export default function SnakeAndLadder() {
     timerSoundRef.current.volume = vol;
     diceRollSoundRef.current = createDiceRollAudio({
       muted,
-      src: diceSound
+      presetId: diceSfxPresetId
     });
     if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
@@ -1839,7 +1854,7 @@ export default function SnakeAndLadder() {
       timerSoundRef.current?.pause();
       diceRollSoundRef.current?.pause();
     };
-  }, [accountId, muted]);
+  }, [accountId, muted, diceSfxPresetId]);
 
   useEffect(() => {
     [
@@ -3545,6 +3560,29 @@ export default function SnakeAndLadder() {
                 </button>
               </div>
               <div className="mt-4 space-y-3 pr-1">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/70">Dice roll sound</h3>
+                  <div className="grid gap-2">
+                    {DICE_SFX_PRESETS.map((preset) => {
+                      const active = preset.id === diceSfxPresetId;
+                      return (
+                        <button
+                          key={preset.id}
+                          type="button"
+                          onClick={() => setDiceSfxPresetId(preset.id)}
+                          aria-pressed={active}
+                          className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
+                              : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                          }`}
+                        >
+                          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white">{preset.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
                 <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                   <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
                   <p className="mt-1 text-[0.7rem] text-white/60">Boards, tokens, and table themes.</p>

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -1,10 +1,104 @@
-import { diceSound } from '../assets/soundData.js'
 import { getGameVolume } from './sound.js'
 
-export function createDiceRollAudio ({ muted = false, src = diceSound } = {}) {
-  const audio = new Audio(src)
-  audio.preload = 'auto'
-  audio.muted = muted
-  audio.volume = getGameVolume()
-  return audio
+export const DICE_SFX_PRESETS = Object.freeze([
+  { id: 'classic-wood', label: 'Classic Wood' },
+  { id: 'marble-rattle', label: 'Marble Rattle' },
+  { id: 'metallic-clack', label: 'Metallic Clack' },
+  { id: 'soft-felt', label: 'Soft Felt' },
+  { id: 'arcade-pop', label: 'Arcade Pop' }
+])
+
+let sharedCtx = null
+
+function getAudioCtx () {
+  if (typeof window === 'undefined') return null
+  const Ctx = window.AudioContext || window.webkitAudioContext
+  if (!Ctx) return null
+  if (!sharedCtx) sharedCtx = new Ctx()
+  if (sharedCtx.state === 'suspended') {
+    sharedCtx.resume().catch(() => {})
+  }
+  return sharedCtx
+}
+
+function tick (ctx, time, frequency, duration, type = 'square', gain = 0.18) {
+  const osc = ctx.createOscillator()
+  const amp = ctx.createGain()
+  osc.type = type
+  osc.frequency.setValueAtTime(frequency, time)
+  amp.gain.setValueAtTime(0.0001, time)
+  amp.gain.exponentialRampToValueAtTime(Math.max(0.0001, gain), time + 0.004)
+  amp.gain.exponentialRampToValueAtTime(0.0001, time + duration)
+  osc.connect(amp)
+  amp.connect(ctx.destination)
+  osc.start(time)
+  osc.stop(time + duration + 0.01)
+}
+
+function noiseBurst (ctx, time, duration = 0.035, gain = 0.1, highpass = 450) {
+  const buffer = ctx.createBuffer(1, Math.floor(ctx.sampleRate * duration), ctx.sampleRate)
+  const channel = buffer.getChannelData(0)
+  for (let i = 0; i < channel.length; i += 1) channel[i] = (Math.random() * 2 - 1) * (1 - i / channel.length)
+
+  const src = ctx.createBufferSource()
+  src.buffer = buffer
+  const hp = ctx.createBiquadFilter()
+  hp.type = 'highpass'
+  hp.frequency.value = highpass
+  const amp = ctx.createGain()
+  amp.gain.setValueAtTime(gain, time)
+  amp.gain.exponentialRampToValueAtTime(0.0001, time + duration)
+  src.connect(hp)
+  hp.connect(amp)
+  amp.connect(ctx.destination)
+  src.start(time)
+}
+
+function playPreset (ctx, presetId, volume) {
+  const now = ctx.currentTime + 0.01
+  const v = Math.max(0.02, Math.min(1, volume))
+  switch (presetId) {
+    case 'marble-rattle':
+      tick(ctx, now, 680, 0.045, 'triangle', 0.14 * v)
+      tick(ctx, now + 0.035, 740, 0.05, 'triangle', 0.12 * v)
+      noiseBurst(ctx, now + 0.01, 0.03, 0.06 * v, 700)
+      break
+    case 'metallic-clack':
+      tick(ctx, now, 920, 0.035, 'sawtooth', 0.1 * v)
+      tick(ctx, now + 0.022, 480, 0.06, 'square', 0.08 * v)
+      noiseBurst(ctx, now, 0.025, 0.05 * v, 1200)
+      break
+    case 'soft-felt':
+      tick(ctx, now, 320, 0.08, 'sine', 0.12 * v)
+      tick(ctx, now + 0.028, 260, 0.09, 'sine', 0.1 * v)
+      noiseBurst(ctx, now + 0.014, 0.035, 0.03 * v, 300)
+      break
+    case 'arcade-pop':
+      tick(ctx, now, 540, 0.03, 'square', 0.12 * v)
+      tick(ctx, now + 0.04, 820, 0.025, 'triangle', 0.1 * v)
+      tick(ctx, now + 0.07, 620, 0.02, 'square', 0.08 * v)
+      break
+    case 'classic-wood':
+    default:
+      tick(ctx, now, 430, 0.055, 'triangle', 0.14 * v)
+      tick(ctx, now + 0.03, 360, 0.05, 'triangle', 0.1 * v)
+      noiseBurst(ctx, now + 0.008, 0.028, 0.05 * v, 520)
+      break
+  }
+}
+
+export function createDiceRollAudio ({ muted = false, presetId = 'classic-wood' } = {}) {
+  return {
+    muted,
+    volume: getGameVolume(),
+    currentTime: 0,
+    pause () {},
+    play () {
+      if (this.muted) return Promise.resolve()
+      const ctx = getAudioCtx()
+      if (!ctx) return Promise.resolve()
+      playPreset(ctx, presetId, this.volume)
+      return Promise.resolve()
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Prevent off-board dice/tokens from being affected by user-driven board rotation while preserving existing camera behaviour and token slide logic.
- Provide five user-selectable dice-roll SFX options without adding binary audio files to the repo.

### Description
- Reworked the Snake board scene graph in `webapp/src/components/SnakeBoard3D.jsx` by introducing `rotationRoot` (rotating gameplay layer) and `staticRoot` (non-rotating elements), moving tiles/snakes/ladders/on-board tokens to `rotationRoot` and dice + reserve tokens to `staticRoot`.
- Split token groups into `boardTokensGroup` and `reserveTokensGroup` and updated `updateTokens` to dynamically parent tokens based on whether `position >= 1`, so off-board tokens remain static during board rotation.
- Updated slide and camera follow code paths to find tokens across both token groups and to use the token's parent when computing heights, preserving slide animations and camera restore state.
- Replaced the old file-backed dice audio with a procedural WebAudio implementation in `webapp/src/utils/diceAudio.js` exposing five presets, and added UI to pick a preset in the Snake menu that is persisted to `localStorage` and wired to `createDiceRollAudio`.

### Testing
- Ran linter on the modified files with `npx eslint` which executed (repo ignore rules produced only warnings about ignored files).
- Built the webapp bundle with `npm --prefix webapp run build` which completed successfully and produced the production output.
- Launched a dev instance and captured a smoke-check screenshot via Playwright to verify the Snake menu/board UI loads (artifact produced).
- The repository-level `npm run -s build` still reports an unrelated, pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` which is outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b101609c5c8329839cdc22bea89ddb)