### PR TITLE
Adjust Ludo Battle Royal broadcast camera zoom distance

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -374,6 +374,7 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.04 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.2 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
+const CAMERA_BROADCAST_DISTANCE_MULTIPLIER = 1.14;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 0.82,
   forwardOffset: 0.6,
@@ -5011,7 +5012,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const target = boardLookTarget.clone().lerp(seatWorld, CAMERA_TURN_PLAYER_LERP);
     target.y = (arena.tableInfo?.surfaceY ?? boardLookTarget.y) + offset;
 
-    const currentDistance = camera.position.distanceTo(boardLookTarget);
+    const currentDistance = camera.position.distanceTo(boardLookTarget) * CAMERA_BROADCAST_DISTANCE_MULTIPLIER;
     const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
     if (direction.lengthSq() < 1e-6) return null;
     direction.normalize();
@@ -5050,7 +5051,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const target = focusTarget.clone();
     target.y = (arena.tableInfo?.surfaceY ?? target.y) + offset;
 
-    const currentDistance = camera.position.distanceTo(boardLookTarget);
+    const currentDistance = camera.position.distanceTo(boardLookTarget) * CAMERA_BROADCAST_DISTANCE_MULTIPLIER;
     const direction = camera.position.clone().sub(boardLookTarget).setY(0);
     if (direction.lengthSq() < 1e-6) direction.set(0, 0, 1);
     direction.normalize();


### PR DESCRIPTION
### Motivation
- Reduce how close the automatic broadcast camera frames turn/dice/token views in the Ludo Battle Royal arena while keeping user-controlled zoom and existing turn logic unchanged.

### Description
- Introduced `CAMERA_BROADCAST_DISTANCE_MULTIPLIER` and applied it to the distance calculations in `resolveTurnCameraState` and `resolveFocusCameraState` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx`, so broadcast-driven camera poses are computed with a slightly larger distance.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported no errors (noting the project eslint ignore warning); this check passed.
- Started the dev server with `npm --prefix webapp run dev` which launched successfully, and attempted a Playwright screenshot which timed out in this environment.
- Started a production build with `npm --prefix webapp run build` which began but did not complete within the session window.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29f54101083298e413e049a069e23)