### PR TITLE
Improve spin-accurate aim preview and natural pocket jaw rebounds

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -221,3 +221,71 @@ public class SpinActivationTests
         Assert.That(ball.SpinEffectsEnabled, Is.True);
     }
 }
+
+
+public class SpinPreviewDirectionTests
+{
+    [Test]
+    public void SpinPreviewMatchesRuntimeForPostImpactDirections()
+    {
+        var solver = new BilliardsSolver();
+        solver.InitStandardTable();
+        var start = new Vec2(0.3, 0.5);
+        var target = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.15, 0.5) } };
+        var shot = new BilliardsSolver.ShotParams
+        {
+            Direction = new Vec2(1, 0),
+            Speed = 2.1,
+            Spin = new BilliardsSolver.ShotSpin { Side = 0.65, Top = 0.2, Back = 0 },
+            CueElevationDeg = 0
+        };
+
+        var preview = solver.PreviewShot(shot, start, target);
+        var runtime = solver.SimulateFirstImpact(shot, start, target);
+
+        Assert.That(preview.TargetPostVelocity.HasValue, Is.True);
+        Assert.That(runtime.TargetVelocity.HasValue, Is.True);
+        Assert.That((preview.ContactPoint - runtime.Point).Length, Is.LessThan(PhysicsConstants.BallRadius * 0.5));
+
+        var previewCue = preview.CuePostVelocity.Normalized();
+        var runtimeCue = runtime.CueVelocity.Normalized();
+        var previewTarget = preview.TargetPostVelocity!.Value.Normalized();
+        var runtimeTarget = runtime.TargetVelocity!.Value.Normalized();
+
+        Assert.That((previewCue - runtimeCue).Length, Is.LessThan(1e-6));
+        Assert.That((previewTarget - runtimeTarget).Length, Is.LessThan(1e-6));
+    }
+
+    [Test]
+    public void SideSpinChangesTargetDirectionComparedToNoSpin()
+    {
+        var solver = new BilliardsSolver();
+        solver.InitStandardTable();
+        var start = new Vec2(0.3, 0.5);
+        var target = new List<BilliardsSolver.Ball> { new BilliardsSolver.Ball { Position = new Vec2(1.1, 0.5) } };
+
+        var baseImpact = solver.SimulateFirstImpact(new BilliardsSolver.ShotParams
+        {
+            Direction = new Vec2(1, 0),
+            Speed = 2.0,
+            Spin = BilliardsSolver.ShotSpin.None,
+            CueElevationDeg = 0
+        }, start, target);
+
+        var spinImpact = solver.SimulateFirstImpact(new BilliardsSolver.ShotParams
+        {
+            Direction = new Vec2(1, 0),
+            Speed = 2.0,
+            Spin = new BilliardsSolver.ShotSpin { Side = 0.8, Top = 0.0, Back = 0.0 },
+            CueElevationDeg = 0
+        }, start, target);
+
+        Assert.That(baseImpact.TargetVelocity.HasValue, Is.True);
+        Assert.That(spinImpact.TargetVelocity.HasValue, Is.True);
+
+        var noSpinDir = baseImpact.TargetVelocity!.Value.Normalized();
+        var withSpinDir = spinImpact.TargetVelocity!.Value.Normalized();
+        Assert.That(Math.Abs(withSpinDir.Y), Is.GreaterThan(Math.Abs(noSpinDir.Y) + 1e-4));
+        Assert.That(Math.Abs(spinImpact.TargetThrowAngleDeg), Is.GreaterThan(0.1));
+    }
+}

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -363,6 +363,7 @@ public class BilliardsSolver
         public Vec2 Point;
         public Vec2 CueVelocity;
         public Vec2? TargetVelocity;
+        public double TargetThrowAngleDeg;
     }
 
     /// <summary>Integrates positions and handles cushion reflections for one step.</summary>
@@ -714,8 +715,14 @@ public class BilliardsSolver
                     if (t <= dt)
                     {
                         cue.Position += cue.Velocity * t;
-                        Collision.ResolveBallBall(cue.Position, cue.Velocity, b.Position, new Vec2(0, 0), out var cuePost, out var targetPost);
-                        impact = new Impact { Point = cue.Position, CueVelocity = cuePost, TargetVelocity = targetPost };
+                        ResolveBallBallWithSpin(cue, b, out var cuePost, out var targetPost, out var throwAngleDeg);
+                        impact = new Impact
+                        {
+                            Point = cue.Position,
+                            CueVelocity = cuePost,
+                            TargetVelocity = targetPost,
+                            TargetThrowAngleDeg = throwAngleDeg
+                        };
                         return true;
                     }
                 }
@@ -773,6 +780,44 @@ public class BilliardsSolver
 
         impact = new Impact();
         return false;
+    }
+
+    private static void ResolveBallBallWithSpin(Ball cue, Ball target, out Vec2 cuePost, out Vec2 targetPost, out double throwAngleDeg)
+    {
+        Collision.ResolveBallBall(cue.Position, cue.Velocity, target.Position, target.Velocity, out cuePost, out targetPost);
+
+        throwAngleDeg = 0;
+        var targetSpeed = targetPost.Length;
+        if (targetSpeed < PhysicsConstants.Epsilon)
+            return;
+
+        var normal = (target.Position - cue.Position).Normalized();
+        if (normal.Length < PhysicsConstants.Epsilon)
+            return;
+
+        double normalizedSide = Math.Clamp(cue.SideSpin / PhysicsConstants.MaxTipOffsetRatio, -1.0, 1.0);
+        double normalizedForward = Math.Clamp(cue.ForwardSpin / PhysicsConstants.MaxTipOffsetRatio, -1.0, 1.0);
+        double throwScale = Math.Clamp(
+            normalizedSide * PhysicsConstants.SpinThrowSideFactor
+            + normalizedForward * PhysicsConstants.SpinThrowForwardFactor,
+            -1.0,
+            1.0);
+
+        double throwAngleRad = (PhysicsConstants.SpinThrowMaxAngleDeg * throwScale) * Math.PI / 180.0;
+        throwAngleDeg = throwAngleRad * 180.0 / Math.PI;
+        if (Math.Abs(throwAngleRad) < PhysicsConstants.Epsilon)
+            return;
+
+        double cos = Math.Cos(throwAngleRad);
+        double sin = Math.Sin(throwAngleRad);
+        Vec2 rotatedTargetDir = new Vec2(
+            normal.X * cos - normal.Y * sin,
+            normal.X * sin + normal.Y * cos);
+        targetPost = rotatedTargetDir.Normalized() * targetSpeed;
+
+        // cue ball receives opposite tangent component to preserve a believable split.
+        var tangent = new Vec2(-normal.Y, normal.X);
+        cuePost += tangent * (-throwScale) * targetSpeed * PhysicsConstants.SpinCueDeflectionFactor;
     }
 
     private static void AppendPathPoint(List<Vec2> path, Vec2 point, ref Vec2 lastSample, bool force)

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -6,10 +6,10 @@ public static class PhysicsConstants
     public const double BallRadius = 0.028575;        // metres (57.15 mm diameter)
     public const double Restitution = 0.915;           // elastic coefficient (clean cushion hits 0.85–0.92)
     public const double CushionRestitution = 0.93; // slightly livelier cushions for a touch more bounce
-    // connectors retain only a quarter of the cushion bounce (lose ~75% of speed)
-    public const double ConnectorRestitution = CushionRestitution * 0.25;
-    // pocket edges fully absorb balls (no bounce)
-    public const double PocketRestitution = 0.0;
+    // connectors are lively enough to avoid unnaturally funneling balls into pockets.
+    public const double ConnectorRestitution = CushionRestitution * 0.82;
+    // pocket jaw faces still bounce; actual pocketing is handled by capture zones.
+    public const double PocketRestitution = CushionRestitution * 0.68;
     public const double Mu = 0.2;                      // linear damping (m/s^2)
     public const double Gravity = 9.81;                // m/s^2
     public const double AirDrag = 0.05;                // linear damping in flight (m/s^2)
@@ -40,6 +40,10 @@ public static class PhysicsConstants
     public const double MaxCueElevationDegrees = 85.0; // clamp to UI upper bound
     public const double MaxTipOffsetRatio = 0.9;       // max cue tip offset as a fraction of radius
     public const double PreviewPointSpacing = BallRadius * 0.85; // spacing for curved aim preview
+    public const double SpinThrowMaxAngleDeg = 5.0;    // max object-ball throw from side spin on impact
+    public const double SpinThrowSideFactor = 0.9;     // side-spin contribution to throw
+    public const double SpinThrowForwardFactor = 0.28; // follow/draw contribution to throw
+    public const double SpinCueDeflectionFactor = 0.16; // cue-ball tangent deflection from spin transfer
     public const double TableWidth = 2.627;            // 9ft table reduced by ~7.5%
     public const double TableHeight = 1.07707;
     public const double FixedDt = 1.0 / 120.0;         // simulation step
@@ -52,7 +56,7 @@ public static class PhysicsConstants
     // Pocket geometry derived from WPA spec (metres)
     public const double CornerPocketMouth = 0.1014984; // scaled with table reduction
     public const double SidePocketMouth = 0.1116013;    // scaled with table reduction
-    public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
+    public const double PocketCaptureRadius = 0.0815;  // tightened to reduce magnetic pocket captures
     public const double CornerPocketScale = 0.965;      // slightly tighten corner pocket/cutout radius
     public const double PocketAngleCutScale = 1.035;    // extend angle cut slightly for truer mouth mapping
     public const double CornerJawRadiusScale = 0.94;
@@ -61,11 +65,11 @@ public static class PhysicsConstants
     public const double SideJawDepthScale = 1.08;
     // Shift the pocket capture center outward for the chrome plate cut.
     public const double SidePocketOutset = 0.006;
-    // Offset pocket mouth guards to stop balls slipping between jaws and cushions.
-    public const double PocketMouthGuardInset = BallRadius * 0.35;
+    // Keep guards minimal so jaws/cushions bounce naturally at the pocket lips.
+    public const double PocketMouthGuardInset = BallRadius * 0.12;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 40;
     public const int SideJawSegments = 30;
-    public const int JawCushionSegments = 3;           // how many segments nearest the rails behave as cushions
+    public const int JawCushionSegments = 7;           // wider cushion band around jaw lips for natural rebounds
 }


### PR DESCRIPTION
### Motivation

- Make the on-screen aiming target line and cue-ball direction reflect true post-impact directions when spin is applied. 
- Reduce the current "magnetic" / guided behavior near pocket jaws and cushions so balls rebound more naturally instead of being funneled into pockets.

### Description

- Added spin-aware ball-ball impact resolution `ResolveBallBallWithSpin(...)` and wire it into preview/runtime impact detection so both preview and runtime include spin-induced target throw and cue deflection (updated `TryFindImpact(...)` and `Impact` with `TargetThrowAngleDeg`).
- Introduced tunable spin-throw constants in `PhysicsConstants` (`SpinThrowMaxAngleDeg`, `SpinThrowSideFactor`, `SpinThrowForwardFactor`, `SpinCueDeflectionFactor`) and apply them during post-impact direction adjustment.
- Rebalanced pocket/jaw/cushion tuning constants in `PhysicsConstants` to reduce assisted pocketing by increasing connector/pocket edge restitution, tightening `PocketCaptureRadius`, reducing `PocketMouthGuardInset`, and widening the jaw cushion band (`JawCushionSegments`).
- Added unit tests (`SpinPreviewDirectionTests`) verifying preview vs runtime agreement for post-impact directions and that side spin produces measurable target direction change and non-zero throw angle (`billiards.Tests/UnitTest1.cs`).

### Testing

- Added/updated unit tests in `billiards.Tests/UnitTest1.cs` covering spin-aware preview/runtime direction alignment and spin-induced target deviation, but tests were not executed in this environment because the `dotnet` CLI is unavailable (attempted `dotnet test` returned `bash: command not found: dotnet`).
- Basic local compilation/run of test harness could not be validated here; functional validation should be performed in CI or a dev environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3baf410cc83298d0b7d262c80fb39)