### PR TITLE
Improve Pool Royale spin controller realism

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -36,4 +36,23 @@ describe('Pool Royale spin controller mapping', () => {
     expect(inner).toBeGreaterThan(0);
     expect(outer).toBeGreaterThan(inner);
   });
+
+  it('applies softer spin close to center and stronger spin near cue-tip edge', () => {
+    const nearCenter = mapSpinForPhysics({ x: 0.2, y: 0.2 });
+    const mid = mapSpinForPhysics({ x: 0.5, y: 0.5 });
+    const edge = mapSpinForPhysics({ x: 0.75, y: 0.75 });
+    const nearMag = Math.hypot(nearCenter.x, nearCenter.y);
+    const midMag = Math.hypot(mid.x, mid.y);
+    const edgeMag = Math.hypot(edge.x, edge.y);
+    expect(midMag).toBeGreaterThan(nearMag * 1.6);
+    expect(edgeMag).toBeGreaterThan(midMag * 1.05);
+  });
+
+  it('couples side and vertical spin like a real cue-tip strike', () => {
+    const pureSide = mapSpinForPhysics({ x: 0.75, y: 0 });
+    const mixed = mapSpinForPhysics({ x: 0.75, y: 0.75 });
+    const pureTop = mapSpinForPhysics({ x: 0, y: 0.75 });
+    expect(Math.abs(mixed.x)).toBeLessThan(Math.abs(pureSide.x));
+    expect(Math.abs(mixed.y)).toBeLessThan(Math.abs(pureTop.y));
+  });
 });

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,6 +11,12 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = -0.012;
+const SPIN_RESPONSE_GAMMA = 1.35;
+const SIDE_SPIN_POWER = 1.08;
+const TOP_BACK_POWER = 1.15;
+const SIDE_TO_FORWARD_LOSS = 0.22;
+const VERTICAL_TO_SIDE_LOSS = 0.18;
+const BACKSPIN_SIDE_DRAG = 0.12;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -187,10 +193,38 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  const magnitude = Math.hypot(quantized.x, quantized.y);
+  if (magnitude <= 1e-6) {
+    return { x: 0, y: 0 };
+  }
+
+  // Real cue-tip strikes are non-linear: small offsets around center produce much
+  // softer spin while edge strikes accelerate quickly toward maximum rpm.
+  const normalizedMagnitude = clamp(magnitude / MAX_SPIN_OFFSET, 0, 1);
+  const responseMagnitude = Math.pow(normalizedMagnitude, SPIN_RESPONSE_GAMMA);
+  const scaled = {
+    x: (quantized.x / magnitude) * responseMagnitude * MAX_SPIN_OFFSET,
+    y: (quantized.y / magnitude) * responseMagnitude * MAX_SPIN_OFFSET
+  };
+
+  const sideBase = Math.sign(scaled.x) * Math.pow(Math.abs(scaled.x), SIDE_SPIN_POWER);
+  const forwardBase = Math.sign(scaled.y) * Math.pow(Math.abs(scaled.y), TOP_BACK_POWER);
+  const sidePenalty = clamp(1 - Math.abs(forwardBase) * VERTICAL_TO_SIDE_LOSS, 0.72, 1);
+  const forwardPenalty = clamp(1 - Math.abs(sideBase) * SIDE_TO_FORWARD_LOSS, 0.68, 1);
+
+  // Backspin carries a little extra cloth drag that weakens side-spin retention.
+  const backspinDrag = scaled.y < 0
+    ? clamp(1 - Math.abs(scaled.y) * BACKSPIN_SIDE_DRAG, 0.78, 1)
+    : 1;
+
+  const realisticOffset = {
+    x: sideBase * sidePenalty * backspinDrag,
+    y: forwardBase * forwardPenalty
+  };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
-    quantized.y,
+    -realisticOffset.x,
+    realisticOffset.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Replace the previous near-linear spin mapping with a more realistic cue-tip response so on-screen spin directions remain familiar while ball behavior matches real-life follow/draw/english interactions.

### Description
- Added a non-linear response curve and tuning constants (`SPIN_RESPONSE_GAMMA`, `SIDE_SPIN_POWER`, `TOP_BACK_POWER`, etc.) to `mapSpinForPhysics` to make spin magnitude grow softly near center and faster toward the cue-tip edge in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Introduced coupling between side and forward/backspin so mixed strikes reduce each component appropriately and applied a small backspin side-drag to model cloth interaction and side-spin loss.
- Kept user-facing direction mapping intact by converting the computed realistic offsets through the existing `mapUiOffsetToCueFrame` path so existing previews and axis conventions remain unchanged.
- Expanded `test/poolRoyaleSpinController.test.js` with unit checks for non-linear magnitude growth and mixed-spin coupling while preserving existing directional assertions.

### Testing
- Ran the focused unit suite with `npm test -- test/poolRoyaleSpinController.test.js --runInBand` and all tests passed (`7` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24296e9608329958d8dd207baf966)