### PR TITLE
Improve Pool Royale spin controller with realistic cue-ball spin response

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -36,4 +36,22 @@ describe('Pool Royale spin controller mapping', () => {
     expect(inner).toBeGreaterThan(0);
     expect(outer).toBeGreaterThan(inner);
   });
+
+  it('applies progressive spin response so outer hits gain more effective spin', () => {
+    const nearCenter = mapSpinForPhysics({ x: 0, y: 0.35 });
+    const mid = mapSpinForPhysics({ x: 0, y: 0.6 });
+    const outer = mapSpinForPhysics({ x: 0, y: 1 });
+    const nearMag = Math.abs(nearCenter.y);
+    const midMag = Math.abs(mid.y);
+    const outerMag = Math.abs(outer.y);
+    expect(midMag - nearMag).toBeGreaterThan(0.1);
+    expect(outerMag - midMag).toBeGreaterThan(0.12);
+  });
+
+  it('reduces side-spin efficiency when strong top/back spin is also requested', () => {
+    const pureSide = Math.abs(mapSpinForPhysics({ x: 1, y: 0 }).x);
+    const mixedSide = Math.abs(mapSpinForPhysics({ x: 1, y: 1 }).x);
+    expect(mixedSide).toBeLessThan(pureSide);
+  });
+
 });

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,6 +11,10 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const STUN_TOPSPIN_BIAS = -0.012;
+const REALISTIC_SPIN_CURVE = 1.35;
+const REALISTIC_SPIN_BLEND = 0.82;
+const REALISTIC_SIDE_REDUCTION_BY_VERTICAL = 0.3;
+const REALISTIC_VERTICAL_REDUCTION_BY_SIDE = 0.12;
 
 export const SPIN_DIRECTIONS = [
   {
@@ -187,10 +191,27 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  const magnitude = clamp(Math.hypot(quantized.x, quantized.y), 0, MAX_SPIN_OFFSET);
+  const normalizedMagnitude = magnitude / Math.max(MAX_SPIN_OFFSET, 1e-6);
+  const curvedMagnitude = Math.pow(normalizedMagnitude, REALISTIC_SPIN_CURVE);
+  const blendedMagnitude =
+    normalizedMagnitude * (1 - REALISTIC_SPIN_BLEND) + curvedMagnitude * REALISTIC_SPIN_BLEND;
+  const scale =
+    magnitude > 1e-6 ? (blendedMagnitude * MAX_SPIN_OFFSET) / magnitude : 0;
+  const shaped = {
+    x: quantized.x * scale,
+    y: quantized.y * scale
+  };
+  const verticalCoupling = 1 - REALISTIC_SIDE_REDUCTION_BY_VERTICAL * Math.abs(shaped.y) / MAX_SPIN_OFFSET;
+  const lateralCoupling = 1 - REALISTIC_VERTICAL_REDUCTION_BY_SIDE * Math.abs(shaped.x) / MAX_SPIN_OFFSET;
+  const realistic = {
+    x: shaped.x * clamp(verticalCoupling, 0.6, 1),
+    y: shaped.y * clamp(lateralCoupling, 0.75, 1)
+  };
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
-    quantized.y,
+    -realistic.x,
+    realistic.y,
     cameraRight,
     cameraUp,
     cueForward


### PR DESCRIPTION
### Motivation
- Improve the cue-ball spin mapping so the on-table behavior matches real-world expectations (stronger effect toward tip edge and trade-offs between vertical and side spin) while preserving the current directional semantics. 

### Description
- Replaced the direct mapping stage inside `mapSpinForPhysics` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` with a shaped mapping that applies a non-linear curve (`REALISTIC_SPIN_CURVE`) and blended magnitude (`REALISTIC_SPIN_BLEND`).
- Added cross-axis coupling that reduces side-spin efficiency when strong vertical spin is present and slightly reduces vertical effectiveness when strong side spin is present (`REALISTIC_SIDE_REDUCTION_BY_VERTICAL` / `REALISTIC_VERTICAL_REDUCTION_BY_SIDE`).
- Kept the existing UI→cue-frame mapping and preserved left/right and top/back directional behavior by returning results through `mapUiOffsetToCueFrame`.
- Extended `test/poolRoyaleSpinController.test.js` to assert progressive (non-linear) spin growth from center-to-edge and mixed-spin coupling behavior.

### Testing
- Ran the focused test suite with `npm test -- test/poolRoyaleSpinController.test.js --runInBand` and all tests passed (7 tests, 1 suite).
- Verified the updated files: `webapp/src/pages/Games/poolRoyaleSpinUtils.js` and `test/poolRoyaleSpinController.test.js` were updated and exercised by the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24296e9608329958d8dd207baf966)