### PR TITLE
Improve Ludo Battle Royal camera consistency and dice tracking

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2514,6 +2514,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     currentTarget: null,
     activePriority: -Infinity,
     followObject: null,
+    followOffset: null,
     baseTurnView: null
   });
   const humanSelectionRef = useRef(null);
@@ -4773,6 +4774,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
           controls.target.lerp(liftedTarget.target, 0.28);
+          const followOffset = cameraTurnStateRef.current.followOffset;
+          if (camera && followOffset?.isVector3) {
+            const desiredPosition = liftedTarget.target.clone().add(followOffset);
+            camera.position.lerp(desiredPosition, 0.22);
+          }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
         }
       }
@@ -4931,6 +4937,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     cameraTurnStateRef.current.activePriority = -Infinity;
     cameraTurnStateRef.current.followObject = null;
+    cameraTurnStateRef.current.followOffset = null;
   }, []);
 
   const cancelCameraViewAnimation = useCallback(() => {
@@ -5008,7 +5015,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (!baseView) return null;
       return {
         position: baseView.position.clone(),
-        target: player === 0 ? baseView.target.clone() : target
+        target: baseView.target.clone()
       };
     }
 
@@ -5111,6 +5118,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       const nextFocusState = resolveFocusCameraState(nextTarget, offset);
       if (nextFocusState) {
+        if (cameraTurnStateRef.current.followObject) {
+          const camera = cameraRef.current;
+          cameraTurnStateRef.current.followOffset = camera
+            ? camera.position.clone().sub(nextFocusState.target)
+            : null;
+        } else {
+          cameraTurnStateRef.current.followOffset = null;
+        }
         animateCameraPose(nextFocusState.target, nextFocusState.position, 280);
       }
       if (ttl > 0) {
@@ -5121,6 +5136,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           cameraFocusTimeoutRef.current = null;
           cameraTurnStateRef.current.activePriority = -Infinity;
           cameraTurnStateRef.current.followObject = null;
+          cameraTurnStateRef.current.followOffset = null;
           const returnTarget = resolveTurnLookTarget(stateRef.current?.turn ?? 0, CAMERA_TARGET_LIFT);
           if (returnTarget) {
             const restoreFocusState = resolveFocusCameraState(returnTarget, CAMERA_TARGET_LIFT);


### PR DESCRIPTION
### Motivation
- Ensure the player-at-bottom sees the same turn framing as the top player so turn camera parity is consistent during play. 
- Make the camera visibly follow dice movement on the table when dice are rolled so the result is easier to follow. 
- Keep a stable relative camera offset while in focus-follow mode and clear it when focus ends so follow behavior is predictable.

### Description
- Updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` to add a `followOffset` entry on `cameraTurnStateRef` and clear it when focus/follow is cancelled. 
- When `setCameraFocus` enables follow mode the code now records the camera->target offset (`followOffset`) so the camera maintains a consistent relative position while following an object. 
- Adjusted turn camera resolution (`resolveTurnCameraState`) so top/bottom seats use the same base target framing (`baseView.target`) to unify the look for both top and bottom turns. 
- In the main animation loop, when `followObject` is active the code now lerps both `controls.target` and `camera.position` using the recorded `followOffset` so the camera tracks moving dice/objects smoothly.

### Testing
- Started the web app in dev mode with `npm --prefix webapp run dev -- --host 127.0.0.1 --port 4173 --strictPort` to validate the changed Ludo scene compiles and runs (success). 
- Ran ESLint on the modified file with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which produced only a file-ignore warning and no errors. 
- Attempted an automated Playwright screenshot to validate runtime camera follow, but the browser/script timed out in this environment (no artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b279f0ee748329bb80595033642e20)