### PR TITLE
Adjust Air Hockey goals inward and add cushion openings with pocket nets

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1472,7 +1472,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       emissiveIntensity: 0.6
     });
     materialsRef.current.goal = goalMaterial;
-    const goalInsetTowardCenter = railThickness * 0.3;
+    const goalInsetTowardCenter = railThickness * 0.48;
     const northGoal = new THREE.Mesh(goalGeometry, goalMaterial);
     northGoal.position.set(0, 0.055 * SCALE_WIDTH, -PLAYFIELD.h / 2 - railThickness * 0.7 + goalInsetTowardCenter);
     tableGroup.add(northGoal);
@@ -1521,6 +1521,29 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         direction * (PLAYFIELD.h / 2 + railThickness * 0.78 - goalInsetTowardCenter)
       );
       tableGroup.add(net);
+
+      const cushionGap = new THREE.Mesh(
+        new THREE.BoxGeometry(PLAYFIELD.goalW * 1.04, 0.24 * SCALE_WIDTH, railThickness * 1.26),
+        goalCutoutMaterial
+      );
+      cushionGap.position.set(
+        0,
+        0.078 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.22 - goalInsetTowardCenter)
+      );
+      tableGroup.add(cushionGap);
+
+      const pocketNet = new THREE.Mesh(
+        new THREE.CylinderGeometry(PLAYFIELD.goalW * 0.44, PLAYFIELD.goalW * 0.36, 0.19 * SCALE_WIDTH, 24, 1, true),
+        goalNetMaterial
+      );
+      pocketNet.rotation.x = Math.PI / 2;
+      pocketNet.position.set(
+        0,
+        0.055 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.64 - goalInsetTowardCenter)
+      );
+      tableGroup.add(pocketNet);
     };
     createGoalMouth(-1);
     createGoalMouth(1);


### PR DESCRIPTION
### Motivation
- Improve goal placement so goals read slightly more inward on the portrait screen for clearer visual framing and gameplay feedback.
- Make the rail area at each goal visually open (like a pocket) rather than a continuous cushion to match the requested design intent.
- Replace a single flat net visual with a pocket-style net to better communicate a hollow goal mouth.

### Description
- Increased the inward inset applied to goals by changing `goalInsetTowardCenter` to pull goals closer to the table center in `AirHockey3D`.
- Added a dark cushion cutout mesh at each goal mouth so the cushions are visibly trimmed/open where the goals sit.
- Added cylindrical pocket-style net geometry behind each goal mouth (rotated and positioned to match the mouth) and reused existing net material for consistent shading.
- Modified file: `webapp/src/components/AirHockey3D.jsx` to implement the above geometry and positioning changes.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- Attempted automated visual verification via Playwright screenshots, but `Page.screenshot` timed out in this environment and screenshots could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b140f2ba748329b5120384f14ac2bc)