### PR TITLE
Fix Pool Royale spin controller direction mapping

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -14,8 +14,8 @@ describe('Pool Royale spin controller mapping', () => {
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(1);
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(-1);
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(-1);
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(1);
   });
 
   it('keeps vertical spin aligned so topspin drives forward motion', () => {
@@ -24,10 +24,10 @@ describe('Pool Royale spin controller mapping', () => {
   });
 
   it('preserves diagonal quadrants while keeping vertical spin aligned', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: 1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: -1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: 1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: 1 });
   });
 
   it('scales spin strength with distance from center', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -189,7 +189,7 @@ export const mapSpinForPhysics = (spin, options = {}) => {
   const quantized = normalizeSpinInput(adjusted);
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
+    quantized.x,
     quantized.y,
     cameraRight,
     cameraUp,


### PR DESCRIPTION
### Motivation
- The spin controller horizontal axis was inverted relative to the visible cue-ball direction line, causing on-screen spin input to not match the cue direction guidance.

### Description
- Forward `x` sign to the cue-frame mapping in `mapSpinForPhysics` by removing the negation of `quantized.x` and update `test/poolRoyaleSpinController.test.js` expectations to match the corrected left/right and diagonal orientation.

### Testing
- Ran the unit tests with `npm test -- --runInBand test/poolRoyaleSpinController.test.js` and the spin controller test suite passed (5/5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b170be0e588329ab7785813278b17a)