### PR TITLE
Align Pool Royale cue-ball launch with visible aim guide

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24994,7 +24994,15 @@ const powerRef = useRef(hud.power);
         );
         // Keep first-contact aiming locked to the visible guide line. Spin remains
         // active only for post-impact cue/target behavior.
-        const shotAimDir = aimDir.clone();
+        const shotAimDir = guideAimDir2D?.clone?.() ?? aimDir.clone();
+        if (shotAimDir.lengthSq() < 1e-6) {
+          shotAimDir.copy(aimDir);
+        }
+        if (shotAimDir.lengthSq() < 1e-6) {
+          shotAimDir.set(0, 1);
+        } else {
+          shotAimDir.normalize();
+        }
         const prediction = calcTarget(cue, shotAimDir.clone(), balls);
         const predictedTravelRaw = prediction.targetBall
           ? cue.pos.distanceTo(prediction.targetBall.pos)


### PR DESCRIPTION
### Motivation
- Players reported the cue ball did not travel in the same direction shown by the on-screen aim line, causing confusing feedback during shots.
- The change aims to ensure the physics impulse uses the exact guide used for the visible aim, and to avoid edge-case zero-length direction vectors that could produce unpredictable launches.

### Description
- Use the visible guide direction by deriving the shot direction from `guideAimDir2D` with a fallback to `aimDir` via `const shotAimDir = guideAimDir2D?.clone?.() ?? aimDir.clone();`.
- Add defensive handling to copy `aimDir` when `shotAimDir` is nearly zero and to default to `(0,1)` if still invalid, then normalize the vector before prediction/use.
- Change is limited to `webapp/src/pages/Games/PoolRoyale.jsx` and keeps first-contact aiming aligned with what the player sees.

### Testing
- Built the webapp with `npm -C webapp run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fd0ac3b48329b9ce30cc21bfe2bd)