### PR TITLE
Make Murlan camera push forward when tilting up

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2005,6 +2005,8 @@ const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
 const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.8;
+const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
+const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -2926,7 +2928,10 @@ export default function MurlanRoyaleArena({ search }) {
     targetDistance: 1
   });
   const cameraLockedPositionRef = useRef(new THREE.Vector3());
+  const cameraLockedBasePositionRef = useRef(new THREE.Vector3());
   const cameraForwardScratchRef = useRef(new THREE.Vector3());
+  const cameraOrbitSphericalRef = useRef({ phi: null, phiMin: null, phiMax: null });
+  const cameraForwardOffsetScratchRef = useRef(new THREE.Vector3());
   const cameraTurnAnimationRef = useRef(null);
   const cameraTurnHoldTimeoutRef = useRef(null);
 
@@ -2934,6 +2939,32 @@ export default function MurlanRoyaleArena({ search }) {
     const { camera, controls } = threeStateRef.current;
     if (!camera || !controls) return;
     const lockedPosition = cameraLockedPositionRef.current;
+    const basePosition = cameraLockedBasePositionRef.current;
+    const defaultTarget = cameraDefaultTargetRef.current;
+    const orbit = cameraOrbitSphericalRef.current;
+    const orbitalOffset = camera.position.clone().sub(controls.target);
+    const currentSpherical = new THREE.Spherical().setFromVector3(orbitalOffset);
+    const phiMin = Number.isFinite(orbit.phiMin) ? orbit.phiMin : controls.minPolarAngle;
+    const phiMax = Number.isFinite(orbit.phiMax) ? orbit.phiMax : controls.maxPolarAngle;
+    const basePhi = Number.isFinite(orbit.phi) ? orbit.phi : currentSpherical.phi;
+    const upTiltRange = Math.max(1e-4, basePhi - phiMin);
+    const upTiltRatio = THREE.MathUtils.clamp((basePhi - currentSpherical.phi) / upTiltRange, 0, 1);
+    const forwardOffset = cameraForwardOffsetScratchRef.current
+      .copy(defaultTarget)
+      .sub(basePosition)
+      .setY(0);
+    if (forwardOffset.lengthSq() > 1e-6) {
+      forwardOffset
+        .normalize()
+        .multiplyScalar(CAMERA_UP_TILT_FORWARD_BLEND * upTiltRatio);
+    } else {
+      forwardOffset.set(0, 0, 0);
+    }
+    const liftedY = THREE.MathUtils.lerp(basePosition.y, defaultTarget.y, upTiltRatio * 0.22);
+    const desiredLockedPosition = basePosition.clone().add(forwardOffset);
+    desiredLockedPosition.y = liftedY;
+    const blend = upTiltRatio > 0.0001 ? CAMERA_UP_TILT_FORWARD_LERP : 1;
+    lockedPosition.lerp(desiredLockedPosition, blend);
     if (camera.position.distanceToSquared(lockedPosition) <= 1e-8) return;
     const forward = cameraForwardScratchRef.current;
     camera.getWorldDirection(forward);
@@ -4379,6 +4410,12 @@ export default function MurlanRoyaleArena({ search }) {
       controls.target.copy(target);
       controls.update();
       cameraLockedPositionRef.current.copy(camera.position);
+      cameraLockedBasePositionRef.current.copy(camera.position);
+      cameraOrbitSphericalRef.current = {
+        phi: cameraSpherical.phi,
+        phiMin: controls.minPolarAngle,
+        phiMax: controls.maxPolarAngle
+      };
       cameraDefaultTargetRef.current.copy(target);
       const lookVector = controls.target.clone().sub(camera.position);
       const targetDistance = Math.max(0.1, lookVector.length());


### PR DESCRIPTION
### Motivation
- Players requested the camera to gradually move inward toward the center of the table when they tilt the view upwards (portrait), matching the behavior used in the chess battle royale camera.

### Description
- Implemented a forward-push blend when the camera is tilted up by adding two tuning constants: `CAMERA_UP_TILT_FORWARD_BLEND` and `CAMERA_UP_TILT_FORWARD_LERP` in `MurlanRoyaleArena.jsx`.
- Added camera state refs `cameraLockedBasePositionRef`, `cameraOrbitSphericalRef`, and `cameraForwardOffsetScratchRef` and updated the camera lock logic so the locked camera position is interpolated toward a forward offset and slightly lifted Y based on an `upTiltRatio` derived from the orbit `phi` values.
- Store the base locked camera position and initial spherical `phi` bounds when the controls are created so the inward push is proportional to the initial orbit and remains smooth during user rotation.
- File modified: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (camera initialization and `enforceRotationOnlyCamera` logic updated).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (`vite build`) with the app bundle produced.
- Ran `npx eslint` which produced a repository-level ignore warning for this path but no blocking lint errors; there were no new errors introduced by the change.
- Started the dev server with `npm --prefix webapp run dev` and validated the change by loading the Murlan Royale page and capturing a screenshot using Playwright; the page loaded and the screenshot was produced (artifact `artifacts/murlan-camera-change.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13aa3d67483299a256c267d1f2c01)