### PR TITLE
Add Checkers Battle Royal pages, routing, assets, and store integration

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -12,6 +12,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
+  checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
   'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -40,6 +40,8 @@ import DominoRoyalLobby from './pages/Games/DominoRoyalLobby.jsx';
 
 const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal.jsx'));
 const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
+const CheckersBattleRoyal = React.lazy(() => import('./pages/Games/CheckersBattleRoyal.jsx'));
+const CheckersBattleRoyalLobby = React.lazy(() => import('./pages/Games/CheckersBattleRoyalLobby.jsx'));
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 import PoolRoyaleCareer from './pages/Games/PoolRoyaleCareer.jsx';
@@ -158,6 +160,23 @@ export default function App() {
               element={(
                 <Suspense fallback={<div className="p-4 text-center">Loading Chess Battle Royal…</div>}>
                   <ChessBattleRoyal />
+                </Suspense>
+              )}
+            />
+
+            <Route
+              path="/games/checkersbattleroyal/lobby"
+              element={(
+                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Lobby…</div>}>
+                  <CheckersBattleRoyalLobby />
+                </Suspense>
+              )}
+            />
+            <Route
+              path="/games/checkersbattleroyal"
+              element={(
+                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Battle Royal…</div>}>
+                  <CheckersBattleRoyal />
                 </Suspense>
               )}
             />

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -20,6 +20,7 @@ export const gameThumbnails = {
   snake: '/assets/icons/Snake%20and%20ladder%20game%20logo.png',
   murlanroyale: '/assets/icons/Murlan%20Royal%20logo.png',
   chessbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+  checkersbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
   tabletennisroyal: '/assets/icons/table-tennis-royale.svg'
 };
@@ -125,6 +126,10 @@ export const lobbyOptionIcons = {
     '/assets/icons/murlan-royale.svg'
   ),
   chessbattleroyal: buildLobbyIconSet(
+    ['mode-ai', 'mode-online', 'queue-instant', 'queue-mobile', 'queue-hdr'],
+    '/assets/icons/chess-royale.svg'
+  ),
+  checkersbattleroyal: buildLobbyIconSet(
     ['mode-ai', 'mode-online', 'queue-instant', 'queue-mobile', 'queue-hdr'],
     '/assets/icons/chess-royale.svg'
   ),

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -62,6 +62,14 @@ const gamesCatalog = [
     image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
     description: 'Strategic chess showdowns with royal flair.'
   },
+
+  {
+    name: 'Checkers Battle Royal',
+    route: '/games/checkersbattleroyal/lobby',
+    slug: 'checkersbattleroyal',
+    image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+    description: 'Classic checkers duels with royal 3D presentation.'
+  },
   {
     name: 'Table Tennis Royal',
     route: '/games/tabletennisroyal/lobby',

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -1,0 +1,507 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
+import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
+import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
+import {
+  CHESS_CHAIR_OPTIONS,
+  CHESS_TABLE_OPTIONS,
+  CHESS_BATTLE_OPTION_LABELS
+} from '../../config/chessBattleInventoryConfig.js';
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from '../../config/poolRoyaleInventoryConfig.js';
+import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import { chessBattleAccountId, getChessBattleInventory } from '../../utils/chessBattleInventory.js';
+
+const SIZE = 8;
+const BEAUTIFUL_GAME_URLS = [
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf'
+];
+
+const CHIP_SETS = [
+  { id: 'ruby-cyan', label: 'Ruby/Cyan', light: '#ef4444', dark: '#06b6d4' },
+  { id: 'emerald-violet', label: 'Emerald/Violet', light: '#10b981', dark: '#8b5cf6' },
+  { id: 'amber-slate', label: 'Amber/Slate', light: '#f59e0b', dark: '#334155' },
+  { id: 'rose-ice', label: 'Rose/Ice', light: '#fb7185', dark: '#67e8f9' }
+];
+
+const createInitial = () => {
+  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
+  for (let r = 0; r < 3; r += 1) for (let c = 0; c < SIZE; c += 1) if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
+  for (let r = 5; r < SIZE; r += 1) for (let c = 0; c < SIZE; c += 1) if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
+  return board;
+};
+
+const inBounds = (r, c) => r >= 0 && r < SIZE && c >= 0 && c < SIZE;
+const getMoves = (board, r, c) => {
+  const piece = board[r][c];
+  if (!piece) return [];
+  const dirs = piece.king
+    ? [[1, 1], [1, -1], [-1, 1], [-1, -1]]
+    : piece.side === 'light'
+      ? [[-1, 1], [-1, -1]]
+      : [[1, 1], [1, -1]];
+  const captures = [];
+  const normals = [];
+  dirs.forEach(([dr, dc]) => {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) return;
+    if (!board[nr][nc]) normals.push({ r: nr, c: nc });
+    else if (board[nr][nc].side !== piece.side) {
+      const jr = nr + dr;
+      const jc = nc + dc;
+      if (inBounds(jr, jc) && !board[jr][jc]) captures.push({ r: jr, c: jc, capture: [nr, nc] });
+    }
+  });
+  return captures.length ? captures : normals;
+};
+
+async function loadBeautifulBoard(loader) {
+  let err = null;
+  for (const url of BEAUTIFUL_GAME_URLS) {
+    try {
+      const gltf = await loader.loadAsync(url);
+      if (gltf?.scene) return gltf.scene;
+    } catch (e) {
+      err = e;
+    }
+  }
+  throw err || new Error('ABeautifulGame failed to load');
+}
+
+async function resolveHdriUrl(variant) {
+  const fallbackRes = variant?.fallbackResolution || '4k';
+  const fallback = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${variant?.assetId || 'colorful_studio'}_${fallbackRes}.hdr`;
+  if (!variant?.assetId) return fallback;
+  try {
+    const res = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(variant.assetId)}`);
+    if (!res.ok) return fallback;
+    const data = await res.json();
+    const urls = [];
+    const walk = (value) => {
+      if (!value) return;
+      if (typeof value === 'string') {
+        const low = value.toLowerCase();
+        if (value.startsWith('http') && (low.endsWith('.hdr') || low.endsWith('.exr'))) urls.push(value);
+      } else if (Array.isArray(value)) value.forEach(walk);
+      else if (typeof value === 'object') Object.values(value).forEach(walk);
+    };
+    walk(data);
+    return urls.find((u) => u.includes(`/${fallbackRes}/`)) || urls[0] || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export default function CheckersBattleRoyal() {
+  useTelegramBackButton();
+  const navigate = useNavigate();
+  const mountRef = useRef(null);
+
+  const boardRef = useRef(createInitial());
+  const selectedRef = useRef(null);
+  const piecesGroupRef = useRef(null);
+  const boardOriginRef = useRef({ x: 0, y: 0.75, z: 0, tile: 2.65 });
+
+  const sceneRef = useRef(null);
+  const tableRef = useRef(null);
+  const chairsRef = useRef([]);
+  const envRef = useRef({ map: null, skybox: null });
+
+  const [turn, setTurn] = useState('light');
+  const [status, setStatus] = useState('Loading arena…');
+  const [showAppearance, setShowAppearance] = useState(false);
+
+  const inv = useMemo(() => {
+    const inventory = getChessBattleInventory(chessBattleAccountId());
+    return {
+      tableId: inventory.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
+      chairId: inventory.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
+      tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+      hdriId: inventory.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID
+    };
+  }, []);
+
+  const [appearance, setAppearance] = useState(inv);
+  const [chipSetId, setChipSetId] = useState(CHIP_SETS[0].id);
+
+  const chipSet = CHIP_SETS.find((s) => s.id === chipSetId) || CHIP_SETS[0];
+
+  const renderPieces = useMemo(
+    () => () => {
+      const group = piecesGroupRef.current;
+      if (!group) return;
+      group.clear();
+      const board = boardRef.current;
+      const { x, y, z, tile } = boardOriginRef.current;
+      for (let r = 0; r < SIZE; r += 1) {
+        for (let c = 0; c < SIZE; c += 1) {
+          const piece = board[r][c];
+          if (!piece) continue;
+          const chip = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.9, 0.9, 0.34, 40),
+            new THREE.MeshStandardMaterial({
+              color: piece.side === 'light' ? chipSet.light : chipSet.dark,
+              roughness: 0.25,
+              metalness: 0.52
+            })
+          );
+          chip.castShadow = true;
+          chip.position.set(x + (c - 3.5) * tile, y + 0.2, z + (r - 3.5) * tile);
+          if (piece.king) {
+            const ring = new THREE.Mesh(
+              new THREE.TorusGeometry(0.5, 0.11, 12, 30),
+              new THREE.MeshStandardMaterial({ color: '#f8fafc', metalness: 0.92, roughness: 0.18 })
+            );
+            ring.rotation.x = Math.PI / 2;
+            ring.position.y = 0.23;
+            chip.add(ring);
+          }
+          group.add(chip);
+        }
+      }
+    },
+    [chipSet.dark, chipSet.light]
+  );
+
+  useEffect(() => {
+    renderPieces();
+  }, [renderPieces, turn]);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    sceneRef.current = scene;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.shadowMap.enabled = true;
+    mount.appendChild(renderer.domElement);
+
+    const camera = new THREE.PerspectiveCamera(
+      ARENA_CAMERA_DEFAULTS.fov,
+      mount.clientWidth / mount.clientHeight,
+      ARENA_CAMERA_DEFAULTS.near,
+      ARENA_CAMERA_DEFAULTS.far
+    );
+    camera.position.set(0, 36, 42);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 0, 0);
+    controls.enablePan = false;
+    controls.minDistance = 22;
+    controls.maxDistance = 70;
+    controls.minPolarAngle = 0.42;
+    controls.maxPolarAngle = Math.PI * 0.47;
+
+    scene.add(new THREE.AmbientLight('#ffffff', 0.5));
+    const key = new THREE.DirectionalLight('#ffffff', 1.08);
+    key.position.set(18, 26, 12);
+    key.castShadow = true;
+    scene.add(key);
+
+    const piecesGroup = new THREE.Group();
+    piecesGroupRef.current = piecesGroup;
+    scene.add(piecesGroup);
+
+    const pickTiles = [];
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+
+    const applyMove = (r, c) => {
+      const board = boardRef.current;
+      const selected = selectedRef.current;
+      const piece = board[r][c];
+      if (piece && piece.side === turn) {
+        selectedRef.current = { r, c };
+        return;
+      }
+      if (!selected) return;
+      const moves = getMoves(board, selected.r, selected.c);
+      const move = moves.find((m) => m.r === r && m.c === c);
+      if (!move) return;
+      const next = board.map((row) => row.slice());
+      const moving = { ...next[selected.r][selected.c] };
+      next[selected.r][selected.c] = null;
+      if (move.capture) next[move.capture[0]][move.capture[1]] = null;
+      if (moving.side === 'light' && r === 0) moving.king = true;
+      if (moving.side === 'dark' && r === SIZE - 1) moving.king = true;
+      next[r][c] = moving;
+      boardRef.current = next;
+      selectedRef.current = null;
+      setTurn((prev) => (prev === 'light' ? 'dark' : 'light'));
+    };
+
+    const onPointerUp = (event) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObjects(pickTiles, false)[0];
+      if (hit?.object?.userData) applyMove(hit.object.userData.r, hit.object.userData.c);
+    };
+
+    const buildSceneAssets = async () => {
+      const tableTheme = CHESS_TABLE_OPTIONS.find((t) => t.id === appearance.tableId) || CHESS_TABLE_OPTIONS[0];
+      const table = createMurlanStyleTable({ tableTheme: tableTheme?.id, tableScale: 1.16 });
+      table.group.position.set(0, -0.6, 0);
+      const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+      applyTableMaterials(table.parts, finish);
+      tableRef.current = table;
+      scene.add(table.group);
+
+      const chairOption = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
+      const chairColor = chairOption?.primary || chairOption?.seatColor || '#8b0000';
+      const chairMat = new THREE.MeshStandardMaterial({ color: chairColor, roughness: 0.42, metalness: 0.22 });
+      const makeChair = (z, ry) => {
+        const g = new THREE.Group();
+        const seat = new THREE.Mesh(new THREE.BoxGeometry(5.6, 1.5, 5.4), chairMat);
+        const back = new THREE.Mesh(new THREE.BoxGeometry(5.6, 4.8, 1.3), chairMat);
+        seat.position.y = 0.75;
+        back.position.set(0, 3.1, -2);
+        seat.castShadow = true;
+        back.castShadow = true;
+        g.add(seat, back);
+        g.position.set(0, -0.3, z);
+        g.rotation.y = ry;
+        scene.add(g);
+        return g;
+      };
+      chairsRef.current = [makeChair(18.4, Math.PI), makeChair(-18.4, 0)];
+
+      const boardRoot = await loadBeautifulBoard(new GLTFLoader());
+      boardRoot.scale.setScalar(0.125);
+      boardRoot.position.set(0, 0.72, 0);
+      boardRoot.traverse((child) => {
+        if (!child.isMesh) return;
+        const n = `${child.name || ''}`.toLowerCase();
+        if (/(pawn|rook|knight|bishop|queen|king)/.test(n)) child.visible = false;
+        child.castShadow = true;
+        child.receiveShadow = true;
+      });
+      scene.add(boardRoot);
+
+      const bbox = new THREE.Box3().setFromObject(boardRoot);
+      const center = bbox.getCenter(new THREE.Vector3());
+      boardOriginRef.current = { x: center.x, y: bbox.max.y + 0.05, z: center.z, tile: 2.65 };
+
+      const hdriVariant = POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === appearance.hdriId) ||
+        POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === POOL_ROYALE_DEFAULT_HDRI_ID) ||
+        POOL_ROYALE_HDRI_VARIANTS[0];
+      const hdriUrl = await resolveHdriUrl(hdriVariant);
+      const loaderEnv = hdriUrl.toLowerCase().endsWith('.exr') ? new EXRLoader() : new RGBELoader();
+      const envMap = await loaderEnv.loadAsync(hdriUrl);
+      envMap.mapping = THREE.EquirectangularReflectionMapping;
+      scene.environment = envMap;
+      scene.background = envMap;
+      const skybox = new GroundedSkybox(envMap, 1.5, 40, 128);
+      scene.add(skybox);
+      envRef.current = { map: envMap, skybox, hdriId: appearance.hdriId };
+
+      const pickMaterial = new THREE.MeshBasicMaterial({ visible: false });
+      const { x, y, z, tile } = boardOriginRef.current;
+      for (let r = 0; r < SIZE; r += 1) {
+        for (let c = 0; c < SIZE; c += 1) {
+          const pick = new THREE.Mesh(new THREE.BoxGeometry(tile * 0.94, 0.25, tile * 0.94), pickMaterial);
+          pick.position.set(x + (c - 3.5) * tile, y + 0.16, z + (r - 3.5) * tile);
+          pick.userData = { r, c };
+          pickTiles.push(pick);
+          scene.add(pick);
+        }
+      }
+    };
+
+    renderer.domElement.addEventListener('pointerup', onPointerUp);
+
+    void buildSceneAssets()
+      .then(() => {
+        renderPieces();
+        setStatus('Ready');
+      })
+      .catch((error) => {
+        console.error('Checkers scene boot error:', error);
+        setStatus('Failed to load board/table/chairs/HDRI.');
+      });
+
+    let raf = 0;
+    const animate = () => {
+      controls.update();
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(animate);
+    };
+    animate();
+
+    const onResize = () => {
+      camera.aspect = mount.clientWidth / mount.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(mount.clientWidth, mount.clientHeight);
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      renderer.domElement.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('resize', onResize);
+      renderer.dispose();
+      mount.removeChild(renderer.domElement);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    if (tableRef.current?.parts) {
+      const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+      applyTableMaterials(tableRef.current.parts, finish);
+    }
+
+    const chairOption = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
+    const nextChairColor = new THREE.Color(chairOption?.primary || chairOption?.seatColor || '#8b0000');
+    chairsRef.current.forEach((chairGroup) => {
+      chairGroup?.traverse?.((child) => {
+        if (child?.isMesh && child.material?.color) {
+          child.material.color.copy(nextChairColor);
+          child.material.needsUpdate = true;
+        }
+      });
+    });
+
+    const activeTableTheme = CHESS_TABLE_OPTIONS.find((t) => t.id === appearance.tableId) || CHESS_TABLE_OPTIONS[0];
+    if (tableRef.current?.group?.userData?.tableThemeId !== activeTableTheme?.id) {
+      if (tableRef.current?.group) scene.remove(tableRef.current.group);
+      const nextTable = createMurlanStyleTable({ tableTheme: activeTableTheme?.id, tableScale: 1.16 });
+      nextTable.group.position.set(0, -0.6, 0);
+      nextTable.group.userData = { ...(nextTable.group.userData || {}), tableThemeId: activeTableTheme?.id };
+      const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+      applyTableMaterials(nextTable.parts, finish);
+      tableRef.current = nextTable;
+      scene.add(nextTable.group);
+    }
+
+    const currentHdriId = envRef.current?.hdriId;
+    if (currentHdriId === appearance.hdriId) return;
+
+    const applyHdri = async () => {
+      const variant = POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === appearance.hdriId) ||
+        POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === POOL_ROYALE_DEFAULT_HDRI_ID) ||
+        POOL_ROYALE_HDRI_VARIANTS[0];
+      const url = await resolveHdriUrl(variant);
+      const loaderEnv = url.toLowerCase().endsWith('.exr') ? new EXRLoader() : new RGBELoader();
+      const envMap = await loaderEnv.loadAsync(url);
+      envMap.mapping = THREE.EquirectangularReflectionMapping;
+      scene.environment = envMap;
+      scene.background = envMap;
+      if (envRef.current?.skybox) scene.remove(envRef.current.skybox);
+      const skybox = new GroundedSkybox(envMap, 1.5, 40, 128);
+      scene.add(skybox);
+      envRef.current = { map: envMap, skybox, hdriId: appearance.hdriId };
+    };
+
+    void applyHdri();
+  }, [appearance]);
+
+  const optionButton = (active) => `rounded-lg border px-2 py-1 text-[11px] ${active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`;
+
+  return (
+    <div className="min-h-screen bg-[#050814] text-white">
+      <div className="flex items-center justify-between px-4 py-3 text-xs">
+        <button onClick={() => navigate('/games/checkersbattleroyal/lobby')} className="rounded bg-white/10 px-3 py-1">Lobby</button>
+        <div>Checkers Battle Royal • Turn: {turn}</div>
+        <button onClick={() => setShowAppearance((v) => !v)} className="rounded bg-white/10 px-3 py-1">Appearance</button>
+      </div>
+
+      <div className="px-4 pb-2 text-[11px] text-white/70">
+        Board: ABeautifulGame • Table: {appearance.tableId} • Chair: {appearance.chairId} • HDRI: {CHESS_BATTLE_OPTION_LABELS.environmentHdri?.[appearance.hdriId] || appearance.hdriId}
+      </div>
+
+      <div ref={mountRef} className="h-[70vh] w-full" />
+      <div className="px-4 py-2 text-center text-xs text-white/70">{status}</div>
+
+      {showAppearance && (
+        <div className="mx-3 mb-4 rounded-2xl border border-white/15 bg-[#0b1324]/95 p-3">
+          <div className="mb-2 text-xs font-semibold">Checkers Arena Setup (Chess Battle Royal style)</div>
+          <div className="mb-2 text-[11px] text-white/60">Use same option sets as Chess Battle Royal. (These controls are synced to the same inventory categories.)</div>
+
+          <div className="mb-2 text-[11px] text-white/70">Chips</div>
+          <div className="mb-3 flex flex-wrap gap-2">
+            {CHIP_SETS.map((set) => (
+              <button key={set.id} onClick={() => setChipSetId(set.id)} className={optionButton(chipSetId === set.id)}>{set.label}</button>
+            ))}
+          </div>
+
+          <div className="mb-2 text-[11px] text-white/70">Tables</div>
+          <div className="mb-3 flex max-h-24 flex-wrap gap-2 overflow-auto">
+            {CHESS_TABLE_OPTIONS.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setAppearance((prev) => ({ ...prev, tableId: opt.id }))}
+                className={optionButton(appearance.tableId === opt.id)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mb-2 text-[11px] text-white/70">Chairs</div>
+          <div className="mb-3 flex max-h-24 flex-wrap gap-2 overflow-auto">
+            {CHESS_CHAIR_OPTIONS.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setAppearance((prev) => ({ ...prev, chairId: opt.id }))}
+                className={optionButton(appearance.chairId === opt.id)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mb-2 text-[11px] text-white/70">Table Finish</div>
+          <div className="mb-3 flex max-h-24 flex-wrap gap-2 overflow-auto">
+            {MURLAN_TABLE_FINISHES.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setAppearance((prev) => ({ ...prev, tableFinish: opt.id }))}
+                className={optionButton(appearance.tableFinish === opt.id)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mb-2 text-[11px] text-white/70">HDRI</div>
+          <div className="flex max-h-24 flex-wrap gap-2 overflow-auto">
+            {POOL_ROYALE_HDRI_VARIANTS.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setAppearance((prev) => ({ ...prev, hdriId: opt.id }))}
+                className={optionButton(appearance.hdriId === opt.id)}
+              >
+                {opt.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -1,0 +1,512 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramFirstName,
+  getTelegramPhotoUrl,
+  getTelegramUsername
+} from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction, getOnlineCount } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { socket } from '../../utils/socket.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+
+const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
+const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+const AI_FLAG_STORAGE_KEY = 'checkersBattleRoyalAiFlag';
+
+export default function CheckersBattleRoyalLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [avatar, setAvatar] = useState('');
+  const [mode, setMode] = useState('ai');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [onlineCount, setOnlineCount] = useState(null);
+  const [accountId, setAccountId] = useState('');
+  const [matching, setMatching] = useState(false);
+  const [matchStatus, setMatchStatus] = useState('');
+  const [matchError, setMatchError] = useState('');
+  const [preferredSide, setPreferredSide] = useState('auto');
+  const pendingTableRef = useRef('');
+  const cleanupRef = useRef(() => {});
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    import('./CheckersBattleRoyal.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem('checkersBattleRoyalPlayerFlag');
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    ensureAccountId()
+      .then((id) => {
+        if (cancelled) return;
+        setAccountId(id || '');
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const fetchOnline = () => {
+      getOnlineCount()
+        .then((d) => {
+          if (!active) return;
+          setOnlineCount(d?.count ?? 0);
+        })
+        .catch(() => {});
+    };
+    fetchOnline();
+    const interval = setInterval(fetchOnline, 20000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const navigateToGame = (extraParams = {}) => {
+    const params = new URLSearchParams();
+    const initData = window.Telegram?.WebApp?.initData;
+    const isOnline = mode === 'online';
+
+    if (isOnline && stake.token) params.set('token', stake.token);
+    if (isOnline && stake.amount) params.set('amount', stake.amount);
+    if (avatar) params.set('avatar', avatar);
+    if (extraParams.tgId) params.set('tgId', extraParams.tgId);
+    if (isOnline && (extraParams.trackedAccountId || accountId))
+      params.set('accountId', extraParams.trackedAccountId || accountId);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (!isOnline && selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    if (preferredSide) params.set('preferredSide', preferredSide);
+    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (isOnline && initData) params.set('init', encodeURIComponent(initData));
+    params.set('mode', mode);
+
+    Object.entries(extraParams).forEach(([key, value]) => {
+      if (value != null && key !== 'tgId' && key !== 'trackedAccountId') {
+        params.set(key, value);
+      }
+    });
+
+    navigate(`/games/checkersbattleroyal?${params.toString()}`);
+  };
+
+  const cleanupLobby = ({ account, skipRefReset } = {}) => {
+    socket.off('gameStart');
+    socket.off('lobbyUpdate');
+    if (pendingTableRef.current && (account || accountId)) {
+      socket.emit('leaveLobby', {
+        accountId: account || accountId,
+        tableId: pendingTableRef.current
+      });
+    }
+    pendingTableRef.current = '';
+    setMatching(false);
+    setMatchStatus('');
+    if (!skipRefReset) cleanupRef.current = null;
+  };
+
+  const startGame = async () => {
+    const isOnline = mode === 'online';
+    if (matching) return;
+    let tgId;
+    let trackedAccountId;
+    if (isOnline) {
+      try {
+        trackedAccountId = await ensureAccountId();
+        if (trackedAccountId) setAccountId((prev) => prev || trackedAccountId);
+        const balRes = await getAccountBalance(trackedAccountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        tgId = getTelegramId();
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'checkersbattle',
+          players: 2,
+          accountId: trackedAccountId,
+        });
+      } catch {}
+
+      if (!trackedAccountId) {
+        setMatchError('Unable to resolve your player account. Reopen Telegram and try again.');
+        setMatching(false);
+        setMatchStatus('');
+        return;
+      }
+    }
+
+    if (!isOnline) {
+      navigateToGame({ tgId, trackedAccountId });
+      return;
+    }
+
+    setMatchError('');
+    setMatching(true);
+    setMatchStatus('Connecting to lobby…');
+
+    const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
+      if (!tid || tid !== pendingTableRef.current) return;
+      const others = list.filter((p) => String(p.id) !== String(trackedAccountId || accountId));
+      if (others.length > 0) {
+        setMatchStatus('Opponent joined. Locking seats…');
+      } else {
+        setMatchStatus('Waiting for another player…');
+      }
+    };
+
+    const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
+      if (!startedId || startedId !== pendingTableRef.current) return;
+      const meIndex = players.findIndex((p) => String(p.id) === String(trackedAccountId || accountId));
+      const opp = players.find((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const mySide =
+        players.find((p) => String(p.id) === String(trackedAccountId || accountId))?.side ||
+        (meIndex === 0 ? 'white' : 'black');
+      cleanupLobby({ account: trackedAccountId });
+      navigateToGame({
+        tgId,
+        trackedAccountId,
+        tableId: startedId,
+        side: mySide,
+        opponentName: opp?.name,
+        opponentAvatar: opp?.avatar
+      });
+    };
+
+    cleanupRef.current = () => cleanupLobby({ account: trackedAccountId, skipRefReset: true });
+
+    socket.on('gameStart', handleGameStart);
+    socket.on('lobbyUpdate', handleLobbyUpdate);
+    socket.emit('register', { playerId: trackedAccountId });
+
+    const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
+    socket.emit(
+      'seatTable',
+      {
+        accountId: trackedAccountId || accountId,
+        gameType: 'checkers',
+        stake: stake.amount ?? 0,
+        maxPlayers: 2,
+        playerName: friendlyName,
+        avatar,
+        preferredSide
+      },
+      (res) => {
+        if (!res?.success || !res.tableId) {
+          setMatchError('Could not join the online lobby. Please try again.');
+          cleanupLobby({ account: trackedAccountId });
+          return;
+        }
+        pendingTableRef.current = res.tableId;
+        setMatchStatus('Waiting for another player…');
+        socket.emit('confirmReady', {
+          accountId: trackedAccountId,
+          tableId: res.tableId
+        });
+      }
+    );
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <GameLobbyHeader
+          slug="checkersbattleroyal"
+          title="Checkers Battle Royal Lobby"
+          badge={onlineCount != null ? `${onlineCount} online` : 'Syncing…'}
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+              {avatar ? (
+                <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+              <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+              </div>
+            </button>
+          </div>
+          <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match start screen.</p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                key: 'ai',
+                label: 'Vs AI',
+                desc: 'Instant practice',
+                accent: 'from-sky-400/30 via-indigo-500/10 to-transparent',
+                icon: '🤖',
+                iconKey: 'mode-ai'
+              },
+              {
+                key: 'online',
+                label: 'Online',
+                desc: 'Stake & match',
+                accent: 'from-sky-400/30 via-indigo-500/10 to-transparent',
+                icon: '⚔️',
+                iconKey: 'mode-online'
+              }
+            ].map(({ key, label, desc, accent, icon, iconKey }) => {
+              const active = mode === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setMode(key)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', iconKey)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
+          </p>
+        </div>
+
+        {mode === 'online' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+            <p className="text-center text-white/60 text-xs">
+              Staking uses your TPC account{accountId ? ` #${accountId}` : ''} as escrow for every online round.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pick Your Pieces</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Sides</span>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                {
+                  key: 'auto',
+                  label: 'Auto',
+                  desc: 'Random seats, no duplicates',
+                  accent: 'from-slate-400/30 via-slate-500/10 to-transparent',
+                  icon: '🎲'
+                },
+                {
+                  key: 'white',
+                  label: 'White',
+                  desc: 'You start first',
+                  accent: 'from-white/40 via-white/10 to-transparent',
+                  icon: '♔'
+                },
+                {
+                  key: 'black',
+                  label: 'Black',
+                  desc: 'Opponent opens',
+                  accent: 'from-gray-500/30 via-gray-700/10 to-transparent',
+                  icon: '♚'
+                }
+              ].map(({ key, label, desc, accent, icon }) => {
+                const active = preferredSide === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setPreferredSide(key)}
+                    className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
+                    }`}
+                  >
+                    <div className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}>
+                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                        {icon}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold">{label}</span>
+                        {active && <span className="text-[10px] font-bold uppercase">Selected</span>}
+                      </div>
+                      <div className="text-xs text-white/60">{desc}</div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-white/60 text-center">
+              Auto randomizes colors while ensuring both players get different sides.
+            </p>
+          </div>
+        )}
+
+        
+
+        {mode === 'online' && matching && (
+          <div className="space-y-2 rounded-2xl border border-primary/40 bg-primary/5 p-4 shadow">
+            <h3 className="font-semibold text-primary">Matching players…</h3>
+            <p className="text-sm text-white/60">{matchStatus || 'Syncing with the lobby…'}</p>
+            {matchError && <p className="text-sm text-red-400">{matchError}</p>}
+            <button
+              type="button"
+              className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white/80 hover:border-white/30"
+              onClick={() => cleanupLobby({ account: accountId })}
+            >
+              Cancel matchmaking
+            </button>
+          </div>
+        )}
+
+        <button
+          onClick={startGame}
+          disabled={matching}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {mode === 'online'
+            ? matching
+              ? 'Finding Online Match…'
+              : 'Find Online Match'
+            : 'Play vs AI'}
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) {
+                window.localStorage?.setItem('checkersBattleRoyalPlayerFlag', FLAG_EMOJIS[idx]);
+              }
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) {
+                window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+              }
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -431,6 +431,7 @@ const PREVIEW_BY_TYPE = {
 
 const PREVIEW_BY_SLUG = {
   chessbattleroyal: 'chess-royals',
+  checkersbattleroyal: 'chess-royals',
   'domino-royal': 'domino'
 };
 
@@ -677,6 +678,14 @@ const storeMeta = {
     typeLabels: CHESS_TYPE_LABELS,
     accountId: CHESS_STORE_ACCOUNT_ID
   },
+  checkersbattleroyal: {
+    name: 'Checkers Battle Royal',
+    items: CHESS_BATTLE_STORE_ITEMS,
+    defaults: CHESS_BATTLE_DEFAULT_LOADOUT,
+    labels: CHESS_BATTLE_OPTION_LABELS,
+    typeLabels: CHESS_TYPE_LABELS,
+    accountId: CHESS_STORE_ACCOUNT_ID
+  },
   ludobattleroyal: {
     name: 'Ludo Battle Royal',
     items: LUDO_BATTLE_STORE_ITEMS,
@@ -895,6 +904,7 @@ export default function Store() {
       snookerroyale: SNOOKER_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'snookerroyale' })),
       airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
+      checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'checkersbattleroyal' })),
       ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'ludobattleroyal' })),
       murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'murlanroyale' })),
       'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'domino-royal' })),
@@ -911,6 +921,7 @@ export default function Store() {
       snookerroyale: (type, optionId) => isSnookerOptionUnlocked(type, optionId, snookerOwned),
       airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      checkersbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
       murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned),
       'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned),
@@ -927,6 +938,7 @@ export default function Store() {
       snookerroyale: (item) => SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      checkersbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       murlanroyale: (item) => MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       'domino-royal': (item) => DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
@@ -942,6 +954,7 @@ export default function Store() {
       tabletennisroyal: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
+      checkersbattleroyal: CHESS_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
       murlanroyale: MURLAN_TYPE_LABELS,
       'domino-royal': DOMINO_TYPE_LABELS,
@@ -1483,7 +1496,7 @@ export default function Store() {
         for (const entry of group.items) {
           if (slug === 'airhockey') {
             setAirOwned(addAirHockeyUnlock(entry.type, entry.optionId, resolvedAccountId));
-          } else if (slug === 'chessbattleroyal') {
+          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal') {
             setChessOwned(addChessBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
           } else if (slug === 'ludobattleroyal') {
             setLudoOwned(addLudoBattleUnlock(entry.type, entry.optionId, resolvedAccountId));


### PR DESCRIPTION
### Motivation
- Introduce a new Checkers Battle Royal game and lobby so players can play checkers with the existing battle-royal arena and inventory system.
- Reuse existing Chess Battle Royal assets/inventory flows to minimize duplication while providing a dedicated checkers UX.
- Wire the new game into routing, catalog, asset mappings, and online lobby policies so it functions like other online games.

### Description
- Added two new React pages `CheckersBattleRoyal.jsx` and `CheckersBattleRoyalLobby.jsx` implementing a 3D checkers board, piece rendering, move/capture logic, appearance controls, and lobby matchmaking UI with socket interactions.
- Registered lazy routes and lobby routes in `App.jsx` so `/games/checkersbattleroyal` and `/games/checkersbattleroyal/lobby` are available and lazily loaded.
- Updated `onlineGamePolicy.js` to allow the new game type (`checkersbattleroyal`) for online seat/table requests.
- Extended `gameAssets.js`, `gamesCatalog.js`, and `Store.jsx` to include thumbnail/icon mappings, catalog entry, store preview/type labels, and store integration for `checkersbattleroyal` reusing chess battle asset sets and inventory resolvers.

### Testing
- Performed a frontend build to validate bundling and route imports by running a local build of the webapp (`vite`/project build), which completed successfully as a smoke check.
- No automated unit tests were added or modified for this change; existing frontend smoke/build checks were used to validate integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6654217608329a2d2beedba4cb7bb)