### PR TITLE
Snake & Ladder: remove 2D tilt buttons and enable drag-based camera tilt control

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3818,7 +3818,8 @@ export default function SnakeBoard3D({
   appearanceKey,
   frameRate = 90,
   cameraViewMode = '3d',
-  camera2dTilt = 0.2
+  camera2dTilt = 0.2,
+  onCameraTiltChange
 }) {
   const mountRef = useRef(null);
   const cameraRef = useRef(null);
@@ -3843,6 +3844,7 @@ export default function SnakeBoard3D({
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
   const cameraViewModeRef = useRef(cameraViewMode);
   const frameAccumulatorRef = useRef(0);
+  const cameraTiltRef = useRef(clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2));
   const [tokenPrototypeVersion, setTokenPrototypeVersion] = useState(0);
   const fallbackAppearanceKey = useMemo(() => JSON.stringify(appearance ?? {}), [appearance]);
   const keyForEffect = appearanceKey ?? fallbackAppearanceKey;
@@ -3855,6 +3857,10 @@ export default function SnakeBoard3D({
   useEffect(() => {
     cameraViewModeRef.current = cameraViewMode;
   }, [cameraViewMode]);
+
+  useEffect(() => {
+    cameraTiltRef.current = clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2);
+  }, [camera2dTilt]);
 
   useEffect(() => {
     frameRateRef.current = Math.max(30, frameRate || 90);
@@ -3934,6 +3940,16 @@ export default function SnakeBoard3D({
       controls.touches = { ONE: THREE.TOUCH.DOLLY, TWO: THREE.TOUCH.DOLLY_PAN };
       controls.update();
       return;
+    }
+
+    const desiredPolar = THREE.MathUtils.lerp(CAM.phiMin, CAM.phiMax, tiltRatio);
+    const offset = camera.position.clone().sub(controls.target);
+    if (offset.lengthSq() > 0.000001) {
+      const spherical = new THREE.Spherical().setFromVector3(offset);
+      spherical.phi = clamp(desiredPolar, CAM.phiMin, CAM.phiMax);
+      offset.setFromSpherical(spherical);
+      camera.position.copy(controls.target).add(offset);
+      controls.update();
     }
 
     if (cameraRestoreRef.current) {
@@ -4039,21 +4055,36 @@ export default function SnakeBoard3D({
     const boardRotationRoot = board.rotationRoot || board.root;
     const dragState = {
       pointerId: null,
-      lastX: 0
+      lastX: 0,
+      lastY: 0
     };
     const onPointerDown = (event) => {
-      if (cameraViewModeRef.current === '2d') return;
       if (event.button !== 0 && event.pointerType !== 'touch') return;
       dragState.pointerId = event.pointerId;
       dragState.lastX = event.clientX;
+      dragState.lastY = event.clientY;
       renderer.domElement.setPointerCapture?.(event.pointerId);
     };
     const onPointerMove = (event) => {
-      if (cameraViewModeRef.current === '2d') return;
       if (dragState.pointerId !== event.pointerId) return;
       const deltaX = event.clientX - dragState.lastX;
+      const deltaY = event.clientY - dragState.lastY;
       dragState.lastX = event.clientX;
-      if (Math.abs(deltaX) < 0.25) return;
+      dragState.lastY = event.clientY;
+      const absX = Math.abs(deltaX);
+      const absY = Math.abs(deltaY);
+
+      if (absY >= absX && absY >= 0.25 && typeof onCameraTiltChange === 'function') {
+        const nextTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
+        if (Math.abs(nextTilt - cameraTiltRef.current) > 0.0001) {
+          cameraTiltRef.current = nextTilt;
+          onCameraTiltChange(nextTilt);
+        }
+        return;
+      }
+
+      if (cameraViewModeRef.current === '2d') return;
+      if (absX < 0.25) return;
       boardRotationRoot.rotation.y += deltaX * BOARD_ROTATION_DRAG_SPEED;
     };
     const onPointerEnd = (event) => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3503,6 +3503,7 @@ export default function SnakeAndLadder() {
           frameRate={frameRateValue}
           cameraViewMode={cameraViewMode}
           camera2dTilt={camera2dTilt}
+          onCameraTiltChange={setCamera2dTilt}
         />
       </div>
       <div
@@ -3730,30 +3731,6 @@ export default function SnakeAndLadder() {
       </div>
       <div className="relative z-10 flex flex-col justify-end items-center w-full h-full p-4 pb-32 space-y-4 pointer-events-none">
         <div className="pointer-events-auto w-full">
-          {cameraViewMode === '2d' ? (
-            <div
-              className="fixed z-30 flex flex-col gap-2 pointer-events-auto"
-              style={{
-                right: 'calc(0.75rem + env(safe-area-inset-right, 0px))',
-                top: 'calc(9.5rem + env(safe-area-inset-top, 0px))'
-              }}
-            >
-              <button
-                type="button"
-                onClick={() => setCamera2dTilt((value) => Math.max(0, value - 0.08))}
-                className="rounded-full border border-white/20 bg-black/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/90"
-              >
-                Move Up
-              </button>
-              <button
-                type="button"
-                onClick={() => setCamera2dTilt((value) => Math.min(1, value + 0.08))}
-                className="rounded-full border border-white/20 bg-black/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/90"
-              >
-                Move Down
-              </button>
-            </div>
-          ) : null}
           <BottomLeftIcons
             onInfo={() => setShowInfo(true)}
             showMute


### PR DESCRIPTION
### Motivation
- Replace the temporary on-screen 2D tilt buttons with a gesture-driven camera tilt so players can change angle by dragging the board (same UX as Domino Battle Royal). 
- Ensure tilt control is available and consistent in both 2D and 3D views using a single shared state.

### Description
- Removed the `Move Up` / `Move Down` 2D tilt buttons from `webapp/src/pages/Games/SnakeAndLadder.jsx` and passed an `onCameraTiltChange` callback into the board component via `onCameraTiltChange={setCamera2dTilt}`.
- Added an `onCameraTiltChange` prop and a `cameraTiltRef` to `webapp/src/components/SnakeBoard3D.jsx` to report continuous tilt updates from pointer gestures.
- Updated pointer handling in `SnakeBoard3D` so vertical drag adjusts camera tilt (calls `onCameraTiltChange`) while horizontal drag continues to rotate the board in 3D; small deadzones prevent accidental moves.
- Synced the shared tilt ratio into the 3D camera polar angle so tilt changes affect both 2D top-down and 3D orbit views (computed via spherical conversion and clamped to `CAM.phiMin`/`CAM.phiMax`).

### Testing
- Ran `npm run build` (production build) in the `webapp` folder but the Vite transform stage remained long-running in this environment and the process was aborted, so a full production build artifact could not be validated.
- Launched a local dev server attempts and tried a Playwright navigation/screenshot to `http://127.0.0.1:4173`, but the page navigation timed out and the screenshot could not be captured, so runtime verification in a browser was not completed.
- Unit/runtime behavior to verify locally: confirm `onCameraTiltChange` updates when dragging vertically on the board, horizontal drags rotate the board in 3D, and toggling `2D/3D` preserves a consistent tilt value (manual QA recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b132b7a2e4832993d2f46c5f121d76)