### PR TITLE
Fix Pool Royale cue direction line with topspin and sidespin

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6912,12 +6912,31 @@ function applyRailImpulse(ball, impact) {
 
 function resolveSwerveAimDir(
   aimDir,
-  _spin,
-  _powerStrength,
-  _forceSwerve = false,
-  _liftStrength = 0
+  spin,
+  powerStrength,
+  forceSwerve = false,
+  liftStrength = 0
 ) {
-  return aimDir;
+  if (!aimDir) return aimDir;
+  const dir = aimDir.clone();
+  if (dir.lengthSq() < 1e-8) return aimDir;
+  dir.normalize();
+  const sideSpin = spin?.x ?? 0;
+  const topSpin = spin?.y ?? 0;
+  const sideWeight = Math.min(1, Math.abs(sideSpin));
+  const topWeight = Math.min(1, Math.max(0, topSpin));
+  const active = forceSwerve || sideWeight > 1e-4 || topWeight > 1e-4;
+  if (!active) return dir;
+  const power = THREE.MathUtils.clamp(powerStrength ?? 0, 0, 1);
+  const lift = Math.max(0, liftStrength ?? 0);
+  const sideDir = new THREE.Vector2(-dir.y, dir.x);
+  if (sideDir.lengthSq() > 1e-8) sideDir.normalize();
+  const sideDeflect = sideSpin * (0.035 + power * 0.05) * (1 + lift * 0.15);
+  const forwardBias = topSpin * (0.012 + power * 0.015);
+  dir.addScaledVector(sideDir, sideDeflect);
+  dir.addScaledVector(dir.clone(), forwardBias);
+  if (dir.lengthSq() > 1e-8) dir.normalize();
+  return dir;
 }
 
 function buildSwerveAimLinePoints(
@@ -6925,19 +6944,61 @@ function buildSwerveAimLinePoints(
   controlPoint,
   start,
   end,
-  _dir,
-  _perp,
-  _spin,
-  _powerStrength,
-  _swerveActive,
-  _liftStrength = 0
+  dir,
+  perp,
+  spin,
+  powerStrength,
+  swerveActive,
+  liftStrength = 0
 ) {
-  if (!points) return [start, end];
-  points.length = 2;
-  if (!points[0]) points[0] = new THREE.Vector3();
-  if (!points[1]) points[1] = new THREE.Vector3();
-  points[0].copy(start);
-  points[1].copy(end);
+  if (!points || !start || !end) return [start, end].filter(Boolean);
+  const travel = start.distanceTo(end);
+  const sideSpin = spin?.x ?? 0;
+  const topSpin = spin?.y ?? 0;
+  const power = THREE.MathUtils.clamp(powerStrength ?? 0, 0, 1);
+  const lift = Math.max(0, liftStrength ?? 0);
+  const sideStrength = Math.min(1, Math.abs(sideSpin));
+  const topStrength = Math.min(1, Math.max(0, topSpin));
+  const curveStrength =
+    sideStrength * (0.09 + power * 0.09) + topStrength * (0.015 + power * 0.025);
+  const shouldCurve = Boolean(swerveActive) || curveStrength > 1e-4;
+
+  const lineDir = dir && dir.lengthSq() > 1e-8
+    ? dir.clone().normalize()
+    : end.clone().sub(start).normalize();
+  const linePerp = perp && perp.lengthSq() > 1e-8
+    ? perp.clone().normalize()
+    : new THREE.Vector3(-lineDir.z, 0, lineDir.x).normalize();
+
+  if (!shouldCurve || !Number.isFinite(travel) || travel < 1e-4) {
+    points.length = 2;
+    if (!points[0]) points[0] = new THREE.Vector3();
+    if (!points[1]) points[1] = new THREE.Vector3();
+    points[0].copy(start);
+    points[1].copy(end);
+    return points;
+  }
+
+  const segmentCount = 14;
+  points.length = segmentCount + 1;
+  if (!controlPoint) controlPoint = new THREE.Vector3();
+  controlPoint
+    .copy(start)
+    .addScaledVector(lineDir, travel * (0.46 + topStrength * 0.06))
+    .addScaledVector(
+      linePerp,
+      travel * curveStrength * Math.sign(sideSpin || 1) * (1 + lift * 0.18)
+    );
+  for (let i = 0; i <= segmentCount; i += 1) {
+    if (!points[i]) points[i] = new THREE.Vector3();
+    const t = i / segmentCount;
+    const omt = 1 - t;
+    points[i]
+      .copy(start)
+      .multiplyScalar(omt * omt)
+      .add(controlPoint.clone().multiplyScalar(2 * omt * t))
+      .add(end.clone().multiplyScalar(t * t));
+  }
   return points;
 }
 


### PR DESCRIPTION
### Motivation
- The on-screen cue-ball direction guide did not reflect applied topspin and sidespin, and in some cases the guide would disappear; aim feedback must match physics to help player aiming.
- We need the pre-impact direction preview to bend in response to spin so the visual guide matches the shot trajectory and side-spin behavior.
- Provide robust fallbacks so the aim line is always rendered even when inputs are partially missing.

### Description
- Reimplemented `resolveSwerveAimDir` to accept `spin`, `powerStrength`, `forceSwerve`, and `liftStrength` and to compute a spin-aware pre-impact direction by applying side deflection and forward bias proportional to `sideSpin` and `topSpin` (with `power`/`lift` scaling). The function now returns a normalized preview direction instead of the unmodified `aimDir`.
- Reworked `buildSwerveAimLinePoints` to accept `dir`, `perp`, `spin`, `powerStrength`, `swerveActive`, and `liftStrength` and to produce a curved multi-point guide path when spin influence is present (Bezier-like control point based on travel, spin, and lift); it falls back to a straight two-point line when spin influence or travel is negligible.
- Added guardrails and input validation so the aim-line generator handles missing/degenerate `points`, `start`, `end`, and direction inputs gracefully, ensuring the cue direction line remains available in edge cases.

### Testing
- Built the web frontend with `npm --prefix webapp run build` and the production build completed successfully (vite build succeeded). ✅
- Formatted and validated source formatting with `npx prettier --check` (fixed with `--write` then re-check) and the file now conforms to Prettier. ✅
- Ran a visual smoke test by launching the dev server (`npm --prefix webapp run dev`) and capturing a portrait screenshot via Playwright to verify the updated aim visuals rendered without errors. ✅
- Note: `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` reported the file is ignored by project ESLint settings so it could not be validated by the repo lint config; this is informational and not a runtime failure. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18f49904c8329a7687ab1b9de68a4)