### PR TITLE
Adjust Air Hockey goals inward, trim cushions at goals, and raise top HUD menu

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -188,7 +188,7 @@ const HUD_VERTICAL_SHIFT_REM = 9;
 const HUD_TOP_ROW_LIFT_REM = 2.5;
 const HUD_ICON_ROW_TOP_REM = 0.9;
 const HUD_MENU_LEFT_REM = 0.5;
-const AIR_HOCKEY_MENU_TOP_TWEAK_REM = -0.25;
+const AIR_HOCKEY_MENU_TOP_TWEAK_REM = -1.05;
 const AIR_HOCKEY_TARGET_CENTER_TOP_TWEAK_REM = -0.25;
 const AIR_HOCKEY_RIGHT_ICON_STACK_DOWN_REM = 0.6;
 const AIR_HOCKEY_TOP_VIEW_CAMERA_DISTANCE_SCALE = 0.9;
@@ -1472,11 +1472,12 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       emissiveIntensity: 0.6
     });
     materialsRef.current.goal = goalMaterial;
+    const goalInsetTowardCenter = railThickness * 0.3;
     const northGoal = new THREE.Mesh(goalGeometry, goalMaterial);
-    northGoal.position.set(0, 0.055 * SCALE_WIDTH, -PLAYFIELD.h / 2 - railThickness * 0.7);
+    northGoal.position.set(0, 0.055 * SCALE_WIDTH, -PLAYFIELD.h / 2 - railThickness * 0.7 + goalInsetTowardCenter);
     tableGroup.add(northGoal);
     const southGoal = new THREE.Mesh(goalGeometry, goalMaterial);
-    southGoal.position.set(0, 0.055 * SCALE_WIDTH, PLAYFIELD.h / 2 + railThickness * 0.7);
+    southGoal.position.set(0, 0.055 * SCALE_WIDTH, PLAYFIELD.h / 2 + railThickness * 0.7 - goalInsetTowardCenter);
     tableGroup.add(southGoal);
 
     const goalCutoutGeometry = new THREE.BoxGeometry(
@@ -1506,7 +1507,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       mouth.position.set(
         0,
         0.048 * SCALE_WIDTH,
-        direction * (PLAYFIELD.h / 2 + railThickness * 0.08)
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.08 - goalInsetTowardCenter)
       );
       tableGroup.add(mouth);
 
@@ -1517,12 +1518,36 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       net.position.set(
         0,
         0.072 * SCALE_WIDTH,
-        direction * (PLAYFIELD.h / 2 + railThickness * 0.78)
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.78 - goalInsetTowardCenter)
       );
       tableGroup.add(net);
     };
     createGoalMouth(-1);
     createGoalMouth(1);
+
+    const goalTrimMaterial = new THREE.MeshStandardMaterial({
+      color: 0x09121d,
+      roughness: 0.82,
+      metalness: 0.08,
+      emissive: new THREE.Color(0x02060b),
+      emissiveIntensity: 0.24
+    });
+    const goalCushionTrimGeometry = new THREE.BoxGeometry(
+      PLAYFIELD.goalW * 0.92,
+      0.2 * SCALE_WIDTH,
+      railThickness * 0.5
+    );
+    const addGoalCushionTrim = (direction) => {
+      const trim = new THREE.Mesh(goalCushionTrimGeometry, goalTrimMaterial);
+      trim.position.set(
+        0,
+        0.072 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.22 - goalInsetTowardCenter)
+      );
+      tableGroup.add(trim);
+    };
+    addGoalCushionTrim(-1);
+    addGoalCushionTrim(1);
 
     const createGoalLabel = (text, accent) => {
       const width = 1024;


### PR DESCRIPTION
### Motivation
- Improve visual alignment of Air Hockey goals by pulling them slightly toward the table center so the openings read more correctly on portrait/mobile screens.
- Move the 2D HUD menu icon higher on the screen to match user expectation for top-placed controls in portrait.
- Remove visible green cushion where goals are cut so the goal openings visually match the goal size and do not show cushion geometry.

### Description
- Raised the HUD menu top tweak by changing `AIR_HOCKEY_MENU_TOP_TWEAK_REM` from `-0.25` to `-1.05` in `webapp/src/components/AirHockey3D.jsx` to move the menu icon upward on the page.
- Introduced `goalInsetTowardCenter` and applied it to the north/south goal Z positions so both goals are pulled inward toward the table center.
- Shifted the goal mouth and goal net transforms to match the new goal offset so the entire opening moves together.
- Added dark `goalTrim` meshes placed at each goal opening to physically cover/trim the cushion at the goal area so green cushion cloth is not visible inside goal openings.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished without errors).
- Ran `npx eslint webapp/src/components/AirHockey3D.jsx` which produced a single ignore warning but no lint errors were reported.
- Attempted an automated visual check using Playwright to capture a screenshot, but the screenshot step timed out in this environment (Playwright calls failed to complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1364728948329a8cdeb14ea2cc0f6)