### PR TITLE
Restore Pool Royale to 10:00 snapshot — reinstate cue-strike physics and pocket capture

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -33,6 +33,11 @@ namespace Aiming
         public AnimationCurve pullbackEasing = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
         public AnimationCurve strikeEaseIn = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
+        [Header("Spin input")]
+        [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
+        public Vector2 spinInput;
+        public CueStrikePhysics strikePhysics = new CueStrikePhysics();
+
         Vector3 _aimDirection = Vector3.forward;
         Vector3 _targetDirection = Vector3.forward;
         float _currentPullback;
@@ -78,6 +83,11 @@ namespace Aiming
         public void BeginCharge()
         {
             _charging = true;
+        }
+
+        public void SetSpinInput(Vector2 normalizedSpin)
+        {
+            spinInput = Vector2.ClampMagnitude(normalizedSpin, 1f);
         }
 
         public void CancelCharge()
@@ -154,7 +164,7 @@ namespace Aiming
                 ballRadius = ballRadius,
                 tableBounds = tableBounds,
                 requiresPower = false,
-                highSpin = false,
+                highSpin = spinInput.sqrMagnitude > 0.0001f,
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
             return aiming.GetAimSolution(ctx);
@@ -218,7 +228,7 @@ namespace Aiming
             }
 
             float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
-            cueBallBody.AddForce(strikeDirection * impulseMagnitude, ForceMode.Impulse);
+            strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueStrikePhysics.cs
+++ b/Assets/Scripts/Gameplay/CueStrikePhysics.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    // Adapted to this project from the open-source pool-sharky cue strike pattern
+    // (AddForceAtPosition-based cue hit), then extended for full spin and torque control.
+    [System.Serializable]
+    public class CueStrikePhysics
+    {
+        [Header("Spin translation from tip offset")]
+        [Tooltip("Max normalized UI spin radius that maps to the cue-ball contact point.")]
+        [Range(0.1f, 1f)] public float maxSpinInput = 0.85f;
+        [Tooltip("How far from center the cue can hit (as a fraction of ball radius).")]
+        [Range(0.1f, 1f)] public float contactRadiusFactor = 0.82f;
+
+        [Header("Open-source style impulse model")]
+        [Tooltip("Extra forward impulse for top spin (follow).")]
+        public float topSpinForwardImpulseScale = 0.12f;
+        [Tooltip("Reverse impulse for back spin (draw).")]
+        public float backSpinReverseImpulseScale = 0.10f;
+        [Tooltip("Torque multiplier for side spin (left/right english).")]
+        public float sideSpinTorqueScale = 0.05f;
+        [Tooltip("Torque multiplier for top/back spin.")]
+        public float verticalSpinTorqueScale = 0.06f;
+
+        public void Apply(Rigidbody cueBallBody, Vector3 strikeDirection, float impulseMagnitude, Vector2 spinInput, float ballRadius)
+        {
+            if (cueBallBody == null)
+            {
+                return;
+            }
+
+            Vector3 planarDirection = Vector3.ProjectOnPlane(strikeDirection, Vector3.up);
+            if (planarDirection.sqrMagnitude < 1e-6f)
+            {
+                planarDirection = strikeDirection.sqrMagnitude > 1e-6f ? strikeDirection.normalized : Vector3.forward;
+            }
+            else
+            {
+                planarDirection.Normalize();
+            }
+
+            Vector2 clampedSpin = Vector2.ClampMagnitude(spinInput, maxSpinInput);
+            Vector3 right = Vector3.Cross(Vector3.up, planarDirection).normalized;
+            Vector3 contactOffset = ((right * clampedSpin.x) + (Vector3.up * clampedSpin.y)) * (ballRadius * contactRadiusFactor);
+            Vector3 contactPoint = cueBallBody.worldCenterOfMass + contactOffset;
+
+            cueBallBody.AddForceAtPosition(planarDirection * impulseMagnitude, contactPoint, ForceMode.Impulse);
+
+            if (Mathf.Abs(clampedSpin.x) > Mathf.Epsilon || Mathf.Abs(clampedSpin.y) > Mathf.Epsilon)
+            {
+                Vector3 torque = (Vector3.up * (-clampedSpin.x) * sideSpinTorqueScale +
+                    right * clampedSpin.y * verticalSpinTorqueScale) * impulseMagnitude;
+                cueBallBody.AddTorque(torque, ForceMode.Impulse);
+
+                float follow = Mathf.Max(0f, clampedSpin.y) * topSpinForwardImpulseScale;
+                float draw = Mathf.Max(0f, -clampedSpin.y) * backSpinReverseImpulseScale;
+                float spinLinearImpulse = (follow - draw) * impulseMagnitude;
+                if (Mathf.Abs(spinLinearImpulse) > Mathf.Epsilon)
+                {
+                    cueBallBody.AddForce(planarDirection * spinLinearImpulse, ForceMode.Impulse);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketCaptureResolver.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCaptureResolver.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Determines when a ball crosses pocket mouth and is committed to falling.
+    /// Separate from collision so entering balls are not unrealistically bounced out.
+    /// </summary>
+    [System.Serializable]
+    public class PocketCaptureResolver
+    {
+        [SerializeField] private bool deterministicRejection = true;
+        [SerializeField, Min(0f)] private float sinkSpeed = 3.2f;
+
+        private readonly HashSet<int> committedBallIds = new HashSet<int>();
+
+        public bool IsCommitted(int id) => committedBallIds.Contains(id);
+        public void ClearCommitted(int id) => committedBallIds.Remove(id);
+
+        public bool TryCapture(IPoolBallBody ball, PocketMouth mouth, PocketCaptureZone capture, out bool committed)
+        {
+            committed = false;
+            if (ball == null || !ball.IsValid || mouth == null || capture == null || !mouth.IsConfigured)
+            {
+                return false;
+            }
+
+            Vector2 mouthCenter = mouth.MouthCenter;
+            Vector2 openDir = mouth.FallDirection;
+            Vector2 toBall = ball.Position2 - mouthCenter;
+            float depth = Vector2.Dot(toBall, openDir);
+            float lateral = Mathf.Abs(Vector2.Dot(toBall, new Vector2(openDir.y, -openDir.x)));
+
+            if (lateral > (mouth.MouthWidth * 0.5f + capture.CaptureThreshold))
+            {
+                return false;
+            }
+
+            if (depth < capture.MinimumCaptureDepth)
+            {
+                return false;
+            }
+
+            Vector2 vel = ball.Velocity2;
+            float speed = vel.magnitude;
+            if (speed < 1e-5f)
+            {
+                Commit(ball, openDir, capture, ref committed);
+                return true;
+            }
+
+            float angle = Vector2.Angle(vel.normalized, openDir);
+            bool validAngle = angle <= capture.RejectionAngleTolerance;
+            bool tooFastForGuaranteed = speed > capture.CleanCaptureSpeedThreshold;
+
+            if (!validAngle)
+            {
+                return false;
+            }
+
+            if (tooFastForGuaranteed)
+            {
+                bool reject = deterministicRejection
+                    ? angle > capture.RejectionAngleTolerance * 0.85f
+                    : Random.value < capture.FastGlanceRejectionChance;
+                if (reject)
+                {
+                    return false;
+                }
+            }
+
+            Commit(ball, openDir, capture, ref committed);
+            return true;
+        }
+
+        private void Commit(IPoolBallBody ball, Vector2 openDir, PocketCaptureZone capture, ref bool committed)
+        {
+            if (capture.CommitOnCapture)
+            {
+                committedBallIds.Add(ball.Id);
+                committed = true;
+            }
+
+            // 2D + 3D shared behavior: once captured, pull velocity into pocket centerline.
+            ball.Velocity2 = openDir * sinkSpeed;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketCaptureZone.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCaptureZone.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Dedicated capture volume behind mouth. Independent from jaw collision response.
+    /// </summary>
+    public class PocketCaptureZone : MonoBehaviour
+    {
+        [Header("Capture thresholds")]
+        [SerializeField, Min(0f)] private float captureThreshold = 0.012f;
+        [SerializeField, Min(0f)] private float minimumCaptureDepth = 0.018f;
+        [SerializeField, Range(0f, 90f)] private float rejectionAngleTolerance = 65f;
+        [SerializeField, Min(0f)] private float cleanCaptureSpeedThreshold = 1.8f;
+        [SerializeField] private bool commitOnCapture = true;
+
+        [Header("Fallback tuning")]
+        [SerializeField, Range(0f, 1f)] private float fastGlanceRejectionChance = 0.5f;
+
+        public float CaptureThreshold => captureThreshold;
+        public float MinimumCaptureDepth => minimumCaptureDepth;
+        public float RejectionAngleTolerance => rejectionAngleTolerance;
+        public float CleanCaptureSpeedThreshold => cleanCaptureSpeedThreshold;
+        public bool CommitOnCapture => commitOnCapture;
+        public float FastGlanceRejectionChance => fastGlanceRejectionChance;
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Resolves jaw-face + rounded-tip contacts using explicit billiards response.
+    /// </summary>
+    [System.Serializable]
+    public class PocketCollisionResolver
+    {
+        [SerializeField, Min(0f)] private float positionalSlop = 0.0002f;
+        [SerializeField, Min(0f)] private float maxPushOut = 0.02f;
+
+        public bool Resolve(IPoolBallBody ball, PocketMouth mouth)
+        {
+            if (ball == null || !ball.IsValid || ball.IsKinematic || mouth == null || !mouth.IsConfigured)
+            {
+                return false;
+            }
+
+            bool any = false;
+            any |= ResolveJaw(ball, mouth.LeftJaw);
+            any |= ResolveJaw(ball, mouth.RightJaw);
+            any |= ResolveTip(ball, mouth.LeftJaw.StartTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth.LeftJaw.EndTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth.RightJaw.StartTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            any |= ResolveTip(ball, mouth.RightJaw.EndTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            return any;
+        }
+
+        private bool ResolveJaw(IPoolBallBody ball, PocketJawDefinition jaw)
+        {
+            FiniteJawSegment segment = jaw.Segment;
+            if (!PocketGeometry.TryCircleVsCapsule(
+                    ball.Position2,
+                    ball.Radius,
+                    segment,
+                    jaw.JawRadius,
+                    out Vector2 normal,
+                    out float penetration,
+                    out _))
+            {
+                return false;
+            }
+
+            ApplyCollisionResponse(ball, normal, penetration, jaw.JawRestitution, jaw.JawFriction);
+            return true;
+        }
+
+        private bool ResolveTip(IPoolBallBody ball, JawTip tip, float restitution, float friction)
+        {
+            if (!PocketGeometry.TryCircleVsTip(ball.Position2, ball.Radius, tip, out Vector2 normal, out float penetration))
+            {
+                return false;
+            }
+
+            ApplyCollisionResponse(ball, normal, penetration, restitution, friction);
+            return true;
+        }
+
+        private void ApplyCollisionResponse(IPoolBallBody ball, Vector2 normal, float penetration, float restitution, float friction)
+        {
+            float push = Mathf.Min(Mathf.Max(0f, penetration + positionalSlop), maxPushOut);
+            ball.Position2 += normal * push;
+
+            Vector2 vel = ball.Velocity2;
+            float vn = Vector2.Dot(vel, normal);
+
+            // Only reflect when moving into the jaw.
+            if (vn < 0f)
+            {
+                Vector2 vN = normal * vn;
+                Vector2 vT = vel - vN;
+                Vector2 reflectedN = -vN * Mathf.Clamp01(restitution);
+                Vector2 dampedT = vT * Mathf.Clamp01(1f - friction);
+                ball.Velocity2 = reflectedN + dampedT;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketGeometry.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketGeometry.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Finite, bounded jaw segment in table space.
+    /// Collision uses closest-point-on-segment, never infinite lines.
+    /// </summary>
+    [System.Serializable]
+    public struct FiniteJawSegment
+    {
+        public Vector2 start;
+        public Vector2 end;
+
+        public Vector2 Direction => end - start;
+        public float Length => Direction.magnitude;
+
+        public Vector2 ClosestPoint(Vector2 point, out float t)
+        {
+            Vector2 d = end - start;
+            float lenSq = d.sqrMagnitude;
+            if (lenSq < 1e-8f)
+            {
+                t = 0f;
+                return start;
+            }
+
+            // Segment-bounded projection: clamp [0..1] guarantees finite jaw only.
+            t = Mathf.Clamp01(Vector2.Dot(point - start, d) / lenSq);
+            return start + d * t;
+        }
+
+        public Vector2 ClosestPoint(Vector2 point)
+        {
+            return ClosestPoint(point, out _);
+        }
+    }
+
+    /// <summary>
+    /// Rounded jaw cap used for realistic grazing / rattle / rejection.
+    /// </summary>
+    [System.Serializable]
+    public struct JawTip
+    {
+        public Vector2 center;
+        public float radius;
+
+        public Vector2 ClosestPoint(Vector2 point)
+        {
+            Vector2 delta = point - center;
+            float len = delta.magnitude;
+            if (len < 1e-6f)
+            {
+                return center + Vector2.right * radius;
+            }
+
+            return center + (delta / len) * radius;
+        }
+    }
+
+    public static class PocketGeometry
+    {
+        public static bool TryCircleVsCapsule(
+            Vector2 center,
+            float sphereRadius,
+            FiniteJawSegment segment,
+            float capsuleRadius,
+            out Vector2 normal,
+            out float penetration,
+            out Vector2 closest)
+        {
+            closest = segment.ClosestPoint(center);
+            Vector2 delta = center - closest;
+            float distance = delta.magnitude;
+            float totalRadius = sphereRadius + Mathf.Max(0f, capsuleRadius);
+            penetration = totalRadius - distance;
+
+            if (penetration <= 0f)
+            {
+                normal = Vector2.zero;
+                return false;
+            }
+
+            if (distance < 1e-6f)
+            {
+                Vector2 tangent = segment.Direction.normalized;
+                normal = new Vector2(-tangent.y, tangent.x);
+                if (normal.sqrMagnitude < 1e-6f)
+                {
+                    normal = Vector2.up;
+                }
+            }
+            else
+            {
+                normal = delta / distance;
+            }
+
+            return true;
+        }
+
+        public static bool TryCircleVsTip(
+            Vector2 center,
+            float sphereRadius,
+            JawTip tip,
+            out Vector2 normal,
+            out float penetration)
+        {
+            Vector2 delta = center - tip.center;
+            float distance = delta.magnitude;
+            float totalRadius = sphereRadius + Mathf.Max(0f, tip.radius);
+            penetration = totalRadius - distance;
+
+            if (penetration <= 0f)
+            {
+                normal = Vector2.zero;
+                return false;
+            }
+
+            normal = distance < 1e-6f ? Vector2.up : delta / distance;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Inspector-facing jaw data. Points are in table local space (2D footprint: X/Z by default).
+    /// </summary>
+    public class PocketJawDefinition : MonoBehaviour
+    {
+        [Header("Jaw bounds (local table space)")]
+        [SerializeField] private Vector2 start = new Vector2(-0.05f, 0f);
+        [SerializeField] private Vector2 end = new Vector2(0.05f, 0f);
+
+        [Header("Jaw contact")]
+        [SerializeField, Min(0f)] private float jawRadius = 0.012f;
+        [SerializeField, Range(0f, 1f)] private float jawRestitution = 0.2f;
+        [SerializeField, Range(0f, 1f)] private float jawFriction = 0.35f;
+
+        public FiniteJawSegment Segment => new FiniteJawSegment { start = start, end = end };
+        public JawTip StartTip => new JawTip { center = start, radius = jawRadius };
+        public JawTip EndTip => new JawTip { center = end, radius = jawRadius };
+
+        public float JawRadius => jawRadius;
+        public float JawRestitution => jawRestitution;
+        public float JawFriction => jawFriction;
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = new Color(0.9f, 0.4f, 0.15f, 1f);
+            DrawCircle(start, jawRadius);
+            DrawCircle(end, jawRadius);
+
+            Gizmos.color = new Color(1f, 0.7f, 0.25f, 1f);
+            Vector3 a = new Vector3(start.x, transform.position.y, start.y);
+            Vector3 b = new Vector3(end.x, transform.position.y, end.y);
+            Gizmos.DrawLine(a, b);
+        }
+
+        private void DrawCircle(Vector2 p, float r)
+        {
+            const int steps = 24;
+            Vector3 prev = Vector3.zero;
+            for (int i = 0; i <= steps; i++)
+            {
+                float t = i / (float)steps;
+                float ang = t * Mathf.PI * 2f;
+                Vector3 cur = new Vector3(
+                    p.x + Mathf.Cos(ang) * r,
+                    transform.position.y,
+                    p.y + Mathf.Sin(ang) * r);
+                if (i > 0)
+                {
+                    Gizmos.DrawLine(prev, cur);
+                }
+                prev = cur;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// Defines the corner pocket mouth from two finite jaws + center/fall direction.
+    /// </summary>
+    public class PocketMouth : MonoBehaviour
+    {
+        [SerializeField] private PocketJawDefinition leftJaw;
+        [SerializeField] private PocketJawDefinition rightJaw;
+
+        [Header("Pocket shape")]
+        [SerializeField, Min(0.01f)] private float mouthWidth = 0.115f;
+        [SerializeField, Min(0f)] private float shelfDepth = 0.028f;
+        [SerializeField] private Vector2 pocketCenter = new Vector2(0f, -0.06f);
+        [SerializeField] private Vector2 fallDirection = new Vector2(0f, -1f);
+        [SerializeField, Range(0f, 1f)] private float cushionRestitution = 0.35f;
+
+        public PocketJawDefinition LeftJaw => leftJaw;
+        public PocketJawDefinition RightJaw => rightJaw;
+        public float MouthWidth => mouthWidth;
+        public float ShelfDepth => shelfDepth;
+        public float CushionRestitution => cushionRestitution;
+        public Vector2 PocketCenter => pocketCenter;
+        public Vector2 FallDirection => fallDirection.sqrMagnitude < 1e-6f ? Vector2.down : fallDirection.normalized;
+
+        public bool IsConfigured => leftJaw != null && rightJaw != null;
+
+        public Vector2 MouthCenter
+        {
+            get
+            {
+                if (!IsConfigured)
+                {
+                    return Vector2.zero;
+                }
+
+                return (leftJaw.Segment.end + rightJaw.Segment.start) * 0.5f;
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!IsConfigured)
+            {
+                return;
+            }
+
+            Vector2 mouthCenter = MouthCenter;
+            Vector2 openDir = FallDirection;
+            Vector2 right = new Vector2(openDir.y, -openDir.x);
+            Vector2 half = right * (mouthWidth * 0.5f);
+            Vector2 mouthA = mouthCenter - half;
+            Vector2 mouthB = mouthCenter + half;
+            Vector2 shelfA = mouthA + openDir * shelfDepth;
+            Vector2 shelfB = mouthB + openDir * shelfDepth;
+
+            Gizmos.color = Color.cyan;
+            DrawLine2D(mouthA, mouthB);
+
+            Gizmos.color = new Color(0.25f, 0.85f, 1f, 1f);
+            DrawLine2D(mouthA, shelfA);
+            DrawLine2D(mouthB, shelfB);
+            DrawLine2D(shelfA, shelfB);
+
+            Gizmos.color = Color.blue;
+            DrawSphere2D(pocketCenter, 0.008f);
+            DrawLine2D(mouthCenter, mouthCenter + openDir * 0.08f);
+        }
+
+        private void DrawLine2D(Vector2 a, Vector2 b)
+        {
+            Gizmos.DrawLine(new Vector3(a.x, transform.position.y, a.y), new Vector3(b.x, transform.position.y, b.y));
+        }
+
+        private void DrawSphere2D(Vector2 p, float radius)
+        {
+            Gizmos.DrawSphere(new Vector3(p.x, transform.position.y, p.y), radius);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsAdapters.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsAdapters.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    public interface IPoolBallBody
+    {
+        int Id { get; }
+        float Radius { get; }
+        Vector2 Position2 { get; set; }
+        Vector2 Velocity2 { get; set; }
+        bool IsValid { get; }
+        bool IsKinematic { get; }
+        void AddImpulse2(Vector2 impulse);
+    }
+
+    public sealed class PoolBallBody2D : IPoolBallBody
+    {
+        private readonly Rigidbody2D body;
+        private readonly CircleCollider2D circle;
+
+        public PoolBallBody2D(Rigidbody2D body, CircleCollider2D circle, int id)
+        {
+            this.body = body;
+            this.circle = circle;
+            Id = id;
+        }
+
+        public int Id { get; }
+        public float Radius => circle != null ? Mathf.Abs(circle.radius * Mathf.Max(circle.transform.lossyScale.x, circle.transform.lossyScale.y)) : 0.028575f;
+        public Vector2 Position2 { get => body.position; set => body.position = value; }
+        public Vector2 Velocity2 { get => body.velocity; set => body.velocity = value; }
+        public bool IsValid => body != null;
+        public bool IsKinematic => body == null || body.bodyType != RigidbodyType2D.Dynamic;
+
+        public void AddImpulse2(Vector2 impulse)
+        {
+            body.AddForce(impulse, ForceMode2D.Impulse);
+        }
+    }
+
+    public sealed class PoolBallBody3D : IPoolBallBody
+    {
+        private readonly Rigidbody body;
+        private readonly SphereCollider sphere;
+
+        public PoolBallBody3D(Rigidbody body, SphereCollider sphere, int id)
+        {
+            this.body = body;
+            this.sphere = sphere;
+            Id = id;
+        }
+
+        public int Id { get; }
+        public float Radius => sphere != null ? Mathf.Abs(sphere.radius * Mathf.Max(sphere.transform.lossyScale.x, sphere.transform.lossyScale.z)) : 0.028575f;
+        public Vector2 Position2
+        {
+            get => new Vector2(body.position.x, body.position.z);
+            set
+            {
+                Vector3 p = body.position;
+                p.x = value.x;
+                p.z = value.y;
+                body.position = p;
+            }
+        }
+
+        public Vector2 Velocity2
+        {
+            get => new Vector2(body.velocity.x, body.velocity.z);
+            set
+            {
+                Vector3 v = body.velocity;
+                v.x = value.x;
+                v.z = value.y;
+                body.velocity = v;
+            }
+        }
+
+        public bool IsValid => body != null;
+        public bool IsKinematic => body == null || body.isKinematic;
+
+        public void AddImpulse2(Vector2 impulse)
+        {
+            body.AddForce(new Vector3(impulse.x, 0f, impulse.y), ForceMode.Impulse);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver2D.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver2D.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// 2D adapter: same math and tuning, mapped to XY table plane.
+    /// </summary>
+    public class PocketPhysicsDriver2D : MonoBehaviour
+    {
+        [System.Serializable]
+        private class BallBinding
+        {
+            public int id;
+            public Rigidbody2D body;
+            public CircleCollider2D circle;
+        }
+
+        [SerializeField] private PocketMouth pocketMouth;
+        [SerializeField] private PocketCaptureZone captureZone;
+        [SerializeField] private List<BallBinding> balls = new List<BallBinding>();
+
+        [SerializeField] private PocketCollisionResolver collisionResolver = new PocketCollisionResolver();
+        [SerializeField] private PocketCaptureResolver captureResolver = new PocketCaptureResolver();
+
+        private void FixedUpdate()
+        {
+            if (pocketMouth == null || captureZone == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < balls.Count; i++)
+            {
+                BallBinding b = balls[i];
+                if (b == null || b.body == null || b.circle == null)
+                {
+                    continue;
+                }
+
+                var adapter = new PoolBallBody2D(b.body, b.circle, b.id);
+                collisionResolver.Resolve(adapter, pocketMouth);
+                captureResolver.TryCapture(adapter, pocketMouth, captureZone, out _);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Aiming.Pockets
+{
+    /// <summary>
+    /// 3D adapter: uses XZ table footprint, keeps Y for vertical fall visuals.
+    /// </summary>
+    public class PocketPhysicsDriver3D : MonoBehaviour
+    {
+        [System.Serializable]
+        private class BallBinding
+        {
+            public int id;
+            public Rigidbody body;
+            public SphereCollider sphere;
+        }
+
+        [SerializeField] private PocketMouth pocketMouth;
+        [SerializeField] private PocketCaptureZone captureZone;
+        [SerializeField] private List<BallBinding> balls = new List<BallBinding>();
+        [SerializeField, Min(0f)] private float downwardFallSpeed = 2.4f;
+
+        [SerializeField] private PocketCollisionResolver collisionResolver = new PocketCollisionResolver();
+        [SerializeField] private PocketCaptureResolver captureResolver = new PocketCaptureResolver();
+
+        private void FixedUpdate()
+        {
+            if (pocketMouth == null || captureZone == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < balls.Count; i++)
+            {
+                BallBinding b = balls[i];
+                if (b == null || b.body == null || b.sphere == null)
+                {
+                    continue;
+                }
+
+                var adapter = new PoolBallBody3D(b.body, b.sphere, b.id);
+                collisionResolver.Resolve(adapter, pocketMouth);
+
+                if (captureResolver.TryCapture(adapter, pocketMouth, captureZone, out bool committed) && committed)
+                {
+                    Vector3 v = b.body.velocity;
+                    v.y = -downwardFallSpeed;
+                    b.body.velocity = v;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
+++ b/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class CueStrikePhysicsTests
+    {
+        [Test]
+        public void Apply_NoSpin_AddsForwardVelocity()
+        {
+            var go = new GameObject("CueBall");
+            var rb = go.AddComponent<Rigidbody>();
+            rb.useGravity = false;
+
+            var physics = new CueStrikePhysics();
+            physics.Apply(rb, Vector3.forward, 2f, Vector2.zero, 0.028575f);
+
+            Assert.Greater(rb.velocity.z, 0f);
+            Assert.That(rb.angularVelocity.sqrMagnitude, Is.EqualTo(0f).Within(1e-6f));
+
+            Object.DestroyImmediate(go);
+        }
+
+        [Test]
+        public void Apply_WithSideSpin_AddsAngularVelocity()
+        {
+            var go = new GameObject("CueBall");
+            var rb = go.AddComponent<Rigidbody>();
+            rb.useGravity = false;
+
+            var physics = new CueStrikePhysics();
+            physics.Apply(rb, Vector3.forward, 2f, new Vector2(0.75f, 0f), 0.028575f);
+
+            Assert.Greater(rb.velocity.z, 0f);
+            Assert.Greater(rb.angularVelocity.y, 0f);
+
+            Object.DestroyImmediate(go);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/Pockets/PocketGeometryTests.cs
+++ b/Assets/Tests/PlayMode/Pockets/PocketGeometryTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using UnityEngine;
+using Aiming.Pockets;
+
+namespace Aiming.Tests.Pockets
+{
+    public class PocketGeometryTests
+    {
+        [Test]
+        public void FiniteSegment_ClosestPoint_ClampsOutsideRange()
+        {
+            var seg = new FiniteJawSegment
+            {
+                start = new Vector2(0f, 0f),
+                end = new Vector2(1f, 0f)
+            };
+
+            Vector2 c = seg.ClosestPoint(new Vector2(2f, 0.3f), out float t);
+            Assert.That(t, Is.EqualTo(1f).Within(1e-6f));
+            Assert.That(c.x, Is.EqualTo(1f).Within(1e-6f));
+            Assert.That(c.y, Is.EqualTo(0f).Within(1e-6f));
+        }
+
+        [Test]
+        public void CircleVsCapsule_DetectsJawContact()
+        {
+            var seg = new FiniteJawSegment
+            {
+                start = new Vector2(-0.05f, 0f),
+                end = new Vector2(0.05f, 0f)
+            };
+
+            bool hit = PocketGeometry.TryCircleVsCapsule(
+                center: new Vector2(0f, 0.02f),
+                sphereRadius: 0.01f,
+                segment: seg,
+                capsuleRadius: 0.015f,
+                out Vector2 normal,
+                out float penetration,
+                out _);
+
+            Assert.IsTrue(hit);
+            Assert.Greater(penetration, 0f);
+            Assert.Greater(normal.y, 0f);
+        }
+
+        [Test]
+        public void CircleVsTip_DetectsRoundedCapCollision()
+        {
+            var tip = new JawTip { center = new Vector2(0f, 0f), radius = 0.01f };
+            bool hit = PocketGeometry.TryCircleVsTip(
+                center: new Vector2(0.015f, 0f),
+                sphereRadius: 0.01f,
+                tip: tip,
+                out Vector2 normal,
+                out float penetration);
+
+            Assert.IsTrue(hit);
+            Assert.Greater(penetration, 0f);
+            Assert.Greater(normal.x, 0f);
+        }
+    }
+}

--- a/docs/unity-pocket-jaw-capture-system.md
+++ b/docs/unity-pocket-jaw-capture-system.md
@@ -1,0 +1,56 @@
+# Unity Pocket Jaw + Capture System (2D/3D)
+
+This module adds production-oriented pocket behavior for corner jaws and capture:
+
+- finite jaw segments (bounded, non-infinite)
+- rounded jaw tips (capsule/circle endpoint behavior)
+- tunable jaw restitution/friction
+- separate capture resolver behind mouth
+- shared logic for both 2D and 3D via adapters
+
+## Added scripts
+
+- `Assets/Scripts/Gameplay/Pockets/PocketGeometry.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketMouth.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketCaptureZone.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketCaptureResolver.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketPhysicsAdapters.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver2D.cs`
+- `Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs`
+
+## Scene wiring (quick setup)
+
+1. Create a `PocketRoot` GameObject at your target pocket.
+2. Add `PocketMouth` + `PocketCaptureZone` to `PocketRoot`.
+3. Create two child objects, each with `PocketJawDefinition`:
+   - one for near jaw rail segment
+   - one for far jaw rail segment
+4. Assign these two jaw components in `PocketMouth` (`leftJaw`, `rightJaw`).
+5. Add either:
+   - `PocketPhysicsDriver3D` for Rigidbody/SphereCollider balls
+   - `PocketPhysicsDriver2D` for Rigidbody2D/CircleCollider2D balls
+6. Populate the driver ball list (`id`, body, collider).
+7. Enter play mode and tune in Inspector.
+
+## Tuning guidance
+
+- Increase `jawRadius` if jaw tips feel too sharp.
+- Lower `jawRestitution` when pockets feel pinball-like.
+- Increase `jawFriction` to reduce skate/glance escapes.
+- Increase `minimumCaptureDepth` to require deeper pocket entry.
+- Lower `cleanCaptureSpeedThreshold` to reject more fast glancing shots.
+- Tighten `rejectionAngleTolerance` (smaller angle) for harder pocket acceptance.
+
+## Behavior notes
+
+- Collision and capture are intentionally separate systems.
+- Jaw collision is solved in table 2D footprint for stability.
+- 3D mode applies additional downward velocity once committed.
+
+## Known limitations
+
+- This module focuses on corner-pocket mouth behavior; side-pocket geometry requires separate mouth definitions.
+- Driver ball lists are manual in this version (easy to swap to auto-registration if needed).
+- Deterministic fast-glance rejection is optional; if disabled it uses probabilistic rejection.

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24851,7 +24851,7 @@ const powerRef = useRef(hud.power);
       const applyShotAtImpact = (payload) => {
         if (!payload || payload.applied) return;
         payload.applied = true;
-        const { base, aimDir, physicsSpin, clampedPower, liftStrength } = payload;
+        const { base, aimDir, physicsSpin, clampedPower } = payload;
         const offsetScaled = {
           x: physicsSpin?.x ?? 0,
           y: physicsSpin?.y ?? 0
@@ -24871,6 +24871,12 @@ const powerRef = useRef(hud.power);
         if (shotDir.lengthSq() > 1e-8) shotDir.normalize();
         const sideAxis = TMP_VEC3_D.set(-shotDir.z, 0, shotDir.x);
         if (sideAxis.lengthSq() > 1e-8) sideAxis.normalize();
+        // Unity-style cue strike transfer:
+        // 1) linear impulse from cue direction and shot speed
+        // 2) angular impulse from cue-tip offset (r x J)
+        // This keeps the current on-screen spin controller while moving the
+        // shot model to the same rigidbody pattern used by open-source Unity
+        // pool projects.
         const rOffset = TMP_VEC3_E
           .copy(sideAxis)
           .multiplyScalar(offsetScaled.x * BALL_R)
@@ -25174,33 +25180,13 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
-          const ranges = spinRangeRef.current || {};
-          const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const baseSide = physicsSpin.x * (ranges.side ?? 0);
-          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
-          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
-          if (physicsSpin.y < 0) {
-            spinTop *= BACKSPIN_MULTIPLIER;
-          } else if (physicsSpin.y > 0) {
-            spinTop *= TOPSPIN_MULTIPLIER;
-          }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          const shotImpactPayload = {
+            base,
+            aimDir: shotAimDir,
+            physicsSpin,
+            clampedPower,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25299,6 +25285,24 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
+          const impactThreshold = THREE.MathUtils.clamp(
+            strokeProfile.impactThreshold ?? 0.9,
+            0,
+            1
+          );
+          const expectedImpactTime =
+            startTime +
+            Math.max(0, pullbackDuration) +
+            Math.max(1, strikeDuration) *
+              (strokeProfile.forwardOnly ? impactThreshold : 1);
+          const triggerShotImpact = () => {
+            applyShotAtImpact(shotImpactPayload);
+            pendingImpactRef.current = null;
+          };
+          pendingImpactRef.current = {
+            time: expectedImpactTime,
+            apply: triggerShotImpact
+          };
           const impactPos = idlePos.clone();
           // Match the reference cue-stick behavior for spin:
           // topspin adds a tiny forward follow-through after contact,
@@ -25457,14 +25461,18 @@ const powerRef = useRef(hud.power);
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true
+              releaseStartsFromCurrentPull: true,
+              onImpact: triggerShotImpact,
+              shotApplied: false
             };
           } else {
+            triggerShotImpact();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;


### PR DESCRIPTION
### Motivation
- Return Pool Royale to the state from the 10:00 snapshot by rolling back recent gameplay changes and restoring the prior cue strike and pocket behavior.
- Reintroduce a Unity-style, spin-aware cue strike transfer model (impulse + torque from cue-tip offset) to match the project's earlier physics pattern.
- Restore a dedicated pocket jaw + capture subsystem to improve pocket collision and deterministic capture behavior for both 2D and 3D modes.

### Description
- Reintegrated cue strike physics and spin handling by adding `Assets/Scripts/Gameplay/CueStrikePhysics.cs` and wiring it into `Assets/Scripts/Gameplay/CueController.cs` (added `spinInput`, `SetSpinInput`, and `strikePhysics.Apply(...)`).
- Restored a pocket subsystem under `Assets/Scripts/Gameplay/Pockets/` with `PocketGeometry.cs`, `PocketJawDefinition.cs`, `PocketMouth.cs`, `PocketCaptureZone.cs`, `PocketCollisionResolver.cs`, `PocketCaptureResolver.cs`, `PocketPhysicsAdapters.cs`, `PocketPhysicsDriver2D.cs`, and `PocketPhysicsDriver3D.cs` to provide finite jaw segments, rounded tips, collision response and capture logic.
- Updated the web gameplay flow in `webapp/src/pages/Games/PoolRoyale.jsx` to apply a Unity-style cue strike on impact, schedule impact timing (`pendingImpactRef`) and transfer spin via impulse/torque (added shot impact payload and trigger logic), and removed the prior inline spin/lift duplication.
- Added documentation `docs/unity-pocket-jaw-capture-system.md` and play-mode tests `Assets/Tests/PlayMode/CueStrikePhysicsTests.cs` and `Assets/Tests/PlayMode/Pockets/PocketGeometryTests.cs` to validate physics and geometry behavior.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully (build output produced).
- Unity play-mode tests were added to the repo but were not executed in this rollout, so their results are not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d62861c483298e64f04378fd8801)