### PR TITLE
Make Ludo camera consistent for top/bottom turns and have camera follow dice

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3689,7 +3689,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     diceTransitionRef.current = null;
   };
 
-  const animateDicePosition = (dice, destination, { duration = 450, lift = 0.04 } = {}) => {
+  const animateDicePosition = (dice, destination, { duration = 450, lift = 0.04, onComplete } = {}) => {
     if (!dice || !destination) return;
     const target = destination.clone ? destination.clone() : new THREE.Vector3().copy(destination);
     stopDiceTransition();
@@ -3717,6 +3717,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         requestAnimationFrame(step);
       } else {
         dice.position.copy(target);
+        if (typeof onComplete === 'function') {
+          onComplete(target.clone());
+        }
         if (diceTransitionRef.current === handle) {
           diceTransitionRef.current = null;
         }
@@ -3734,9 +3737,37 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (immediate) {
       stopDiceTransition();
       dice.position.copy(target);
+      setCameraFocus({
+        target,
+        follow: false,
+        ttl: 0.55,
+        priority: 2,
+        force: true,
+        offset: CAMERA_TARGET_LIFT + 0.02
+      });
       return;
     }
-    animateDicePosition(dice, target, { duration: 520, lift: 0.05 });
+    setCameraFocus({
+      object: dice,
+      follow: true,
+      priority: 3,
+      force: true,
+      offset: CAMERA_TARGET_LIFT + 0.03
+    });
+    animateDicePosition(dice, target, {
+      duration: 520,
+      lift: 0.05,
+      onComplete: (landingTarget) => {
+        setCameraFocus({
+          target: landingTarget,
+          follow: false,
+          ttl: 0.8,
+          priority: 2,
+          force: true,
+          offset: CAMERA_TARGET_LIFT + 0.02
+        });
+      }
+    });
   };
 
   const updateTurnIndicator = (player, immediate = false) => {
@@ -5008,7 +5039,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (!baseView) return null;
       return {
         position: baseView.position.clone(),
-        target: player === 0 ? baseView.target.clone() : target
+        target: baseView.target.clone()
       };
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the bottom player's turn camera matches the top player's framing so turn presentation is symmetric and predictable.
- Improve readability of dice actions by having the camera follow dice motion on the table and briefly hold focus after landing.

### Description
- Extend `animateDicePosition` to accept an `onComplete` callback so callers can react precisely when dice motion finishes by passing `onComplete` in the options.
- Update `moveDiceToRail` to set camera focus to follow the dice during animated rail movement and to hold focus on the landing target after the transition, while immediate moves also trigger a short focus hold.
- Make top/bottom seat turn-camera logic symmetric by returning the same `baseView.target` for top/bottom seat cases inside `resolveTurnCameraState`, which makes the bottom player's turn view mirror the top player's framing.
- Use `setCameraFocus` with appropriate priorities and TTLs so the camera behavior is deterministic during dice transitions and turn changes.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, which reported no errors but indicated the file is ignored by repo lint patterns (warning only).
- Started the local dev server with `npm --prefix webapp run dev` (Vite started and served the app) to perform a runtime visual check.
- Executed a Playwright script to open `/games/ludobattleroyal` and capture a screenshot, producing the artifact `browser:/tmp/codex_browser_invocations/fcf882f16d3f9d92/artifacts/artifacts/ludo-camera-update.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b279f0ee748329bb80595033642e20)