### PR TITLE
Tune Snooker Royal 2D and rail-overhead camera framing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5103,10 +5103,10 @@ const BREAK_VIEW = Object.freeze({
   phi: CAMERA.maxPhi - 0.01
 });
 const CAMERA_RAIL_SAFETY = 0.006;
-const TOP_VIEW_MARGIN = 1.14; // lift the top view slightly to keep both near pockets visible on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.14; // lift the 2D camera slightly higher so portrait top view sits a little more elevated
+const TOP_VIEW_MARGIN = 1.16; // lift the top view a touch more so the full table stays in frame on portrait
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.18; // raise the 2D camera slightly more to reveal the whole table on portrait
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.14; // lift the 2D camera slightly higher so portrait top view sits a little more elevated
+const TOP_VIEW_RADIUS_SCALE = 1.18; // raise the 2D camera slightly more to reveal the whole table on portrait
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * 0.006,
@@ -5114,13 +5114,13 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
-  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.019 // nudge rail-overhead framing further inward so the bottom pockets stay visible on portrait
+  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.028 // nudge rail-overhead framing further inward so the lower pockets stay visible on portrait
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
-const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.06; // lift rail-overhead camera a little more for clearer bottom-pocket visibility
+const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.1; // lift rail-overhead camera a little more for clearer bottom-pocket visibility
 // Keep the rail overhead broadcast framing nearly identical to the 2D top view while
 // leaving a small tilt for depth cues.
-const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI; // align broadcast overhead with the 2D top-view angle
+const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI + 0.01; // keep overhead framing close to 2D while adding a slight broadcast tilt
 const BROADCAST_MARGIN_WIDTH = (PLAY_W / 2) * (TOP_VIEW_MARGIN - 1);
 const BROADCAST_MARGIN_LENGTH = (PLAY_H / 2) * (TOP_VIEW_MARGIN - 1);
 const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) => {
@@ -5170,7 +5170,7 @@ const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended to
 const CUE_VIEW_AIM_LINE_LERP = 0.1; // aiming line interpolation factor while the camera is near cue view
 const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor while the camera is near standing view
 const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
-const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.048; // tilt rail-overhead aim view slightly more downward so lower pockets remain readable
+const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.064; // tilt rail-overhead aim view slightly more downward so lower pockets remain readable
 const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens so both near short-rail pockets stay in frame on portrait
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the full Snooker Royal table is visible in the 2D top view and ensure the short-rail/bottom pockets remain readable in rail-overhead broadcast views.
- Address reported issues where the bottom pockets were clipped or partially off-screen in portrait and overhead camera modes.

### Description
- Raised the 2D/top-view framing by increasing `TOP_VIEW_MARGIN`, `TOP_VIEW_MIN_RADIUS_SCALE`, and `TOP_VIEW_RADIUS_SCALE` to lift the 2D camera a bit on portrait screens in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Nudged the rail-overhead broadcast framing inward by increasing `RAIL_OVERHEAD_SCREEN_OFFSET.z` so lower pockets are pulled into the visible area.
- Increased the rail-overhead broadcast radius scale by adjusting `RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE` and added a slight tilt via `RAIL_OVERHEAD_PHI` to match the updated top-view composition.
- Improved overhead aiming visibility by raising `RAIL_OVERHEAD_AIM_PHI_LIFT` so bottom pockets stay readable during overhead aim transitions.

### Testing
- Ran `npm test -- --runInBand test/snookerRoyalInventoryRoutes.test.js` which passed (`1 passed`).
- Attempted an automated Playwright screenshot of `/games/snookerroyale` which timed out in this environment (screenshot capture failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b123afd19c8329b60a5437eff47c7e)