### PR TITLE
Align Snake & Ladder 2D camera with Ludo Battle Royal behavior

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3813,9 +3813,7 @@ export default function SnakeBoard3D({
   appearance = {},
   appearanceKey,
   frameRate = 90,
-  cameraViewMode = '3d',
-  camera2dTilt = 0.2,
-  onCameraTiltChange
+  cameraViewMode = '3d'
 }) {
   const mountRef = useRef(null);
   const cameraRef = useRef(null);
@@ -3840,7 +3838,6 @@ export default function SnakeBoard3D({
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
   const cameraViewModeRef = useRef(cameraViewMode);
   const frameAccumulatorRef = useRef(0);
-  const cameraTiltRef = useRef(clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2));
   const [tokenPrototypeVersion, setTokenPrototypeVersion] = useState(0);
   const fallbackAppearanceKey = useMemo(() => JSON.stringify(appearance ?? {}), [appearance]);
   const keyForEffect = appearanceKey ?? fallbackAppearanceKey;
@@ -3854,9 +3851,6 @@ export default function SnakeBoard3D({
     cameraViewModeRef.current = cameraViewMode;
   }, [cameraViewMode]);
 
-  useEffect(() => {
-    cameraTiltRef.current = clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2);
-  }, [camera2dTilt]);
 
   useEffect(() => {
     frameRateRef.current = Math.max(30, frameRate || 90);
@@ -3902,67 +3896,63 @@ export default function SnakeBoard3D({
     const boardLookTarget = board?.boardLookTarget;
     if (!board || !camera || !controls || !boardLookTarget) return;
 
-    const min2dTilt = 0.001;
-    const max2dTilt = 0.42;
-    const tiltRatio = clamp01(Number.isFinite(camera2dTilt) ? camera2dTilt : 0.2);
-    const topDownPolar = THREE.MathUtils.lerp(min2dTilt, max2dTilt, tiltRatio);
+    const topDownPolar = 0.001;
     if (cameraViewMode === '2d') {
       if (!cameraRestoreRef.current) {
         cameraRestoreRef.current = {
           position: camera.position.clone(),
           target: controls.target.clone(),
+          enableZoom: controls.enableZoom,
           enableRotate: controls.enableRotate,
+          enablePan: controls.enablePan,
           minPolarAngle: controls.minPolarAngle,
           maxPolarAngle: controls.maxPolarAngle,
           minAzimuthAngle: controls.minAzimuthAngle,
-          maxAzimuthAngle: controls.maxAzimuthAngle
+          maxAzimuthAngle: controls.maxAzimuthAngle,
+          minDistance: controls.minDistance,
+          maxDistance: controls.maxDistance
         };
       }
-      const topDownDistance = clamp(CAM.minR * 2.25, CAM.minR * 1.55, CAM.maxR * 0.96);
-      const verticalDistance = Math.cos(topDownPolar) * topDownDistance;
-      const forwardDistance = Math.sin(topDownPolar) * topDownDistance;
-      camera.position.set(
-        boardLookTarget.x,
-        boardLookTarget.y + verticalDistance,
-        boardLookTarget.z + forwardDistance
-      );
+      removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
+      removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
+      removeAnimationsByType(animationsRef.current, 'cameraTokenFocus');
+      turnCameraStateRef.current = null;
+      cinematicRestoreRef.current = null;
+      const topDownDistance = clamp(CAM.maxR, CAM.minR, CAM.maxR);
+      camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
       controls.target.copy(boardLookTarget);
+      controls.enableZoom = true;
       controls.enableRotate = false;
       controls.enablePan = false;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
-      controls.touches = { ONE: THREE.TOUCH.DOLLY, TWO: THREE.TOUCH.DOLLY_PAN };
+      controls.minDistance = CAM.minR;
+      controls.maxDistance = CAM.maxR;
+      controls.touches = { ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_PAN };
       controls.update();
       return;
-    }
-
-    const desiredPolar = THREE.MathUtils.lerp(CAM.phiMin, CAM.phiMax, tiltRatio);
-    const offset = camera.position.clone().sub(controls.target);
-    if (offset.lengthSq() > 0.000001) {
-      const spherical = new THREE.Spherical().setFromVector3(offset);
-      spherical.phi = clamp(desiredPolar, CAM.phiMin, CAM.phiMax);
-      offset.setFromSpherical(spherical);
-      camera.position.copy(controls.target).add(offset);
-      controls.update();
     }
 
     if (cameraRestoreRef.current) {
       const restore = cameraRestoreRef.current;
       camera.position.copy(restore.position);
       controls.target.copy(restore.target);
+      controls.enableZoom = restore.enableZoom;
       controls.enableRotate = restore.enableRotate;
-      controls.enablePan = false;
+      controls.enablePan = restore.enablePan;
       controls.minPolarAngle = restore.minPolarAngle;
       controls.maxPolarAngle = restore.maxPolarAngle;
       controls.minAzimuthAngle = restore.minAzimuthAngle;
       controls.maxAzimuthAngle = restore.maxAzimuthAngle;
+      controls.minDistance = restore.minDistance;
+      controls.maxDistance = restore.maxDistance;
       controls.touches = { ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_PAN };
       controls.update();
       cameraRestoreRef.current = null;
     }
-  }, [cameraViewMode, camera2dTilt]);
+  }, [cameraViewMode]);
 
   useEffect(() => {
     seatCallbackRef.current = typeof onSeatPositionsChange === 'function' ? onSeatPositionsChange : null;
@@ -4069,15 +4059,6 @@ export default function SnakeBoard3D({
       dragState.lastY = event.clientY;
       const absX = Math.abs(deltaX);
       const absY = Math.abs(deltaY);
-
-      if (absY >= absX && absY >= 0.25 && typeof onCameraTiltChange === 'function') {
-        const nextTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
-        if (Math.abs(nextTilt - cameraTiltRef.current) > 0.0001) {
-          cameraTiltRef.current = nextTilt;
-          onCameraTiltChange(nextTilt);
-        }
-        return;
-      }
 
       if (cameraViewModeRef.current === '2d') return;
       if (absX < 0.25) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1193,7 +1193,6 @@ export default function SnakeAndLadder() {
   const [cheatMsg, setCheatMsg] = useState(null);
   const [showInfo, setShowInfo] = useState(false);
   const [cameraViewMode, setCameraViewMode] = useState('3d');
-  const [camera2dTilt, setCamera2dTilt] = useState(0.2);
   const [showExactHelp, setShowExactHelp] = useState(false);
   const [muted, setMuted] = useState(isGameMuted());
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
@@ -3502,8 +3501,6 @@ export default function SnakeAndLadder() {
           appearanceKey={appearanceKey}
           frameRate={frameRateValue}
           cameraViewMode={cameraViewMode}
-          camera2dTilt={camera2dTilt}
-          onCameraTiltChange={setCamera2dTilt}
         />
       </div>
       <div


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder in-game camera behave identically to the Battle Royal Ludo camera so the 2D/3D view toggle is deterministic and consistent across games. 
- Remove the ad-hoc 2D tilt-drag behavior and stop cinematic/turn/dice focus animations from fighting the top-down camera state.

### Description
- Force true top-down polar when switching to 2D and use the scene max radius for the top-down distance so the board is centered and framed like Ludo (`topDownPolar = 0.001`, camera at `CAM.maxR`).
- Save and restore the full `OrbitControls` state when toggling (including `enableZoom`, `enablePan`, `minDistance`, and `maxDistance`) so returning to 3D restores prior settings.
- Cancel active cinematic/focus animations when entering 2D by clearing `cameraTurnFocus`, `cameraDiceZoom`, and `cameraTokenFocus` so those animations cannot override the top-down pose.
- Remove the camera tilt-drag prop/state and touch-tilt handling (no more `camera2dTilt` and `onCameraTiltChange`) and simplify pointer drag so rotation only affects the board in 3D.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx` and observed only lint warnings from the repo ignore settings (no errors).
- Started the dev server with `npm --prefix webapp run dev` and executed a Playwright script to load `/games/snake` in a mobile portrait viewport and captured a screenshot for visual verification (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2953f3aac8329944f6504ff2dd940)