### PR TITLE
Pool Royale: match cue follow-through to spin on pull/release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5766,6 +5766,7 @@ const TMP_VEC3_CUE_SAMPLE_POINT = new THREE.Vector3();
 const TMP_VEC3_OBSTRUCTION_TARGET = new THREE.Vector3();
 const TMP_VEC3_POWER = new THREE.Vector3();
 const TMP_VEC3_IMPACT = new THREE.Vector3();
+const TMP_VEC3_FOLLOW_DIR = new THREE.Vector3();
 const TMP_COLOR_POWER = new THREE.Color();
 const POWER_LINE_COLOR_LOW = new THREE.Color(0xf9d648);
 const POWER_LINE_COLOR_MID = new THREE.Color(0xf59e0b);
@@ -25242,7 +25243,27 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
+          // Match the reference cue-stick behavior for spin:
+          // topspin adds a tiny forward follow-through after contact,
+          // while backspin keeps a clean stop at impact.
+          const topspinFactor = THREE.MathUtils.clamp(
+            Math.max(0, appliedSpin?.y ?? 0) * clampedPower,
+            0,
+            1
+          );
+          const followExtra = THREE.MathUtils.clamp(
+            topspinFactor * BALL_R * 0.32,
+            0,
+            BALL_R * 0.34
+          );
           const followPos = impactPos.clone();
+          if (followExtra > 1e-6) {
+            TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
+            if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
+              TMP_VEC3_FOLLOW_DIR.normalize();
+              followPos.addScaledVector(TMP_VEC3_FOLLOW_DIR, followExtra);
+            }
+          }
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =


### PR DESCRIPTION
### Motivation
- Make the in-game cue-stick behave like the reference: when a pull/release shot uses topspin the cue should micro follow-through past contact, while backspin/neutral shots should stop at impact.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to compute a topspin-aware micro follow-through when preparing the cue `followPos` for forward strokes by adding a small `followExtra` advance scaled by `appliedSpin.y` and `clampedPower`.
- Added a temporary vector `TMP_VEC3_FOLLOW_DIR` to compute and reuse the forward direction from `pullPos`→`impactPos` without per-frame allocations.
- Kept backspin/neutral behavior unchanged by only applying the micro follow-through when the computed `followExtra` is positive and non-zero.

### Testing
- Ran unit tests: `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, and the suite passed (4 tests, all green).
- Launched the dev server and attempted a Playwright screenshot to validate the visual cue behavior, but the screenshot step timed out in this environment (render attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b188fbc1308329bfed1ef5a96653ae)