### PR TITLE
Adjust Pool Royale spin controller response curve and center behavior

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -1,4 +1,4 @@
-import { mapSpinForPhysics, STUN_TOPSPIN_BIAS } from '../webapp/src/pages/Games/poolRoyaleSpinUtils.js';
+import { mapSpinForPhysics } from '../webapp/src/pages/Games/poolRoyaleSpinUtils.js';
 
 const getSigns = (vec) => ({
   x: Math.sign(vec.x),
@@ -6,11 +6,10 @@ const getSigns = (vec) => ({
 });
 
 describe('Pool Royale spin controller mapping', () => {
-  it('maps the center to a slight stun bias with minimal roll', () => {
+  it('maps the center to true stun (no spin)', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(center.y).toBeLessThanOrEqual(0);
-    expect(center.y).toBeGreaterThanOrEqual(STUN_TOPSPIN_BIAS);
+    expect(Math.abs(center.y)).toBe(0);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -10,7 +10,7 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const STUN_TOPSPIN_BIAS = -0.012;
+export const SPIN_RESPONSE_EXPONENT = 1.45;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -139,14 +139,28 @@ export const computeQuantizedOffsetScaled = (
 export const normalizeSpinInput = (spin) => {
   let x = clamp(spin?.x ?? 0, -1, 1);
   let y = clamp(spin?.y ?? 0, -1, 1);
-  const distance = Math.hypot(x, y);
-  if (distance <= Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)) {
-    if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) {
-      return { x: 0, y: 0 };
-    }
-    return { x: 0, y: Math.sign(y) * STUN_TOPSPIN_BIAS };
+
+  // Keep straight high/low and left/right shots easier to select by gently
+  // snapping near-axis drag noise to the principal axis.
+  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0;
+  if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0;
+
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  if (distance <= deadzone) {
+    return { x: 0, y: 0 };
   }
-  return clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+
+  const activeSpan = Math.max(MAX_SPIN_OFFSET - deadzone, 1e-6);
+  const normalized = clamp((distance - deadzone) / activeSpan, 0, 1);
+  const shaped = normalized ** SPIN_RESPONSE_EXPONENT;
+  const magnitude = deadzone + shaped * activeSpan;
+  const scale = magnitude / Math.max(distance, 1e-6);
+  return {
+    x: clamped.x * scale,
+    y: clamped.y * scale
+  };
 };
 
 export const mapUiOffsetToCueFrame = (


### PR DESCRIPTION
### Motivation
- Align the spin controller behavior with the provided reference so the controller keeps the same visual layout but produces a true no-spin center and a more progressive outer-spin response. 
- Reduce accidental near-axis noise so straight/top/back or left/right shots are easier to select while preserving existing left/right mapping and directional signs.

### Description
- Reworked spin normalization in `webapp/src/pages/Games/poolRoyaleSpinUtils.js` by replacing the previous small stun bias with a deadzone that maps the center to true no-spin and adding `SPIN_RESPONSE_EXPONENT` to shape a progressive response curve. 
- Added near-axis snapping using `STRAIGHT_SPIN_DEADZONE` and ensured inputs are clamped to `MAX_SPIN_OFFSET` before shaping magnitude to preserve direction and quantization behavior. 
- Kept the world-to-cue frame mapping (`mapUiOffsetToCueFrame`) unchanged so layout and direction signs remain identical. 
- Updated `test/poolRoyaleSpinController.test.js` to reflect the new center behavior and to keep direction/strength regression coverage.

### Testing
- Ran the controller unit tests with `npm test -- --runInBand test/poolRoyaleSpinController.test.js`, and the suite passed (7 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b388c9ca6c8329b155c3d0f0bc56d4)