### PR TITLE
Keep Snake board camera position fixed while turning; rotate look target for left/right drag

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1628,9 +1628,20 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
 
-  const position = camera.position.clone();
+  const position = startCameraState?.position?.clone() ?? camera.position.clone();
 
   return { position, target };
+}
+
+function rotateCameraLookTarget(camera, controls, yawDelta) {
+  if (!camera || !controls || !Number.isFinite(yawDelta) || Math.abs(yawDelta) <= 1e-6) return;
+  const currentTarget = controls.target?.clone?.() ?? new THREE.Vector3();
+  const lookVector = currentTarget.sub(camera.position);
+  if (lookVector.lengthSq() <= 1e-6) return;
+  lookVector.applyAxisAngle(WORLD_UP, yawDelta);
+  controls.target.copy(camera.position.clone().add(lookVector));
+  camera.lookAt(controls.target);
+  controls.update();
 }
 
 function computeDiceCameraFocusState(board, camera) {
@@ -4085,7 +4096,7 @@ export default function SnakeBoard3D({
 
       if (cameraViewModeRef.current === '2d') return;
       if (absX < 0.25) return;
-      boardRotationRoot.rotation.y += deltaX * BOARD_ROTATION_DRAG_SPEED;
+      rotateCameraLookTarget(cameraRef.current, boardRef.current?.controls, deltaX * BOARD_ROTATION_DRAG_SPEED);
     };
     const onPointerEnd = (event) => {
       if (dragState.pointerId !== event.pointerId) return;


### PR DESCRIPTION
### Motivation
- Ensure the 3D camera does not translate its world position when focusing on the active player's turn, so top/bottom player turns preserve the initial camera coordinates.  
- Make horizontal user drags only yaw the camera view (look direction) instead of moving the camera or rotating the board, matching desired UX for left/right look.  

### Description
- Modified `computeTurnCameraFocusState` in `webapp/src/components/SnakeBoard3D.jsx` to use the game `startCameraState.position` (if available) as the fixed camera position when focusing on a player's seat, so only the look `target` changes.  
- Added a new helper `rotateCameraLookTarget(camera, controls, yawDelta)` that rotates the camera's look vector around `WORLD_UP` without translating the camera position.  
- Rewired horizontal drag handling to call `rotateCameraLookTarget(...)` instead of modifying `boardRotationRoot.rotation.y`, so left/right drags yaw the view only; vertical drag/tilt behavior remains unchanged.  

### Testing
- Ran production build with `npm run build` from the `webapp/` directory and the build completed successfully.  
- Started local dev server with `npm run dev` and captured a rendering screenshot to verify the scene loads after the change (screenshot captured from a 430x932 viewport).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13f731e7483299108147743403a62)