### PR TITLE
Fix Checkers Battle Royal load crash when remote GLTF assets are unavailable

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -4535,7 +4535,8 @@ async function resolveBeautifulGameAssets(targetBoardSize) {
 
   if (boardAssets) return boardAssets;
 
-  throw new Error('Checkers Battle Royal: failed to load ABeautifulGame assets');
+  console.warn('Checkers Battle Royal: ABeautifulGame assets unavailable, using procedural fallback');
+  return buildBeautifulGameFallback(targetBoardSize);
 }
 
 async function resolveBeautifulGameTouchAssets(targetBoardSize) {


### PR DESCRIPTION
### Motivation
- The Checkers Battle Royal scene could abort loading and block the route when all remote ABeautifulGame GLTF URLs returned errors (403/404); the loader previously threw a fatal error instead of falling back to a procedural asset set.

### Description
- Updated `resolveBeautifulGameAssets` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to log a warning and return `buildBeautifulGameFallback(targetBoardSize)` when remote GLTF/PolyHaven assets cannot be loaded, preventing a thrown error and allowing the scene to continue with the existing procedural board/piece assets.

### Testing
- Built the webapp successfully with `npm --prefix webapp run build` which completed without errors.
- Launched the dev server and loaded `http://127.0.0.1:4173/games/checkersbattleroyal?mode=ai` and captured screenshots after load to verify the game renders visually (`artifacts/checkers-loaded-1.png`, `artifacts/checkers-loaded-2.png`).
- Ran an automated Playwright check that confirmed `PAGEERROR_COUNT 0` during load and no unhandled runtime exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b64adfba84832992032f043964d46a)