### PR TITLE
Fix corner pocket physics and camera switching; improve AI shot planning and spin handling

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -41,7 +41,7 @@
  */
 
 const LOOKAHEAD_DEPTH = 2
-const LOOKAHEAD_CANDIDATES = 3
+const LOOKAHEAD_CANDIDATES = 4
 const MONTE_CARLO_BASE_SAMPLES = 28
 const POWER_SCALE = 0.8
 
@@ -608,8 +608,20 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   let hasNext = false
   if (nextTargets.length > 0) {
     hasNext = true
-    const next = nextTargets[0]
-    nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
+    const nextRanked = nextTargets
+      .map((next) => {
+        const proximity = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
+        const nextPocketEntries = (req.state.pockets || [])
+          .map((pocket) => pocketEntry(pocket, r, req.state.width, req.state.height, next))
+          .filter(Boolean)
+        const laneOpen = nextPocketEntries.some((entryPoint) =>
+          !pathBlocked(next, entryPoint, balls, [cueBallId, target.id, next.id], r)
+        )
+        const laneScore = laneOpen ? 1 : 0
+        return proximity * 0.7 + laneScore * 0.3
+      })
+      .sort((a, b) => b - a)
+    nextScore = nextRanked[0] ?? 0
   }
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
@@ -760,10 +772,14 @@ export function planShot (req) {
     : [0.5 * POWER_SCALE, 0.7 * POWER_SCALE, 0.85 * POWER_SCALE]
   const spins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.3, side: 0, back: -0.3 },
-    { top: -0.3, side: 0.3, back: 0 },
-    { top: -0.3, side: -0.3, back: 0 },
-    { top: 0, side: 0.3, back: 0 }
+    { top: 0.45, side: 0, back: 0 },
+    { top: 0.35, side: 0.25, back: 0 },
+    { top: 0.35, side: -0.25, back: 0 },
+    { top: 0.2, side: 0.45, back: 0 },
+    { top: 0.2, side: -0.45, back: 0 },
+    { top: 0, side: 0, back: 0.35 },
+    { top: 0, side: 0.3, back: 0.25 },
+    { top: 0, side: -0.3, back: 0.25 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6638,12 +6638,20 @@ function reflectRails(ball) {
     const pocketGuardClearance =
       nearestPocketIndex >= 4 ? SIDE_POCKET_GUARD_CLEARANCE : POCKET_GUARD_CLEARANCE;
     const inGuardZone = nearestPocketDist < pocketGuardClearance;
+    const nearestPocketIsCorner = nearestPocketIndex < 4;
     let bestImpact = null;
     let bestPenetration = 0;
     for (const segment of CUSHION_SEGMENTS) {
       if (!segment?.normal || !segment?.start || !segment?.end) continue;
       if (nearPocket && segment.type === 'rail') continue;
-      if (inCaptureZone && inGuardZone && segment.type === 'cut') continue;
+      if (
+        inCaptureZone &&
+        inGuardZone &&
+        segment.type === 'cut' &&
+        !nearestPocketIsCorner
+      ) {
+        continue;
+      }
       if (segment.type === 'jaw' && segment.center && segment.captureRadius != null) {
         if (ball.pos.distanceTo(segment.center) <= segment.captureRadius) continue;
       }
@@ -18980,6 +18988,39 @@ const powerRef = useRef(hud.power);
           };
         };
 
+        const maybeForceCornerPocketView = (ball) => {
+          if (!ball?.active) return;
+          TMP_VEC2_VIEW.set(ball.vel?.x ?? 0, ball.vel?.y ?? 0);
+          if (TMP_VEC2_VIEW.lengthSq() < 1e-6 && ball.launchDir) {
+            TMP_VEC2_VIEW.copy(ball.launchDir);
+          }
+          if (TMP_VEC2_VIEW.lengthSq() < 1e-6) return;
+          const speed = TMP_VEC2_VIEW.length();
+          if (speed < STOP_EPS) return;
+          const nearestCorner = findNearestCornerPocketAlongDirection(ball.pos, TMP_VEC2_VIEW);
+          const pocketId = nearestCorner?.pocketId;
+          const pocketCenter = nearestCorner?.pocketCenter;
+          if (!pocketId || !pocketCenter) return;
+          const toPocket = pocketCenter.clone().sub(ball.pos);
+          const distance = toPocket.length();
+          if (!Number.isFinite(distance) || distance <= 0 || distance > POCKET_CAM_EARLY_TRIGGER_DIST) return;
+          toPocket.normalize();
+          const toward = TMP_VEC2_VIEW.clone().normalize().dot(toPocket);
+          if (toward < 0.8) return;
+          const now = performance.now();
+          const currentIntent = pocketSwitchIntentRef.current;
+          if (currentIntent?.ballId === ball.id && currentIntent.preferredPocketId === pocketId) {
+            return;
+          }
+          pocketSwitchIntentRef.current = {
+            ballId: ball.id,
+            forced: true,
+            allowEarly: true,
+            preferredPocketId: pocketId,
+            createdAt: now
+          };
+        };
+
         const getMaxOrbitRadius = () =>
           topViewRef.current
             ? CAMERA.maxR
@@ -26744,8 +26785,8 @@ const powerRef = useRef(hud.power);
           const sideSpin = decision.spin?.side ?? 0;
           const verticalSpin = (decision.spin?.back ?? 0) - (decision.spin?.top ?? 0);
           const spin = {
-            x: THREE.MathUtils.clamp(sideSpin, -0.6, 0.6),
-            y: THREE.MathUtils.clamp(verticalSpin, -0.6, 0.6)
+            x: THREE.MathUtils.clamp(sideSpin, -0.85, 0.85),
+            y: THREE.MathUtils.clamp(verticalSpin, -0.85, 0.85)
           };
           const quality = Number.isFinite(decision.quality) ? decision.quality : 0;
           const isSafety =
@@ -29950,6 +29991,7 @@ const powerRef = useRef(hud.power);
             if (activeShotView.axis === 'short') {
               maybeForceShortRailPocketView(cueBall);
             }
+            maybeForceCornerPocketView(cueBall);
             if (cueBall.vel.lengthSq() > 1e-6) {
               activeShotView.lastCueDir = cueBall.vel.clone().normalize();
             }
@@ -29960,6 +30002,9 @@ const powerRef = useRef(hud.power);
                   : null;
               if (activeShotView.axis === 'short' && targetBall) {
                 maybeForceShortRailPocketView(targetBall);
+              }
+              if (targetBall) {
+                maybeForceCornerPocketView(targetBall);
               }
               if (!targetBall?.active) {
                 activeShotView.exitAfterHold = true;
@@ -30069,6 +30114,9 @@ const powerRef = useRef(hud.power);
             const movingBalls = ballsList.filter(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
+            movingBalls.forEach((ball) => {
+              maybeForceCornerPocketView(ball);
+            });
             const movingCount = movingBalls.length;
             const lastPocketBall = lastPocketBallRef.current;
             let bestPocketView = null;
@@ -30289,7 +30337,6 @@ const powerRef = useRef(hud.power);
                 potted.push({ id: b.id, color: colorId, pocket: pocketId });
                 pottedIds.add(b.id);
                 const shouldForceCornerPocketView =
-                  !suppressPocketCameras &&
                   !topViewRef.current &&
                   pocketIndex < 4;
                 if (shouldForceCornerPocketView) {
@@ -30477,7 +30524,6 @@ const powerRef = useRef(hud.power);
               potted.push({ id: b.id, color: colorId, pocket: pocketId });
               pottedIds.add(b.id);
               const shouldForceCornerPocketView =
-                !suppressPocketCameras &&
                 !topViewRef.current &&
                 pocketIndex < 4;
               if (shouldForceCornerPocketView) {


### PR DESCRIPTION
### Motivation
- Corner-pocket shots were behaving inconsistently compared to middle pockets due to overly aggressive cushion-cut suppression near pocket guard zones.  
- The camera system needed earlier corner-pocket coverage so corner pots are framed by pocket cameras instead of the rail-overhead view.  
- AI shot selection and spin choices required better next-shot awareness and a richer spin candidate set for improved positional play.

### Description
- Relaxed cushion-cut gating so the in-capture/guard suppression (`inCaptureZone && inGuardZone && segment.type === 'cut'`) skips only for non-corner pockets by adding `nearestPocketIsCorner` logic, restoring natural corner cut behavior (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Added `maybeForceCornerPocketView` to proactively set `pocketSwitchIntentRef` when a moving ball is clearly approaching a corner pocket and wired it into the action/moving-ball camera flow so corner-pocket cameras are requested before the ball is potted (`PoolRoyale.jsx`).  
- Ensured corner pot events force pocket-camera takeover for corner pockets (pocket camera logic adjusted where potted balls are handled) so the pocket camera frames corner pots instead of relying on overhead broadcast paths (`PoolRoyale.jsx`).  
- Increased AI planning breadth by changing `LOOKAHEAD_CANDIDATES` from `3` to `4` and updated next-shot scoring to combine cue-ball proximity with lane openness (checks `pathBlocked` on pocket entry points) when computing `nextScore` in `lib/poolAi.js`.  
- Expanded the AI spin candidate set used by `planShot` and increased the applied spin clamp for engine decisions so AI-chosen side/top/back spin is more expressive and survives mapping into the in-game spin vector (`lib/poolAi.js` and `PoolRoyale.jsx`).

### Testing
- Built the web client with `npm -C webapp run build` and the build completed successfully (no compilation errors).  
- Started the dev server with `npm -C webapp run dev` and verified the app served (local dev server launched), and attempted a Playwright screenshot of the Pool Royale page but the browser automation timed out in this environment.  
- Changes were committed to version control (`git commit`) and the modified files are `webapp/src/pages/Games/PoolRoyale.jsx` and `lib/poolAi.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ea7f5a3c83298421fb9a875fe573)