### PR TITLE
Fix cue-ball direction preview for topspin and sidespin in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -7070,7 +7070,8 @@ function resolveCueFollowPreview({
     (0.18 + impactPower * 0.22) *
     (1 - cutPenalty * 0.3);
   if (sideInfluence > 1e-4) {
-    const perp = new THREE.Vector3(-previewDir.z, 0, previewDir.x);
+    const sideBasis = aimVec.lengthSq() > 1e-8 ? aimVec : previewDir;
+    const perp = new THREE.Vector3(-sideBasis.z, 0, sideBasis.x);
     if (perp.lengthSq() > 1e-8) {
       perp.normalize();
       previewDir.add(perp.multiplyScalar(spinX * sideInfluence));
@@ -29032,10 +29033,15 @@ const powerRef = useRef(hud.power);
             cuePowerStrength,
             liftStrength
           });
-          const followEnd = end
+          const cueFollowStart = end
+            .clone()
+            .add(cueFollowPreview.dir.clone().multiplyScalar(BALL_R * 0.08));
+          const followEnd = cueFollowStart
             .clone()
             .add(cueFollowPreview.dir.clone().multiplyScalar(cueFollowPreview.length));
-          cueAfterGeom.setFromPoints([end, followEnd]);
+          cueFollowStart.y = BALL_CENTER_Y + BALL_R * 0.02;
+          followEnd.y = cueFollowStart.y;
+          cueAfterGeom.setFromPoints([cueFollowStart, followEnd]);
           cueAfter.visible = true;
           cueAfterPower.material.color.copy(resolvePowerLineColor(cuePowerStrength));
           cueAfterPower.material.opacity = 0.35 + 0.45 * cuePowerStrength;
@@ -29338,15 +29344,20 @@ const powerRef = useRef(hud.power);
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
             aimDir: baseDir,
-            spin: aimPreviewSpin,
+            spin: mapSpinForPhysics(remoteSpinNormalized),
             powerStrength,
             cuePowerStrength,
             liftStrength: 0
           });
-          const followEnd = end
+          const cueFollowStart = end
+            .clone()
+            .add(cueFollowPreview.dir.clone().multiplyScalar(BALL_R * 0.08));
+          const followEnd = cueFollowStart
             .clone()
             .add(cueFollowPreview.dir.clone().multiplyScalar(cueFollowPreview.length));
-          cueAfterGeom.setFromPoints([end, followEnd]);
+          cueFollowStart.y = BALL_CENTER_Y + BALL_R * 0.02;
+          followEnd.y = cueFollowStart.y;
+          cueAfterGeom.setFromPoints([cueFollowStart, followEnd]);
           cueAfter.visible = true;
           cueAfterPower.material.color.copy(resolvePowerLineColor(cuePowerStrength));
           cueAfterPower.material.opacity = 0.35 + 0.45 * cuePowerStrength;


### PR DESCRIPTION
### Motivation
- Improve accuracy and visibility of the cue-ball follow/direction preview when top/follow spin and side spin are applied so the visual guide matches actual ball behaviour. 
- Remote/online previews used a different spin mapping than gameplay physics, causing mismatched direction lines in some cases. 
- Small aim-line segments were sometimes hidden near the impact point, so the preview line must be nudged to remain visible.

### Description
- Use the aiming vector as the stable side-spin basis in `resolveCueFollowPreview` so lateral deflection is computed from `aimVec` when available instead of from the preview direction. 
- Offset the cue-follow preview start slightly forward and lift it a small amount, and set the follow line endpoints at a consistent height so the cue-after line remains visible near impact points. 
- Map remote/online preview spin through `mapSpinForPhysics(...)` when building the remote `cueFollowPreview` so remote previews use the same spin-to-physics conversion as local gameplay. 
- Changes applied to `webapp/src/pages/Games/PoolRoyale.jsx` (small, focused edits to preview and geometry setup logic).

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which returned repository ignore warning but no errors. 
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and it started successfully. 
- Captured a Playwright screenshot of the running app (screenshot artifact generated) to exercise the updated aim/preview rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18f49904c8329a7687ab1b9de68a4)