### PR TITLE
Align aim preview with physics spin and increase overall cue-ball spin strength

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1750,7 +1750,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 900;
 const POCKET_VIEW_EARLY_HOLD_MS = 160;
-const SPIN_GLOBAL_SCALE = 0.66; // mirror Snooker Royale spin strength so cue-ball response matches exactly
+const SPIN_GLOBAL_SCALE = 1.15; // boost total cue-ball spin response so all controller directions apply stronger english
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1903,9 +1903,9 @@ const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so 
 const SPIN_RING_RATIO = 1;
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
 const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.15;
-const SIDE_SPIN_MULTIPLIER = 1.5;
-const BACKSPIN_MULTIPLIER = 1.5;
-const TOPSPIN_MULTIPLIER = 1.5;
+const SIDE_SPIN_MULTIPLIER = 1.8;
+const BACKSPIN_MULTIPLIER = 1.8;
+const TOPSPIN_MULTIPLIER = 1.8;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -6961,6 +6961,14 @@ function resolvePowerLineColor(powerStrength) {
 function resolveAimPreviewSpin(spin) {
   const normalized = normalizeSpinInput(spin);
   return { x: normalized?.x ?? 0, y: normalized?.y ?? 0 };
+}
+
+function scalePhysicsSpin(spin, scale = SPIN_GLOBAL_SCALE) {
+  const safeScale = Number.isFinite(scale) ? Math.max(0, scale) : 1;
+  return {
+    x: (spin?.x ?? 0) * safeScale,
+    y: (spin?.y ?? 0) * safeScale
+  };
 }
 
 function updatePowerLinePoints(geom, start, end, powerStrength) {
@@ -24998,7 +25006,7 @@ const powerRef = useRef(hud.power);
         };
         const liftAngle = resolveUserCueLift();
         const liftStrength = normalizeCueLift(liftAngle);
-        const physicsSpin = mapSpinForPhysics(appliedSpin);
+        const physicsSpin = scalePhysicsSpin(mapSpinForPhysics(appliedSpin));
         const swerveActive = false;
         const guideAimDir2D = resolveSwerveAimDir(
           aimDir.clone(),
@@ -28733,7 +28741,7 @@ const powerRef = useRef(hud.power);
         const appliedSpin = applySpinConstraints(aimDir, true);
         const aimPreviewSpin = resolveAimPreviewSpin(appliedSpin);
         const liftStrength = normalizeCueLift(resolveUserCueLift());
-        const physicsSpin = mapSpinForPhysics(appliedSpin);
+        const physicsSpin = scalePhysicsSpin(mapSpinForPhysics(appliedSpin));
         const ranges = spinRangeRef.current || {};
         const newCollisions = new Set();
         let shouldSlowAim = false;
@@ -29093,7 +29101,7 @@ const powerRef = useRef(hud.power);
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
             aimDir: dir,
-            spin: aimPreviewSpin,
+            spin: physicsSpin,
             powerStrength,
             cuePowerStrength,
             liftStrength
@@ -29341,7 +29349,7 @@ const powerRef = useRef(hud.power);
           const remoteSpinNormalized = normalizeSpinInput(remoteSpin);
           const aimPreviewSpin = resolveAimPreviewSpin(remoteSpinNormalized);
           const remoteSwerveActive = false;
-          const remotePhysicsSpin = mapSpinForPhysics(remoteSpinNormalized);
+          const remotePhysicsSpin = scalePhysicsSpin(mapSpinForPhysics(remoteSpinNormalized));
           const guideAimDir2D = resolveSwerveAimDir(
             remoteAimDir,
             remotePhysicsSpin,
@@ -29410,7 +29418,7 @@ const powerRef = useRef(hud.power);
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
             aimDir: baseDir,
-            spin: mapSpinForPhysics(remoteSpinNormalized),
+            spin: remotePhysicsSpin,
             powerStrength,
             cuePowerStrength,
             liftStrength: 0


### PR DESCRIPTION
### Motivation
- Aim guide must match the actual cue-ball path so the visible direction line precisely predicts the post-impact trajectory. 
- The game needs stronger, more responsive english (side/top/back spin) so spin inputs feel impactful across all directions. 
- Keep spin mapping consistent between preview and physics to remove discrepancies between what the player sees and what the simulation produces.

### Description
- Increased global spin amplification by changing `SPIN_GLOBAL_SCALE` from `0.66` to `1.15` to boost overall cue-ball spin response. 
- Raised directional multipliers by updating `SIDE_SPIN_MULTIPLIER`, `BACKSPIN_MULTIPLIER`, and `TOPSPIN_MULTIPLIER` from `1.5` to `1.8` to increase side/top/back spin strength. 
- Added a helper `scalePhysicsSpin(spin, scale = SPIN_GLOBAL_SCALE)` and applied it wherever `mapSpinForPhysics(...)` was consumed so physics and previews use a single scaled spin vector. 
- Aligned the cue-follow/aim preview to use the scaled physics spin (`physicsSpin`) for both local and remote aim previews so the shown direction line uses the same mapping as shot execution. 
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` (spin constants, helper, and replacements around shot/preview logic).

### Testing
- Attempted a production build with `npm -C webapp run build`, which reached the Vite transform phase but was long-running in this environment and was stopped manually. 
- Performed code inspections with `rg`/`sed` to verify the new `scalePhysicsSpin` helper and that `mapSpinForPhysics(...)` call sites now consume the scaled spin. 
- Verified the working tree contains only the intended changes in `webapp/src/pages/Games/PoolRoyale.jsx` before finalizing the edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b291713d388329836ef28ee0cab672)