### PR TITLE
Align Snooker Royal spin and cue-pull controls with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1613,13 +1613,15 @@ const CUE_TIP_GAP = BALL_R * 1.02 + CUE_TIP_CLEARANCE; // pull the blue tip into
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.7;
+const CUE_PULL_VISUAL_MULTIPLIER = 1.28;
+const CUE_PULL_DISTANCE_SCALE = 0.5;
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
 const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.12; // ensure every stroke pulls slightly farther back for readability at all angles
+const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
+const CUE_PULL_RETURN_PUSH = 0.97; // push the cue forward to contact more decisively after pullback
 const CUE_STROKE_MIN_MS = 95;
 const CUE_STROKE_MAX_MS = 420;
 const CUE_STROKE_SPEED_MIN = BALL_R * 18;
@@ -19173,7 +19175,19 @@ const powerRef = useRef(hud.power);
               x: 0,
               y: 0
             };
-            legality = checkSpinLegality2D(cueBall, requested, ballsList, {
+            const viewClamped = clampSpinToVisibleHemisphere(
+              requested,
+              aimVec,
+              cueBall,
+              activeCamera
+            );
+            if (
+              viewClamped.x !== requested.x ||
+              viewClamped.y !== requested.y
+            ) {
+              spinRequestRef.current = { ...viewClamped };
+            }
+            legality = checkSpinLegality2D(cueBall, viewClamped, ballsList, {
               axes,
               view: viewVec
                 ? { x: viewVec.x, y: viewVec.y }
@@ -21418,7 +21432,7 @@ const powerRef = useRef(hud.power);
       const computeCuePull = (
         pullTarget = 0,
         maxPull = CUE_PULL_BASE,
-        { instant = false, preserveLarger = false } = {}
+        { instant = false, preserveLarger = false, smoothingOverride = null } = {}
       ) => {
         const slider = sliderInstanceRef.current;
         const dragging = Boolean(slider?.dragging);
@@ -21429,11 +21443,27 @@ const powerRef = useRef(hud.power);
           : pullTarget ?? 0;
         const boostedTarget = desiredTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
         const clampedTarget = THREE.MathUtils.clamp(boostedTarget, 0, effectiveMax);
-        const smoothing = instant || dragging ? 1 : CUE_PULL_SMOOTHING;
+        const smoothing = instant || dragging
+          ? 1
+          : Number.isFinite(smoothingOverride)
+            ? THREE.MathUtils.clamp(smoothingOverride, 0.04, 1)
+            : CUE_PULL_SMOOTHING;
+        const isReturning =
+          !dragging &&
+          !instant &&
+          clampedTarget <= 0 &&
+          (cuePullCurrentRef.current ?? 0) > 0;
+        const returnSmoothing = isReturning
+          ? Math.max(smoothing, CUE_PULL_RETURN_PUSH)
+          : smoothing;
         const nextPull =
-          smoothing >= 1
+          returnSmoothing >= 1
             ? clampedTarget
-            : THREE.MathUtils.lerp(cuePullCurrentRef.current ?? 0, clampedTarget, smoothing);
+            : THREE.MathUtils.lerp(
+                cuePullCurrentRef.current ?? 0,
+                clampedTarget,
+                returnSmoothing
+              );
         cuePullTargetRef.current = clampedTarget;
         cuePullCurrentRef.current = nextPull;
         return nextPull;
@@ -21478,8 +21508,8 @@ const powerRef = useRef(hud.power);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
         const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
         const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const logicTarget = CUE_LOGIC_PULL_EASE_RANGE * easedRatio;
-        const target = Math.max(logicTarget, amplifiedMax * ratio * CUE_PULL_VISUAL_MULTIPLIER);
+        const pullVisualScale = amplifiedMax * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
+        const target = Math.max(CUE_LOGIC_PULL_EASE_RANGE * easedRatio, pullVisualScale * easedRatio);
         return Math.min(target, visualMax);
       };
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);


### PR DESCRIPTION
### Motivation
- Make Snooker Royal use the same spin controller and cue/power-slider behavior as Pool Royale so touch/drag, spin clamping and shot feel match across games.

### Description
- Adjusted cue-pull tuning constants (`CUE_PULL_VISUAL_MULTIPLIER`, added `CUE_PULL_DISTANCE_SCALE`, `CUE_PULL_GLOBAL_VISIBILITY_BOOST`, `CUE_PULL_RETURN_PUSH`) to mirror Pool Royale visual and return behavior.
- Clamp spin input to the visible hemisphere before legality checks by using the same flow as Pool Royale (`clampSpinToVisibleHemisphere` then `checkSpinLegality2D`).
- Enhanced cue-pull interpolation to accept an optional `smoothingOverride` and apply a stronger return smoothing when pull is released so slider release feels like Pool Royale.
- Changed `computePullTargetFromPower` to use the aligned pull-distance model and eased scaling so power-to-pull mapping matches Pool Royale behavior.

### Testing
- Started the dev server with `npm -C webapp run dev` and verified the Snooker Royal page served successfully (Vite dev server came up).
- Attempted a production build with `npm -C webapp run build`, which started but did not complete within the runtime window in this environment.
- Attempted a Playwright screenshot to validate UI visuals, but the browser capture timed out in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39b4ed1e48329b05aefa61b244e3a)