### PR TITLE
Tune Pool Royale cushions, overlays, and tournament flow UX

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -1,12 +1,11 @@
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { getPlayerId, ensureAccountId } from '../utils/telegram.js';
+import { ensureAccountId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
 import { getGameVolume } from '../utils/sound.js';
-import ConfirmPopup from './ConfirmPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
 
 
@@ -38,17 +37,11 @@ export default function GiftPopup({
   const validPlayers = players.filter((p) => p.id);
   const [selected, setSelected] = useState(NFT_GIFTS[0]);
   const [target, setTarget] = useState(validPlayers[0]?.index || 0);
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [infoMsg, setInfoMsg] = useState('');
-  const [pendingGift, setPendingGift] = useState(null);
   const resolvedTitle = title ?? 'Send Gift';
 
   const handleInfoClose = () => {
     setInfoMsg('');
-    if (pendingGift) {
-      onGiftSent && onGiftSent(pendingGift);
-      setPendingGift(null);
-    }
   };
   useEffect(() => {
     if (validPlayers.length > 0 && !validPlayers.some((p) => p.index === target)) {
@@ -60,7 +53,6 @@ export default function GiftPopup({
 
   const handleSend = async () => {
     if (!recipient) return;
-    setConfirmOpen(false);
     try {
       const fromId = await ensureAccountId();
       const res = await sendGift(fromId, recipient.id, selected.id);
@@ -94,8 +86,8 @@ export default function GiftPopup({
           }, 5000);
         }
       }
-      setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
-      setPendingGift({ from: senderIndex, to: target, gift: selected });
+      onGiftSent && onGiftSent({ from: senderIndex, to: target, gift: selected });
+      setInfoMsg('Gift sent.');
     } catch {
       setInfoMsg('Failed to send gift');
     }
@@ -168,7 +160,7 @@ export default function GiftPopup({
           </div>
           <button
             className={sendButtonClassName}
-            onClick={() => setConfirmOpen(true)}
+            onClick={handleSend}
           >
             Send <GiftIcon icon={selected.icon} className="w-4 h-4 inline" /> {selected.name}
           </button>
@@ -177,12 +169,6 @@ export default function GiftPopup({
           </p>
         </div>
       </div>
-      <ConfirmPopup
-        open={confirmOpen}
-        message="10% charge and the amount of the gift will be deducted from your balance. Continue?"
-        onConfirm={handleSend}
-        onCancel={() => setConfirmOpen(false)}
-      />
       <InfoPopup
         open={Boolean(infoMsg)}
         onClose={handleInfoClose}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1706,9 +1706,9 @@ input:focus {
 }
 
 .pool-royale-chat-bubble {
-  left: calc(0.75rem + 3.15rem + 0.5rem);
-  bottom: calc(0.75rem + 5.35rem);
-  transform: none;
+  left: 50%;
+  bottom: 50%;
+  transform: translate(-50%, 50%);
 }
 
 .texas-holdem-chat-bubble {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1541,8 +1541,8 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 0.9; // increase jaw rebound energy so cushion cuts feel a bit bouncier
-const CUSHION_CUT_FRICTION_SCALE = 1.12; // trim grab slightly so added bounce is visible without making cuts skid
+const CUSHION_CUT_RESTITUTION_SCALE = 0.96; // boost jaw rebound energy so angle-cut returns feel closer to real-table physics
+const CUSHION_CUT_FRICTION_SCALE = 1.08; // ease jaw grab so rebound carries naturally after angle-cut contact
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
 let SIDE_POCKET_SPAN =
@@ -12222,6 +12222,7 @@ function PoolRoyaleGame({
     return params.get('token') || 'TPC';
   }, [location.search]);
   const [winnerOverlay, setWinnerOverlay] = useState(null);
+  const [showTournamentProgressPopup, setShowTournamentProgressPopup] = useState(false);
   const [finalPotLabel, setFinalPotLabel] = useState('');
   const [rematchStatus, setRematchStatus] = useState(null);
   const [incomingRematch, setIncomingRematch] = useState(null);
@@ -15398,7 +15399,7 @@ const powerRef = useRef(hud.power);
   );
   const handlePlayAgain = useCallback(() => {
     if (tournamentMode) {
-      window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+      setShowTournamentProgressPopup(true);
       return;
     }
     if (isOnlineMatch) {
@@ -15412,12 +15413,12 @@ const powerRef = useRef(hud.power);
     try {
       const raw = window.localStorage.getItem(tournamentStateKey);
       if (!raw) {
-        window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+        setShowTournamentProgressPopup(true);
         return;
       }
       const st = JSON.parse(raw);
       if (!st || st.complete) {
-        window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+        setShowTournamentProgressPopup(true);
         return;
       }
       const round = st.currentRound || 0;
@@ -15433,7 +15434,7 @@ const powerRef = useRef(hud.power);
         break;
       }
       if (!pendingMatch) {
-        window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+        setShowTournamentProgressPopup(true);
         return;
       }
       st.pendingMatch = pendingMatch;
@@ -15441,12 +15442,12 @@ const powerRef = useRef(hud.power);
         pendingMatch.pair[0] === userSeed ? pendingMatch.pair[1] : pendingMatch.pair[0];
       window.localStorage.setItem(tournamentOppKey, JSON.stringify(st.seedToPlayer?.[opponentSeed] || null));
       window.localStorage.setItem(tournamentStateKey, JSON.stringify(st));
-      window.location.assign(`/games/poolroyale${location.search || ''}`);
+      resetMatchState();
     } catch (err) {
       console.warn('Pool Royale continue tournament failed', err);
-      window.location.assign(`/pool-royale-bracket.html${location.search || ''}`);
+      setShowTournamentProgressPopup(true);
     }
-  }, [location.search, tournamentMode, tournamentOppKey, tournamentStateKey]);
+  }, [location.search, resetMatchState, tournamentMode, tournamentOppKey, tournamentStateKey]);
   useEffect(() => () => clearRematchTimers(), [clearRematchTimers]);
   const simulateRoundAI = useCallback((st, round) => {
     const next = st.rounds[round + 1];
@@ -15486,12 +15487,12 @@ const powerRef = useRef(hud.power);
       try {
         const raw = window.localStorage.getItem(tournamentStateKey);
         if (!raw) {
-          window.location.assign(`/pool-royale-bracket.html${location.search}`);
+          setShowTournamentProgressPopup(true);
           return { unlocks: [], complete: false, nftReward: null };
         }
         const st = JSON.parse(raw);
         if (!st?.pendingMatch) {
-          window.location.assign(`/pool-royale-bracket.html${location.search}`);
+          setShowTournamentProgressPopup(true);
           return { unlocks: [], complete: false, nftReward: null };
         }
         const r = st.pendingMatch.round;
@@ -15569,6 +15570,7 @@ const powerRef = useRef(hud.power);
       tournamentLastResultKey,
       tournamentAiFlagStorageKey,
       tournamentMode,
+      setShowTournamentProgressPopup,
       tournamentOppKey,
       tournamentPlayers,
       tournamentStateKey,
@@ -31657,9 +31659,9 @@ const powerRef = useRef(hud.power);
   const hudGapClass = usePortraitHudLayout ? 'gap-5' : 'gap-7';
   const bottomHudLayoutClass = usePortraitHudLayout ? 'justify-center px-4 w-full' : 'justify-center';
   const chatGiftOverlayClass =
-    'fixed inset-0 z-50 flex items-center justify-center bg-black/70';
+    'fixed inset-0 z-50 flex items-center justify-center bg-transparent';
   const chatGiftPanelClass =
-    'w-[min(340px,88vw)] rounded-2xl border border-[#233050] bg-[#0b1220] p-4 text-white shadow-[0_18px_40px_rgba(0,0,0,0.5)]';
+    'w-[min(340px,88vw)] rounded-2xl border border-[#233050]/70 bg-[#0b1220]/45 p-4 text-white shadow-[0_18px_40px_rgba(0,0,0,0.38)] backdrop-blur-md';
   const chatGiftHeaderClass = 'flex items-center justify-between gap-2';
   const chatGiftTitleClass = 'text-sm font-semibold tracking-[0.04em] text-white';
   const chatGiftCloseButtonClass =
@@ -31776,6 +31778,28 @@ const powerRef = useRef(hud.power);
           <p className="mt-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/90">One match decides the champion.</p>
         </div>
       )}
+      {showTournamentProgressPopup && tournamentMode ? (
+        <div className="absolute inset-0 z-[122] flex items-center justify-center bg-black/65 px-4">
+          <div className="w-[min(94vw,56rem)] rounded-2xl border border-emerald-300/50 bg-slate-950/92 p-3 shadow-[0_22px_54px_rgba(0,0,0,0.6)]">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-100">Tournament progress</p>
+              <button
+                type="button"
+                className="rounded-full border border-white/20 px-2 py-1 text-xs text-white/80"
+                onClick={() => setShowTournamentProgressPopup(false)}
+              >
+                Close
+              </button>
+            </div>
+            <iframe
+              title="Pool Royale tournament bracket"
+              src={`/pool-royale-bracket.html${location.search ? `${location.search}&embed=1` : '?embed=1'}`}
+              className="h-[68vh] w-full rounded-xl border border-white/10 bg-black/40"
+            />
+          </div>
+        </div>
+      ) : null}
+
       {winnerOverlay && (
         <div className="absolute inset-0 z-[120] flex items-center justify-center bg-black/70 px-4">
           <div className="flex flex-col items-center gap-4 text-center">
@@ -32087,7 +32111,7 @@ const powerRef = useRef(hud.power);
         </>
       )}
 
-      {(!isPortrait || (isPortrait && configOpen && !isFreePractice && !hideNonEssentialHud)) && (
+      {(!isPortrait || (isPortrait && configOpen && !hideNonEssentialHud)) && (
       <div
         className={`${isPortrait ? 'fixed left-1/2 -translate-x-1/2 items-center' : 'absolute items-start'} z-50 flex flex-col gap-2 transition-opacity duration-200 ${replayActive ? 'opacity-0' : 'opacity-100'}`}
         style={{


### PR DESCRIPTION
### Motivation
- Improve Pool Royale feel by making cushion angle-cuts rebound more like a real table and reduce overly damped returns.
- Surface Practice Mode menu in portrait the same as normal matches so players can access settings during practice.
- Make gifting faster and less intrusive by allowing single-click sends and keep the gameplay visible while gifts are sent.
- Avoid full-page navigation when continuing Career / Tournament flows so the 3D table stays loaded and progress is shown without reloading the game.

### Description
- Increased the cushion-cut physics aggressiveness by updating `CUSHION_CUT_RESTITUTION_SCALE` to `0.96` and lowering `CUSHION_CUT_FRICTION_SCALE` to `1.08` in `webapp/src/pages/Games/PoolRoyale.jsx` to make angle-cut bounces livelier.
- Removed the one-click gift confirmation flow in `webapp/src/components/GiftPopup.jsx` by deleting the `ConfirmPopup` usage and wiring the send button to call `handleSend` directly, and invoke `onGiftSent` immediately after a successful send.
- Made the gift/chat overlay background transparent and the gift panel translucent by adjusting `chatGiftOverlayClass` and `chatGiftPanelClass` in `PoolRoyale.jsx`, and tuned the panel styling for better visibility of the running game.
- Repositioned Pool Royale chat bubbles to center-screen via CSS (`.pool-royale-chat-bubble`) in `webapp/src/index.css` so chat aligns with gift animations and the middle of the game view.
- Added an in-game tournament progress popup state (`showTournamentProgressPopup`) and an embedded bracket `iframe` that is shown instead of navigating away in `continueTournament`, `handlePlayAgain`, and related tournament fallback paths so the game stays loaded while showing bracket progress.
- Enabled the menu/config panel in portrait practice by removing the `!isFreePractice` gate so the settings panel appears under the menu icon as in normal gameplay.
- Removed unused imports and updated a few small callsites to use the new behavior (e.g. `ConfirmPopup` removal and minor code cleanups).

### Testing
- Ran `npx eslint webapp/src/components/GiftPopup.jsx webapp/src/pages/Games/PoolRoyale.jsx webapp/src/index.css` which produced only repository-ignore warnings for these files (no blocking errors).
- Executed `npm run lint` which reported many pre-existing, unrelated lint errors in generated/dist files; these failures are repo-wide and not introduced by this change.
- Started the dev server (`npm --prefix webapp run dev -- --host 0.0.0.0`) and captured a mobile screenshot of the running app to validate UI placement; screenshot artifact was produced (`artifacts/pool-royale-update-mobile.png`).
- Committed the changes and created the PR; no unit tests were added or modified for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b637869310832982444c8461f750c9)