### PR TITLE
Improve spin input normalization with center stun and eased minimum directional spin

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,8 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.012;
+export const CENTER_STUN_RADIUS = 0.008;
+export const MIN_DIRECTIONAL_SPIN = 0.015;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -139,14 +140,24 @@ export const computeQuantizedOffsetScaled = (
 export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
-  const distance = Math.hypot(x, y);
-  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
-    if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
-      return { x: 0, y: 0 };
-    }
-    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  if (distance <= CENTER_STUN_RADIUS) {
+    return { x: 0, y: 0 };
   }
-  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+
+  const blendDenominator = Math.max(1e-6, MAX_SPIN_OFFSET - CENTER_STUN_RADIUS);
+  const blend = clamp((distance - CENTER_STUN_RADIUS) / blendDenominator, 0, 1);
+  const easedBlend = blend * blend * (3 - 2 * blend);
+  const magnitude =
+    MIN_DIRECTIONAL_SPIN +
+    (MAX_SPIN_OFFSET - MIN_DIRECTIONAL_SPIN) * easedBlend;
+  const directionScale = 1 / Math.max(distance, 1e-6);
+
+  return {
+    x: clamped.x * directionScale * magnitude,
+    y: clamped.y * directionScale * magnitude
+  };
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation

- Make cue-ball spin input more predictable by removing the old small top-spin bias and introducing a small center "stun" deadzone and a smooth ramp to directional spin.

### Description

- Added constants `CENTER_STUN_RADIUS` and `MIN_DIRECTIONAL_SPIN` and removed `STUN_TOPSPIN_BIAS` to change deadzone and minimum spin behavior.
- Updated `normalizeSpinInput` to use `clampToMaxOffset`, treat inputs within `CENTER_STUN_RADIUS` as true zero, and otherwise compute a smooth eased blend from the center to `MAX_SPIN_OFFSET` to produce a scaled directional magnitude.
- Replaced the previous conditional deadzone/topspin handling with an eased interpolation (`easedBlend`) and applied the computed `magnitude` to the normalized direction vector for consistent directional spin.
- Kept existing world-mapping logic unchanged and refactored to rely on the clamped coordinates for stable behavior.

### Testing

- Ran the project unit test suite with `yarn test`, and all tests passed.
- Ran linting with `yarn lint`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b250fd018c8329ae65079eafa4bcb5)