### PR TITLE
Revert "Fix Checkers Battle Royal load crash when remote GLTF assets are unavailable"

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -4535,8 +4535,7 @@ async function resolveBeautifulGameAssets(targetBoardSize) {
 
   if (boardAssets) return boardAssets;
 
-  console.warn('Checkers Battle Royal: ABeautifulGame assets unavailable, using procedural fallback');
-  return buildBeautifulGameFallback(targetBoardSize);
+  throw new Error('Checkers Battle Royal: failed to load ABeautifulGame assets');
 }
 
 async function resolveBeautifulGameTouchAssets(targetBoardSize) {


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#16849