### PR TITLE
Enable vertical touch-drag camera tilt in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4360,8 +4360,17 @@ export default function MurlanRoyaleArena({ search }) {
       const cameraOffset = camera.position.clone().sub(target);
       const cameraSpherical = new THREE.Spherical().setFromVector3(cameraOffset);
       const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 24 : 20);
-      controls.minPolarAngle = cameraSpherical.phi;
-      controls.maxPolarAngle = cameraSpherical.phi;
+      const verticalSwing = THREE.MathUtils.degToRad(isPortrait ? 14 : 10);
+      controls.minPolarAngle = THREE.MathUtils.clamp(
+        cameraSpherical.phi - verticalSwing,
+        ARENA_CAMERA_DEFAULTS.phiMin,
+        ARENA_CAMERA_DEFAULTS.phiMax
+      );
+      controls.maxPolarAngle = THREE.MathUtils.clamp(
+        cameraSpherical.phi + verticalSwing,
+        ARENA_CAMERA_DEFAULTS.phiMin,
+        ARENA_CAMERA_DEFAULTS.phiMax
+      );
       controls.minAzimuthAngle = cameraSpherical.theta - horizontalSwing;
       controls.maxAzimuthAngle = cameraSpherical.theta + horizontalSwing;
       controls.minDistance = desiredRadius;


### PR DESCRIPTION
### Motivation
- Players should be able to adjust the camera pitch by dragging the screen up/down on mobile (portrait) without adding UI buttons, matching behavior used in other Royale games.

### Description
- Replaced the previous polar-angle lock with a bounded polar-angle window centered on the camera's current spherical `phi` so vertical dragging changes pitch while remaining constrained.
- Introduced `verticalSwing` tuned per orientation (`14°` portrait, `10°` landscape) and clamped the resulting `minPolarAngle`/`maxPolarAngle` to `ARENA_CAMERA_DEFAULTS.phiMin`/`phiMax` to avoid extreme angles.
- Kept horizontal orbit, azimuth swing, and fixed camera distance unchanged so only vertical control was added.
- Changed file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (adjusted OrbitControls polar-angle setup).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (dev server started successfully).
- Executed a Playwright script that loaded `/games/murlanroyale` at a 390×844 viewport and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12e5ffa4c83299f582e660245b629)