### PR TITLE
Tune Snooker Royal 2D and rail overhead camera positioning

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5104,9 +5104,9 @@ const BREAK_VIEW = Object.freeze({
 });
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.16; // lift the top view a touch more so the full table stays in frame on portrait
-const TOP_VIEW_MIN_RADIUS_SCALE = 1.22; // raise the 2D camera a touch more so portrait framing sits slightly higher
+const TOP_VIEW_MIN_RADIUS_SCALE = 1.26; // raise the 2D camera a little more so portrait framing sits slightly higher
 const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
-const TOP_VIEW_RADIUS_SCALE = 1.22; // raise the 2D camera a touch more so portrait framing sits slightly higher
+const TOP_VIEW_RADIUS_SCALE = 1.26; // raise the 2D camera a little more so portrait framing sits slightly higher
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
 const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
   x: PLAY_W * 0.006,
@@ -5114,7 +5114,7 @@ const TOP_VIEW_SCREEN_OFFSET = Object.freeze({
 });
 const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
-  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.04 // push rail-overhead framing a little farther so the table sits higher on portrait screens
+  z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.055 // push rail-overhead framing farther so the table sits a bit closer to the top on portrait screens
 });
 const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
 const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.1; // lift rail-overhead camera a little more for clearer bottom-pocket visibility


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the 2D top-down camera shows the table slightly higher on the screen for better visibility and UX.
- Adjust rail overhead broadcast camera so the table appears a bit more toward the top of the page in overhead/broadcast modes.

### Description
- Increased `TOP_VIEW_MIN_RADIUS_SCALE` from `1.22` to `1.26` to raise the 2D/top-down camera distance slightly for portrait screens.
- Increased `TOP_VIEW_RADIUS_SCALE` from `1.22` to `1.26` so the resolved top-down framing is consistently higher.
- Increased `RAIL_OVERHEAD_SCREEN_OFFSET.z` from `TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.04` to `TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.055` to push the rail overhead framing upward on the page.
- All changes are in `webapp/src/pages/Games/SnookerRoyal.jsx` and keep rail-overhead radius linkage consistent with the 2D top view.

### Testing
- Ran `npm --prefix webapp run build` to ensure the webapp bundles successfully; build completed without errors.
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served for visual verification.
- Captured a Playwright screenshot of the running page to validate the visual positioning; screenshot artifact was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b139fcf86c8329bb2ee6256738f982)