### PR TITLE
Align Snooker Royal table chassis and cameras with Pool Royale

### DIFF
--- a/webapp/src/config/snookerRoyalTables.js
+++ b/webapp/src/config/snookerRoyalTables.js
@@ -1,38 +1,38 @@
-const BASE_TABLE_SCALE = 1.46;
-const BASE_TABLE_MOBILE_SCALE = 1.52;
-const BASE_TABLE_COMPACT_SCALE = 1.36;
-const BASE_PLAYFIELD_WIDTH_MM = 3569; // official 12ft snooker playfield width
+const BASE_TABLE_SCALE = 1.44;
+const BASE_TABLE_MOBILE_SCALE = 1.44;
+const BASE_TABLE_COMPACT_SCALE = 1.44;
+const BASE_PLAYFIELD_WIDTH_MM = 2540; // keep Snooker Royal chassis matched to Pool Royale 9ft playfield width
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
   '12ft': {
     id: '12ft',
-    label: '12 ft (Championship)',
-    playfield: Object.freeze({ widthMm: 3569, heightMm: 1778 }), // official 12ft snooker playfield (11ft 8.5in x 5ft 10in)
+    label: '12 ft (Pool Royale Match)',
+    playfield: Object.freeze({ widthMm: 2540, heightMm: 1270 }), // Pool Royale 9ft chassis dimensions for parity
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
       corner: 114.3,
       side: 127
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
     scaleOverrides: Object.freeze({
       scale: 1.56,
-      mobileScale: 1.68,
+      mobileScale: 1.72,
       compactScale: 1.48
     })
   },
   '10ft': {
     id: '10ft',
-    label: '10 ft (Club)',
-    playfield: Object.freeze({ widthMm: 3048, heightMm: 1524 }), // official 10ft snooker playfield
+    label: '10 ft (Pool Royale Compact)',
+    playfield: Object.freeze({ widthMm: 2235, heightMm: 1118 }), // Pool Royale 8ft chassis dimensions for parity
     ballDiameterMm: 57.15,
     pocketMouthMm: Object.freeze({
-      corner: 114.3,
-      side: 127
+      corner: 171.45,
+      side: 152.4
     }),
-    cushionCutAngleDeg: 27,
-    sideCushionCutAngleDeg: 27,
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
     cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 })
   }
 });
@@ -52,7 +52,7 @@ function deriveMobileScale(baseScale, mobileScale = BASE_TABLE_MOBILE_SCALE) {
 
 function deriveCompactScale(baseScale, compactScale = BASE_TABLE_COMPACT_SCALE) {
   const scaled = baseScale * 0.94;
-  return Math.max(1.08, Math.min(compactScale, scaled));
+  return Math.max(1.1, Math.min(compactScale, scaled));
 }
 
 export const TABLE_SIZE_OPTIONS = Object.freeze(

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1414,7 +1414,7 @@ const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
 const POCKET_CAM_INWARD_SCALE = 0.82; // pull pocket cameras further inward for tighter framing
-const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_DIAMETER * 4.1; // push middle-pocket cameras farther toward the corner-side edges
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // match Pool Royale middle-pocket camera edge shift
 const POCKET_CAM_DISTANCE_PULL = BALL_DIAMETER * 7; // pull pocket cameras inward by ~7 balls (adds ~3 balls more)
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
@@ -1565,7 +1565,7 @@ const POCKET_SOUND_TAIL = 1;
 const LEG_SCALE = 6.2;
 const LEG_HEIGHT_FACTOR = 4;
 const LEG_HEIGHT_MULTIPLIER = 4.5;
-const BASE_TABLE_LIFT = 4.1;
+const BASE_TABLE_LIFT = 3.6;
 const TABLE_DROP = 0.4;
 const TABLE_HEIGHT_REDUCTION = 0.82;
 const TABLE_HEIGHT_SCALE = 1.56;
@@ -1575,9 +1575,9 @@ const TABLE_LIFT =
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;
 const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
-const LEG_ELEVATION_SCALE = 1.02; // extend the current leg length slightly so the playfield lifts higher
+const LEG_ELEVATION_SCALE = 0.96; // mirror Pool Royale leg extension so playfield height matches exactly
 const LEG_LENGTH_SHRINK = 0.867; // lengthen legs to extend the base downward with the taller table stance
-const BASE_HEIGHT_REDUCTION = 0.9; // shorten table bases by 10% so the bases rise with the lifted stance
+const BASE_HEIGHT_REDUCTION = 0.8; // mirror Pool Royale base reduction so rail-to-floor profile stays identical
 const LEG_LENGTH_SCALE =
   BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE * LEG_LENGTH_SHRINK * BASE_HEIGHT_REDUCTION;
 const LEG_HEIGHT_OFFSET = FRAME_TOP_Y - 0.3; // relationship between leg room and visible leg height
@@ -5014,7 +5014,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.95; // drop standing camera slightly lower while keeping a stable portrait read of the table
+const STANDING_VIEW_PHI = 0.92; // match Pool Royale standing camera tilt
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -5030,7 +5030,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.34; // bring standing camera slightly closer so table action reads larger on portrait screens
+const STANDING_VIEW_DISTANCE_SCALE = 0.36; // match Pool Royale standing camera distance
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5145,7 +5145,7 @@ const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
 );
-const CUE_VIEW_PHI_LIFT = 0.04; // lower cue camera a bit so aiming sits closer to table level
+const CUE_VIEW_PHI_LIFT = 0.06; // match Pool Royale cue-camera elevation
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,


### PR DESCRIPTION
### Motivation
- Achieve visual and physical parity between Snooker Royal and Pool Royale so Snooker uses the same table chassis footprint, rail/cushion heights and camera framing while retaining Snooker markings and gameplay rules.
- Keep ball, pocket, cushion and rail proportions consistent so cues, pockets and camera distances read identically across both modes for a seamless player experience.

### Description
- Updated physical table spec defaults in `webapp/src/config/snookerRoyalTables.js` to use Pool Royale–equivalent baseline scales/widths and pocket/cushion parameters, and tightened the compact-scale clamp.
- Adjusted Snooker scene constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to match Pool Royale baselines for vertical stance and framing: `BASE_TABLE_LIFT`, `LEG_ELEVATION_SCALE`, `BASE_HEIGHT_REDUCTION`, `STANDING_VIEW_PHI`, `STANDING_VIEW_DISTANCE_SCALE`, `CUE_VIEW_PHI_LIFT`, and `POCKET_CAM_SIDE_EDGE_SHIFT`.
- Changes preserve Snooker-specific markings and game logic while unifying chassis dimensions, rail heights, pocket/cushion sizing and camera distance/tilt to Pool Royale values.
- No external skill files were used for this change; edits were limited to the Snooker Royal configuration and scene constant files.

### Testing
- Built the web app with `npm run build` (from `webapp/`) and the production build completed successfully.
- Started a local dev server with `npm run dev` to validate runtime behavior and attempted an automated visual capture; the dev server launched successfully but Playwright screenshot attempts timed out while capturing the heavy WebGL scene. The app still built and served correctly.
- No unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14c873a0483298fa0926b8e40e91d)