### PR TITLE
Ludo: restore bottom-player start camera and follow dice on turn transitions

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2517,6 +2517,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     followOffset: null,
     baseTurnView: null
   });
+  const initialBottomCameraViewRef = useRef(null);
   const humanSelectionRef = useRef(null);
   const fitRef = useRef(() => {});
   const cameraRef = useRef(null);
@@ -4489,6 +4490,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     configureDiceAnchors({ dice: boardData.dice, boardGroup, chairs, tableInfo });
     moveDiceToRail(0, true);
     updateTurnIndicator(0, true);
+    if (camera && controls) {
+      initialBottomCameraViewRef.current = {
+        position: camera.position.clone(),
+        target: controls.target.clone()
+      };
+      cameraTurnStateRef.current.baseTurnView = {
+        position: initialBottomCameraViewRef.current.position.clone(),
+        target: initialBottomCameraViewRef.current.target.clone()
+      };
+    }
     setCameraFocus({ target: resolveTurnLookTarget(0), priority: 1, force: true });
     setCameraViewForTurn(0, 0);
 
@@ -5077,11 +5088,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (isCamera2d) return;
     const camera = cameraRef.current;
     const controls = controlsRef.current;
-    if (player === 0 && camera && controls) {
-      cameraTurnStateRef.current.baseTurnView = {
-        position: camera.position.clone(),
-        target: controls.target.clone()
-      };
+    if (player === 0) {
+      const initialBottomView = initialBottomCameraViewRef.current;
+      if (initialBottomView?.position?.isVector3 && initialBottomView?.target?.isVector3) {
+        cameraTurnStateRef.current.baseTurnView = {
+          position: initialBottomView.position.clone(),
+          target: initialBottomView.target.clone()
+        };
+        animateCameraPose(
+          cameraTurnStateRef.current.baseTurnView.target,
+          cameraTurnStateRef.current.baseTurnView.position,
+          duration
+        );
+        return;
+      }
+      if (camera && controls) {
+        cameraTurnStateRef.current.baseTurnView = {
+          position: camera.position.clone(),
+          target: controls.target.clone()
+        };
+      }
     }
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
@@ -5420,8 +5446,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);
-      setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
       setCameraViewForTurn(nextTurn);
+      const diceObject = diceRef.current;
+      if (diceObject?.isObject3D) {
+        setCameraFocus({
+          object: diceObject,
+          follow: true,
+          ttl: 0.72,
+          priority: 5,
+          offset: CAMERA_TARGET_LIFT + 0.04,
+          force: true
+        });
+      } else {
+        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      }
       updated = true;
       const status =
         nextTurn === 0


### PR DESCRIPTION
### Motivation
- Make camera transitions feel natural during turn handoff by having the view pivot to the next player while simultaneously following the dice motion. 
- Ensure when the human (bottom) player gets the turn the camera returns exactly to the initial startup pose for consistent UX.

### Description
- Added a new ref `initialBottomCameraViewRef` to persist the original bottom-seat camera pose captured at scene setup in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- During board/dice initialization the code now saves the current camera `position` and `target` into `initialBottomCameraViewRef` so later bottom turns can restore it exactly.
- Updated `setCameraViewForTurn` so when `player === 0` it restores and animates to the saved bottom view if available, otherwise falls back to capturing the current camera pose.
- Changed `advanceTurn` so after computing the next turn it calls `setCameraViewForTurn(nextTurn)` and then applies a short high-priority camera focus that follows the dice object (if present) to align dice motion and camera handoff.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully (Vite build finished).
- Launched the dev server and ran a Playwright script to capture a portrait screenshot (`width: 430, height: 932`) for visual verification; the first Playwright run timed out and a retry succeeded and produced an artifact screenshot.
- No gameplay rule changes were tested; only camera/visual flow was validated via the build and the headless screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b282198fe08329ad4128964650e95e)