### PR TITLE
NavItem: add slight upward translation (-translate-y-1) to link

### DIFF
--- a/webapp/src/components/NavItem.jsx
+++ b/webapp/src/components/NavItem.jsx
@@ -5,7 +5,7 @@ export default function NavItem({ to, icon: Icon, label }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex flex-col items-center text-sm ${
+        `flex flex-col items-center text-sm -translate-y-1 ${
           isActive
             ? 'text-accent drop-shadow-[0_0_6px_rgba(250,204,21,0.8)]'
             : 'text-text hover:text-accent'


### PR DESCRIPTION
### Motivation
- Improve vertical alignment and spacing of navigation items by shifting the link content slightly upward using the `-translate-y-1` utility.

### Description
- Updated `webapp/src/components/NavItem.jsx` to include `-translate-y-1` in the `className` on the `NavLink` so icons and labels sit slightly higher.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1278f7f54832980833b334661e51e)