### PR TITLE
Fix corner pocket behaviour, improve AI shot planning, and pre-switch pocket camera

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -193,6 +193,9 @@ public class CueCamera : MonoBehaviour
     public float pocketCameraMiddleZone = 0.32f;
     // Radius around each corner pocket used to start the dedicated pocket camera.
     public float cornerPocketCameraRadius = 0.24f;
+    // Extra trigger radius while the object ball is travelling so we can cut to
+    // the pocket camera before the ball reaches the jaw and gets potted.
+    public float cornerPocketApproachRadius = 0.1f;
     // Depth below the rail lip that counts as the ball having dropped into the
     // pocket before we cut back to the rail broadcast view.
     public float pocketDropDepth = 0.05f;
@@ -727,9 +730,18 @@ public class CueCamera : MonoBehaviour
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
         Vector3 cornerPocket;
+        float dynamicPocketRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+        if (TargetBall != null)
+        {
+            Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
+            if (targetRb != null && targetRb.velocity.sqrMagnitude > velocityThreshold)
+            {
+                dynamicPocketRadius += Mathf.Max(0f, cornerPocketApproachRadius);
+            }
+        }
         bool shouldUsePocketCamera = TargetBall != null
             && TargetBall.gameObject.activeInHierarchy
-            && TryGetCornerPocketForBall(TargetBall.position, out cornerPocket);
+            && TryGetCornerPocketForBall(TargetBall.position, dynamicPocketRadius, out cornerPocket);
         if (shouldUsePocketCamera)
         {
             usingTargetCamera = true;
@@ -1369,10 +1381,10 @@ public class CueCamera : MonoBehaviour
         targetViewYaw = GetShortRailYaw(broadcastSideSign);
     }
 
-    private bool TryGetCornerPocketForBall(Vector3 ballPosition, out Vector3 pocket)
+    private bool TryGetCornerPocketForBall(Vector3 ballPosition, float triggerRadius, out Vector3 pocket)
     {
         pocket = Vector3.zero;
-        float radius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+        float radius = Mathf.Max(0.01f, triggerRadius);
         float radiusSq = radius * radius;
 
         Vector3 min = tableBounds.min;

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -53,10 +53,10 @@ public static class PhysicsConstants
     public const double CornerPocketMouth = 0.1014984; // scaled with table reduction
     public const double SidePocketMouth = 0.1116013;    // scaled with table reduction
     public const double PocketCaptureRadius = 0.087875; // scaled with table reduction
-    public const double CornerPocketScale = 0.965;      // slightly tighten corner pocket/cutout radius
-    public const double PocketAngleCutScale = 1.035;    // extend angle cut slightly for truer mouth mapping
-    public const double CornerJawRadiusScale = 0.94;
-    public const double CornerJawInset = 0.006;
+    public const double CornerPocketScale = 0.985;      // align corner acceptance closer to side-pocket behaviour
+    public const double PocketAngleCutScale = 1.0;      // keep corner angle-cut neutral to avoid over-snapping
+    public const double CornerJawRadiusScale = 0.98;    // round corner jaws so cut shots deflect more naturally
+    public const double CornerJawInset = 0.004;
     public const double SideJawInset = 0.006;
     public const double SideJawDepthScale = 1.08;
     // Shift the pocket capture center outward for the chrome plate cut.

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -563,6 +563,42 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   return best
 }
 
+
+function buildSpinCandidates (cue, target, pocket, req) {
+  const base = [
+    { top: 0, side: 0, back: 0 },
+    { top: 0.22, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.22 },
+    { top: 0.18, side: 0.15, back: 0 },
+    { top: 0.18, side: -0.15, back: 0 }
+  ]
+  const nextTargets = nextTargetsAfter(target.id, req)
+  if (!nextTargets.length) return base
+
+  const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+  const naturalCueAfter = estimateCueAfterShot(cue, target, entry, 0.7, { top: 0, side: 0, back: 0 }, req.state)
+  const next = nextTargets
+    .slice()
+    .sort((a, b) => dist(a, naturalCueAfter) - dist(b, naturalCueAfter))[0]
+  if (!next) return base
+
+  const toNext = { x: next.x - naturalCueAfter.x, y: next.y - naturalCueAfter.y }
+  const shotDir = { x: entry.x - target.x, y: entry.y - target.y }
+  const shotLen = Math.hypot(shotDir.x, shotDir.y) || 1
+  const sideUnit = { x: -shotDir.y / shotLen, y: shotDir.x / shotLen }
+  const sideProjection = (toNext.x * sideUnit.x + toNext.y * sideUnit.y) / Math.max(req.state.ballRadius * 20, 1)
+  const forwardProjection = (toNext.x * shotDir.x + toNext.y * shotDir.y) / Math.max(shotLen * req.state.ballRadius * 12, 1)
+
+  const adaptive = {
+    top: Math.max(-0.35, Math.min(0.35, forwardProjection > 0 ? 0.1 + forwardProjection : 0.05)),
+    back: Math.max(0, Math.min(0.35, forwardProjection < -0.04 ? -forwardProjection : 0)),
+    side: Math.max(-0.35, Math.min(0.35, sideProjection))
+  }
+  adaptive.top = Math.max(0, adaptive.top - adaptive.back)
+
+  return [adaptive, ...base]
+}
+
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false, options = {}) {
   const r = req.state.ballRadius
   const cueBallId = resolveCueBallId(req.state)
@@ -608,8 +644,17 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   let hasNext = false
   if (nextTargets.length > 0) {
     hasNext = true
-    const next = nextTargets[0]
-    nextScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
+    let bestShape = 0
+    for (const next of nextTargets.slice(0, 4)) {
+      const cueDistanceScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
+      let nextPocketAlign = 0
+      for (const nextPocket of req.state.pockets) {
+        nextPocketAlign = Math.max(nextPocketAlign, pocketAlignment(nextPocket, next, req.state.width, req.state.height))
+      }
+      const shape = 0.68 * cueDistanceScore + 0.32 * nextPocketAlign
+      if (shape > bestShape) bestShape = shape
+    }
+    nextScore = bestShape
   }
   const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
@@ -758,12 +803,12 @@ export function planShot (req) {
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
     : [0.5 * POWER_SCALE, 0.7 * POWER_SCALE, 0.85 * POWER_SCALE]
-  const spins = [
+  const defaultSpins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.3, side: 0, back: -0.3 },
-    { top: -0.3, side: 0.3, back: 0 },
-    { top: -0.3, side: -0.3, back: 0 },
-    { top: 0, side: 0.3, back: 0 }
+    { top: 0.25, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.25 },
+    { top: 0.15, side: 0.25, back: 0 },
+    { top: 0.15, side: -0.25, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
@@ -832,7 +877,7 @@ export function planShot (req) {
           target,
           pocket,
           powers[0],
-          spins[0],
+          defaultSpins[0],
           balls,
           strict,
           { lookaheadDepth: LOOKAHEAD_DEPTH, rng }
@@ -849,8 +894,9 @@ export function planShot (req) {
           }
         }
 
+        const spins = buildSpinCandidates(cuePos, target, pocket, req)
         for (const power of powers) {
-          for (const spin of spins) {
+          for (const spin of spins.concat(defaultSpins)) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
               return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)


### PR DESCRIPTION
### Motivation
- Corner-pocket shots were producing unnatural deflections and inconsistent acceptance compared with middle pockets, hurting gameplay feel near corner jaws.
- The AI needed to think about the next target and choose spin to leave the cue ball in good ‘shape’ rather than only maximising immediate pot chance.
- Broadcast framing should switch to a pocket camera earlier for corner pots so the pot is captured by the pocket camera (not the overhead/rail camera) once the ball is clearly approaching a corner pocket.

### Description
- Adjusted corner pocket geometry constants in `billiards/PhysicsConstants.cs` to reduce over-snapping at corner jaws and make corner acceptance match middle-pocket behaviour (`CornerPocketScale`, `PocketAngleCutScale`, `CornerJawRadiusScale`, `CornerJawInset`).
- Added adaptive spin candidate generation `buildSpinCandidates` in `lib/poolAi.js` that predicts the natural cue-ball path and proposes spins to improve position for likely next targets, and integrated this with existing spin search (now explores adaptive + default spin sets).
- Reworked next-shot evaluation in `lib/poolAi.js` to score runout/shape across multiple next targets and pocket alignments instead of a single next-ball heuristic, and folded this into shot quality calculation.
- Modified Unity broadcast camera in `billiards.Unity/CueCamera.cs` to pre-emptively switch to the corner pocket camera while an object ball is approaching a corner (added `cornerPocketApproachRadius` and dynamic trigger radius) so the pocket camera takes over before the ball reaches the jaw and is potted.

### Testing
- Ran `node --check lib/poolAi.js` to validate the modified AI module and syntax; this check succeeded.
- Attempted `dotnet test billiards.Tests/Billiards.Tests.csproj` but it could not be executed in this environment because `dotnet` is not installed, so C# unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ea7f5a3c83298421fb9a875fe573)