### PR TITLE
Refactor Pool Royale spin controller to natural radial input

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -102,10 +102,9 @@ import { markCareerStageCompleted } from '../../utils/poolRoyaleCareerProgress.j
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import {
   clampToUnitCircle,
-  computeQuantizedOffsetScaled,
+  mapRadialJoystickInput,
   mapSpinForPhysics,
   normalizeSpinInput,
-  smoothDamp,
   SPIN_STUN_RADIUS
 } from './poolRoyaleSpinUtils.js';
 import {
@@ -31274,18 +31273,9 @@ const powerRef = useRef(hud.power);
     let revertTimer = null;
     let activePointer = null;
     let moved = false;
-    let rafId = null;
-    let lastTime = null;
-    const spinState = {
-      current: { x: 0, y: 0 },
-      target: { x: 0, y: 0 },
-      velocity: { x: 0, y: 0 }
-    };
 
-    const SMOOTH_TIME = 0.085;
-    const MAX_SPEED = 6;
-    const MAX_STEP_SECONDS = 0.04;
-    const SETTLE_EPS = 0.0015;
+    const SPIN_STICK_DEADZONE = 0.085;
+    const SPIN_STICK_EXPONENT = 1.3;
 
     const clampToLimits = (nx, ny) => {
       const limits = spinLimitsRef.current || DEFAULT_SPIN_LIMITS;
@@ -31341,20 +31331,7 @@ const powerRef = useRef(hud.power);
       updateSpinDotPosition(clamped, legality.blocked);
     };
 
-    const applySnapTarget = () => {
-      const snapped = computeQuantizedOffsetScaled(
-        spinState.target.x,
-        spinState.target.y
-      );
-      spinState.target = clampToPlayable(snapped.x, snapped.y);
-      spinRequestRef.current = { ...spinState.target };
-      startSpring();
-    };
-
     const resetSpin = () => {
-      spinState.current = { x: 0, y: 0 };
-      spinState.target = { x: 0, y: 0 };
-      spinState.velocity = { x: 0, y: 0 };
       applySpin(0, 0);
     };
     resetSpin();
@@ -31364,11 +31341,13 @@ const powerRef = useRef(hud.power);
       const rect = box.getBoundingClientRect();
       const cx = clientX ?? rect.left + rect.width / 2;
       const cy = clientY ?? rect.top + rect.height / 2;
-      let nx = ((cx - rect.left) / rect.width) * 2 - 1;
-      let ny = -(((cy - rect.top) / rect.height) * 2 - 1);
-      spinState.target = clampToPlayable(nx, ny);
-      spinRequestRef.current = { ...spinState.target };
-      startSpring();
+      const nx = ((cx - rect.left) / rect.width) * 2 - 1;
+      const ny = -(((cy - rect.top) / rect.height) * 2 - 1);
+      const curved = mapRadialJoystickInput(nx, ny, {
+        deadzone: SPIN_STICK_DEADZONE,
+        exponent: SPIN_STICK_EXPONENT
+      });
+      applySpin(curved.x, curved.y);
     };
 
     const scaleBox = (value) => {
@@ -31392,59 +31371,6 @@ const powerRef = useRef(hud.power);
       }
     };
 
-    const startSpring = () => {
-      if (rafId) return;
-      rafId = requestAnimationFrame(stepSpring);
-    };
-
-    const stepSpring = (timestamp) => {
-      if (!showSpinController) {
-        rafId = null;
-        return;
-      }
-      if (!lastTime) lastTime = timestamp;
-      const dt = Math.min((timestamp - lastTime) / 1000, MAX_STEP_SECONDS);
-      lastTime = timestamp;
-      const { current, target, velocity } = spinState;
-      const nextX = smoothDamp(
-        current.x,
-        target.x,
-        velocity.x,
-        SMOOTH_TIME,
-        MAX_SPEED,
-        dt
-      );
-      const nextY = smoothDamp(
-        current.y,
-        target.y,
-        velocity.y,
-        SMOOTH_TIME,
-        MAX_SPEED,
-        dt
-      );
-      current.x = nextX.value;
-      current.y = nextY.value;
-      velocity.x = nextX.velocity;
-      velocity.y = nextY.velocity;
-      applySpin(current.x, current.y, { updateRequest: false });
-      const dx = target.x - current.x;
-      const dy = target.y - current.y;
-      const settled =
-        Math.abs(dx) < SETTLE_EPS &&
-        Math.abs(dy) < SETTLE_EPS &&
-        Math.hypot(velocity.x, velocity.y) < SETTLE_EPS;
-      if (settled) {
-        spinState.current = { ...target };
-        spinState.velocity = { x: 0, y: 0 };
-      }
-      const shouldContinue = activePointer !== null || !settled;
-      if (shouldContinue) {
-        rafId = requestAnimationFrame(stepSpring);
-      } else {
-        rafId = null;
-        lastTime = null;
-      }
-    };
 
     const handlePointerDown = (e) => {
       if (activePointer !== null) releasePointer();
@@ -31475,7 +31401,6 @@ const powerRef = useRef(hud.power);
     const handlePointerUp = (e) => {
       if (activePointer !== e.pointerId) return;
       finishInteraction(50);
-      applySnapTarget();
     };
 
     const handlePointerCancel = (e) => {
@@ -31483,7 +31408,6 @@ const powerRef = useRef(hud.power);
       releasePointer();
       clearTimer();
       scaleBox(1);
-      applySnapTarget();
     };
 
     if (showPlayerControls) {
@@ -31497,10 +31421,6 @@ const powerRef = useRef(hud.power);
       spinDotElRef.current = null;
       releasePointer();
       clearTimer();
-      if (rafId) {
-        cancelAnimationFrame(rafId);
-        rafId = null;
-      }
       resetSpinRef.current = () => {};
       spinRequestRef.current = { x: 0, y: 0 };
       spinLegalityRef.current = { blocked: false, reason: '' };

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -86,6 +86,32 @@ export const clampToUnitCircle = (x, y) => {
   return { x: x * scale, y: y * scale };
 };
 
+// Radial stick response adapted from open-source gamepad deadzone approaches
+// used by Godot and SDL communities (MIT-style implementations):
+// keep a deadzone near center, then remap remaining travel smoothly to the edge.
+export const mapRadialJoystickInput = (
+  x,
+  y,
+  options = {}
+) => {
+  const deadzone = clamp(options.deadzone ?? 0.09, 0, 0.95);
+  const exponent = clamp(options.exponent ?? 1.28, 0.6, 3);
+  const unit = clampToUnitCircle(x, y);
+  const magnitude = Math.hypot(unit.x, unit.y);
+  if (magnitude <= deadzone) {
+    return { x: 0, y: 0 };
+  }
+  const availableRange = Math.max(1 - deadzone, 1e-6);
+  const normalizedMagnitude = clamp((magnitude - deadzone) / availableRange, 0, 1);
+  const curvedMagnitude = Math.pow(normalizedMagnitude, exponent);
+  if (magnitude <= 1e-6) return { x: 0, y: 0 };
+  const inv = 1 / magnitude;
+  return {
+    x: unit.x * inv * curvedMagnitude,
+    y: unit.y * inv * curvedMagnitude
+  };
+};
+
 export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
   const length = Math.hypot(x, y);
   if (!Number.isFinite(length) || length <= maxOffset) {


### PR DESCRIPTION
### Motivation
- Make the Pool Royale spin control feel more natural and responsive by removing the previous spring/snap smoothing and quantization that produced unintuitive cue-ball spin behavior.
- Replace the old interaction flow with a free radial mapping that behaves like common open-source joystick deadzone handling to provide predictable touch/gamepad response.
- Preserve existing spin legality and table-clamp checks so gameplay rules and collision limits remain unchanged.

### Description
- Added `mapRadialJoystickInput` to `webapp/src/pages/Games/poolRoyaleSpinUtils.js`, implementing a radial deadzone + exponential remap (configurable `deadzone` and `exponent`).
- Rewired the Pool Royale spin controller in `webapp/src/pages/Games/PoolRoyale.jsx` to feed pointer input through `mapRadialJoystickInput` and `applySpin`, and removed the old spring/snap pipeline (`smoothDamp`, `computeQuantizedOffsetScaled`, RAF-driven spring state and snap target logic).
- Kept the existing clamp/legalization pipeline (`clampToPlayable`, `checkSpinLegality2D`, and `normalizeSpinInput`) so spin remains constrained by table/ball rules.
- Cleaned up unused state/scheduling related to the previous spring approach and updated imports accordingly.

### Testing
- Built the webapp successfully with Vite using `npm --prefix webapp run build` and observed a successful production build.
- Started the dev server (`npm --prefix webapp run dev`) to validate the app booted and served the changed page in a local environment.
- Attempted an automated browser screenshot via Playwright to visually validate the controller, but the screenshot tool timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30ca088c88329a9d5ed7ce182e45c)