### PR TITLE
Make cue-ball default roll forward and adjust topspin baseline

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -9,8 +9,12 @@ describe('Pool Royale spin controller mapping', () => {
   it('maps the center to a slight stun bias with minimal roll', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(center.y).toBeLessThanOrEqual(0);
     expect(center.y).toBeGreaterThanOrEqual(STUN_TOPSPIN_BIAS);
+  });
+
+  it('adds baseline forward roll to low top/back spin inputs', () => {
+    expect(mapSpinForPhysics({ x: 0, y: -0.05 }).y).toBeGreaterThan(-0.05);
+    expect(mapSpinForPhysics({ x: 0, y: 0.05 }).y).toBeGreaterThan(0.05);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.012;
+export const STUN_TOPSPIN_BIAS = 0.012;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -143,9 +143,9 @@ export const normalizeSpinInput = (spin) => {
   const distance = Math.hypot(x, y);
   if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
     if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
-      return { x: 0, y: 0 };
+      return { x: 0, y: STUN_TOPSPIN_BIAS };
     }
-    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
+    return { x: 0, y: clamp(y + STUN_TOPSPIN_BIAS, -MAX_SPIN_OFFSET, MAX_SPIN_OFFSET) };
   }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };


### PR DESCRIPTION
### Motivation
- Ensure the cue ball's low-magnitude spin behavior matches the aim/direction line by giving neutral hits a slight forward roll and making applied topspin increase forward roll. 
- Improve player feel so the cue ball naturally rolls forward by default and responds more strongly when topspin is used.

### Description
- Flipped the stun/topspin bias constant by changing `STUN_TOPSPIN_BIAS` from `-0.012` to `0.012` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Updated `normalizeSpinInput` so center/deadzone inputs return a small forward bias (`{ x: 0, y: STUN_TOPSPIN_BIAS }`) and near-center `y` values are offset by the bias then clamped to `MAX_SPIN_OFFSET` instead of returning zero or a sign-multiplied negative value.
- Added a test asserting low-magnitude top/back spin inputs are biased forward and adjusted the existing center test expectation in `test/poolRoyaleSpinController.test.js`.

### Testing
- Ran `npm test -- test/poolRoyaleSpinController.test.js --runInBand` and observed all tests in that suite pass.
- Test output: 1 test suite passed, 6 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b1c9a134832995778b0d233f89a8)