### PR TITLE
Adjust camera framing and hide leaderboard in landscape for Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1932,9 +1932,9 @@ const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INW
 const CHAIR_SEAT_INWARD_FACTOR = 0.92;
 const CHAIR_VISUAL_SCALE = 1.12 * 1.15;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.54, landscape: 0.6 });
-const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 0.98, landscape: 0.86 });
-const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.46, landscape: 0.54 });
+const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.08, landscape: 0.94 });
+const CAMERA_TARGET_LIFT = -0.02 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
@@ -3108,11 +3108,14 @@ export default function MurlanRoyaleArena({ search }) {
     const scoreboard = store.scoreboard;
     if (!scoreboard?.context || !scoreboard.texture || !scoreboard.mesh || !scoreboard.canvas) return;
     const { canvas, context, texture, mesh } = scoreboard;
+    const mount = mountRef.current;
+    const isLandscapeViewport =
+      Boolean(mount) && mount.clientWidth > mount.clientHeight;
     const { width, height } = canvas;
 
     context.clearRect(0, 0, width, height);
 
-    if (!entries?.length) {
+    if (!entries?.length || isLandscapeViewport) {
       mesh.visible = false;
       texture.needsUpdate = true;
       return;


### PR DESCRIPTION
### Motivation
- Improve Murlan Royale seating camera so the view is slightly higher, looks a bit more downwards, and appears closer to the table to match the requested visual framing.  
- Hide the in-arena leaderboard in landscape orientation because it is not needed on wide screens.

### Description
- Tuned seated camera constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by updating `CAMERA_SEATED_RETREAT_OFFSETS`, `CAMERA_SEATED_ELEVATION_OFFSETS`, and `CAMERA_TARGET_LIFT` to achieve a higher, slightly more downward, and slightly closer camera framing.  
- Changed the in-arena scoreboard rendering in `updateScoreboardDisplay` to detect viewport orientation using `mountRef` and suppress the scoreboard when the viewport is landscape (`mount.clientWidth > mount.clientHeight`).  
- All changes are contained in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed.  
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which completed but the file is currently ignored by the repo eslint patterns (warning reported).  
- Attempted an automated Playwright screenshot of the running `webapp` dev server, but the Chromium runner crashed (SIGSEGV) in this environment so a headless visual verification could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1407f05d083298c62f4ba688be910)