### PR TITLE
Fix Snake & Ladder camera turn focus and stabilize 2D view

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1608,6 +1608,13 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
     : Number(turnIndex);
   const seatIndex = Math.trunc(rawSeatIndex);
   if (!Number.isFinite(seatIndex) || seatIndex < 0 || seatIndex >= anchors.length) return null;
+  const startCameraState = board.startCameraState;
+  if (seatIndex === 0 && startCameraState?.position && startCameraState?.target) {
+    return {
+      position: startCameraState.position.clone(),
+      target: startCameraState.target.clone()
+    };
+  }
   const anchor = anchors[seatIndex];
   const boardLookTarget = board.boardLookTarget;
   if (!anchor || !boardLookTarget) return null;
@@ -2575,6 +2582,10 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   controls.maxPolarAngle = CAM.phiMax;
   controls.target.copy(boardLookTarget);
   controls.update();
+  const startCameraState = {
+    position: camera.position.clone(),
+    target: boardLookTarget.clone()
+  };
 
   const fit = () => {
     const w = host.clientWidth;
@@ -2685,7 +2696,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     updateHdriZoom,
     controls,
     tableInfo,
-    seatAnchors: chairs.map(({ anchor }) => anchor)
+    seatAnchors: chairs.map(({ anchor }) => anchor),
+    startCameraState
   };
 }
 
@@ -3829,6 +3841,7 @@ export default function SnakeBoard3D({
   const previousTurnRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
+  const cameraViewModeRef = useRef(cameraViewMode);
   const frameAccumulatorRef = useRef(0);
   const [tokenPrototypeVersion, setTokenPrototypeVersion] = useState(0);
   const fallbackAppearanceKey = useMemo(() => JSON.stringify(appearance ?? {}), [appearance]);
@@ -3838,6 +3851,10 @@ export default function SnakeBoard3D({
   const tokenShape = appearanceMemo?.tokenShape;
   const railTheme = appearanceMemo?.rail;
   const snakeTheme = appearanceMemo?.snakeSkin;
+
+  useEffect(() => {
+    cameraViewModeRef.current = cameraViewMode;
+  }, [cameraViewMode]);
 
   useEffect(() => {
     frameRateRef.current = Math.max(30, frameRate || 90);
@@ -3909,10 +3926,12 @@ export default function SnakeBoard3D({
       );
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
+      controls.enablePan = false;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
+      controls.touches = { ONE: THREE.TOUCH.DOLLY, TWO: THREE.TOUCH.DOLLY_PAN };
       controls.update();
       return;
     }
@@ -3922,10 +3941,12 @@ export default function SnakeBoard3D({
       camera.position.copy(restore.position);
       controls.target.copy(restore.target);
       controls.enableRotate = restore.enableRotate;
+      controls.enablePan = false;
       controls.minPolarAngle = restore.minPolarAngle;
       controls.maxPolarAngle = restore.maxPolarAngle;
       controls.minAzimuthAngle = restore.minAzimuthAngle;
       controls.maxAzimuthAngle = restore.maxAzimuthAngle;
+      controls.touches = { ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_PAN };
       controls.update();
       cameraRestoreRef.current = null;
     }
@@ -4011,7 +4032,8 @@ export default function SnakeBoard3D({
       ...board,
       boardLookTarget: arena.boardLookTarget,
       controls: arena.controls,
-      seatAnchors: arena.seatAnchors ?? []
+      seatAnchors: arena.seatAnchors ?? [],
+      startCameraState: arena.startCameraState ?? null
     };
 
     const boardRotationRoot = board.rotationRoot || board.root;
@@ -4020,12 +4042,14 @@ export default function SnakeBoard3D({
       lastX: 0
     };
     const onPointerDown = (event) => {
+      if (cameraViewModeRef.current === '2d') return;
       if (event.button !== 0 && event.pointerType !== 'touch') return;
       dragState.pointerId = event.pointerId;
       dragState.lastX = event.clientX;
       renderer.domElement.setPointerCapture?.(event.pointerId);
     };
     const onPointerMove = (event) => {
+      if (cameraViewModeRef.current === '2d') return;
       if (dragState.pointerId !== event.pointerId) return;
       const deltaX = event.clientX - dragState.lastX;
       dragState.lastX = event.clientX;


### PR DESCRIPTION
### Motivation
- Ensure the camera framing is identical to game start when the bottom player (seat `0`) gets the turn so the view doesn’t drift from the initial composition.
- Make the 2D board view immutable except for zoom so the board center stays focused and the board does not rotate while in 2D mode.

### Description
- Persist the initial arena camera pose as `startCameraState` (position + target) during arena setup and return it from `buildArena` so it is available to the board runtime as `board.startCameraState`.
- Update `computeTurnCameraFocusState` to return the persisted `startCameraState` when `seatIndex === 0`, restoring the original game-start framing for the bottom player’s turn.
- Add `cameraViewModeRef` and guard pointer handlers so board-drag rotation is disabled while `cameraViewMode === '2d'`.
- Tighten `OrbitControls` settings for 2D mode by disabling pan, setting touch mappings to zoom-only in 2D, and restoring sensible touch behavior when leaving 2D.

### Testing
- Ran `npm -C webapp run build` which completed successfully and produced the production bundles.
- Started the dev server with `npm -C webapp run dev` which launched Vite and served the app (local + network URLs reported).
- Attempted an automated Playwright screenshot to validate visual behavior, but the browser run timed out/crashed in this environment (Chromium instability/SIGSEGV), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11f1936a4832998773073357e0edb)