### PR TITLE
Trigger cue-ball impulse at visible cue contact (align cue animation & physics)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25180,12 +25180,13 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
-          applyShotAtImpact({
+          const shotImpactPayload = {
             base,
             aimDir: shotAimDir,
             physicsSpin,
-            clampedPower
-          });
+            clampedPower,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25439,12 +25440,15 @@ const powerRef = useRef(hud.power);
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
               strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.9,
+              shotApplied: false,
+              onImpact: () => applyShotAtImpact(shotImpactPayload),
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
           } else {
+            applyShotAtImpact(shotImpactPayload);
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Players see the cue stick pull back but the cue ball moves immediately at shot start, so animation and physics are visually out of sync.
- The change aligns the visible cue stroke (pull → push → impact) with when the physics impulse is applied so live shots and replays match one source-of-truth timing.

### Description
- Prepare a per-shot `shotImpactPayload` and stop applying the shot impulse immediately at fire time, deferring application until the stroke impact moment (file changed: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Wire `cueStrokeStateRef.current.onImpact` to call `applyShotAtImpact(shotImpactPayload)` so the physics is triggered when the cue stroke reaches its impact threshold in the animation.
- Add `shotApplied` flag and an `applied` field on the payload to ensure the impact is only applied once during the stroke window.
- Preserve a fallback: when `ENABLE_CUE_STROKE_ANIMATION` is disabled the shot is applied immediately so gameplay remains functional without animation.

### Testing
- Ran lint on the changed file with `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which reported the file is ignored by project lint patterns so no per-file errors were emitted for this patch.
- Ran the repository lint command `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx` which surfaced many unrelated repo-wide lint errors in generated/dist files and is therefore not actionable for this small change.
- Started the webapp dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and validated the app loads by capturing a Playwright screenshot of `http://127.0.0.1:4173` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39c2830a08329888ff8cb93d74f2a)