### PR TITLE
Enable zooming in Ludo Battle Royal 2D camera mode

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2853,13 +2853,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
       controls.enablePan = false;
-      controls.enableZoom = false;
+      controls.enableZoom = true;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
-      controls.minDistance = topDownDistance;
-      controls.maxDistance = topDownDistance;
+      controls.minDistance = CAM.minR;
+      controls.maxDistance = CAM.maxR;
     } else {
       const saved = saved3dCameraStateRef.current;
       controls.enableRotate = saved?.enableRotate ?? true;


### PR DESCRIPTION
### Motivation
- Let players zoom in/out while in the 2D top-down Ludo view instead of locking camera distance, improving control and UX on mobile portrait screens.

### Description
- In `webapp/src/pages/Games/LudoBattleRoyal.jsx` keep `OrbitControls.enableZoom = true` when switching to 2D and use `CAM.minR`/`CAM.maxR` for `minDistance`/`maxDistance` instead of forcing a fixed `topDownDistance`, allowing distance adjustments while preserving the top-down orientation.

### Testing
- Built the web app with `npm --prefix webapp run build` (success), ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which emitted a non-blocking ignore warning, started the dev server (`npm --prefix webapp run dev`) and executed a Playwright script to load `/games/ludobattleroyal` and capture a mobile-portrait screenshot (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1093a4eb483298a397d82eb0e14db)