### PR TITLE
fix(pool-royale): prevent full-page crash with error boundary

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1,4 +1,5 @@
 import React, {
+  Component,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -33662,6 +33663,66 @@ const powerRef = useRef(hud.power);
   );
 }
 
+class PoolRoyaleErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, message: '', stack: '' };
+  }
+
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+      message:
+        typeof error?.message === 'string'
+          ? error.message
+          : 'Pool Royale encountered an unexpected error.',
+      stack: typeof error?.stack === 'string' ? error.stack : ''
+    };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('Pool Royale crashed', error, info);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+    return (
+      <div className="min-h-screen w-full bg-slate-950 text-white flex items-center justify-center p-6">
+        <div className="max-w-md w-full rounded-2xl border border-white/20 bg-slate-900/90 p-5 space-y-3">
+          <h2 className="text-xl font-semibold">Pool Royale hit a runtime error</h2>
+          <p className="text-sm text-slate-300">
+            We prevented a full app crash so you can safely return to the lobby.
+          </p>
+          <p className="text-xs break-words text-amber-300">{this.state.message}</p>
+          {this.state.stack ? (
+            <pre className="max-h-32 overflow-auto rounded bg-black/50 p-2 text-[10px] leading-tight text-slate-300 whitespace-pre-wrap">
+              {this.state.stack}
+            </pre>
+          ) : null}
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => window.location.assign('/games/poolroyale/lobby')}
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium hover:bg-blue-500"
+            >
+              Back to lobby
+            </button>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-lg border border-white/25 px-3 py-2 text-sm font-medium hover:bg-white/10"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
 export default function PoolRoyale() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -33800,19 +33861,21 @@ export default function PoolRoyale() {
     return params.get('opponentAvatar') || '';
   }, [location.search]);
   return (
-    <PoolRoyaleGame
-      variantKey={variantKey}
-      ballSetKey={ballSetKey}
-      tableSizeKey={tableSizeKey}
-      playType={playType}
-      mode={mode}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      playerAvatar={playerAvatar}
-      opponentName={opponentName}
-      opponentAvatar={opponentAvatar}
-      initialTrainingLevel={initialTrainingLevel}
-    />
+    <PoolRoyaleErrorBoundary>
+      <PoolRoyaleGame
+        variantKey={variantKey}
+        ballSetKey={ballSetKey}
+        tableSizeKey={tableSizeKey}
+        playType={playType}
+        mode={mode}
+        accountId={accountId}
+        tgId={tgId}
+        playerName={playerName}
+        playerAvatar={playerAvatar}
+        opponentName={opponentName}
+        opponentAvatar={opponentAvatar}
+        initialTrainingLevel={initialTrainingLevel}
+      />
+    </PoolRoyaleErrorBoundary>
   );
 }


### PR DESCRIPTION
### Motivation
- Pool Royale could throw unexpected runtime errors that crashed the entire route and took down the app shell, so the route needs to fail gracefully.

### Description
- Add a `PoolRoyaleErrorBoundary` React class component to `webapp/src/pages/Games/PoolRoyale.jsx` to catch render/runtime errors and log details to console.
- Import `Component` from React and wrap the `PoolRoyaleGame` render tree with the new `PoolRoyaleErrorBoundary` so the protection covers the full Pool Royale route.
- Provide a safe fallback UI that shows the error message/stack and offers recovery actions (`Back to lobby`, `Reload`).

### Testing
- Ran lint: `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` and observed only an ignore warning (no blocking errors).
- Ran production build: `npm --prefix webapp run build` and confirmed build artifacts (`webapp/dist`) were produced.
- Exercised the Pool Royale route with automated browser checks (Playwright scripts) against the local preview/dev server and observed a successful run reporting zero page errors and zero console errors while noting intermittent environment timeouts on some attempts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4eb7be4a483298bfd57d6ec9581bb)