### PR TITLE
Fix cue-follow preview so topspin and side-spin steer the direction line

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5248,6 +5248,32 @@ const REPLAY_CAMERA_SWITCH_THRESHOLD = BALL_R * 0.35;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const signed = (value, fallback = 1) =>
   value > 0 ? 1 : value < 0 ? -1 : fallback;
+const resolveCueFollowDirection = ({ cueFollowDir, baseDir, perp, physicsSpin }) => {
+  const resolved = cueFollowDir.clone();
+  const spinY = physicsSpin?.y || 0;
+  const spinX = physicsSpin?.x || 0;
+  if (spinY >= -1e-6) {
+    const topSpinWeight = Math.max(0, spinY) * AIM_SPIN_PREVIEW_FORWARD;
+    const sideSpinWeight = spinX * AIM_SPIN_PREVIEW_SIDE;
+    if (topSpinWeight > 1e-8) {
+      resolved.add(baseDir.clone().multiplyScalar(topSpinWeight));
+    }
+    if (Math.abs(sideSpinWeight) > 1e-8) {
+      resolved.add(perp.clone().multiplyScalar(sideSpinWeight));
+    }
+  }
+  const backSpinWeight = Math.max(0, -spinY);
+  if (backSpinWeight > 1e-8) {
+    const drawLerp = Math.min(1, backSpinWeight * BACKSPIN_DIRECTION_PREVIEW);
+    const drawDir = baseDir.clone().negate();
+    resolved.lerp(drawDir, drawLerp);
+  }
+  if (resolved.lengthSq() > 1e-8) {
+    resolved.normalize();
+    return resolved;
+  }
+  return baseDir.clone();
+};
 const resolveShortRailBroadcastDirection = ({
   pocketCenter = null,
   approachDir = null,
@@ -24682,17 +24708,13 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : dir.clone();
-          const cueFollowDirSpinAdjusted = cueFollowDir.clone();
+          const cueFollowDirSpinAdjusted = resolveCueFollowDirection({
+            cueFollowDir,
+            baseDir: dir,
+            perp,
+            physicsSpin
+          });
           const spinVerticalInfluence = (physicsSpin.y || 0) * 0.68;
-          const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
-          if (backSpinWeight > 1e-8) {
-            const drawLerp = Math.min(1, backSpinWeight * BACKSPIN_DIRECTION_PREVIEW);
-            const drawDir = dir.clone().negate();
-            cueFollowDirSpinAdjusted.lerp(drawDir, drawLerp);
-            if (cueFollowDirSpinAdjusted.lengthSq() > 1e-8) {
-              cueFollowDirSpinAdjusted.normalize();
-            }
-          }
           const cueFollowLength =
             BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
           const followEnd = end
@@ -24939,17 +24961,13 @@ const powerRef = useRef(hud.power);
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
             : baseDir.clone();
-          const cueFollowDirSpinAdjusted = cueFollowDir.clone();
+          const cueFollowDirSpinAdjusted = resolveCueFollowDirection({
+            cueFollowDir,
+            baseDir,
+            perp,
+            physicsSpin: remotePhysicsSpin
+          });
           const spinVerticalInfluence = (remotePhysicsSpin.y || 0) * 0.68;
-          const backSpinWeight = Math.max(0, -(remotePhysicsSpin.y || 0));
-          if (backSpinWeight > 1e-8) {
-            const drawLerp = Math.min(1, backSpinWeight * BACKSPIN_DIRECTION_PREVIEW);
-            const drawDir = baseDir.clone().negate();
-            cueFollowDirSpinAdjusted.lerp(drawDir, drawLerp);
-            if (cueFollowDirSpinAdjusted.lengthSq() > 1e-8) {
-              cueFollowDirSpinAdjusted.normalize();
-            }
-          }
           const cueFollowLength =
             BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
           const followEnd = end


### PR DESCRIPTION
### Motivation
- The cue-ball follow/preview line did not reflect topspin (follow) and lateral side-spin correctly while backspin behavior was already working, causing the visual aim guide to mislead players.
- Provide a single, consistent calculation so both local and remote previews match the intended on-screen cue-ball roll and drift behavior.

### Description
- Added a shared helper `resolveCueFollowDirection` in `webapp/src/pages/Games/SnookerRoyal.jsx` that composes forward and lateral contributions from spin and preserves draw/backspin handling. 
- Replaced duplicated ad-hoc cue-follow adjustments in the local player aim preview and the remote/player-replicated preview to use `resolveCueFollowDirection`. 
- The helper uses existing tuning constants (`AIM_SPIN_PREVIEW_FORWARD`, `AIM_SPIN_PREVIEW_SIDE`, and `BACKSPIN_DIRECTION_PREVIEW`) so weights and existing backspin preview behavior remain consistent. 
- Small cleanup: removed the old inline backspin lerp logic where replaced with the shared resolver to keep behavior unified.

### Testing
- Ran the unit test `test/poolRoyaleSpinController.test.js` with `npm test -- test/poolRoyaleSpinController.test.js --runInBand`, and the suite passed (5 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a78035c883298f123154804437b6)