### PR TITLE
Adjust Pool Royale portrait HUD controls layout

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13542,7 +13542,7 @@ function PoolRoyaleGame({
   }, []);
   const portraitViewport = typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth;
   const sharedHudLiftPx = portraitViewport ? 20 : 30;
-  const spinControllerLiftPx = portraitViewport ? 8 : 14;
+  const spinControllerLiftPx = portraitViewport ? 12 : 14;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -32726,6 +32726,7 @@ const powerRef = useRef(hud.power);
               L{currentTrainingInfo.level} • {completedTrainingCount}/{TRAINING_LEVEL_COUNT} done • ❤️ {trainingShotsRemaining}
             </div>
           ) : (
+            !isPortrait && (
             <button
               type="button"
               onClick={handlePracticeRestart}
@@ -32735,6 +32736,7 @@ const powerRef = useRef(hud.power);
             >
               ↻
             </button>
+            )
           )}
         </div>
       )}
@@ -33085,10 +33087,10 @@ const powerRef = useRef(hud.power);
           ref={leftControlsRef}
           className={`pointer-events-none absolute z-50 flex flex-col gap-2.5 ${(replayActive || shotBroadcastActive) ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
         style={{
-          right: `${rightHudShiftPx}px`,
+          left: `${rightHudShiftPx}px`,
           bottom: `${sideControlsBottomPx + rightControlsLiftPx + sideActionButtonsLiftPx}px`,
           transform: `scale(${uiScale * 1.08})`,
-          transformOrigin: 'bottom right'
+          transformOrigin: 'bottom left'
         }}
       >
         {!isTopDownView && (
@@ -33202,19 +33204,21 @@ const powerRef = useRef(hud.power);
         </div>
       )}
 
-      {isPortrait && !replayActive && !isFreePractice && !hideNonEssentialHud && (
+      {isPortrait && !replayActive && !hideNonEssentialHud && (
         <div
           className="pointer-events-auto fixed left-1/2 z-50 flex -translate-x-1/2 items-center gap-4"
           style={{ top: `calc(env(safe-area-inset-top, 0px) + ${PORTRAIT_TOP_ACTION_BAR_DROP_REM}rem)` }}
         >
-          <button
-            type="button"
-            onClick={() => setShowGift(true)}
-            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-            aria-label="Open gifts"
-          >
-            <span aria-hidden="true">🎁</span>
-          </button>
+          {!isFreePractice && (
+            <button
+              type="button"
+              onClick={() => setShowGift(true)}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Open gifts"
+            >
+              <span aria-hidden="true">🎁</span>
+            </button>
+          )}
           <button
             ref={configButtonRef}
             type="button"
@@ -33226,14 +33230,26 @@ const powerRef = useRef(hud.power);
           >
             <span aria-hidden="true">☰</span>
           </button>
-          <button
-            type="button"
-            onClick={() => setShowChat(true)}
-            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-            aria-label="Open chat"
-          >
-            <span aria-hidden="true">💬</span>
-          </button>
+          {isFreePractice ? (
+            <button
+              type="button"
+              onClick={handlePracticeRestart}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Restart practice"
+              title="Restart practice"
+            >
+              <span aria-hidden="true">↻</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowChat(true)}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Open chat"
+            >
+              <span aria-hidden="true">💬</span>
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
### Motivation
- Align the Pool Royale portrait HUD with the requested UX: move the 2D/3D/rail-overhead view icons into a vertical row on the opposite (left) side, keep the top action bar centered in portrait practice, and nudge the spin controller slightly upward so controls read better on mobile portrait screens.
- Reduce duplicated restart/menu buttons in Practice mode and ensure the top-center menu/restart layout matches normal gameplay while preserving non-portrait behavior.

### Description
- Anchored the left control stack to the left side by switching the control container from `right` to `left` and changing the transform origin to `bottom left` so the view toggle buttons render as a vertical row on the left; change in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Moved the portrait practice top-action layout to show the centered menu button and render the restart control inline there for free practice, while keeping the previous right-side restart only for non-portrait contexts; conditional rendering updated in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Raised the portrait spin controller slightly by changing `spinControllerLiftPx` from `8` to `12` to move the spin controller a bit higher on the viewport; edit in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Small adjustments to conditional checks around gifts/chat/restart so the top-center row shows the desired controls depending on `isFreePractice` and `isPortrait`, and the left control stack is pointer/scale-adjusted with existing UI scale values.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (build warnings from chunk sizing only, no errors). 
- Started the dev server (`npm --prefix webapp run dev`) and validated the lobby route with a Playwright screenshot, which succeeded and produced an artifact of the updated UI. 
- Attempted a Playwright screenshot for the live game route which timed out in this environment (screenshot attempt failed due to page screenshot timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62f9a70a48329bc060a53a82a263e)