### PR TITLE
Fix Pool Royale spin controller directional responsiveness

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5820,7 +5820,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_VIEW_BLOCK_THRESHOLD = -0.18;
+const SPIN_VIEW_BLOCK_THRESHOLD = -1; // allow full 360° spin input so every controller side stays responsive
 
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
@@ -5852,36 +5852,12 @@ const computeCueViewVector = (cueBall, camera) => {
   return TMP_VEC2_VIEW.clone().normalize();
 };
 
-const clampSpinToVisibleHemisphere = (spinInput, aimDir, cueBall, camera) => {
-  if (!spinInput || !aimDir || !cueBall || !camera) return spinInput;
-  const viewVec = computeCueViewVector(cueBall, camera);
-  if (!viewVec) return spinInput;
-  const axes = prepareSpinAxes(aimDir);
-  TMP_VEC2_SPIN.set(0, 0);
-  TMP_VEC2_SPIN.addScaledVector(axes.perp, spinInput.x ?? 0);
-  TMP_VEC2_SPIN.addScaledVector(axes.axis, spinInput.y ?? 0);
-  if (TMP_VEC2_SPIN.lengthSq() < 1e-8) return spinInput;
-  TMP_VEC2_VIEW.set(viewVec.x, viewVec.y).normalize();
-  const viewDot = TMP_VEC2_SPIN.dot(TMP_VEC2_VIEW);
-  if (viewDot >= 0) return spinInput;
-  const dx = camera.position.x - cueBall.pos.x;
-  const dz = camera.position.z - cueBall.pos.y;
-  const planarDistance = Math.hypot(dx, dz);
-  const elevation = Math.atan2(camera.position.y ?? 0, Math.max(planarDistance, 1e-6));
-  const relax =
-    elevation <= 0
-      ? 0
-      : THREE.MathUtils.clamp(
-          (elevation - 0.35) / (0.75 - 0.35),
-          0,
-          1
-        );
-  TMP_VEC2_SPIN.addScaledVector(TMP_VEC2_VIEW, -viewDot * (1 - relax));
-  return {
-    x: TMP_VEC2_SPIN.dot(axes.perp),
-    y: TMP_VEC2_SPIN.dot(axes.axis)
-  };
+const clampSpinToVisibleHemisphere = (spinInput, _aimDir, _cueBall, _camera) => {
+  // Keep controller input 1:1 with the user's chosen strike direction on screen.
+  // Do not remap to the camera-facing hemisphere; it made some sides feel unresponsive.
+  return spinInput;
 };
+
 
 const resolveCameraBasis = (camera) => {
   if (!camera) return null;
@@ -31171,6 +31147,7 @@ const powerRef = useRef(hud.power);
     },
     []
   );
+
 
   // Spin controller interactions
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Players reported the spin controller feeling unresponsive or mismatched with the cue-ball direction line because input was being remapped to the camera-facing hemisphere and some directions were blocked.

### Description
- Stop remapping spin input to the camera-visible hemisphere by making the visible-hemisphere clamp a passthrough so controller input remains 1:1 with the user drag (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Relax the view-block threshold (`SPIN_VIEW_BLOCK_THRESHOLD`) so the spin controller can reach full 360° directional input while preserving existing cushion/ball blocking logic.

### Testing
- Started the local dev server with `npm --prefix webapp run dev` and Vite reported the app ready (dev server start succeeded).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed but produced a repository-ignore warning (no lint errors in-file).
- Attempted automated UI verification via Playwright to capture a screenshot, but the browser process crashed in the container (Chromium SIGSEGV) so screenshot validation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b170be0e588329ab7785813278b17a)