### PR TITLE
Integrate AddForceAtPosition-based cue strike with spin (open-source adapted)

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -33,6 +33,11 @@ namespace Aiming
         public AnimationCurve pullbackEasing = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
         public AnimationCurve strikeEaseIn = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
+        [Header("Spin input")]
+        [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
+        public Vector2 spinInput;
+        public CueStrikePhysics strikePhysics = new CueStrikePhysics();
+
         Vector3 _aimDirection = Vector3.forward;
         Vector3 _targetDirection = Vector3.forward;
         float _currentPullback;
@@ -78,6 +83,11 @@ namespace Aiming
         public void BeginCharge()
         {
             _charging = true;
+        }
+
+        public void SetSpinInput(Vector2 normalizedSpin)
+        {
+            spinInput = Vector2.ClampMagnitude(normalizedSpin, 1f);
         }
 
         public void CancelCharge()
@@ -154,7 +164,7 @@ namespace Aiming
                 ballRadius = ballRadius,
                 tableBounds = tableBounds,
                 requiresPower = false,
-                highSpin = false,
+                highSpin = spinInput.sqrMagnitude > 0.0001f,
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
             return aiming.GetAimSolution(ctx);
@@ -218,7 +228,7 @@ namespace Aiming
             }
 
             float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
-            cueBallBody.AddForce(strikeDirection * impulseMagnitude, ForceMode.Impulse);
+            strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueStrikePhysics.cs
+++ b/Assets/Scripts/Gameplay/CueStrikePhysics.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    // Adapted to this project from the open-source pool-sharky cue strike pattern
+    // (AddForceAtPosition-based cue hit), then extended for full spin and torque control.
+    [System.Serializable]
+    public class CueStrikePhysics
+    {
+        [Header("Spin translation from tip offset")]
+        [Tooltip("Max normalized UI spin radius that maps to the cue-ball contact point.")]
+        [Range(0.1f, 1f)] public float maxSpinInput = 0.85f;
+        [Tooltip("How far from center the cue can hit (as a fraction of ball radius).")]
+        [Range(0.1f, 1f)] public float contactRadiusFactor = 0.82f;
+
+        [Header("Open-source style impulse model")]
+        [Tooltip("Extra forward impulse for top spin (follow).")]
+        public float topSpinForwardImpulseScale = 0.12f;
+        [Tooltip("Reverse impulse for back spin (draw).")]
+        public float backSpinReverseImpulseScale = 0.10f;
+        [Tooltip("Torque multiplier for side spin (left/right english).")]
+        public float sideSpinTorqueScale = 0.05f;
+        [Tooltip("Torque multiplier for top/back spin.")]
+        public float verticalSpinTorqueScale = 0.06f;
+
+        public void Apply(Rigidbody cueBallBody, Vector3 strikeDirection, float impulseMagnitude, Vector2 spinInput, float ballRadius)
+        {
+            if (cueBallBody == null)
+            {
+                return;
+            }
+
+            Vector3 planarDirection = Vector3.ProjectOnPlane(strikeDirection, Vector3.up);
+            if (planarDirection.sqrMagnitude < 1e-6f)
+            {
+                planarDirection = strikeDirection.sqrMagnitude > 1e-6f ? strikeDirection.normalized : Vector3.forward;
+            }
+            else
+            {
+                planarDirection.Normalize();
+            }
+
+            Vector2 clampedSpin = Vector2.ClampMagnitude(spinInput, maxSpinInput);
+            Vector3 right = Vector3.Cross(Vector3.up, planarDirection).normalized;
+            Vector3 contactOffset = ((right * clampedSpin.x) + (Vector3.up * clampedSpin.y)) * (ballRadius * contactRadiusFactor);
+            Vector3 contactPoint = cueBallBody.worldCenterOfMass + contactOffset;
+
+            cueBallBody.AddForceAtPosition(planarDirection * impulseMagnitude, contactPoint, ForceMode.Impulse);
+
+            if (Mathf.Abs(clampedSpin.x) > Mathf.Epsilon || Mathf.Abs(clampedSpin.y) > Mathf.Epsilon)
+            {
+                Vector3 torque = (Vector3.up * (-clampedSpin.x) * sideSpinTorqueScale +
+                    right * clampedSpin.y * verticalSpinTorqueScale) * impulseMagnitude;
+                cueBallBody.AddTorque(torque, ForceMode.Impulse);
+
+                float follow = Mathf.Max(0f, clampedSpin.y) * topSpinForwardImpulseScale;
+                float draw = Mathf.Max(0f, -clampedSpin.y) * backSpinReverseImpulseScale;
+                float spinLinearImpulse = (follow - draw) * impulseMagnitude;
+                if (Mathf.Abs(spinLinearImpulse) > Mathf.Epsilon)
+                {
+                    cueBallBody.AddForce(planarDirection * spinLinearImpulse, ForceMode.Impulse);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
+++ b/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class CueStrikePhysicsTests
+    {
+        [Test]
+        public void Apply_NoSpin_AddsForwardVelocity()
+        {
+            var go = new GameObject("CueBall");
+            var rb = go.AddComponent<Rigidbody>();
+            rb.useGravity = false;
+
+            var physics = new CueStrikePhysics();
+            physics.Apply(rb, Vector3.forward, 2f, Vector2.zero, 0.028575f);
+
+            Assert.Greater(rb.velocity.z, 0f);
+            Assert.That(rb.angularVelocity.sqrMagnitude, Is.EqualTo(0f).Within(1e-6f));
+
+            Object.DestroyImmediate(go);
+        }
+
+        [Test]
+        public void Apply_WithSideSpin_AddsAngularVelocity()
+        {
+            var go = new GameObject("CueBall");
+            var rb = go.AddComponent<Rigidbody>();
+            rb.useGravity = false;
+
+            var physics = new CueStrikePhysics();
+            physics.Apply(rb, Vector3.forward, 2f, new Vector2(0.75f, 0f), 0.028575f);
+
+            Assert.Greater(rb.velocity.z, 0f);
+            Assert.Greater(rb.angularVelocity.y, 0f);
+
+            Object.DestroyImmediate(go);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the simplistic single-impulse cue strike with a modular, open-source-style cue-hit that supports full spin (side, top/back) so the game can reuse an on-screen spin controller while improving spin fidelity and modularity.

### Description
- Introduced `CueStrikePhysics` (`Assets/Scripts/Gameplay/CueStrikePhysics.cs`) which applies hits using `AddForceAtPosition` and adds torque + follow/draw impulses to model side and vertical spin. 
- Updated `CueController` (`Assets/Scripts/Gameplay/CueController.cs`) to accept normalized spin via `SetSpinInput(Vector2)` and to route strikes through the new `strikePhysics.Apply(...)` path instead of directly calling `AddForce(...)`, and to drive `highSpin` from the spin input.
- Added play-mode tests at `Assets/Tests/PlayMode/CueStrikePhysicsTests.cs` that validate no-spin forward impulse and side-spin angular velocity generation.
- Code comments note the implementation is adapted from open-source Unity pool patterns (AddForceAtPosition cue-hit) and extended for torque/linear spin behavior.

### Testing
- Created and inspected new files and diffs for `CueController`, `CueStrikePhysics`, and `CueStrikePhysicsTests` and verified there are no diff-check issues using `git diff --check`.
- Added two NUnit play-mode tests (`Apply_NoSpin_AddsForwardVelocity` and `Apply_WithSideSpin_AddsAngularVelocity`) which are included in `Assets/Tests/PlayMode/CueStrikePhysicsTests.cs` but Unity Test Runner could not be executed here because the Unity CLI is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b393a5b2f883298719b248196fa941)