### PR TITLE
Remove Snake menu sound picker and refine 2D camera (centered, taller, adjustable tilt)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3805,7 +3805,8 @@ export default function SnakeBoard3D({
   appearance = {},
   appearanceKey,
   frameRate = 90,
-  cameraViewMode = '3d'
+  cameraViewMode = '3d',
+  camera2dTilt = 0.2
 }) {
   const mountRef = useRef(null);
   const cameraRef = useRef(null);
@@ -3882,7 +3883,10 @@ export default function SnakeBoard3D({
     const boardLookTarget = board?.boardLookTarget;
     if (!board || !camera || !controls || !boardLookTarget) return;
 
-    const topDownPolar = 0.001;
+    const min2dTilt = 0.001;
+    const max2dTilt = 0.42;
+    const tiltRatio = clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2);
+    const topDownPolar = THREE.MathUtils.lerp(min2dTilt, max2dTilt, tiltRatio);
     if (cameraViewMode === '2d') {
       if (!cameraRestoreRef.current) {
         cameraRestoreRef.current = {
@@ -3895,8 +3899,14 @@ export default function SnakeBoard3D({
           maxAzimuthAngle: controls.maxAzimuthAngle
         };
       }
-      const topDownDistance = clamp(CAM.minR * 1.5, CAM.minR, CAM.maxR);
-      camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
+      const topDownDistance = clamp(CAM.minR * 2.25, CAM.minR * 1.55, CAM.maxR * 0.96);
+      const verticalDistance = Math.cos(topDownPolar) * topDownDistance;
+      const forwardDistance = Math.sin(topDownPolar) * topDownDistance;
+      camera.position.set(
+        boardLookTarget.x,
+        boardLookTarget.y + verticalDistance,
+        boardLookTarget.z + forwardDistance
+      );
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
       controls.minPolarAngle = topDownPolar;
@@ -3919,7 +3929,7 @@ export default function SnakeBoard3D({
       controls.update();
       cameraRestoreRef.current = null;
     }
-  }, [cameraViewMode]);
+  }, [cameraViewMode, camera2dTilt]);
 
   useEffect(() => {
     seatCallbackRef.current = typeof onSeatPositionsChange === 'function' ? onSeatPositionsChange : null;
@@ -4260,7 +4270,7 @@ export default function SnakeBoard3D({
     }
     prevPlayerPositionsRef.current = sanitizedPositions;
 
-    if (movement && shouldFollowTileChange(movement.from, movement.to)) {
+    if (cameraViewMode !== '2d' && movement && shouldFollowTileChange(movement.from, movement.to)) {
       const camera = cameraRef.current;
       const controls = board.controls;
       const followState = computeTokenFollowCameraState(board, camera, movement.from, movement.to);
@@ -4290,7 +4300,8 @@ export default function SnakeBoard3D({
     keyForEffect,
     tokenTheme,
     tokenShape,
-    tokenPrototypeVersion
+    tokenPrototypeVersion,
+    cameraViewMode
   ]);
 
   useEffect(() => {
@@ -4348,7 +4359,7 @@ export default function SnakeBoard3D({
     const camera = cameraRef.current;
     const controls = board.controls;
     const followState = computeTokenFollowCameraState(board, camera, slide.from, slide.to);
-    if (camera && controls && followState && shouldFollowTileChange(slide.from, slide.to)) {
+    if (cameraViewMode !== '2d' && camera && controls && followState && shouldFollowTileChange(slide.from, slide.to)) {
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
       const restoreState =
@@ -4390,7 +4401,7 @@ export default function SnakeBoard3D({
         return false;
       }
     });
-  }, [slide, onSlideComplete]);
+  }, [slide, onSlideComplete, cameraViewMode]);
 
   useEffect(() => {
     if (!diceEvent || !boardRef.current) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -89,7 +89,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
-import { createDiceRollAudio, DICE_SFX_PRESETS } from "../../utils/diceAudio.js";
+import { createDiceRollAudio } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -190,7 +190,6 @@ const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
-const DICE_SFX_STORAGE_KEY = 'snakeDiceSfxPreset';
 const SNAKE_COMMENTARY_PRESETS = Object.freeze([
   {
     id: 'english',
@@ -1194,6 +1193,7 @@ export default function SnakeAndLadder() {
   const [cheatMsg, setCheatMsg] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
   const [cameraViewMode, setCameraViewMode] = useState('3d');
+  const [camera2dTilt, setCamera2dTilt] = useState(0.2);
   const [showExactHelp, setShowExactHelp] = useState(false);
   const [muted, setMuted] = useState(isGameMuted());
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
@@ -1212,15 +1212,6 @@ export default function SnakeAndLadder() {
       if (stored === '0') return false;
     }
     return false;
-  });
-  const [diceSfxPresetId, setDiceSfxPresetId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(DICE_SFX_STORAGE_KEY);
-      if (stored && DICE_SFX_PRESETS.some((preset) => preset.id === stored)) {
-        return stored;
-      }
-    }
-    return DICE_SFX_PRESETS[0]?.id || 'classic-wood';
   });
   const [showConfig, setShowConfig] = useState(false);
   const [showTrailEnabled, setShowTrailEnabled] = useState(true);
@@ -1382,12 +1373,6 @@ export default function SnakeAndLadder() {
       window.localStorage.setItem(COMMENTARY_MUTE_STORAGE_KEY, commentaryMuted ? '1' : '0');
     }
   }, [commentaryMuted]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(DICE_SFX_STORAGE_KEY, diceSfxPresetId);
-    }
-  }, [diceSfxPresetId]);
   const playersRef = useRef([]);
   const refreshPlayersNeeded = useCallback(
     (playersList = playersRef.current, capacityValue) => {
@@ -1834,10 +1819,7 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(SNAKE_SFX.timer);
     timerSoundRef.current.volume = vol;
-    diceRollSoundRef.current = createDiceRollAudio({
-      muted,
-      presetId: diceSfxPresetId
-    });
+    diceRollSoundRef.current = createDiceRollAudio({ muted });
     if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
@@ -1854,7 +1836,7 @@ export default function SnakeAndLadder() {
       timerSoundRef.current?.pause();
       diceRollSoundRef.current?.pause();
     };
-  }, [accountId, muted, diceSfxPresetId]);
+  }, [accountId, muted]);
 
   useEffect(() => {
     [
@@ -3520,6 +3502,7 @@ export default function SnakeAndLadder() {
           appearanceKey={appearanceKey}
           frameRate={frameRateValue}
           cameraViewMode={cameraViewMode}
+          camera2dTilt={camera2dTilt}
         />
       </div>
       <div
@@ -3560,29 +3543,6 @@ export default function SnakeAndLadder() {
                 </button>
               </div>
               <div className="mt-4 space-y-3 pr-1">
-                <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-white/70">Dice roll sound</h3>
-                  <div className="grid gap-2">
-                    {DICE_SFX_PRESETS.map((preset) => {
-                      const active = preset.id === diceSfxPresetId;
-                      return (
-                        <button
-                          key={preset.id}
-                          type="button"
-                          onClick={() => setDiceSfxPresetId(preset.id)}
-                          aria-pressed={active}
-                          className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
-                              : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                          }`}
-                        >
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white">{preset.label}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
                 <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                   <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
                   <p className="mt-1 text-[0.7rem] text-white/60">Boards, tokens, and table themes.</p>
@@ -3770,6 +3730,30 @@ export default function SnakeAndLadder() {
       </div>
       <div className="relative z-10 flex flex-col justify-end items-center w-full h-full p-4 pb-32 space-y-4 pointer-events-none">
         <div className="pointer-events-auto w-full">
+          {cameraViewMode === '2d' ? (
+            <div
+              className="fixed z-30 flex flex-col gap-2 pointer-events-auto"
+              style={{
+                right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
+                top: 'calc(9.5rem + env(safe-area-inset-top, 0px))'
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setCamera2dTilt((value) => Math.max(0, value - 0.08))}
+                className="rounded-full border border-white/20 bg-black/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/90"
+              >
+                Move Up
+              </button>
+              <button
+                type="button"
+                onClick={() => setCamera2dTilt((value) => Math.min(1, value + 0.08))}
+                className="rounded-full border border-white/20 bg-black/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/90"
+              >
+                Move Down
+              </button>
+            </div>
+          ) : null}
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
             showMute


### PR DESCRIPTION
### Motivation
- Remove the extra sound-effect options that were added to the Snake & Ladder menu because they are not needed and add unnecessary complexity.  
- Keep the dice-roll audio working with a simple default rather than a per‑preset menu.  
- Make the 2D view behave like a fixed overhead board camera (don’t follow players/turns) and make the board fit better in portrait.  
- Allow players to adjust the 2D camera angle (tilt) on-screen as in other games (e.g., chess battle royale). 

### Description
- Removed the in‑menu “Dice roll sound” picker and the associated preset state/localStorage handling from `webapp/src/pages/Games/SnakeAndLadder.jsx`.  
- Simplified dice-roll audio initialization to use `createDiceRollAudio({ muted })` and removed the preset dependency so sounds still play without the picker.  
- Updated `SnakeBoard3D.jsx` to: center the camera on the board in 2D mode, raise/increase the framing distance so the whole board is visible, and clamp controls for true top‑down behavior.  
- Disabled all turn/token follow camera animations while in 2D mode (no automatic camera movement to follow players or dice).  
- Added a `camera2dTilt` prop and on-screen `Move Up` / `Move Down` buttons in the Snake page so users can adjust the 2D tilt live; the tilt value is used to interpolate the polar angle used for 2D framing.  
- Files changed: `webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/components/SnakeBoard3D.jsx`. 

### Testing
- Ran `npm --prefix webapp run build` and the webapp build completed successfully.  
- Started the dev server (`vite`) and captured browser screenshots of the Snake route using Playwright; screenshots were produced successfully.  
- Ran `eslint` which reported ignore warnings for the project configuration (files are ignored by repo ESLint settings), not code errors.  
- No unit tests were modified; manual visual validation performed via the headless browser screenshots.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10a4d654c8329be15c2c776aeffa4)