### PR TITLE
Improve Pool Royale practice HUD, gift UX, and in-table tournament flow

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -6,7 +6,6 @@ import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
 import { getGameVolume } from '../utils/sound.js';
-import ConfirmPopup from './ConfirmPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 
 
@@ -38,17 +37,11 @@ export default function GiftPopup({
   const validPlayers = players.filter((p) => p.id);
   const [selected, setSelected] = useState(NFT_GIFTS[0]);
   const [target, setTarget] = useState(validPlayers[0]?.index || 0);
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [infoMsg, setInfoMsg] = useState('');
-  const [pendingGift, setPendingGift] = useState(null);
   const resolvedTitle = title ?? 'Send Gift';
 
   const handleInfoClose = () => {
     setInfoMsg('');
-    if (pendingGift) {
-      onGiftSent && onGiftSent(pendingGift);
-      setPendingGift(null);
-    }
   };
   useEffect(() => {
     if (validPlayers.length > 0 && !validPlayers.some((p) => p.index === target)) {
@@ -60,7 +53,6 @@ export default function GiftPopup({
 
   const handleSend = async () => {
     if (!recipient) return;
-    setConfirmOpen(false);
     try {
       const fromId = await ensureAccountId();
       const res = await sendGift(fromId, recipient.id, selected.id);
@@ -94,8 +86,7 @@ export default function GiftPopup({
           }, 5000);
         }
       }
-      setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
-      setPendingGift({ from: senderIndex, to: target, gift: selected });
+      onGiftSent && onGiftSent({ from: senderIndex, to: target, gift: selected });
     } catch {
       setInfoMsg('Failed to send gift');
     }
@@ -168,7 +159,7 @@ export default function GiftPopup({
           </div>
           <button
             className={sendButtonClassName}
-            onClick={() => setConfirmOpen(true)}
+            onClick={handleSend}
           >
             Send <GiftIcon icon={selected.icon} className="w-4 h-4 inline" /> {selected.name}
           </button>
@@ -177,12 +168,6 @@ export default function GiftPopup({
           </p>
         </div>
       </div>
-      <ConfirmPopup
-        open={confirmOpen}
-        message="10% charge and the amount of the gift will be deducted from your balance. Continue?"
-        onConfirm={handleSend}
-        onCancel={() => setConfirmOpen(false)}
-      />
       <InfoPopup
         open={Boolean(infoMsg)}
         onClose={handleInfoClose}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1706,9 +1706,10 @@ input:focus {
 }
 
 .pool-royale-chat-bubble {
-  left: calc(0.75rem + 3.15rem + 0.5rem);
-  bottom: calc(0.75rem + 5.35rem);
-  transform: none;
+  left: 50%;
+  top: 50%;
+  bottom: auto;
+  transform: translate(-50%, -50%);
 }
 
 .texas-holdem-chat-bubble {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1541,8 +1541,8 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 0.9; // increase jaw rebound energy so cushion cuts feel a bit bouncier
-const CUSHION_CUT_FRICTION_SCALE = 1.12; // trim grab slightly so added bounce is visible without making cuts skid
+const CUSHION_CUT_RESTITUTION_SCALE = 1.02; // nudge jaw rebound energy up so angle-cut returns feel closer to a real table
+const CUSHION_CUT_FRICTION_SCALE = 1.05; // keep a natural grab profile so the extra rebound stays controlled
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
 let SIDE_POCKET_SPAN =
@@ -13479,6 +13479,7 @@ function PoolRoyaleGame({
   const [showChat, setShowChat] = useState(false);
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
+  const [tournamentProgressPopup, setTournamentProgressPopup] = useState(null);
   const configPanelRef = useRef(null);
   const configButtonRef = useRef(null);
   const accountIdRef = useRef(accountId || '');
@@ -15398,7 +15399,10 @@ const powerRef = useRef(hud.power);
   );
   const handlePlayAgain = useCallback(() => {
     if (tournamentMode) {
-      window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+      setTournamentProgressPopup({
+        title: 'Tournament progress',
+        message: 'Tournament stays loaded on the table. Use Continue tournament to jump directly into the next match.'
+      });
       return;
     }
     if (isOnlineMatch) {
@@ -15406,7 +15410,7 @@ const powerRef = useRef(hud.power);
       return;
     }
     resetMatchState();
-  }, [isOnlineMatch, location.search, resetMatchState, sendRematchInvite, tournamentMode]);
+  }, [isOnlineMatch, resetMatchState, sendRematchInvite, tournamentMode]);
   const continueTournament = useCallback(() => {
     if (!tournamentMode) return;
     try {
@@ -15441,12 +15445,16 @@ const powerRef = useRef(hud.power);
         pendingMatch.pair[0] === userSeed ? pendingMatch.pair[1] : pendingMatch.pair[0];
       window.localStorage.setItem(tournamentOppKey, JSON.stringify(st.seedToPlayer?.[opponentSeed] || null));
       window.localStorage.setItem(tournamentStateKey, JSON.stringify(st));
-      window.location.assign(`/games/poolroyale${location.search || ''}`);
+      setTournamentProgressPopup({
+        title: 'Tournament progress',
+        message: 'Next bracket match prepared. Starting directly from this table without reloading.'
+      });
+      resetMatchState();
     } catch (err) {
       console.warn('Pool Royale continue tournament failed', err);
       window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
     }
-  }, [location.search, tournamentMode, tournamentOppKey, tournamentStateKey]);
+  }, [location.search, resetMatchState, tournamentMode, tournamentOppKey, tournamentStateKey]);
   useEffect(() => () => clearRematchTimers(), [clearRematchTimers]);
   const simulateRoundAI = useCallback((st, round) => {
     const next = st.rounds[round + 1];
@@ -31657,7 +31665,7 @@ const powerRef = useRef(hud.power);
   const hudGapClass = usePortraitHudLayout ? 'gap-5' : 'gap-7';
   const bottomHudLayoutClass = usePortraitHudLayout ? 'justify-center px-4 w-full' : 'justify-center';
   const chatGiftOverlayClass =
-    'fixed inset-0 z-50 flex items-center justify-center bg-black/70';
+    'fixed inset-0 z-50 flex items-center justify-center bg-black/25 backdrop-blur-[1px]';
   const chatGiftPanelClass =
     'w-[min(340px,88vw)] rounded-2xl border border-[#233050] bg-[#0b1220] p-4 text-white shadow-[0_18px_40px_rgba(0,0,0,0.5)]';
   const chatGiftHeaderClass = 'flex items-center justify-between gap-2';
@@ -32087,7 +32095,7 @@ const powerRef = useRef(hud.power);
         </>
       )}
 
-      {(!isPortrait || (isPortrait && configOpen && !isFreePractice && !hideNonEssentialHud)) && (
+      {(!isPortrait || (isPortrait && configOpen && !hideNonEssentialHud)) && (
       <div
         className={`${isPortrait ? 'fixed left-1/2 -translate-x-1/2 items-center' : 'absolute items-start'} z-50 flex flex-col gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{
@@ -33230,26 +33238,14 @@ const powerRef = useRef(hud.power);
           >
             <span aria-hidden="true">☰</span>
           </button>
-          {isFreePractice ? (
-            <button
-              type="button"
-              onClick={handlePracticeRestart}
-              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-              aria-label="Restart practice"
-              title="Restart practice"
-            >
-              <span aria-hidden="true">↻</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setShowChat(true)}
-              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-              aria-label="Open chat"
-            >
-              <span aria-hidden="true">💬</span>
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setShowChat(true)}
+            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+            aria-label="Open chat"
+          >
+            <span aria-hidden="true">💬</span>
+          </button>
         </div>
       )}
 
@@ -33533,6 +33529,23 @@ const powerRef = useRef(hud.power);
           />
         </div>
       )}
+
+
+      {tournamentProgressPopup ? (
+        <div className="absolute inset-0 z-[125] flex items-center justify-center bg-black/55 px-4">
+          <div className="w-[min(92vw,24rem)] rounded-2xl border border-emerald-300/55 bg-slate-950/90 p-4 text-center text-white shadow-[0_18px_40px_rgba(0,0,0,0.55)] backdrop-blur">
+            <p className="text-[11px] font-black uppercase tracking-[0.24em] text-emerald-200">{tournamentProgressPopup.title}</p>
+            <p className="mt-2 text-sm text-white/85">{tournamentProgressPopup.message}</p>
+            <button
+              type="button"
+              onClick={() => setTournamentProgressPopup(null)}
+              className="mt-4 rounded-full border border-emerald-300 bg-emerald-300 px-4 py-1.5 text-[11px] font-bold uppercase tracking-[0.2em] text-black"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       {err && (
         <div className="pointer-events-none absolute left-1/2 top-4 z-50 -translate-x-1/2 px-4">


### PR DESCRIPTION
### Motivation
- Make Pool Royale feel more like real table play by nudging cushion-cut rebound physics for more natural angle-cut returns.
- Restore the Practice Mode menu flow so portrait users can open the settings menu from the menu icon as in normal play.
- Streamline gifting so users can send gifts with a single click while keeping gameplay visible, and align chat/gift visual positioning.
- Avoid forcing a page reload when advancing tournament matches by keeping the table loaded and showing progress inline.

### Description
- Tuned cushion-cut physics constants in `webapp/src/pages/Games/PoolRoyale.jsx` by increasing `CUSHION_CUT_RESTITUTION_SCALE` and reducing `CUSHION_CUT_FRICTION_SCALE` to produce bouncier, yet controlled, angle-cut returns.
- Restored portrait HUD/menu behavior and always show the chat action in the top action row so `Menu`/practice controls are accessible without leaving the table by changing the portrait config control conditions in `PoolRoyale.jsx` and related UI placement.
- Simplified gift flow by removing the confirm popup and making `GiftPopup` send immediately on click; `webapp/src/components/GiftPopup.jsx` now calls `onGiftSent` directly and retains `InfoPopup` for errors.
- Made the gift/chat modal overlay less obtrusive by changing the overlay class to a lighter/translucent backdrop in `PoolRoyale.jsx` so gameplay remains visible while sending gifts.
- Repositioned the Pool Royale chat bubble to the center of the screen by updating `.pool-royale-chat-bubble` in `webapp/src/index.css` to align with gift animation focus.
- Kept tournament state in-table by adding `tournamentProgressPopup` state and UI in `PoolRoyale.jsx`; `handlePlayAgain` now opens an inline progress popup when in tournament mode and `continueTournament` prepares the next match and resets the match state instead of forcing a navigation reload.

### Testing
- Ran `npx eslint` against the changed files which completed with warnings only (ignored patterns triggered warnings). (succeeded with warnings)
- Ran `npm run build` which failed due to a pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` unrelated to these edits (build failure unrelated to changes). (failed)
- Started the dev server (`npm --prefix webapp run dev`) and exercised the UI via an automated Playwright script that captured a screenshot of the updated home/game page to validate layout changes visually. (dev server and screenshot captured successfully)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b637869310832982444c8461f750c9)