### PR TITLE
Adjust Snooker Royal camera framing for portrait and broadcast visibility

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5035,7 +5035,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.36; // match Pool Royale standing-camera distance limit for the same close orbit feel
+const STANDING_VIEW_DISTANCE_SCALE = 0.34; // bring standing camera slightly closer so table action reads larger on portrait screens
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5109,9 +5109,9 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.11; // align Snooker 2D overhead framing with Pool Royale so the full table stays in frame
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.12; // lift the 2D camera a touch higher while preserving full-table framing
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.11; // align Snooker 2D overhead framing with Pool Royale so the full table stays in frame
+const TOP_VIEW_RADIUS_SCALE = 1.12; // lift the 2D camera a touch higher while preserving full-table framing
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * 0.006,
@@ -5140,12 +5140,12 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
     (halfLength / Math.tan(halfVertical)) * RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance) * CAMERA_DISPLAY_SCALE;
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1.05; // pull the broadcast overhead camera back for fuller table framing
+const RAIL_OVERHEAD_DISTANCE_BIAS = 1; // mirror Pool Royale rail-overhead distance so both near short-rail pockets stay in frame
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
 const CUE_VIEW_RADIUS_RATIO = 0.0205; // match Pool Royale cue-camera radius limit for identical close-up behavior
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.09;
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.08;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26


### PR DESCRIPTION
### Motivation
- Improve player visibility on portrait screens by raising the 2D/top camera a bit, ensure the rail-overhead broadcast framing shows both near short-rail pockets, and bring standing/cue cameras visually closer for a tighter player view.

### Description
- Tweaked camera tuning constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to adjust framing and proximity for portrait and broadcast views.
- Changed `STANDING_VIEW_DISTANCE_SCALE` from `0.36` to `0.34` to pull the standing camera closer to the cloth.
- Increased `TOP_VIEW_MIN_RADIUS_SCALE` and `TOP_VIEW_RADIUS_SCALE` from `1.11` to `1.12` to raise the 2D/top camera slightly.
- Set `RAIL_OVERHEAD_DISTANCE_BIAS` from `1.05` to `1` so rail-overhead cameras match Pool Royale behavior and keep both bottom pockets visible.
- Tightened `CUE_VIEW_MIN_RADIUS` from `CAMERA.minR * 0.09` to `CAMERA.minR * 0.08` to bring the cue camera a bit closer.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Launched a preview server and captured a visual verification screenshot using the preview at `http://localhost:4173` to confirm framing changes were visible.
- Attempted `npm --prefix webapp run -s lint` but it failed because there is no `lint` script defined in `webapp/package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1025eb85c8329946e00abef7c2364)