### PR TITLE
Fix Pool Royale spin controller horizontal mapping to match cue direction line

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -14,8 +14,8 @@ describe('Pool Royale spin controller mapping', () => {
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(1);
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(-1);
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 0 })).x).toBe(-1);
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 0 })).x).toBe(1);
   });
 
   it('keeps vertical spin aligned so topspin drives forward motion', () => {
@@ -24,10 +24,10 @@ describe('Pool Royale spin controller mapping', () => {
   });
 
   it('preserves diagonal quadrants while keeping vertical spin aligned', () => {
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: 1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: -1, y: -1 });
-    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: 1, y: 1 });
-    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: -1 }))).toEqual({ x: -1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: -1 }))).toEqual({ x: 1, y: -1 });
+    expect(getSigns(mapSpinForPhysics({ x: -1, y: 1 }))).toEqual({ x: -1, y: 1 });
+    expect(getSigns(mapSpinForPhysics({ x: 1, y: 1 }))).toEqual({ x: 1, y: 1 });
   });
 
   it('scales spin strength with distance from center', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -189,7 +189,7 @@ export const mapSpinForPhysics = (spin, options = {}) => {
   const quantized = normalizeSpinInput(adjusted);
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
+    quantized.x,
     quantized.y,
     cameraRight,
     cameraUp,


### PR DESCRIPTION
### Motivation
- Players reported the spin controller's left/right feel did not match the cue-ball direction line, causing confusing aim feedback. 
- The change ensures the spin UI maps 1:1 to the cue frame so the visual cue line and applied spin are consistent for accurate aiming.

### Description
- Removed the horizontal inversion in `mapSpinForPhysics` by passing `quantized.x` (not `-quantized.x`) into `mapUiOffsetToCueFrame` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` so UI X maps directly to the cue-frame X. 
- Updated expectations in `test/poolRoyaleSpinController.test.js` to match the corrected left/right convention and diagonal quadrant assertions. 
- Vertical spin behavior (topspin/backspin) and quantization logic were left unchanged so back/top spin semantics remain intact.

### Testing
- Ran the targeted unit test with `npm test -- test/poolRoyaleSpinController.test.js --runInBand`, and all tests passed. 
- Attempted an automated Playwright screenshot against the running dev server to visually validate the controller, but the screenshot step timed out in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b170be0e588329ab7785813278b17a)