### PR TITLE
Fix Snake & Ladder turn-focus camera to respect player zoom

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1608,13 +1608,6 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
     : Number(turnIndex);
   const seatIndex = Math.trunc(rawSeatIndex);
   if (!Number.isFinite(seatIndex) || seatIndex < 0 || seatIndex >= anchors.length) return null;
-  const startCameraState = board.startCameraState;
-  if (seatIndex === 0 && startCameraState?.position && startCameraState?.target) {
-    return {
-      position: startCameraState.position.clone(),
-      target: startCameraState.target.clone()
-    };
-  }
   const anchor = anchors[seatIndex];
   const boardLookTarget = board.boardLookTarget;
   if (!anchor || !boardLookTarget) return null;
@@ -1628,7 +1621,9 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
 
-  const position = startCameraState?.position?.clone() ?? camera.position.clone();
+  // Keep the camera exactly where the player left it (including manual zoom distance)
+  // and only rotate the look target for turn-focus cues.
+  const position = camera.position.clone();
 
   return { position, target };
 }


### PR DESCRIPTION
### Motivation
- Players expect the camera to keep their chosen zoom/distance while the game only turns to look at the active player, dice results, and token movement instead of resetting the view.

### Description
- Modified `computeTurnCameraFocusState` in `webapp/src/components/SnakeBoard3D.jsx` to remove the fallback that snapped the camera to `board.startCameraState` and instead use the current `camera.position.clone()` so user zoom/distance is preserved.
- Camera turn-focus logic now only adjusts the look `target` while keeping the camera position unchanged, preventing unexpected zoom jumps during turn/dice/token animations.

### Testing
- Ran unit tests: `npm test -- test/snakeGame.test.js --runInBand --forceExit` which passed all tests in the suite (10 tests passed). Note: tests required `--forceExit` due to open handles in the test environment.
- Ran API tests: `npm test -- test/snakeApi.test.js --runInBand --forceExit` which passed (1 passed, 1 skipped).
- Performed a UI smoke capture using Playwright against `/games/snake` to verify the camera behavior visually (screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2766ca614832986f9abecc8eb0a14)