### PR TITLE
Fix Ludo 2D camera: keep centered and fully zoomed out

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1526,6 +1526,7 @@ const CAM = {
   phiMin: ARENA_CAMERA_DEFAULTS.phiMin,
   phiMax: ARENA_CAMERA_DEFAULTS.phiMax
 };
+const CAMERA_2D_DISTANCE_FACTOR = 1;
 const TRACK_COORDS = Object.freeze([
   [6, 1],
   [6, 2],
@@ -2836,24 +2837,40 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           maxPolarAngle: controls.maxPolarAngle,
           minAzimuthAngle: controls.minAzimuthAngle,
           maxAzimuthAngle: controls.maxAzimuthAngle,
-          enableRotate: controls.enableRotate
+          enableRotate: controls.enableRotate,
+          enablePan: controls.enablePan,
+          enableZoom: controls.enableZoom,
+          minDistance: controls.minDistance,
+          maxDistance: controls.maxDistance
         };
       }
-      const topDownDistance = clamp(CAM.minR * 1.35, CAM.minR, CAM.maxR);
+      cancelCameraFocusAnimation();
+      cancelCameraViewAnimation();
+      cameraTurnStateRef.current.activePriority = -Infinity;
+      cameraTurnStateRef.current.followObject = null;
+      const topDownDistance = clamp(CAM.maxR * CAMERA_2D_DISTANCE_FACTOR, CAM.minR, CAM.maxR);
       camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
+      controls.enablePan = false;
+      controls.enableZoom = false;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
+      controls.minDistance = topDownDistance;
+      controls.maxDistance = topDownDistance;
     } else {
       const saved = saved3dCameraStateRef.current;
       controls.enableRotate = saved?.enableRotate ?? true;
+      controls.enablePan = saved?.enablePan ?? false;
+      controls.enableZoom = saved?.enableZoom ?? true;
       controls.minPolarAngle = saved?.minPolarAngle ?? CAM.phiMin;
       controls.maxPolarAngle = saved?.maxPolarAngle ?? CAM.phiMax;
       controls.minAzimuthAngle = saved?.minAzimuthAngle ?? -Infinity;
       controls.maxAzimuthAngle = saved?.maxAzimuthAngle ?? Infinity;
+      controls.minDistance = saved?.minDistance ?? CAM.minR;
+      controls.maxDistance = saved?.maxDistance ?? CAM.maxR;
       if (saved?.position && saved?.target) {
         camera.position.copy(saved.position);
         controls.target.copy(saved.target);


### PR DESCRIPTION
### Motivation
- The 2D board view was automatically panning/looking at the active player and was too close to show the whole table, so the camera must remain centered on the board and be higher in 2D mode.

### Description
- Cancel active camera focus/view animations and clear any follow target when switching into 2D so the camera no longer moves toward the active player's seat.
- Position the camera over the board center using a top-down distance derived from `CAM.maxR` via a new `CAMERA_2D_DISTANCE_FACTOR` constant to ensure the full table fits in frame.
- Lock `OrbitControls` in 2D by disabling rotate/pan/zoom and clamping `minDistance`/`maxDistance` to the top-down distance to prevent drift.
- Preserve and restore the full 3D `controls` state (rotate/pan/zoom flags and distance bounds) when toggling back to 3D to avoid regressions.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production bundle.
- Launched the dev server with `npm --prefix webapp run dev` and captured a Playwright screenshot of `http://localhost:4173/games/ludobattleroyal` to validate the 2D framing and stability (artifact produced).
- Ran project linting via the repo `npm run lint` which surfaced many pre-existing repository-wide issues unrelated to this change, and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` returned only an ignore-warning for the file in this setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b102ce9c588329b2477698f4033258)