### PR TITLE
Adjust bottom nav icon/text position upward

### DIFF
--- a/webapp/src/components/NavItem.jsx
+++ b/webapp/src/components/NavItem.jsx
@@ -5,7 +5,7 @@ export default function NavItem({ to, icon: Icon, label }) {
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex flex-col items-center text-sm -translate-y-1 ${
+        `flex flex-col items-center text-sm -translate-y-2 ${
           isActive
             ? 'text-accent drop-shadow-[0_0_6px_rgba(250,204,21,0.8)]'
             : 'text-text hover:text-accent'


### PR DESCRIPTION
### Motivation
- Move the bottom navigation item content (icons and labels) visually slightly upward while leaving the navbar fixed at the bottom.

### Description
- Update `NavItem` vertical translation from `-translate-y-1` to `-translate-y-2` in `webapp/src/components/NavItem.jsx` so icons and labels sit a bit higher.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully.
- Captured a mobile-portrait screenshot using an automated Playwright script to validate the visual change (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12dbfd7b0832980f9ccb5571e8847)