### PR TITLE
Fix Ludo 2D camera to stay centered and raise top-down height

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2828,10 +2828,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
     const topDownPolar = 0.001;
     if (nextIs2d) {
+      cancelCameraFocusAnimation();
+      cancelCameraViewAnimation();
       if (!saved3dCameraStateRef.current) {
         saved3dCameraStateRef.current = {
           position: camera.position.clone(),
           target: controls.target.clone(),
+          minDistance: controls.minDistance,
+          maxDistance: controls.maxDistance,
           minPolarAngle: controls.minPolarAngle,
           maxPolarAngle: controls.maxPolarAngle,
           minAzimuthAngle: controls.minAzimuthAngle,
@@ -2839,10 +2843,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           enableRotate: controls.enableRotate
         };
       }
-      const topDownDistance = clamp(CAM.minR * 1.35, CAM.minR, CAM.maxR);
+      const topDownDistance = CAM.maxR * 1.45;
       camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
       controls.target.copy(boardLookTarget);
+      cameraTurnStateRef.current.currentTarget = boardLookTarget.clone();
       controls.enableRotate = false;
+      controls.minDistance = topDownDistance;
+      controls.maxDistance = topDownDistance;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
@@ -2850,6 +2857,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     } else {
       const saved = saved3dCameraStateRef.current;
       controls.enableRotate = saved?.enableRotate ?? true;
+      controls.minDistance = saved?.minDistance ?? CAM.minR;
+      controls.maxDistance = saved?.maxDistance ?? CAM.maxR;
       controls.minPolarAngle = saved?.minPolarAngle ?? CAM.phiMin;
       controls.maxPolarAngle = saved?.maxPolarAngle ?? CAM.phiMax;
       controls.minAzimuthAngle = saved?.minAzimuthAngle ?? -Infinity;
@@ -2865,7 +2874,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
     controls.update();
     syncSkyboxToCameraRef.current?.();
-  }, []);
+  }, [cancelCameraFocusAnimation, cancelCameraViewAnimation]);
 
   const handleToggleCamera2d = useCallback(() => {
     setIsCamera2d((current) => {


### PR DESCRIPTION
### Motivation
- Prevent the 2D top-down camera from shifting to follow the active player's turn and ensure the whole board is visible in portrait mobile view. 
- Provide a stable, centered top-down framing for Ludo Battle Royal so the UI and token layout are consistently visible during gameplay.

### Description
- Modified `applyCameraViewMode` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to cancel ongoing camera focus/view animations by calling `cancelCameraFocusAnimation()` and `cancelCameraViewAnimation()` when entering 2D mode. 
- Raised the 2D top-down distance to `CAM.maxR * 1.45` and locked OrbitControls zoom by setting `controls.minDistance` and `controls.maxDistance` to the top-down distance so the table stays fully in frame. 
- Save and restore `minDistance`/`maxDistance` from `saved3dCameraStateRef` so 3D orbit limits are restored when leaving 2D mode, and set `cameraTurnStateRef.current.currentTarget` to the board center while in 2D.

### Testing
- Ran ESLint on the modified file with `npx eslint --no-ignore --no-warn-ignored webapp/src/pages/Games/LudoBattleRoyal.jsx` and it completed successfully. 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and performed a runtime check, toggling to 2D and capturing a screenshot of `/games/ludobattleroyal`. 
- Verified the 2D camera remains centered and the board is framed higher in the captured screenshot (manual visual validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b102ce9c588329b2477698f4033258)