### PR TITLE
Align player hands, stack community cards, and unify card back texture in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1257,6 +1257,7 @@ async function loadCharacterModel(theme, renderer = null) {
 }
 
 function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme = CARD_THEMES[0], playerColor = '#1d4ed8' } = {}) {
+  void playerColor;
   const cardsGroup = new THREE.Group();
   const handCards = Array.isArray(handCardsInput) && handCardsInput.length
     ? handCardsInput.slice(0, 5)
@@ -1285,7 +1286,8 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     });
     const backMaterial = new THREE.MeshStandardMaterial({
       map: backTexture,
-      color: new THREE.Color(idx === safeCount - 1 ? playerColor : cardTheme?.backColor || '#1d4ed8'),
+      // Keep this identical to the Lucky Card logo back (no per-player tinting).
+      color: new THREE.Color('#ffffff'),
       roughness: 0.6,
       metalness: 0.15
     });
@@ -1956,15 +1958,11 @@ const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
 const COMMUNITY_CARD_TOP_TILT = 0;
 const COMMUNITY_CARD_SCALE = 1.08;
-const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
-const COMMUNITY_CARD_MAX_SPREAD = COMMUNITY_CARD_SPACING * 12;
 const COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET = Math.sin(COMMUNITY_CARD_TOP_TILT) * CARD_H * 0.5;
-const COMMUNITY_CARD_FAN_ARC_LIFT = 0;
 const COMMUNITY_CARD_CLOSER_TO_HUMAN = 0;
 const COMMUNITY_CARD_BOTTOM_SHIFT_Y = 0.012 * MODEL_SCALE;
 const COMMUNITY_CARD_LEFT_SHIFT = 0;
 const COMMUNITY_CARD_DIRECTIONAL_LIFT = 0;
-const COMMUNITY_CARD_SIDE_ORIENTATION_YAW = 0;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
@@ -3253,11 +3251,11 @@ export default function MurlanRoyaleArena({ search }) {
         const humanLineOffset = cards.length > 1
           ? -spread / 2 + (cardIdx / Math.max(cards.length - 1, 1)) * spread
           : 0;
-        const lateral = isHumanCard ? humanLineOffset : (cards.length > 1 ? (centeredOffset * spread) / Math.max(cards.length - 1, 1) : 0);
+        const lateral = humanLineOffset;
         const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
         const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
         const fanDirection = isHumanCard ? HUMAN_HAND_FAN_DIRECTION : 1;
-        const fanYaw = isHumanCard && HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
+        const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
         const lateralAxis = right;
@@ -3301,13 +3299,6 @@ export default function MurlanRoyaleArena({ search }) {
     const tableAnchor = three.tableAnchor.clone();
     const tableCount = state.tableCards.length;
     const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
-    const bottomCardSpacing = Math.max(humanSeat?.spacing ?? 0, COMMUNITY_CARD_SPACING);
-    const bottomCardMaxSpread = Math.max(humanSeat?.maxSpread ?? 0, COMMUNITY_CARD_MAX_SPREAD);
-    const tableSpread = tableCount > 1
-      ? Math.min((tableCount - 1) * bottomCardSpacing, bottomCardMaxSpread)
-      : 0;
-    const tableSpacing = tableCount > 1 ? tableSpread / (tableCount - 1) : 0;
-    const tableStartX = tableCount > 1 ? -tableSpread / 2 : 0;
     const tableLookBase = tableAnchor.clone().setY(tableAnchor.y + 0.28 * MODEL_SCALE);
     if (humanSeat?.forward) {
       tableAnchor.addScaledVector(humanSeat.forward, COMMUNITY_CARD_CLOSER_TO_HUMAN);
@@ -3324,20 +3315,24 @@ export default function MurlanRoyaleArena({ search }) {
       updateCardFace(mesh, 'front');
       setCommunityCardLegibility(mesh, true);
       const target = tableAnchor.clone();
-      const { normalizedOffset } = calcFanCardPose(tableCount, idx);
-      const communityFanYaw = normalizedOffset * COMMUNITY_CARD_SIDE_ORIENTATION_YAW;
-      const lateralOffset = tableStartX + idx * tableSpacing;
+      const pileDepthOffset = idx * CARD_D * 0.82;
+      const pileLiftOffset = idx * 0.0012;
       if (humanSeat?.right) {
-        target.addScaledVector(humanSeat.right, lateralOffset + COMMUNITY_CARD_LEFT_SHIFT);
+        target.addScaledVector(humanSeat.right, COMMUNITY_CARD_LEFT_SHIFT);
       } else {
-        target.x += lateralOffset + COMMUNITY_CARD_LEFT_SHIFT;
+        target.x += COMMUNITY_CARD_LEFT_SHIFT;
       }
-      target.y += 0.075 * MODEL_SCALE + COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET + COMMUNITY_CARD_FAN_ARC_LIFT + COMMUNITY_CARD_BOTTOM_SHIFT_Y + COMMUNITY_CARD_DIRECTIONAL_LIFT;
+      if (humanSeat?.forward) {
+        target.addScaledVector(humanSeat.forward, pileDepthOffset);
+      } else {
+        target.z += pileDepthOffset;
+      }
+      target.y += 0.075 * MODEL_SCALE + COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET + COMMUNITY_CARD_BOTTOM_SHIFT_Y + COMMUNITY_CARD_DIRECTIONAL_LIFT + pileLiftOffset;
       setMeshPosition(
         mesh,
         target,
         communityLookTarget,
-        { face: 'front', flat: true, flatTiltX: COMMUNITY_CARD_TOP_TILT, flatYawY: communityFanYaw },
+        { face: 'front', flat: true, flatTiltX: COMMUNITY_CARD_TOP_TILT, flatYawY: 0 },
         immediate,
         three.animations
       );


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale card presentation consistent with the other games: left/right player hands should share the same horizontal layout and orientation as top/bottom seats, community cards should sit in a single pile like Texas Hold’em, and the back of every card must use the identical Lucky Card/logo-backed texture with no per-player tinting.

### Description
- Updated `createCharacterCards` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to remove per-player tinting from the back material so card backs render using the exact Lucky Card/logo texture (`backMaterial.color` set to `#ffffff` and kept texture-driven).
- Aligned left/right player hand layout to use the same straight horizontal line logic as bottom/top hands by using the same lateral offset math (`lateral = humanLineOffset`) and simplified yaw selection (`HUMAN_HAND_UNIFORM_YAW_FROM_LEFT` usage).
- Reworked community/table card placement from a fanned/spread row into a single stacked pile by removing the spread computation and instead layering cards at the table anchor with small depth/lift offsets (`pileDepthOffset` and `pileLiftOffset`) while keeping cards flat and front-facing for legibility.
- Small cleanup to avoid an unused `playerColor` warning (added `void playerColor;`) and removed a few now-unused community spacing constants to simplify the scene logic.

### Testing
- Ran lint checks with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` and `npm run lint -- --no-warn-ignored webapp/src/pages/Games/MurlanRoyaleArena.jsx`; no code errors were reported (file-level ignore/warning present).
- Attempted an automated visual smoke test via Playwright to capture a screenshot of `/games/murlanroyale`, but Chromium crashed during launch in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b67159dc832990356d3534857d22)