### PR TITLE
Improve aiming/spin preview, add per-ball pocket glow, and disable dynamic pocket camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1674,14 +1674,15 @@ const POCKET_CAM = Object.freeze({
 const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
-const POCKET_GLOW_ENABLED = false;
+const POCKET_GLOW_ENABLED = true;
 const POCKET_GLOW_RADIUS = BALL_R * 1.32;
 const POCKET_GLOW_LIFT = BALL_R * 0.78;
-const POCKET_GLOW_OPACITY = 0.62;
+const POCKET_GLOW_OPACITY = 0.82;
 const POCKET_GLOW_COLORS = Object.freeze({
   good: 0x2eea73,
   foul: 0xff4b4b
 });
+const DISABLE_DYNAMIC_CAMERA = true;
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
 const POCKET_GUARANTEED_ALIGNMENT = 0.85;
 const POCKET_EARLY_ALIGNMENT = 0.7;
@@ -5307,7 +5308,7 @@ const CAMERA = {
 const CAMERA_CUSHION_CLEARANCE = TABLE.THICK * 0.6; // keep orbit height safely above cushion lip while hugging the rail
 const AIM_LINE_MIN_Y = CUE_Y; // ensure the orbit never dips below the aiming line height
 const CAMERA_AIM_LINE_MARGIN = BALL_R * 0.075; // keep extra clearance above the aim line for the tighter orbit distance
-const AIM_LINE_WIDTH = Math.max(1.25, BALL_R * 0.15) * 1.2; // thinner guides for cue/target direction lines with better clarity
+const AIM_LINE_WIDTH = Math.max(1.25, BALL_R * 0.15) * 1.35; // slightly thicker guides for cue/target/direction readability
 const AIM_TICK_HALF_LENGTH = Math.max(0.6, BALL_R * 0.975); // keep the impact tick proportional to the cue ball
 const AIM_DASH_SIZE = Math.max(0.45, BALL_R * 0.75);
 const AIM_GAP_SIZE = Math.max(0.45, BALL_R * 0.5);
@@ -6959,7 +6960,7 @@ function resolvePowerLineColor(powerStrength) {
 
 function resolveAimPreviewSpin(spin) {
   const normalized = normalizeSpinInput(spin);
-  return { x: -(normalized?.x ?? 0), y: normalized?.y ?? 0 };
+  return { x: normalized?.x ?? 0, y: normalized?.y ?? 0 };
 }
 
 function updatePowerLinePoints(geom, start, end, powerStrength) {
@@ -7050,11 +7051,18 @@ function resolveCueFollowPreview({
   const topspinWeight = Math.max(0, spinY);
   const backspinLerp = resolveBackspinPreviewLerp(backspinWeight);
   const topspinLerp = Math.min(0.35, Math.pow(topspinWeight, 0.6) * 0.35);
+  const straightVerticalSpin = Math.abs(spinX) <= STRAIGHT_SPIN_DEADZONE && Math.abs(spinY) > 1e-4;
   const previewDir = spinAdjusted.clone();
   const backwards = aimVec.clone().multiplyScalar(-1);
   const cutAlignment = THREE.MathUtils.clamp(previewDir.dot(aimVec), -1, 1);
   const cutPenalty = Math.sqrt(Math.max(0, 1 - Math.abs(cutAlignment)));
-  if (BACKSPIN_DIRECTION_PREVIEW > 0 && backspinLerp > 1e-4) {
+  if (straightVerticalSpin) {
+    if (spinY < 0 && BACKSPIN_DIRECTION_PREVIEW > 0) {
+      previewDir.copy(backwards);
+    } else if (spinY > 0) {
+      previewDir.copy(aimVec);
+    }
+  } else if (BACKSPIN_DIRECTION_PREVIEW > 0 && backspinLerp > 1e-4) {
     const drawBlend = THREE.MathUtils.clamp(
       backspinLerp * BACKSPIN_DIRECTION_PREVIEW * (0.7 + 0.3 * impactPower),
       0,
@@ -7082,7 +7090,7 @@ function resolveCueFollowPreview({
     }
   }
   const physicsFollowInfluence = THREE.MathUtils.clamp(0.35 + impactPower * 0.45, 0.25, 0.9);
-  if (Math.abs(spinY) > 1e-4) {
+  if (!straightVerticalSpin && Math.abs(spinY) > 1e-4) {
     previewDir.addScaledVector(aimVec, spinY * physicsFollowInfluence);
   }
   if (Math.abs(spinX) > 1e-4) {
@@ -7328,6 +7336,19 @@ const toBallColorId = (id) => {
   if (lower.startsWith('stripe')) return 'STRIPE';
   if (lower.startsWith('solid')) return 'SOLID';
   return lower.toUpperCase();
+};
+
+const resolvePocketGlowToneFromBall = (ballColorId, fallback = 'good') => {
+  if (!ballColorId || typeof ballColorId !== 'string') return fallback;
+  const normalized = ballColorId.toUpperCase();
+  if (normalized === 'CUE') return 'foul';
+  return `ball_${normalized.toLowerCase()}`;
+};
+
+const resolvePocketGlowColorHex = (ballColorId) => {
+  if (!ballColorId || typeof ballColorId !== 'string') return null;
+  const normalized = ballColorId.toLowerCase();
+  return BASE_BALL_COLORS[normalized] ?? null;
 };
 
 function alignRailsToCushions(table, frame, railMeshes = null) {
@@ -8409,9 +8430,29 @@ export function Table3D(
         })
       }
     : {};
+  const pocketGlowBallMaterials = new Map();
+  const resolvePocketGlowMaterial = (tone = 'good') => {
+    if (!POCKET_GLOW_ENABLED) return null;
+    if (pocketGlowMaterials[tone]) return pocketGlowMaterials[tone];
+    if (!tone?.startsWith?.('ball_')) return pocketGlowMaterials.good;
+    const cached = pocketGlowBallMaterials.get(tone);
+    if (cached) return cached;
+    const colorId = tone.slice(5).toUpperCase();
+    const colorHex = resolvePocketGlowColorHex(colorId) ?? POCKET_GLOW_COLORS.good;
+    const material = new THREE.MeshBasicMaterial({
+      color: colorHex,
+      transparent: true,
+      opacity: POCKET_GLOW_OPACITY,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      side: THREE.DoubleSide
+    });
+    pocketGlowBallMaterials.set(tone, material);
+    return material;
+  };
   const createPocketGlowMesh = (tone = 'good') => {
     if (!POCKET_GLOW_ENABLED || !pocketGlowGeometry) return null;
-    const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
+    const material = resolvePocketGlowMaterial(tone);
     if (!material) return null;
     const glow = new THREE.Mesh(pocketGlowGeometry, material);
     glow.rotation.x = -Math.PI / 2;
@@ -8422,7 +8463,7 @@ export function Table3D(
   };
   const setPocketGlowTone = (entry, tone = 'good') => {
     if (!entry?.glowMesh) return;
-    const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
+    const material = resolvePocketGlowMaterial(tone);
     if (material) entry.glowMesh.material = material;
     entry.glowTone = tone;
   };
@@ -25082,13 +25123,14 @@ const powerRef = useRef(hud.power);
             (!isShortShot &&
               (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD));
           const allowLongShotCameraSwitch =
+            !DISABLE_DYNAMIC_CAMERA &&
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
             !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
             allowRailOverheadActionView;
           const broadcastSystem =
             broadcastSystemRef.current ?? activeBroadcastSystem ?? null;
           const suppressPocketCameras =
-            broadcastSystem?.avoidPocketCameras;
+            DISABLE_DYNAMIC_CAMERA || broadcastSystem?.avoidPocketCameras;
           const forceActionActivation = broadcastSystem?.forceActionActivation;
           const orbitSnapshot = sphRef.current
             ? {
@@ -28141,7 +28183,7 @@ const powerRef = useRef(hud.power);
           potted.forEach((entry) => {
             const dropEntry = pocketDropRef.current.get(entry.id);
             if (dropEntry?.glowMesh) {
-              setPocketGlowTone(dropEntry, shotWasFoul ? 'foul' : 'good');
+              setPocketGlowTone(dropEntry, shotWasFoul ? 'foul' : (dropEntry.glowTone ?? 'good'));
             }
           });
         }
@@ -29990,6 +30032,7 @@ const powerRef = useRef(hud.power);
           }
         }
         const suppressPocketCameras =
+          DISABLE_DYNAMIC_CAMERA ||
           (broadcastSystemRef.current ?? activeBroadcastSystem ?? null)
             ?.avoidPocketCameras;
         const earlyPocketIntent = pocketSwitchIntentRef.current;
@@ -30428,7 +30471,11 @@ const powerRef = useRef(hud.power);
                 );
               const restY =
                 railRunStart.y - POCKET_HOLDER_REST_DROP - tiltDrop;
+              const mappedColor = toBallColorId(b.id);
+              const colorId =
+                mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
               if (!isCueBall) {
+                const glowTone = resolvePocketGlowToneFromBall(colorId, shotWasFoul ? 'foul' : 'good');
                 const dropEntry = {
                   start: dropStart,
                   fromY: BALL_CENTER_Y,
@@ -30455,20 +30502,25 @@ const powerRef = useRef(hud.power);
                   rollStartAt: null,
                   rollProgress: 0,
                   pocketId,
-                  resting: false
+                  resting: false,
+                  glowTone,
+                  glowMesh: null
                 };
                 if (b.mesh) {
                   b.mesh.visible = true;
                   b.mesh.scale.set(1, 1, 1);
                   b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
                 }
+                const glowMesh = createPocketGlowMesh(glowTone);
+                if (glowMesh) {
+                  glowMesh.position.set(c.x, BALL_CENTER_Y - POCKET_GLOW_LIFT, c.y);
+                  table?.add?.(glowMesh);
+                  dropEntry.glowMesh = glowMesh;
+                }
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
                 removePocketDropEntry(b.id);
               }
-              const mappedColor = toBallColorId(b.id);
-              const colorId =
-                mappedColor ?? (typeof b.id === 'string' ? b.id.toUpperCase() : 'UNKNOWN');
               potted.push({ id: b.id, color: colorId, pocket: pocketId });
               pottedIds.add(b.id);
               const shouldForceCornerPocketView =
@@ -30882,6 +30934,8 @@ const powerRef = useRef(hud.power);
         pocketDropRef.current.clear();
         pocketGlowGeometry.dispose?.();
         Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        pocketGlowBallMaterials.forEach((material) => material?.dispose?.());
+        pocketGlowBallMaterials.clear();
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- Make the aiming/target/cue-direction lines more readable by increasing their thickness.  
- Ensure pure straight topspin/backspin show a straight cue-ball direction preview and make the spin controller match that preview exactly.  
- Improve the potted-ball pocket animation with a stronger, color-matched glow and keep the glow visible while the ball animates in the pocket, and prevent automatic dynamic camera switches during pocket views.

### Description
- Increased the guide line thickness used for aiming/target/cue-direction by updating `AIM_LINE_WIDTH` to improve readability.  
- Aligned spin preview mapping by changing `resolveAimPreviewSpin` to remove the previous X inversion so UI spin → preview direction is consistent.  
- Adjusted `resolveCueFollowPreview` to detect pure vertical spin (no side spin) and force the preview to be strictly forward for topspin and strictly backward for backspin while keeping other spin behaviors intact.  
- Added `DISABLE_DYNAMIC_CAMERA` flag and gated pocket/action camera switch paths so automatic dynamic pocket/action camera switching can be suppressed.  
- Enabled pocket glow visuals and intensified them: turned on `POCKET_GLOW_ENABLED`, increased `POCKET_GLOW_OPACITY`, added per-ball-color glow material resolution/caching, spawn and attach glow meshes to pocket-drop entries so glow persists during the pocket-holder animation, and updated glow tone handling to preserve per-ball color (foul overrides only when required).  
- Added proper disposal/cleanup for dynamically created pocket glow materials and meshes.  
- All code changes are in `webapp/src/pages/Games/PoolRoyale.jsx` (aim/spin preview, pocket glow, camera gating and helper functions).

### Testing
- Ran repository lint (`npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx`) which failed because the repo-wide lint run includes many pre-existing baseline issues unrelated to this change, so the failure is not caused by the modified file.  
- Ran a whitespace/diff check on the modified file with `git diff --check` which reported no issues.  
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and the server started successfully.  
- Captured a visual smoke-check screenshot from the running dev server via Playwright to validate rendering changes; the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b27d024f00832983627b2710c3c796)