### PR TITLE
Fix Snake & Ladder camera to rotate in place

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1609,9 +1609,10 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   const seatIndex = Math.trunc(rawSeatIndex);
   if (!Number.isFinite(seatIndex) || seatIndex < 0 || seatIndex >= anchors.length) return null;
   const startCameraState = board.startCameraState;
-  if (seatIndex === 0 && startCameraState?.position && startCameraState?.target) {
+  const fixedPosition = startCameraState?.position?.clone() ?? camera.position.clone();
+  if ((seatIndex === 0 || seatIndex === 2) && startCameraState?.target) {
     return {
-      position: startCameraState.position.clone(),
+      position: fixedPosition,
       target: startCameraState.target.clone()
     };
   }
@@ -1628,9 +1629,19 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
 
-  const position = camera.position.clone();
+  const position = fixedPosition;
 
   return { position, target };
+}
+
+function rotateCameraTargetHorizontally(camera, controls, angleDelta) {
+  if (!camera || !controls || !Number.isFinite(angleDelta) || Math.abs(angleDelta) < 1e-6) return;
+  const offset = controls.target.clone().sub(camera.position);
+  if (offset.lengthSq() < 1e-6) return;
+  offset.applyAxisAngle(WORLD_UP, angleDelta);
+  controls.target.copy(camera.position).add(offset);
+  camera.lookAt(controls.target);
+  controls.update();
 }
 
 function computeDiceCameraFocusState(board, camera) {
@@ -4052,7 +4063,6 @@ export default function SnakeBoard3D({
       startCameraState: arena.startCameraState ?? null
     };
 
-    const boardRotationRoot = board.rotationRoot || board.root;
     const dragState = {
       pointerId: null,
       lastX: 0,
@@ -4085,7 +4095,7 @@ export default function SnakeBoard3D({
 
       if (cameraViewModeRef.current === '2d') return;
       if (absX < 0.25) return;
-      boardRotationRoot.rotation.y += deltaX * BOARD_ROTATION_DRAG_SPEED;
+      rotateCameraTargetHorizontally(cameraRef.current, boardRef.current?.controls, -deltaX * BOARD_ROTATION_DRAG_SPEED);
     };
     const onPointerEnd = (event) => {
       if (dragState.pointerId !== event.pointerId) return;


### PR DESCRIPTION
### Motivation
- Player turns and manual left/right look should not translate the camera position; the camera must keep its startup coordinates and only change where it looks. 
- Top/bottom players (startup framing) must retain the exact initial camera framing when it is their turn. 
- Touch/drag horizontal input should rotate the view direction around the camera, not move the camera or board.

### Description
- Updated `computeTurnCameraFocusState` in `webapp/src/components/SnakeBoard3D.jsx` to use a fixed start position (`startCameraState.position`) for turn focus and to preserve the startup target for top/bottom seats (seat `0` and `2`).
- Replaced in-place board rotation on horizontal drag with a new helper `rotateCameraTargetHorizontally(camera, controls, angleDelta)` which rotates the `controls.target` around a fixed camera position without changing the camera coordinates. 
- Wired horizontal pointer drag to call `rotateCameraTargetHorizontally(...)` instead of mutating `board.rotationRoot`, so left/right gestures only change the look direction and do not translate the camera.

### Testing
- Ran unit tests with `npm test -- test/snakeGame.test.js --runInBand --forceExit` and the suite passed (all tests in `test/snakeGame.test.js` succeeded). 
- Started the web dev server with `npm --prefix webapp run dev` and validated the scene visually by capturing a mobile-portrait screenshot from the running app (screenshot saved during the run). 
- Ran `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx` but repository-wide lint configuration produced many preexisting issues and the target file is ignored by the linting config, so no per-file lint failure was introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13f731e7483299108147743403a62)