### PR TITLE
Remove corner pocket mouth-guard helpers to fix corner-jaw anomalies

### DIFF
--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -77,7 +77,7 @@ public class BilliardsSolver
         double sideJawInset = PhysicsConstants.SideJawInset;
         double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8) * PhysicsConstants.SideJawDepthScale;
         double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
-        double mouthGuardInset = Math.Max(0.0, PhysicsConstants.PocketMouthGuardInset);
+        double sideMouthGuardInset = Math.Max(0.0, PhysicsConstants.SidePocketMouthGuardInset);
 
         // Straight cushion spans (long rails)
         AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
@@ -169,47 +169,29 @@ public class BilliardsSolver
             new Vec2(width - sideJawInset, height / 2 + sideCut),
             new Vec2(-1, 0));
 
-        AddPocketMouthGuard(
-            new Vec2(cornerCut, 0),
-            new Vec2(0, cornerCut),
-            new Vec2(1, 1),
-            mouthGuardInset);
-        AddPocketMouthGuard(
-            new Vec2(width - cornerCut, 0),
-            new Vec2(width, cornerCut),
-            new Vec2(-1, 1),
-            mouthGuardInset);
-        AddPocketMouthGuard(
-            new Vec2(width, height - cornerCut),
-            new Vec2(width - cornerCut, height),
-            new Vec2(-1, -1),
-            mouthGuardInset);
-        AddPocketMouthGuard(
-            new Vec2(0, height - cornerCut),
-            new Vec2(cornerCut, height),
-            new Vec2(1, -1),
-            mouthGuardInset);
+        // Corner mouth helpers were causing double-contact anomalies between
+        // corner jaws and angle cuts, so keep corners on jaw/cut geometry only.
 
         AddPocketMouthGuard(
             new Vec2(width / 2 - sideCut, 0),
             new Vec2(width / 2 + sideCut, 0),
             new Vec2(0, 1),
-            mouthGuardInset);
+            sideMouthGuardInset);
         AddPocketMouthGuard(
             new Vec2(width / 2 - sideCut, height),
             new Vec2(width / 2 + sideCut, height),
             new Vec2(0, -1),
-            mouthGuardInset);
+            sideMouthGuardInset);
         AddPocketMouthGuard(
             new Vec2(0, height / 2 - sideCut),
             new Vec2(0, height / 2 + sideCut),
             new Vec2(1, 0),
-            mouthGuardInset);
+            sideMouthGuardInset);
         AddPocketMouthGuard(
             new Vec2(width, height / 2 - sideCut),
             new Vec2(width, height / 2 + sideCut),
             new Vec2(-1, 0),
-            mouthGuardInset);
+            sideMouthGuardInset);
 
         double baseCapture = Math.Max(PhysicsConstants.BallRadius * 1.05, PhysicsConstants.PocketCaptureRadius);
         double cornerCapture = Math.Max(PhysicsConstants.BallRadius * 1.05, baseCapture * cornerScale);

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -61,8 +61,9 @@ public static class PhysicsConstants
     public const double SideJawDepthScale = 1.08;
     // Shift the pocket capture center outward for the chrome plate cut.
     public const double SidePocketOutset = 0.006;
-    // Offset pocket mouth guards to stop balls slipping between jaws and cushions.
-    public const double PocketMouthGuardInset = BallRadius * 0.35;
+    // Offset side-pocket mouth guards to stop balls slipping between jaws and cushions.
+    // Corner pockets intentionally do not use helper guards (jaw + angle-cut only).
+    public const double SidePocketMouthGuardInset = BallRadius * 0.35;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 40;


### PR DESCRIPTION
### Motivation
- Corner pocket mouth-helper guards placed between the jaws and the angle cuts were producing abnormal double-contact behavior while middle pockets behaved correctly, so corners should match the jaw + angle-cut geometry used visually.
- The intent is to preserve the stable middle/side pocket helper behavior while eliminating the helpers that cause anomalies at corner pockets.

### Description
- Removed corner pocket mouth-guard insertions from `BilliardsSolver.InitStandardTable()` so corner pockets rely only on corner jaw arcs and connector (angle-cut) geometry (`billiards/BilliardsSolver.cs`).
- Kept `AddPocketMouthGuard` calls for the four side/middle pockets and wired them to a dedicated constant `SidePocketMouthGuardInset` (`billiards/BilliardsSolver.cs`).
- Replaced the single generic pocket-guard constant with an explicit `SidePocketMouthGuardInset` and clarified the comment that corner pockets intentionally do not use helper guards (`billiards/PhysicsConstants.cs`).
- Added a short comment describing why corner helpers were removed to prevent double-contact anomalies (`billiards/BilliardsSolver.cs`).

### Testing
- Attempted to run the unit test suite with `dotnet test billiards.Tests/Billiards.Tests.csproj`, but the environment does not have `dotnet` installed so automated tests could not be executed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40579b7b0832985e9d1e76885c315)