### PR TITLE
Fix Pool Royale center stun behavior so topspin rolls forward

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -6,11 +6,23 @@ const getSigns = (vec) => ({
 });
 
 describe('Pool Royale spin controller mapping', () => {
-  it('maps the center to a slight stun bias with minimal roll', () => {
+  it('maps the exact center to a true stun hit with zero spin', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(center.y).toBeLessThanOrEqual(0);
-    expect(center.y).toBeGreaterThanOrEqual(STUN_TOPSPIN_BIAS);
+    expect(center.y).toBe(0);
+  });
+
+  it('ramps small offsets from center instead of forcing stun bias on topspin requests', () => {
+    const smallTop = mapSpinForPhysics({ x: 0, y: 0.05 });
+    const strongerTop = mapSpinForPhysics({ x: 0, y: 0.1 });
+    expect(smallTop.y).toBeGreaterThan(0);
+    expect(strongerTop.y).toBeGreaterThan(smallTop.y);
+  });
+
+  it('applies stun bias only on near-horizontal center-line strikes', () => {
+    const nearCenterSide = mapSpinForPhysics({ x: 0.1, y: 0 });
+    expect(nearCenterSide.x).toBeLessThan(0);
+    expect(nearCenterSide.y).toBe(STUN_TOPSPIN_BIAS);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -140,11 +140,14 @@ export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
   const distance = Math.hypot(x, y);
-  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
+  if (distance <= STRAIGHT_SPIN_DEADZONE) {
+    return { x: 0, y: 0 };
+  }
+  if (distance <= SPIN_STUN_RADIUS) {
     if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
-      return { x: 0, y: 0 };
+      return { x, y: STUN_TOPSPIN_BIAS };
     }
-    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
+    return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
   }
   return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };


### PR DESCRIPTION
### Motivation
- The straight top-spin input was being treated as a stun (preventing forward roll) even when the user aimed above the cue-ball center, which breaks expected cue-ball follow behavior.
- The stun effect should only apply for true center hits or very near-center horizontal strikes while preserving the existing side/top/backspin mapping elsewhere.

### Description
- Adjusted `normalizeSpinInput` in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` to return true zero spin for exact center hits and to stop forcing a vertical stun bias for small topspin requests.
- Introduced a rule where inputs inside the stun radius but not within the straight deadzone are treated as near-center: near-horizontal center-line strikes get the `STUN_TOPSPIN_BIAS` while other small offsets are mapped normally with `clampToMaxOffset` so topspin will produce forward roll.
- Updated unit tests in `test/poolRoyaleSpinController.test.js` to assert center-zero stun, small-topspin ramping behavior, and the near-horizontal stun-bias rule while keeping the existing directional/strength expectations.

### Testing
- Ran the targeted test file with `npm test -- --runInBand test/poolRoyaleSpinController.test.js` and all tests in that suite passed (`9 passed, 9 total`).
- Verified the changed expectations cover center-zero stun, ramping small topspin, near-horizontal stun behavior, directional alignment, and spin scaling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b250fd018c8329ae65079eafa4bcb5)