### PR TITLE
Align corner pocket jaw mouth behavior with side pockets

### DIFF
--- a/billiards.Tests/UnitTest1.cs
+++ b/billiards.Tests/UnitTest1.cs
@@ -166,7 +166,7 @@ public class CushionGeometryTests
         var solver = new BilliardsSolver();
         solver.InitStandardTable();
         var preview = solver.PreviewShot(new Vec2(0.45, 0.45), new Vec2(-1, -1), 2.0, new List<BilliardsSolver.Ball>());
-        double expected = PhysicsConstants.CornerPocketMouth / Math.Sqrt(2.0);
+        double expected = PhysicsConstants.CornerPocketMouth * PhysicsConstants.CornerPocketScale / Math.Sqrt(2.0);
         Assert.That(Math.Abs(preview.ContactPoint.X - expected), Is.LessThan(0.001));
         Assert.That(Math.Abs(preview.ContactPoint.Y - expected), Is.LessThan(0.001));
     }
@@ -219,5 +219,34 @@ public class SpinActivationTests
         solver.Step(new List<BilliardsSolver.Ball> { ball }, 0.2);
 
         Assert.That(ball.SpinEffectsEnabled, Is.True);
+    }
+}
+
+public class PocketMouthGuardGeometryTests
+{
+    [Test]
+    public void CornerAndSidePocketMouthGuardsUseSameInsetDistance()
+    {
+        var solver = new BilliardsSolver();
+        solver.InitStandardTable();
+
+        double sideTargetY = PhysicsConstants.SidePocketMouthGuardInset;
+        double cornerDiag = PhysicsConstants.CornerPocketMouthGuardInset / Math.Sqrt(2.0);
+
+        Assert.That(
+            solver.PocketEdges.Exists(e =>
+                Math.Abs(e.A.Y - sideTargetY) < 1e-9 &&
+                Math.Abs(e.B.Y - sideTargetY) < 1e-9 &&
+                Math.Abs(e.Normal.X) < 1e-9 &&
+                e.Normal.Y > 0.99),
+            Is.True,
+            "Expected top side-pocket mouth guard inset was not generated.");
+
+        Assert.That(
+            solver.PocketEdges.Exists(e =>
+                Math.Abs(e.A.X + e.A.Y - (PhysicsConstants.CornerPocketMouth * PhysicsConstants.CornerPocketScale / Math.Sqrt(2.0) + cornerDiag)) < 1e-9 &&
+                Math.Abs(e.B.X + e.B.Y - (PhysicsConstants.CornerPocketMouth * PhysicsConstants.CornerPocketScale / Math.Sqrt(2.0) + cornerDiag)) < 1e-9),
+            Is.True,
+            "Expected top-left corner mouth guard inset was not generated.");
     }
 }

--- a/billiards/BilliardsSolver.cs
+++ b/billiards/BilliardsSolver.cs
@@ -78,6 +78,7 @@ public class BilliardsSolver
         double sideDepth = Math.Max(sideCut * 1.05, PhysicsConstants.BallRadius * 1.8) * PhysicsConstants.SideJawDepthScale;
         double sideOutset = Math.Max(0.0, PhysicsConstants.SidePocketOutset);
         double sideMouthGuardInset = Math.Max(0.0, PhysicsConstants.SidePocketMouthGuardInset);
+        double cornerMouthGuardInset = Math.Max(0.0, PhysicsConstants.CornerPocketMouthGuardInset);
 
         // Straight cushion spans (long rails)
         AddCushionSegment(new Vec2(cornerCut, 0), new Vec2(width / 2 - sideCut, 0), new Vec2(0, 1));
@@ -169,8 +170,26 @@ public class BilliardsSolver
             new Vec2(width - sideJawInset, height / 2 + sideCut),
             new Vec2(-1, 0));
 
-        // Corner mouth helpers were causing double-contact anomalies between
-        // corner jaws and angle cuts, so keep corners on jaw/cut geometry only.
+        AddPocketMouthGuard(
+            new Vec2(cornerCut, 0),
+            new Vec2(0, cornerCut),
+            new Vec2(1, 1),
+            cornerMouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width - cornerCut, 0),
+            new Vec2(width, cornerCut),
+            new Vec2(-1, 1),
+            cornerMouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(width, height - cornerCut),
+            new Vec2(width - cornerCut, height),
+            new Vec2(-1, -1),
+            cornerMouthGuardInset);
+        AddPocketMouthGuard(
+            new Vec2(cornerCut, height),
+            new Vec2(0, height - cornerCut),
+            new Vec2(1, -1),
+            cornerMouthGuardInset);
 
         AddPocketMouthGuard(
             new Vec2(width / 2 - sideCut, 0),

--- a/billiards/PhysicsConstants.cs
+++ b/billiards/PhysicsConstants.cs
@@ -62,8 +62,9 @@ public static class PhysicsConstants
     // Shift the pocket capture center outward for the chrome plate cut.
     public const double SidePocketOutset = 0.006;
     // Offset side-pocket mouth guards to stop balls slipping between jaws and cushions.
-    // Corner pockets intentionally do not use helper guards (jaw + angle-cut only).
     public const double SidePocketMouthGuardInset = BallRadius * 0.35;
+    // Mirror side-pocket jaw behavior so corner jaws react consistently at the mouth.
+    public const double CornerPocketMouthGuardInset = BallRadius * 0.35;
 
     // Tesselation density for proxy mesh generation (higher => smoother normals)
     public const int CornerJawSegments = 40;


### PR DESCRIPTION
### Motivation

- Corner pocket jaws were behaving differently from middle (side) pocket jaws at the mouth, causing inconsistent ball-jaw interactions and poor UX. 
- The intent is to make corner pocket mouth geometry and collision treatment match side-pocket mouth guards so corner shots behave like middle-pocket shots.

### Description

- Added a new physics constant `CornerPocketMouthGuardInset` in `billiards/PhysicsConstants.cs` to allow separate tuning of corner mouth guard offsets. 
- Updated `InitStandardTable()` in `billiards/BilliardsSolver.cs` to compute `cornerMouthGuardInset` and emit four corner `AddPocketMouthGuard(...)` calls so corner mouths have explicit mouth-guard edges. 
- Adjusted an existing expectation in `CushionGeometryTests` to account for `CornerPocketScale` and added a new geometry regression test `PocketMouthGuardGeometryTests` in `billiards.Tests/UnitTest1.cs` that verifies both side and corner mouth-guard insets are generated.

### Testing

- Static check `git diff --check` ran and reported no issues. 
- Attempted to run unit tests with `dotnet test billiards.Tests/billiards.Tests.csproj`, but `dotnet` is not available in this environment so the test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629d8781083299b9599c60f894612)