### PR TITLE
Adjust Murlan camera framing and hide landscape leaderboard

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1932,10 +1932,10 @@ const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INW
 const CHAIR_SEAT_INWARD_FACTOR = 0.92;
 const CHAIR_VISUAL_SCALE = 1.12 * 1.15;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0.08, landscape: 0.5 });
-const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.54, landscape: 0.6 });
-const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 0.98, landscape: 0.86 });
+const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.46, landscape: 0.54 });
+const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.06, landscape: 0.9 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
-const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
+const CAMERA_FOCUS_CENTER_LIFT = -0.2 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
@@ -3108,11 +3108,13 @@ export default function MurlanRoyaleArena({ search }) {
     const scoreboard = store.scoreboard;
     if (!scoreboard?.context || !scoreboard.texture || !scoreboard.mesh || !scoreboard.canvas) return;
     const { canvas, context, texture, mesh } = scoreboard;
+    const mount = mountRef.current;
+    const isLandscape = mount ? mount.clientWidth > mount.clientHeight : false;
     const { width, height } = canvas;
 
     context.clearRect(0, 0, width, height);
 
-    if (!entries?.length) {
+    if (!entries?.length || isLandscape) {
       mesh.visible = false;
       texture.needsUpdate = true;
       return;


### PR DESCRIPTION
### Motivation
- Improve portrait mobile framing for the Murlan Royale table so the camera appears slightly higher, closer to the table, and looks a bit more downward. 
- Remove the in-world leaderboard when the viewport is in landscape because it is unnecessary on wide screens.

### Description
- Tuned seated camera constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by changing `CAMERA_SEATED_RETREAT_OFFSETS`, `CAMERA_SEATED_ELEVATION_OFFSETS`, and `CAMERA_FOCUS_CENTER_LIFT` to adjust distance, elevation and aim. 
- Added a landscape check in `updateScoreboardDisplay` that reads `mountRef.current` and hides the in-world scoreboard (`mesh.visible = false`) when the viewport is landscape. 
- Committed the updated `MurlanRoyaleArena.jsx` with these changes.

### Testing
- Built the web app with `npm --prefix webapp run build` which completed successfully. 
- Ran lint on the file (`npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`) which executed but the file is ignored by repo lint settings (warning only). 
- Launched the dev server and captured a landscape screenshot of `/games/murlanroyale` via an automated Playwright script to validate camera and leaderboard behavior, which produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1407f05d083298c62f4ba688be910)