### PR TITLE
Reset Pool Royale spin normalization to original controller behavior

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,10 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const CENTER_STUN_RADIUS = 0.008;
-export const MIN_DIRECTIONAL_SPIN = 0.015;
-export const STUN_TOPSPIN_BIAS = -0.01;
-export const SPIN_PROGRESSIVE_CURVE = 1.8;
+export const STUN_TOPSPIN_BIAS = -0.012;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -142,25 +139,14 @@ export const computeQuantizedOffsetScaled = (
 export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
-  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
-  const distance = Math.hypot(clamped.x, clamped.y);
-  if (distance <= CENTER_STUN_RADIUS) {
-    return { x: 0, y: STUN_TOPSPIN_BIAS };
+  const distance = Math.hypot(x, y);
+  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
+    if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
+      return { x: 0, y: 0 };
+    }
+    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
   }
-
-  const blendDenominator = Math.max(1e-6, MAX_SPIN_OFFSET - CENTER_STUN_RADIUS);
-  const blend = clamp((distance - CENTER_STUN_RADIUS) / blendDenominator, 0, 1);
-  const easedBlend = blend * blend * (3 - 2 * blend);
-  const progressiveBlend = Math.pow(easedBlend, SPIN_PROGRESSIVE_CURVE);
-  const magnitude =
-    MIN_DIRECTIONAL_SPIN +
-    (MAX_SPIN_OFFSET - MIN_DIRECTIONAL_SPIN) * progressiveBlend;
-  const directionScale = 1 / Math.max(distance, 1e-6);
-
-  return {
-    x: clamped.x * directionScale * magnitude,
-    y: clamped.y * directionScale * magnitude
-  };
+  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale spinning controller logic to the original open-source normalization style (simple deadzone + max-offset clamping) while preserving the current on-screen spin direction mapping. 
- Keep the UX and directional behavior players currently experience unchanged by not altering the cue-frame mapping or inversion logic.
- Bring back the original center stun bias constant used by this controller path to match prior physics behaviour.

### Description
- Replaced the progressive-response shaping in `normalizeSpinInput` with the original deadzone + `clampToMaxOffset` behavior and simplified branch logic in `webapp/src/pages/Games/poolRoyaleSpinUtils.js`.
- Removed the previous progressive curve math and related constants from the normalization path and returned early for small-center inputs (yielding either zero or a small stun topspin bias).
- Restored `STUN_TOPSPIN_BIAS` to `-0.012` used by the original controller.
- Left `mapSpinForPhysics` and the cue-frame direction mapping unchanged so left/right and top/back directions on screen remain the same.

### Testing
- Ran the spin controller unit tests with `npx jest test/poolRoyaleSpinController.test.js --runInBand`, which passed (7 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2af525c4c8329a78a2868d3968c0c)