### PR TITLE
Restore rules-driven 8-ball/9-ball turn resolution in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27980,70 +27980,8 @@ const powerRef = useRef(hud.power);
           }
           trainingOutOfAttempts = remainingTrainingShots <= 0;
         }
-        const shooterPlayer = currentState?.activePlayer === 'B' ? 'B' : 'A';
-        const otherPlayer = shooterPlayer === 'B' ? 'A' : 'B';
-        const safeMetaState =
-          safeState && typeof safeState.meta === 'object' ? safeState.meta.state : null;
-        const currentMetaState =
-          currentState && typeof currentState.meta === 'object' ? currentState.meta.state : null;
-        const openingBreakInProgress =
-          Boolean(safeMetaState?.breakInProgress || currentMetaState?.breakInProgress) ||
-          (currentState?.currentBreak ?? 0) === 0;
-        if (!isTraining && openingBreakInProgress && !cueBallPotted && !safeState?.foul) {
-          const breakPotCount = potted.filter(
-            (entry) => String(entry?.id || '').toLowerCase() !== 'cue'
-          ).length;
-          const breakNextPlayer = breakPotCount > 0 ? shooterPlayer : otherPlayer;
-          const nextMeta =
-            safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
-          if (nextMeta?.state && typeof nextMeta.state === 'object') {
-            nextMeta.state = {
-              ...nextMeta.state,
-              currentPlayer: breakNextPlayer,
-              ballInHand: false
-            };
-          }
-          safeState = {
-            ...safeState,
-            activePlayer: breakNextPlayer,
-            meta: nextMeta ?? safeState.meta
-          };
-        }
-        if (!isTraining && cueBallPotted) {
-          const nextPlayer = currentState?.activePlayer === 'B' ? 'A' : 'B';
-          const nextMeta =
-            safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
-          if (nextMeta?.state && typeof nextMeta.state === 'object') {
-            nextMeta.state = {
-              ...nextMeta.state,
-              currentPlayer: nextPlayer,
-              ballInHand: true
-            };
-          }
-          safeState = {
-            ...safeState,
-            activePlayer: nextPlayer,
-            foul: safeState?.foul ?? { points: 0, reason: 'scratch' },
-            meta: nextMeta ?? safeState.meta
-          };
-        }
-        if (!isTraining && safeState?.foul) {
-          const foulNextPlayer = currentState?.activePlayer === 'B' ? 'A' : 'B';
-          const nextMeta =
-            safeState && typeof safeState.meta === 'object' ? { ...safeState.meta } : safeState?.meta;
-          if (nextMeta?.state && typeof nextMeta.state === 'object') {
-            nextMeta.state = {
-              ...nextMeta.state,
-              currentPlayer: foulNextPlayer,
-              ballInHand: true
-            };
-          }
-          safeState = {
-            ...safeState,
-            activePlayer: foulNextPlayer,
-            meta: nextMeta ?? safeState.meta
-          };
-        }
+        // Preserve variant rule outcomes for turn handling (8-ball / 9-ball) as returned by PoolRoyaleRules.
+        // Do not override break, foul, or scratch turn transitions here.
         if (shotRecording) {
           shotRecording.replayFoul = safeState?.foul
             ? { ...safeState.foul }


### PR DESCRIPTION
### Motivation
- Ensure turn handoff for 8-ball and 9-ball follows the authoritative rules engine instead of being re-mapped by the UI layer.
- Prevent UI-side post-shot overrides from conflicting with `PoolRoyaleRules.applyShot(...)` outputs for break, scratch, and foul cases.

### Description
- Removed the post-shot block in `webapp/src/pages/Games/PoolRoyale.jsx` that forcibly reassigned `activePlayer`/meta on break, scratch and foul branches. 
- Replaced that logic with a short comment clarifying that variant rule outcomes returned by `PoolRoyaleRules.applyShot(...)` must be preserved and not overridden. 
- Scope of the change is limited to the shot-resolution / turn-handoff area; no other gameplay or UI behavior was altered.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleRules.test.ts` against the modified code. 
- The test suite passed: 1 test suite, 3 tests all green (tests for UK/American/9-ball rule behaviors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b7e375b88329bf270670490bda85)