### PR TITLE
Align topspin cue-follow preview with physics spin mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -29028,7 +29028,7 @@ const powerRef = useRef(hud.power);
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
             aimDir: dir,
-            spin: aimPreviewSpin,
+            spin: physicsSpin,
             powerStrength,
             cuePowerStrength,
             liftStrength


### PR DESCRIPTION
### Motivation
- The cue-ball follow/aim preview line showed incorrect direction for topspin; the visual preview must use the same cue-frame spin mapping as physics so topspin follow-lines match actual in-game behavior.

### Description
- Use `physicsSpin` (the result of `mapSpinForPhysics`) when calling `resolveCueFollowPreview` instead of the UI-only `aimPreviewSpin` in `webapp/src/pages/Games/PoolRoyale.jsx` so the cue-follow preview reflects the physics spin mapping.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleSpinController.test.js test/poolRoyaleCueStrokeTimeline.test.js` and both test suites passed (2 suites, 9 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a78035c883298f123154804437b6)