### PR TITLE
Restore Pool Royale cue-stick impact timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25180,13 +25180,12 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
-          const shotImpactPayload = {
+          applyShotAtImpact({
             base,
             aimDir: shotAimDir,
             physicsSpin,
-            clampedPower,
-            applied: false
-          };
+            clampedPower
+          });
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25285,24 +25284,6 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const impactThreshold = THREE.MathUtils.clamp(
-            strokeProfile.impactThreshold ?? 0.9,
-            0,
-            1
-          );
-          const expectedImpactTime =
-            startTime +
-            Math.max(0, pullbackDuration) +
-            Math.max(1, strikeDuration) *
-              (strokeProfile.forwardOnly ? impactThreshold : 1);
-          const triggerShotImpact = () => {
-            applyShotAtImpact(shotImpactPayload);
-            pendingImpactRef.current = null;
-          };
-          pendingImpactRef.current = {
-            time: expectedImpactTime,
-            apply: triggerShotImpact
-          };
           const impactPos = idlePos.clone();
           // Match the reference cue-stick behavior for spin:
           // topspin adds a tiny forward follow-through after contact,
@@ -25461,18 +25442,14 @@ const powerRef = useRef(hud.power);
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true,
-              onImpact: triggerShotImpact,
-              shotApplied: false
+              releaseStartsFromCurrentPull: true
             };
           } else {
-            triggerShotImpact();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
-            pendingImpactRef.current = null;
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;


### PR DESCRIPTION
### Motivation
- The cue-stick animation felt different after a deferred-impact change; the goal is to restore the previous immediate-impact behavior so the strike feels like the reference implementation.
- Keep the existing cue animation visuals and camera logic while reverting only the timing/path that defers applying shot physics.

### Description
- Re-applied shot physics immediately by calling `applyShotAtImpact({...})` at shot start instead of creating and scheduling a deferred `shotImpactPayload` and `pendingImpactRef`.
- Removed the deferred-impact wiring from the cue stroke state (no `onImpact` callback, `shotApplied` flag, or scheduled `pendingImpactRef` use in this path) while leaving the stroke animation parameters unchanged in `cueStrokeStateRef`.
- Change made in `webapp/src/pages/Games/PoolRoyale.jsx` and limited to the shot execution / cue stroke setup block.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully.
- Started the dev server with `npm -C webapp run dev -- --host 0.0.0.0 --port 4173` and verified the app runs in a portrait viewport; a screenshot was captured to confirm UI and cue visuals.
- No automated test failures were observed during the build and dev smoke checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3acef22a48329a0adcb25da0d5bd9)